### PR TITLE
The addReplyTo doesn't take an array as argument in contact form

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -217,7 +217,7 @@ class ContactControllerContact extends JControllerForm
 
 				$mail = JFactory::getMailer();
 				$mail->addRecipient($email);
-				$mail->addReplyTo(array($email, $name));
+				$mail->addReplyTo($email, $name);
 				$mail->setSender(array($mailfrom, $fromname));
 				$mail->setSubject($copysubject);
 				$mail->setBody($copytext);


### PR DESCRIPTION
#### Summary of Changes

When sending out an email via the contact form and selecting to also send an email to yourself an error will be thrown

![image](https://cloud.githubusercontent.com/assets/359377/14031703/5b4719ac-f20e-11e5-87df-c11d439b42e0.png)
#### Testing Instructions
1. Get the latest staging version
2. Install the latest staging with sample data
3. Go to the Single contact menu item
4. Open the contact form and fill in all fields
5. Make sure you check the box for sending a copy to yourself
6. Send the email
7. The error will show up
8. Apply this patch
9. Send the form again and it will send the emails
