### PR TITLE
Correct errors with utf8mb4 conversion and rerun if updating a 3.5.0

### DIFF
--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
@@ -1,37 +1,31 @@
 --
 -- Step 2 of the UTF-8 Multibyte (utf8mb4) conversion for MySQL
 --
--- Add back indexes previosly dropped with step 1, utf8mb4-conversion-01.sql,
--- but with limited lenghts of columns, and then perform the conversions
--- for utf8mb4.
+-- Enlarge some database columns to avoid data losses, then convert all tables
+-- to utf8mb4 or utf8, then set default character sets and collations for all
+-- tables, then add back indexes previosly dropped with step 1,
+-- utf8mb4-conversion-01.sql, but addd them back with limited lenghts of
+-- columns.
 --
 -- Do not rename this file or any other of the utf8mb4-conversion-*.sql
 -- files unless you want to change PHP code, too.
 --
--- This file here will the be processed with reporting exceptions.
+-- IMPORTANT: When adding an index modification to this file for limiting the
+-- length by which one or more columns go into that index,
+--
+-- 1. remember to add the statement to drop the index to the file for step 1,
+--    utf8mb4-conversion-01.sql, and
+--
+-- 2. check if the index is created created or modified in some old schema
+--    update sql in an "ALTER TABLE" statement and limit the column length
+--    there, too ("CREATE TABLE" is ok, no need to modify those).
+--
+-- This file here will the be processed with reporting exceptions, in opposite
+-- to the file for step 1.
 --
 
 --
--- Step 2.1: Limit indexes to first 100 so their max allowed lengths would not get exceeded with utf8mb4
---
-
-ALTER TABLE `#__banners` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
-ALTER TABLE `#__banner_clients` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
-ALTER TABLE `#__categories` ADD KEY `idx_path` (`path`(100));
-ALTER TABLE `#__categories` ADD KEY `idx_alias` (`alias`(100));
-ALTER TABLE `#__content_types` ADD KEY `idx_alias` (`type_alias`(100));
-ALTER TABLE `#__finder_links` ADD KEY `idx_title` (`title`(100));
-ALTER TABLE `#__menu` ADD KEY `idx_alias` (`alias`(100));
-ALTER TABLE `#__menu` ADD UNIQUE `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(100),`language`);
-ALTER TABLE `#__redirect_links` ADD KEY `idx_old_url` (`old_url`(100));
-ALTER TABLE `#__tags` ADD KEY `idx_path` (`path`(100));
-ALTER TABLE `#__tags` ADD KEY `idx_alias` (`alias`(100));
-ALTER TABLE `#__ucm_content` ADD KEY `idx_alias` (`core_alias`(100));
-ALTER TABLE `#__ucm_content` ADD KEY `idx_title` (`core_title`(100));
-ALTER TABLE `#__ucm_content` ADD KEY `idx_content_type` (`core_type_alias`(100));
-
---
--- Step 2.2: Enlarge columns to avoid data loss on later conversion to utf8mb4
+-- Step 2.1: Enlarge columns to avoid data loss on later conversion to utf8mb4
 --
 
 ALTER TABLE `#__banners` MODIFY `alias` varchar(400) NOT NULL DEFAULT '';
@@ -52,7 +46,7 @@ ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(400) NOT NULL DEFAULT '
 ALTER TABLE `#__users` MODIFY `name` varchar(400) NOT NULL DEFAULT '';
 
 --
--- Step 2.3: Convert all tables to utf8mb4 chracter set with utf8mb4_unicode_ci collation
+-- Step 2.2: Convert all tables to utf8mb4 chracter set with utf8mb4_unicode_ci collation
 -- except #__finder_xxx tables, those will have utf8mb4_general_ci collation.
 -- Note: The database driver for mysql will change utf8mb4 to utf8 if utf8mb4 is not supported     
 --
@@ -127,7 +121,7 @@ ALTER TABLE `#__utf8_conversion` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb
 ALTER TABLE `#__viewlevels` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 --
--- Step 2.4: Set collation to utf8mb4_bin for formerly utf8_bin collated columns
+-- Step 2.3: Set collation to utf8mb4_bin for formerly utf8_bin collated columns
 -- and for the lang_code column of the languages table
 --
 
@@ -140,9 +134,12 @@ ALTER TABLE `#__menu` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE 
 ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__tags` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__users` MODIFY `name` varchar(400) NOT NULL DEFAULT '';
+ALTER TABLE `#__utf8_conversion` MODIFY `md5_file1` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
+ALTER TABLE `#__utf8_conversion` MODIFY `md5_file2` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 
 --
