### PR TITLE
Converts com_templates hardcoded BS modals to use JLayout/modal + Fix

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -367,202 +367,84 @@ if($this->type == 'font')
 <?php echo JHtml::_('bootstrap.endTab'); ?>
 <?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copy&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-	  method="post" name="adminForm" id="adminForm">
-	<div  id="collapseModal" class="modal hide fade">
-		<div class="modal-header">
-			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-			<h3><?php echo JText::_('COM_TEMPLATES_TEMPLATE_COPY');?></h3>
-		</div>
-		<div class="modal-body">
-			<div id="template-manager-css" class="form-horizontal">
-				<div class="control-group">
-					<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL')?></label>
-					<div class="controls">
-						<input class="input-xlarge" type="text" id="new_name" name="new_name"  />
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="modal-footer">
-			<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-			<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_COPY'); ?></button>
-		</div>
-	</div>
+<?php // Collapse Modal
+$collapseModalData = array(
+	'selector'	=> 'collapseModal',
+	'params'	=> array(
+		'title'		=> JText::_('COM_TEMPLATES_TEMPLATE_COPY'),
+		'footer'	=> $this->loadTemplate('modal_collapse_footer')
+	),
+	'body'		=> $this->loadTemplate('modal_collapse_body')
+);
+?>
+<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copy&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
+	<?php echo JLayoutHelper::render('joomla.modal.main', $collapseModalData); ?>
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 <?php if ($this->type != 'home'): ?>
-	<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.renameFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-		  method="post" >
-		<div  id="renameModal" class="modal hide fade">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-				<h3><?php echo JText::sprintf('COM_TEMPLATES_RENAME_FILE', $this->fileName); ?></h3>
-			</div>
-			<div class="modal-body">
-				<div id="template-manager-css" class="form-horizontal">
-					<div class="control-group">
-						<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>"><?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?></label>
-						<div class="controls">
-							<input class="input-xlarge" type="text" name="new_name" required />
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="modal-footer">
-				<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-				<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_BUTTON_RENAME'); ?></button>
-			</div>
-		</div>
+	<?php // Rename Modal
+	$renameModalData = array(
+		'selector'	=> 'renameModal',
+		'params'	=> array(
+			'title'		=> JText::sprintf('COM_TEMPLATES_RENAME_FILE', $this->fileName),
+			'footer'	=> $this->loadTemplate('modal_rename_footer')
+		),
+		'body'		=> $this->loadTemplate('modal_rename_body')
+	);
+	?>
+	<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.renameFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post">
+		<?php echo JLayoutHelper::render('joomla.modal.main', $renameModalData); ?>
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 <?php endif; ?>
 <?php if ($this->type != 'home'): ?>
-	<div  id="deleteModal" class="modal hide fade">
-		<div class="modal-header">
-			<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-			<h3><?php echo JText::_('COM_TEMPLATES_ARE_YOU_SURE');?></h3>
-		</div>
-		<div class="modal-body">
-			<p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>
-		</div>
-		<div class="modal-footer">
-			<form method="post" action="">
-				<input type="hidden" name="option" value="com_templates" />
-				<input type="hidden" name="task" value="template.delete" />
-				<input type="hidden" name="id" value="<?php echo $input->getInt('id'); ?>" />
-				<input type="hidden" name="file" value="<?php echo $this->file; ?>" />
-				<?php echo JHtml::_('form.token'); ?>
-				<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-				<button type="submit" class="btn btn-danger"><?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?></button>
-			</form>
-		</div>
-	</div>
+	<?php // Delete Modal
+	$deleteModalData = array(
+		'selector'	=> 'deleteModal',
+		'params'	=> array(
+			'title'		=> JText::_('COM_TEMPLATES_ARE_YOU_SURE'),
+			'footer'	=> $this->loadTemplate('modal_delete_footer')
+		),
+		'body'		=> $this->loadTemplate('modal_delete_body')
+	);
+	?>
+	<?php echo JLayoutHelper::render('joomla.modal.main', $deleteModalData); ?>
 <?php endif; ?>
