### PR TITLE
Fix missing redirect to the URL configured in com_user in multilanguage environment

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -549,8 +549,14 @@ class PlgSystemLanguageFilter extends JPlugin
 				$lang_code = $this->current_lang;
 			}
 
+			if (is_null($this->app->getUserState('users.login.form.return'))) {
 			// Try to get association from the current active menu item
 			$active = $menu->getActive();
+			}
+			else{
+				$items = $menu->getItems( 'link', $this->app->getUserState('users.login.form.return'));
+				$active = $items[0];
+			}
 			$foundAssociation = false;
 
 			if ($active)
@@ -565,6 +571,10 @@ class PlgSystemLanguageFilter extends JPlugin
 					$associationItemid = $associations[$lang_code];
 					$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
 					$foundAssociation = true;
+				}
+				elseif (!is_null($this->app->getUserState('users.login.form.return')))
+				{
+					$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $active->id);
 				}
 				elseif ($active->home)
 				{

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -373,7 +373,7 @@ class PlgUserProfile extends JPlugin
 		$option     = JFactory::getApplication()->input->getCmd('option');
 		$tosarticle = $this->params->get('register_tos_article');
 		$tosenabled = ($this->params->get('register-require_tos', 0) == 2) ? true : false;
-		if (($task == 'register') && ($tosenabled) && ($tosarticle) && ($option == 'com_user'))
+		if (($task == 'register') && ($tosenabled) && ($tosarticle) && ($option == 'com_users'))
 		{
 			// Check that the tos is checked.
 			if ((!($data['profile']['tos'])))


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Added to onUserLogin method of Class PlgSystemLanguageFilter some further test to take into account a previously set users.login.form.return parameter that the plugin incorrectly overwrite in case of MultiLanguage menu association.
#### Testing Instructions
- configure a redirect URL in the Option of the Login Form menu item 
- install at least one optional language for contents, we take here Italian for instance
- activate the Language Filter plugin and set its option to “Automatic Language Change” to YES and “Item Associations” to YES
- create a user that have his front language configured as Italian in his profile
- publish a Language Module switcher
- create one menu for English language and one menu for Italian language associating all the menu in English with the corresponding menu language in Italian as follow
- after have published the menus on the front end for the corresponding languages, set the language to English using the Language Switcher Flags
- try to log in with the user you created before that has in his profile the Italian language as user language front end
- the system just after the login will try to switch automatically the front end language to Italian in order to follow the user profile preference, but the redirection configured in the User Profile option will not work anymore

A PDF file with some screenshots is also attached to better describe the testing environment. The bug is not related to the "Login for Guest / Logout for registered" method shown in the PDF, but this use case underline the importance of having the redirect after login working, since without it Joomla will raise an access denied error.

[languagefilter.pdf](https://github.com/joomla/joomla-cms/files/200684/languagefilter.pdf)
