### PR TITLE
Redo Fix modal scrolling #9140 + fix for Batch

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8191,8 +8191,3 @@ body.modal-open {
 .js-pstats-data-details dt {
 	width: 220px;
 }
-@media (max-width: 767px) {
-	.field-media-wrapper .modal .modal-body {
-		padding: 5px 0;
-	}
-}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8198,5 +8198,4 @@ body.modal-open {
 }
 .modal-body {
 	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8196,6 +8196,3 @@ body.modal-open {
 		padding: 5px 0;
 	}
 }
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1342,10 +1342,3 @@ body.modal-open {
 .js-pstats-data-details dt {
 	width: 220px;
 }
-
-/* Corrects the media modal padding on small devices */
-@media (max-width: 767px) {
-	.field-media-wrapper .modal .modal-body {
-		padding: 5px 0;
-	}
-}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1349,9 +1349,3 @@ body.modal-open {
 		padding: 5px 0;
 	}
 }
-
-/* Fix iOS scrolling inside bootstrap modals (using iframe) */
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
-}

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7521,12 +7521,3 @@ body.modal-open {
 .well .chzn-container {
 	max-width: 100%;
 }
-@media (max-width: 767px) {
-	.field-media-wrapper .modal .modal-body {
-		padding: 5px 0;
-	}
-}
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
-}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -652,16 +652,3 @@ body.modal-open {
 		max-width: 100%;
 	}
 }
-
-/* Corrects the media modal padding on small devices */
-@media (max-width: 767px) {
-	.field-media-wrapper .modal .modal-body {
-		padding: 5px 0;
-	}
-}
-
-/* Fix iOS scrolling inside bootstrap modals (using iframe) */
-.modal-body {
-	-webkit-overflow-scrolling: touch;
-	overflow-y: auto !important;
-}


### PR DESCRIPTION
**Redo Fix modal scrolling** #9140 + fix for Batch
The scrolling issue on iOS is a known issue of BS2 and BS3 modals.

Pull Request too for **Batch overflow Issues**: #9683, #9807, #9772, #9551, #9709.
#### Summary of Changes
- remove css of PR #9140 previously added to fix scrolling on iOS after addition of BS modals in 3.5.0 RC (now managed by main.php layout of the BS modal).
- change modal event handler to shown.bs.modal and hide.bs.modal (http://getbootstrap.com/javascript/#modals-events) to be able to check height when modal has been made visible to the user, and then apply some changes (max-height and overflow) only if window viewport height is too small for the rendered modal.
- apply max-height and over-flow when needed on modal body, to allow scrolling inside a modal when on small devices.
#### Testing Instructions
- **To be tested on staging** (on 3.5.1 stable, you will have all the admin submenus disappeared)
- test on as many browsers and devices as you can (desktop, tablet, mobile, FF, IE, Chrome, Safari...)
- test all modal types : User, Batch (test dropdown!), article Versions (iframe url)...
- test on admin and frontend, with Isis, Protostar, and other templates...
  You should be able to scroll inside and use modals on all devices.

Details on browsers, platform and devices used for testing are welcomed ;-)

Thanks!
