### PR TITLE
Frontend com_modules fixes (Ref #9629)

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -9,6 +9,11 @@
 
 defined('_JEXEC') or die;
 
+if (JFactory::getApplication()->isSite())
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
 JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -27,7 +27,9 @@ class ModulesViewModules extends JViewLegacy
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  void
+	 * @return  mixed  A string if successful, otherwise a Error object.
+	 *
+	 * @since   1.6
 	 */
 	public function display($tpl = null)
 	{
@@ -49,11 +51,16 @@ class ModulesViewModules extends JViewLegacy
 			return false;
 		}
 
-		$this->addToolbar();
+		// We don't need the toolbar in the modal window.
+		if ($this->getLayout() !== 'modal')
+		{
+			$this->addToolbar();
+		}
 
 		// Include the component HTML helpers.
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-		parent::display($tpl);
+
+		return parent::display($tpl);
 	}
 
 	/**

--- a/components/com_modules/controller.php
+++ b/components/com_modules/controller.php
@@ -16,15 +16,15 @@ defined('_JEXEC') or die;
  */
 class ModulesController extends JControllerLegacy
 {
-/**
- * Constructor.
- *
- * @param   array  $config  An optional associative array of configuration settings.
- * Recognized key values include 'name', 'default_task', 'model_path', and
- * 'view_path' (this list is not meant to be comprehensive).
- *
- * @since   3.5
- */
+	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *                          Recognized key values include 'name', 'default_task', 'model_path', and
+	 *                          'view_path' (this list is not meant to be comprehensive).
+	 *
+	 * @since   3.5
+	 */
 	public function __construct($config = array())
 	{
 		$this->input = JFactory::getApplication()->input;

--- a/components/com_modules/modules.php
+++ b/components/com_modules/modules.php
@@ -9,15 +9,12 @@
 
 defined('_JEXEC') or die;
 
-$controller   = JControllerLegacy::getInstance('Modules');
-$language     = JFactory::getLanguage();
-$extension    = 'com_modules';
-$base_dir     = JPATH_ADMINISTRATOR;
-$language_tag = $language->getTag();
+// Load the required admin language files
+$lang = JFactory::getLanguage();
+$lang->load('joomla', JPATH_ADMINISTRATOR);
+$lang->load('com_modules', JPATH_ADMINISTRATOR);
 
-$language->load('', $base_dir, $language_tag, true);
-$language->load($extension, $base_dir, $language_tag, true);
-
+// Trigger the controller
+$controller = JControllerLegacy::getInstance('Modules');
 $controller->execute(JFactory::getApplication()->input->get('task'));
-
 $controller->redirect();


### PR DESCRIPTION
Pull Request for Issue #9629.
#### Summary of Changes

The com_modules admin view that the toolbar button loads is missing several checks for this function, to include:
- An instruction to not load the toolbar for the modal view causing the `JToolbarHelper` not found error
- Missing CSRF token check (it's passed in the URL but the layout never made the check)
#### Testing Instructions

Apply the patch and the module toolbar button should correctly work on the frontend
