### PR TITLE
[imp] Displaying language code in categoryedit and categoryparent fields dropdowns

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -139,6 +139,16 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				}
 			}
 
+			// Displays language code if not set to All
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName('language'))
+				->where($db->quoteName('id') . '=' . (int) $options[$i]->value)
+				->from($db->quoteName('#__categories'));
+
+			$db->setQuery($query);
+			$language = $db->loadResult();
+
 			if ($options[$i]->published == 1)
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
@@ -146,6 +156,11 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			else
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
+			}
+
+			if ($language !== '*')
+			{
+				$options[$i]->text = $options[$i]->text . ' (' . $language . ')';
 			}
 		}
 

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -107,7 +107,22 @@ class JFormFieldCategoryParent extends JFormFieldList
 				$options[$i]->text = JText::_('JGLOBAL_ROOT_PARENT');
 			}
 
+			// Displays language code if not set to All
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName('language'))
+				->where($db->quoteName('id') . '=' . (int) $options[$i]->value)
+				->from($db->quoteName('#__categories'));
+
+			$db->setQuery($query);
+			$language = $db->loadResult();
+
 			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+
+			if ($language !== '*')
+			{
+				$options[$i]->text = $options[$i]->text . ' (' . $language . ')';
+			}
 		}
 
 		// Get the current user object.


### PR DESCRIPTION
Similar patches to https://github.com/joomla/joomla-cms/pull/9739

When the field categoryedit is used, the list of categories will now display the language code (xx-XX) when it is not set to "All" languages.

To test, for example, edit an article and click on the Parent field.

You should get:

![screen shot 2016-04-06 at 08 41 19](https://cloud.githubusercontent.com/assets/869724/14308002/6ec49bac-fbd3-11e5-9abb-fbff5cff8c4e.png)

Although the field `categoryparent` is not used in core (should it be tagged as deprecated?), it may be used by third party extensions. I therefore also modified it the same way.
To test, change in /administrator/components/com_categories/models/forms/category.xml the field name "parent_id" from

```
    <field
        name="parent_id"
        type="categoryedit"
        label="COM_CATEGORIES_FIELD_PARENT_LABEL"
        description="COM_CATEGORIES_FIELD_PARENT_DESC"/>
```

to

```
    <field
        name="parent_id"
        type="categoryparent"
        label="COM_CATEGORIES_FIELD_PARENT_LABEL"
        description="COM_CATEGORIES_FIELD_PARENT_DESC"/>
```

This patch, imho, is more important than https://github.com/joomla/joomla-cms/pull/9741, although I see the usefulness of #9741.

In an ideal world, both would be useful, but the dropdown width is so narrow that I am not sure we can add both the id and the language in the list.

In any case, we can merged this series with the language and decide later if displaying also the id in the 3 fields concerned if OK. 

Testers and comments welcome:
@brianteeman @MATsxm @SharkyKZ @andrepereiradasilva 
@joomla/cms-maintainers 
