### PR TITLE
Info/error/success messages on mobile #5643

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8044,6 +8044,7 @@ a.grid_true {
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
 	padding-bottom: 10px;
+	clear: both;
 	background-color: #f5f5f5;
 	border-bottom: 1px solid #e3e3e3;
 	border-right: 1px solid #e3e3e3;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8044,6 +8044,7 @@ a.grid_true {
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
 	padding-bottom: 10px;
+	clear: both;
 	background-color: #f5f5f5;
 	border-bottom: 1px solid #e3e3e3;
 	border-right: 1px solid #e3e3e3;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1172,6 +1172,7 @@ a.grid_true {
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
 	padding-bottom: 10px;
+	clear: both;
 	background-color: @wellBackground;
 	border-bottom: 1px solid darken(@wellBackground, 7%);
 	border-right: 1px solid darken(@wellBackground, 7%);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/5643.
#### Summary of Changes

This PR is for solving one of issue with 16 months.
In the admin panel, you can't see the Info/error/success messages on mopbile and tablet view when you're in a view that have a sidebar.
#### Testing Instructions
1. Use latest staging
2. Resize browser window to mobile xs size
3. Do any action on a view with admin sidebar that returns a message (ex: edit a user and press save and close)
4. Result: You CAN'T see the success message.
   ![image](https://cloud.githubusercontent.com/assets/9630530/14213658/20faeade-f831-11e5-8963-06e4cfd22da9.png)
5. Apply this patch
6. Repeat steps 2 and 3
7. Result: You CAN see the success message.
   ![image](https://cloud.githubusercontent.com/assets/9630530/14213761/a272b538-f831-11e5-893a-f80fd90eb53c.png)
