### PR TITLE
Change order of processing in finalizeRestore - thanks @nikosdion

### DIFF
--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -155,6 +155,19 @@ if (!function_exists('finalizeRestore'))
 	 */
 	function finalizeRestore($siteRoot, $restorePath)
 	{
+		// Clear OPcache
+		if (function_exists('opcache_reset'))
+		{
+			opcache_reset();
+		}
+		elseif (function_exists('apc_clear_cache'))
+		{
+			@apc_clear_cache();
+		}
+
+		// Make sure Joomla!'s code can figure out which files exist and need be removed
+		clearstatcache();
+
 		if (!defined('JPATH_ROOT'))
 		{
 			define('JPATH_ROOT', $siteRoot);
@@ -167,24 +180,15 @@ if (!function_exists('finalizeRestore'))
 			require_once ($filePath);
 		}
 
-		// Make sure Joomla!'s code can figure out which files exist and need be removed
-		clearstatcache();
-
 		// Remove obsolete files - prevents errors occuring in some system plugins
 		if (class_exists('JoomlaInstallerScript'))
 		{
-			$script = new JoomlaInstallerScript;
+			$script = new JoomlaInstallerScript();
 			$script->deleteUnexistingFiles();
 		}
 
-		// Clear OPcache
-		if (function_exists('opcache_reset'))
-		{
-			opcache_reset();
-		}
-		elseif (function_exists('apc_clear_cache'))
-		{
-			@apc_clear_cache();
-		}
+		// We have modified the filesystem, therefore we must clear the stat cache a second time.
+		clearstatcache();
+
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #9788 .
#### Summary of Changes

Change order of processing in restore finalisation of the Joomla! Update component for handling problem described in issue #9788 .

The code for this PR was provided by @nikosdion , thanks a lot for that.
#### Testing Instructions

Am not sure if everbody will be able to reproduce the issue, maybe it is dependent on hosting.

Pre-requisite:
1. Have Zend opcache in PHP enabled and running and nothing from administrator folder being excluded from opcache with so-called "blackist" (IMO misleading name Zend have chosen for the feature to esxclude things from the cache).
2. Use a 3.5.1 or current staging without any patch applied.
3. Be able to reproduce the problem as descibed below in Step 1.

Step 1: Try to update to "3.5.2-dev + patch with this PR" using Joomla! Update component aka "online update" with following custom URL: [http://test5.richard-fath.de/list_test8.xml](http://test5.richard-fath.de/list_test8.xml)

Result: The update is aborted with an error dialog as described with issue #9788 before any files are written.

Step 2: Go to any other page of the backend.

Step 3: Apply the patch of this PR e.g. with the patchtester.

Step 4: If you use Joomla! caching, clear backend cache.

Step 5: Repeat Step 1.

Result: The update starts and runs as expected.
