### PR TITLE
CLI script to make version bump

### DIFF
--- a/build/bump.php
+++ b/build/bump.php
@@ -202,7 +202,7 @@ foreach ($languageXmlFiles as $languageXmlFile)
 	if (file_exists($rootPath . $languageXmlFile))
 	{
 		$fileContents = file_get_contents($rootPath . $languageXmlFile);
-		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '.0</version>', $fileContents);
+		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '</version>', $fileContents);
 		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
 		file_put_contents($rootPath . $languageXmlFile, $fileContents);
 	}

--- a/build/bump.php
+++ b/build/bump.php
@@ -4,7 +4,7 @@
  * Updates all versions xmls and version.php
  *
  * Usage:
- * 1. php build/bump.php <version>
+ * 1. php build/bump.php -v <version>
  *
  * Examples:
  * - php build/bump.php -v 3.6.0-dev
@@ -12,7 +12,7 @@
  * - php build/bump.php -v 3.6.0-beta2
  * - php build/bump.php -v 3.6.0-rc1
  * - php build/bump.php -v 3.6.0
- * - /usr/bin/php /path/to/joomla-cms/build/bump.php 3.7.0
+ * - /usr/bin/php /path/to/joomla-cms/build/bump.php -v 3.7.0
  *
  * @package    Joomla.Build
  * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
@@ -36,20 +36,21 @@ const PHP_TAB = "\t";
 $versionFile      = '/libraries/cms/version/version.php';
 
 $coreXmlFiles     = array(
-						'/administrator/manifests/files/joomla.xml',
-						);
+			'/administrator/manifests/files/joomla.xml',
+			);
 
 $languageXmlFiles = array(
-					'/administrator/manifests/packages/pkg_en-GB.xml',
-					'/language/en-GB/en-GB.xml',
-					'/language/en-GB/install.xml',
-					'/administrator/language/en-GB/en-GB.xml',
-					'/administrator/language/en-GB/install.xml',
-					'/installation/language/en-GB/en-GB.xml',
-						);
+			'/administrator/manifests/packages/pkg_en-GB.xml',
+			'/language/en-GB/en-GB.xml',
+			'/language/en-GB/install.xml',
+			'/administrator/language/en-GB/en-GB.xml',
+			'/administrator/language/en-GB/install.xml',
+			'/installation/language/en-GB/en-GB.xml',
+			);
 
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:");
+
 if (empty($opts['v']))
 {
 	usage($argv[0]);
@@ -124,7 +125,7 @@ echo PHP_EOL;
 echo 'Version data:'. PHP_EOL;
 echo '- Main:' . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . PHP_EOL;
 echo '- Release:' . PHP_TAB . PHP_TAB . $version['release'] . PHP_EOL;
-echo '- Full:'  . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . '.' . $version['dev_devel']. PHP_EOL;
+echo '- Full:'  . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . '.' . $version['dev_devel'] . PHP_EOL;
 echo '- Build:' . PHP_TAB . PHP_TAB . $version['build'] . PHP_EOL;
 echo '- Dev Level:' . PHP_TAB . PHP_TAB . $version['dev_devel'] . PHP_EOL;
 echo '- Dev Status:' . PHP_TAB . PHP_TAB . $version['dev_status'] . PHP_EOL;
@@ -174,4 +175,4 @@ foreach ($languageXmlFiles as $languageXmlFile)
 	}
 }
 
-echo "Version bump complete!\n";
+echo 'Version bump complete!' . PHP_EOL;

