### PR TITLE
Correction after PR 9652

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -1,7 +1,7 @@
 --
 -- Reset UTF-8 Multibyte (utf8mb4) or UTF-8 conversion status
--- to force a new conversion when updating from a version lower
--- than 3.5.1.
+-- to force a new conversion when updating from version 3.5.0
 --
 
-UPDATE `#__utf8_conversion` SET `converted` = 0;
+UPDATE `#__utf8_conversion` SET `converted` = 0
+ WHERE (SELECT COUNT(*) FROM `#__schemas` WHERE `extension_id`=700 AND `version_id` LIKE '3.5.0%') = 1;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -3,4 +3,4 @@
 -- to force a new conversion when updating from version 3.5.0
 --
 
-UPDATE `#__utf8_conversion` SET converted = 0 WHERE (SELECT COUNT(*) FROM `#__extensions` WHERE `extension_id`=700 AND `manifest_cache` LIKE '%"version":"3.5.0"%') = 1;
+UPDATE `#__utf8_conversion` SET `converted` = 0 WHERE (SELECT COUNT(*) FROM `#__extensions` WHERE `extension_id`=700 AND `manifest_cache` LIKE '%"version":"3.5.1%') = 1;

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -1,5 +1,6 @@
 --
 -- Reset UTF-8 Multibyte (utf8mb4) or UTF-8 conversion status
+-- to force a new conversion when updating from a version lower
 -- than 3.5.1.
 --
 

--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -1,6 +1,6 @@
 --
 -- Reset UTF-8 Multibyte (utf8mb4) or UTF-8 conversion status
--- to force a new conversion when updating from version 3.5.0
+-- than 3.5.1.
 --
 
-UPDATE `#__utf8_conversion` SET `converted` = 0 WHERE (SELECT COUNT(*) FROM `#__extensions` WHERE `extension_id`=700 AND `manifest_cache` LIKE '%"version":"3.5.1%') = 1;
+UPDATE `#__utf8_conversion` SET `converted` = 0;

--- a/libraries/cms/schema/changeitem/mysql.php
+++ b/libraries/cms/schema/changeitem/mysql.php
@@ -59,6 +59,19 @@ class JSchemaChangeitemMysql extends JSchemaChangeitem
 		// We can only make check queries for alter table and create table queries
 		$command = strtoupper($wordArray[0] . ' ' . $wordArray[1]);
 
