### PR TITLE
Refactor mod_menu layouts for better maintainability

### DIFF
--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -67,7 +67,7 @@ if (($tagId = $params->get('tag_id', '')))
 		case 'separator':
 		case 'component':
 		case 'heading':
-		case 'url':			
+		case 'url':
 			require JModuleHelper::getLayoutPath('mod_menu', 'default_' . $item->type);
 			break;
 

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -58,7 +58,7 @@ if (($tagId = $params->get('tag_id', '')))
 
 	if ($item->parent)
 	{
-		$class .= ' parent dropdown-submenu';
+		$class .= ' parent';
 	}
 
 	echo '<li class="' . $class . '">';

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -9,24 +9,21 @@
 
 defined('_JEXEC') or die;
 
-// Note. It is important to remove spaces between elements.
-?>
-<?php // The menu class is deprecated. Use nav instead. ?>
-<ul class="nav menu<?php echo $class_sfx;?>"<?php
-	$tag = '';
+$id = '';
 
-	if ($params->get('tag_id') != null)
-	{
-		$tag = $params->get('tag_id') . '';
-		echo ' id="' . $tag . '"';
-	}
-?>>
-<?php
-foreach ($list as $i => &$item)
+if (($tagId = $params->get('tag_id', '')))
+{
+	$id = ' id="' . $tagId . '"';
+}
+
+// The menu class is deprecated. Use nav instead
+?>
+<ul class="nav menu<?php echo $class_sfx; ?>"<?php echo $id; ?>>
+<?php foreach ($list as $i => &$item)
 {
 	$class = 'item-' . $item->id;
 
-	if (($item->id == $active_id) OR ($item->type == 'alias' AND $item->params->get('aliasoptions') == $active_id))
+	if (($item->id == $active_id) || ($item->type == 'alias' && $item->params->get('aliasoptions') == $active_id))
 	{
 		$class .= ' current';
 	}
@@ -61,22 +58,16 @@ foreach ($list as $i => &$item)
 
 	if ($item->parent)
 	{
-		$class .= ' parent';
+		$class .= ' parent dropdown-submenu';
 	}
 
-	if (!empty($class))
-	{
-		$class = ' class="' . trim($class) . '"';
-	}
+	echo '<li class="' . $class . '">';
 
-	echo '<li' . $class . '>';
-
-	// Render the menu item.
 	switch ($item->type) :
 		case 'separator':
-		case 'url':
 		case 'component':
 		case 'heading':
+		case 'url':			
 			require JModuleHelper::getLayoutPath('mod_menu', 'default_' . $item->type);
 			break;
 
@@ -88,17 +79,17 @@ foreach ($list as $i => &$item)
 	// The next item is deeper.
 	if ($item->deeper)
 	{
-		echo '<ul class="nav-child unstyled small">';
+		echo '<ul class="nav-child unstyled dropdown-menu">';
 	}
+	// The next item is shallower.
 	elseif ($item->shallower)
 	{
-		// The next item is shallower.
 		echo '</li>';
 		echo str_repeat('</ul></li>', $item->level_diff);
 	}
+	// The next item is on the same level.
 	else
 	{
-		// The next item is on the same level.
 		echo '</li>';
 	}
 }

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -79,7 +79,7 @@ if (($tagId = $params->get('tag_id', '')))
 	// The next item is deeper.
 	if ($item->deeper)
 	{
-		echo '<ul class="nav-child unstyled dropdown-menu">';
+		echo '<ul class="nav-child unstyled small">';
 	}
 	// The next item is shallower.
 	elseif ($item->shallower)

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -42,7 +42,7 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 }
-else if ($item->browserNav == 2)
+elseif ($item->browserNav == 2)
 {
 	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes';
 

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -9,34 +9,44 @@
 
 defined('_JEXEC') or die;
 
-// Note. It is important to remove spaces between elements.
-$class = $item->anchor_css ? 'class="' . $item->anchor_css . '" ' : '';
-$title = $item->anchor_title ? 'title="' . $item->anchor_title . '" ' : '';
+$attributes = array();
+
+if ($item->anchor_title)
+{
+	$attributes['title'] = $item->anchor_title;
+}
+
+if ($item->anchor_css)
+{
+	$attributes['class'] = $item->anchor_css;
+}
+
+if ($item->anchor_rel)
+{
+	$attributes['rel'] = $item->anchor_rel;
+}
+
+$linktype = $item->title;
 
 if ($item->menu_image)
 {
-	$item->params->get('menu_text', 1) ?
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" /><span class="image-title">' . $item->title . '</span> ' :
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" />';
-}
-else
-{
-	$linktype = $item->title;
+	$linktype = JHtml::_('image', $item->menu_image, $item->title);
+
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
 }
 
-switch ($item->browserNav)
+if ($item->browserNav == 1)
 {
-	default:
-	case 0:
-?><a <?php echo $class; ?>href="<?php echo $item->flink; ?>" <?php echo $title; ?>><?php echo $linktype; ?></a><?php
-		break;
-	case 1:
-		// _blank
-?><a <?php echo $class; ?>href="<?php echo $item->flink; ?>" target="_blank" <?php echo $title; ?>><?php echo $linktype; ?></a><?php
-		break;
-	case 2:
-	// Use JavaScript "window.open"
-?><a <?php echo $class; ?>href="<?php echo $item->flink; ?>" onclick="window.open(this.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes');return false;" <?php echo $title; ?>><?php echo $linktype; ?></a>
-<?php
-		break;
+	$attributes['target'] = '_blank';
 }
+else if ($item->browserNav == 2)
+{
+	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes';
+
+	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
+}
+
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink)), $linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -9,37 +9,44 @@
 
 defined('_JEXEC') or die;
 