--- a/build/bump.php
+++ b/build/bump.php
@@ -76,8 +76,10 @@ if (isset($versionParts[1]) && !preg_match('#(dev|alpha|beta|rc)[0-9]*#', $versi
 setlocale(LC_ALL, 'en_GB');
 date_default_timezone_set('Europe/London');
 
-// Make sure file and folder permissions are set correctly
+// Make sure file and folder permissions are set correctly.
 umask(022);
+
+// Get version dev status.
 $dev_status = 'Stable';
 
 if (!isset($versionParts[1]))

--- a/build/bump.php
+++ b/build/bump.php
@@ -13,6 +13,8 @@
  * - php build/bump.php -v 3.6.0-beta2
  * - php build/bump.php -v 3.6.0-rc1
  * - php build/bump.php -v 3.6.0
+ * - php build/bump.php -v 3.6.0 -c Unicorn
+ * - php build/bump.php -v 3.6.0 -c "Custom Codename"
  * - /usr/bin/php /path/to/joomla-cms/build/bump.php -v 3.7.0
  *
  * @package    Joomla.Build
@@ -26,7 +28,8 @@ function usage($command)
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
 	echo PHP_TAB . '[options]:'.PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-beta1-dev, 3.6.0-rc1, 3.6.0' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'Version (ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-beta1-dev, 3.6.0-rc1, 3.6.0)' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '-c <codename>:' . PHP_TAB . 'Codename [optional] (ex: Unicorn)' . PHP_EOL;
 	echo PHP_EOL;
 }
 
@@ -50,7 +53,7 @@ $languageXmlFiles = array(
 			);
 
 // Check arguments (exit if incorrect cli arguments).
-$opts = getopt("v:");
+$opts = getopt("v:c:");
 
 if (empty($opts['v']))
 {
@@ -137,6 +140,12 @@ $version = array(
 		'credate'    => date('F Y'),
 		);
 
+// Version Codename.
+if (!empty($opts['c']))
+{
+	$version['codename'] = trim($opts['c']);
+}
+
 // Prints version information.
 echo PHP_EOL;
 echo 'Version data:'. PHP_EOL;
@@ -150,6 +159,10 @@ echo '- Release date:' . PHP_TAB . PHP_TAB . $version['reldate'] . PHP_EOL;
 echo '- Release time:' . PHP_TAB . PHP_TAB . $version['reltime'] . PHP_EOL;
 echo '- Release timezone:'  . PHP_TAB . $version['reltz'] . PHP_EOL;
 echo '- Creation date:' . PHP_TAB . $version['credate'] . PHP_EOL;
+if (!empty($version['codename']))
+{
+	echo '- Codename:' . PHP_TAB . PHP_TAB . $version['codename'] . PHP_EOL;
+}
 echo PHP_EOL;
 
 $rootPath = dirname(__DIR__);
@@ -165,6 +178,10 @@ if (file_exists($rootPath . $versionFile))
 	$fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);
+	if (!empty($version['codename']))
+	{
+		$fileContents = preg_replace("#CODENAME\s*=\s*'[^\']*'#", "CODENAME = '" . $version['codename'] . "'", $fileContents);
+	}
 	file_put_contents($rootPath . $versionFile, $fileContents);
 }
 

--- a/build/bump.php
+++ b/build/bump.php
@@ -146,7 +146,7 @@ if (file_exists($rootPath . $versionFile))
 	$fileContents = preg_replace("#RELEASE\s*=\s*'[^\']*'#", "RELEASE = '" . $version['main'] . "'", $fileContents);
 	$fileContents = preg_replace("#DEV_LEVEL\s*=\s*'[^\']*'#", "DEV_LEVEL = '" . $version['dev_devel'] . "'", $fileContents);
 	$fileContents = preg_replace("#DEV_STATUS\s*=\s*'[^\']*'#", "DEV_STATUS = '" . $version['dev_status'] . "'", $fileContents);
