### PR TITLE
[com_templates] Only show enabled templates in templates view

### DIFF
--- a/administrator/components/com_templates/models/templates.php
+++ b/administrator/components/com_templates/models/templates.php
@@ -88,8 +88,8 @@ class TemplatesModelTemplates extends JModelList
 		);
 		$query->from($db->quoteName('#__extensions') . ' AS a');
 
-		// Filter by extension type.
-		$query->where($db->quoteName('type') . ' = ' . $db->quote('template'));
+		// Filter by extension enabled and extension type.
+		$query->where('a.enabled = 1')->where('a.type = ' . $db->quote('template'));
 
 		// Filter by client.
 		$clientId = $this->getState('filter.client_id');


### PR DESCRIPTION
Pull Request for new Issue.
#### Summary of Changes

When you have a template disabled (e.g. beez3) although the template doesn't appear in `Extensions -> Templates -> Styles`, it appears in `Extensions -> Templates -> Templates`.

To solve this issue, this simple PR adds a additional where to the `com_templates` `templates` model query.
#### Testing Instructions
##### Fast test

Experience developer can check code difference.
##### Normal test
1. Use 3.5.0 or latest staging
2. Go to  `Extensions -> Manage -> Manage`, filter by `Type = Template` and disable beez3 and hathor.
3. Now go to  `Extensions -> Templates -> Styles` and check that hathor and beez3 are not there.
4. Now go to  `Extensions -> Templates -> Templates` and check that hathor and beez3 ARE there.
5. Apply this patch
6. Repeat steps 2 to 4 and check that hathor and beez3 ARE NOT there.