-// Note. It is important to remove spaces between elements.
-$class = $item->anchor_css ? 'class="' . $item->anchor_css . '" ' : '';
-$title = $item->anchor_title ? 'title="' . $item->anchor_title . '" ' : '';
-$rel   = $item->anchor_rel ? 'rel="' . $item->anchor_rel . '" ' : '';
+$attributes = array();
+
+if ($item->anchor_title)
+{
+	$attributes['title'] = $item->anchor_title;
+}
+
+if ($item->anchor_css)
+{
+	$attributes['class'] = $item->anchor_css;
+}
+
+if ($item->anchor_rel)
+{
+	$attributes['rel'] = $item->anchor_rel;
+}
+
+$linktype = $item->title;
 
 if ($item->menu_image)
 {
-	$item->params->get('menu_text', 1) ?
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" /><span class="image-title">' . $item->title . '</span> ' :
-	$linktype = '<img src="' . $item->menu_image . '" alt="' . $item->title . '" />';
+	$linktype = JHtml::_('image', $item->menu_image, $item->title);
+
+	if ($item->params->get('menu_text', 1))
+	{
+		$linktype .= '<span class="image-title">' . $item->title . '</span>';
+	}
 }
-else
+
+if ($item->browserNav == 1)
 {
-	$linktype = $item->title;
+	$attributes['target'] = '_blank';
+}
+else if ($item->browserNav == 2)
+{
+	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,' . $params->get('window_open');
+
+	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-$flink = $item->flink;
-$flink = JFilterOutput::ampReplace(htmlspecialchars($flink));
-
-switch ($item->browserNav) :
-	default:
-	case 0:
-?><a <?php echo $class; ?>href="<?php echo $flink; ?>" <?php echo $title . $rel; ?>><?php echo $linktype; ?></a><?php
-		break;
-	case 1:
-		// _blank
-?><a <?php echo $class; ?>href="<?php echo $flink; ?>" target="_blank" <?php echo $title . $rel; ?>><?php echo $linktype; ?></a><?php
-		break;
-	case 2:
-		// Use JavaScript "window.open"
-		$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,' . $params->get('window_open');
-			?><a <?php echo $class; ?>href="<?php echo $flink; ?>" onclick="window.open(this.href,'targetWindow','<?php echo $options;?>');return false;" <?php echo $title; ?>><?php echo $linktype; ?></a><?php
-		break;
-endswitch;
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink)), $linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -42,7 +42,7 @@ if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
 }
-else if ($item->browserNav == 2)
+elseif ($item->browserNav == 2)
 {
 	$options = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,' . $params->get('window_open');
 


### PR DESCRIPTION
#### Summary of Changes

A month ago I've proposed some changes to mod_menus separator and heading layouts. In addition, the changes made in this PR aim to make the other three layouts a bit more or easier maintainable, correct CodeSniffer warnings and separate code from markup where possible. No functionality was changed, added or removed.
#### Testing Instructions

If you want to go crazy, you can review the code and check the markup before and after the patch, which might not be the most exciting approach.

Instead, after applying the patch, just create different types of menu items (mostly of type url and / or component for this PR) and change their parameters, like assigning images, changing the target window / method and so on.
