### PR TITLE
Fixed not updating modified date when doing bulk update in Redirect (#9859)

### DIFF
--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -58,6 +58,47 @@ class RedirectControllerLinks extends JControllerAdmin
 	}
 
 	/**
+	 * Method to duplicate URLs in records.
+	 *
+	 * @return  void.
+	 *
+	 * @since   3.5
+	 */
+	public function duplicateUrls()
+	{
+		// Check for request forgeries.
+		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+
+		$ids     = $this->input->get('cid', array(), 'array');
+		$newUrl  = $this->input->getString('new_url');
+		$comment = $this->input->getString('comment');
+
+		if (empty($ids))
+		{
+			JError::raiseWarning(500, JText::_('COM_REDIRECT_NO_ITEM_SELECTED'));
+		}
+		else
+		{
+			// Get the model.
+			$model = $this->getModel();
+
+			JArrayHelper::toInteger($ids);
+
+			// Remove the items.
+			if (!$model->duplicateUrls($ids, $newUrl, $comment))
+			{
+				JError::raiseWarning(500, $model->getError());
+			}
+			else
+			{
+				$this->setMessage(JText::plural('COM_REDIRECT_N_LINKS_UPDATED', count($ids)));
+			}
+		}
+
+		$this->setRedirect('index.php?option=com_redirect&view=links');
+	}
+
+	/**
 	 * Proxy for getModel.
 	 *
 	 * @param   string  $name    The name of the model.

--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -175,7 +175,7 @@ class RedirectModelLink extends JModelAdmin
 		if (!empty($pks))
 		{
 			$date = JFactory::getDate()->toSql();
-			
+
 			// Update the link rows.
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__redirect_links'))

--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -174,12 +174,15 @@ class RedirectModelLink extends JModelAdmin
 
 		if (!empty($pks))
 		{
+			$date = JFactory::getDate()->toSql();
+			
 			// Update the link rows.
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__redirect_links'))
 				->set($db->quoteName('new_url') . ' = ' . $db->quote($url))
 				->set($db->quoteName('published') . ' = ' . (int) 1)
 				->set($db->quoteName('comment') . ' = ' . $db->quote($comment))
+				->set($db->quoteName('modified_date') . ' = ' . $db->quote($date))
 				->where($db->quoteName('id') . ' IN (' . implode(',', $pks) . ')');
 			$db->setQuery($query);
 

--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -174,15 +174,12 @@ class RedirectModelLink extends JModelAdmin
 
 		if (!empty($pks))
 		{
-			$date = JFactory::getDate()->toSql();
-
 			// Update the link rows.
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__redirect_links'))
 				->set($db->quoteName('new_url') . ' = ' . $db->quote($url))
 				->set($db->quoteName('published') . ' = ' . (int) 1)
 				->set($db->quoteName('comment') . ' = ' . $db->quote($comment))
-				->set($db->quoteName('modified_date') . ' = ' . $db->quote($date))
 				->where($db->quoteName('id') . ' IN (' . implode(',', $pks) . ')');
 			$db->setQuery($query);
 
@@ -200,4 +197,66 @@ class RedirectModelLink extends JModelAdmin
 
 		return true;
 	}
+
+	/**
+	 * Method to duplicate URL links.
+	 *
+	 * @param   array   &$pks     An array of link ids.
+	 * @param   string  $url      The new URL to set for the redirect.
+	 * @param   string  $comment  A comment for the redirect links.
+	 *
+	 * @return  boolean  Returns true on success, false on failure.
+	 *
+	 * @since   3.5
+	 */
+	public function duplicateUrls(&$pks, $url, $comment = null)
+	{
+		$user = JFactory::getUser();
+		$db = $this->getDbo();
+
+		// Sanitize the ids.
+		$pks = (array) $pks;
+		JArrayHelper::toInteger($pks);
+
+		// Access checks.
+		if (!$user->authorise('core.edit', 'com_redirect'))
+		{
+			$pks = array();
+			$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'));
+
+			return false;
+		}
+
+		if (!empty($pks))
+		{
+			$date = JFactory::getDate()->toSql();
+
+			// Update the link rows.
+			$query = $db->getQuery(true)
+				->update($db->quoteName('#__redirect_links'))
+				->set($db->quoteName('new_url') . ' = ' . $db->quote($url))
+				->set($db->quoteName('modified_date') . ' = ' . $db->quote($date))
+				->where($db->quoteName('id') . ' IN (' . implode(',', $pks) . ')');
+
+			if(!empty($comment))
+			{
+				$query->set($db->quoteName('comment') . ' = ' . $db->quote($comment));
+			}
+			$db->setQuery($query);
+
+			try
+			{
+				$db->execute();
+			}
+			catch (RuntimeException $e)
+			{
+				$this->setError($e->getMessage());
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 }

--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -238,7 +238,7 @@ class RedirectModelLink extends JModelAdmin
 				->set($db->quoteName('modified_date') . ' = ' . $db->quote($date))
 				->where($db->quoteName('id') . ' IN (' . implode(',', $pks) . ')');
 
-			if(!empty($comment))
+			if (!empty($comment))
 			{
 				$query->set($db->quoteName('comment') . ' = ' . $db->quote($comment));
 			}

--- a/administrator/components/com_redirect/views/links/tmpl/default_addform.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_addform.php
@@ -32,7 +32,7 @@ defined('_JEXEC') or die;
 							<input type="text" name="comment" id="comment" value="" size="50" title="<?php echo JText::_('COM_REDIRECT_FIELD_COMMENT_DESC'); ?>" />
 						</div>
 					</div>
-					<button class="btn btn-primary" type="button" onclick="this.form.task.value='links.activate';this.form.submit();"><?php echo JText::_('COM_REDIRECT_BUTTON_UPDATE_LINKS'); ?></button>
+					<button class="btn btn-primary" type="button" onclick="this.form.task.value='links.duplicateUrls';this.form.submit();"><?php echo JText::_('COM_REDIRECT_BUTTON_UPDATE_LINKS'); ?></button>
 				</fieldset>
 			</div>
 		</div>


### PR DESCRIPTION
Pull Request for Issue #9859 & #9873.
#### Summary of Changes

Added code to update "modified_date" when doing bulk update for Destination URL do Link model. Also, the "Destination URL" functionality was moved into a separate method in model in order to fix #9873 in clear way.
#### Testing Instructions #9859

_(Copied from the original issue)_
##### Steps to reproduce the issue

The redirect component has a fairly hidden feature to mass update existing links - its at the bottom of the list called Destination URL.
Select some existing links and click on Destination URL
Enter a new Destination URL and a comment
And then update links button to process
##### Expected result

Destination url is changed
comment is added
Last Updated Date is modified
#### Testing Instructions #9873 (ADDED LATER)

_(Copied from the original issue)_
##### Steps to reproduce the issue
1. Go to "Redirect" component in back-end and select some URLs (some of them should be disabled)
2. Click on link "Destination URL" (below table)
3. Enter some URL
4. Leave "Comment" field empty
5. Click on "Update links"
##### Expected result
- Selected rows will have new URL
- Their state (Enabled/disabled) will remain the same
- Their comment will remain the same 
