### PR TITLE
[PostgreSQL] Upgrade to Joomla 3.5 error

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-26.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-26.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "#__contentitem_tag_map" DROP INDEX "#__contentitem_tag_map_idx_tag";
-ALTER TABLE "#__contentitem_tag_map" DROP INDEX "#__contentitem_tag_map_idx_type";
+DROP INDEX "#__contentitem_tag_map_idx_tag";
+DROP INDEX "#__contentitem_tag_map_idx_type";


### PR DESCRIPTION
Pull Request for Issue #9537 .
#### Summary of Changes

fix drop index syntax thx to @waader
#### Testing Instructions

Joomla! Update: Options
Change the Update source config to something like this
![updates](https://cloud.githubusercontent.com/assets/181681/14058843/02429db0-f32e-11e5-971a-74ea781acedc.PNG)

Hack the list.xml file 
![hack1](https://cloud.githubusercontent.com/assets/181681/14058859/5e69a250-f32e-11e5-9997-53abf9184d69.PNG)

Hack the extension_sts.xml file 
change  the repo  from https://github.com/joomla/joomla-cms/releases/download/3.5.0
to yours local
![hack2](https://cloud.githubusercontent.com/assets/181681/14058897/068423b6-f32f-11e5-8170-f62ae7471f2c.PNG)

use this update pkg instead of the official one  wich is the same + this #pr
[Joomla_3.5.0-Stable-Update_Package.zip](https://github.com/joomla/joomla-cms/files/190385/Joomla_3.5.0-Stable-Update_Package.zip)

execute this query on your db

```
UPDATE  #__update_sites
set location ='http://localhost/pr/list.xml'
where update_site_id =1;
```

now you can upgrade to 3.5
