### PR TITLE
Add showon to fieldsets in component config

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -47,8 +47,23 @@ JFactory::getDocument()->addScriptDeclaration(
 		<div class="span10">
 			<ul class="nav nav-tabs" id="configTabs">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
+					<?php $rel = ''; ?>
+					<?php if (!empty($fieldSet->showon)) : ?>
+						<?php JHtml::_('jquery.framework'); ?>
+						<?php JHtml::_('script', 'jui/cms.js', false, true); ?>
+						<?php $showonarr = array(); ?>
+						<?php foreach (preg_split('%\[AND\]|\[OR\]%', $fieldSet->showon) as $showonfield) : ?>
+							<?php $showon   = explode(':', $showonfield, 2); ?>
+							<?php $showonarr[] = array(
+								'field'  => $this->form->getFormControl() . '[' . $showon[0] . ']',
+								'values' => explode(',', $showon[1]),
+								'op'     => (preg_match('%\[(AND|OR)\]' . $showonfield . '%', $fieldSet->showon, $matches)) ? $matches[1] : ''
+							); ?>
+						<?php endforeach; ?>
+						<?php $rel = ' data-showon=\'' . json_encode($showonarr) . '\''; ?>
+					<?php endif; ?>
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
-					<li><a href="#<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($label); ?></a></li>
+					<li<?php echo $rel; ?>><a href="#<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($label); ?></a></li>
 				<?php endforeach; ?>
 			</ul>
 			<div class="tab-content">


### PR DESCRIPTION
#### Summary of Changes

This expands the existing showon feature to fieldsets (tabs) in component options. This may for example be used by components if they want to show advanced options when a specific parameter is toggled.
#### Testing Instructions

Add a showon attribute (see https://docs.joomla.org/Form_field#Showon) to a fieldset in a components config.xml. Example in https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/config.xml#L298
Change

```
    <fieldset name="editinglayout" label="COM_CONTENT_EDITING_LAYOUT"
                description="COM_CONTENT_CONFIG_EDITOR_LAYOUT">
```

to

```
    <fieldset name="editinglayout" label="COM_CONTENT_EDITING_LAYOUT"
                description="COM_CONTENT_CONFIG_EDITOR_LAYOUT"
                showon="show_title:1">
```

Then test if the fieldsets shows/hides when the chosen parameter is toggled.
In the example given the "Show Title" parameter in the com_content options would toggle the "Editing Layout" tab.
### Note

This only affects component options. If someone knows how to do it for module, template and plugin options feel free to create a PR either against this one or as an own one. I tried with the module but couldn't figure it out yet.
