### PR TITLE
Update to com_redirect's Edit Link View File

### DIFF
--- a/administrator/components/com_redirect/models/forms/link.xml
+++ b/administrator/components/com_redirect/models/forms/link.xml
@@ -16,6 +16,7 @@
 			type="text"
 			label="COM_REDIRECT_FIELD_OLD_URL_LABEL"
 			description="COM_REDIRECT_FIELD_OLD_URL_DESC"
+			class="input-xxlarge"
 			size="50"
 			required="true" />
 
@@ -24,6 +25,7 @@
 			type="text"
 			label="COM_REDIRECT_FIELD_NEW_URL_LABEL"
 			description="COM_REDIRECT_FIELD_NEW_URL_DESC"
+			class="input-xxlarge"
 			size="50"
 			required="true" />
 
@@ -39,6 +41,7 @@
 			type="list"
 			label="JSTATUS"
 			description="JFIELD_PUBLISHED_DESC"
+			class="chzn-color-state"
 			size="1"
 			required="true"
 			default="1">


### PR DESCRIPTION
I recently had to use the com_redirect for a project and found it a little annoying that the two URL input fields were such a small width. So...
#### Summary of Changes

This simple PR adds classes to extend the length of the two URL text input fields. I also add the "chzn-color-state" class to the published dropdown field.
#### Testing Instructions

Add a new Redirect link (or edit an existing one) under Components -> Redirect. Notice how small the two URL text input fields are. Apply this PR. Add a new Redirect link and notice the larger text input fields and the colors applied to the Status dropdown field.