+		// Check for special update statement to reset utf8mb4 conversion status
+		if (($command == 'UPDATE `#__UTF8_CONVERSION`'
+			|| $command == 'UPDATE #__UTF8_CONVERSION')
+			&& strtoupper($wordArray[2]) == 'SET'
+			&& strtolower(substr(str_replace('`', '', $wordArray[3]), 0, 9)) == 'converted')
+		{
+			// Statement is special statement to reset conversion status
+			$this->queryType = 'UTF8CNV';
+
+			// Done with method
+			return;
+		}
+
 		if ($command === 'ALTER TABLE')
 		{
 			$alterCommand = strtoupper($wordArray[3] . ' ' . $wordArray[4]);

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -71,7 +71,25 @@ class JSchemaChangeset
 
 		foreach ($updateQueries as $obj)
 		{
-			$this->changeItems[] = JSchemaChangeitem::getInstance($db, $obj->file, $obj->updateQuery);
+			$changeItem = JSchemaChangeitem::getInstance($db, $obj->file, $obj->updateQuery);
+
+			if ($changeItem->queryType === 'UTF8CNV')
+			{
+				// Execute the special update query for utf8mb4 conversion status reset
+				try
+				{
+					$this->db->setQuery($changeItem->updateQuery)->execute();
+				}
+				catch (Exception $e)
+				{
+					JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+				}
+			}
+			else
+			{
+				// Normal change item
+				$this->changeItems[] = $changeItem;
+			}
 		}
 
 		// If on mysql, add a query at the end to check for utf8mb4 conversion status


### PR DESCRIPTION
#### Summary of Changes

This Pull Request does following corrections on the PR #9652 merged before:
1. Change the subquery to limit the version number in the SQL statement for reset of conversion status so it uses schema version and not extension version. The extension version is already updated to the new one before the schema update SQL scripts run when updating, and so the only way to check if we are updating from 3.5.0\* to anything later is to check schema version, because in SQL there is no "version_compare" or so function.
2. Add forgotten name quotes for the "converted" column in the same SQL statement

In addition it extends the schema manager's change set so the reset query (limited to updating a 3.5.0\* schema) is executed before the check query for conversion status is executed. This makes the re-execution of the conversion when updating a 3.5.0\* also work for the update method "copy files and run db fix".
#### Testing Instructions
##### Pre-requisites

Use a 3.5.0 which has been updated before from a pre-3.5.0 with a mysql database supporting utf8mb4 so the utf8mb4 conversion has been done.

**If you do not have such an updated 3.5.0 you can use a clean new 3.5.0 and simulate** the effect of missing stuff in the utf8mb4 conversion of the 3.5.0 **by executing following SQL statement in phpMyAdmin**:

> ALTER TABLE `#__users` DROP KEY `idx_name`;
> ALTER TABLE `#__users` ADD KEY `idx_name` (`name`(191));

(Replace `#__` by your db prefix.)

So or so the starting situation is the index `idx_name` of the users table includes the name column with the first 191 characters, check this in phpMyAdmin.
##### Test preparation
1. Make a database dump of your system prepared as described with the pre-requisites so you can use it as starting point for each of the following tests.
2. Make a copy of the Joomla! file system so you can use it in Step 3 of Test 1 to fall back to 3.5.0.
##### Test 1: Update from 3.5.0 to 3.5.1-rc2 with Joomla! Update component

Step 1: Update to 3.5.1 RC 2 (unpatched). If the testing channel is not OK yet you can use following custom URL: [http://test5.richard-fath.de/list_test4.xml](http://test5.richard-fath.de/list_test4.xml).

The package behind this custom URL is a normal 3.5.1 RC 2.

Step 2: Verify in phpMyAdmin that the index `idx_name` of table `#__users` has not changed, i.e. still includes the name column with 191 chars.

Step 3: Restore the 3.5.0 database by deleting all tables and then importing the dump made with test preparation, and fall back to the Joomla! 3.5.0 filesystem saved with test preparation.

Step 4: Update to 3.5.1 RC 2 + patch with this PR. Use following custom URL for the udpate: [http://test5.richard-fath.de/list_test5.xml](http://test5.richard-fath.de/list_test5.xml).

The package behind this custom URL is a 3.5.1 RC 2 + this PR here.

Step 5: Check the index `idx_name` of table `#__users` in phpMyAdmin.

Result: Now the index `idx_name` of table `#__users` includes the name column with 100 chars.

Conclusion: With this PR, the utf8mb4 conversion is executed when updating from 3.5.0 via Joomla! Update component, without this PR it is not.
##### Test 2: Update from 3.5.0 to 3.5.1-rc2 with "copy files and run db fix" method

Step 1: Start with a newly installed 3.5.1 RC 2 and apply the patch of this PR e.g. with patchtester, or use the result of Test 1.

Step 2: Restore the 3.5.0 database by deleting all tables and then importing the dump made with test preparation.

Step 3: Go to "Extensions -> Manage -> Database" in backend.

Result:

> Warning: Database is not up to date!
> 4 Database Problems Found.
> - Database schema version (3.5.0-2016-03-01) does not match CMS version (3.5.1-2016-03-29).
> - Database update version (3.5.0) does not match CMS version (3.5.1-rc2).
> - Table 'gaga1_user_keys' does not have column 'user_id' with type varchar(150). (From file 3.5.1-2016-03-25.sql.)
> - The Joomla! Core database tables have not been converted yet to UTF-8 Multibyte (utf8mb4).

(replace `gaga1` by your db prefix)

Step 4: Click the "Fix" button.

Result:

> Database table structure is up to date.
> Other Information
> - Database schema version (in #__schemas): 3.5.1-2016-03-29.
> - Update version (in #__extensions): 3.5.1-rc2.
> - Database driver: mysqli.
> - 94 database changes were checked successfully.
> - 145 database changes did not alter table structure and were skipped.

Step 5: Reload the page to make sure the reset will not be executed again when the schema manager runs again.

Result: Same as before, no changes.

Step 6: Check the index `idx_name` of table `#__users` in phpMyAdmin.

Result: Now the index `idx_name` of table `#__users` includes the name column with 100 chars.

Conclusion: Reset of conversion status to force rerun of conversion works also with the "copy files and run db fix" method when this PR is applied.
##### Optional free tests
1. You can repeat Test 2 with an unpatched 3.5.1. RC 2 to verify that without this PR it will not show the conversion as to be done in the list of open database problems, and it will not run the conversion when using the "Fix" button.
2. You can test updating a pre-3.5.0 to the patched 3.5.1-rc2 to make sure this PR does not break anything.
3. You can update the patched 3.5.1-rc2 to e.g. a faked 3.5.2 by hacking an own update container behind an own custom URL (or using the new com_joomlaupdate being in preparation, with the new feature Upload & Install).
