### PR TITLE
PDO insertid does not return last inserted row id

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -666,8 +666,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		$this->connect();
 
-		// Error suppress this to prevent PDO warning us that the driver doesn't support this operation.
-		return @$this->connection->lastInsertId();
+		return $this->setQuery('SELECT LAST_INSERT_ID() AS id')->execute()->fetchObject()->id;
 	}
 
 	/**


### PR DESCRIPTION
Found a way to make it work, I think.

Should fix #9534 and #9582.
