### PR TITLE
It should be 3.5.1-rc2 not 3.5.1-rc22

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>3.5.1-rc22</version>
+	<version>3.5.1-rc2</version>
 	<creationDate>March 2016</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 


### PR DESCRIPTION
#### Summary of Changes

Fixes Version number to match version.php @wilsonge I guess it was just a typo on releasing RC2? As it break the database checker on 3.5.1-rc2(2) ;)
