### PR TITLE
Fix overlaying alert area in hathor template

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -374,7 +374,7 @@ class JFormFieldRules extends JFormField
 		}
 
 		$html[] = '</div></div>';
-
+		$html[] = '<div class="clr"></div>';
 		$html[] = '<div class="alert">';
 
 		if ($section == 'component' || $section == null)


### PR DESCRIPTION
Pull Request for Issue # .
In the hathor template the rules are partially overlapped by the information area of permission settings
#### Summary of Changes:

Add <div class="clr"></div>  between rules and alert-info in the rules field
#### Testing Instructions

Choose the hathor template in your backend.
Open an article, scroll down to permissions
![1-before](https://cloud.githubusercontent.com/assets/1035262/14472358/23162886-00f3-11e6-9a6f-8c17062c09b4.PNG)

See that the Information overlaps the rules

Apply the Patch
Refresh the view
The alert-info is below the rules
![2-after](https://cloud.githubusercontent.com/assets/1035262/14472374/334f1122-00f3-11e6-83c3-7f4a1c1f6419.PNG)
