### PR TITLE
Message position in com_language

### DIFF
--- a/administrator/components/com_languages/views/language/view.html.php
+++ b/administrator/components/com_languages/views/language/view.html.php
@@ -90,7 +90,5 @@ class LanguagesViewLanguage extends JViewLegacy
 
 		JToolbarHelper::divider();
 		JToolbarHelper::help('JHELP_EXTENSIONS_LANGUAGE_MANAGER_EDIT');
-
-		$this->sidebar = JHtmlSidebar::render();
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #9617

No need to render non-existent sidebar.

To test Go to Extensions=>Languages=>Content Languages.
Create a new Content Language, don't fill any field and click Save.

See #9617 for images.

Patch and retest.
You should get:
![screen shot 2016-03-27 at 18 48 00](https://cloud.githubusercontent.com/assets/869724/14066543/80483304-f44c-11e5-97fb-3aeca5db069b.png)

@brianteeman @MATsxm 
