### PR TITLE
Convert all remaining templates to HTML5

### DIFF
--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -10,5 +10,5 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($version)) : ?>
-	<p align="center"><?php echo $version; ?></p>
+	<p class="text-center"><?php echo $version; ?></p>
 <?php endif; ?>

--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -18,6 +18,9 @@ $lang->load('tpl_hathor', JPATH_ADMINISTRATOR)
 $app = JFactory::getApplication();
 $doc = JFactory::getDocument();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -86,8 +86,8 @@ else
 
 ?>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo  $this->language; ?>" lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
 <head>
 <jdoc:include type="head" />
 <!--[if lt IE 9]>

--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -89,7 +89,7 @@ else
 
 ?>
 <!DOCTYPE html>
-<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 	<jdoc:include type="head" />
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->

--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -75,7 +75,7 @@ if ($this->params->get('boldText'))
 }
 
 // Load template javascript
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -88,14 +88,11 @@ else
 }
 
 ?>
-
 <!DOCTYPE html>
 <html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>" >
 <head>
-<jdoc:include type="head" />
-<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-<![endif]-->
+	<jdoc:include type="head" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -69,7 +69,7 @@ if ($this->params->get('boldText'))
 }
 
 // Load template javascript
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -85,17 +85,11 @@ else
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
 <head>
-<jdoc:include type="head" />
-<!-- Load additional CSS styles for Internet Explorer -->
-<!--[if IE 8]>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
-<![endif]-->
-<!--[if IE 7]>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
-<![endif]-->
-<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-<![endif]-->
+	<jdoc:include type="head" />
+	<!-- Load additional CSS styles for Internet Explorer -->
+	<!--[if IE 8]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie8.css" /><![endif]-->
+	<!--[if IE 7]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7.css" /><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body id="minwidth" class="cpanel-page">
 <div id="containerwrap">

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -15,6 +15,9 @@ $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -79,8 +79,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
 <head>
 <jdoc:include type="head" />
 <!-- Load additional CSS styles for Internet Explorer -->

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -83,7 +83,7 @@ else
 
 ?>
 <!DOCTYPE html>
-<html lang="<?php echo $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<!-- Load additional CSS styles for Internet Explorer -->

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -10,23 +10,27 @@
 defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
+$doc = JFactory::getDocument();
 
-// Output as HTML5
-JFactory::getDocument()->setHtml5(true);
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 	<meta charset="utf-8" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
 	<!-- Load additional CSS styles for rtl sites -->
 	<?php if ($this->direction == 'rtl') : ?>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" />
 	<?php endif; ?>
 	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -10,11 +10,14 @@
 defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/error.css" type="text/css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -30,7 +30,7 @@ if (is_callable(array($doc, 'setHtml5')))
 	<?php endif; ?>
 	<!-- Load additional CSS styles for rtl sites -->
 	<?php if ($this->direction == 'rtl') : ?>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" />
 	<?php endif; ?>
 	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -28,7 +28,7 @@ JFactory::getDocument()->setHtml5(true);
 	<?php if ($this->direction == 'rtl') : ?>
 		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/template_rtl.css" rel="stylesheet" type="text/css" />
 	<?php endif; ?>
-
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="errors">
 	<div>

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -87,20 +87,14 @@ else
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
-	<head>
+<head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
 	<!-- Load additional CSS styles for Internet Explorer -->
-	<!--[if IE 8]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie8.css" rel="stylesheet" type="text/css" />
-	<![endif]-->
-	<!--[if IE 7]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
-	<![endif]-->
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
-	</head>
+	<!--[if IE 8]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie8.css" /><![endif]-->
+	<!--[if IE 7]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" /><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
+</head>
 <body id="minwidth-body">
 <div id="containerwrap">
 	<!-- Header Logo -->
@@ -177,7 +171,7 @@ else
 		?>
 	</p>
 </div>
