### PR TITLE
fix testSetHeader test

### DIFF
--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1315,8 +1315,7 @@ class JApplicationWebTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				array('name' => 'foo', 'value' => 'bar'),
-				array('name' => 'foo', 'value' => 'car')
+				array('name' => 'foo', 'value' => 'bar')
 			),
 			TestReflection::getValue($this->class, 'response')->headers
 		);


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

in line 1314 "$this->class->setHeader('foo', 'car');", the method is called without the $replace argument, meaning it uses the default of "false".

The way headers are set, allowing a duplicate here means the header is replaced in JApplicationWeb::header.  If $replace isn't enforced in setHeader then duplicates mean the header gets replaced anyway.

The attempted entry is removed from the assertEquals test.

This change is in conjunction with a JApplicationWeb PR I have waiting
https://github.com/joomla/joomla-cms/pull/9836

in line 1314 "$this->class->setHeader('foo', 'car');", the method is called without the $replace argument, meaning it uses the default of "false".

The way headers are set, allowing a duplicate here means the header is replaced in JApplicationWeb::header.  If $replace isn't enforced in setHeader then duplicates mean the header gets replaced anyway.

The attempted entry is removed from the assertEquals test.

This change is in conjunction with a JApplicationWeb PR I have waiting
https://github.com/joomla/joomla-cms/pull/9836
#### Testing Instructions
