### PR TITLE
Utf8mb4 refactoring - remove duplicate code and fix utf8mb4 to utf8 statement downgrade

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1670,7 +1670,7 @@ class JoomlaInstallerScript
 	 *
 	 * @since   3.5
 	 */
-	private function convertTablesToUtf8mb4()
+	public function convertTablesToUtf8mb4()
 	{
 		$db = JFactory::getDbo();
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -36,7 +36,7 @@ class JoomlaInstallerScript
 		$this->clearRadCache();
 		$this->updateAssets();
 		$this->clearStatsCache();
-		$this->convertTablesToUtf8mb4();
+		$this->convertTablesToUtf8mb4(true);
 		$this->cleanJoomlaCache();
 
 		// VERY IMPORTANT! THIS METHOD SHOULD BE CALLED LAST, SINCE IT COULD
@@ -1666,11 +1666,13 @@ class JoomlaInstallerScript
 	/**
 	 * Converts the site's database tables to support UTF-8 Multibyte.
 	 *
+	 * @param   boolean  $doDbFixMsg  Flag if message to be shown to check db fix
+	 *
 	 * @return  void
 	 *
 	 * @since   3.5
 	 */
-	public function convertTablesToUtf8mb4()
+	public function convertTablesToUtf8mb4($doDbFixMsg = false)
 	{
 		$db = JFactory::getDbo();
 
@@ -1703,7 +1705,14 @@ class JoomlaInstallerScript
 		}
 		catch (Exception $e)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
+			// Render the error message from the Exception object
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+
+			if ($doDbFixMsg)
+			{
+				// Show an error message telling to check database problems
+				JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');
+			}
 
 			return;
 		}
@@ -1765,8 +1774,7 @@ class JoomlaInstallerScript
 			}
 		}
 
-		// Show if there was some error
-		if ($converted == 0)
+		if ($doDbFixMsg && $converted == 0)
 		{
 			// Show an error message telling to check database problems
 			JFactory::getApplication()->enqueueMessage(JText::_('JLIB_DATABASE_ERROR_DATABASE_UPGRADE_FAILED'), 'error');

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -76,7 +76,7 @@ class InstallerModelDatabase extends InstallerModel
 
 		if (count($statusArray['error']) == 0)
 		{
-			$installer->convertTablesToUtf8mb4();
+			$installer->convertTablesToUtf8mb4(false);
 		}
 	}
 

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -56,9 +56,6 @@ class InstallerModelDatabase extends InstallerModel
 	 */
 	public function fix()
 	{
-		// Prepare the utf8mb4 conversion check table
-		$this->prepareUtf8mb4StatusTable();
-
 		if (!$changeSet = $this->getItems())
 		{
 			return false;

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -79,7 +79,7 @@ class InstallerModelDatabase extends InstallerModel
 
 		if (count($statusArray['error']) == 0)
 		{
-			$this->convertTablesToUtf8mb4();
+			$installer->convertTablesToUtf8mb4();
 		}
 	}
 
@@ -263,114 +263,6 @@ class InstallerModelDatabase extends InstallerModel
 				return true;
 			}
 		}
