### PR TITLE
Remove the incorrect z-index in mod_multilangstatus

### DIFF
--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -12,8 +12,6 @@ defined('_JEXEC') or die;
 // Include jQuery
 JHtml::_('jquery.framework');
 
-JFactory::getDocument()->addStyleDeclaration('.navbar-fixed-bottom {z-index:1050;}');
-
 $link = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
 $footer = '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">' . JText::_('JTOOLBAR_CLOSE') . '</button>';
 ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

When you have multilanguage status module active the modals are not correctly displayed because the admin status bar as a higher z-index.

![image](https://cloud.githubusercontent.com/assets/9630530/14533678/ecf8e5ce-025d-11e6-8740-18e44cbe890f.png)

That z-index is putted there by mod_multilangstatus.

This PR removes that forced z-index.
#### Testing Instructions
1. Use latest staging with admin multilanguage status module enabled
2. Try to do a batch (in article for instance)
3. Check the admin status bar is not darkened like the rest of the page
4. Apply the patch
5. Do step 2 again, you will see now the admin status bar it's darkened like the rest of the page
