### PR TITLE
JError doc block updates

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -9,13 +9,31 @@
 
 defined('JPATH_PLATFORM') or die;
 
-// Error Definition: Illegal Options
+/**
+ * Error Definition: Illegal Options
+ *
+ * @var    integer
+ * @since  11.1
+ * @deprecated  12.1 (Platform) & 4.0 (CMS)
+ */
 const JERROR_ILLEGAL_OPTIONS = 1;
 
-// Error Definition: Callback does not exist
+/**
+ * Error Definition: Callback does not exist
+ *
+ * @var    integer
+ * @since  11.1
+ * @deprecated  12.1 (Platform) & 4.0 (CMS)
+ */
 const JERROR_CALLBACK_NOT_CALLABLE = 2;
 
-// Error Definition: Illegal Handler
+/**
+ * Error Definition: Illegal Handler
+ *
+ * @var    integer
+ * @since  11.1
+ * @deprecated  12.1 (Platform) & 4.0 (CMS)
+ */
 const JERROR_ILLEGAL_MODE = 3;
 
 /**
@@ -40,6 +58,7 @@ abstract class JError
 	 *                  is present to allow an easy transition into exception handling for code written against the
 	 *                  existing JError API in Joomla.
 	 * @since  11.1
+	 * @deprecated  12.1 (Platform) & 4.0 (CMS)
 	 */
 	public static $legacy = false;
 
@@ -48,13 +67,16 @@ abstract class JError
 	 *
 	 * @var    array
 	 * @since  11.1
