### PR TITLE
Disable SMTP auto TLS during mailer creation

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -513,6 +513,10 @@ class JMail extends PHPMailer
 		{
 			$this->SMTPSecure = $secure;
 		}
+		elseif ($secure == 'none')
+		{
+			$this->SMTPAutoTLS = false;
+		}
 
 		if (($this->SMTPAuth !== null && $this->Host !== null && $this->Username !== null && $this->Password !== null)
 			|| ($this->SMTPAuth === null && $this->Host !== null))


### PR DESCRIPTION
Pull Request for Issue #9373 .
#### Summary of Changes

Force to disable SMTP auto TLS if SMTP security is set to "none" in Joomla Global configuration.
It is farther improvement of PR https://github.com/joomla/joomla-cms/pull/9528
#### Testing Instructions
1. Setup mailer to SMTP
2. Set SMTP port: 587
3. Set SMTP security: none
4. Set some SMTP username and password
5. Set SMTP host, in my case it was 127.0.0.1
6. Try to send email, you will get error message "SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting"

In my case I am connecting with SMTP over localhost on port 587, but I do no need to use any security like TLS or SSL, but PHPMailer forces to verify TLS.
