### PR TITLE
Updates Composer dependencies to latest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ Desktop.ini
 /libraries/vendor/ircmaxell/password-compat/phpunit.xml.dist
 /libraries/vendor/ircmaxell/password-compat/README.md
 /libraries/vendor/ircmaxell/password-compat/version-test.php
+/libraries/vendor/joomla/*/.gitignore
+/libraries/vendor/joomla/*/.gitmodules
 /libraries/vendor/joomla/*/docs
 /libraries/vendor/joomla/*/Tests
 /libraries/vendor/joomla/*/vendor

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e4a0c44baa97f2acbd3ef1fe14f63200",
+    "hash": "d500f4784ce37841dad0b29e32660849",
     "content-hash": "800b07fe877fd7416bf7c046ad42a55a",
     "packages": [
         {
@@ -51,29 +51,29 @@
         },
         {
             "name": "joomla/application",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/application.git",
-                "reference": "a50d524bdc31488aad46da0da8cb59b1767fc4fd"
+                "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/application/zipball/a50d524bdc31488aad46da0da8cb59b1767fc4fd",
-                "reference": "a50d524bdc31488aad46da0da8cb59b1767fc4fd",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/9ac5463d5437759dc523bf02d59d279a43f361e0",
+                "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0",
                 "shasum": ""
             },
             "require": {
                 "joomla/input": "~1.2",
                 "joomla/registry": "~1.1",
-                "php": ">=5.3.10",
+                "php": ">=5.3.10|>=7.0",
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "joomla/session": "~1.1",
+                "joomla/session": "^1.2.1",
                 "joomla/test": "~1.1",
                 "joomla/uri": "~1.1",
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "squizlabs/php_codesniffer": "1.*"
             },
             "suggest": {
@@ -103,7 +103,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2015-10-09 12:10:44"
+            "time": "2016-03-18 15:08:10"
         },
         {
             "name": "joomla/compat",
@@ -193,22 +193,31 @@
         },
         {
             "name": "joomla/event",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/event.git",
-                "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901"
+                "reference": "d8cc2a4757c4556f0ab12e58903e9d168077018b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/event/zipball/bb957bc45aba897e465384bbe21cd0eb79aca901",
-                "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901",
+                "url": "https://api.github.com/repos/joomla-framework/event/zipball/d8cc2a4757c4556f0ab12e58903e9d168077018b",
+                "reference": "d8cc2a4757c4556f0ab12e58903e9d168077018b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.10"
+                "php": ">=5.3.10|>=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8|~5.0",
+                "squizlabs/php_codesniffer": "1.*"
             },
             "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Joomla\\Event\\": "src/",
@@ -226,7 +235,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2014-02-09 01:30:54"
+            "time": "2016-03-13 19:41:09"
         },
         {
             "name": "joomla/filter",
@@ -432,24 +441,24 @@
         },
         {
             "name": "joomla/string",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/string.git",
-                "reference": "1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a"
+                "reference": "05197132a075ee22a3f0f7da31a19a6d5b4717db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/string/zipball/1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a",
-                "reference": "1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a",
+                "url": "https://api.github.com/repos/joomla-framework/string/zipball/05197132a075ee22a3f0f7da31a19a6d5b4717db",
+                "reference": "05197132a075ee22a3f0f7da31a19a6d5b4717db",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.10"
+                "php": ">=5.3.10|>=7.0"
             },
             "require-dev": {
                 "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "squizlabs/php_codesniffer": "1.*"
             },
             "type": "joomla-package",
@@ -462,7 +471,24 @@
                 "psr-4": {
                     "Joomla\\String\\": "src/",
                     "Joomla\\String\\Tests\\": "Tests/"
-                }
+                },
+                "files": [
+                    "src/phputf8/utf8.php",
+                    "src/phputf8/ord.php",
+                    "src/phputf8/str_ireplace.php",
+                    "src/phputf8/str_pad.php",
+                    "src/phputf8/str_split.php",
+                    "src/phputf8/strcasecmp.php",
+                    "src/phputf8/strcspn.php",
+                    "src/phputf8/stristr.php",
+                    "src/phputf8/strrev.php",
+                    "src/phputf8/strspn.php",
+                    "src/phputf8/trim.php",
+                    "src/phputf8/ucfirst.php",
+                    "src/phputf8/ucwords.php",
+                    "src/phputf8/utils/ascii.php",
+                    "src/phputf8/utils/validation.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -475,7 +501,7 @@
                 "joomla",
                 "string"
             ],
-            "time": "2015-05-03 16:08:20"
+            "time": "2016-01-30 20:04:23"
         },
         {
             "name": "joomla/uri",
@@ -604,16 +630,16 @@
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v1.2.1",
+            "version": "v1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc"
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
-                "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
+                "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
                 "shasum": ""
             },
             "require": {
@@ -648,7 +674,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-02-29 17:25:04"
+            "time": "2016-03-18 20:34:03"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -751,7 +777,7 @@
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
@@ -807,16 +833,16 @@
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.0.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "4271c55cbc0a77b2641f861b978123e46b3da969"
+                "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4271c55cbc0a77b2641f861b978123e46b3da969",
-                "reference": "4271c55cbc0a77b2641f861b978123e46b3da969",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+                "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
                 "shasum": ""
             },
             "require": {
@@ -825,7 +851,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -855,20 +881,20 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2015-11-04 20:28:58"
+            "time": "2016-01-20 09:13:37"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.3",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
-                "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/584e52cb8f788a887553ba82db6caacb1d6260bb",
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb",
                 "shasum": ""
             },
             "require": {
@@ -904,7 +930,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-02-23 07:41:20"
+            "time": "2016-03-04 07:54:35"
         }
     ],
     "packages-dev": [
@@ -1063,22 +1089,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "~2.0"
@@ -1086,7 +1114,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -1119,7 +1147,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2016-02-15 07:46:21"
         },
         {
             "name": "phpunit/dbunit",
@@ -1422,16 +1450,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.23",
+            "version": "4.8.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483"
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e351261f9cd33daf205a131a1ba61c6d33bd483",
-                "reference": "6e351261f9cd33daf205a131a1ba61c6d33bd483",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1066c562c52900a142a0e2bbf0582994671385e",
+                "reference": "a1066c562c52900a142a0e2bbf0582994671385e",
                 "shasum": ""
             },
             "require": {
@@ -1490,7 +1518,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-07 10:39:46"
+            "time": "2016-03-14 06:16:08"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1666,23 +1694,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.3",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6e7133793a8e5a5714a551a8324337374be209df"
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6e7133793a8e5a5714a551a8324337374be209df",
-                "reference": "6e7133793a8e5a5714a551a8324337374be209df",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
@@ -1712,7 +1740,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-12-02 08:37:27"
+            "time": "2016-02-26 18:40:46"
         },
         {
             "name": "sebastian/exporter",

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Base class for a Joomla! Web application.
@@ -478,9 +479,6 @@ class JApplicationWeb extends JApplicationBase
 	 */
 	public function redirect($url, $status = 303)
 	{
-		// Import library dependencies.
-		jimport('phputf8.utils.ascii');
-
 		// Check for relative internal links.
 		if (preg_match('#^index\.php#', $url))
 		{
@@ -528,7 +526,7 @@ class JApplicationWeb extends JApplicationBase
 		else
 		{
 			// We have to use a JavaScript redirect here because MSIE doesn't play nice with utf-8 URLs.
-			if (($this->client->engine == JApplicationWebClient::TRIDENT) && !utf8_is_ascii($url))
+			if (($this->client->engine == JApplicationWebClient::TRIDENT) && !StringHelper::is_ascii($url))
 			{
 				$html = '<html><head>';
 				$html .= '<meta http-equiv="content-type" content="text/html; charset=' . $this->charSet . '" />';

--- a/libraries/vendor/composer/autoload_files.php
+++ b/libraries/vendor/composer/autoload_files.php
@@ -6,7 +6,22 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname(dirname($vendorDir));
 
 return array(
+    '2fb9d6f23c8e8faefc193a4cde0cab4f' => $vendorDir . '/joomla/string/src/phputf8/utf8.php',
+    'e6851e0ae7328fe5412fcec73928f3d9' => $vendorDir . '/joomla/string/src/phputf8/ord.php',
+    'd9ad1b7c85c100a18c404a13824b846e' => $vendorDir . '/joomla/string/src/phputf8/str_ireplace.php',
+    '62bad9b6730d2f83493d2337bf61519d' => $vendorDir . '/joomla/string/src/phputf8/str_pad.php',
+    'c4d521b8d54308532dce032713d4eec0' => $vendorDir . '/joomla/string/src/phputf8/str_split.php',
+    'fa973e71cace925de2afdc692b861b1d' => $vendorDir . '/joomla/string/src/phputf8/strcasecmp.php',
+    '0c98c2f1295d9f4d093cc77d5834bb04' => $vendorDir . '/joomla/string/src/phputf8/strcspn.php',
+    'a52639d843b4094945115c178a91ca86' => $vendorDir . '/joomla/string/src/phputf8/stristr.php',
+    '73ee7d0297e683c4c2e7798ef040fb2f' => $vendorDir . '/joomla/string/src/phputf8/strrev.php',
+    'd55633c05ddb996e0005f35debaa7b5b' => $vendorDir . '/joomla/string/src/phputf8/strspn.php',
+    '944e69d23b93558fc0714353cf0c8beb' => $vendorDir . '/joomla/string/src/phputf8/trim.php',
+    '31264bab20f14a8fc7a9d4265d91ee98' => $vendorDir . '/joomla/string/src/phputf8/ucfirst.php',
+    '05d739a990f75f0c44ebe1f032b33148' => $vendorDir . '/joomla/string/src/phputf8/ucwords.php',
+    '4292e2fa66516089e6006723267587b4' => $vendorDir . '/joomla/string/src/phputf8/utils/ascii.php',
+    '87465e33b7551b401bf051928f220e9a' => $vendorDir . '/joomla/string/src/phputf8/utils/validation.php',
     'e40631d46120a9c38ea139981f8dab26' => $vendorDir . '/ircmaxell/password-compat/lib/password.php',
-    'bd9634f2d41831496de0d3dfe4c94881' => $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
     '5255c38a0faeba867671b61dfda6d864' => $vendorDir . '/paragonie/random_compat/lib/random.php',
+    'bd9634f2d41831496de0d3dfe4c94881' => $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
 );

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -173,45 +173,6 @@
         ]
     },
     {
-        "name": "joomla/event",
-        "version": "1.1.1",
-        "version_normalized": "1.1.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/event.git",
-            "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/event/zipball/bb957bc45aba897e465384bbe21cd0eb79aca901",
-            "reference": "bb957bc45aba897e465384bbe21cd0eb79aca901",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.10"
-        },
-        "time": "2014-02-09 01:30:54",
-        "type": "joomla-package",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Event\\": "src/",
-                "Joomla\\Event\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Event Package",
-        "homepage": "https://github.com/joomla-framework/event",
-        "keywords": [
-            "event",
-            "framework",
-            "joomla"
-        ]
-    },
-    {
         "name": "joomla/compat",
         "version": "1.2.0",
         "version_normalized": "1.2.0.0",
@@ -302,113 +263,6 @@
         ]
     },
     {
-        "name": "joomla/string",
-        "version": "1.3.1",
-        "version_normalized": "1.3.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/string.git",
-            "reference": "1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/string/zipball/1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a",
-            "reference": "1a61294f887a95ec3eb2e4dac12ba18ab6b2bf5a",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.10"
-        },
-        "require-dev": {
-            "joomla/test": "~1.0",
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*"
-        },
-        "time": "2015-05-03 16:08:20",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\String\\": "src/",
-                "Joomla\\String\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla String Package",
-        "homepage": "https://github.com/joomla-framework/string",
-        "keywords": [
-            "framework",
-            "joomla",
-            "string"
-        ]
-    },
-    {
-        "name": "joomla/application",
-        "version": "1.5.0",
-        "version_normalized": "1.5.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/application.git",
-            "reference": "a50d524bdc31488aad46da0da8cb59b1767fc4fd"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/application/zipball/a50d524bdc31488aad46da0da8cb59b1767fc4fd",
-            "reference": "a50d524bdc31488aad46da0da8cb59b1767fc4fd",
-            "shasum": ""
-        },
-        "require": {
-            "joomla/input": "~1.2",
-            "joomla/registry": "~1.1",
-            "php": ">=5.3.10",
-            "psr/log": "~1.0"
-        },
-        "require-dev": {
-            "joomla/session": "~1.1",
-            "joomla/test": "~1.1",
-            "joomla/uri": "~1.1",
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*"
-        },
-        "suggest": {
-            "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
-            "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
-        },
-        "time": "2015-10-09 12:10:44",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Application\\": "src/",
-                "Joomla\\Application\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Application Package",
-        "homepage": "https://github.com/joomla-framework/application",
-        "keywords": [
-            "application",
-            "framework",
-            "joomla"
-        ]
-    },
-    {
         "name": "joomla/registry",
         "version": "1.5.0",
         "version_normalized": "1.5.0.0",
@@ -462,60 +316,6 @@
             "framework",
             "joomla",
             "registry"
-        ]
-    },
-    {
-        "name": "symfony/polyfill-util",
-        "version": "v1.0.0",
-        "version_normalized": "1.0.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/symfony/polyfill-util.git",
-            "reference": "4271c55cbc0a77b2641f861b978123e46b3da969"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/4271c55cbc0a77b2641f861b978123e46b3da969",
-            "reference": "4271c55cbc0a77b2641f861b978123e46b3da969",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.3.3"
-        },
-        "time": "2015-11-04 20:28:58",
-        "type": "library",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.0-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Symfony\\Polyfill\\Util\\": ""
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "MIT"
-        ],
-        "authors": [
-            {
-                "name": "Nicolas Grekas",
-                "email": "p@tchwork.com"
-            },
-            {
-                "name": "Symfony Community",
-                "homepage": "https://symfony.com/contributors"
-            }
-        ],
-        "description": "Symfony utilities for portability of PHP codes",
-        "homepage": "https://symfony.com",
-        "keywords": [
-            "compat",
-            "compatibility",
-            "polyfill",
-            "shim"
         ]
     },
     {
@@ -729,37 +529,256 @@
         ]
     },
     {
-        "name": "symfony/yaml",
-        "version": "v2.8.3",
-        "version_normalized": "2.8.3.0",
+        "name": "joomla/utilities",
+        "version": "1.4.0",
+        "version_normalized": "1.4.0.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/symfony/yaml.git",
-            "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995"
+            "url": "https://github.com/joomla-framework/utilities.git",
+            "reference": "ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/symfony/yaml/zipball/2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
-            "reference": "2a4ee40acb880c56f29fb1b8886e7ffe94f3b995",
+            "url": "https://api.github.com/repos/joomla-framework/utilities/zipball/ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b",
+            "reference": "ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b",
             "shasum": ""
         },
         "require": {
-            "php": ">=5.3.9"
+            "joomla/string": "~1.3",
+            "php": ">=5.3.10"
         },
