### PR TITLE
Registration model doesn't create messages on failed registration email

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -595,7 +595,7 @@ class UsersModelRegistration extends JModelForm
 			// Send a system message to administrators receiving system mails
 			$db = $this->getDbo();
 			$query->clear()
-				->select($db->quoteName(array('name', 'email', 'sendEmail', 'id')))
+				->select($db->quoteName('id'))
 				->from($db->quoteName('#__users'))
 				->where($db->quoteName('block') . ' = ' . (int) 0)
 				->where($db->quoteName('sendEmail') . ' = ' . (int) 1);
@@ -603,7 +603,7 @@ class UsersModelRegistration extends JModelForm
 
 			try
 			{
-				$sendEmail = $db->loadColumn();
+				$userids = $db->loadColumn();
 			}
 			catch (RuntimeException $e)
 			{
@@ -612,12 +612,12 @@ class UsersModelRegistration extends JModelForm
 				return false;
 			}
 
-			if (count($sendEmail) > 0)
+			if (count($userids) > 0)
 			{
 				$jdate = new JDate;
 
 				// Build the query to add the messages
-				foreach ($sendEmail as $userid)
+				foreach ($userids as $userid)
 				{
 					$values = array(
 						$db->quote($userid),


### PR DESCRIPTION
Pull Request for Issue #8900 .

Correction of message to admins on user registration email send failure.

Testing Instructions:

1. Set dummy SMTP settings in Global Configuration.
2. Register a user, see "Warning!: An error was encountered while sending the registration email. A message has been sent to the administrator of this site." message.
3. There is no message in /administrator/index.php?option=com_messages
4. Apply patch.
5. Register user, see message in /administrator/index.php?option=com_messages