### PR TITLE
Handle PHP warnings in send test email JSON response

### DIFF
--- a/media/system/js/sendtestmail-uncompressed.js
+++ b/media/system/js/sendtestmail-uncompressed.js
@@ -26,7 +26,30 @@ jQuery(document).ready(function ($)
 
 		$.ajax({
 				url: sendtestmail_url,
-				data: email_data
+				data: email_data,
+				dataFilter: function(data, type)
+				{
+					if ((typeof type === 'undefined' || type.indexOf('json') !== -1) 
+						&& typeof data === 'string' && (data.indexOf('{') !== 0 || data[data.length-1] !== '}'))
+					{
+						var json = data.match(/{"success":(true|false),"message":.+,"messages":.+,"data":.+}/i);
+						if (json)
+						{
+							if (typeof JSON.stringify === 'function')
+							{
+								var response = $.parseJSON(json[0]);
+								if (typeof response.messages !== 'object') 
+									response.messages = {};
+								if (typeof response.messages.error === 'undefined') 
+									response.messages.error = [];
+								response.messages.error.push(data.replace(json[0], ' '));
+								data = JSON.stringify(response);
+							}
+							else data = json[0];
+						}
+					}
+					return data;
+				}
 			})
 
 		.done(function (response)


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Filter raw JSON response, catch any PHP warnings and add them to error messages of JSON response. 

It fixes case when there is a PHP warning in response. Now there will be no message displayed to the user, because parsing JSON response would fail.
#### Testing Instructions
1. Enable error reporting
2. Setup mailer in Joomla Global Configuration to fail SMTP TLS or SSL verification, e.g. security: none when it requires SSL
3. JSON request would fail and there will be know message to the user.

You will get similar response:

```
<br />
<b>Warning</b>:  stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages
:
error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed in <b>/libraries/vendor/phpmailer/phpmailer/class.smtp.php</b> on line 
<b>343</b><br />
{"success":true,"message":null,"messages":{"notice":["SMTP Error: Could not connect to SMTP host."],"error"
:["Test mail could not be sent."]},"data":false}
```
