### PR TITLE
Enable SMTPDebug if JDEBUG is true

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -51,6 +51,12 @@ class JMail extends PHPMailer
 		{
 			JLog::add(sprintf('Error in JMail API: %s', $message), JLog::ERROR, 'mail');
 		};
+
+		// If debug mode is enabled then set SMTPDebug to the maximum level
+		if (defined('JDEBUG') && JDEBUG)
+		{
+			$this->SMTPDebug = 4;
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Summary of Changes

PHPMailer has a configurable `SMTPDebug` property that allows logging of different types of messages from its internal API.  Joomla doesn't change this from the default '0' (so no logging) under any condition.  This PR adjusts `JMail` to set this property to the highest level when `JDEBUG` is true.
#### Testing Instructions

Apply the patch, enable debug mode, ensure the debug plugin is set to log everything (or at least messages in the 'mail' category), and do something that triggers a SMTP transaction.  A more verbose set of messages should be found in the log in the 'mail' category detailing the transaction.
