### PR TITLE
JFormFieldUser broken since 3.5.0

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -75,7 +75,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<tr class="row<?php echo $i % 2; ?>">
 						<td>
 							<a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
-								data-user-field="<?php echo $this->escape($field);?>">
+								data-user-field="<?php echo $this->escape($field);?>" onclick="if (window.parent) window.parent.jSelectUser(this);">
 								<?php echo $item->name; ?>
 							</a>
 						</td>

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -47,7 +47,7 @@ extract($displayData);
  */
 
 $link = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required='
-	. ($required ? 1 : 0) . '&amp;field={field-user-id}'
+	. ($required ? 1 : 0) . '&amp;field=' . htmlspecialchars($id, ENT_COMPAT, 'UTF-8')
 	. (isset($groups) ? ('&amp;groups=' . base64_encode(json_encode($groups))) : '')
 	. (isset($excluded) ? ('&amp;excluded=' . base64_encode(json_encode($excluded))) : '');
 


### PR DESCRIPTION
Pull Request for Issue #9593 .
#### Summary of Changes

mootools modal needs the field id
#### Testing Instructions

Switch to the Hathor template. I know it's out of date and never updated, but it serves this point for now. Go to Content > Articles > Add New Article. Click on the User icon next to the Created By field. The Modal window shows up (it should be based on MooTools). Click on any user in there and nothing happens.
Apply patch redo. Also check that isis still works as expected

Kudos to @OctavianC for finding and proposing the solution
