### PR TITLE
Add another check to the renderfield layout of com_contact to determine whether or not a field is required

### DIFF
--- a/components/com_contact/layouts/joomla/form/renderfield.php
+++ b/components/com_contact/layouts/joomla/form/renderfield.php
@@ -27,12 +27,28 @@ if (!empty($options['showonEnabled']))
 
 $class = empty($options['class']) ? '' : ' ' . $options['class'];
 $rel   = empty($options['rel']) ? '' : ' ' . $options['rel'];
+
+/**
+ * @TODO:
+ *
+ * As mentioned in #8473 (https://github.com/joomla/joomla-cms/pull/8473), ...
+ * as long as we cannot access the field properties properly, this seems to
+ * be the way to go for now.
+ *
+ * On a side note: Parsing html is seldom a good idea.
+ * https://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454
+ */
+preg_match('/class=\"([^\"]+)\"/i', $input, $match);
+
+$required      = (strpos($input, 'aria-required="true"') !== false || (!empty($match[1]) && strpos($match[1], 'required') !== false));
+$typeOfSpacer  = (strpos($label, 'spacer-lbl') !== false);
+
 ?>
 <div class="control-group<?php echo $class; ?>"<?php echo $rel; ?>>
 	<?php if (empty($options['hiddenLabel'])) : ?>
 		<div class="control-label">
 			<?php echo $label; ?>
-			<?php if (strpos($input, 'aria-required="true"') === false && strpos($label, 'spacer-lbl') === false) : ?>
+			<?php if (!$required && !$typeOfSpacer) : ?>
 				<span class="optional"><?php echo JText::_('COM_CONTACT_OPTIONAL'); ?></span>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
#### Summary of Changes

This PR fixes issue #9552 reported by [RoscioZ](https://github.com/RoscioZ)

In #8473 I introduced a component specific renderfield override so that layouts can be "free" of static form / field rendering code blocks. As mentioned in the description and discussion, the implementation is not very clean. [Parsing HTML is seldom a good idea](https://stackoverflow.com/questions/1732348/regex-match-open-tags-except-xhtml-self-contained-tags/1732454#1732454).
#### Testing Instructions

To check that the reported problem has been fixed:
1. Create a contact item in the backend
2. Create a menu item for that contact
3. Enable the "Captcha - ReCaptcha" plugin and select that plugin in the site tab of the global configuration
**Note:** You may have to generate a key to be able to use / see the captcha on your webseite. Any key that is valid for a website is also valid on localhost.
4. Open the contact page in the frontend. As reported, the captcha field shows the (optional) suffix, which should not be there
5. Apply the patch - the suffix should be gone
