### PR TITLE
Simplify JMail::Send() and improve doc block

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -79,7 +79,8 @@ class JMail extends PHPMailer
 	/**
 	 * Send the mail
 	 *
-	 * @return  mixed  True if successful; JError if using legacy tree (no exception thrown in that case).
+	 * @return  boolean|JException  Boolean true if successful, boolean false if the `mailonline` configuration is set to 0,
+	 *                              or a JException object if the mail function does not exist or sending the message fails.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException
@@ -90,21 +91,13 @@ class JMail extends PHPMailer
 		{
 			if (($this->Mailer == 'mail') && !function_exists('mail'))
 			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseNotice(500, JText::_('JLIB_MAIL_FUNCTION_DISABLED'));
-				}
-				else
-				{
-					throw new RuntimeException(sprintf('%s::Send mail not enabled.', get_class($this)));
-				}
+				return JError::raiseNotice(500, JText::_('JLIB_MAIL_FUNCTION_DISABLED'));
 			}
 
 			try
 			{
 				// Try sending with default settings
 				$result = parent::send();
-
 			}
 			catch (phpmailerException $e)
 			{
@@ -134,24 +127,15 @@ class JMail extends PHPMailer
 
 			if ($result == false)
 			{
-				if (class_exists('JError'))
-				{
-					$result = JError::raiseNotice(500, JText::_($this->ErrorInfo));
-				}
-				else
-				{
-					throw new RuntimeException(sprintf('%s::Send failed: "%s".', get_class($this), $this->ErrorInfo));
-				}
+				$result = JError::raiseNotice(500, JText::_($this->ErrorInfo));
 			}
 
 			return $result;
 		}
-		else
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_MAIL_FUNCTION_OFFLINE'));
 
-			return false;
-		}
+		JFactory::getApplication()->enqueueMessage(JText::_('JLIB_MAIL_FUNCTION_OFFLINE'));
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
#### Summary of Changes
- Clarifies the doc block of `JMail::Send()` regarding its return values and the conditions they are returned in
- Removes `class_exists()` checks on `JError`, it exists in the CMS so there's no way this will throw exceptions
#### Testing Instructions

Review it
