### PR TITLE
Update template.css

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8170,8 +8170,8 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
-}
 .modal-body {
 	-webkit-overflow-scrolling: touch;
 	overflow-y: auto !important;
+}
 }


### PR DESCRIPTION
Pull Request for Issue #9551  .
#### Summary of Changes

moved } to incorporate .modal-body into the @media (max-width: 767px) 
#### Testing Instructions

in a menu, or content window select some items then click batch attempt to "move or copy" you will find the window is too small.
Apply this patch
repeat the test and on a standard screen it overflows correctly to allow you to select an item.
If possible test on multiple view ports particularly if you have a device has the max-width as above.
Not sure if it would be better removing it from the constraint totally.
