### PR TITLE
Check if SSL is available when enabling in configuration

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -132,6 +132,9 @@ class ConfigModelApplication extends ConfigModelForm
 			if (!$result)
 			{
 				$data['force_ssl'] = 0;
+
+				// Also update the user state
+				JFactory::getApplication()->setUserState('com_config.config.global.data.force_ssl', 0);
 			}
 		}
 

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -118,6 +118,23 @@ class ConfigModelApplication extends ConfigModelForm
 			return false;
 		}
 
+		// Check if we need to verify the SSL certificate
+		if (0 !== $data['force_ssl'])
+		{
+			// Check if SSL is available
+			$host = JUri::getInstance()->getHost();
+			$get = stream_context_create(array('ssl' => array('capture_peer_cert' => true)));
+			$read = stream_socket_client('ssl://' . $host . ':443', $errorNumber, $errorMessage, 30, STREAM_CLIENT_CONNECT, $get);
+			$cert = stream_context_get_params($read);
+			$result = array_key_exists('peer_certificate', $cert['options']['ssl']);
+
+			// There is no SSL certificate, do not enable SSL
+			if (!$result)
+			{
+				$data['force_ssl'] = 0;
+			}
+		}
+
 		// Save the rules
 		if (isset($data['rules']))
 		{

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -118,7 +118,7 @@ class ConfigModelApplication extends ConfigModelForm
 			return false;
 		}
 
-		// Check if we need to verify the SSL certificate
+		// Check if we can set the Force SSL option
 		if ((int) $data['force_ssl'] !== 0 && (int) $data['force_ssl'] !== (int) JFactory::getConfig()->get('force_ssl', '0'))
 		{
 			try

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -135,6 +135,9 @@ class ConfigModelApplication extends ConfigModelForm
 
 				// Also update the user state
 				$app->setUserState('com_config.config.global.data.force_ssl', 0);
+				
+				// Inform the user
+				$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_SSL_NOT_AVAILABLE'), 'notice');
 			}
 		}
 

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -134,7 +134,7 @@ class ConfigModelApplication extends ConfigModelForm
 				$data['force_ssl'] = 0;
 
 				// Also update the user state
-				JFactory::getApplication()->setUserState('com_config.config.global.data.force_ssl', 0);
+				$app->setUserState('com_config.config.global.data.force_ssl', 0);
 			}
 		}
 

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -121,12 +121,23 @@ class ConfigModelApplication extends ConfigModelForm
 		// Check if we need to verify the SSL certificate
 		if (0 !== $data['force_ssl'])
 		{
-			// Check if SSL is available
+			// Connection details
 			$host = JUri::getInstance()->getHost();
-			$get = stream_context_create(array('ssl' => array('capture_peer_cert' => true)));
-			$read = stream_socket_client('ssl://' . $host . ':443', $errorNumber, $errorMessage, 30, STREAM_CLIENT_CONNECT, $get);
+
+			// Check if TLS is available
+			$get = stream_context_create(array('tls' => array('capture_peer_cert' => true)));
+			$read = stream_socket_client('tls://' . $host . ':443', $errorNumber, $errorMessage, 30, STREAM_CLIENT_CONNECT, $get);
 			$cert = stream_context_get_params($read);
-			$result = array_key_exists('peer_certificate', $cert['options']['ssl']);
+			$result = array_key_exists('peer_certificate', $cert['options']['tls']);
+
+			if (!$result)
+			{
+				// Check if SSL is available
+				$get = stream_context_create(array('ssl' => array('capture_peer_cert' => true)));
+				$read = stream_socket_client('ssl://' . $host . ':443', $errorNumber, $errorMessage, 30, STREAM_CLIENT_CONNECT, $get);
+				$cert = stream_context_get_params($read);
+				$result = array_key_exists('peer_certificate', $cert['options']['ssl']);
+			}
 
 			// There is no SSL certificate, do not enable SSL
 			if (!$result)
@@ -135,7 +146,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				// Also update the user state
 				$app->setUserState('com_config.config.global.data.force_ssl', 0);
-				
+
 				// Inform the user
 				$app->enqueueMessage(JText::_('COM_CONFIG_ERROR_SSL_NOT_AVAILABLE'), 'notice');
 			}

--- a/administrator/language/en-GB/en-GB.com_config.ini
+++ b/administrator/language/en-GB/en-GB.com_config.ini
@@ -28,6 +28,7 @@ COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE="Could not make configuration.php
 COM_CONFIG_ERROR_HELPREFRESH_ERROR_STORE="The new Help Sites list could not be saved."
 COM_CONFIG_ERROR_HELPREFRESH_FETCH="The current Help Sites list could not be fetched from the remote server."
 COM_CONFIG_ERROR_ROOT_ASSET_NOT_FOUND="The asset for global configuration could not be found. Permissions have not been saved."
+COM_CONFIG_ERROR_SSL_NOT_AVAILABLE="HTTPS has not been enabled as it is not available on this server."
 COM_CONFIG_ERROR_REMOVING_SUPER_ADMIN="You can't remove your own Super User permissions."
 COM_CONFIG_ERROR_WRITE_FAILED="Could not write to the configuration file"
 COM_CONFIG_FIELD_CACHE_HANDLER_DESC="Choose cache handler to enable caching. Native caching mechanism is file-based. Please make sure the cache folders are writable."


### PR DESCRIPTION
Pull Request for Issue #9583 .
#### Summary of Changes

If you are forcing SSL on your site either the Entire site or Administrator part but there is no SSL certificate present you will no longer be able to access the site. You will need to FTP into your site and change the configuration file manually to be able to get in. To prevent this nuisance, this PR will add a check to see if an SSL connection is possible to the site. If not possible, SSL will not be enabled.
#### Testing Instructions
##### Testing on a non-SSL enabled site
1. Open a Joomla site that has no SSL enabled
2. Go to the System -> Global Configuration -> Server
3. Set the option **Force SSL** to **Entire Site**
4. Save the configuration
5. You are now locked out of the site
6. Manually edit the configuration.php file and set the force_ssl back to 0
   
   ``` php
   public $force_ssl = '0';
   ```
7. Apply the patch
8. Go to the System -> Global Configuration -> Server
9. Set the option **Force SSL** to **Entire Site**
10. Save the configuration
11. You will not be locked out and the SSL option remains stored as 0
##### Testing on a SSL enabled site
1. Open a Joomla site that has no SSL enabled
2. Go to the System -> Global Configuration -> Server
3. Set the option **Force SSL** to **Entire Site**
4. Save the configuration
5. SSL will be used everywhere on the site
6. Go to the System -> Global Configuration -> Server
7. Set the option **Force SSL** to **None**
8. Save the configuration
9. Apply the patch
10. Go to the System -> Global Configuration -> Server
11. Set the option **Force SSL** to **Entire Site**
12. Save the configuration
13. SSL will be used everywhere on the site

There are actually no differences for SSL enabled site, just testing things keep working as they are now.
