### PR TITLE
Clear cache when user is performing an admin task

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -33,10 +33,12 @@ class PlgSystemCache extends JPlugin
 		parent::__construct($subject, $config);
 
 		// Set the language in the class.
+		$app = JFactory::getApplication();
 		$options = array(
 			'defaultgroup' => 'page',
 			'browsercache' => $this->params->get('browsercache', false),
 			'caching'      => false,
+			'cachebase'    => $app->get('cache_path', JPATH_SITE . '/cache')
 		);
 
 		$this->_cache     = JCache::getInstance('page', $options);
@@ -59,6 +61,13 @@ class PlgSystemCache extends JPlugin
 
 		if ($app->isAdmin())
 		{
+			// Clear cache when user is performing a task different from login and logout
+			$task = $app->input->get('task');
+			if (!in_array($task, array('login', 'logout', null))) 
+			{
+				$this->_cache->clean();
+			}
+			
 			return;
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

I was about to introduce it as a separate plug-in but there is no reason why this could not get into core. This PR make system cache a little bit smarter. Every time user is performing a task (like save, publish, delete, trash etc) plug-in will clear cache so users will get latest page version and administrator will not need to clear it by his own. Login and logout tasks are excluded.
#### Testing Instructions
- Enable "System - Cache" plugin
- Go to your front page
- Go to menu "System/Clear cache" there should a an item called page
- Unpublish one of modules
- Go to menu "System/Clear cache" there should be no page item any more