-	$fileContents = preg_replace("#BUILD\s*=\s*'[^\']*'#", "BUILD = ''", $fileContents);
+	$fileContents = preg_replace("#BUILD\s*=\s*'[^\']*'#", "BUILD = '" . $version['build'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);

--- a/build/bump.php
+++ b/build/bump.php
@@ -3,8 +3,7 @@
  * Script used to make a version bump
  * Updates all versions xmls and version.php
  *
- * Usage:
- * 1. php build/bump.php -v <version>
+ * Usage: php build/bump.php -v <version> -c <codename>
  *
  * Examples:
  * - php build/bump.php -v 3.6.0-dev

--- a/build/bump.php
+++ b/build/bump.php
@@ -9,6 +9,7 @@
  * Examples:
  * - php build/bump.php -v 3.6.0-dev
  * - php build/bump.php -v 3.6.0-beta1
+ * - php build/bump.php -v 3.6.0-beta1-dev
  * - php build/bump.php -v 3.6.0-beta2
  * - php build/bump.php -v 3.6.0-rc1
  * - php build/bump.php -v 3.6.0
@@ -25,7 +26,7 @@ function usage($command)
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
 	echo PHP_TAB . '[options]:'.PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-rc1, 3.6.0' . PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-beta1-dev, 3.6.0-rc1, 3.6.0' . PHP_EOL;
 	echo PHP_EOL;
 }
 
@@ -72,6 +73,12 @@ if (isset($versionParts[1]) && !preg_match('#(dev|alpha|beta|rc)[0-9]*#', $versi
 	die();
 }
 
+if (isset($versionParts[2]) && $versionParts[2] !== 'dev')
+{
+	usage($argv[0]);
+	die();
+}
+
 // Make sure we use the correct language and timezone.
 setlocale(LC_ALL, 'en_GB');
 date_default_timezone_set('Europe/London');
@@ -106,14 +113,22 @@ else
 	}
 }
 
+if (!isset($versionParts[2]))
+{
+	$versionParts[2] = '';
+}
+else
+{
+	$dev_status = 'Development';
+}
+
 // Set version properties.
 $versionSubParts = explode('.', $versionParts[0]);
 
 $version = array(
 		'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
 		'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
-		'dev'        => $versionParts[1],
-		'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : ''),
+		'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
 		'dev_status' => $dev_status,
 		'build'      => '',
 		'reldate'    => date('j-F-Y'),

--- a/build/bump.php
+++ b/build/bump.php
@@ -108,17 +108,17 @@ else
 $versionSubParts = explode('.', $versionParts[0]);
 
 $version = array(
-				'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
-				'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
-				'dev'        => $versionParts[1],
-				'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : ''),
-				'dev_status' => $dev_status,
-				'build'      => '',
-				'reldate'    => date('j-F-Y'),
-				'reltime'    => date('H:i'),
-				'reltz'      => 'GMT',
-				'credate'    => date('F Y'),
-				);
+		'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
+		'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
+		'dev'        => $versionParts[1],
+		'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : ''),
+		'dev_status' => $dev_status,
+		'build'      => '',
+		'reldate'    => date('j-F-Y'),
+		'reltime'    => date('H:i'),
+		'reltz'      => 'GMT',
+		'credate'    => date('F Y'),
+		);
 
 // Prints version information.
 echo PHP_EOL;