--- Step 2.5: Set default character set and collation for all tables
+-- Step 2.4: Set default character set and collation for all tables
 --
 
 ALTER TABLE `#__assets` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -213,3 +210,24 @@ ALTER TABLE `#__user_profiles` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_uni
 ALTER TABLE `#__user_usergroup_map` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__utf8_conversion` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 ALTER TABLE `#__viewlevels` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+--
+-- Step 2.5: Limit indexes to first 100 so their max allowed lengths would not get exceeded with utf8mb4
+--
+
+ALTER TABLE `#__banners` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
+ALTER TABLE `#__banner_clients` ADD KEY `idx_metakey_prefix` (`metakey_prefix`(100));
+ALTER TABLE `#__categories` ADD KEY `idx_path` (`path`(100));
+ALTER TABLE `#__categories` ADD KEY `idx_alias` (`alias`(100));
+ALTER TABLE `#__content_types` ADD KEY `idx_alias` (`type_alias`(100));
+ALTER TABLE `#__finder_links` ADD KEY `idx_title` (`title`(100));
+ALTER TABLE `#__menu` ADD KEY `idx_alias` (`alias`(100));
+ALTER TABLE `#__menu` ADD UNIQUE `idx_client_id_parent_id_alias_language` (`client_id`,`parent_id`,`alias`(100),`language`);
+ALTER TABLE `#__menu` ADD KEY `idx_path` (`path`(100));
+ALTER TABLE `#__redirect_links` ADD KEY `idx_old_url` (`old_url`(100));
+ALTER TABLE `#__tags` ADD KEY `idx_path` (`path`(100));
+ALTER TABLE `#__tags` ADD KEY `idx_alias` (`alias`(100));
+ALTER TABLE `#__ucm_content` ADD KEY `idx_alias` (`core_alias`(100));
+ALTER TABLE `#__ucm_content` ADD KEY `idx_title` (`core_title`(100));
+ALTER TABLE `#__ucm_content` ADD KEY `idx_content_type` (`core_type_alias`(100));
+ALTER TABLE `#__users` ADD KEY `idx_name` (`name`(100));

--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
@@ -134,7 +134,6 @@ ALTER TABLE `#__menu` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE 
 ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__tags` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__users` MODIFY `name` varchar(400) NOT NULL DEFAULT '';
 
 --
 -- Step 2.4: Set default character set and collation for all tables

--- a/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
+++ b/administrator/components/com_admin/sql/others/mysql/utf8mb4-conversion-02.sql
@@ -135,8 +135,6 @@ ALTER TABLE `#__newsfeeds` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COL
 ALTER TABLE `#__tags` MODIFY `alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__ucm_content` MODIFY `core_alias` varchar(400) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 ALTER TABLE `#__users` MODIFY `name` varchar(400) NOT NULL DEFAULT '';
-ALTER TABLE `#__utf8_conversion` MODIFY `md5_file1` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
-ALTER TABLE `#__utf8_conversion` MODIFY `md5_file2` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL DEFAULT '';
 
 --
 -- Step 2.4: Set default character set and collation for all tables

--- a/administrator/components/com_admin/sql/updates/mysql/2.5.0-2011-12-24.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/2.5.0-2011-12-24.sql
@@ -1,3 +1,8 @@
 ALTER TABLE `#__menu` DROP INDEX `idx_client_id_parent_id_alias`;
 
-ALTER TABLE `#__menu` ADD UNIQUE `idx_client_id_parent_id_alias_language` ( `client_id` , `parent_id` , `alias` , `language` );
+--
+-- The following statment had to be modified for utf8mb4, changing
+-- `alias` to `alias`(100)
+--
+
+ALTER TABLE `#__menu` ADD UNIQUE `idx_client_id_parent_id_alias_language` ( `client_id` , `parent_id` , `alias`(100) , `language` );

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -1,0 +1,6 @@
+--
+-- Reset UTF-8 Multibyte (utf8mb4) or UTF-8 conversion status
+-- to force a new conversion when updating from version 3.5.0
+--
+
+UPDATE `#__utf8_conversion` SET converted = 0 WHERE (SELECT COUNT(*) FROM `#__extensions` WHERE `extension_id`=700 AND `manifest_cache` LIKE '%"version":"3.5.0"%') = 1;

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -42,6 +42,10 @@ class InstallerModelDatabase extends InstallerModel
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
+
+		// Prepare the utf8mb4 conversion check table
+		$this->prepareUtf8mb4StatusTable();
+
 		parent::populateState('name', 'asc');
 	}
 
@@ -67,9 +71,16 @@ class InstallerModelDatabase extends InstallerModel
 		$installer->deleteUnexistingFiles();
 		$this->fixDefaultTextFilters();
 