-        "time": "2016-02-23 07:41:20",
-        "type": "library",
+        "require-dev": {
+            "phpunit/phpunit": "4.*",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "time": "2015-09-05 16:41:24",
+        "type": "joomla-package",
         "extra": {
             "branch-alias": {
-                "dev-master": "2.8-dev"
+                "dev-master": "1.x-dev"
             }
         },
         "installation-source": "dist",
         "autoload": {
             "psr-4": {
-                "Symfony\\Component\\Yaml\\": ""
+                "Joomla\\Utilities\\": "src/",
+                "Joomla\\Utilities\\Tests\\": "Tests/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Utilities Package",
+        "homepage": "https://github.com/joomla-framework/utilities",
+        "keywords": [
+            "framework",
+            "joomla",
+            "utilities"
+        ]
+    },
+    {
+        "name": "joomla/string",
+        "version": "1.4.0",
+        "version_normalized": "1.4.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/string.git",
+            "reference": "05197132a075ee22a3f0f7da31a19a6d5b4717db"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/string/zipball/05197132a075ee22a3f0f7da31a19a6d5b4717db",
+            "reference": "05197132a075ee22a3f0f7da31a19a6d5b4717db",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.10|>=7.0"
+        },
+        "require-dev": {
+            "joomla/test": "~1.0",
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "time": "2016-01-30 20:04:23",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\String\\": "src/",
+                "Joomla\\String\\Tests\\": "Tests/"
             },
-            "exclude-from-classmap": [
-                "/Tests/"
+            "files": [
+                "src/phputf8/utf8.php",
+                "src/phputf8/ord.php",
+                "src/phputf8/str_ireplace.php",
+                "src/phputf8/str_pad.php",
+                "src/phputf8/str_split.php",
+                "src/phputf8/strcasecmp.php",
+                "src/phputf8/strcspn.php",
+                "src/phputf8/stristr.php",
+                "src/phputf8/strrev.php",
+                "src/phputf8/strspn.php",
+                "src/phputf8/trim.php",
+                "src/phputf8/ucfirst.php",
+                "src/phputf8/ucwords.php",
+                "src/phputf8/utils/ascii.php",
+                "src/phputf8/utils/validation.php"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla String Package",
+        "homepage": "https://github.com/joomla-framework/string",
+        "keywords": [
+            "framework",
+            "joomla",
+            "string"
+        ]
+    },
+    {
+        "name": "joomla/application",
+        "version": "1.5.1",
+        "version_normalized": "1.5.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/application.git",
+            "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/application/zipball/9ac5463d5437759dc523bf02d59d279a43f361e0",
+            "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/input": "~1.2",
+            "joomla/registry": "~1.1",
+            "php": ">=5.3.10|>=7.0",
+            "psr/log": "~1.0"
+        },
+        "require-dev": {
+            "joomla/session": "^1.2.1",
+            "joomla/test": "~1.1",
+            "joomla/uri": "~1.1",
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "suggest": {
+            "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
+            "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
+        },
+        "time": "2016-03-18 15:08:10",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Application\\": "src/",
+                "Joomla\\Application\\Tests\\": "Tests/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Application Package",
+        "homepage": "https://github.com/joomla-framework/application",
+        "keywords": [
+            "application",
+            "framework",
+            "joomla"
+        ]
+    },
+    {
+        "name": "joomla/event",
+        "version": "1.2.0",
+        "version_normalized": "1.2.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/event.git",
+            "reference": "d8cc2a4757c4556f0ab12e58903e9d168077018b"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/event/zipball/d8cc2a4757c4556f0ab12e58903e9d168077018b",
+            "reference": "d8cc2a4757c4556f0ab12e58903e9d168077018b",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.10|>=7.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "time": "2016-03-13 19:41:09",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Event\\": "src/",
+                "Joomla\\Event\\Tests\\": "Tests/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Event Package",
+        "homepage": "https://github.com/joomla-framework/event",
+        "keywords": [
+            "event",
+            "framework",
+            "joomla"
+        ]
+    },
+    {
+        "name": "paragonie/random_compat",
+        "version": "v1.4.1",
+        "version_normalized": "1.4.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/paragonie/random_compat.git",
+            "reference": "c7e26a21ba357863de030f0b9e701c7d04593774"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/paragonie/random_compat/zipball/c7e26a21ba357863de030f0b9e701c7d04593774",
+            "reference": "c7e26a21ba357863de030f0b9e701c7d04593774",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.2.0"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "4.*|5.*"
+        },
+        "suggest": {
+            "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+        },
+        "time": "2016-03-18 20:34:03",
+        "type": "library",
+        "installation-source": "dist",
+        "autoload": {
+            "files": [
+                "lib/random.php"
             ]
         },
         "notification-url": "https://packagist.org/downloads/",
@@ -768,21 +787,22 @@
         ],
         "authors": [
             {
-                "name": "Fabien Potencier",
-                "email": "fabien@symfony.com"
-            },
-            {
-                "name": "Symfony Community",
-                "homepage": "https://symfony.com/contributors"
+                "name": "Paragon Initiative Enterprises",
+                "email": "security@paragonie.com",
+                "homepage": "https://paragonie.com"
             }
         ],
-        "description": "Symfony Yaml Component",
-        "homepage": "https://symfony.com"
+        "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+        "keywords": [
+            "csprng",
+            "pseudorandom",
+            "random"
+        ]
     },
     {
         "name": "symfony/polyfill-php56",
-        "version": "v1.1.0",
-        "version_normalized": "1.1.0.0",
+        "version": "v1.1.1",
+        "version_normalized": "1.1.1.0",
         "source": {
             "type": "git",
             "url": "https://github.com/symfony/polyfill-php56.git",
@@ -838,84 +858,37 @@
         ]
     },
     {
-        "name": "joomla/utilities",
-        "version": "1.4.0",
-        "version_normalized": "1.4.0.0",
+        "name": "symfony/yaml",
+        "version": "v2.8.4",
+        "version_normalized": "2.8.4.0",
         "source": {
             "type": "git",
-            "url": "https://github.com/joomla-framework/utilities.git",
-            "reference": "ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b"
+            "url": "https://github.com/symfony/yaml.git",
+            "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/utilities/zipball/ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b",
-            "reference": "ecf18231ff86ab06cf555a7c3ed4dd447ae39e9b",
+            "url": "https://api.github.com/repos/symfony/yaml/zipball/584e52cb8f788a887553ba82db6caacb1d6260bb",
+            "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb",
             "shasum": ""
         },
         "require": {
-            "joomla/string": "~1.3",
-            "php": ">=5.3.10"
+            "php": ">=5.3.9"
         },
-        "require-dev": {
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*"
-        },
-        "time": "2015-09-05 16:41:24",
-        "type": "joomla-package",
+        "time": "2016-03-04 07:54:35",
+        "type": "library",
         "extra": {
             "branch-alias": {
-                "dev-master": "1.x-dev"
+                "dev-master": "2.8-dev"
             }
         },
         "installation-source": "dist",
         "autoload": {
             "psr-4": {
-                "Joomla\\Utilities\\": "src/",
-                "Joomla\\Utilities\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Utilities Package",
-        "homepage": "https://github.com/joomla-framework/utilities",
-        "keywords": [
-            "framework",
-            "joomla",
-            "utilities"
-        ]
-    },
-    {
-        "name": "paragonie/random_compat",
-        "version": "v1.2.1",
-        "version_normalized": "1.2.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/paragonie/random_compat.git",
-            "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/paragonie/random_compat/zipball/f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
-            "reference": "f078eba3bcf140fd69b5fcc3ea5ac809abf729dc",
-            "shasum": ""
-        },
-        "require": {
-            "php": ">=5.2.0"
-        },
-        "require-dev": {
-            "phpunit/phpunit": "4.*|5.*"
-        },
-        "suggest": {
-            "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-        },
-        "time": "2016-02-29 17:25:04",
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "files": [
-                "lib/random.php"
+                "Symfony\\Component\\Yaml\\": ""
+            },
+            "exclude-from-classmap": [
+                "/Tests/"
             ]
         },
         "notification-url": "https://packagist.org/downloads/",
@@ -924,16 +897,69 @@
         ],
         "authors": [
             {
-                "name": "Paragon Initiative Enterprises",
-                "email": "security@paragonie.com",
-                "homepage": "https://paragonie.com"
+                "name": "Fabien Potencier",
+                "email": "fabien@symfony.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
             }
         ],
-        "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+        "description": "Symfony Yaml Component",
+        "homepage": "https://symfony.com"
+    },
+    {
+        "name": "symfony/polyfill-util",
+        "version": "v1.1.1",
+        "version_normalized": "1.1.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/polyfill-util.git",
+            "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+            "reference": "8de62801aa12bc4dfcf85eef5d21981ae7bb3cc4",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.3"
+        },
+        "time": "2016-01-20 09:13:37",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.1-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Polyfill\\Util\\": ""
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Nicolas Grekas",
+                "email": "p@tchwork.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony utilities for portability of PHP codes",
+        "homepage": "https://symfony.com",
         "keywords": [
-            "csprng",
-            "pseudorandom",
-            "random"
+            "compat",
+            "compatibility",
+            "polyfill",
+            "shim"
         ]
     }
 ]

