### PR TITLE
[imp] Multilanguage: allowing any login redirection from login module or login/logout menu items

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -137,8 +137,8 @@ class UsersControllerUser extends UsersController
 	public function menulogout()
 	{
 		// Get the ItemID of the page to redirect after logout
-		$itemid = JFactory::getApplication()->getMenu()->getActive()->params->get('logout');
-		$app = JFactory::getApplication();
+		$app    = JFactory::getApplication();
+		$itemid = $app->getMenu()->getActive()->params->get('logout');
 
 		// Get the language of the page when multilang is on
 		if (JLanguageMultilang::isEnabled())

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -139,8 +139,43 @@ class UsersControllerUser extends UsersController
 		// Get the ItemID of the page to redirect after logout
 		$itemid = JFactory::getApplication()->getMenu()->getActive()->params->get('logout');
 
+		// Get the language of the page when multilang is on
+		if (JLanguageMultilang::isEnabled())
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('language')
+				->from($db->quoteName('#__menu'))
+				->where('client_id = 0')
+				->where('id =' . $itemid);
+
+			$db->setQuery($query);
+
+			try
+			{
+				$language = $db->loadResult();
+			}
+			catch (RuntimeException $e)
+			{
+				return;
+			}
+
+			if ($language !== '*')
+			{
+				$lang = '&lang=' . $language;
+			}
+			else
+			{
+				$lang = '';
+			}
+		}
+		else
+		{
+			$lang = '';
+		}
+
 		// URL to redirect after logout, default page if no ItemID is set
