### PR TITLE
Fixes articles options hierarchy (precedence)

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -95,6 +95,9 @@ class ContentViewArticle extends JViewLegacy
 					$this->setLayout($layout);
 				}
 
+				// Get MENU parameters from state 'parameters.menu' and NOT 'params' (where they have already been merged with the COMPONENT DEFAULT ones).
+				$temp = $this->state->get('parameters.menu');
+
 				// $item->params are the article params, $temp are the menu item params
 				// Merge so that the menu item params take priority
 				$item->params->merge($temp);


### PR DESCRIPTION
Pull Request for Issue #9491
#### Summary of Changes

This is a fix for **part of** what was found in #9491 and particularly the fact that options declared at the article level are disregarded.
#### Testing Instructions

for com_content:
- Set the global option for "Show title" as **"Hide"**
- In an article set the "Show title" option as "**Show**"
- In an associated "Single article" menu item set "Show title" as "**Use Global**"
##### Without this patch:

Article title **is not** displayed
##### With this patch:

Article title **is** displayed

As a proof that options set at the menu level overrides what is declared at the global and article level, now set "Show article" as "**Hide**" in the menu item: title is not displayed.
