### PR TITLE
[Installation] Languages view UX improvements

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -136,6 +136,7 @@ INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 ;Languages view
 INSTL_LANGUAGES="Install Language packages"
 INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE="Language"
+INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE_TAG="Language Tag"
 INSTL_LANGUAGES_COLUMN_HEADER_VERSION="Version"
 INSTL_LANGUAGES_DESC="The Joomla interface is available in several languages. Choose your preferred languages by choosing the checkboxes and then install them by selecting the Next button.<br />Note: this operation will take about 10 seconds to download and install every language. To avoid timeouts please select no more than 3 languages to install."
 INSTL_LANGUAGES_MESSAGE_PLEASE_WAIT="This operation will take up to 10 seconds per language to complete<br />Please wait while we download and install the languages ..."

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -106,7 +106,7 @@ class InstallationModelLanguages extends JModelBase
 			$query = $db->getQuery(true);
 
 			// Select the required fields from the updates table.
-			$query->select($db->qn(array('update_id', 'name', 'version')))
+			$query->select($db->qn(array('update_id', 'name', 'element', 'version')))
 				->from($db->qn('#__updates'))
 				->order($db->qn('name'));
 

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -70,35 +70,46 @@ $version = new JVersion;
 		<table class="table table-striped table-condensed">
 			<thead>
 					<tr>
+						<th width="1%" class="center">
+							&nbsp;
+						</th>
 						<th>
 							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE'); ?>
 						</th>
-						<th>
+						<th width="15%">
+							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_LANGUAGE_TAG'); ?>
+						</th>
+						<th width="5%" class="center">
 							<?php echo JText::_('INSTL_LANGUAGES_COLUMN_HEADER_VERSION'); ?>
 						</th>
 					</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->items as $i => $language) : ?>
+				<?php
+				$version = new JVersion;
+				$currentShortVersion = preg_replace('#^([0-9\.]+)(|.*)$#', '$1', $version->getShortVersion());
+				foreach ($this->items as $i => $language) : 
+					// Get language code and language image.
+					preg_match('#^pkg_([a-z]{2,3}-[A-Z]{2})$#', $language->element, $element);
+					$language->code = $element[1];
+				?>
 					<tr>
 						<td>
-							<label class="checkbox">
-								<input
-									type="checkbox"
-									id="cb<?php echo $i; ?>"
-									name="cid[]"
-									value="<?php echo $language->update_id; ?>"
-									/> <?php echo $language->name; ?>
-
-									<?php // Display a Note if language pack version is not equal to Joomla version ?>
-									<?php if (substr($language->version, 0, 3) != $version::RELEASE
-											|| substr($language->version, 0, 5) != $version->getShortVersion()) : ?>
-										<div class="small"><?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?></div>
-									<?php endif; ?>
-							</label>
+							<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $language->update_id; ?>" />
 						</td>
 						<td>
-							<span class="badge"><?php echo $language->version; ?></span>
+							<label for="cb<?php echo $i; ?>"><?php echo $language->name; ?></label>
+						</td>
+						<td>
+							<?php echo $language->code; ?>
+  						</td>
+						<td class="center">
+						<?php // Display a Note if language pack version is not equal to Joomla version ?>
+						<?php if (substr($language->version, 0, 3) != $version::RELEASE || substr($language->version, 0, 5) != $currentShortVersion) : ?>
+							<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
+						<?php else : ?>
+							<span class="label label-success"><?php echo $language->version; ?></span>
+						<?php endif; ?>
 						</td>
 					</tr>
 				<?php endforeach; ?>

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -88,7 +88,7 @@ $version = new JVersion;
 				<?php
 				$version = new JVersion;
 				$currentShortVersion = preg_replace('#^([0-9\.]+)(|.*)$#', '$1', $version->getShortVersion());
-				foreach ($this->items as $i => $language) : 
+				foreach ($this->items as $i => $language) :
 					// Get language code and language image.
 					preg_match('#^pkg_([a-z]{2,3}-[A-Z]{2})$#', $language->element, $element);
 					$language->code = $element[1];


### PR DESCRIPTION
#### Summary of Changes

Following https://github.com/joomla/joomla-cms/pull/9089 wihich gave some UX improvements to com_installer languages view, this PR does the same thing for the languages view in the installer.
###### Before patch

![image](https://cloud.githubusercontent.com/assets/9630530/14228457/831f76f8-f90d-11e5-91b8-bfdf828704b7.png)
###### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/14228473/c0bf49de-f90d-11e5-95ce-04071a0666a7.png)
#### Testing Instructions
##### Lazy test
1. Use your current staging (with installation directory)
2. Go to http://yourdomain.tld/installation/index.php?view=languages&lang=en-GB and you will see the "Before patch" scenario
3. Apply this patch
4. Repeat step 2 and you will see the "After patch" scenario
##### Normal test
1. Download and make a new install with this joomla package (https://github.com/andrepereiradasilva/joomla-cms/archive/installer-languages-ux-improvements.zip)
2. Install without sample data (so you can install languages later)
3. When you reach the languages install part you will see the "After patch" scenario
4. Test if language install works fine.
