### PR TITLE
Page Break error after upgrade Joomla 3.5.1

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -772,4 +772,16 @@ class ContentModelArticle extends JModelAdmin
 		parent::cleanCache('mod_articles_news');
 		parent::cleanCache('mod_articles_popular');
 	}
+
+	/**
+	 * Void hit function for pagebreak when editing content from frontend
+	 *
+	 * @return  void
+	 *
+	 * @since   3.5.2
+	 */
+	public function hit()
+	{
+		return;
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #9748 .
#### Summary of Changes

a simply stupid solution
added a void `hit()` function in the admin content model to prevent
`Fatal error: Call to undefined method ContentModelArticle::hit()`
#### Testing Instructions

 see #9766 , #9748
