### PR TITLE
Correct check to determine if captcha was enabled

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -14,9 +14,11 @@ JHtml::_('behavior.formvalidator');
 
 $captchaEnabled = false;
 
+$captchaSet = $this->params->get('captcha', JFactory::getApplication()->get('captcha', '0'));
+
 foreach (JPluginHelper::getPlugin('captcha') as $plugin)
 {
-	if ($this->params->get('captcha', JFactory::getApplication()->get('captcha', '0')) === $plugin->name)
+	if ($captchaSet === $plugin->name)
 	{
 		$captchaEnabled = true;
 		break;

--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -16,7 +16,7 @@ $captchaEnabled = false;
 
 foreach (JPluginHelper::getPlugin('captcha') as $plugin)
 {
-	if (JFactory::getApplication()->get('captcha', '0') === $plugin->name)
+	if ($this->params->get('captcha', JFactory::getApplication()->get('captcha', '0')) === $plugin->name)
 	{
 		$captchaEnabled = true;
 		break;


### PR DESCRIPTION
#### Summary of Changes

As reported by @yvesh the (my) implementation of the check to determine if a captcha plugin was enabled ignores the component specific settings (like com_users would do). With this PR the global configuration params act as the fallback as it should be.
#### Testing Instructions
1. Create a contact item
2. Create a menu item to that contact
3. Enable the captcha plugin (make sure you have a valid key pair)
4. Set the global configuration parameter (site tab) of "Default Captcha" to e.g. "- None Selected -"
5. Set the  "Allow Captcha on Contact" in the com_contact options form tab to "Captcha - ReCaptcha"
6. Visit the contact page - you should notice that the captcha field / check is missing
7. Apply the patch - the captcha field shows based on the global / components settings

Big thanks to @yvesh and @degobbis - next **[favorite drink here]** is on me.
