### PR TITLE
Validate the sender data in JFactory::createMailer()

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -671,8 +671,26 @@ abstract class JFactory
 		// Create a JMail object
 		$mail = JMail::getInstance();
 
-		// Set default sender without Reply-to
-		$mail->SetFrom(JMailHelper::cleanLine($mailfrom), JMailHelper::cleanLine($fromname), 0);
+		// Clean the email address
+		$mailfrom = JMailHelper::cleanLine($mailfrom);
+
+		// Set default sender without Reply-to if the mailfrom is a valid address
+		if (JMailHelper::isEmailAddress($mailfrom))
+		{
+			// Wrap in try/catch to catch phpmailerExceptions if it is throwing them
+			try
+			{
+				// Check for a false return value if exception throwing is disabled
+				if ($mail->setFrom($mailfrom, JMailHelper::cleanLine($fromname), false) === false)
+				{
+					JLog::add(__METHOD__ . '() could not set the sender data.', JLog::WARNING, 'mail');
+				}
+			}
+			catch (phpmailerException $e)
+			{
+				JLog::add(__METHOD__ . '() could not set the sender data.', JLog::WARNING, 'mail');
+			}
+		}
 
 		// Default mailer is to use PHP's mail function
 		switch ($mailer)
@@ -682,11 +700,11 @@ abstract class JFactory
 				break;
 
 			case 'sendmail':
-				$mail->IsSendmail();
+				$mail->isSendmail();
 				break;
 
 			default:
-				$mail->IsMail();
+				$mail->isMail();
 				break;
 		}
 


### PR DESCRIPTION
#### Summary of Changes

Because `PHPMailer::setFrom()` throws Exceptions (or returns boolean false depending on configuration), assuming that errors are correctly checked, it is possible for the creation of a `JMail` object via `JFactory` to fail catastrophically.  This PR changes `JFactory::createMailer()` to validate the e-mail address in the global configuration before attempting to set it in the PHPMailer API and will handle error states if `setFrom()` fails, which allows a `JMail` object to be created but will NOT contain the sender data if so.
#### Testing Instructions

Validate `JMail` objects are created with invalid sender data in your global configuration.
