### PR TITLE
Allow to add script/stylesheet version with JHtml

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -615,13 +615,14 @@ abstract class JHtml
 	 *                                       <tr><td>Firefox</td>                    <td>mozilla</td>	<td>5.0</td></tr>
 	 *                                    </table>
 	 * @param   boolean  $detect_debug    detect debug to search for compressed files if debug is on
+	 * @param   string   $version         add version to stylesheet. empty for no version, null to auto, other for custom (see JDocument::addStyleSheetVersion)
 	 *
 	 * @return  mixed  nothing if $path_only is false, null, path or array of path if specific css browser files were detected
 	 *
 	 * @see     JBrowser
 	 * @since   1.5
 	 */
-	public static function stylesheet($file, $attribs = array(), $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true)
+	public static function stylesheet($file, $attribs = array(), $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true, $version = '')
 	{
 		$includes = static::includeRelativeFiles('css', $file, $relative, $detect_browser, $detect_debug);
 
@@ -648,7 +649,15 @@ abstract class JHtml
 
 			foreach ($includes as $include)
 			{
-				$document->addStylesheet($include, 'text/css', null, $attribs);
+				if ($version === '')
+				{
+					$document->addStylesheet($include, 'text/css', null, $attribs);
+				}
+				else
+				{
+					$document->addStyleSheetVersion($include, $version, 'text/css', null, $attribs);
+				}
+				
 			}
 		}
 	}
@@ -662,13 +671,14 @@ abstract class JHtml
 	 * @param   boolean  $path_only       return the path to the file only.
 	 * @param   boolean  $detect_browser  detect browser to include specific browser js files.
 	 * @param   boolean  $detect_debug    detect debug to search for compressed files if debug is on.
+	 * @param   string   $version         add version to script. empty for no version, null to auto, other for custom (see JDocument::addScriptVersion)
 	 *
 	 * @return  mixed  nothing if $path_only is false, null, path or array of path if specific js browser files were detected.
 	 *
 	 * @see     JHtml::stylesheet()
 	 * @since   1.5
 	 */
-	public static function script($file, $framework = false, $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true)
+	public static function script($file, $framework = false, $relative = false, $path_only = false, $detect_browser = true, $detect_debug = true, $version = '')
 	{
 		// Include MooTools framework
 		if ($framework)
@@ -701,7 +711,14 @@ abstract class JHtml
 
 			foreach ($includes as $include)
 			{
-				$document->addScript($include);
+				if ($version === '')
+				{
+					$document->addScript($include);
+				}
+				else
+				{
+					$document->addScriptVersion($include, $version);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
#### Summary of Changes

This PR is for allowing to add script and stylesheet versioning with JHtml.
#### Testing Instructions
- Apply this patch in latest staging
- Add the following code to isis template index.php (in https://github.com/joomla/joomla-cms/blob/staging/administrator/templates/isis/index.php#L22)

``` php
// Script with no version
JHtml::_('script', 'system/jquery.Jcrop.min.js', false, true);
// Script with auto version
JHtml::_('script', 'system/jquery.Jcrop.min.js', false, true, false, true, true, null);
// Script with custom version
JHtml::_('script', 'system/jquery.Jcrop.min.js', false, true, false, true, true, 'custom-version');

// Stylesheet with no version
JHtml::_('stylesheet', 'system/jquery.Jcrop.min.css', array(), true);
// Stylesheet with auto version
JHtml::_('stylesheet', 'system/jquery.Jcrop.min.css', array(), true, false, true, true, null);
// Stylesheet with custom version
JHtml::_('stylesheet', 'system/jquery.Jcrop.min.css', array(), true, false, true, true, 'custom-version');
```
- Now go to any page in the admin panel
- View the html source and check if this lines are in the html head section

``` html
<head>
[...]
<link rel="stylesheet" href="/media/system/css/jquery.Jcrop.min.css" type="text/css" />
<link rel="stylesheet" href="/media/system/css/jquery.Jcrop.min.css?<some-hash>" type="text/css" />
<link rel="stylesheet" href="/media/system/css/jquery.Jcrop.min.css?custom-version" type="text/css" />
[...]
<script src="/media/system/js/jquery.Jcrop.min.js" type="text/javascript"></script>
<script src="/media/system/js/jquery.Jcrop.min.js?<some-hash>" type="text/javascript"></script>
<script src="/media/system/js/jquery.Jcrop.min.js?custom-version" type="text/javascript"></script>
[...]
</head>
```