-
-<div  id="fileModal" class="modal hide fade">
-	<div class="modal-header">
-		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-		<h3><?php echo JText::_('COM_TEMPLATES_NEW_FILE_HEADER');?></h3>
-	</div>
-	<div class="modal-body">
-		<div class="column">
-			<?php echo $this->loadTemplate('folders');?>
-		</div>
-		<div class="column">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-				  class="well" >
-				<fieldset>
-					<label><?php echo JText::_('COM_TEMPLATES_NEW_FILE_TYPE');?></label>
-					<select name="type" required >
-						<option value="null">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT');?> -</option>
-						<option value="css">css</option>
-						<option value="php">php</option>
-						<option value="js">js</option>
-						<option value="xml">xml</option>
-						<option value="ini">ini</option>
-						<option value="less">less</option>
-						<option value="txt">txt</option>
-					</select>
-					<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME');?></label>
-					<input type="text" name="name" required />
-					<input type="hidden" class="address" name="address" />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
-				</fieldset>
-			</form>
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-				  class="well" enctype="multipart/form-data" >
-				<fieldset>
-					<input type="hidden" class="address" name="address" />
-					<input type="file" name="files" required />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD');?>" class="btn btn-primary" />
-				</fieldset>
-			</form>
-			<?php if ($this->type != 'home'): ?>
-				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-					  class="well" enctype="multipart/form-data" >
-					<fieldset>
-						<input type="hidden" class="address" name="address" />
-						<div class="control-group">
-							<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>"><?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?></label>
-							<div class="controls">
-								<input type="text" id="new_name" name="new_name" required />
-							</div>
-						</div>
-						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE');?>" class="btn btn-primary" />
-					</fieldset>
-				</form>
-			<?php endif; ?>
-		</div>
-	</div>
-	<div class="modal-footer">
-		<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-	</div>
-</div>
-<div  id="folderModal" class="modal hide fade">
-	<div class="modal-header">
-		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-		<h3><?php echo JText::_('COM_TEMPLATES_MANAGE_FOLDERS');?></h3>
-	</div>
-	<div class="modal-body">
-		<div class="column">
-			<?php echo $this->loadTemplate('folders');?>
-		</div>
-		<div class="column">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-				  class="well" >
-				<fieldset>
-					<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME');?></label>
-					<input type="text" name="name" required />
-					<input type="hidden" class="address" name="address" />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
-				</fieldset>
-			</form>
-		</div>
-	</div>
-	<div class="modal-footer">
-		<form id="deleteFolder" method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.deleteFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>">
-			<fieldset>
-				<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-				<input type="hidden" class="address" name="address" />
-				<?php echo JHtml::_('form.token'); ?>
-				<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?>" class="btn btn-danger" />
-			</fieldset>
-		</form>
-	</div>
-</div>
+<?php // File Modal
+$fileModalData = array(
+	'selector'	=> 'fileModal',
+	'params'	=> array(
+		'title'		=> JText::_('COM_TEMPLATES_NEW_FILE_HEADER'),
+		'footer'	=> $this->loadTemplate('modal_file_footer')
+	),
+	'body'		=> $this->loadTemplate('modal_file_body')
+);
+?>
+<?php echo JLayoutHelper::render('joomla.modal.main', $fileModalData); ?>
+<?php // Folder Modal
+$folderModalData = array(
+	'selector'	=> 'folderModal',
+	'params'	=> array(
+		'title'		=> JText::_('COM_TEMPLATES_MANAGE_FOLDERS'),
+		'footer'	=> $this->loadTemplate('modal_folder_footer')
+	),
+	'body'		=> $this->loadTemplate('modal_folder_body')
+);
+?>
+<?php echo JLayoutHelper::render('joomla.modal.main', $folderModalData); ?>
 <?php if ($this->type != 'home'): ?>
