### PR TITLE
Fix cloaking of email addresses in Contact category lists

### DIFF
--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -65,7 +65,7 @@ class ContactViewCategory extends JViewCategory
 			$item->params = clone($this->params);
 			$item->params->merge($temp);
 
-			if ($item->params->get('show_email', 0) == 1)
+			if ($item->params->get('show_email_headings', 0) == 1)
 			{
 				$item->email_to = trim($item->email_to);
 


### PR DESCRIPTION
**Issue**

Email cloaking in contact category component view does not work,

**Steps to reproduce the issue**

Set up a contact category menu item displaying a contact category containing contacts with email addresses. Make sure show email address is enabled for this menu item and the email cloaking plugin is enabled.

**Expected result**

The email address should be cloaked and if required prefixed with mailto:

**Actual result**

A plain uncloaked email address is shown.
Incorrect parameter name checked to determine if a contact's email address should be pre-processed before display.

**Summary of Changes**

"show_email_headings" checked instead of incorrect "show_email" parameter.

Email cloaking now works correctly
