### PR TITLE
Improve inline js/css type rendering in html5

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -212,7 +212,6 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate script declarations
 		foreach ($document->_script as $type => $content)
 		{
-		
 			$buffer .= $tab . '<script';
 
 			if (!is_null($type) && (!$document->isHtml5() || !in_array($type, $defaultJsMimes)))

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -127,12 +127,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= ' />' . $lnEnd;
 		}
 
+		$defaultCssMimes = array('text/css');
+
 		// Generate stylesheet links
 		foreach ($document->_styleSheets as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '"';
 
-			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || $strAttr['mime'] != 'text/css'))
+			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultCssMimes)))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}
@@ -156,7 +158,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate stylesheet declarations
 		foreach ($document->_style as $type => $content)
 		{
-			$buffer .= $tab . '<style type="' . $type . '">' . $lnEnd;
+			$buffer .= $tab . '<style';
+
+			if (!is_null($type) && (!$document->isHtml5() || !in_array($type, $defaultCssMimes)))
+			{
+				$buffer .= ' type="' . $type . '"';
+			}
+
+			$buffer .= '>' . $lnEnd;
 
 			// This is for full XHTML support.
 			if ($document->_mime != 'text/html')
@@ -175,15 +184,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= $tab . '</style>' . $lnEnd;
 		}
 
+		$defaultJsMimes = array('text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript');
+
 		// Generate script file links
 		foreach ($document->_scripts as $strSrc => $strAttr)
 		{
 			$buffer .= $tab . '<script src="' . $strSrc . '"';
-			$defaultMimes = array(
-				'text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript'
-			);
 
-			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultMimes)))
+			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultJsMimes)))
 			{
 				$buffer .= ' type="' . $strAttr['mime'] . '"';
 			}
@@ -204,7 +212,15 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate script declarations
 		foreach ($document->_script as $type => $content)
 		{
-			$buffer .= $tab . '<script type="' . $type . '">' . $lnEnd;
+		
+			$buffer .= $tab . '<script';
+
+			if (!is_null($type) && (!$document->isHtml5() || !in_array($type, $defaultJsMimes)))
+			{
+				$buffer .= ' type="' . $type . '"';
+			}
+
+			$buffer .= '>' . $lnEnd;
 
 			// This is for full XHTML support.
 			if ($document->_mime != 'text/html')
@@ -226,7 +242,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate script language declarations.
 		if (count(JText::script()))
 		{
-			$buffer .= $tab . '<script type="text/javascript">' . $lnEnd;
+			$buffer .= $tab . '<script';
+
+			if (!$document->isHtml5())
+			{
+				$buffer .= ' type="text/javascript"';
+			}
+
+			$buffer .= '>' . $lnEnd;
 
 			if ($document->_mime != 'text/html')
 			{


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

This PR improves inline js/css rendering in HTML5.

In HTML5 there are default type for:
- `script` tag: `text/javascript`
- `style` tag: `text/css`

So they are not needing when the document is rendered in HTML5.

Joomla already removes them in HTML5 for external js/css files, but not for inline js/css.
This PR improves that.
#### Testing Instructions
- Use latest staging
- Go to protostar homepage and view source. You will get some

``` html
<script type="text/javascript">[...]</script>
```
- Apply patch 
- You willl now get

``` html
<script>[...]</script>
```

To test the style tag you can add to your protostar `index.php` file, for instance:

``` php
$doc->addStyleDeclaration('p {margin:0}');
```

That should be rendered, after the patch. as

``` html
<style>
p {margin:0}
</style>
```

Also check code difference.
