### PR TITLE
filter articles on article category list view gone on pagination

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -154,11 +154,13 @@ class ContentModelCategory extends JModelList
 			$this->setState('filter.access', false);
 		}
 
+		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+
 		// Optional filter text
-		$this->setState('list.filter', $app->input->getString('filter-search'));
+		$search = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
+		$this->setState('list.filter', $search);
 
 		// Filter.order
-		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
 		$orderCol = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
 
 		if (!in_array($orderCol, $this->filter_fields))


### PR DESCRIPTION
Pull Request for Issue #7943 .
#### Summary of Changes

Get search value using getUserStateFromRequest instead of getting search value from  $app->input
#### Testing Instructions
- On the admininistrator go to Menus > All front end views, and click into 'Article Category List'
- Click on 'List Layouts' tab and set 'Filter field' to title.
- Save the changes
- Switch to the site and click to the 'Article Category List' menu entry (on the right).
- Set the dropdown to 5 (we need a pagination)
- type 'e' on the filter and hit return
- Click on the pagination buttons. The 'e' should be kept on the filter input box.
