### PR TITLE
Added drag and drop functionality to the item ordering of featured articles (Ref #8138)

### DIFF
--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -90,14 +90,14 @@
 			default="a.title ASC"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="fp.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="fp.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
 			<option value="a.state ASC">JSTATUS_ASC</option>
 			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
-			<option value="fp.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
-			<option value="fp.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -6,15 +6,11 @@
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
-
 defined('_JEXEC') or die;
-
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
-
 $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -23,39 +19,36 @@ $canOrder  = $user->authorise('core.edit.state', 'com_content.article');
 $archived  = $this->state->get('filter.published') == 2 ? true : false;
 $trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder == 'fp.ordering';
-
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_content&task=featured.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'articleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
-
-$assoc = JLanguageAssociations::isEnabled();
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=featured'); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
-			<?php echo $this->sidebar; ?>
-		</div>
-		<div id="j-main-container" class="span10">
-	<?php else : ?>
-		<div id="j-main-container">
-	<?php endif;?>
-		<?php
-		// Search tools bar
-		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
-		?>
-		<?php if (empty($this->items)) : ?>
-			<div class="alert alert-no-items">
-				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-			</div>
+	<div id="j-sidebar-container" class="span2">
+		<?php echo $this->sidebar; ?>
+	</div>
+	<div id="j-main-container" class="span10">
 		<?php else : ?>
-			<table class="table table-striped" id="articleList">
-				<thead>
+		<div id="j-main-container">
+			<?php endif;?>
+			<?php
+			// Search tools bar
+			echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
+			?>
+			<?php if (empty($this->items)) : ?>
+				<div class="alert alert-no-items">
+					<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+				</div>
+			<?php else : ?>
+				<table class="table table-striped" id="articleList">
+					<thead>
 					<tr>
 						<th width="1%" class="nowrap center hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', '', 'a.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
+							<?php echo JHtml::_('searchtools.sort', '', 'fp.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
 						</th>
 						<th width="1%" class="center">
 							<?php echo JHtml::_('grid.checkall'); ?>
@@ -65,12 +58,6 @@ $assoc = JLanguageAssociations::isEnabled();
 						</th>
 						<th>
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
-						</th>
-						<th width="10%" class="nowrap">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ORDERING', 'fp.ordering', $listDirn, $listOrder); ?>
-							<?php if ($canOrder && $saveOrder) :?>
-								<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'featured.saveorder'); ?>
-							<?php endif; ?>
 						</th>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
@@ -91,141 +78,123 @@ $assoc = JLanguageAssociations::isEnabled();
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
 					</tr>
-				</thead>
-				<tfoot>
+					</thead>
+					<tfoot>
 					<tr>
 						<td colspan="10">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>
-				</tfoot>
-				<tbody>
-				<?php $count = count($this->items); ?>
-				<?php foreach ($this->items as $i => $item) :
-					$item->max_ordering = 0;
-					$ordering   = ($listOrder == 'fp.ordering');
-					$assetId    = 'com_content.article.' . $item->id;
-					$canCreate  = $user->authorise('core.create', 'com_content.category.' . $item->catid);
-					$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
-					$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
-					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
-					?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
-						<td class="order nowrap center hidden-phone">
-							<?php
-							$iconClass = '';
-							if (!$canChange)
-							{
-								$iconClass = ' inactive';
-							}
-							elseif (!$saveOrder)
-							{
-								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
-							}
-							?>
-							<span class="sortable-handler<?php echo $iconClass ?>">
+					</tfoot>
+					<tbody>
+					<?php $count = count($this->items); ?>
+					<?php foreach ($this->items as $i => $item) :
+						$item->max_ordering = 0;
+						$ordering   = ($listOrder == 'fp.ordering');
+						$assetId    = 'com_content.article.' . $item->id;
+						$canCreate  = $user->authorise('core.create', 'com_content.category.' . $item->catid);
+						$canEdit    = $user->authorise('core.edit', 'com_content.article.' . $item->id);
+						$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
+						$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
+						?>
+						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
+							<td class="order nowrap center hidden-phone">
+								<?php
+								$iconClass = '';
+								if (!$canChange)
+								{
+									$iconClass = ' inactive';
+								}
+								elseif (!$saveOrder)
+								{
+									$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
+								}
+								?>
+								<span class="sortable-handler<?php echo $iconClass ?>">
 								<span class="icon-menu"></span>
 							</span>
-							<?php if ($canChange && $saveOrder) : ?>
-								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
-							<?php endif; ?>
-						</td>
-						<td class="center">
-							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
-						</td>
-						<td class="center">
-							<div class="btn-group">
-								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
-								<?php
-								// Create dropdown items
-								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
-
-								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
-
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
-								?>
-							</div>
-						</td>
-						<td class="has-context">
-							<div class="pull-left break-word">
-								<?php if ($item->checked_out) : ?>
-									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+								<?php if ($canChange && $saveOrder) : ?>
+									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
 								<?php endif; ?>
-								<?php if ($item->language == '*') : ?>
-									<?php $language = JText::alt('JALL', 'language'); ?>
-								<?php else : ?>
-									<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-								<?php endif; ?>
-								<?php if ($canEdit) : ?>
-									<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id);?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
-										<?php echo $this->escape($item->title); ?></a>
-								<?php else : ?>
-									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
-								<?php endif; ?>
-								<span class="small break-word">
+							</td>
+							<td class="center">
+								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
+							</td>
+							<td class="center">
+								<div class="btn-group">
+									<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+									<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
+									<?php
+									// Create dropdown items
+									$action = $archived ? 'unarchive' : 'archive';
+									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
+									$action = $trashed ? 'untrash' : 'trash';
+									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
+									// Render dropdown list
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									?>
+								</div>
+							</td>
+							<td class="has-context">
+								<div class="pull-left break-word">
+									<?php if ($item->checked_out) : ?>
+										<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
+									<?php endif; ?>
+									<?php if ($item->language == '*') : ?>
+										<?php $language = JText::alt('JALL', 'language'); ?>
+									<?php else : ?>
+										<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+									<?php endif; ?>
+									<?php if ($canEdit) : ?>
+										<a href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&return=featured&id=' . $item->id);?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+											<?php echo $this->escape($item->title); ?></a>
+									<?php else : ?>
+										<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
+									<?php endif; ?>
+									<span class="small break-word">
 									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								</span>
