### PR TITLE
Instructions for full screen CodeMirror #9870

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -27,6 +27,8 @@ JFactory::getDocument()->addScriptDeclaration('
 ');
 ?>
 
+<p class="label"><?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $params->get('fullScreen', 'F10')); ?></p>
+
 <?php echo '<textarea name="', $name, '" id="', $id, '" cols="', $cols, '" rows="', $rows, '">', $content, '</textarea>'; ?>
 
 <?php echo $displayData->buttons; ?>


### PR DESCRIPTION
Pull Request for Issue #9870 .
#### Summary of Changes

Added the missing instructions on how to toggle full screen for CodeMirror.
#### Testing Instructions
- Make sure you have CodeMirror selected as your preferred editor from System > Global Configuration > Default Editor.
- Create or edit an article
- The instructions should show up above the editor in the form of `Press F10 to toggle Full Screen editing.`
