### PR TITLE
Changing list formfields to use a default class "advancedSelect" for Chosen support

### DIFF
--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -70,7 +70,7 @@
 		<field
 			name="published"
 			type="list"
-			class="chzn-color-state"
+			class="advancedSelect chzn-color-state"
 			id="published"
 			label="JSTATUS"
 			description="JFIELD_PUBLISHED_DESC"

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1067,6 +1067,7 @@ class MenusModelItem extends JModelAdmin
 					$field->addAttribute('name', $tag);
 					$field->addAttribute('type', 'menuitem');
 					$field->addAttribute('language', $tag);
+					$field->addAttribute('class', 'advancedSelect');
 					$field->addAttribute('label', $language->title);
 					$field->addAttribute('translate_label', 'false');
 					$option = $field->addChild('option', 'COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.formvalidator');
-JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('formbehavior.chosen');
 
 JText::script('ERROR');
 JText::script('JGLOBAL_VALIDATION_FORM_FAILED');

--- a/libraries/joomla/form/fields/accesslevel.php
+++ b/libraries/joomla/form/fields/accesslevel.php
@@ -38,10 +38,16 @@ class JFormFieldAccessLevel extends JFormFieldList
 	 */
 	protected function getInput()
 	{
+		// Default to the class "advancedSelect" to support Chosen.
+		if (empty($this->class))
+		{
+			$this->class = 'advancedSelect';
+		}
+
 		$attr = '';
 
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= $this->class ? ' class="' . $this->class . '"' : '';
 		$attr .= $this->disabled ? ' disabled' : '';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 		$attr .= $this->multiple ? ' multiple' : '';

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -142,8 +142,14 @@ class JFormFieldGroupedList extends JFormField
 		$html = array();
 		$attr = '';
 
+		// Default to the class "advancedSelect" to support Chosen.
+		if (empty($this->class))
+		{
+			$this->class = 'advancedSelect';
+		}
+
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= $this->class ? ' class="' . $this->class . '"' : '';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 		$attr .= $this->multiple ? ' multiple' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -38,8 +38,30 @@ class JFormFieldList extends JFormField
 		$html = array();
 		$attr = '';
 
+		// Get the field options.
+		$options = (array) $this->getOptions();
+
+		// Default to the class "advancedSelect" to support Chosen.
+		if (empty($this->class))
+		{
+			$this->class = 'advancedSelect';
+		}
+
+		// In case of a huge amount of options we disable Chosen by removing the "advancedSelect" class.
+		if (count($options) > 10000)
+		{
+			$classes = explode(' ', $this->class);
+			$key     = array_search('advancedSelect', $classes);
+
+			if (is_int($key))
+			{
+				unset($classes[$key]);
+				$this->class = implode(' ', $classes);
+			}
+		}
+
 		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="' . $this->class . '"' : '';
+		$attr .= $this->class ? ' class="' . $this->class . '"' : '';
 		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
 		$attr .= $this->multiple ? ' multiple' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';
@@ -53,9 +75,6 @@ class JFormFieldList extends JFormField
 
 		// Initialize JavaScript field attributes.
 		$attr .= $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
-
-		// Get the field options.
-		$options = (array) $this->getOptions();
 
 		// Create a read-only list (no name) with hidden input(s) to store the value(s).
 		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true')

--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -231,9 +231,15 @@ class JFormFieldComponentlayout extends JFormField
 				}
 			}
 
+			// Default to the class "advancedSelect" to support Chosen.
+			if (empty($this->class))
+			{
+				$this->class = 'advancedSelect';
+			}
+
 			// Compute attributes for the grouped list
 			$attr = $this->element['size'] ? ' size="' . (int) $this->element['size'] . '"' : '';
-			$attr .= $this->element['class'] ? ' class="' . (string) $this->element['class'] . '"' : '';
+			$attr .= $this->class ? ' class="' . $this->class . '"' : '';
 
 			// Prepare HTML code
 			$html = array();


### PR DESCRIPTION
This is an updated and bit improved version of #3721.
Originally it started as a way to automatically disable Chosen when there are a lot of options. It expanded a bit from there.
### Issue

Chosen has performance issues when facing a huge amount of options. Since the menu item view (like most views) use `JHtml::_('formbehavior.chosen', 'select');` to load Chosen on every `<select>`, this can break the creation of menu items.
This PR makes use of the default behaviour of `JHtml::_('formbehavior.chosen');` which triggers on the class `.advancedSelect`.
### Proposed Solution

This PR will do a few things:
- Changing the `list`, `groupedlist`, `accesslevel` and `componentlayout` formfields so it defaults to the class "advancedSelect" if no class is given. Currently there is no default at all.
- Changing the `list` formfield so it removes this class if there are more than 10'000 options.
- Changing the call `JHtml::_('formbehavior.chosen', 'select');` to use the default `JHtml::_('formbehavior.chosen');` in the menu item view.

For now, the scope is only the menu item edit form, however it would be possible to expand it to other places as well if we decide to follow that route. Especially if we use a default class within the fields, we don't have to edit 100+ XML files to add the class there.

If a developer decides he doesn't want to use Chosen for a specific field, he could just add a random class to the field in the XML and Chosen wouldn't be loaded anymore.

There may be better ideas of course :smile: 
### Testing
- Make sure the menu item edit screen looks the same before and after the patch. Especially the dropdown lists should look and behave the same (using Chosen).
- Try testing with some big data, like 10'000 categories and check that the category selection doesn't use chosen anymore.
