### PR TITLE
Implement error handling in JMail

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -167,37 +167,54 @@ class JMail extends PHPMailer
 	 *                        <code>array([0] => email Address, [1] => Name)</code>
 	 *                        or as a string
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
 	public function setSender($from)
 	{
-		if (is_array($from))
+		// Wrapped in try/catch if PHPMailer is configured to throw exceptions
+		try
 		{
-			// If $from is an array we assume it has an address and a name
-			if (isset($from[2]))
+			if (is_array($from))
 			{
-				// If it is an array with entries, use them
-				$this->setFrom(JMailHelper::cleanLine($from[0]), JMailHelper::cleanLine($from[1]), (bool) $from[2]);
+				// If $from is an array we assume it has an address and a name
+				if (isset($from[2]))
+				{
+					// If it is an array with entries, use them
+					$result = $this->setFrom(JMailHelper::cleanLine($from[0]), JMailHelper::cleanLine($from[1]), (bool) $from[2]);
+				}
+				else
+				{
+					$result = $this->setFrom(JMailHelper::cleanLine($from[0]), JMailHelper::cleanLine($from[1]));
+				}
+			}
+			elseif (is_string($from))
+			{
+				// If it is a string we assume it is just the address
+				$result = $this->setFrom(JMailHelper::cleanLine($from));
 			}
 			else
 			{
-				$this->setFrom(JMailHelper::cleanLine($from[0]), JMailHelper::cleanLine($from[1]));
+				// If it is neither, we log a message and throw an exception
+				JLog::add(JText::sprintf('JLIB_MAIL_INVALID_EMAIL_SENDER', $from), JLog::WARNING, 'jerror');
+
+				throw new UnexpectedValueException(sprintf('Invalid email Sender: %s, JMail::setSender(%s)', $from));
+			}
+
+			// Check for boolean false return if exception handling is disabled
+			if ($result === false)
+			{
+				return false;
 			}
 		}
-		elseif (is_string($from))
+		catch (phpmailerException $e)
 		{
-			// If it is a string we assume it is just the address
-			$this->setFrom(JMailHelper::cleanLine($from));
-		}
-		else
-		{
-			// If it is neither, we log a message and throw an exception
-			JLog::add(JText::sprintf('JLIB_MAIL_INVALID_EMAIL_SENDER', $from), JLog::WARNING, 'jerror');
+			// The parent method will have already called the logging callback, just log our deprecated error handling message
+			JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
 
-			throw new UnexpectedValueException(sprintf('Invalid email Sender: %s, JMail::setSender(%s)', $from));
+			return false;
 		}
 
 		return $this;
@@ -246,7 +263,7 @@ class JMail extends PHPMailer
 	 * @param   mixed   $name       Either a string or array of strings [name(s)]
 	 * @param   string  $method     The parent method's name.
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
 	 * @throws  InvalidArgumentException
@@ -271,7 +288,23 @@ class JMail extends PHPMailer
 				{
 					$recipientEmail = JMailHelper::cleanLine($recipientEmail);
 					$recipientName = JMailHelper::cleanLine($recipientName);
-					call_user_func('parent::' . $method, $recipientEmail, $recipientName);
+
+					// Wrapped in try/catch if PHPMailer is configured to throw exceptions
+					try
+					{
+						// Check for boolean false return if exception handling is disabled
+						if (call_user_func('parent::' . $method, $recipientEmail, $recipientName) === false)
+						{
+							return false;
+						}
+					}
+					catch (phpmailerException $e)
+					{
+						// The parent method will have already called the logging callback, just log our deprecated error handling message
+						JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
+
+						return false;
+					}
 				}
 			}
 			else
@@ -281,14 +314,46 @@ class JMail extends PHPMailer
 				foreach ($recipient as $to)
 				{
 					$to = JMailHelper::cleanLine($to);
-					call_user_func('parent::' . $method, $to, $name);
+
+					// Wrapped in try/catch if PHPMailer is configured to throw exceptions
+					try
+					{
+						// Check for boolean false return if exception handling is disabled
+						if (call_user_func('parent::' . $method, $to, $name) === false)
+						{
+							return false;
+						}
+					}
+					catch (phpmailerException $e)
+					{
+						// The parent method will have already called the logging callback, just log our deprecated error handling message
+						JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
+
+						return false;
+					}
 				}
 			}
 		}
 		else
 		{
 			$recipient = JMailHelper::cleanLine($recipient);
-			call_user_func('parent::' . $method, $recipient, $name);
+
+			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
+			try
+			{
+				// Check for boolean false return if exception handling is disabled
+				if (call_user_func('parent::' . $method, $recipient, $name) === false)
+				{
+					return false;
+				}
+			}
+			catch (phpmailerException $e)
+			{
+				// The parent method will have already called the logging callback, just log our deprecated error handling message
+				JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
+
+				return false;
+			}
 		}
 
 		return $this;