--- a/build/bump.php
+++ b/build/bump.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Script used to make a version bump
+ * Updates all versions xmls and version.php
+ *
+ * Usage:
+ * 1. php build/bump.php <version>
+ *
+ * Examples:
+ * - php build/bump.php -v 3.6.0-dev
+ * - php build/bump.php -v 3.6.0-beta1
+ * - php build/bump.php -v 3.6.0-beta2
+ * - php build/bump.php -v 3.6.0-rc1
+ * - php build/bump.php -v 3.6.0
+ * - /usr/bin/php /path/to/joomla-cms/build/bump.php 3.7.0
+ *
+ * @package    Joomla.Build
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Functions.
+function usage($command)
+{
+	echo PHP_EOL;
+	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
+	echo PHP_TAB . '[options]:'.PHP_EOL;
+	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-rc1, 3.6.0' . PHP_EOL;
+	echo PHP_EOL;
+}
+
+// Constants.
+const PHP_TAB = "\t";
+
+// File paths.
+$versionFile      = '/libraries/cms/version/version.php';
+
+$coreXmlFiles     = array(
+						'/administrator/manifests/files/joomla.xml',
+						);
+
+$languageXmlFiles = array(
+					'/administrator/manifests/packages/pkg_en-GB.xml',
+					'/language/en-GB/en-GB.xml',
+					'/language/en-GB/install.xml',
+					'/administrator/language/en-GB/en-GB.xml',
+					'/administrator/language/en-GB/install.xml',
+					'/installation/language/en-GB/en-GB.xml',
+						);
+
+// Check arguments (exit if incorrect cli arguments).
+$opts = getopt("v:");
+if (empty($opts['v']))
+{
+	usage($argv[0]);
+	die();
+}
+
+// Check version string (exit if not correct).
+$versionParts = explode('-', $opts['v']);
+
+if (!preg_match('#^[0-9]+\.[0-9]+\.[0-9]+$#', $versionParts[0]))
+{
+	usage($argv[0]);
+	die();
+}
+
+if (isset($versionParts[1]) && !preg_match('#(dev|alpha|beta|rc)[0-9]*#', $versionParts[1]))
+{
+	usage($argv[0]);
+	die();
+}
+
+// Make sure we use the correct language and timezone.
+setlocale(LC_ALL, 'en_GB');
+date_default_timezone_set('Europe/London');
+
+// Make sure file and folder permissions are set correctly
+umask(022);
+$dev_status = 'Stable';
+
+if (!isset($versionParts[1]))
+{
+	$versionParts[1] = '';
+}
+else
+{
+	if (preg_match('#^dev#', $versionParts[1]))
+	{
+		$dev_status = 'Development';
+	}
+	elseif (preg_match('#^alpha#', $versionParts[1]))
+	{
+		$dev_status = 'Alpha';
+	}
+	elseif (preg_match('#^beta#', $versionParts[1]))
+	{
+		$dev_status = 'Beta';
+	}
+	elseif (preg_match('#^rc#', $versionParts[1]))
+	{
+		$dev_status = 'Release Candidate';
+	}
+}
+
+// Set version properties.
+$versionSubParts = explode('.', $versionParts[0]);
+
+$version = array(
+				'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
+				'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
+				'dev'        => $versionParts[1],
+				'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : ''),
+				'dev_status' => $dev_status,
+				'build'      => '',
+				'reldate'    => date('j-F-Y'),
+				'reltime'    => date('H:i'),
+				'reltz'      => 'GMT',
+				'credate'    => date('F Y'),
+				);
+
+// Prints version information.
+echo PHP_EOL;
+echo 'Version data:'. PHP_EOL;
+echo '- Main:' . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . PHP_EOL;
+echo '- Release:' . PHP_TAB . PHP_TAB . $version['release'] . PHP_EOL;
+echo '- Full:'  . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . '.' . $version['dev_devel']. PHP_EOL;
+echo '- Build:' . PHP_TAB . PHP_TAB . $version['build'] . PHP_EOL;
+echo '- Dev Level:' . PHP_TAB . PHP_TAB . $version['dev_devel'] . PHP_EOL;
+echo '- Dev Status:' . PHP_TAB . PHP_TAB . $version['dev_status'] . PHP_EOL;
+echo '- Release date:' . PHP_TAB . PHP_TAB . $version['reldate'] . PHP_EOL;
+echo '- Release time:' . PHP_TAB . PHP_TAB . $version['reltime'] . PHP_EOL;
+echo '- Release timezone:'  . PHP_TAB . $version['reltz'] . PHP_EOL;
+echo '- Creation date:' . PHP_TAB . $version['credate'] . PHP_EOL;
+echo PHP_EOL;
+
+$rootPath = dirname(__DIR__);
+
+// Updates the version in version class.
+if (file_exists($rootPath . $versionFile))
+{
+	$fileContents = file_get_contents($rootPath . $versionFile);
+	$fileContents = preg_replace("#RELEASE\s*=\s*'[^\']*'#", "RELEASE = '" . $version['main'] . "'", $fileContents);
+	$fileContents = preg_replace("#DEV_LEVEL\s*=\s*'[^\']*'#", "DEV_LEVEL = '" . $version['dev_devel'] . "'", $fileContents);
+	$fileContents = preg_replace("#DEV_STATUS\s*=\s*'[^\']*'#", "DEV_STATUS = '" . $version['dev_status'] . "'", $fileContents);
+	$fileContents = preg_replace("#BUILD\s*=\s*'[^\']*'#", "BUILD = ''", $fileContents);
+	$fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
+	$fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
+	$fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);
+	file_put_contents($rootPath . $versionFile, $fileContents);
+}
+
+// Updates the version and creation date in core xml files.
+foreach ($coreXmlFiles as $coreXmlFile)
+{
+	if (file_exists($rootPath . $coreXmlFile))
+	{
+		$fileContents = file_get_contents($rootPath . $coreXmlFile);
+		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['main'] . '.' . $version['dev_devel'] . '</version>', $fileContents);
+		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+		file_put_contents($rootPath . $coreXmlFile, $fileContents);
+	}
+}
+
+// Updates the version and creation date in language xml files.
+foreach ($languageXmlFiles as $languageXmlFile)
+{
+	if (file_exists($rootPath . $languageXmlFile))
+	{
+		$fileContents = file_get_contents($rootPath . $languageXmlFile);
+		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '.0</version>', $fileContents);
+		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+		file_put_contents($rootPath . $languageXmlFile, $fileContents);
+	}
+}
+
+echo "Version bump complete!\n";