-<script type="text/javascript">
+<script>
 	(function($){
 		$(document).ready(function () {
 			// Patches to fix some wrong render of chosen fields

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -82,8 +82,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo  $this->language; ?>" lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
 	<head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -83,10 +83,19 @@ else
 {
 	$logo = $this->baseurl . '/templates/' . $this->template . '/images/logo.png';
 }
-
+$doc->addScriptDeclaration("(function($){
+		$(document).ready(function () {
+			// Patches to fix some wrong render of chosen fields
+			$('.chzn-container, .chzn-drop, .chzn-choices .search-field input').each(function (index) {
+				$(this).css({
+					'width': 'auto'
+				});
+			});
+		});
+	})(jQuery);");
 ?>
 <!DOCTYPE html>
-<html lang="<?php echo  $this->language; ?>" dir="<?php echo  $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
@@ -171,17 +180,5 @@ else
 		?>
 	</p>
 </div>
-<script>
-	(function($){
-		$(document).ready(function () {
-			// Patches to fix some wrong render of chosen fields
-			$('.chzn-container, .chzn-drop, .chzn-choices .search-field input').each(function (index) {
-				$(this).css({
-					'width': 'auto'
-				});
-			});
-		});
-	})(jQuery);
-</script>
 </body>
 </html>

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -15,6 +15,9 @@ $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -79,8 +79,8 @@ else
 }
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 <jdoc:include type="head" />
 

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -85,19 +85,12 @@ else
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
-<jdoc:include type="head" />
-
-<!-- Load additional CSS styles for Internet Explorer -->
-<!--[if IE 7]>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" type="text/css" />
-<![endif]-->
-<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-<![endif]-->
-
-<!-- Load Template JavaScript -->
-<script type="text/javascript" src="<?php echo $this->baseurl; ?>/templates/<?php  echo  $this->template;  ?>/js/template.js"></script>
-
+	<jdoc:include type="head" />
+	<!-- Load additional CSS styles for Internet Explorer -->
+	<!--[if IE 7]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" /><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
+	<!-- Load Template JavaScript -->
+	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js"></script>
 </head>
 <body id="login-page">
 	<div id="containerwrap">

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -13,6 +13,9 @@ $app  = JFactory::getApplication();
 $lang = JFactory::getLanguage();
 $doc  = JFactory::getDocument();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -44,20 +44,18 @@ if (is_file($file))
 {
 	$doc->addStyleSheetVersion($file);
 }
+
+// Link color
+if ($this->params->get('linkColor'))
+{
+	$doc->addStyleDeclaration('a { color: ' . $this->params->get('linkColor') . '; }');
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
-	<!-- Link color -->
-	<?php if ($this->params->get('linkColor')) : ?>
-		<style>
-			a {
-				color: <?php echo $this->params->get('linkColor'); ?>;
-			}
-		</style>
-	<?php endif; ?>
 </head>
 <body class="contentpane component">
 	<jdoc:include type="message" />

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -45,20 +45,15 @@ if (is_file($file))
 	$doc->addStyleSheetVersion($file);
 }
 ?>
-
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
-
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	<!-- Link color -->
 	<?php if ($this->params->get('linkColor')) : ?>
-		<style type="text/css">
-			a
-			{
+		<style>
+			a {
 				color: <?php echo $this->params->get('linkColor'); ?>;
 			}
 		</style>

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -44,7 +44,7 @@ if (is_file($file))
 ?>
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<!--[if lt IE 9]>

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -15,6 +15,9 @@ $lang            = JFactory::getLanguage();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -60,9 +60,9 @@ $statusFixed   = $params->get('statusFixed', '1');
 $stickyToolbar = $params->get('stickyToolbar', '1');
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -22,6 +22,9 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Detecting Active Variables
 $option   = $input->get('option', '');
 $view     = $input->get('view', '');

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -122,9 +122,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js"></script>
 	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js"></script>
 	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js"></script>
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 
 <body class="admin <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " ";?>" data-spy="scroll" data-target=".subhead" data-offset="87">

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -22,8 +22,11 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
-// Output as HTML5
-$doc->setHtml5(true);
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 
 // Detecting Active Variables
 $option   = $input->get('option', '');
@@ -71,22 +74,22 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>
 	<?php if (is_file($file)) : ?>
-		<link rel="stylesheet" href="<?php echo $file; ?>" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $file; ?>" />
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template<?php echo ($this->direction == 'rtl' ? '-rtl' : ''); ?>.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template<?php echo ($this->direction == 'rtl' ? '-rtl' : ''); ?>.css" />
 	<link href="<?php echo $this->baseurl ?>/templates/<?php echo $this->template; ?>/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
 	<?php // Template color ?>
 	<?php if ($params->get('templateColor')) : ?>
-	<style type="text/css">
+	<style>
 		.navbar-inner, .navbar-inverse .navbar-inner, .nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle
 		{
 			background: <?php echo $params->get('templateColor');?>;
@@ -100,7 +103,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // Template header color ?>
 	<?php if ($params->get('headerColor')) : ?>
-	<style type="text/css">
+	<style>
 		.header
 		{
 			background: <?php echo $params->get('headerColor');?>;
@@ -109,16 +112,16 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // Sidebar background color ?>
 	<?php if ($params->get('sidebarColor')) : ?>
-		<style type="text/css">
+		<style>
 			.nav-list > .active > a, .nav-list > .active > a:hover {
 				background: <?php echo $params->get('sidebarColor'); ?>;
 			}
 		</style>
 	<?php endif; ?>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js" type="text/javascript"></script>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js" type="text/javascript"></script>
-	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js"></script>
+	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js"></script>
 	<!--[if lt IE 9]>
 		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -17,6 +17,9 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -133,7 +133,7 @@ $doc->addScriptDeclaration(
 	<jdoc:include type="head" />
 	<!-- Template color -->
 	<?php if ($navbar_color) : ?>
-		<style type="text/css">
+		<style>
 			.navbar-inner, .navbar-inverse .navbar-inner, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle, #status.status-top {
 				background: <?php echo $navbar_color; ?>;
 			}
@@ -141,7 +141,7 @@ $doc->addScriptDeclaration(
 	<?php endif; ?>
 	<!-- Template header color -->
 	<?php if ($header_color) : ?>
-		<style type="text/css">
+		<style>
 			.header {
 				background: <?php echo $header_color; ?>;
 			}
@@ -150,7 +150,7 @@ $doc->addScriptDeclaration(
 
 	<!-- Sidebar background color -->
 	<?php if ($this->params->get('sidebarColor')) : ?>
-		<style type="text/css">
+		<style>
 			.nav-list > .active > a, .nav-list > .active > a:hover {
 				background: <?php echo $this->params->get('sidebarColor'); ?>;
 			}
@@ -159,19 +159,15 @@ $doc->addScriptDeclaration(
 
 	<!-- Link color -->
 	<?php if ($this->params->get('linkColor')) : ?>
-		<style type="text/css">
+		<style>
 			a, .j-toggle-sidebar-button
 			{
 				color: <?php echo $this->params->get('linkColor'); ?>;
 			}
 		</style>
 	<?php endif; ?>
-
-	<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>">
 <!-- Top Navigation -->
 <nav class="navbar<?php echo $navbar_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -294,7 +294,7 @@ $doc->addScriptDeclaration(
 
 	<?php if (!$this->countModules('status') || (!$statusFixed && $this->countModules('status'))) : ?>
 		<footer class="footer">
-			<p align="center">
+			<p class="text-center">
 				<jdoc:include type="modules" name="footer" style="no" />
 				&copy; <?php echo $sitename; ?> <?php echo date('Y'); ?></p>
 		</footer>

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -123,12 +123,11 @@ $doc->addScriptDeclaration(
 );
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-
 	<!-- Template color -->
 	<?php if ($navbar_color) : ?>
 		<style type="text/css">

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -70,7 +70,7 @@ function colorIsLight($color)
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<style type="text/css">
+	<style>
 		/* Background color */
 		<?php if($background_color): ?>
 		.view-login {
@@ -100,11 +100,8 @@ function colorIsLight($color)
 		}
 		<?php endif; ?>
 	</style>
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " "; ?>">
 	<!-- Container -->
 	<div class="container">

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -13,6 +13,9 @@ $app  = JFactory::getApplication();
 $doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Color Params
 $background_color = $this->params->get('loginBackgroundColor') ? $this->params->get('loginBackgroundColor') : '';
 $color_is_light = ($background_color && colorIsLight($background_color));

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -65,7 +65,7 @@ function colorIsLight($color)
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 </head>

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -16,6 +16,7 @@ JFactory::getDocument()->setHtml5(true);
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -9,24 +9,24 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="templates/system/css/error.css" type="text/css" />
 </head>
 <body>
-	<table width="550" align="center" class="outline">
+	<table style="text-align: center; width: 550px;" class="outline">
 	<tr>
-		<td align="center">
+		<td style="text-align: center;">
 			<h1>
 				<?php echo $this->error->getCode() ?> - <?php echo JText::_('JERROR_AN_ERROR_HAS_OCCURRED') ?>
 			</h1>
 		</td>
 	</tr>
 	<tr>
-		<td width="39%" align="center">
+		<td width="39%" style="text-align: center;">
 			<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 			<p><a href="index.php"><?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT') ?></a></p>
 			<p>

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -18,6 +18,7 @@ JFactory::getDocument()->setHtml5(true);
 	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="templates/system/css/error.css" type="text/css" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
 	<table style="text-align: center; width: 550px;" class="outline">

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -9,15 +9,21 @@
 
 defined('_JEXEC') or die;
 
-// Output as HTML5
-JFactory::getDocument()->setHtml5(true);
+$app = JFactory::getApplication();
+$doc = JFactory::getDocument();
+
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 <head>
 	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="templates/system/css/error.css" type="text/css" />
+	<link rel="stylesheet" href="templates/system/css/error.css" />
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -17,10 +17,10 @@ $doc->setHtml5(true);
 $color = $this->params->get('templatecolor');
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', 'text/css', 'print');
 
 $files = JHtml::_('stylesheet', 'templates/' . $this->template . '/css/general.css', null, false, true);
 
@@ -53,12 +53,8 @@ if ($this->direction == 'rtl')
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-<!--[if lte IE 6]>
-	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" type="text/css" />
-<![endif]-->
-<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-<![endif]-->
+	<!--[if lte IE 6]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" /><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<div id="all">

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -10,6 +10,10 @@
 defined('_JEXEC') or die;
 
 $doc   = JFactory::getDocument();
+
+// Output as HTML5
+$doc->setHtml5(true);
+
 $color = $this->params->get('templatecolor');
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -17,9 +17,9 @@ $doc->setHtml5(true);
 $color = $this->params->get('templatecolor');
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css', $type = 'text/css', $media = 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen');
 $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
 
 $files = JHtml::_('stylesheet', 'templates/' . $this->template . '/css/general.css', null, false, true);

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -45,8 +45,8 @@ if ($this->direction == 'rtl')
 	}
 }
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 <!--[if lte IE 6]>

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -61,16 +61,9 @@ if (is_callable(array($doc, 'setHtml5')))
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
-	<!--[if lte IE 6]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" />
-	<![endif]-->
-	<!--[if IE 7]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" />
-	<![endif]-->
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
-
+	<!--[if lte IE 6]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" /><![endif]-->
+	<!--[if IE 7]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" /><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	<style>
 	<!--
 		#errorboxbody

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -24,6 +24,9 @@ $navposition = $params->get('navposition');
 $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
+
+// Output as HTML5
+$doc->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -15,61 +15,63 @@ $showbottom      = 0;
 
 // Get params
 $app         = JFactory::getApplication();
+$doc         = JFactory::getDocument();
 $params      = $app->getTemplate(true)->params;
 $logo        = $params->get('logo');
 $color       = $params->get('templatecolor');
 $navposition = $params->get('navposition');
 
 // Get language and direction
-$doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/system.css" type="text/css" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" type="text/css" media="screen" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/layout.css" type="text/css" media="screen" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/print.css" type="text/css" media="Print" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" type="text/css" />
-
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/system.css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" media="screen" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/layout.css" media="screen" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/print.css" media="Print" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" />
 	<?php $files = JHtml::_('stylesheet', 'templates/' . $this->template . '/css/general.css', null, false, true); ?>
 	<?php if ($files) : ?>
 		<?php if (!is_array($files)) : ?>
 			<?php $files = array($files); ?>
 		<?php endif; ?>
 	<?php foreach ($files as $file) : ?>
-		<link rel="stylesheet" href="<?php echo $file; ?>" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $file; ?>" />
 	<?php endforeach; ?>
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" />
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/templates/<?php echo $this->template; ?>/css/template_rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/templates/<?php echo $this->template; ?>/css/template_rtl.css" />
 		<?php if (file_exists(JPATH_SITE . '/templates/' . $this->template . '/css/' . $color . '_rtl.css')) : ?>
-			<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo $color ?>_rtl.css" type="text/css" />
+			<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo $color ?>_rtl.css" />
 		<?php endif; ?>
 	<?php endif; ?>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
 	<!--[if lte IE 6]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" />
 	<![endif]-->
 	<!--[if IE 7]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" />
 	<![endif]-->
 	<!--[if lt IE 9]>
 		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
 	<![endif]-->
 
-	<style type="text/css">
+	<style>
 	<!--
 		#errorboxbody
 		{margin:30px}

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -25,14 +25,11 @@ $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 ?>
-
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-<meta http-equiv="content-type" content="text/html; charset=utf-8" />
-<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-
+	<meta charset="utf-8" />
+	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/system.css" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" type="text/css" media="screen,projection" />

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -35,8 +35,8 @@ $doc->setHtml5(true);
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/system.css" type="text/css" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" type="text/css" media="screen,projection" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/layout.css" type="text/css" media="screen,projection" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/position.css" type="text/css" media="screen" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/layout.css" type="text/css" media="screen" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/print.css" type="text/css" media="Print" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" type="text/css" />
 

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -47,11 +47,11 @@ if (in_array($option, $bootstrap))
 }
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css', $type = 'text/css', $media = 'screen');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', $type = 'text/css', $media = 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', 'text/css', 'print');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css', 'text/css', 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', 'text/css', 'screen');
 
 if ($this->direction == 'rtl')
 {
@@ -63,10 +63,10 @@ if ($this->direction == 'rtl')
 }
 
 JHtml::_('bootstrap.framework');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/md_stylechanger.js', 'text/javascript');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/hide.js', 'text/javascript');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/respond.src.js', 'text/javascript');
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js', 'text/javascript');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/md_stylechanger.js');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/hide.js');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/respond.src.js');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js');
 
 // Check for a custom CSS file
 $userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
@@ -84,14 +84,12 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 		<meta name="HandheldFriendly" content="true" />
 		<meta name="apple-mobile-web-app-capable" content="YES" />
 		<jdoc:include type="head" />
-		<!--[if IE 7]>
-		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
-		<![endif]-->
+		<!--[if IE 7]><link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" /><![endif]-->
 		<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	</head>
 	<body id="shadow">
 		<?php if ($color == 'image'):?>
-			<style type="text/css">
+			<style>
 				.logoheader {
 					background:url('<?php echo $this->baseurl . '/' . htmlspecialchars($headerImage); ?>') no-repeat right;
 				}

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -87,6 +87,7 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 		<!--[if IE 7]>
 		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
 		<![endif]-->
+		<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	</head>
 	<body id="shadow">
 		<?php if ($color == 'image'):?>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -37,6 +37,9 @@ $bootstrap      = explode(',', $templateparams->get('bootstrap'));
 $jinput         = JFactory::getApplication()->input;
 $option         = $jinput->get('option', '', 'cmd');
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 if (in_array($option, $bootstrap))
 {
 	// Load optional rtl Bootstrap css and Bootstrap bugfixes
@@ -72,9 +75,7 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 {
 	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
 }
-
 ?>
-
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 	<head>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -76,16 +76,13 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 ?>
 
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
 	<head>
 		<?php require __DIR__ . '/jsstrings.php';?>
-
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes"/>
 		<meta name="HandheldFriendly" content="true" />
 		<meta name="apple-mobile-web-app-capable" content="YES" />
-
 		<jdoc:include type="head" />
-
 		<!--[if IE 7]>
 		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" type="text/css" />
 		<![endif]-->

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -75,6 +75,16 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 {
 	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
 }
+
+if ($color == 'image')
+{
+	$doc->addStyleDeclaration('.logoheader {
+					background:url(\'' . $this->baseurl . '/' . htmlspecialchars($headerImage) . '\') no-repeat right;
+				}
+				body {
+					background: ' . $templateparams->get('backgroundcolor') . ';
+				}');
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
@@ -88,17 +98,6 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 		<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	</head>
 	<body id="shadow">
-		<?php if ($color == 'image'):?>
-			<style>
-				.logoheader {
-					background:url('<?php echo $this->baseurl . '/' . htmlspecialchars($headerImage); ?>') no-repeat right;
-				}
-				body {
-					background: <?php echo $templateparams->get('backgroundcolor'); ?>;
-				}
-			</style>
-		<?php endif; ?>
-
 		<div id="all">
 			<div id="back">
 				<header id="header">

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -47,11 +47,11 @@ if (in_array($option, $bootstrap))
 }
 
 $doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', $type = 'text/css', $media = 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/layout.css', $type = 'text/css', $media = 'screen');
 $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/print.css', $type = 'text/css', $media = 'print');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css', $type = 'text/css', $media = 'screen,projection');
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', $type = 'text/css', $media = 'screen,projection');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css', $type = 'text/css', $media = 'screen');
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color) . '.css', $type = 'text/css', $media = 'screen');
 
 if ($this->direction == 'rtl')
 {

--- a/templates/beez3/jsstrings.php
+++ b/templates/beez3/jsstrings.php
@@ -21,8 +21,7 @@ JText::script('TPL_BEEZ3_DECREASE_SIZE');
 JText::script('TPL_BEEZ3_OPENMENU');
 JText::script('TPL_BEEZ3_CLOSEMENU');
 ?>
-
-<script type="text/javascript">
+<script>
 	var big        = '<?php echo (int) $this->params->get('wrapperLarge'); ?>%';
 	var small      = '<?php echo (int) $this->params->get('wrapperSmall'); ?>%';
 	var bildauf    = '<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/images/plus.png';

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -14,6 +14,9 @@ $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -25,7 +25,7 @@ JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
 
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 <jdoc:include type="head" />

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -25,16 +25,13 @@ $doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/tem
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
-
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-<jdoc:include type="head" />
-<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-<![endif]-->
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+	<jdoc:include type="head" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane modal">
 	<jdoc:include type="message" />

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -15,8 +15,11 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 
 // Getting params from template
 $params = $app->getTemplate(true)->params;
@@ -63,25 +66,25 @@ else
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<?php // Use of Google Font ?>
 	<?php if ($params->get('googleFont')) : ?>
-		<link href='//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>' rel='stylesheet' type='text/css' />
-		<style type="text/css">
+		<link href="//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" rel="stylesheet" />
+		<style>
 			h1,h2,h3,h4,h5,h6,.site-title{
 				font-family: '<?php echo str_replace('+', ' ', $params->get('googleFontName')); ?>', sans-serif;
 			}
 		</style>
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template.css" />
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" />
 	<?php endif; ?>
 	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
 	<?php // Template color ?>
 	<?php if ($params->get('templateColor')) : ?>
-		<style type="text/css">
+		<style>
 			body.site
 			{
 				border-top: 3px solid <?php echo $params->get('templateColor'); ?>;

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -68,7 +68,7 @@ else
 	<?php if ($params->get('googleFont')) : ?>
 		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" />
 		<style>
-			h1,h2,h3,h4,h5,h6,.site-title{
+			h1,h2,h3,h4,h5,h6,.site-title {
 				font-family: '<?php echo str_replace('+', ' ', $params->get('googleFontName')); ?>', sans-serif;
 			}
 		</style>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -15,6 +15,9 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -53,9 +53,9 @@ else
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<?php // Use of Google Font ?>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -66,7 +66,7 @@ else
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<?php // Use of Google Font ?>
 	<?php if ($params->get('googleFont')) : ?>
-		<link href="//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" rel="stylesheet" />
+		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=<?php echo $params->get('googleFontName'); ?>" />
 		<style>
 			h1,h2,h3,h4,h5,h6,.site-title{
 				font-family: '<?php echo str_replace('+', ' ', $params->get('googleFontName')); ?>', sans-serif;
@@ -106,11 +106,8 @@ else
 			}
 		</style>
 	<?php endif; ?>
-	<!--[if lt IE 9]>
-		<script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="site <?php echo $option
 	. ' view-' . $view
 	. ($layout ? ' layout-' . $layout : ' no-layout')

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -97,7 +97,7 @@ else
 	<?php if ($this->params->get('googleFont')) : ?>
 		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName'); ?>" />
 		<style>
-			h1,h2,h3,h4,h5,h6,.site-title{
+			h1,h2,h3,h4,h5,h6,.site-title {
 				font-family: '<?php echo str_replace('+', ' ', $this->params->get('googleFontName')); ?>', sans-serif;
 			}
 		</style>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -89,7 +89,7 @@ else
 }
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -95,8 +95,8 @@ else
 	<jdoc:include type="head" />
 	<?php // Use of Google Font ?>
 	<?php if ($this->params->get('googleFont')) : ?>
-		<link href='//fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName'); ?>' rel='stylesheet' type='text/css' />
-		<style type="text/css">
+		<link rel="stylesheet" href="//fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName'); ?>" />
+		<style>
 			h1,h2,h3,h4,h5,h6,.site-title{
 				font-family: '<?php echo str_replace('+', ' ', $this->params->get('googleFontName')); ?>', sans-serif;
 			}
@@ -104,26 +104,21 @@ else
 	<?php endif; ?>
 	<?php // Template color ?>
 	<?php if ($this->params->get('templateColor')) : ?>
-	<style type="text/css">
-		body.site
-		{
+	<style>
+		body.site {
 			border-top: 3px solid <?php echo $this->params->get('templateColor'); ?>;
 			background-color: <?php echo $this->params->get('templateBackgroundColor'); ?>
 		}
-		a
-		{
+		a {
 			color: <?php echo $this->params->get('templateColor'); ?>;
 		}
 		.nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .nav-pills > .active > a, .nav-pills > .active > a:hover,
-		.btn-primary
-		{
+		.btn-primary {
 			background: <?php echo $this->params->get('templateColor'); ?>;
 		}
 	</style>
 	<?php endif; ?>
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 
 <body class="site <?php echo $option

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -15,6 +15,9 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 
@@ -25,9 +28,6 @@ $layout   = $app->input->getCmd('layout', '');
 $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
-
-// Output as HTML5
-$doc->setHtml5(true);
 
 if($task == "edit" || $layout == "form" )
 {

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -9,8 +9,8 @@
 
 defined('_JEXEC') or die;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -18,6 +18,7 @@ JFactory::getDocument()->setHtml5(true);
 <head>
 	<jdoc:include type="head" />
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -8,6 +8,10 @@
  */
 
 defined('_JEXEC') or die;
+
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -11,13 +11,12 @@ defined('_JEXEC') or die;
 
 // Output as HTML5
 JFactory::getDocument()->setHtml5(true);
-
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" />
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -36,6 +36,7 @@ $doc->setHtml5(true);
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/media/cms/css/debug.css" type="text/css" />
 	<?php endif; ?>
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
 	<div class="error">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -20,6 +20,9 @@ $doc             = JFactory::getDocument();
 $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
+
+// Output as HTML5
+$doc->setHtml5(true);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -21,10 +21,10 @@ $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
 	<?php if ($this->direction == 'rtl') : ?>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -21,20 +21,23 @@ $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" />
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error_rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error_rtl.css" />
 	<?php endif; ?>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/media/cms/css/debug.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/media/cms/css/debug.css" />
 	<?php endif; ?>
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -11,6 +11,9 @@ defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
 
+// Output as HTML5
+JFactory::getDocument()->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -26,15 +26,15 @@ $twofactormethods = UsersHelper::getTwoFactorMethods();
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline.css" />
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline_rtl.css" type="text/css" />
+		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline_rtl.css" />
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" />
 	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
-<jdoc:include type="message" />
+	<jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->get('offline_image') && file_exists($app->get('offline_image'))) : ?>
 			<img src="<?php echo $app->get('offline_image'); ?>" alt="<?php echo htmlspecialchars($app->get('sitename')); ?>" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -19,7 +19,7 @@ require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
 $twofactormethods = UsersHelper::getTwoFactorMethods();
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -31,6 +31,7 @@ $twofactormethods = UsersHelper::getTwoFactorMethods();
 		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline_rtl.css" type="text/css" />
 	<?php endif; ?>
 	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
 <jdoc:include type="message" />


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

Basic conversion of all site and admin templates to HTML5 (some where still XHTML 1.0 Transitional).
#### Testing Instructions
1. Install patch
2. Check if pages in all templates (normal, component popup - ex: mail/print, error pages, offline and login) site and admin are working properly.

Check also the code changes.
#### Observations

All should now start with this code:

``` html
<!DOCTYPE html>
<html lang="en-gb" dir="ltr">
<head>
[...]
    <meta charset="utf-8" />
[...]
```

Suggestions and/or improvements are welcomed.
