### PR TITLE
Fix Deprecated warning in JReCaptcha on PHP7

### DIFF
--- a/plugins/captcha/recaptcha/recaptchalib.php
+++ b/plugins/captcha/recaptcha/recaptchalib.php
@@ -51,7 +51,7 @@ class JReCaptcha
 	 *
 	 * @param string $secret shared secret between site and ReCAPTCHA server.
 	 */
-	function JReCaptcha($secret)
+	public function __construct($secret)
 	{
 		if ($secret == null || $secret == "")
 		{


### PR DESCRIPTION
#### Summary of Changes

If we use recaptcha version 2 on PHP7, there will be a warning message like this

> Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; JReCaptcha has a deprecated constructor in E:\www\joomla35\plugins\captcha\recaptcha\recaptchalib.php on line 42

This small PR just fixes that warning
#### Testing Instructions

This change is a very small and clear, so I think maintainer just need to have a quick review and merge it.