--- a/build/bump.php
+++ b/build/bump.php
@@ -43,13 +43,14 @@ $coreXmlFiles     = array(
 			);
 
 $languageXmlFiles = array(
-			'/administrator/manifests/packages/pkg_en-GB.xml',
 			'/language/en-GB/en-GB.xml',
 			'/language/en-GB/install.xml',
 			'/administrator/language/en-GB/en-GB.xml',
 			'/administrator/language/en-GB/install.xml',
 			'/installation/language/en-GB/en-GB.xml',
 			);
+
+$languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
 
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
@@ -206,6 +207,15 @@ foreach ($languageXmlFiles as $languageXmlFile)
 		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
 		file_put_contents($rootPath . $languageXmlFile, $fileContents);
 	}
+}
+
+// Updates the version and creation date in language package xml file.
+if (file_exists($rootPath . $languagePackXmlFile))
+{
+	$fileContents = file_get_contents($rootPath . $languagePackXmlFile);
+	$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '.1</version>', $fileContents);
+	$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+	file_put_contents($rootPath . $languagePackXmlFile, $fileContents);
 }
 
 echo 'Version bump complete!' . PHP_EOL;


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

This PR adds a new CLI script to make the version bumps auto.

Linux bash usage examples:

``` bash
# Inside joomla root folder.
php build/bump.php -v 3.5.5-dev
php build/bump.php -v 3.5.5-beta1
php build/bump.php -v 3.5.5-beta1-dev
php build/bump.php -v 3.5.5-beta2
php build/bump.php -v 3.5.5-rc1
php build/bump.php -v 3.5.5
php build/bump.php -v 3.6.0 -c Unicorn
php build/bump.php -v 3.6.0 -c "My Custom Codename"

# Inside joomla build folder.
php bump.php -v 3.5.5-dev

# Anywhere
/usr/bin/php /path/to/joomla-cms/build/bump.php -v 3.5.5
```
###### Result example

![bump](https://cloud.githubusercontent.com/assets/9630530/14384290/1f8d8d26-fd92-11e5-832b-15ba38adc7af.png)
#### Testing Instructions
1. Apply patch with the patchtester.
2. Run CLI script with a version of your choice.
3. Check if the version variables/strings are changed in all files.
   ➤ [Files that should change](https://github.com/andrepereiradasilva/joomla-cms/blob/version-bump/build/bump.php#L39-L53)
#### Observations

If anything is missing or incorrect please say.

As it is, this does not tag the version bump, neither uploads to github. Just changes the files.

Suggestions and/or improvements are welcome.
