### PR TITLE
[Protostar] Add offline template as example

### DIFF
--- a/templates/protostar/css/offline.css
+++ b/templates/protostar/css/offline.css
@@ -21,8 +21,7 @@ body.site {
 }
 
 .inner {
-	margin-left: auto;
-	margin-right: auto; 
+	margin: 0 auto;
 	max-width: 30em;
 	background-color: #ffffff;
 }

--- a/templates/protostar/css/offline.css
+++ b/templates/protostar/css/offline.css
@@ -1,0 +1,54 @@
+/**
+ * @copyright	Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+.outer {
+    display: table;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+}
+
+.middle {
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.inner {
+    margin-left: auto;
+    margin-right: auto; 
+    width: 30em;
+	background-color: #ffffff;
+}
+
+.header {
+	text-align: center;
+	margin: 0 0 1em 0;
+}
+
+img {
+	max-width: 100%;
+	height: auto;
+	border: 0;
+}
+
+form, fieldset {
+	margin: 0;
+	padding: 0;
+}
+
+label {
+	display: block;
+	margin: 0;
+}
+
+input[type="text"], input[type="password"] {
+	box-sizing: border-box;
+	width: 100%;
+	height: auto;
+}
+
+input {
+	margin: .5em 0 1em 0;
+}

--- a/templates/protostar/css/offline.css
+++ b/templates/protostar/css/offline.css
@@ -19,7 +19,7 @@
     margin-left: auto;
     margin-right: auto; 
     width: 30em;
-	background-color: #ffffff;
+    background-color: #ffffff;
 }
 
 .header {

--- a/templates/protostar/css/offline.css
+++ b/templates/protostar/css/offline.css
@@ -3,23 +3,28 @@
  * @license		GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+body.site {
+	margin: 0;
+	padding: 0;
+}
+
 .outer {
-    display: table;
-    position: absolute;
-    height: 100%;
-    width: 100%;
+	display: table;
+	position: absolute;
+	height: 100%;
+	width: 100%;
 }
 
 .middle {
-    display: table-cell;
-    vertical-align: middle;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 .inner {
-    margin-left: auto;
-    margin-right: auto; 
-    width: 30em;
-    background-color: #ffffff;
+	margin-left: auto;
+	margin-right: auto; 
+	max-width: 30em;
+	background-color: #ffffff;
 }
 
 .header {

--- a/templates/protostar/css/offline.css
+++ b/templates/protostar/css/offline.css
@@ -1,6 +1,6 @@
 /**
  * @copyright	Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
- * @license		GNU General Public License version 2 or later; see LICENSE.txt
+ * @license	GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 body.site {

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -119,11 +119,11 @@ else
 						<input name="username" id="username" type="text" title="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" />
 
 						<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-						<input type="password" name="password" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+						<input type="password" name="password" id="password" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
 
 						<?php if (count($twofactormethods) > 1) : ?>
 						<label for="secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input type="text" name="secretkey" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input type="text" name="secretkey" id="secretkey" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 						<?php endif; ?>
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGIN'); ?>" />

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -42,6 +42,7 @@ JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Logo file or site title param
 $sitename = $app->get('sitename');
+
 if ($this->params->get('logoFile'))
 {
 	$logo = '<img src="' . JUri::root() . $this->params->get('logoFile') . '" alt="' . $sitename . '" />';

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Templates.protostar
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
+
+$twofactormethods = UsersHelper::getTwoFactorMethods();
+$app              = JFactory::getApplication();
+$doc              = JFactory::getDocument();
+$this->language   = $doc->language;
+$this->direction  = $doc->direction;
+
+// Output as HTML5
+$doc->setHtml5(true);
+
+$fullWidth = 1;
+
+// Add JavaScript Frameworks
+JHtml::_('bootstrap.framework');
+$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+
+// Add Stylesheets
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+
+// Check for a custom CSS file
+$userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
+
+if (file_exists($userCss) && filesize($userCss) > 0)
+{
+	$doc->addStyleSheetVersion('templates/' . $this->template . '/css/user.css');
+}
+
+// Load optional RTL Bootstrap CSS
+JHtml::_('bootstrap.loadCss', false, $this->direction);
+
+// Logo file or site title param
+$sitename = $app->get('sitename');
+if ($this->params->get('logoFile'))
+{
+	$logo = '<img src="' . JUri::root() . $this->params->get('logoFile') . '" alt="' . $sitename . '" />';
+}
+elseif ($this->params->get('sitetitle'))
+{
+	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($this->params->get('sitetitle')) . '</span>';
+}
+else
+{
+	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
+}
+?>
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<head>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<jdoc:include type="head" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/offline.css" type="text/css" />
+	<?php // Use of Google Font ?>
+	<?php if ($this->params->get('googleFont')) : ?>
+		<link href='//fonts.googleapis.com/css?family=<?php echo $this->params->get('googleFontName'); ?>' rel='stylesheet' type='text/css' />
+		<style type="text/css">
+			h1,h2,h3,h4,h5,h6,.site-title{
+				font-family: '<?php echo str_replace('+', ' ', $this->params->get('googleFontName')); ?>', sans-serif;
+			}
+		</style>
+	<?php endif; ?>
+	<?php // Template color ?>
+	<?php if ($this->params->get('templateColor')) : ?>
+	<style type="text/css">
+		body.site
+		{
+			border-top: 3px solid <?php echo $this->params->get('templateColor'); ?>;
+			background-color: <?php echo $this->params->get('templateBackgroundColor'); ?>
+		}
+		a
+		{
+			color: <?php echo $this->params->get('templateColor'); ?>;
+		}
+		.nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .nav-pills > .active > a, .nav-pills > .active > a:hover,
+		.btn-primary
+		{
+			background: <?php echo $this->params->get('templateColor'); ?>;
+		}
+	</style>
+	<?php endif; ?>
+	<!--[if lt IE 9]>
+		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
+	<![endif]-->
+</head>
+<body class="site">
+	<div class="outer">
+		<div class="middle">
+			<div class="inner well">
+				<div class="header">
+				<?php if (!empty($logo)) : ?>
+					<h1><?php echo $logo; ?></h1>
+				<?php else : ?>
+					<h1><?php echo htmlspecialchars($app->get('sitename')); ?></h1>
+				<?php endif; ?>
+				<?php if ($app->get('offline_image') && file_exists($app->get('offline_image'))) : ?>
+					<img src="<?php echo $app->get('offline_image'); ?>" alt="<?php echo htmlspecialchars($app->get('sitename')); ?>" />
+				<?php endif; ?>
+				<?php if ($app->get('display_offline_message', 1) == 1 && str_replace(' ', '', $app->get('offline_message')) != '') : ?>
+					<p><?php echo $app->get('offline_message'); ?></p>
+				<?php elseif ($app->get('display_offline_message', 1) == 2) : ?>
+					<p><?php echo JText::_('JOFFLINE_MESSAGE'); ?></p>
+				<?php endif; ?>
+				</div>
+				<jdoc:include type="message" />
+				<form action="<?php echo JRoute::_('index.php', true); ?>" method="post" id="form-login">
+					<fieldset>
+						<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
+						<input name="username" id="username" type="text" alt="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" />
+
+						<label for="passwd"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
+						<input type="password" name="password" alt="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+
+						<?php if (count($twofactormethods) > 1) : ?>
+						<label for="secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
+						<input type="text" name="secretkey" alt="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<?php endif; ?>
+
+						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGIN'); ?>" />
+
+						<input type="hidden" name="option" value="com_users" />
+						<input type="hidden" name="task" value="user.login" />
+						<input type="hidden" name="return" value="<?php echo base64_encode(JUri::base()); ?>" />
+						<?php echo JHtml::_('form.token'); ?>
+					</fieldset>
+				</form>
+			</div>
+		</div>
+	</div>
+</body>
+</html>

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -116,14 +116,14 @@ else
 				<form action="<?php echo JRoute::_('index.php', true); ?>" method="post" id="form-login">
 					<fieldset>
 						<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-						<input name="username" id="username" type="text" alt="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" />
+						<input name="username" id="username" type="text" title="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" />
 
-						<label for="passwd"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-						<input type="password" name="password" alt="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+						<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
+						<input type="password" name="password" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
 
 						<?php if (count($twofactormethods) > 1) : ?>
 						<label for="secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input type="text" name="secretkey" alt="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input type="text" name="secretkey" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 						<?php endif; ?>
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGIN'); ?>" />

--- a/templates/protostar/templateDetails.xml
+++ b/templates/protostar/templateDetails.xml
@@ -11,6 +11,7 @@
 	<files>
 		<filename>component.php</filename>
 		<filename>error.php</filename>
+		<filename>offline.php</filename>
 		<filename>favicon.ico</filename>
 		<filename>index.php</filename>
 		<filename>templateDetails.xml</filename>


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

Add a default offline template for protostar to serve as an example.

![image](https://cloud.githubusercontent.com/assets/9630530/14470874/bb39cb50-00e3-11e6-8e89-798ca3efe53d.png)
#### Testing Instructions
1. Use latest staging
2. Install patch
3. Play with offline options in global configuration and check the result in the frontend
4. Test login and login errors
5. Test also customizing protostar template
6. Test also in mobile view
7. Test also in a rtl language
#### Observations

If any frontend developer can review it, i'm open to any suggestions and/or improvements.
