### PR TITLE
Handle spaces in filenames of Media Manager uploads

### DIFF
--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -94,6 +94,7 @@ class MediaControllerFile extends JControllerLegacy
 		foreach ($files as &$file)
 		{
 			$file['name']     = JFile::makeSafe($file['name']);
+			$file['name']     = str_replace(' ', '_', $file['name']);
 			$file['filepath'] = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $this->folder, $file['name'])));
 
 			if (($file['error'] == 1)

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -94,7 +94,7 @@ class MediaControllerFile extends JControllerLegacy
 		foreach ($files as &$file)
 		{
 			$file['name']     = JFile::makeSafe($file['name']);
-			$file['name']     = str_replace(' ', '_', $file['name']);
+			$file['name']     = str_replace(' ', '-', $file['name']);
 			$file['filepath'] = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $this->folder, $file['name'])));
 
 			if (($file['error'] == 1)


### PR DESCRIPTION
#### Summary of Changes

Currently when uploading a file through the Media Manager with a space in its name an error is thrown. All other unwanted chars are already removed by JFile::makeSafe() but this method explicitly allows spaces.

Errors tend to confuse inexperienced users, so this PR ensures that spaces are replaced with dashes instead of causing a failed upload.
#### Testing Instructions
1. In the Media Manager attempt to upload a file with one or more spaces in its name. Upload should fail.
2. Apply patch.
3. Repeat step 1. Upload should succeed and spaces in the filename be replaced with dashes.
