### PR TITLE
Protostar: Html broken on login view with IE11

### DIFF
--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -11,19 +11,18 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
-
 ?>
 <div class="login<?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
-		<div class="page-header">
-			<h1>
-				<?php echo $this->escape($this->params->get('page_heading')); ?>
-			</h1>
-		</div>
+	<div class="page-header">
+		<h1>
+			<?php echo $this->escape($this->params->get('page_heading')); ?>
+		</h1>
+	</div>
 	<?php endif; ?>
 
-	<?php if (($this->params->get('logindescription_show') == 1 && trim($this->params->get('login_description', '')) !== '') || $this->params->get('login_image') !== '') : ?>
-		<div class="login-description">
+	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
+	<div class="login-description">
 	<?php endif; ?>
 
 		<?php if ($this->params->get('logindescription_show') == 1) : ?>
@@ -35,7 +34,7 @@ JHtml::_('behavior.formvalidator');
 		<?php endif; ?>
 
 	<?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
-		</div>
+	</div>
 	<?php endif; ?>
 
 	<form action="<?php echo JRoute::_('index.php?option=com_users&task=user.login'); ?>" method="post" class="form-validate form-horizontal well">
@@ -74,7 +73,9 @@ JHtml::_('behavior.formvalidator');
 
 			<div class="control-group">
 				<div class="controls">
-					<button type="submit" class="btn btn-primary validate"><?php echo JText::_('JLOGIN'); ?></button>
+					<button type="submit" class="btn btn-primary">
+						<?php echo JText::_('JLOGIN'); ?>
+					</button>
 				</div>
 			</div>
 


### PR DESCRIPTION
.#### Steps to reproduce the issue

go to: component/users/?view=login
#### Expected result

correct html (menu should be on the right)
#### Actual result in Internet Explorer 11

![proto](https://cloud.githubusercontent.com/assets/876623/14492781/e4d6282a-0181-11e6-9104-6ae1c3bce6ea.jpg)
#### System information (as much as possible)

Internet Explorer 11
Stage build
#### Additional comments