@@ -300,15 +365,13 @@ class JMail extends PHPMailer
 	 * @param   mixed  $recipient  Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name       Either a string or array of strings [name(s)]
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining.
 	 *
 	 * @since   11.1
 	 */
 	public function addRecipient($recipient, $name = '')
 	{
-		$this->add($recipient, $name, 'addAddress');
-
-		return $this;
+		return $this->add($recipient, $name, 'addAddress');
 	}
 
 	/**
@@ -317,7 +380,7 @@ class JMail extends PHPMailer
 	 * @param   mixed  $cc    Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name  Either a string or array of strings [name(s)]
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
 	 */
@@ -326,7 +389,7 @@ class JMail extends PHPMailer
 		// If the carbon copy recipient is an array, add each recipient... otherwise just add the one
 		if (isset($cc))
 		{
-			$this->add($cc, $name, 'addCC');
+			return $this->add($cc, $name, 'addCC');
 		}
 
 		return $this;
@@ -338,7 +401,7 @@ class JMail extends PHPMailer
 	 * @param   mixed  $bcc   Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name  Either a string or array of strings [name(s)]
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
 	 */
@@ -347,7 +410,7 @@ class JMail extends PHPMailer
 		// If the blind carbon copy recipient is an array, add each recipient... otherwise just add the one
 		if (isset($bcc))
 		{
-			$this->add($bcc, $name, 'addBCC');
+			return $this->add($bcc, $name, 'addBCC');
 		}
 
 		return $this;
@@ -362,7 +425,7 @@ class JMail extends PHPMailer
 	 * @param   mixed   $type         The mime type
 	 * @param   string  $disposition  The disposition of the attachment
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   12.2
 	 * @throws  InvalidArgumentException
@@ -372,28 +435,45 @@ class JMail extends PHPMailer
 		// If the file attachments is an array, add each file... otherwise just add the one
 		if (isset($path))
 		{
-			if (is_array($path))
+			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
+			try
 			{
-				if (!empty($name) && count($path) != count($name))
+				if (is_array($path))
 				{
-					throw new InvalidArgumentException("The number of attachments must be equal with the number of name");
+					if (!empty($name) && count($path) != count($name))
+					{
+						throw new InvalidArgumentException("The number of attachments must be equal with the number of name");
+					}
+
+					foreach ($path as $key => $file)
+					{
+						if (!empty($name))
+						{
+							$result = parent::addAttachment($file, $name[$key], $encoding, $type);
+						}
+						else
+						{
+							$result = parent::addAttachment($file, $name, $encoding, $type);
+						}
+					}
+				}
+				else
+				{
+					$result = parent::addAttachment($path, $name, $encoding, $type);
 				}
 
-				foreach ($path as $key => $file)
+				// Check for boolean false return if exception handling is disabled
+				if ($result === false)
 				{
-					if (!empty($name))
-					{
-						parent::addAttachment($file, $name[$key], $encoding, $type);
-					}
-					else
-					{
-						parent::addAttachment($file, $name, $encoding, $type);
-					}
+					return false;
 				}
 			}
-			else
+			catch (phpmailerException $e)
 			{
-				parent::addAttachment($path, $name, $encoding, $type);
+				// The parent method will have already called the logging callback, just log our deprecated error handling message
+				JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
+
+				return false;
 			}
 		}
 
@@ -439,15 +519,13 @@ class JMail extends PHPMailer
 	 * @param   mixed  $replyto  Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name     Either a string or array of strings [name(s)]
 	 *
