### PR TITLE
Improve modules scaffolding for custom fields

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -534,6 +534,10 @@ class ModulesModelModule extends JModelAdmin
 			$id       = JArrayHelper::getValue($data, 'id');
 		}
 
+		// Add the default fields directory
+		$baseFolder = ($clientId) ? JPATH_ADMINISTRATOR : JPATH_SITE;
+		JForm::addFieldPath($baseFolder . '/modules' . '/' . $module . '/field');
+
 		// These variables are used to add data from the plugin XML files.
 		$this->setState('item.client_id', $clientId);
 		$this->setState('item.module', $module);


### PR DESCRIPTION
#### This is a redo of https://github.com/joomla/joomla-cms/pull/4294
#### Summary of Changes

Right now if you want to include some custom fields in your module you need to include a custom field path in the relative xml file, something like:

```
<fieldset addfieldpath="/modules/<module name>/field">
```

Documented here: https://docs.joomla.org/Creating_a_custom_form_field_type

This PR leverages this, so custom fields will happily reside inside a folder named `field`

Why field and not fields?
Singular word help us transition to autoload and namespace
#### Testing Instructions

Apply this patch with patch tester
edit `modules/mod_custom/mod_custom.xml` and paste after line 27

```
                <field name="testone" class="" type="testone" default="0"
                       label="test one"
                       description="test one" />
```

Create a folder named `field` inside `modules/mod_custom/`
copy testone.php to the folder you just created from https://gist.github.com/dgt41/ec0e2afe879c5d07ffadd2c8a639e1a7

Add a new Custom module and check the options tab:
![screen shot 2016-04-08 at 00 16 57](https://cloud.githubusercontent.com/assets/3889375/14367237/816af312-fd1f-11e5-9b9c-16d2612980fe.png)

If you see a dropdown you have success
#### B/C

No backwards compatibility break
#### Performance

We just add one more folder check to the whole stack, so performance degradation should be unnoticeable. (Joomla itself does that hundreds of times for core libraries)