-		// Finally make sure the database is converted to utf8mb4 or, if not suported
-		// by the server, compatible to it
-		$this->convertTablesToUtf8mb4();
+		/*
+		 * Finally, if the schema updates succeeded, make sure the database is
+		 * converted to utf8mb4 or, if not suported by the server, compatible to it.
+		 */
+		$statusArray = $changeSet->getStatus();
+
+		if (count($statusArray['error']) == 0)
+		{
+			$this->convertTablesToUtf8mb4();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #9526 .

Could also help with the cause for Issue #9511  .

Replaces PR #9590 , and as this it also replaces PRs #9510 and #9549 .
#### Summary of Changes

This PR handles 5 things:
1. Change order of processing in the 2nd conversion script so adding back the indexes takes place after all conversions and default character set and collation changes.
2. Run the conversion only if the database schema does not have unfixed problems.
3. Adapt one old schema update sql to fix the SQL error "1071 Specified key was too long; max key length is 767 bytes SQL=ALTER TABLE #__menu ADD UNIQUE idx_client_id_parent_id_alias_language ( client_id , parent_id , alias , language );".
4. Force a re-run of the conversion with a schema update SQL script when updating from a 3.5.0 to make sure the changes from commit [https://github.com/joomla/joomla-cms/commit/3540293ff1571eb28eb0bd8f53c9b4b4883ac17a](https://github.com/joomla/joomla-cms/commit/3540293ff1571eb28eb0bd8f53c9b4b4883ac17a) are applied (which would not be the case on a 3.5.0 obtained from updating a pre-3.5.0).
5. Add the forgotten "ALTER TABLE `#__users` ADD KEY `idx_name` (`name`(100));" to the conversion script, this has been forgotten with commit [https://github.com/joomla/joomla-cms/commit/3540293ff1571eb28eb0bd8f53c9b4b4883ac17a](https://github.com/joomla/joomla-cms/commit/3540293ff1571eb28eb0bd8f53c9b4b4883ac17a).

Points 1 and 2 will help to avoid to come into the situation which causes the SQL error mentioned with point 3.

Point 4 will work only if using Joomla! Update component to do the update from 3.5.0 to the version where this PR will be included in. After having updated from 3.5.0 with the "copy files and run db fixer" method, the conversion rerun has to be forced by SQL update as in the new SQL script 3.5.1-2016-03-29.sql added with this PR.

Point 5: @wilsonge please check and confirm.
#### Testing Instructions
##### Pre-requisites

The test have to be performed on a database supporting utf8mb4 and being already converted, i.e. at least of version 3.5.0 and having been installed or updated without error.
##### Test 1: Update from 3.5.0 to latest staging + this PR

Step 1: Update from a clean 3.5.0 (clean means unpatched, without this PR applied) to latest staging + this PR, using following custom URL for the Joomla! Update component: [http://test5.richard-fath.de/list_test4.xml](http://test5.richard-fath.de/list_test4.xml)

Result: Update finishs with success.

Step 2: Go to "Extensions -> Manage -> Database".

Result: Success, no open database problems.

Step 3: Check with phpMyadmin if index `idx_name` of table `#__users` contains the `name` column with a length of 100.

Result: Index `idx_name` of table `#__users` is OK.
##### Test 2: DB schema fix

Either use latest staging + this PR applied (e.g. with patchtester), or use the updated Joomla! from Test 1.

Step 1: Simulate a corrupt schema, e.g. by not applied old schema update statement by executing following SQL statement in phpMyAdmin:

> ALTER TABLE `#__menu` DROP KEY `idx_client_id_parent_id_alias_language`;

Step 2: Go to "Extensions -> Manage -> Database"  or if still at that page, reload the page.

Result:

> Warning: Database is not up to date!
> 1 Database Problems Found.
> - Table `#__menu` does not have index 'idx_client_id_parent_id_alias_language'. (From file 2.5.0-2011-12-24.sql.)

Step 3: Click the "Fix" button.

Result: Success, no open database problems.

Step 4: Check with phpMyadmin if index `idx_name` of table `#__users` contains the `name` column with a length of 100.

Result: Index `idx_name` of table `#__users` is OK.
##### Test 3 (optional)

If you also want to replicate the SQL error fixed by this PR (beside others) on an unpatched 3.5.0 (or 3.5.1 RC), repeat Test 2 with an unpatched 3.5.0.

You will get SQL error "1071 Specified key was too long; max key length is 767 bytes" after having clicked the "Fix" button in Step 3.

The only way out will be to edit the 2.5.0-2011-12-24.sql and remove (or comment out) the SQL statement reported with the error, or modify as done with this PR, and then use again the "Fix" button.
