### PR TITLE
Correcting double Translation of options in checkboxes and radio layouts which display undesired untranslated strings in debug mode

### DIFF
--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -84,6 +84,6 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 
 		<label for="<?php echo $oid; ?>" class="checkbox">
 			<?php echo sprintf($format, $oid, $name, $value, implode(' ', $attributes)); ?>
-		<?php echo JText::alt($option->text, $alt); ?></label>
+		<?php echo $option->text; ?></label>
 	<?php endforeach; ?>
 </fieldset>

--- a/layouts/joomla/form/field/radio.php
+++ b/layouts/joomla/form/field/radio.php
@@ -80,7 +80,7 @@ $alt    = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 			<?php endif; ?>
 			<?php echo sprintf($format, $oid, $name, $ovalue, implode(' ', $attributes)); ?>
 			<label for="<?php echo $oid; ?>" <?php echo $optionClass; ?>>
-				<?php echo JText::alt($option->text, $alt); ?>
+				<?php echo $option->text; ?>
 			</label>
 		<?php endforeach; ?>
 	<?php endif; ?>


### PR DESCRIPTION
Remaining issue from https://github.com/joomla/joomla-cms/pull/9915
Enable Debug Language in Global Configuration.

The Yes/No radio buttons display strings between `??**`. It should be `**`:

![screen shot 2016-04-15 at 10 16 03](https://cloud.githubusercontent.com/assets/869724/14555486/37205868-02f3-11e6-930d-d311842b279a.png)

The debug console displays these as Untranslated Strings:

![screen shot 2016-04-15 at 10 16 15](https://cloud.githubusercontent.com/assets/869724/14555506/4add3fa6-02f3-11e6-98b8-ef4ab7b3e3e7.png)

Patch and test again. You will get:

![screen shot 2016-04-15 at 10 09 09](https://cloud.githubusercontent.com/assets/869724/14555532/64fd1da2-02f3-11e6-9134-8f4a80b850c3.png)
![screen shot 2016-04-15 at 10 09 20](https://cloud.githubusercontent.com/assets/869724/14555538/6fc6fb4a-02f3-11e6-8530-550976ede0c2.png)

The issue is the same for checkboxes.
Change in:
ROOT/administrator/components/com_config/model/form/application.xml
`type="radio"`
to
`type="checkboxes"`

and display before and after patch.

This should solve the issue all over core.

@phproberto 
I do not understand why you used `JText::alt()` here. 
