### PR TITLE
[imp] Displaying language code in menuitem field

### DIFF
--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -169,8 +169,19 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			foreach ($items as $link)
 			{
 				$levelPrefix = str_repeat('- ', max(0, $link->level - 1));
+
+				// Displays language code if not set to All
+				if ($link->language !== '*')
+				{
+					$lang = ' (' . $link->language . ')';
+				}
+				else
+				{
+					$lang = '';
+				}
+
 				$groups[$menuType][] = JHtml::_('select.option',
-								$link->value, $levelPrefix . $link->text,
+								$link->value, $levelPrefix . $link->text . $lang,
 								'value',
 								'text',
 								in_array($link->type, $this->disable)
@@ -190,10 +201,23 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 				foreach ($menu->links as $link)
 				{
 					$levelPrefix = str_repeat('- ', $link->level - 1);
-					$groups[$menu->menutype][] = JHtml::_(
-						'select.option', $link->value, $levelPrefix . $link->text, 'value', 'text',
-						in_array($link->type, $this->disable)
-					);
+
+					// Displays language code if not set to All
+					if ($link->language !== '*')
+					{
+						$lang = ' (' . $link->language . ')';
+					}
+					else
+					{
+						$lang = '';
+					}
+
+					$groups[$menu->menutype][] = JHtml::_('select.option',
+										$link->value, $levelPrefix . $link->text . $lang,
+										'value',
+										'text',
+										in_array($link->type, $this->disable)
+									);
 				}
 			}
 		}


### PR DESCRIPTION
When the field `menuitem` is used, the list of menu items will now display the language code (xx-XX) when it is not set to "All" languages.

To test, edit for example the login module.
After patch one will get for the Login or Logout Redirection page:

![menuitem](https://cloud.githubusercontent.com/assets/869724/14273609/30f7e076-fb0c-11e5-8aba-788ee8b832db.png)
