### PR TITLE
Page Break error after upgrade Joomla 3.5.1

### DIFF
--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -101,15 +101,6 @@ class ContentController extends JControllerLegacy
 			return JError::raiseError(403, JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
 		}
 
-		if ($vName == 'article')
-		{
-			// Get/Create the model
-			if ($model = $this->getModel($vName))
-			{
-				$model->hit();
-			}
-		}
-
 		parent::display($cachable, $safeurlparams);
 
 		return $this;

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -300,7 +300,7 @@ class PlgContentJoomla extends JPlugin
 	}
 
 	/**
-	 * Change the state in core_content if the state in a table is changed
+	 * Count the hit of an content article after it was displayed.
 	 *
 	 * @param   string   $context  The context for the content passed to the plugin.
 	 * @param   object   $row      The row relating to the content that was displayed.

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -298,4 +298,14 @@ class PlgContentJoomla extends JPlugin
 
 		return true;
 	}
+
+	public function onContentAfterDisplay($context, &$row, &$params, $page=0)
+	{
+		if ($context == 'com_content.article')
+		{
+			$table = JTable::getInstance('Content', 'JTable');
+			$table->hit($row->id);
+		}
+		return null;
+	}
 }

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -299,13 +299,26 @@ class PlgContentJoomla extends JPlugin
 		return true;
 	}
 
-	public function onContentAfterDisplay($context, &$row, &$params, $page=0)
+	/**
+	 * Change the state in core_content if the state in a table is changed
+	 *
+	 * @param   string   $context  The context for the content passed to the plugin.
+	 * @param   object   $row      The row relating to the content that was displayed.
+	 * @param   object   $params   The params of the article
+	 * @param   integer  $page     The page value
+	 * 
+	 * @return  void
+	 *
+	 * @since   3.5.2
+	 */
+	public function onContentAfterDisplay($context, $row, $params, $page = 0)
 	{
 		if ($context == 'com_content.article')
 		{
 			$table = JTable::getInstance('Content', 'JTable');
 			$table->hit($row->id);
 		}
-		return null;
+
+		return;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #9748 .
#### Summary of Changes

Moved the article hit counter to the joomla content plugin event  onContentAfterDisplay
#### Testing Instructions

see #9748 
#### Comments

feedback is warmly wellcommed