+	 * @deprecated  12.1 (Platform) & 4.0 (CMS)
 	 */
 	protected static $levels = array(E_NOTICE => 'Notice', E_WARNING => 'Warning', E_ERROR => 'Error');
 
 	/**
 	 * Array of message handlers
+	 *
 	 * @var    array
 	 * @since  11.1
+	 * @deprecated  12.1 (Platform) & 4.0 (CMS)
 	 */
 	protected static $handlers = array(
 		E_NOTICE => array('mode' => 'ignore'),
@@ -65,8 +87,9 @@ abstract class JError
 	/**
 	 * Array containing the error stack
 	 *
-	 * @var    array
+	 * @var    JException[]
 	 * @since  11.1
+	 * @deprecated  12.1 (Platform) & 4.0 (CMS)
 	 */
 	protected static $stack = array();
 
@@ -92,7 +115,7 @@ abstract class JError
 	 *
 	 * @param   boolean  $unset  True to remove the error from the stack.
 	 *
-	 * @return  mixed  Last exception object in the error stack or boolean false if none exist
+	 * @return  JException|boolean  Last JException object in the error stack or boolean false if none exist
 	 *
 	 * @deprecated  12.1
 	 * @since   11.1
@@ -121,7 +144,7 @@ abstract class JError
 	/**
 	 * Method for retrieving the exception stack
 	 *
-	 * @return  array  Chronological array of errors that have been stored during script execution
+	 * @return  JException[]  Chronological array of errors that have been stored during script execution
 	 *
 	 * @deprecated  12.1
 	 * @since   11.1
@@ -163,7 +186,7 @@ abstract class JError
 	 *                               like a database DSN).
 	 * @param   boolean  $backtrace  Add a stack backtrace to the exception.
 	 *
-	 * @return  mixed    The JException object
+	 * @return  JException
 	 *
 	 * @since       11.1
 	 * @deprecated  12.1  Use PHP Exception
@@ -182,9 +205,9 @@ abstract class JError
 	/**
 	 * Throw an error
 	 *
-	 * @param   object  &$exception  An exception to throw.
+	 * @param   JException  &$exception  An exception to throw.
 	 *
-	 * @return  reference
+	 * @return  JException  A reference to the handled JException object
 	 *
 	 * @deprecated  12.1  Use PHP Exception
 	 * @see     JException
@@ -241,7 +264,7 @@ abstract class JError
 	 *                         developer-relevant information that the user should
 	 *                         never see, like a database DSN).
 	 *
-	 * @return  object  $error  The configured JError object
+	 * @return  JException  $error  The thrown JException object
 	 *
 	 * @deprecated   12.1       Use PHP Exception
 	 * @see        JError::raise()
@@ -255,8 +278,7 @@ abstract class JError
 	}
 
 	/**
-	 * Wrapper method for the {@link raise()} method with predefined error level of E_WARNING and
-	 * backtrace set to false.
+	 * Wrapper method for the {@link raise()} method with predefined error level of E_WARNING and backtrace set to false.
 	 *
 	 * @param   string  $code  The application-internal error code for this error
 	 * @param   string  $msg   The error message, which may also be shown the user if need be.
@@ -264,7 +286,7 @@ abstract class JError
 	 *                         developer-relevant information that
 	 *                         the user should never see, like a database DSN).
 	 *
-	 * @return  object  The configured JError object
+	 * @return  JException  $error  The thrown JException object
 	 *
 	 * @deprecated  12.1  Use PHP Exception
 	 * @see        JError::raise()
@@ -278,8 +300,7 @@ abstract class JError
 	}
 
 	/**
-	 * Wrapper method for the {@link raise()} method with predefined error
-	 * level of E_NOTICE and backtrace set to false.
+	 * Wrapper method for the {@link raise()} method with predefined error level of E_NOTICE and backtrace set to false.
 	 *
 	 * @param   string  $code  The application-internal error code for this error
 	 * @param   string  $msg   The error message, which may also be shown the user if need be.
@@ -287,7 +308,7 @@ abstract class JError
 	 *                         developer-relevant information that the user
 	 *                         should never see, like a database DSN).
 	 *
-	 * @return  object   The configured JError object
+	 * @return  JException  $error  The thrown JException object
 	 *
 	 * @deprecated       12.1   Use PHP Exception
 	 * @see     raise()
@@ -340,7 +361,7 @@ abstract class JError
 	 * @param   string   $mode     The mode to use for the error handling.
 	 * @param   mixed    $options  Optional: Any options needed for the given mode.
 	 *
-	 * @return  mixed  True on success or a JException object if failed.
+	 * @return  boolean|JException  True on success or a JException object if failed.
 	 *
 	 * @deprecated  12.1  Use PHP Exception
 	 * @since   11.1
@@ -478,7 +499,7 @@ abstract class JError
 	 *
 	 * @param   integer  $level  Error level to translate
 	 *
-	 * @return  mixed  Human readable error level name or boolean false if it doesn't exist
+	 * @return  string|boolean  Human readable error level name or boolean false if it doesn't exist
 	 *
 	 * @deprecated  12.1
 	 * @since   11.1
@@ -500,10 +521,10 @@ abstract class JError
 	 * Ignore error handler
 	 * - Ignores the error
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object   The exception object
+	 * @return  JException   The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see     JError::raise()
@@ -520,10 +541,10 @@ abstract class JError
 	 * Echo error handler
 	 * - Echos the error message to output
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  JException  The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -596,10 +617,10 @@ abstract class JError
 	 * Verbose error handler
 	 * - Echos the error message to output as well as related info
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  JException  The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -642,10 +663,10 @@ abstract class JError
 	 * Die error handler
 	 * - Echos the error message to output and then dies
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  void  Calls die()
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -683,10 +704,10 @@ abstract class JError
 	 * Message error handler
 	 * Enqueues the error message into the system queue
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  JException  The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -707,10 +728,10 @@ abstract class JError
 	 * Log error handler
 	 * Logs the error message to a system log file
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  JException  The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -744,10 +765,10 @@ abstract class JError
 	 * Callback error handler
 	 * - Send the error object to a callback method for error handling
 	 *
-	 * @param   object  &$error   Exception object to handle
-	 * @param   array   $options  Handler options
+	 * @param   JException  &$error   Exception object to handle
+	 * @param   array       $options  Handler options
 	 *
-	 * @return  object  The exception object
+	 * @return  JException  The exception object
 	 *
 	 * @deprecated  12.1
 	 * @see         JError::raise()
@@ -763,7 +784,7 @@ abstract class JError
 	/**
 	 * Display a custom error page and exit gracefully
 	 *
-	 * @param   object  &$error  Exception object
+	 * @param   JException  &$error  Exception object
 	 *
 	 * @return  void
 	 *
@@ -844,7 +865,7 @@ abstract class JError
 	/**
 	 * Render the backtrace
 	 *
-	 * @param   integer  $error  The error
+	 * @param   Exception  $error  The error
 	 *
 	 * @return  string  Contents of the backtrace
 	 *


### PR DESCRIPTION
#### Summary of Changes

Updates the doc blocks of `JError` to reflect what is actually expected versus a generic object.  Note in most cases this is a `JException` object due to references to a `get()` method which does not exist on PHP's `Exception` class.
#### Testing Instructions

Review it
