### PR TITLE
 Batch window issue

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8170,10 +8170,10 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
-}
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
+	.modal-body {
+		-webkit-overflow-scrolling: touch;
+		overflow-y: auto !important;
+	}
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8172,7 +8172,6 @@ body.modal-open {
 	}
 	.modal-body {
 		-webkit-overflow-scrolling: touch;
-		overflow-y: auto !important;
 	}
 }
 .pull-right {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -2790,7 +2790,7 @@ input[type="submit"].btn.btn-mini {
 	color: #8a6d3b;
 }
 .alert h4 {
-  margin: 0 0 .5em;
+	margin: 0 0 .5em;
 }
 .alert .close {
 	position: relative;
@@ -8170,8 +8170,8 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
-}
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
+	.modal-body {
+		-webkit-overflow-scrolling: touch;
+		overflow-y: auto !important;
+	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8172,6 +8172,5 @@ body.modal-open {
 	}
 	.modal-body {
 		-webkit-overflow-scrolling: touch;
-		overflow-y: auto !important;
 	}
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1308,6 +1308,7 @@ body.modal-open {
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
+	overflow-y: auto !important;
 }
 
 /* Stats plugin */
@@ -1323,10 +1324,10 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
+}
 
-	/* Fix iOS scrolling inside bootstrap modals (using iframe) */
-	.modal-body {
-		-webkit-overflow-scrolling: touch;
-		overflow-y: auto !important;
-	}
+/* Fix iOS scrolling inside bootstrap modals (using iframe) */
+.modal-body {
+	-webkit-overflow-scrolling: touch;
+	overflow-y: auto !important;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1326,6 +1326,5 @@ body.modal-open {
 	/* Fix iOS scrolling inside bootstrap modals (using iframe) */
 	.modal-body {
 		-webkit-overflow-scrolling: touch;
-		overflow-y: auto !important;
 	}
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1308,7 +1308,6 @@ body.modal-open {
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;
 	overflow: hidden;
-	overflow-y: auto !important;
 }
 
 /* Stats plugin */
@@ -1324,10 +1323,9 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
-}
-
-/* Fix iOS scrolling inside bootstrap modals (using iframe) */
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
+	/* Fix iOS scrolling inside bootstrap modals (using iframe) */
+	.modal-body {
+		-webkit-overflow-scrolling: touch;
+		overflow-y: auto !important;
+	}
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1323,10 +1323,10 @@ body.modal-open {
 	.field-media-wrapper .modal .modal-body {
 		padding: 5px 0;
 	}
-}
 
-/* Fix iOS scrolling inside bootstrap modals (using iframe) */
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
+	/* Fix iOS scrolling inside bootstrap modals (using iframe) */
+	.modal-body {
+		-webkit-overflow-scrolling: touch;
+		overflow-y: auto !important;
+	}
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2805,7 +2805,7 @@ input[type="submit"].btn.btn-mini {
 	color: #c09853;
 }
 .alert h4 {
-  margin: 0 0 .5em;
+	margin: 0 0 .5em;
 }
 .alert .close {
 	position: relative;


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Moved ".modal-body {" into mediaquery "@media (max-width: 767px)" in less-file of "isis"-template
#### Testing Instructions

in a menu, or content window select some items then click batch attempt to "move or copy" you will find the window is too small.
Apply this patch
repeat the test and on a standard screen it overflows correctly to allow you to select an item.
If possible test on multiple view ports particularly if you have a device has the max-width as above.
Not sure if it would be better removing it from the constraint totally.
