### PR TITLE
Multilanguage: preventing choosing separator, alias, heading or url as associations

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1067,6 +1067,7 @@ class MenusModelItem extends JModelAdmin
 					$field->addAttribute('name', $tag);
 					$field->addAttribute('type', 'menuitem');
 					$field->addAttribute('language', $tag);
+					$field->addAttribute('disable', 'separator,alias,heading,url');
 					$field->addAttribute('label', $language->title);
 					$field->addAttribute('translate_label', 'false');
 					$option = $field->addChild('option', 'COM_MENUS_ITEM_FIELD_ASSOCIATION_NO_VALUE');

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -149,9 +149,12 @@ JFactory::getDocument()->addScriptDeclaration($script);
 		?>
 
 		<?php if ($assoc) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
-			<?php echo $this->loadTemplate('associations'); ?>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php if ($this->item->type !== 'alias' && $this->item->type !== 'url'
+				&& $this->item->type !== 'separator' && $this->item->type !== 'heading') : ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
+				<?php echo $this->loadTemplate('associations'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php endif; ?>
 		<?php endif; ?>
 
 		<?php if (!empty($this->modules)) : ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/9911

Menu items of type alias, separator, url or heading should not be presented as  possible association when editing a menu item.

To test, create a simple multilanguage site (2 languages are enough), enable associations. Create menus in 2 languages, in each of them create menu items to usual contents, switch to the Associations tab and try to associate them to a menu in the other language. All menu items, including alias, separator, url or heading can be chosen in the list.

After patch, you will not be able anymore.

 you will get for example:
![screen shot 2016-04-15 at 12 34 31](https://cloud.githubusercontent.com/assets/869724/14559336/4fa6f92c-0308-11e6-9555-66d9925b70ce.png)

Also this patch does not display the Associations tab for the same menu items (after saving the menu item):
![screen shot 2016-04-15 at 13 01 31](https://cloud.githubusercontent.com/assets/869724/14559607/3c9a6df8-030a-11e6-94ef-8a99ac28f286.png)
