### PR TITLE
Add missing is_array check within TagsTableTag->bind()

### DIFF
--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -58,7 +58,7 @@ class TagsTableTag extends JTableNested
 			$array['metadata'] = (string) $registry;
 		}
 
-		if (isset($array['urls']) && $array['urls'])
+		if (isset($array['urls']) && is_array($array['urls']))
 		{
 			$registry = new Registry;
 			$registry->loadArray($array['urls']);


### PR DESCRIPTION
Column "urls" in table #__tags gets more and more filled each time a single tag is saved. This is caused by a missing check for an array in bind method of com_tags (administrator/components/com_tags/tables/tag.php - L61).

Tested on a **fresh 3.5.0** with no sample data and on 3.4.8.

**Testing instructions:**
- in backend go to "Components -> Tags"  
- create a new tag by clicking on "New"
- enter a title and click on "Save"   
- now in phpMyAdmin go to table "#__tags" and look for the value in the column "urls" of the tag just created: it should be {}   
- in backend save the tag again
- in phpMyAdmin hit F5 - the value of "urls" is now {"0":"{}"}  
- in backend save the tag again  
- in phpMyAdmin hit F5 - the value of "urls" is now {"0":"{\"0\":\"{}\"}"}  

On each save the column gets messed up more (I tried it about 10 times - looks nice :-)   

**Apply the patch and test again**: column "urls" should only be filled with {}.

This was introduced a while ago: bb658686ff7c4da9870518f8fbc0ed3542255172
