### PR TITLE
Clear Joomla Cache on Update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -38,6 +38,7 @@ class JoomlaInstallerScript
 		$this->updateAssets();
 		$this->clearStatsCache();
 		$this->convertTablesToUtf8mb4();
+		$this->cleanJoomlaCache();
 
 		// VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD
 		// LOGOUT ALL THE USERS
@@ -1853,6 +1854,8 @@ class JoomlaInstallerScript
 	 * @param   string  $query  The query to convert
 	 *
 	 * @return  string  The converted query
+	 *
+	 * @since   3.5
 	 */
 	private function convertUtf8mb4QueryToUtf8($query)
 	{
@@ -1867,5 +1870,19 @@ class JoomlaInstallerScript
 
 		// Replace utf8mb4 with utf8
 		return str_replace('utf8mb4', 'utf8', $query);
+	}
+
+	/**
+	 * This method clean the Joomla Cache using the method `clean` from the com_cache model
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5.1
+	 */
+	private function cleanJoomlaCache()
+	{
+		JLoader::import('cache', JPATH_ADMINISTRATOR . '/components/com_cache/models');
+		$model = JModelLegacy::getInstance('cache', 'CacheModel');
+		$model->clean();
 	}
 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1881,7 +1881,7 @@ class JoomlaInstallerScript
 	 */
 	private function cleanJoomlaCache()
 	{
-		JLoader::import('cache', JPATH_ADMINISTRATOR . '/components/com_cache/models');
+		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_cache/models');
 		$model = JModelLegacy::getInstance('cache', 'CacheModel');
 		$model->clean();
 	}


### PR DESCRIPTION
Pull Request for Issue #9626 
#### Summary of Changes

Clear the cache after Update. This does not cover OPCACHE as i don't know if i can place it at the script file too ;)
#### Testing Instructions
- install 3.5.0
- enable caching
- produce some entrys for the cache (navigate a bit in the frontend)
- notice that there are entrys to the cache
- update using this Joomla Core update URL: `http://jah-tz.de/downloads/extensions/dev/core_update.xml`
- notice that the Joomla cache is cleaned after the update.
