### PR TITLE
Update extensionupdatecheck.js

### DIFF
--- a/media/plg_quickicon_extensionupdate/js/extensionupdatecheck.js
+++ b/media/plg_quickicon_extensionupdate/js/extensionupdatecheck.js
@@ -21,24 +21,13 @@ jQuery(document).ready(function() {
 					link.html(plg_quickicon_extensionupdate_text.UPTODATE);
 				} else {
 					var updateString = plg_quickicon_extensionupdate_text.UPDATEFOUND_MESSAGE.replace("%s", updateInfoList.length);
-					if (jQuery('.alert-joomlaupdate').length == 0) {
-						jQuery('#system-message-container').prepend(
-							'<div class="alert alert-error alert-joomlaupdate">'
-							+ updateString
-							+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_extensionupdate_url + '\'">'
-							+ plg_quickicon_extensionupdate_text.UPDATEFOUND_BUTTON + '</button>'
-							+ '</div>'
-						);
-					}
-					else {
-						jQuery('#system-message-container').prepend(
-							'<div class="alert alert-error alert-joomlaupdate span6">'
-							+ updateString
-							+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_extensionupdate_url + '\'">'
-							+ plg_quickicon_extensionupdate_text.UPDATEFOUND_BUTTON + '</button>'
-							+ '</div>'
-						);
-					}
+					jQuery('#system-message-container').prepend(
+						'<div class="alert alert-error alert-joomlaupdate">'
+						+ updateString
+						+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_extensionupdate_url + '\'">'
+						+ plg_quickicon_extensionupdate_text.UPDATEFOUND_BUTTON + '</button>'
+						+ '</div>'
+					);
 					var updateString = plg_quickicon_extensionupdate_text.UPDATEFOUND.replace("%s", updateInfoList.length);
 					link.html(updateString);
 				}

--- a/media/plg_quickicon_joomlaupdate/js/jupdatecheck.js
+++ b/media/plg_quickicon_joomlaupdate/js/jupdatecheck.js
@@ -27,24 +27,13 @@ jQuery(document).ready(function() {
 						var updateString = plg_quickicon_joomlaupdate_text.UPDATEFOUND.replace("%s", updateInfo.version + "");
 						jQuery('#plg_quickicon_joomlaupdate').find('.j-links-link').html(updateString);
 						var updateString = plg_quickicon_joomlaupdate_text.UPDATEFOUND_MESSAGE.replace("%s", updateInfo.version + "");
-						if (jQuery('.alert-joomlaupdate').length == 0) {
-							jQuery('#system-message-container').prepend(
-								'<div class="alert alert-error alert-joomlaupdate">'
-								+ updateString
-								+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_joomlaupdate_url + '\'">'
-								+ plg_quickicon_joomlaupdate_text.UPDATEFOUND_BUTTON + '</button>'
-								+ '</div>'
-							);
-						}
-						else {
-							jQuery('#system-message-container').prepend(
-								'<div class="alert alert-error alert-joomlaupdate span6">'
-								+ updateString
-								+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_joomlaupdate_url + '\'">'
-								+ plg_quickicon_joomlaupdate_text.UPDATEFOUND_BUTTON + '</button>'
-								+ '</div>'
-							);
-						}
+						jQuery('#system-message-container').prepend(
+							'<div class="alert alert-error alert-joomlaupdate">'
+							+ updateString
+							+ ' <button class="btn btn-primary" onclick="document.location=\'' + plg_quickicon_joomlaupdate_url + '\'">'
+							+ plg_quickicon_joomlaupdate_text.UPDATEFOUND_BUTTON + '</button>'
+							+ '</div>'
+						);
 					} else {
 						link.html(plg_quickicon_joomlaupdate_text.UPTODATE);
 					}


### PR DESCRIPTION
Pull Request for Issue #9661 .
#### Summary of Changes

Simplify HTML/CSS created inside JavaScript file. span6 not required for 2nd alert.
#### Testing Instructions

Steps to reproduce the issue

download and install Joomla < 3.5.0
install not-up-to-date extension, ensure extension has auto-updater active
login to Administrator backend
Expected result

After a couple of seconds you would be notified about a Joomla upgrade and Extension upgrades being available. These notifications would be best displayed below each other:

This is common UX
If the alert boxes are of different height due to screen resolution, they appear misaligned
There should also be visual space between the alert boxes to distinguish them. The space should be of a common "width" as used elsewhere in the control panel

Actual result

The boxes are beside each other in resolutions wider than 1200px
The boxes have no space between them
