### PR TITLE
Backend login, remove the dot in link

### DIFF
--- a/administrator/language/en-GB/en-GB.com_login.ini
+++ b/administrator/language/en-GB/en-GB.com_login.ini
@@ -5,6 +5,6 @@
 
 COM_LOGIN="Login"
 COM_LOGIN_JOOMLA_ADMINISTRATION_LOGIN="Joomla! Administration Login"
-COM_LOGIN_RETURN_TO_SITE_HOME_PAGE="Go to site home page."
+COM_LOGIN_RETURN_TO_SITE_HOME_PAGE="Go to site home page"
 COM_LOGIN_VALID="Use a valid username and password to gain access to the Administrator Backend."
 COM_LOGIN_XML_DESCRIPTION="This component lets users login to the site."


### PR DESCRIPTION
#### Summary of Changes

very simple PR just to remove the dot in backend login panel "Go to site home page." link.
#### Testing Instructions

Go to the bottom of the backend login screen, there in a "Go to site home page." link, after patch the dot is removed.
Or just check code difference.
