### PR TITLE
Fix form validation in com_users login view

### DIFF
--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -10,18 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
+JHtml::_('behavior.formvalidator');
+
 ?>
-<div class="login<?php echo $this->pageclass_sfx?>">
+<div class="login<?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
-	<div class="page-header">
-		<h1>
-			<?php echo $this->escape($this->params->get('page_heading')); ?>
-		</h1>
-	</div>
+		<div class="page-header">
+			<h1>
+				<?php echo $this->escape($this->params->get('page_heading')); ?>
+			</h1>
+		</div>
 	<?php endif; ?>
 
-	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
-	<div class="login-description">
+	<?php if (($this->params->get('logindescription_show') == 1 && trim($this->params->get('login_description', '')) !== '') || $this->params->get('login_image') !== '') : ?>
+		<div class="login-description">
 	<?php endif; ?>
 
 		<?php if ($this->params->get('logindescription_show') == 1) : ?>
@@ -33,7 +35,7 @@ JHtml::_('behavior.keepalive');
 		<?php endif; ?>
 
 	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
-	</div>
+		</div>
 	<?php endif; ?>
 
 	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login'); ?>" method="post" class="form-validate form-horizontal well">
@@ -72,9 +74,7 @@ JHtml::_('behavior.keepalive');
 
 			<div class="control-group">
 				<div class="controls">
-					<button type="submit" class="btn btn-primary">
-						<?php echo JText::_('JLOGIN'); ?>
-					</button>
+					<button type="submit" class="btn btn-primary validate"><?php echo JText::_('JLOGIN'); ?></button>
 				</div>
 			</div>
 


### PR DESCRIPTION
#### Summary of Changes

The client side form validation messages in com_users login view, are actually generated by the browser, not by Joomla!. This is because the submit button is missing the "validate" CSS class. Furthermore, the layout does not load the required JavaScript files.

Though most browsers interpret the required attribute and offer some form of client side validation / visualisation, custom registered validation handlers like "validate-username" assigned to the username field are not recognised.
#### Testing Instructions
1. Either go to: http(s)://domain.tld/index.php?option=com_users&view=login or create a menu item to the login form
2. Hit the "Log in" button. Depending on your browser, you should see a message that indicates an invalid required field (e.g. Username).
3. Install / Apply the patch and refresh the page. You should now see the standard validation behavior and messages.