-		$url = $itemid ? 'index.php?Itemid=' . $itemid : JURI::root();
+		$url = $itemid ? 'index.php?Itemid=' . $itemid . $lang : JURI::root();
 
 		// Logout and redirect
 		$this->setRedirect('index.php?option=com_users&task=user.logout&' . JSession::getFormToken() . '=1&return=' . base64_encode($url));

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -137,60 +137,10 @@ class UsersControllerUser extends UsersController
 	public function menulogout()
 	{
 		// Get the ItemID of the page to redirect after logout
-		$app    = JFactory::getApplication();
-		$itemid = $app->getMenu()->getActive()->params->get('logout');
+		$itemid = JFactory::getApplication()->getMenu()->getActive()->params->get('logout');
 
-		// Get the language of the page when multilang is on
-		if (JLanguageMultilang::isEnabled())
-		{
-			if ($itemid)
-			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select('language')
-					->from($db->quoteName('#__menu'))
-					->where('client_id = 0')
-					->where('id =' . $itemid);
-
-				$db->setQuery($query);
-
-				try
-				{
-					$language = $db->loadResult();
-				}
-				catch (RuntimeException $e)
-				{
-					return;
-				}
-
-				if ($language !== '*')
-				{
-					$lang = '&lang=' . $language;
-				}
-				else
-				{
-					$lang = '';
-				}
-
-				// URL to redirect after logout
-				$url = 'index.php?Itemid=' . $itemid . $lang;
-			}
-			else
-			{
-				// Logout is set to default. Get the home page ItemID
-				$lang_code = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
-				$item      = $app->getMenu()->getDefault($lang_code);
-				$itemid    = $item->id;
-
-				// Redirect to Home page after logout
-				$url = 'index.php?Itemid=' . $itemid;
-			}
-		}
-		else
-		{
-			// URL to redirect after logout, default page if no ItemID is set
-			$url = $itemid ? 'index.php?Itemid=' . $itemid : JURI::root();
-		}
+		// URL to redirect after logout, default page if no ItemID is set
+		$url = $itemid ? 'index.php?Itemid=' . $itemid : JURI::root();
 
 		// Logout and redirect
 		$this->setRedirect('index.php?option=com_users&task=user.logout&' . JSession::getFormToken() . '=1&return=' . base64_encode($url));

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -138,44 +138,59 @@ class UsersControllerUser extends UsersController
 	{
 		// Get the ItemID of the page to redirect after logout
 		$itemid = JFactory::getApplication()->getMenu()->getActive()->params->get('logout');
+		$app = JFactory::getApplication();
 
 		// Get the language of the page when multilang is on
 		if (JLanguageMultilang::isEnabled())
 		{
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select('language')
-				->from($db->quoteName('#__menu'))
-				->where('client_id = 0')
-				->where('id =' . $itemid);
-
-			$db->setQuery($query);
-
-			try
+			if ($itemid)
 			{
-				$language = $db->loadResult();
-			}
-			catch (RuntimeException $e)
-			{
-				return;
-			}
+				$db = JFactory::getDbo();
+				$query = $db->getQuery(true)
+					->select('language')
+					->from($db->quoteName('#__menu'))
+					->where('client_id = 0')
+					->where('id =' . $itemid);
 
-			if ($language !== '*')
-			{
-				$lang = '&lang=' . $language;
+				$db->setQuery($query);
+
+				try
+				{
+					$language = $db->loadResult();
+				}
+				catch (RuntimeException $e)
+				{
+					return;
+				}
+
+				if ($language !== '*')
+				{
+					$lang = '&lang=' . $language;
+				}
+				else
+				{
+					$lang = '';
+				}
+
+				// URL to redirect after logout
+				$url = 'index.php?Itemid=' . $itemid . $lang;
 			}
 			else
 			{
-				$lang = '';
+				// Logout is set to default. Get the home page ItemID
+				$lang_code = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+				$item      = $app->getMenu()->getDefault($lang_code);
+				$itemid    = $item->id;
+
+				// Redirect to Home page after logout
+				$url = 'index.php?Itemid=' . $itemid;
 			}
 		}
 		else
 		{
-			$lang = '';
+			// URL to redirect after logout, default page if no ItemID is set
+			$url = $itemid ? 'index.php?Itemid=' . $itemid : JURI::root();
 		}
-
-		// URL to redirect after logout, default page if no ItemID is set
-		$url = $itemid ? 'index.php?Itemid=' . $itemid . $lang : JURI::root();
 
 		// Logout and redirect
 		$this->setRedirect('index.php?option=com_users&task=user.logout&' . JSession::getFormToken() . '=1&return=' . base64_encode($url));

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -34,9 +34,16 @@ class ModLoginHelper
 
 		if ($item)
 		{
-			if ($item->language !== '*')
+			if (JLanguageMultilang::isEnabled())
 			{
-				$lang = '&lang=' . $item->language;
+				if ($item->language !== '*')
+				{
+					$lang = '&lang=' . $item->language;
+				}
+				else
+				{
+					$lang = '';
+				}
 			}
 			else
 			{

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -34,7 +34,16 @@ class ModLoginHelper
 
 		if ($item)
 		{
-			$url = 'index.php?Itemid=' . $item->id;
+			if ($item->language !== '*')
+			{
+				$lang = '&lang=' . $item->language;
+			}
+			else
+			{
+				$lang = '';
+			}
+
+			$url = 'index.php?Itemid=' . $item->id . $lang;
 		}
 		else
 		{

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -563,9 +563,27 @@ class PlgSystemLanguageFilter extends JPlugin
 						$associations = MenusHelper::getAssociations($active->id);
 					}
 
+					// The login menu item contains a redirection.
+					// This will override the automatic change to the user preferred language
 					if ($active->params['login_redirect_url'])
 					{
 						$this->app->setUserState('users.login.form.return', JRoute::_($this->app->getUserState('users.login.form.return'), false));
+					}
+					elseif ($this->app->getUserState('users.login.form.return'))
+					{
+						// The login module contains a menu item redirection. Try to get association from that menu item.
+						$itemid = preg_replace('/\D+/', '', $this->app->getUserState('users.login.form.return'));
+
+						if ($assoc)
+						{
+							$associations = MenusHelper::getAssociations($itemid);
+						}
+						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
+						{
+							$associationItemid = $associations[$lang_code];
+							$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
+							$foundAssociation = true;
+						}
 					}
 					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
@@ -770,5 +788,4 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		return $lang_code;
 	}
-
 }

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -578,6 +578,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						{
 							$associations = MenusHelper::getAssociations($itemid);
 						}
+
 						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 						{
 							$associationItemid = $associations[$lang_code];


### PR DESCRIPTION
Pull Request for Issue #9710 plus some

This PR allows choosing any redirection when login on a multilanguage site.
Before, in the login module as well as in the login or logout menu item, no redirection could be set.
Some redirections were only implemented when there were associations and Automatic change was set using the user preferred site language.
This should still work when no redirection is set.

But now, one can redirect to any menu item in the module without a 404 when the redirection is set to a menu item set to another language than the one displayed with the module, same for the logout menu item. I.e. **the user preferred language will be ignored in these cases.**
NEW: Except if the chosen menu item is associated to one in the user preferred language. See below.

For the login menu item, we do not use the same field `menuitem` than the module, i.e. it is a simple `text` field.

It implies the correct formatting of the url entered for the redirect url in the login menu item: it should always be an internal url and should include `&lang=xx-XX` in it in <b>non SEF</b> although a SEF url may work but not advised if moving site.

Examples: 
- index.php?option=com_content&view=article&id=151&catid=21<b>&lang=es-ES</b>&Itemid=131
- index.php?Itemid=136<b>&lang=fr-FR</b>

To test, patch and try all possibilites: with redirections or not, automatic language change set or not.
