### PR TITLE
Correction: Saving template files with Unix End of Line (EOL) (solves #9592)

### DIFF
--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -512,7 +512,11 @@ class TemplatesModelTemplate extends JModelForm
 			return false;
 		}
 
+		// Make sure EOL is Unix
+		$data['source'] = str_replace(array("\r\n", "\n", "\r"), "\n", $data['source']);
+
 		$return = JFile::write($filePath, $data['source']);
+
 		if (!$return)
 		{
 			$app->enqueueMessage(JText::sprintf('COM_TEMPLATES_ERROR_FAILED_TO_SAVE_FILENAME', $fileName), 'error');

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -513,7 +513,7 @@ class TemplatesModelTemplate extends JModelForm
 		}
 
 		// Make sure EOL is Unix
-		$data['source'] = str_replace(array("\r\n", "\n", "\r"), "\n", $data['source']);
+		$data['source'] = str_replace(array("\r\n", "\r"), "\n", $data['source']);
 
 		$return = JFile::write($filePath, $data['source']);
 


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/issues/9592
When editing a template file, whether with Codemirror or editor None, the files are saved with Windows EOL (CRLF) instead of Unix (LF).

To test, go to administrator=>Templates=>Beez=>Edit template
/administrator/index.php?option=com_templates&view=template&id=503

Edit a php file, for example: component.php
Save and close.

Now Manually open the file on the desktop with a TextEditor (I use BBEdit on Macintosh).

The file has now Windows EOL (CRLF) instead of Unix ending.

Apply this patch and test again: we now have Unix line endings.
