### PR TITLE
Show Tags in Featured layout also above articles.

### DIFF
--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -54,6 +54,9 @@ $info    = $this->item->params->get('info_block_position', 0);
 
 <?php if ($useDefList && ($info == 0 || $info == 2)) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.info_block.block', array('item' => $this->item, 'params' => $params, 'position' => 'above')); ?>
+	<?php if ($info == 0 && $params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+		<?php echo JLayoutHelper::render('joomla.content.tags', $this->item->tags->itemTags); ?>
+	<?php endif; ?>
 <?php endif; ?>
 
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>


### PR DESCRIPTION
#### Summary of Changes

In the "featured articles" layout, tags from the articles are only shown if the position of the info block is set to "below" or "split", but not for "above". This PR displays them for "above", too.
#### Testing Instructions
1. Create some featured articles with tags.
2. Create a _Featured Articles_ menu item. In the _Options_ tab, make the following settings:
   - Position of Article Info: _Above_
   - Show Tags: _Show_
3. In frontend, navigate to the created menu item and look for the tags. None will appear.
4. Apply the PR.
5. Look again. The tags should now be displayed above the article.
6. Set "Position of Article Info" to _Below_ and make sure that the tags now are displayed only below the article
7. Set "Position of Article Info" to _Below_ and make sure that the tags now are displayed only below the article, too.
