### PR TITLE
[categoryedit] - Added the category id at the end of the category name. So we can also search for category id.

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -141,11 +141,13 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 			if ($options[$i]->published == 1)
 			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+				$options[$i]->text = str_repeat('- ', $options[$i]->level)  .$options[$i]->text. ' (' . $options[$i]->value. ') ';
+		
 			}
 			else
 			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
+				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ' (' . $options[$i]->value. ')]';
+	
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

When we have a lot of categories to choose, with the same name (tipically in subcategories) it is impossible to choose the right category as a parent category. So i suggest to add the category id at the end of the category name. So we can also search for category id.
![2016-04-05_1811](https://cloud.githubusercontent.com/assets/897854/14289142/d657b134-fb59-11e5-8f25-9f8af161f623.png)
![2016-04-05_1812](https://cloud.githubusercontent.com/assets/897854/14289186/09e0fd62-fb5a-11e5-8b58-0defc66439c7.png)
