### PR TITLE
Sessionfix

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -732,8 +732,8 @@ class JSession implements IteratorAggregate
 		$this->_state = 'restart';
 
 		// Regenerate session id
-		$this->_handler->regenerate(true, null);
 		$this->_start();
+		$this->_handler->regenerate(true, null);
 		$this->_state = 'active';
 
 		if (!$this->_validate())

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -604,8 +604,16 @@ class JSession implements IteratorAggregate
 		// Perform security checks
 		if (!$this->_validate())
 		{
-			// Destroy the session if it's not valid
-			$this->destroy();
+			// If the session isn't valid because it expired try to restart it
+			// else destroy it.
+			if ($this->_state === 'expired')
+			{
+				$this->restart();
+			}
+			else
+			{
+				$this->destroy();
+			}
 		}
 
 		if ($this->_dispatcher instanceof JEventDispatcher)

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -738,7 +738,10 @@ class JSession implements IteratorAggregate
 
 		if (!$this->_validate())
 		{
-			// Destroy the session if it's not valid
+			/**
+			 * Destroy the session if it's not valid - we can't restart the session here unlike in the start method
+			 * else we risk recursion.
+			 */
 			$this->destroy();
 		}
 


### PR DESCRIPTION
Pull Request for Issue #8851 .
#### Summary of Changes

This fixes two things:
1. The double login that occurs when your session expires
2. When restarting a session the id wasn't being regenerated properly as the session hadn't been started yet. This was causing PHP Warnings in PHP 7 (ref: #9555 //cc @andrepereiradasilva)
#### Testing Instructions
1. Let your session expire (it might help lowering the session time to 1-2 minutes in global configuration)
2. Try and login 
3. Login a second time
4. Apply patch
5. Let session expire again
6. Login first time around successfully.
