### PR TITLE
Clickable Intro Image of Featured Articles

### DIFF
--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -57,12 +57,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 <?php endif; ?>
 
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
-	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/> </div>
+	<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
 <?php endif; ?>
 
 <?php if (!$params->get('show_intro')) : ?>


### PR DESCRIPTION
This PR makes **Intro Images** that are displayed in **Featured Articles** also **clickable to display the full article** just like the Category Blog view.
#### Testing Instructions

Use Joomla with default Testing content, 
and add an Intro Images to Articles, e.g. "First Blog Post":
Content > Articles > search "Second Blog Post" & edit it:
1. add an image (Under tab "Images and Links" > Intro Image), e.g. images/sampledata/parks/landscape/120px_rainforest_bluemountainsnsw.jpg
2. set "Featured" to "Yes"
and save the article. 

The **front-end view "Article Category Blog"** displays the selected image,
which is clickable to display the Full Article View.
![catblog](https://cloud.githubusercontent.com/assets/1217850/14146813/4fa26dce-f699-11e5-97dc-c0c3c9620c61.png)

After clicking on the image the Full Article will be displayed:
![full-article](https://cloud.githubusercontent.com/assets/1217850/14146815/4fbf5b96-f699-11e5-8ccc-48be74e89c5e.png)

The **front-end view "Featured Articles"** displays the selected image,
but it is **not clickable** to display the Full Article View.
![featured-articles](https://cloud.githubusercontent.com/assets/1217850/14146814/4fa63710-f699-11e5-9268-44eaeac1a891.png)
## After the PR

The **front-end view "Featured Articles"** displays the selected image,
and the **image should be clickable** to display the Full Article View.