--- a/libraries/vendor/joomla/application/src/Web/WebClient.php
+++ b/libraries/vendor/joomla/application/src/Web/WebClient.php
@@ -261,10 +261,20 @@ class WebClient
 			$this->browser = self::IE;
 			$patternBrowser = 'MSIE';
 		}
+		elseif (stripos($userAgent, 'Trident') !== false)
+		{
+			$this->browser = self::IE;
+			$patternBrowser = ' rv';
+		}
 		elseif ((stripos($userAgent, 'Firefox') !== false) && (stripos($userAgent, 'like Firefox') === false))
 		{
 			$this->browser = self::FIREFOX;
 			$patternBrowser = 'Firefox';
+		}
+		elseif (stripos($userAgent, 'OPR') !== false)
+		{
+			$this->browser = self::OPERA;
+			$patternBrowser = 'OPR';
 		}
 		elseif (stripos($userAgent, 'Chrome') !== false)
 		{
@@ -286,7 +296,7 @@ class WebClient
 		if ($this->browser)
 		{
 			// Build the REGEX pattern to match the browser version string within the user agent string.
-			$pattern = '#(?<browser>Version|' . $patternBrowser . ')[/ ]+(?<version>[0-9.|a-zA-Z.]*)#';
+			$pattern = '#(?<browser>Version|' . $patternBrowser . ')[/ :]+(?<version>[0-9.|a-zA-Z.]*)#';
 
 			// Attempt to find version strings in the user agent string.
 			$matches = array();

--- a/libraries/vendor/joomla/event/src/DispatcherAwareTrait.php
+++ b/libraries/vendor/joomla/event/src/DispatcherAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Part of the Joomla Framework Event Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Event;
+
+/**
+ * Defines the trait for a Dispatcher Aware Class.
+ *
+ * @since  1.2.0
+ */
+trait DispatcherAwareTrait
+{
+	/**
+	 * Event Dispatcher
+	 *
+	 * @var    DispatcherInterface
+	 * @since  1.2.0
+	 */
+	private $dispatcher;
+
+	/**
+	 * Get the event dispatcher.
+	 *
+	 * @return  DispatcherInterface
+	 *
+	 * @since   1.2.0
+	 * @throws  \UnexpectedValueException May be thrown if the dispatcher has not been set.
+	 */
+	public function getDispatcher()
+	{
+		if ($this->dispatcher)
+		{
+			return $this->dispatcher;
+		}
+
+		throw new \UnexpectedValueException('Dispatcher not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Set the dispatcher to use.
+	 *
+	 * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+	 *
+	 * @return  $this
+	 *
+	 * @since   1.2.0
+	 */
+	public function setDispatcher(DispatcherInterface $dispatcher)
+	{
+		$this->dispatcher = $dispatcher;
+
+		return $this;
+	}
+}

--- a/libraries/vendor/joomla/string/src/Inflector.php
+++ b/libraries/vendor/joomla/string/src/Inflector.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -157,7 +157,7 @@ class Inflector
 	 */
 	private function getCachedPlural($singular)
 	{
-		$singular = String::strtolower($singular);
+		$singular = StringHelper::strtolower($singular);
 
 		// Check if the word is in cache.
 		if (isset($this->cache[$singular]))
@@ -179,7 +179,7 @@ class Inflector
 	 */
 	private function getCachedSingular($plural)
 	{
-		$plural = String::strtolower($plural);
+		$plural = StringHelper::strtolower($plural);
 
 		return array_search($plural, $this->cache);
 	}
@@ -226,7 +226,7 @@ class Inflector
 	 */
 	private function setCache($singular, $plural = null)
 	{
-		$singular = String::strtolower($singular);
+		$singular = StringHelper::strtolower($singular);
 
 		if ($plural === null)
 		{
@@ -234,7 +234,7 @@ class Inflector
 		}
 		else
 		{
-			$plural = String::strtolower($plural);
+			$plural = StringHelper::strtolower($plural);
 		}
 
 		$this->cache[$singular] = $plural;
@@ -336,7 +336,7 @@ class Inflector
 	 *
 	 * @return  boolean  True if word is countable, false otherwise.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function isCountable($word)
 	{
@@ -350,7 +350,7 @@ class Inflector
 	 *
 	 * @return  boolean  True if word is plural, false if not.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function isPlural($word)
 	{
@@ -362,8 +362,15 @@ class Inflector
 			return true;
 		}
 
+		$singularWord = $this->toSingular($word);
+
+		if ($singularWord === false)
+		{
+			return false;
+		}
+
 		// Compute the inflection to cache the values, and compare.
-		return $this->toPlural($this->toSingular($word)) == $word;
+		return $this->toPlural($singularWord) == $word;
 	}
 
 	/**
@@ -373,7 +380,7 @@ class Inflector
 	 *
 	 * @return  boolean  True if word is singular, false if not.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function isSingular($word)
 	{
@@ -385,8 +392,15 @@ class Inflector
 			return true;
 		}
 
+		$pluralWord = $this->toPlural($word);
+
+		if ($pluralWord === false)
+		{
+			return false;
+		}
+
 		// Compute the inflection to cache the values, and compare.
-		return $this->toSingular($this->toPlural($word)) == $word;
+		return $this->toSingular($pluralWord) == $word;
 	}
 
 	/**
@@ -396,7 +410,7 @@ class Inflector
 	 *
 	 * @return  mixed  An inflected string, or false if no rule could be applied.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function toPlural($word)
 	{
@@ -435,7 +449,7 @@ class Inflector
 	 *
 	 * @return  mixed  An inflected string, or false if no rule could be applied.
 	 *
-	 * @since  1.0
+	 * @since   1.0
 	 */
 	public function toSingular($word)
 	{

--- a/libraries/vendor/joomla/string/src/Normalise.php
+++ b/libraries/vendor/joomla/string/src/Normalise.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/libraries/vendor/joomla/string/src/String.php
+++ b/libraries/vendor/joomla/string/src/String.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 

--- a/libraries/vendor/joomla/string/src/StringHelper.php
+++ b/libraries/vendor/joomla/string/src/StringHelper.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework String Package
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -33,22 +33,7 @@ else
 }
 
 /**
- * Include the utf8 package
- */
-if (!defined('UTF8'))
-{
-	require_once __DIR__ . '/phputf8/utf8.php';
-}
-
-if (!function_exists('utf8_strcasecmp'))
-{
-	require_once __DIR__ . '/phputf8/strcasecmp.php';
-}
-
-/**
- * String handling class for utf-8 data
- * Wraps the phputf8 library
- * All functions assume the validity of utf-8 strings.
+ * String handling class for UTF-8 data wrapping the phputf8 library. All functions assume the validity of UTF-8 strings.
  *
  * @since  1.3.0
  */
@@ -89,7 +74,7 @@ abstract class StringHelper
 	 */
 	public static function increment($string, $style = 'default', $n = 0)
 	{
-		$styleSpec = isset(self::$incrementStyles[$style]) ? self::$incrementStyles[$style] : self::$incrementStyles['default'];
+		$styleSpec = isset(static::$incrementStyles[$style]) ? static::$incrementStyles[$style] : static::$incrementStyles['default'];
 
 		// Regular expression search and replace patterns.
 		if (is_array($styleSpec[0]))
@@ -130,19 +115,19 @@ abstract class StringHelper
 
 	/**
 	 * Tests whether a string contains only 7bit ASCII bytes.
-	 * You might use this to conditionally check whether a string
-	 * needs handling as UTF-8 or not, potentially offering performance
+	 *
+	 * You might use this to conditionally check whether a string needs handling as UTF-8 or not, potentially offering performance
 	 * benefits by using the native PHP equivalent if it's just ASCII e.g.;
 	 *
 	 * <code>
-	 * if (String::is_ascii($someString))
+	 * if (StringHelper::is_ascii($someString))
 	 * {
 	 *     // It's just ASCII - use the native PHP version
 	 *     $someString = strtolower($someString);
 	 * }
 	 * else
 	 * {
-	 *     $someString = String::strtolower($someString);
+	 *     $someString = StringHelper::strtolower($someString);
 	 * }
 	 * </code>
 	 *
@@ -154,16 +139,28 @@ abstract class StringHelper
 	 */
 	public static function is_ascii($str)
 	{
-		if (!function_exists('utf8_is_ascii'))
-		{
-			require_once __DIR__ . '/phputf8/utils/ascii.php';
-		}
-
 		return utf8_is_ascii($str);
 	}
 
 	/**
-	 * UTF-8 aware alternative to strpos.
+	 * UTF-8 aware alternative to ord()
+	 *
+	 * Returns the unicode ordinal for a character.
+	 *
+	 * @param   string  $chr  UTF-8 encoded character
+	 *
+	 * @return  integer Unicode ordinal for the character
+	 *
+	 * @see     http://www.php.net/ord
+	 * @since   1.4.0
+	 */
+	public static function ord($chr)
+	{
+		return utf8_ord($chr);
+	}
+
+	/**
+	 * UTF-8 aware alternative to strpos()
 	 *
 	 * Find position of first occurrence of a string.
 	 *
@@ -187,8 +184,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to strrpos
-	 * Finds position of last occurrence of a string
+	 * UTF-8 aware alternative to strrpos()
+	 *
+	 * Finds position of last occurrence of a string.
 	 *
 	 * @param   string   $str     String being examined.
 	 * @param   string   $search  String being searched for.
@@ -205,8 +203,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to substr
-	 * Return part of a string given character offset (and optionally length)
+	 * UTF-8 aware alternative to substr()
+	 *
+	 * Return part of a string given character offset (and optionally length).
 	 *
 	 * @param   string   $str     String being processed
 	 * @param   integer  $offset  Number of UTF-8 characters offset (from left)
@@ -228,13 +227,12 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to strtlower
+	 * UTF-8 aware alternative to strtolower()
 	 *
 	 * Make a string lowercase
-	 * Note: The concept of a characters "case" only exists is some alphabets
-	 * such as Latin, Greek, Cyrillic, Armenian and archaic Georgian - it does
-	 * not exist in the Chinese alphabet, for example. See Unicode Standard
-	 * Annex #21: Case Mappings
+	 *
+	 * Note: The concept of a characters "case" only exists is some alphabets such as Latin, Greek, Cyrillic, Armenian and archaic Georgian - it does
+	 * not exist in the Chinese alphabet, for example. See Unicode Standard Annex #21: Case Mappings
 	 *
 	 * @param   string  $str  String being processed
 	 *
@@ -249,12 +247,12 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to strtoupper
+	 * UTF-8 aware alternative to strtoupper()
+	 *
 	 * Make a string uppercase
-	 * Note: The concept of a characters "case" only exists is some alphabets
-	 * such as Latin, Greek, Cyrillic, Armenian and archaic Georgian - it does
-	 * not exist in the Chinese alphabet, for example. See Unicode Standard
-	 * Annex #21: Case Mappings
+	 *
+	 * Note: The concept of a characters "case" only exists is some alphabets such as Latin, Greek, Cyrillic, Armenian and archaic Georgian - it does
+	 * not exist in the Chinese alphabet, for example. See Unicode Standard Annex #21: Case Mappings
 	 *
 	 * @param   string  $str  String being processed
 	 *
@@ -269,15 +267,15 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to strlen.
+	 * UTF-8 aware alternative to strlen()
 	 *
-	 * Returns the number of characters in the string (NOT THE NUMBER OF BYTES),
+	 * Returns the number of characters in the string (NOT THE NUMBER OF BYTES).
 	 *
 	 * @param   string  $str  UTF-8 string.
 	 *
 	 * @return  integer  Number of UTF-8 characters in string.
 	 *
-	 * @see http://www.php.net/strlen
+	 * @see     http://www.php.net/strlen
 	 * @since   1.3.0
 	 */
 	public static function strlen($str)
@@ -286,8 +284,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to str_ireplace
-	 * Case-insensitive version of str_replace
+	 * UTF-8 aware alternative to str_ireplace()
+	 *
+	 * Case-insensitive version of str_replace()
 	 *
 	 * @param   string   $search   String to search
 	 * @param   string   $replace  Existing string to replace
@@ -301,11 +300,6 @@ abstract class StringHelper
 	 */
 	public static function str_ireplace($search, $replace, $str, $count = null)
 	{
-		if (!function_exists('utf8_ireplace'))
-		{
-			require_once __DIR__ . '/phputf8/str_ireplace.php';
-		}
-
 		if ($count === false)
 		{
 			return utf8_ireplace($search, $replace, $str);
@@ -315,8 +309,30 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to str_split
-	 * Convert a string to an array
+	 * UTF-8 aware alternative to str_pad()
+	 *
+	 * Pad a string to a certain length with another string.
+	 * $padStr may contain multi-byte characters.
+	 *
+	 * @param   string   $input   The input string.
+	 * @param   integer  $length  If the value is negative, less than, or equal to the length of the input string, no padding takes place.
+	 * @param   string   $padStr  The string may be truncated if the number of padding characters can't be evenly divided by the string's length.
+	 * @param   integer  $type    The type of padding to apply
+	 *
+	 * @return  string
+	 *
+	 * @see     http://www.php.net/str_pad
+	 * @since   1.4.0
+	 */
+	public static function str_pad($input, $length, $padStr = ' ', $type = STR_PAD_RIGHT)
+	{
+		return utf8_str_pad($input, $length, $padStr, $type);
+	}
+
+	/**
+	 * UTF-8 aware alternative to str_split()
+	 *
+	 * Convert a string to an array.
 	 *
 	 * @param   string   $str        UTF-8 encoded string to process
 	 * @param   integer  $split_len  Number to characters to split string by
@@ -328,17 +344,13 @@ abstract class StringHelper
 	 */
 	public static function str_split($str, $split_len = 1)
 	{
-		if (!function_exists('utf8_str_split'))
-		{
-			require_once __DIR__ . '/phputf8/str_split.php';
-		}
-
 		return utf8_str_split($str, $split_len);
 	}
 
 	/**
-	 * UTF-8/LOCALE aware alternative to strcasecmp
-	 * A case insensitive string comparison
+	 * UTF-8/LOCALE aware alternative to strcasecmp()
+	 *
+	 * A case insensitive string comparison.
 	 *
 	 * @param   string  $str1    string 1 to compare
 	 * @param   string  $str2    string 2 to compare
@@ -384,8 +396,8 @@ abstract class StringHelper
 			}
 
 			return strcoll(
-				self::transcode(utf8_strtolower($str1), 'UTF-8', $encoding),
-				self::transcode(utf8_strtolower($str2), 'UTF-8', $encoding)
+				static::transcode(utf8_strtolower($str1), 'UTF-8', $encoding),
+				static::transcode(utf8_strtolower($str2), 'UTF-8', $encoding)
 			);
 		}
 
@@ -393,8 +405,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8/LOCALE aware alternative to strcmp
-	 * A case sensitive string comparison
+	 * UTF-8/LOCALE aware alternative to strcmp()
+	 *
+	 * A case sensitive string comparison.
 	 *
 	 * @param   string  $str1    string 1 to compare
 	 * @param   string  $str2    string 2 to compare
@@ -439,15 +452,16 @@ abstract class StringHelper
 				return strcoll($str1, $str2);
 			}
 
-			return strcoll(self::transcode($str1, 'UTF-8', $encoding), self::transcode($str2, 'UTF-8', $encoding));
+			return strcoll(static::transcode($str1, 'UTF-8', $encoding), static::transcode($str2, 'UTF-8', $encoding));
 		}
 
 		return strcmp($str1, $str2);
 	}
 
 	/**
-	 * UTF-8 aware alternative to strcspn
-	 * Find length of initial segment not matching mask
+	 * UTF-8 aware alternative to strcspn()
+	 *
+	 * Find length of initial segment not matching mask.
 	 *
 	 * @param   string   $str     The string to process
 	 * @param   string   $mask    The mask
@@ -461,11 +475,6 @@ abstract class StringHelper
 	 */
 	public static function strcspn($str, $mask, $start = null, $length = null)
 	{
-		if (!function_exists('utf8_strcspn'))
-		{
-			require_once __DIR__ . '/phputf8/strcspn.php';
-		}
-
 		if ($start === false && $length === false)
 		{
 			return utf8_strcspn($str, $mask);
@@ -480,10 +489,10 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to stristr
-	 * Returns all of haystack from the first occurrence of needle to the end.
-	 * needle and haystack are examined in a case-insensitive manner
-	 * Find first occurrence of a string using case insensitive comparison
+	 * UTF-8 aware alternative to stristr()
+	 *
+	 * Returns all of haystack from the first occurrence of needle to the end. Needle and haystack are examined in a case-insensitive manner to
+	 * find the first occurrence of a string using case insensitive comparison.
 	 *
 	 * @param   string  $str     The haystack
 	 * @param   string  $search  The needle
@@ -495,17 +504,13 @@ abstract class StringHelper
 	 */
 	public static function stristr($str, $search)
 	{
-		if (!function_exists('utf8_stristr'))
-		{
-			require_once __DIR__ . '/phputf8/stristr.php';
-		}
-
 		return utf8_stristr($str, $search);
 	}
 
 	/**
-	 * UTF-8 aware alternative to strrev
-	 * Reverse a string
+	 * UTF-8 aware alternative to strrev()
+	 *
+	 * Reverse a string.
 	 *
 	 * @param   string  $str  String to be reversed
 	 *
@@ -516,17 +521,13 @@ abstract class StringHelper
 	 */
 	public static function strrev($str)
 	{
-		if (!function_exists('utf8_strrev'))
-		{
-			require_once __DIR__ . '/phputf8/strrev.php';
-		}
-
 		return utf8_strrev($str);
 	}
 
 	/**
-	 * UTF-8 aware alternative to strspn
-	 * Find length of initial segment matching mask
+	 * UTF-8 aware alternative to strspn()
+	 *
+	 * Find length of initial segment matching mask.
 	 *
 	 * @param   string   $str     The haystack
 	 * @param   string   $mask    The mask
@@ -540,11 +541,6 @@ abstract class StringHelper
 	 */
 	public static function strspn($str, $mask, $start = null, $length = null)
 	{
-		if (!function_exists('utf8_strspn'))
-		{
-			require_once __DIR__ . '/phputf8/strspn.php';
-		}
-
 		if ($start === null && $length === null)
 		{
 			return utf8_strspn($str, $mask);
@@ -559,8 +555,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware substr_replace
-	 * Replace text within a portion of a string
+	 * UTF-8 aware alternative to substr_replace()
+	 *
+	 * Replace text within a portion of a string.
 	 *
 	 * @param   string   $str     The haystack
 	 * @param   string   $repl    The replacement string
@@ -586,10 +583,8 @@ abstract class StringHelper
 	/**
 	 * UTF-8 aware replacement for ltrim()
 	 *
-	 * Strip whitespace (or other characters) from the beginning of a string
-	 * You only need to use this if you are supplying the charlist
-	 * optional arg and it contains UTF-8 characters. Otherwise ltrim will
-	 * work normally on a UTF-8 string
+	 * Strip whitespace (or other characters) from the beginning of a string. You only need to use this if you are supplying the charlist
+	 * optional arg and it contains UTF-8 characters. Otherwise ltrim will work normally on a UTF-8 string.
 	 *
 	 * @param   string  $str       The string to be trimmed
 	 * @param   string  $charlist  The optional charlist of additional characters to trim
@@ -606,11 +601,6 @@ abstract class StringHelper
 			return $str;
 		}
 
-		if (!function_exists('utf8_ltrim'))
-		{
-			require_once __DIR__ . '/phputf8/trim.php';
-		}
-
 		if ($charlist === false)
 		{
 			return utf8_ltrim($str);
@@ -621,10 +611,9 @@ abstract class StringHelper
 
 	/**
 	 * UTF-8 aware replacement for rtrim()
-	 * Strip whitespace (or other characters) from the end of a string
-	 * You only need to use this if you are supplying the charlist
-	 * optional arg and it contains UTF-8 characters. Otherwise rtrim will
-	 * work normally on a UTF-8 string
+	 *
+	 * Strip whitespace (or other characters) from the end of a string. You only need to use this if you are supplying the charlist
+	 * optional arg and it contains UTF-8 characters. Otherwise rtrim will work normally on a UTF-8 string.
 	 *
 	 * @param   string  $str       The string to be trimmed
 	 * @param   string  $charlist  The optional charlist of additional characters to trim
@@ -641,11 +630,6 @@ abstract class StringHelper
 			return $str;
 		}
 
-		if (!function_exists('utf8_rtrim'))
-		{
-			require_once __DIR__ . '/phputf8/trim.php';
-		}
-
 		if ($charlist === false)
 		{
 			return utf8_rtrim($str);
@@ -656,10 +640,9 @@ abstract class StringHelper
 
 	/**
 	 * UTF-8 aware replacement for trim()
-	 * Strip whitespace (or other characters) from the beginning and end of a string
-	 * Note: you only need to use this if you are supplying the charlist
-	 * optional arg and it contains UTF-8 characters. Otherwise trim will
-	 * work normally on a UTF-8 string
+	 *
+	 * Strip whitespace (or other characters) from the beginning and end of a string. You only need to use this if you are supplying the charlist
+	 * optional arg and it contains UTF-8 characters. Otherwise trim will work normally on a UTF-8 string
 	 *
 	 * @param   string  $str       The string to be trimmed
 	 * @param   string  $charlist  The optional charlist of additional characters to trim
@@ -676,11 +659,6 @@ abstract class StringHelper
 			return $str;
 		}
 
-		if (!function_exists('utf8_trim'))
-		{
-			require_once __DIR__ . '/phputf8/trim.php';
-		}
-
 		if ($charlist === false)
 		{
 			return utf8_trim($str);
@@ -690,8 +668,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to ucfirst
-	 * Make a string's first character uppercase or all words' first character uppercase
+	 * UTF-8 aware alternative to ucfirst()
+	 *
+	 * Make a string's first character uppercase or all words' first character uppercase.
 	 *
 	 * @param   string  $str           String to be processed
 	 * @param   string  $delimiter     The words delimiter (null means do not split the string)
@@ -706,11 +685,6 @@ abstract class StringHelper
 	 */
 	public static function ucfirst($str, $delimiter = null, $newDelimiter = null)
 	{
-		if (!function_exists('utf8_ucfirst'))
-		{
-			require_once __DIR__ . '/phputf8/ucfirst.php';
-		}
-
 		if ($delimiter === null)
 		{
 			return utf8_ucfirst($str);
@@ -725,8 +699,9 @@ abstract class StringHelper
 	}
 
 	/**
-	 * UTF-8 aware alternative to ucwords
-	 * Uppercase the first character of each word in a string
+	 * UTF-8 aware alternative to ucwords()
+	 *
+	 * Uppercase the first character of each word in a string.
 	 *
 	 * @param   string  $str  String to be processed
 	 *
@@ -737,11 +712,6 @@ abstract class StringHelper
 	 */
 	public static function ucwords($str)
 	{
-		if (!function_exists('utf8_ucwords'))
-		{
-			require_once __DIR__ . '/phputf8/ucwords.php';
-		}
-
 		return utf8_ucwords($str);
 	}
 
@@ -792,45 +762,32 @@ abstract class StringHelper
 	 */
 	public static function valid($str)
 	{
-		if (!function_exists('utf8_is_valid'))
-		{
-			require_once __DIR__ . '/phputf8/utils/validation.php';
-		}
-
 		return utf8_is_valid($str);
 	}
 
 	/**
-	 * Tests whether a string complies as UTF-8. This will be much
-	 * faster than utf8_is_valid but will pass five and six octet
-	 * UTF-8 sequences, which are not supported by Unicode and
-	 * so cannot be displayed correctly in a browser. In other words
-	 * it is not as strict as utf8_is_valid but it's faster. If you use
-	 * it to validate user input, you place yourself at the risk that
-	 * attackers will be able to inject 5 and 6 byte sequences (which
-	 * may or may not be a significant risk, depending on what you are
-	 * are doing)
+	 * Tests whether a string complies as UTF-8.
+	 *
+	 * This will be much faster than StringHelper::valid() but will pass five and six octet UTF-8 sequences, which are not supported by Unicode and
+	 * so cannot be displayed correctly in a browser. In other words it is not as strict as StringHelper::valid() but it's faster. If you use it to
+	 * validate user input, you place yourself at the risk that attackers will be able to inject 5 and 6 byte sequences (which may or may not be a
+	 * significant risk, depending on what you are are doing).
 	 *
 	 * @param   string  $str  UTF-8 string to check
 	 *
 	 * @return  boolean  TRUE if string is valid UTF-8
 	 *
-	 * @see     valid
+	 * @see     StringHelper::valid
 	 * @see     http://www.php.net/manual/en/reference.pcre.pattern.modifiers.php#54805
 	 * @since   1.3.0
 	 */
 	public static function compliant($str)
 	{
-		if (!function_exists('utf8_compliant'))
-		{
-			require_once __DIR__ . '/phputf8/utils/validation.php';
-		}
-
 		return utf8_compliant($str);
 	}
 
 	/**
-	 * Converts Unicode sequences to UTF-8 string
+	 * Converts Unicode sequences to UTF-8 string.
 	 *
 	 * @param   string  $str  Unicode string to convert
 	 *
@@ -856,7 +813,7 @@ abstract class StringHelper
 	}
 
 	/**
-	 * Converts Unicode sequences to UTF-16 string
+	 * Converts Unicode sequences to UTF-16 string.
 	 *
 	 * @param   string  $str  Unicode string to convert
 	 *

--- a/libraries/vendor/paragonie/random_compat/lib/random.php
+++ b/libraries/vendor/paragonie/random_compat/lib/random.php
@@ -2,6 +2,9 @@
 /**
  * Random_* Compatibility Library
  * for using the new PHP 7 random_* API in PHP 5 projects
+ * 
+ * @version 1.4.1
+ * @released 2016-03-18
  *
  * The MIT License (MIT)
  *
@@ -89,10 +92,10 @@ if (PHP_VERSION_ID < 70000) {
                     PATH_SEPARATOR,
                     strtolower($RandomCompat_basedir)
                 );
-                $RandomCompatUrandom = in_array(
-                    '/dev',
+                $RandomCompatUrandom = (array() !== array_intersect(
+                    array('/dev', '/dev/', '/dev/urandom'),
                     $RandomCompat_open_basedir
-                );
+                ));
                 $RandomCompat_open_basedir = null;
             }
 
@@ -114,7 +117,8 @@ if (PHP_VERSION_ID < 70000) {
             }
             // Unset variables after use
             $RandomCompat_basedir = null;
-            $RandomCompatUrandom = null;
+        } else {
+            $RandomCompatUrandom = false;
         }
 
         /**
@@ -126,6 +130,8 @@ if (PHP_VERSION_ID < 70000) {
             PHP_VERSION_ID >= 50307
             &&
             extension_loaded('mcrypt')
+            &&
+            (DIRECTORY_SEPARATOR !== '/' || $RandomCompatUrandom)
         ) {
             // Prevent this code from hanging indefinitely on non-Windows;
             // see https://bugs.php.net/bug.php?id=69833
@@ -137,6 +143,7 @@ if (PHP_VERSION_ID < 70000) {
                 require_once $RandomCompatDIR.'/random_bytes_mcrypt.php';
             }
         }
+        $RandomCompatUrandom = null;
 
         if (
             !function_exists('random_bytes')

--- a/libraries/vendor/symfony/polyfill-util/LICENSE
+++ b/libraries/vendor/symfony/polyfill-util/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2015 Fabien Potencier
+Copyright (c) 2014-2016 Fabien Potencier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libraries/vendor/symfony/yaml/Dumper.php
+++ b/libraries/vendor/symfony/yaml/Dumper.php
@@ -32,6 +32,10 @@ class Dumper
      */
     public function setIndentation($num)
     {
+        if ($num < 1) {
+            throw new \InvalidArgumentException('The indentation must be greater than zero.');
+        }
+
         $this->indentation = (int) $num;
     }
 

--- a/libraries/vendor/symfony/yaml/Yaml.php
+++ b/libraries/vendor/symfony/yaml/Yaml.php
@@ -88,6 +88,10 @@ class Yaml
      */
     public static function dump($array, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
     {
+        if ($indent < 1) {
+            throw new \InvalidArgumentException('The indentation must be greater than zero.');
+        }
+
         $yaml = new Dumper();
         $yaml->setIndentation($indent);
 


### PR DESCRIPTION
#### Summary of Changes

The following production dependencies are updated:
- Updating joomla/string (1.3.1) to joomla/string (1.4.0) ([Diff](https://github.com/joomla-framework/string/compare/1.3.1...1.4.0))
- Updating joomla/application (1.5.0) to joomla/application (1.5.1) ([Diff](https://github.com/joomla-framework/application/compare/1.5.0...1.5.1))
- Updating joomla/event (1.1.1) to joomla/event (1.2.0) ([Diff](https://github.com/joomla-framework/event/compare/1.1.1...1.2.0))
- Updating paragonie/random_compat (v1.2.1) to paragonie/random_compat (v1.4.1) ([Diff](https://github.com/paragonie/random_compat/compare/v1.2.1...v1.4.1))
- Updating symfony/polyfill-util (v1.0.0) to symfony/polyfill-util (v1.1.1) ([Diff](https://github.com/symfony/polyfill-util/compare/v1.0.0...v1.1.1))
- Updating symfony/polyfill-php56 (v1.1.0) to symfony/polyfill-php56 (v1.1.1) ([Diff](https://github.com/symfony/polyfill-php56/compare/v1.0.0...v1.1.1))
- Updating symfony/yaml (v2.8.3) to symfony/yaml (v2.8.4) ([Diff](https://github.com/symfony/yaml/compare/v2.8.3...v2.8.4))

The following development dependencies are updated:
- Updating sebastian/environment (1.3.3) to sebastian/environment (1.3.5)
- Updating phpspec/prophecy (v1.5.0) to phpspec/prophecy (v1.6.0)
- Updating phpunit/phpunit (4.8.23) to phpunit/phpunit (4.8.24)

Additionally, removes the direct import and use of a phputf8 library function from the `JApplicationWeb` class and uses the `StringHelper` class to access it (required because the new String package tag instructs Composer to include several files from the library as part of the autoloader configuration).
#### Testing Instructions

The CMS continues to function normally.  Operations affected by these updates include:
- Generation of random values (the secret key in the config or random user passwords)
- Redirects on web requests
- Operation of the `JStringInflector` class (aliased to `Joomla\String\Inflector`), specifically correcting internal class references which would have prevented correct operation on a PHP 7 platform

Additionally, two additional methods from the `phputf8` library are exposed via the updated `StringHelper` class.  These are utf8 aware alternatives to PHP's `ord()` and `str_pad()` functions.
