### PR TITLE
Improve templates scaffolding for custom fields

### DIFF
--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -268,6 +268,10 @@ class TemplatesModelStyle extends JModelAdmin
 			$template  = JArrayHelper::getValue($data, 'template');
 		}
 
+		// Add the default fields directory
+		$baseFolder = ($clientId) ? JPATH_ADMINISTRATOR : JPATH_SITE;
+		JForm::addFieldPath($baseFolder . '/templates/' . $template . '/field');
+
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);
 		$this->setState('item.template', $template);

--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -305,6 +305,11 @@ class JFormHelper
 			{
 				array_unshift($paths, trim($path));
 			}
+
+			if (!is_dir($path))
+			{
+				array_unshift($paths, trim($path));
+			}
 		}
 
 		return $paths;


### PR DESCRIPTION
#### This is a redo of https://github.com/joomla/joomla-cms/pull/4294
#### Summary of Changes

Right now if you want to include some custom fields in your template you need to include a custom field path in the relative xml file, something like:

```
<fieldset addfieldpath="/templates/<template name>/field">
```

Documented here: https://docs.joomla.org/Creating_a_custom_form_field_type

This PR leverages this, so custom fields will happily reside inside a folder named `field`

Why field and not fields?
Singular word help us transition to autoload and namespace
#### Testing Instructions

Apply this patch with patch tester
edit `administrator/templates/isis/templateDetails.xml` and paste at line 49

```
                <field name="testone" class="" type="testone" default="0"
                       label="test one"
                       description="test one" />
```

Create a folder named `field` inside `administrator/templates/isis`
copy testone.php to the folder you just created from https://gist.github.com/dgt41/ec0e2afe879c5d07ffadd2c8a639e1a7

Go to Edit Style for Isis and check if the first field is like the one from the image below
![screen shot 2016-04-07 at 23 40 27](https://cloud.githubusercontent.com/assets/3889375/14366171/25b21fe6-fd1a-11e5-805f-a27475413bfc.png)

If so you have a successful test!
#### B/C

No backwards compatibility break
#### Performance

We just add one more folder check to the whole stack, so performance degradation should be unnoticeable. (Joomla itself does that hundreds of times for core libraries)