-	 * @return  JMail  Returns this object for chaining.
+	 * @return  JMail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
 	 */
 	public function addReplyTo($replyto, $name = '')
 	{
-		$this->add($replyto, $name, 'addReplyTo');
-
-		return $this;
+		return $this->add($replyto, $name, 'addReplyTo');
 	}
 
 	/**
@@ -563,10 +641,29 @@ class JMail extends PHPMailer
 		// Are we sending the email as HTML?
 		$this->isHtml($mode);
 
-		$this->addRecipient($recipient);
-		$this->addCc($cc);
-		$this->addBcc($bcc);
-		$this->addAttachment($attachment);
+		/*
+		 * Do not send the message if adding any of the below items fails
+		 */
+
+		if ($this->addRecipient($recipient) === false)
+		{
+			return false;
+		}
+
+		if ($this->addCc($cc) === false)
+		{
+			return false;
+		}
+
+		if ($this->addBcc($bcc) === false)
+		{
+			return false;
+		}
+
+		if ($this->addAttachment($attachment) === false)
+		{
+			return false;
+		}
 
 		// Take care of reply email addresses
 		if (is_array($replyTo))
@@ -575,17 +672,27 @@ class JMail extends PHPMailer
 
 			for ($i = 0; $i < $numReplyTo; $i++)
 			{
-				$this->addReplyTo($replyTo[$i], $replyToName[$i]);
+				if ($this->addReplyTo($replyTo[$i], $replyToName[$i]) === false)
+				{
+					return false;
+				}
 			}
 		}
 		elseif (isset($replyTo))
 		{
-			$this->addReplyTo($replyTo, $replyToName);
+			if ($this->addReplyTo($replyTo, $replyToName) === false)
+			{
+				return false;
+			}
 		}
 
 		// Add sender to replyTo only if no replyTo received
 		$autoReplyTo = (empty($this->ReplyTo)) ? true : false;
-		$this->setSender(array($from, $fromName, $autoReplyTo));
+
+		if ($this->setSender(array($from, $fromName, $autoReplyTo)) === false)
+		{
+			return false;
+		}
 
 		return $this->Send();
 	}
@@ -612,7 +719,11 @@ class JMail extends PHPMailer
 		$message = sprintf(JText::_('JLIB_MAIL_MSG_ADMIN'), $adminName, $type, $title, $author, $url, $url, 'administrator', $type);
 		$message .= JText::_('JLIB_MAIL_MSG') . "\n";
 
-		$this->addRecipient($adminEmail);
+		if ($this->addRecipient($recipient) === false)
+		{
+			return false;
+		}
+
 		$this->setSubject($subject);
 		$this->setBody($message);
 

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -161,6 +161,35 @@ class JMail extends PHPMailer
 	}
 
 	/**
+	 * Set the From and FromName properties.
+	 *
+	 * @param   string   $address  The sender email address
+	 * @param   string   $name     The sender name
+	 * @param   boolean  $auto     Whether to also set the Sender address, defaults to true
+	 *
+	 * @return  boolean
+	 *
+	 * @since   11.1
+	 */
+	public function setFrom($address, $name = '', $auto = true)
+	{
+		try
+		{
+			if (parent::setFrom($address, $name, $auto) === false)
+			{
+				return false;
+			}
+		}
+		catch (phpmailerException $e)
+		{
+			// The parent method will have already called the logging callback, just log our deprecated error handling message
+			JLog::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', JLog::WARNING, 'deprecated');
+
+			return false;
+		}
+	}
+
+	/**
 	 * Set the email sender
 	 *
 	 * @param   mixed  $from  email address and Name of sender


### PR DESCRIPTION
#### Summary of Changes

`JMail` has absolutely zero sense of error handling built into it at all right now, so all APIs assume all transactions can only be completed successfully.  This lack of error handling has in large part played into the number of extensions with mail related errors in 3.5.1 (exposed by the throwing of exceptions).  This PR adds a layer of error handling to `JMail` that is desperately needed.
#### Testing Instructions

JMail should now correctly catch error states (either thrown exceptions or boolean returns) for any methods it wraps.  When an error occurs, a boolean false value is returned.  This should eliminate most of the thrown exceptions, however, as of 4.0 `JMail` should stop catching these exceptions and let them bubble up to the caller (extension code) to handle these errors.
#### B/C Concerns

Technically, this is a break of B/C as the `JMail` methods can now return a boolean false value in addition to returning `$this` instance for method chaining.  Short of adding `JError` style error references, this has to happen.  Personal rant, the implementation of `JMail` is totally screwed by breaking the interface of PHPMailer (adding additional allowed arguments in methods and changing the return types) and having never implemented an error handling layer.  This way at least forces some sense of error handling (and required checking) into implementor's uses, but anyone relying on method chaining gets screwed if a false gets returned.
