### PR TITLE
[searchtools] Integrate searchtools no results message in the searchtools layout

### DIFF
--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -24,13 +24,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php else : ?>
 	<div id="j-main-container">
 	<?php endif; ?>
-		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
-		<div class="clearfix"></div>
-		<?php if (empty($this->data)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
-		<?php else : ?>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false, 'totalResults' => count($this->data)))); ?>
+		<?php if (count($this->data) > 0) : ?>
 		<table class="table table-striped">
 			<thead>
 				<tr>

--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -19,7 +19,9 @@ $customOptions = array(
 	'filtersHidden'       => isset($data['options']['filtersHidden']) ? $data['options']['filtersHidden'] : empty($data['view']->activeFilters),
 	'defaultLimit'        => isset($data['options']['defaultLimit']) ? $data['options']['defaultLimit'] : JFactory::getApplication()->get('list_limit', 20),
 	'searchFieldSelector' => '#filter_search',
-	'orderFieldSelector'  => '#list_fullordering'
+	'orderFieldSelector'  => '#list_fullordering',
+	'totalResults'        => isset($data['options']['totalResults']) ? $data['options']['totalResults'] : -1,
+	'noResultsText'       => isset($data['options']['noResultsText']) ? $data['options']['noResultsText'] : JText::_('JGLOBAL_NO_MATCHING_RESULTS'),
 );
 
 $data['options'] = array_merge($customOptions, $data['options']);
@@ -45,3 +47,6 @@ $filtersClass = $data['view']->activeFilters ? ' js-stools-container-filters-vis
 		<?php echo JLayoutHelper::render('joomla.searchtools.default.filters', $data); ?>
 	</div>
 </div>
+<?php if ($data['options']['totalResults'] === 0) : ?>
+	<?php echo JLayoutHelper::render('joomla.searchtools.default.noitems', $data); ?>
+<?php endif; ?>

--- a/layouts/joomla/searchtools/default/noitems.php
+++ b/layouts/joomla/searchtools/default/noitems.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$data = $displayData;
+?>
+<div class="alert alert-info alert-no-items">
+	<?php echo $data['options']['noResultsText']; ?>
+</div>


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

To make overrides simpler, this PR integrates the searchtools no results info in searchtools layout. This message is part of the searchtools so it should be there.

As a PoC i applied this only in com_cache cache view.

I also changed the background color of the searchtools no results message to be a info, not a warning. This change is only is the "new" layout, the "old" stays the same.
![image](https://cloud.githubusercontent.com/assets/9630530/14279451/3ac090bc-fb25-11e5-86e2-0b24b44e5f26.png)
##### Advantage
- After this PR you can now change all the searchtools look (including no results info) with a simple layout override.
- You retain the ability to change the no result text by passing the `noResultsText` variable to the layout.
#### Testing Instructions
1. Use latest staging
2. Apply patch
3. Go to "System -> Clear cache" (clear the cache if exists)
4. You will see a blue no results message.
5. Now to test B/C go to any other view (articles for instance) and search for something that does not return results (you will see the "old" yellow message)
#### Observations

B/C is preserved as the old method continues to work fine.

If this gets to RTC state i intend to make the changes needed in all the other views.
