### PR TITLE
Correcting tooltip double translations which displays undesired Untranslated strings in debug.

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -267,7 +267,7 @@ class JFormFieldRules extends JFormField
 				$html[] = '<tr>';
 				$html[] = '<td headers="actions-th' . $group->value . '">';
 				$html[] = '<label for="' . $this->id . '_' . $action->name . '_' . $group->value . '" class="hasTooltip" title="'
-					. JHtml::_('tooltipText', JText::_($action->title), JText::_($action->description)) . '">';
+					. JHtml::_('tooltipText', $action->title, $action->description) . '">';
 				$html[] = JText::_($action->title);
 				$html[] = '</label>';
 				$html[] = '</td>';


### PR DESCRIPTION
Enable Debug Language in Global Configuration, then switch to Permissions (issue is the same for all Permissions pages):

You get strings between `??**`. It should be `**`:
![screen shot 2016-04-14 at 18 30 59](https://cloud.githubusercontent.com/assets/869724/14535876/3b8a60d4-0270-11e6-88ec-81347121fcde.png)

Looking at the debug console it makes a mess, showing many errors:

![screen shot 2016-04-14 at 18 37 08](https://cloud.githubusercontent.com/assets/869724/14535930/6df679f4-0270-11e6-9103-0891fd6cd52a.png)

Patch. Issue is corrected:
![screen shot 2016-04-14 at 18 29 30](https://cloud.githubusercontent.com/assets/869724/14535982/a46823fc-0270-11e6-89fa-dc6132dc51a7.png)

Errors are limited to one only for JYES and JNO, which can't be solved.
![screen shot 2016-04-14 at 18 45 07](https://cloud.githubusercontent.com/assets/869724/14536108/206a674e-0271-11e6-9bbe-5044745234f8.png)