-	}
-
-	/**
-	 * Converts the site's database tables to support UTF-8 Multibyte
-	 *
-	 * @return  void
-	 *
-	 * @since   3.5
-	 */
-	public function convertTablesToUtf8mb4()
-	{
-		$db = JFactory::getDbo();
-
-		// Get the SQL file to convert the core tables. Yes, this is hardcoded because we have all sorts of index
-		// conversions and funky things we can't automate in core tables without an actual SQL file.
-		$serverType = $db->getServerType();
-
-		if ($serverType != 'mysql')
-		{
-			return;
-		}
-
-		// Set required conversion status
-		if ($db->hasUTF8mb4Support())
-		{
-			$converted = 2;
-		}
-		else
-		{
-			$converted = 1;
-		}
-
-		// Check conversion status in database
-		$db->setQuery('SELECT ' . $db->quoteName('converted')
-			. ' FROM ' . $db->quoteName('#__utf8_conversion')
-			);
-
-		try
-		{
-			$convertedDB = $db->loadResult();
-		}
-		catch (Exception $e)
-		{
-			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-
-			return;
-		}
-
-		// Nothing to do, saved conversion status from DB is equal to required
-		if ($convertedDB == $converted)
-		{
-			return;
-		}
-
-		// Step 1: Drop indexes later to be added again with column lengths limitations at step 2
-		$fileName1 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/$serverType/utf8mb4-conversion-01.sql";
-
-		if (is_file($fileName1))
-		{
-			$fileContents1 = @file_get_contents($fileName1);
-			$queries1 = $db->splitSql($fileContents1);
-
-			if (!empty($queries1))
-			{
-				foreach ($queries1 as $query1)
-				{
-					try
-					{
-						$db->setQuery($query1)->execute();
-					}
-					catch (Exception $e)
-					{
-						// If the query fails we will go on. It just means the index to be dropped does not exist.
-					}
-				}
-			}
-		}
-
-		// Step 2: Perform the index modifications and conversions
-		$fileName2 = JPATH_ADMINISTRATOR . "/components/com_admin/sql/others/$serverType/utf8mb4-conversion-02.sql";
-
-		if (is_file($fileName2))
-		{
-			$fileContents2 = @file_get_contents($fileName2);
-			$queries2 = $db->splitSql($fileContents2);
-
-			if (!empty($queries2))
-			{
-				foreach ($queries2 as $query2)
-				{
-					try
-					{
-						$db->setQuery($db->convertUtf8mb4QueryToUtf8($query2))->execute();
-					}
-					catch (Exception $e)
-					{
-						$converted = 0;
-
-						// Still render the error message from the Exception object
-						JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-					}
-				}
-			}
-		}
-
-		// Set flag in database if the update is done.
-		$db->setQuery('UPDATE ' . $db->quoteName('#__utf8_conversion')
-			. ' SET ' . $db->quoteName('converted') . ' = ' . $converted . ';')->execute();
 	}
 
 	/**

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -854,29 +854,12 @@ class JInstaller extends JAdapter
 			return 0;
 		}
 
-		$dbDriver = strtolower($db->name);
-
-		if ($dbDriver == 'mysql' || $dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
-		{
-			$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
-		}
-		else
-		{
-			$doUtf8mb4ToUtf8 = false;
-		}
-
 		$update_count = 0;
 
 		// Process each query in the $queries array (children of $tagName).
 		foreach ($queries as $query)
 		{
-			// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-			if ($doUtf8mb4ToUtf8)
-			{
-				$query = $this->convertUtf8mb4QueryToUtf8($query);
-			}
-
-			$db->setQuery($query);
+			$db->setQuery($db->convertUtf8mb4QueryToUtf8($query));
 
 			if (!$db->execute())
 			{
@@ -912,16 +895,9 @@ class JInstaller extends JAdapter
 		$db = & $this->_db;
 		$dbDriver = strtolower($db->name);
 
-		$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
-
 		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 		{
 			$dbDriver = 'mysql';
-		}
-
-		if ($dbDriver != 'mysql')
-		{
-			$doUtf8mb4ToUtf8 = false;
 		}
 
 		$update_count = 0;
@@ -971,13 +947,7 @@ class JInstaller extends JAdapter
 				// Process each query in the $queries array (split out of sql file).
 				foreach ($queries as $query)
 				{
-					// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-					if ($doUtf8mb4ToUtf8)
-					{
-						$query = $this->convertUtf8mb4QueryToUtf8($query);
-					}
-
-					$db->setQuery($query);
+					$db->setQuery($db->convertUtf8mb4QueryToUtf8($query));
 
 					if (!$db->execute())
 					{
@@ -1087,16 +1057,9 @@ class JInstaller extends JAdapter
 			{
 				$dbDriver = strtolower($db->name);
 
-				$doUtf8mb4ToUtf8 = !$this->serverClaimsUtf8mb4Support($dbDriver);
-
 				if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
 				{
 					$dbDriver = 'mysql';
-				}
-
-				if ($dbDriver != 'mysql')
-				{
-					$doUtf8mb4ToUtf8 = false;
 				}
 
 				$schemapath = '';
@@ -1169,13 +1132,7 @@ class JInstaller extends JAdapter
 							// Process each query in the $queries array (split out of sql file).
 							foreach ($queries as $query)
 							{
-								// If we don't have UTF-8 Multibyte support we'll have to convert queries to plain UTF-8
-								if ($doUtf8mb4ToUtf8)
-								{
-									$query = $this->convertUtf8mb4QueryToUtf8($query);
-								}
-
-								$db->setQuery($query);
+								$db->setQuery($db->convertUtf8mb4QueryToUtf8($query));
 
 								if (!$db->execute())
 								{
@@ -2400,86 +2357,5 @@ class JInstaller extends JAdapter
 	public function loadAllAdapters($options = array())
 	{
 		$this->getAdapters($options);
-	}
-
-	/**
-	 * Does the database server claim to have support for UTF-8 Multibyte (utf8mb4) collation?
-	 * 
-	 * This is a modified version of the function in JDatabase::serverClaimsUtf8mb4Support() - it is
-	 * duplicated here for people upgrading from a version lower than 3.5.0 through extension manager
-	 * which will still have the old database driver loaded at this point.
-	 *
-	 * @param   string  $format  The type of database connection.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   3.5.0
-	 */
-	private function serverClaimsUtf8mb4Support($format)
-	{
-		$db = JFactory::getDbo();
-
-		switch ($format)
-		{
-			case 'mysql':
-				$client_version = mysql_get_client_info();
-				$server_version = $db->getVersion();
-				break;
-			case 'mysqli':
-				$client_version = mysqli_get_client_info();
-				$server_version = $db->getVersion();
-				break;
-			case 'pdomysql':
-				$client_version = $db->getOption(PDO::ATTR_CLIENT_VERSION);
-				$server_version = $db->getOption(PDO::ATTR_SERVER_VERSION);
-				break;
-			default:
-				$client_version = false;
-				$server_version = false;
-		}
-
-		if ($client_version && version_compare($server_version, '5.5.3', '>='))
-		{
-			if (strpos($client_version, 'mysqlnd') !== false)
-			{
-				$client_version = preg_replace('/^\D+([\d.]+).*/', '$1', $client_version);
-
-				return version_compare($client_version, '5.0.9', '>=');
-			}
-			else
-			{
-				return version_compare($client_version, '5.5.3', '>=');
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Downgrade a CREATE TABLE or ALTER TABLE query from utf8mb4 (UTF-8 Multibyte) to plain utf8. Used when the server
-	 * doesn't support UTF-8 Multibyte.
-	 *
-	 * This is a modified version of the function in JDatabase::convertUtf8mb4QueryToUtf8() - it is duplicated here for
-	 * people upgrading from a version lower than 3.5.0 through installer which will still have the old database
-	 * driver loaded at this point. This is missing the check for utf8mb4 in JDatabaseDriver we make this check in the
-	 * updater elsewhere.
-	 *
-	 * @param   string  $query  The query to convert
-	 *
-	 * @return  string  The converted query
-	 */
-	private function convertUtf8mb4QueryToUtf8($query)
-	{
-		// If it's not an ALTER TABLE or CREATE TABLE command there's nothing to convert
-		$beginningOfQuery = substr($query, 0, 12);
-		$beginningOfQuery = strtoupper($beginningOfQuery);
-
-		if (!in_array($beginningOfQuery, array('ALTER TABLE ', 'CREATE TABLE')))
-		{
-			return $query;
-		}
-
-		// Replace utf8mb4 with utf8
-		return str_replace('utf8mb4', 'utf8', $query);
 	}
 }

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -890,16 +890,13 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 		}
 
 		// If it's not an ALTER TABLE or CREATE TABLE command there's nothing to convert
-		$beginningOfQuery = substr($query, 0, 12);
-		$beginningOfQuery = strtoupper($beginningOfQuery);
-
-		if (!in_array($beginningOfQuery, array('ALTER TABLE ', 'CREATE TABLE')))
+		if (!preg_match('/^(ALTER|CREATE)\s+TABLE\s+/i', $query))
 		{
 			return $query;
 		}
 
-		// Replace utf8mb4 with utf8
-		return str_replace('utf8mb4', 'utf8', $query);
+		// Replace utf8mb4 with utf8 if not within single or double quotes or name quotes
+		return preg_replace('/[`"\'][^`"\']*[`"\'](*SKIP)(*FAIL)|utf8mb4/i', 'utf8', $query);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for new issue.

Only relevant for mysql databases.
#### Summary of Changes

When implementation of utf8mb4 conversion started a few months ago, we (all who worked together on that) tried to make it work also when using Extension Installer to update Joomla! Core. So we impemented functions to check utf8mb4 support and downgrade "create table" or "alter table" not only in the db driver but also at several places in case of the update is running while still being connected to the old db driver.

Meanwhile this update method is not supported anymore, and with using the Joomla! Update component we can rely on the new, updated db driver being used when running schema updates, and so the duplicate functions are not necessary anymore.

This PR removes these duplicate function impementations and replaces calls to them by calling the corresponding db driver functions.

After this change, the 2 functions to perform the utf8mb4 conversion in script.php and the database schema manager (administrator/components/com_installer/models/database.php) are identical beside a message to check the db fixer in case if some error occurred, which makes sense to be shown on update but not when using the db fixer and so already being in this view. Because the schema manager already includes script.php and uses functions of it just a few lines above the conversion function is called, it is a logical step to make the schema manager use the conversion function from script.php, too.

So this PR also replaces the call to the local conversion function in the schema manager by a call to the one of scrip.php, and remove the duplicate local code. The function in script.php is extended by a parameter telling if the special message to check the db fixer is shown or not.

Finally, this PR corrects following 2 issues with the statement downgrade function for which I once created PR #9504 , which I will close soon in favour of this PR here:
1. If in a "CREATE TABLE" or "ALTER TABLE" statement there is more than 1 space or a tab between the words "CREATE" or "ALTER" and "TABLE", or the keywords are not in uppercase, which is all still valid SQL, the statement will not be detected to be a "CREATE TABLE" or "ALTER TABLE" statement and so not be processed. This will lead to an "unknown character set" SQL error on a db not supporting utf8mb4 e.g. when installing extensions already using utf8mb4 in their sql for creating tables.
2. If a "CREATE TABLE" or "ALTER TABLE" has been detected, the procedure is to simply replace "utf8mb4" by "utf8" in the statement, regardless if it occurs withint quoted text or name quotes. This makes it impossible to use the pattern "utf8mb4" within table or column names, table or column comments or column default values.

This PR fixes both issues.
#### Testing Instructions
##### Pre-requisites

This PR is only relevant for mysql databases.

It needs tests with database sever/client combinations which do **not** support utf8mb4, i.e. either the mysql server version is lower than 5.5.3, or a msqlnd client API with version lower than 5.0.9 is used, or another mysql-related client API with version lower than 5.5.3 is used.

Testers who have only database sever/client combinations which **do** support utf8mb4 are welcome to test that updating Joomla! core with any valid method or installing extensions already using utf8mb4 (e.g. Patchtester) still works the same as before. Please report in this case that you tested with utf8mb4 support.
##### Test 1: Joomla! Update component

Step 1: Update a Joomla! version 3.5.1 or lower to a 3.5.2-dev patched by this PR using following custom URL: [http://test5.richard-fath.de/list_test10.xml](http://test5.richard-fath.de/list_test10.xml).

If you want to continue later with Test 2, you should export your database before doing the update, so you can later use the database dump for Test 2.

Result: Update ends with success.

Step 2: Check "Extensions -> Manage -> Database".

Result:

> Database table structure is up to date.
> Other Information
> - Database schema version (in #__schemas): 3.5.1-2016-03-29.
> - Update version (in #__extensions): 3.5.2-dev.
> - Database driver: mysqli.
> - 94 database changes were checked successfully.
> - 145 database changes did not alter table structure and were skipped.

Step 3: Check database table character sets and collations with phpMyAdmin.

Result: All core tables have utf8mb4 or utf8 charset, depending on utf8mb4 support. All core table have unicode_ci collations, except of those for com_finder, which have general_ci.

Step 4: Check with phpMyAdmin the index `idx_name` of table `#__users`.

Result: The index `idx_name` of table `#__users` includes the `name` column with 100 chars.
##### Test 2: Database Schema Manager aka "DB fixer"

Step 1: Prepare to update a Joomla! version 3.5.1 or lower to a 3.5.2-dev patched by this PR with the "copy files and run db fixer" method.

If you have done Test 1 before and have exported the database before updating, just import back the exported database.

Otherwise use a clean 3.5.1 or lower and copy the files of this PR'S branch to the joomla folder. A zip of this branch can be found here: [https://github.com/richard67/joomla-cms/archive/utf8mb4-refactoring-1.zip](https://github.com/richard67/joomla-cms/archive/utf8mb4-refactoring-1.zip).

Step 2: Go to "Extensions -> Manage -> Database".

Result: Database problems shown for schema update files according to the pre-update schema version, last problem is that utf8mb4 (or utf8) conversion has not been done yet.

Step 3: Use the "Fix" button.

Result: See result of Test 1 Step 2.

Check database as described with Steps 3 and 4 of Test 1.
##### Test 3: Install extensions

Step 1: On current staging patched by this PR, or on the updated 3.5.2-dev patched by this PR which you have after Test 1 or Test 2, install some extension which already uses utf8mb4, e.g. the latest com_patchtester 2.0.0-rc.

Step 2: Check with phpMyAdmin that the database tables for this component have the correct character sets and collations depending on utf8mb4 support, e.g. for patchtester: utf8mb4_unicode_ci or utf8_unicode_ci.

Result: No SQL errors related to character sets or collations, database tables look as expected.
##### Test 4: Statement downgrade bug fix

This test only makes sense on a database server/client combination which does **not** support utf8mb4.

Step 1: Download following dummy extension and then install it, using "Extensions -> Manage -> Install", "Upload & Install Package": [http://test5.richard-fath.de/test_package_utf8mb4.zip](http://test5.richard-fath.de/test_package_utf8mb4.zip).

Result: The installation succeeds without any SQL errors.

Step 2: Check with phpMyAdmin that the package has created a new table `#__test_package_utf8mb4` with default character set=utf8 and default collation = utf8_unicode_ci.

Step 3: Check with phpMyAdmin the structure of this new table.

Result: The table has following 2 columns:
- `utf8mb4_test_1` varchar(40) NOT NULL DEFAULT 'Do not replace utf8mb4 in quoted text.' COMMENT 'Do not replace utf8mb4 in quoted text.',
- `utf8mb4_test_2` varchar(7) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '#fff' COMMENT 'Do not replace utf8mb4 in quoted text.'

Step 4: Uninstall the package to clean up if you need your test system for other tests.

Step 5: Repeat Steps 1 to 4 on an unpatched staging or 3.5.1 or 3.5.0.

Result: Table names, column names, column default values and column comments are wrong because "utf8mb4" has been replaced everywhere by "utf8".