-	<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.resizeImage&id=' . $input->getInt('id') . '&file=' . $this->file); ?>"
-		  method="post" >
-		<div  id="resizeModal" class="modal hide fade">
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-				<h3><?php echo JText::_('COM_TEMPLATES_RESIZE_IMAGE'); ?></h3>
-			</div>
-			<div class="modal-body">
-				<div id="template-manager-css" class="form-horizontal">
-					<div class="control-group">
-						<label for="height" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_HEIGHT'); ?>"><?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT')?></label>
-						<div class="controls">
-							<input class="input-xlarge" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required />
-						</div>
-						<br />
-						<label for="width" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_WIDTH'); ?>"><?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH')?></label>
-						<div class="controls">
-							<input class="input-xlarge" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required />
-						</div>
-					</div>
-				</div>
-			</div>
-			<div class="modal-footer">
-				<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-				<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_BUTTON_RESIZE'); ?></button>
-			</div>
-		</div>
+	<?php // Resize Modal
+	$resizeModalData = array(
+		'selector'	=> 'resizeModal',
+		'params'	=> array(
+			'title'		=> JText::_('COM_TEMPLATES_RESIZE_IMAGE'),
+			'footer'	=> $this->loadTemplate('modal_resize_footer')
+		),
+		'body'		=> $this->loadTemplate('modal_resize_body')
+	);
+	?>
+	<form action="<?php echo JRoute::_('index.php?option=com_templates&task=template.resizeImage&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post">
+		<?php echo JLayoutHelper::render('joomla.modal.main', $resizeModalData); ?>
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 <?php endif; ?>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_collapse_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_collapse_body.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<div id="template-manager-css" class="form-horizontal">
+	<div class="control-group">
+		<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL')?></label>
+		<div class="controls">
+			<input class="input-xlarge" type="text" id="new_name" name="new_name"  />
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_collapse_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_collapse_footer.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
+<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_COPY'); ?></button>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$input = JFactory::getApplication()->input;
+?>
+<form method="post" action="">
+	<input type="hidden" name="option" value="com_templates" />
+	<input type="hidden" name="task" value="template.delete" />
+	<input type="hidden" name="id" value="<?php echo $input->getInt('id'); ?>" />
+	<input type="hidden" name="file" value="<?php echo $this->file; ?>" />
+	<?php echo JHtml::_('form.token'); ?>
+	<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
+	<button type="submit" class="btn btn-danger"><?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?></button>
+</form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$input = JFactory::getApplication()->input;
+?>
+<div class="column">
+	<?php echo $this->loadTemplate('folders');?>
+</div>
+<div class="column">
+	<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
+		<fieldset>
+			<label><?php echo JText::_('COM_TEMPLATES_NEW_FILE_TYPE');?></label>
+			<select name="type" required >
+				<option value="null">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT');?> -</option>
+				<option value="css">css</option>
+				<option value="php">php</option>
+				<option value="js">js</option>
+				<option value="xml">xml</option>
+				<option value="ini">ini</option>
+				<option value="less">less</option>
+				<option value="txt">txt</option>
+			</select>
+			<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME');?></label>
+			<input type="text" name="name" required />
+			<input type="hidden" class="address" name="address" />
+			<?php echo JHtml::_('form.token'); ?>
+			<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
+		</fieldset>
+	</form>
+	<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
+		<fieldset>
+			<input type="hidden" class="address" name="address" />
+			<input type="file" name="files" required />
+			<?php echo JHtml::_('form.token'); ?>
+			<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD');?>" class="btn btn-primary" />
+		</fieldset>
+	</form>
+	<?php if ($this->type != 'home'): ?>
+		<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
+			<fieldset>
+				<input type="hidden" class="address" name="address" />
+				<div class="control-group">
+					<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>"><?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?></label>
+					<div class="controls">
+						<input type="text" id="new_name" name="new_name" required />
+					</div>
+				</div>
+				<?php echo JHtml::_('form.token'); ?>
+				<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE');?>" class="btn btn-primary" />
+			</fieldset>
+		</form>
+	<?php endif; ?>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_footer.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$input = JFactory::getApplication()->input;
+?>
+<div class="column">
+	<?php echo $this->loadTemplate('folders');?>
+</div>
+<div class="column">
+	<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
+		<fieldset>
+			<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME');?></label>
+			<input type="text" name="name" required />
+			<input type="hidden" class="address" name="address" />
+			<?php echo JHtml::_('form.token'); ?>
+			<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
+		</fieldset>
+	</form>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$input = JFactory::getApplication()->input;
+?>
+<form id="deleteFolder" method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.deleteFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>">
+	<fieldset>
+		<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
+		<input type="hidden" class="address" name="address" />
+		<?php echo JHtml::_('form.token'); ?>
+		<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?>" class="btn btn-danger" />
+	</fieldset>
+</form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<div id="template-manager-css" class="form-horizontal">
+	<div class="control-group">
+		<label for="new_name" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>"><?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?></label>
+		<div class="controls">
+			<input class="input-xlarge" type="text" name="new_name" required />
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_footer.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
+<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_BUTTON_RENAME'); ?></button>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<div id="template-manager-css" class="form-horizontal">
+	<div class="control-group">
+		<label for="height" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_HEIGHT'); ?>"><?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT')?></label>
+		<div class="controls">
+			<input class="input-xlarge" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required />
+		</div>
+		<br />
+		<label for="width" class="control-label hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_WIDTH'); ?>"><?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH')?></label>
+		<div class="controls">
+			<input class="input-xlarge" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required />
+		</div>
+	</div>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_footer.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_templates
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
+<button class="btn btn-primary" type="submit"><?php echo JText::_('COM_TEMPLATES_BUTTON_RESIZE'); ?></button>

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8194,3 +8194,6 @@ body.modal-open {
 .js-pstats-data-details dt {
 	width: 220px;
 }
+.modal-footer {
+	clear: both;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1348,3 +1348,8 @@ body.modal-open {
 .js-pstats-data-details dt {
 	width: 220px;
 }
+
+/* Clear div after modal-body rendering */
+.modal-footer {
+	clear: both;
+}

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -74,20 +74,21 @@ $script[] = "   $('#" . $selector . "').on('shown.bs.modal', function() {";
 $script[] = "       $('body').addClass('modal-open');";
 
 // Get height of the modal elements.
-$script[] = "       var modalHeaderHeight = $('div.modal-header:visible').outerHeight(true);";
-$script[] = "       var modalBodyHeightOuter = $('div.modal-body:visible').outerHeight(true);";
-$script[] = "       var modalBodyHeight = $('div.modal-body:visible').height();";
-$script[] = "       var modalFooterHeight = $('div.modal-footer:visible').outerHeight(true);";
+$script[] = "       var modalHeight = $('div.modal:visible').outerHeight(true),";
+$script[] = "           modalHeaderHeight = $('div.modal-header:visible').outerHeight(true),";
+$script[] = "           modalBodyHeightOuter = $('div.modal-body:visible').outerHeight(true),";
+$script[] = "           modalBodyHeight = $('div.modal-body:visible').height(),";
+$script[] = "           modalFooterHeight = $('div.modal-footer:visible').outerHeight(true),";
 
 // Get padding top (jQuery position().top not working on iOS devices and webkit browsers, so use of Javascript instead)
-$script[] = "       var padding = document.getElementById('" . $selector . "').offsetTop;";
+$script[] = "           padding = document.getElementById('" . $selector . "').offsetTop,";
 
 // Calculate max-height of the modal, adapted to window viewport height.
-$script[] = "       var maxModalHeight = ($(window).height()-(padding*2));";
+$script[] = "           maxModalHeight = ($(window).height()-(padding*2)),";
 
 // Calculate max-height for modal-body.
-$script[] = "       var modalBodyPadding = (modalBodyHeightOuter-modalBodyHeight);";
-$script[] = "       var maxModalBodyHeight = maxModalHeight-(modalHeaderHeight+modalFooterHeight+modalBodyPadding);";
+$script[] = "           modalBodyPadding = (modalBodyHeightOuter-modalBodyHeight),";
+$script[] = "           maxModalBodyHeight = maxModalHeight-(modalHeaderHeight+modalFooterHeight+modalBodyPadding);";
 
 if (isset($params['url']))
 {
@@ -108,7 +109,7 @@ if (isset($params['url']))
 else
 {
 	// Set max-height for modal-body if needed, to adapt to viewport height.
-	$script[] = "       if (modalBodyHeight > maxModalBodyHeight){;";
+	$script[] = "       if (modalHeight > maxModalHeight){;";
 	$script[] = "           $('.modal-body').css({'max-height': maxModalBodyHeight, 'overflow-y': 'auto'});";
 	$script[] = "       }";
 }


### PR DESCRIPTION
Pull Request for Issue #9888 .
#### Summary of Changes
- addition of a clear div for modal-footer to fix display issue reported in #9888 and closed #9897
- refactory of the com_templates hardcoded bootsrap modals in default.php, to use JLayouts/modal (the issue was not using the Jlayout modal which includes core hack script to fix BS modal issues)
- addition of each modal body and footer in a separated template
- code style and better handler to detect when auto scrolling to be added and adjust modal height on small devices
#### Testing Instructions

**TEST on current STAGING ONLY!**
See #9888 (comment) for screenshots showing issue, and to help testing this patch.
In addition, test that all other modals (batch, users, versions...) are still working as before.
Same testing requirement as for PR https://github.com/joomla/joomla-cms/pull/9817#issue-147152727

**Note on com_templates admin**
In component templates, admin side, modal buttons to be tested:
- Copy template (collapseModal)
- Rename File (renameModal)
- Delete File (deleteModal)
- New File (fileModal)
- Manage Folders (folderModal)
- Resize Image (resizeModal)

A code review by PLT is welcome! (as addition of 12 news view files...)
