### PR TITLE
[Accessibility] Joomla Article - Tag: Add 'Search' & 'Clear text' button near search text field

### DIFF
--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -39,11 +39,11 @@ JFactory::getDocument()->addScriptDeclaration("
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
-				<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
-					<span class="icon-remove"></span>
-				</button>
 				<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 					<span class="icon-search"></span>
+				</button>
+				<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+					<span class="icon-remove"></span>
 				</button>
 			</div>
 		<?php endif; ?>

--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -27,6 +27,12 @@ $n = count($this->items);
 
 ?>
 
+<script type="text/javascript">
+	var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+</script>
+
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
 	<fieldset class="filters btn-toolbar">
@@ -36,6 +42,12 @@ $n = count($this->items);
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+				<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+					<span class="icon-remove"></span>
+				</button>
+				<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+					<span class="icon-search"></span>
+				</button>
 			</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>

--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -24,15 +24,12 @@ $canCreate = $user->authorise('core.create', 'com_tags');
 $canEditState = $user->authorise('core.edit.state', 'com_tags');
 $items = $this->items;
 $n = count($this->items);
-
-?>
-
-<script type="text/javascript">
-	var resetFilter = function() {
+JFactory::getDocument()->addScriptDeclaration("
+		var resetFilter = function() {
 		document.getElementById('filter-search').value = '';
 	}
-</script>
-
+");
+?>
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
 	<fieldset class="filters btn-toolbar">

--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -42,10 +42,10 @@ $n = count($this->items);
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
-				<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+				<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
 					<span class="icon-remove"></span>
 				</button>
-				<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+				<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 					<span class="icon-search"></span>
 				</button>
 			</div>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -41,6 +41,12 @@ $bscolumns = min($columns, floor(12 / $bsspans));
 $n = count($this->items);
 ?>
 
+<script type="text/javascript">
+	var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+</script>
+
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
 		<fieldset class="filters btn-toolbar">
@@ -50,6 +56,12 @@ $n = count($this->items);
 						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 					</label>
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+					<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+						<span class="icon-remove"></span>
+					</button>
+					<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+						<span class="icon-search"></span>
+					</button>
 				</div>
 			<?php endif; ?>
 			<?php if ($this->params->get('show_pagination_limit')) : ?>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -55,11 +55,11 @@ JFactory::getDocument()->addScriptDeclaration("
 						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 					</label>
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
-					<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
-						<span class="icon-remove"></span>
-					</button>
 					<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 						<span class="icon-search"></span>
+					</button>
+					<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+						<span class="icon-remove"></span>
 					</button>
 				</div>
 			<?php endif; ?>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -39,13 +39,12 @@ if ($bsspans < 1)
 
 $bscolumns = min($columns, floor(12 / $bsspans));
 $n = count($this->items);
-?>
-
-<script type="text/javascript">
-	var resetFilter = function() {
+JFactory::getDocument()->addScriptDeclaration("
+		var resetFilter = function() {
 		document.getElementById('filter-search').value = '';
 	}
-</script>
+");
+?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if ($this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -56,10 +56,10 @@ $n = count($this->items);
 						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 					</label>
 					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
-					<button type="reset" name="filter-clear-button" title="Clear" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+					<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
 						<span class="icon-remove"></span>
 					</button>
-					<button type="button" name="filter-search-button" title="Search" onclick="document.adminForm.submit();" class="btn">
+					<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 						<span class="icon-search"></span>
 					</button>
 				</div>


### PR DESCRIPTION
Redo of PR https://github.com/joomla/joomla-cms/pull/8199 by @FPerisa
Original PR description:

> A Solution for issue #5563
> 
> **The issue:**
> Mobile users could have problems to use the form for searching tags and their articles, because it has no buttons.
> 
> **My solution:**
> Like the issue maker wanted it, I added one button for entering the form field and one button for clearing the input of the field.
> 
> **Testing instructions**
> - Go to the searching form for tags "/all-tags"
> -     Without the patch you see only an input form field and you submit it with pushing enter
> -     With the patch you see nice new buttons
> -     Try them out!
> -     Do the same with the other form where you search the articles of one tag, e.g. "/all-tags/4-green"
> 
> **Expected result:**
> Two new buttons can be used for submitting the form and clearing the input.
> The clear button works only when the form got submitted once, because the form field submits immediately, when the user clicks out of it.
> 
> Worked as a group on that issue: @icampus @kathastaden @flow87 @xsability
