### PR TITLE
Regression: Wrong redirect after login when session expires —menu items and Content Languages

### DIFF
--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -40,7 +40,7 @@ JFactory::getDocument()->addScriptDeclaration(
 );
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_languages&layout=edit&lang_id=' . (int) $this->item->lang_id); ?>" method="post" name="adminForm" id="language-form" class="form-validate form-horizontal">
+<form action="<?php echo JRoute::_('index.php?option=com_languages&view=language&layout=edit&lang_id=' . (int) $this->item->lang_id); ?>" method="post" name="adminForm" id="language-form" class="form-validate form-horizontal">
 
 	<?php echo JLayoutHelper::render('joomla.edit.item_title', $this); ?>
 

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -80,7 +80,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php?option=com_menus&view=item&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 


### PR DESCRIPTION
Pull Request for Issue #9687

This PR to solve the Fatal error when editing a menu item and session expires.
It also solves the issue when editing a Content Language and session expires (before patch it redirects to Languages Installed)
#### Testing Instructions

Set your session to 1 minute.
Edit these items and wait session expires, then login.

Patch and test again.
