### PR TITLE
Module edit backend get slow with a lot of menu items #9516

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -148,7 +148,7 @@ class MenusHelper
 	{
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, 
+			->select('DISTINCT(a.id) AS value, 
 					  a.title AS text, 
 					  a.alias, 
 					  a.level, 
@@ -205,40 +205,6 @@ class MenusHelper
 		}
 
 		$query->where('a.published != -2');
-
-		if (JLanguageMultilang::isEnabled())
-		{
-			$query->group(
-				'a.id , 
-				 a.title , 
-				 a.alias, 
-				 a.level, 
-				 a.menutype, 
-				 a.type, 
-				 a.published, 
-				 a.template_style_id, 
-				 a.checked_out, 
-				 a.language,
-				 a.lft,
-				 l.title , 
-				 l.image');
-		}
-		else
-		{
-			$query->group(
-				'a.id , 
-				 a.title , 
-				 a.alias, 
-				 a.level, 
-				 a.menutype, 
-				 a.type, 
-				 a.published, 
-				 a.template_style_id, 
-				 a.checked_out, 
-				 a.language,
-				 a.lft');
-		}
-
 		$query->order('a.lft ASC');
 
 		// Get the options.


### PR DESCRIPTION
Pull Request for Issue  #9516 .
#### Summary of Changes

query  clean  (distinct instead of group by)
#### Testing Instructions

edit a module item from backend with debug plugin enabled and look for
![before0](https://cloud.githubusercontent.com/assets/181681/14185692/4a8243b8-f77b-11e5-9545-74f7133f6fe1.png)
apply the patch and edit a module 
![after0](https://cloud.githubusercontent.com/assets/181681/14185727/67fa5476-f77b-11e5-9121-81c8ae898ad0.PNG)
