### PR TITLE
Solve SEF canonical issues

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -31,28 +31,26 @@ class PlgSystemSef extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	public function onAfterDispatch()
+	public function onAfterRoute()
 	{
-		$doc = $this->app->getDocument();
+		$doc = JFactory::getDocument();
 
 		if (!$this->app->isSite() || $doc->getType() !== 'html')
 		{
 			return;
 		}
 
-		$uri     = JUri::getInstance();
-		$domain  = $this->params->get('domain');
+		$domain  = $this->params->get('domain', '');
 
-		if ($domain === false || $domain === '')
+		if ($domain !== '')
 		{
-			$domain = $uri->toString(array('scheme', 'host', 'port'));
-		}
+			$uri    = JUri::getInstance();
+			$link   = $domain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);
 
-		$link = $domain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);
-
-		if (rawurldecode($uri->toString()) !== $link)
-		{
-			$doc->addHeadLink(htmlspecialchars($link), 'canonical');
+			if (rawurldecode($uri->toString()) !== $link)
+			{
+				$doc->addHeadLink(htmlspecialchars($link), 'canonical');
+			}
 		}
 	}
 

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -71,7 +71,7 @@ class PlgSystemSef extends JPlugin
 		// If a canonical html doesn't exists already add a canonical html tag using the SEF plugin domain field.
 		else
 		{
-			$canonical = $sefDomain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);
+			$canonical = $sefDomain . JUri::getInstance()->toString(array('path', 'query', 'fragment'));
 		}
 
 		// Add the canonical link.

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -41,32 +41,49 @@ class PlgSystemSef extends JPlugin
 		}
 
 		// Check if canonical already exists (for instance, added by a component) so we don't override it.
-		$exists = false;
-		foreach ($doc->_links as $link)
+		$canonical = '';
+		foreach ($doc->_links as $linkUrl => $link)
 		{
 			if (isset($link['relation']) && $link['relation'] === 'canonical')
 			{
-				$exists = true;
+				$canonical = $linkUrl;
 				break;
 			}
 		}
 
-		// If a canonical html tag already exists, don't do anything.
-		if ($exists)
+		$domain = $this->params->get('domain', '');
+
+		// If a canonical html tag already exists and we don't override it on SEF with a custom domain, don't do anything.
+		if (!empty($canonical) && empty($domain))
 		{
 			return;
 		}
 
-		// Add the canonical link if it's different from the current URI.
-		$domain    = $this->params->get('domain', '');
-		$uri       = JUri::getInstance();
-		$domain    = (empty($domain)) ? $uri->toString(array('scheme', 'host', 'port')) : $domain;
-		$canonical = $domain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);
+		$uri    = JUri::getInstance();
+		$domain = (empty($domain)) ? $uri->toString(array('scheme', 'host', 'port')) : $domain;
 
-		if (rawurldecode($uri->toString()) !== $canonical)
+		// If a canonical html tag already exists and we override it on SEF with a custom domain, get the new canonical.
+		if (!empty($canonical) && !empty($domain))
 		{
-			$doc->addHeadLink(htmlspecialchars($canonical), 'canonical');
+			// Remove current canonical link.
+			unset($doc->_links[$canonical]);
+
+			// Set the current canonical link but use the SEF system plugin domain field.
+			$canonical = $domain . JUri::getInstance($canonical)->toString(array('path', 'query', 'fragment'));
 		}
+		// If a canonical html doesn't exists already.
+		else
+		{
+			// Set the new canonical link, but only if it uses the SEF system plugin domain field or the canonical uri it's different from the current uri.
+			$canonical = $domain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);
+			if (rawurldecode($uri->toString()) === $canonical)
+			{
+				return;
+			}
+		}
+
+		// Add the canonical link.
+		$doc->addHeadLink(htmlspecialchars($canonical), 'canonical');
 	}
 
 	/**

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -51,8 +51,6 @@ class PlgSystemSef extends JPlugin
 			}
 		}
 
-		$domain = $this->params->get('domain', '');
-
 		// If a canonical html tag already exists, don't do anything.
 		if ($exists)
 		{
@@ -60,6 +58,7 @@ class PlgSystemSef extends JPlugin
 		}
 
 		// Add the canonical link if it's different from the current URI.
+		$domain    = $this->params->get('domain', '');
 		$uri       = JUri::getInstance();
 		$domain    = (empty($domain)) ? $uri->toString(array('scheme', 'host', 'port')) : $domain;
 		$canonical = $domain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -42,13 +42,13 @@ class PlgSystemSef extends JPlugin
 
 		$sefDomain = $this->params->get('domain', '');
 
-		// Don't add a canonical id no alternative domain has added in SEF plugin domain field.
+		// Don't add a canonical html tag if no alternative domain has added in SEF plugin domain field.
 		if (empty($sefDomain))
 		{
 			return;
 		}
 
-		// Check if canonical already exists (for instance, added by a component).
+		// Check if a canonical html tag already exists (for instance, added by a component).
 		$canonical = '';
 		foreach ($doc->_links as $linkUrl => $link)
 		{
@@ -68,7 +68,7 @@ class PlgSystemSef extends JPlugin
 			// Set the current canonical link but use the SEF system plugin domain field.
 			$canonical = $sefDomain . JUri::getInstance($canonical)->toString(array('path', 'query', 'fragment'));
 		}
-		// If a canonical html doesn't exists already add a canonical using the SEF plugin domain field.
+		// If a canonical html doesn't exists already add a canonical html tag using the SEF plugin domain field.
 		else
 		{
 			$canonical = $sefDomain . JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()), false);

--- a/plugins/system/sef/sef.xml
+++ b/plugins/system/sef/sef.xml
@@ -22,6 +22,7 @@
 				<field name="domain" type="url"
 					description="PLG_SEF_DOMAIN_DESCRIPTION"
 					label="PLG_SEF_DOMAIN_LABEL"
+					hint="https://www.domain.tld"
 					filter="url"
 					validate="url"
 				/>

--- a/plugins/system/sef/sef.xml
+++ b/plugins/system/sef/sef.xml
@@ -22,7 +22,7 @@
 				<field name="domain" type="url"
 					description="PLG_SEF_DOMAIN_DESCRIPTION"
 					label="PLG_SEF_DOMAIN_LABEL"
-					hint="https://www.domain.tld"
+					hint="https://www.example.com"
 					filter="url"
 					validate="url"
 				/>


### PR DESCRIPTION
This Pull Request is related to issues https://github.com/joomla/joomla-cms/issues/9333 and https://github.com/joomla/joomla-cms/issues/9556.

Also to PR https://github.com/joomla/joomla-cms/pull/9559
#### Summary of Changes

Add a better check for adding the canonical html tag.
#### Testing Instructions
1. Apply this patch. With SEF system plugin active
2. Do the following test scenarios:

| Domain in the SEF plugin field | Canonical added by a component | Result |
| --- | --- | --- |
| (empty) | No | The canonical html tag will NOT be added |
| (empty) | Yes | No change (the component added canonical html tag stays the same) |
| Yes | No | The canonical html tag will be added with the new domain typed in the SEF plugin domain field (ex: https://www.example.com/menu-item/). |
| Yes | Yes | The canonical html tag will be the same as added by the component but now with the new domain typed in the SEF plugin domain field. |
