### PR TITLE
[imp] Displaying language code in category field dropdown

### DIFF
--- a/libraries/legacy/form/field/category.php
+++ b/libraries/legacy/form/field/category.php
@@ -56,6 +56,25 @@ class JFormFieldCategory extends JFormFieldList
 				$options = JHtml::_('category.options', $extension);
 			}
 
+			// Displays language code if not set to All
+			foreach ($options as $option)
+			{
+				// Create a new query object.
+				$db = JFactory::getDbo();
+				$query = $db->getQuery(true)
+					->select($db->quoteName('language'))
+					->where($db->quoteName('id') . '=' . (int) $option->value)
+					->from($db->quoteName('#__categories'));
+
+				$db->setQuery($query);
+				$language = $db->loadResult();
+
+				if ($language !== '*')
+				{
+					$option->text = $option->text . ' (' . $language . ')';
+				}
+			}
+
 			// Verify permissions.  If the action attribute is set, then we scan the options.
 			if ((string) $this->element['action'])
 			{


### PR DESCRIPTION
Similar to #9735

When the field `category` is used, the list of categories will now display the language code (xx-XX) when it is not set to "All" languages.

To test, for example, create a category list menu item.
Click on the Choose a Category field (The field is used 28 times in core). You should get:

![screen shot 2016-04-05 at 12 36 14](https://cloud.githubusercontent.com/assets/869724/14280677/7f3ed302-fb34-11e5-8ad8-fdf8cf25282c.png)
