### PR TITLE
[imp] Use advancedSelect for mod_languages and finder

### DIFF
--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -383,7 +383,7 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $branches[$bk]->nodes, 't[]', 'class="inputbox"', 'id', 'title', $active,
+				'select.genericlist', $branches[$bk]->nodes, 't[]', 'class="inputbox advancedSelect"', 'id', 'title', $active,
 				'tax-' . JFilterOutput::stringUrlSafe($bv->title)
 			);
 			$html .= '</div>';
@@ -438,7 +438,7 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $operators, 'w1', 'class="inputbox filter-date-operator"', 'value', 'text', $idxQuery->when1, 'finder-filter-w1'
+				'select.genericlist', $operators, 'w1', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when1, 'finder-filter-w1'
 			);
 			$html .= JHtml::calendar($idxQuery->date1, 'd1', 'filter_date1', '%Y-%m-%d', $attribs);
 			$html .= '</li>';
@@ -450,7 +450,7 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $operators, 'w2', 'class="inputbox filter-date-operator"', 'value', 'text', $idxQuery->when2, 'finder-filter-w2'
+				'select.genericlist', $operators, 'w2', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when2, 'finder-filter-w2'
 			);
 			$html .= JHtml::calendar($idxQuery->date2, 'd2', 'filter_date2', '%Y-%m-%d', $attribs);
 			$html .= '</li>';

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -383,7 +383,8 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $branches[$bk]->nodes, 't[]', 'class="inputbox advancedSelect"', 'id', 'title', $active,
+				'select.genericlist',
+				$branches[$bk]->nodes, 't[]', 'class="inputbox advancedSelect"', 'id', 'title', $active,
 				'tax-' . JFilterOutput::stringUrlSafe($bv->title)
 			);
 			$html .= '</div>';
@@ -438,7 +439,8 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $operators, 'w1', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when1, 'finder-filter-w1'
+				'select.genericlist',
+				$operators, 'w1', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when1, 'finder-filter-w1'
 			);
 			$html .= JHtml::calendar($idxQuery->date1, 'd1', 'filter_date1', '%Y-%m-%d', $attribs);
 			$html .= '</li>';
@@ -450,7 +452,8 @@ abstract class JHtmlFilter
 			$html .= '</label>';
 			$html .= '<br />';
 			$html .= JHtml::_(
-				'select.genericlist', $operators, 'w2', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when2, 'finder-filter-w2'
+				'select.genericlist',
+				$operators, 'w2', 'class="inputbox filter-date-operator advancedSelect"', 'value', 'text', $idxQuery->when2, 'finder-filter-w2'
 			);
 			$html .= JHtml::calendar($idxQuery->date2, 'd2', 'filter_date2', '%Y-%m-%d', $attribs);
 			$html .= '</li>';

--- a/components/com_finder/views/search/tmpl/default.php
+++ b/components/com_finder/views/search/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.core');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen');
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::stylesheet('com_finder/finder.css', false, true, false);
 ?>

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_SITE . '/components/com_finder/helpers/html');
 
 JHtml::_('jquery.framework');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen');
 JHtml::_('bootstrap.tooltip');
 
 // Load the smart search component language file.

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('stylesheet', 'mod_languages/template.css', array(), true);
 if ($params->get('dropdown', 1))
 {
-	JHtml::_('formbehavior.chosen', 'select');
+	JHtml::_('formbehavior.chosen');
 }
 ?>
 <div class="mod-languages<?php echo $moduleclass_sfx; ?>">
@@ -22,7 +22,7 @@ if ($params->get('dropdown', 1))
 
 <?php if ($params->get('dropdown', 1)) : ?>
 	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current()); ?>">
-	<select class="inputbox" onchange="document.location.replace(this.value);" >
+	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
 		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo $language->link; ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
 		<?php echo $language->title_native; ?></option>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9653

This PR implements the default selector advancedSelect for mod_languages module and smartsearch (module and component view).

This will avoid displaying as chosen every Select on a page not using chosen.
#### Testing Instructions

Install a simple multilang site.
Display a Language switcher for each language: one using dropdown, the other using flags.
Create a Smartsearch module. Set the parameters to Show "Advanced Search".
First unpublish it.

Patch.  
Modify ROOT/components/com_content/views/form/tmpl/edit.php, i.e. comment
`//JHtml::_('formbehavior.chosen', 'select');`

Login frontend as Super Admin and edit an article in the language for which the switcher is set to dropdown.
The Select boxes in the Publishing tab are not using Chosen. The dropdown for mod_languages is.

![screen shot 2016-03-30 at 16 32 46](https://cloud.githubusercontent.com/assets/869724/14145717/1d013c28-f695-11e5-9b81-a200f0008123.png)

Publish the SmartSearch Module, switch the language to the one using flags in the Switcher.

Edit again an article.
The smart Advanced Search dropdowns use chosen while the article Select Boxes don't.
