### PR TITLE
Title of wrong menu item changed for com_contact

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-10-30.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.0-2015-10-30.sql
@@ -1,1 +1,1 @@
-UPDATE `#__menu` SET `title` = 'com_contact_contacts' WHERE `id` = 8;
+UPDATE `#__menu` SET `title` = 'com_contact_contacts' WHERE `client_id` = 1 AND `level` = 2 AND `title` = 'com_contact';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-30.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.5.0-2015-10-30.sql
@@ -1,1 +1,1 @@
-UPDATE "#__menu" SET "title" = 'com_contact_contacts' WHERE "id" = 8;
+UPDATE "#__menu" SET "title" = 'com_contact_contacts' WHERE "client_id" = 1 AND "level" = 2 AND "title" = 'com_contact';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-10-30.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.5.0-2015-10-30.sql
@@ -1,1 +1,1 @@
-UPDATE [#__menu] SET [title] = 'com_contact_contacts' WHERE [id] = 8;
+UPDATE [#__menu] SET [title] = 'com_contact_contacts' WHERE [client_id] = 1 AND [level] = 2 AND [title] = 'com_contact';


### PR DESCRIPTION
Pull Request for Issue #9525

Original issue description

> ### Steps to reproduce the issue
> 
> Upgrade from Joomla 3.4.8 to Joomla 3.5 on a very long living site.
> ### Expected result
> 
> The title of admin menu item with title "com_contact" is renamed to "com_contact_contacts".
> ### Actual result
> 
> The title of a menu item which is used on the frontend (title = 'Geschiedenis') is renamed to "com_contact_contacts". That means the main menu on my site now contains a item with title "com_contact_contacts".
> System information (as much as possible)
> 
> ```
> - Upgrade from 3.4.8 to 3.5
> - Long living installation, migrations and upgrades since Joomla 1.5
> - Using MySQL database
> - The IDs of the backend menu items (client_id = 1) are not equal to the ones in a clean Joomla installation.
> ```
> ### Additional comments
> 
> Issue is caused by #8212 which uses a hardcoded menu item ID (8) to update the menu item title. Menu item ID 8 may be used for another than the meant one.
> Fix proposal
> 
> I think other people with (somehow) non-default menu item IDs may/will have the same problem. My proposal is to only change the title for menu items which matches the follow criteria:
> a) only backend menu items (client_id = 1)
> b) with title = 'com_contact'
> c) in a submenu (level = 2)
> 
> For MySQL the following query does the job from phpMyAdmin:
> UPDATE jml_menu SET title = 'com_contact_contacts' WHERE client_id = 1 AND level = 2 AND title = 'com_contact'
> 
> If you agree I wil be happy to change the queries and submit another PR. I also can help testing for MySQL because I did not upgrade my production installation yet.
