### PR TITLE
Fix wrong component name "com_user" to "com_users" in profile plg

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -373,7 +373,7 @@ class PlgUserProfile extends JPlugin
 		$option     = JFactory::getApplication()->input->getCmd('option');
 		$tosarticle = $this->params->get('register_tos_article');
 		$tosenabled = ($this->params->get('register-require_tos', 0) == 2) ? true : false;
-		if (($task == 'register') && ($tosenabled) && ($tosarticle) && ($option == 'com_user'))
+		if (($task == 'register') && ($tosenabled) && ($tosarticle) && ($option == 'com_users'))
 		{
 			// Check that the tos is checked.
 			if ((!($data['profile']['tos'])))


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

 server side validation is not triggered due to a misspelled com_users component. "com_user" string changed to "com_users"
#### Testing Instructions

Activate the user profile plugin
Choose TOS field as mandatory
Try to register leaving or selecting "no" as choice in the TOS radio button: The form should be rejected and user should not be created
