### PR TITLE
Update article hit counter always fix #9563

### DIFF
--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -101,7 +101,7 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
-		if ($vName == 'article' && $cachable)
+		if ($vName == 'article')
 		{
 			// Get/Create the model
 			if ($model = $this->getModel($vName))


### PR DESCRIPTION
Pull Request for Issue #9563 .
#### Summary of Changes

Update article hit counter always 
#### Testing Instructions

> #### Steps to reproduce the issue
> 
> Backend -> Articles Management -> Counter visits Articles
> #### Expected result
> 
> The counter advances after each visit Article, also logged users
> #### Actual result
> 
> The counter advances only after visits from people who are not logged in; the count does not advance for logged-in users visits