-								<div class="small">
-									<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+									<div class="small">
+										<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+									</div>
 								</div>
-							</div>
-						</td>
-						<td class="order">
-							<?php if ($canChange && $saveOrder) : ?>
-								<div class="input-prepend">
-									<?php if ($listDirn == 'ASC') : ?>
-										<span class="add-on"><?php echo $this->pagination->orderUpIcon($i, true, 'featured.orderup', 'JLIB_HTML_MOVE_UP', $ordering); ?></span>
-										<span class="add-on"><?php echo $this->pagination->orderDownIcon($i, $count, true, 'featured.orderdown', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
-									<?php elseif ($listDirn == 'DESC') : ?>
-										<span class="add-on"><?php echo $this->pagination->orderUpIcon($i, true, 'featured.orderdown', 'JLIB_HTML_MOVE_UP', $ordering); ?></span>
-										<span class="add-on"><?php echo $this->pagination->orderDownIcon($i, $count, true, 'featured.orderup', 'JLIB_HTML_MOVE_DOWN', $ordering); ?></span>
-									<?php endif; ?>
-									<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
-								</div>
-							<?php else : ?>
-								<?php echo $item->ordering; ?>
-							<?php endif; ?>
-						</td>
-						<td class="small hidden-phone">
-							<?php echo $this->escape($item->access_level); ?>
-						</td>
-						<td class="small hidden-phone">
-							<?php if ($item->created_by_alias) : ?>
-								<?php echo $this->escape($item->author_name); ?>
-								<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
-							<?php else : ?>
-								<?php echo $this->escape($item->author_name); ?>
-							<?php endif; ?>
-						</td>
-						<td class="small hidden-phone">
-							<?php if ($item->language == '*'):?>
-								<?php echo JText::alt('JALL', 'language'); ?>
-							<?php else:?>
-								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-							<?php endif;?>
-						</td>
-						<td class="nowrap small hidden-phone">
-							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-						</td>
-						<td class="center hidden-phone">
-							<?php echo (int) $item->hits; ?>
-						</td>
-						<td class="center hidden-phone">
-							<?php echo (int) $item->id; ?>
-						</td>
-					</tr>
+							</td>
+							<td class="small hidden-phone">
+								<?php echo $this->escape($item->access_level); ?>
+							</td>
+							<td class="small hidden-phone">
+								<?php if ($item->created_by_alias) : ?>
+									<?php echo $this->escape($item->author_name); ?>
+									<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
+								<?php else : ?>
+									<?php echo $this->escape($item->author_name); ?>
+								<?php endif; ?>
+							</td>
+							<td class="small hidden-phone">
+								<?php if ($item->language == '*'):?>
+									<?php echo JText::alt('JALL', 'language'); ?>
+								<?php else:?>
+									<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+								<?php endif;?>
+							</td>
+							<td class="nowrap small hidden-phone">
+								<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+							</td>
+							<td class="center hidden-phone">
+								<?php echo (int) $item->hits; ?>
+							</td>
+							<td class="center hidden-phone">
+								<?php echo (int) $item->id; ?>
+							</td>
+						</tr>
 					<?php endforeach; ?>
-				</tbody>
-			</table>
-		<?php endif; ?>
+					</tbody>
+				</table>
+			<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="featured" value="1" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<?php echo JHtml::_('form.token'); ?>
-	</div>
+			<input type="hidden" name="task" value="" />
+			<input type="hidden" name="featured" value="1" />
+			<input type="hidden" name="boxchecked" value="0" />
+			<?php echo JHtml::_('form.token'); ?>
+		</div>
 </form>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -97,7 +97,7 @@ if ($saveOrder)
 						$canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || $item->checked_out == 0;
 						$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 						?>
-						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
+						<tr class="row<?php echo $i % 2; ?>">
 							<td class="order nowrap center hidden-phone">
 								<?php
 								$iconClass = '';

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -23,6 +23,14 @@ $canOrder  = $user->authorise('core.edit.state', 'com_content.article');
 $archived  = $this->state->get('filter.published') == 2 ? true : false;
 $trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder == 'fp.ordering';
+
+if ($saveOrder)
+{
+	$saveOrderingUrl = 'index.php?option=com_content&task=featured.saveOrderAjax&tmpl=component';
+	JHtml::_('sortablelist.sortable', 'articleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
+}
+
+$assoc = JLanguageAssociations::isEnabled();
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=featured'); ?>" method="post" name="adminForm" id="adminForm">
@@ -46,6 +54,9 @@ $saveOrder = $listOrder == 'fp.ordering';
 			<table class="table table-striped" id="articleList">
 				<thead>
 					<tr>
+						<th width="1%" class="nowrap center hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', '', 'a.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
+						</th>
 						<th width="1%" class="center">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
@@ -100,6 +111,25 @@ $saveOrder = $listOrder == 'fp.ordering';
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
+						<td class="order nowrap center hidden-phone">
+							<?php
+							$iconClass = '';
+							if (!$canChange)
+							{
+								$iconClass = ' inactive';
+							}
+							elseif (!$saveOrder)
+							{
+								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
+							}
+							?>
+							<span class="sortable-handler<?php echo $iconClass ?>">
+								<span class="icon-menu"></span>
+							</span>
+							<?php if ($canChange && $saveOrder) : ?>
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+							<?php endif; ?>
+						</td>
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 						</td>


### PR DESCRIPTION
Pull Request for Issue #8138
#### Summary of Changes

Added ordering Heading button
Added sort-able drag and drop button with drag and drop functionality
Added save ordering functionality to save the ordering when the items are sorted with drag and drop
#### Testing Instructions
1. Go to Back end > Content > Articles
2. Can sort the article items by drag and drop 
3. Go to Back end > Content > Featured Articles
4. Can not sort the article items by drag and drop
5. Apply the patch
6. Go to Back end > Content > Featured Articles
7. Now the view shows the drag and drop functionality
