### PR TITLE
Smart Search "Warning: mb_strpos(): Empty delimiter"

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -22,7 +22,7 @@ if ($show_description)
 	$pad_length = $term_length < $desc_length ? floor(($desc_length - $term_length) / 2) : 0;
 
 	// Find the position of the search term
-	$pos = JString::strpos(JString::strtolower($this->result->description), JString::strtolower($this->query->input));
+	$pos = $term_length ? JString::strpos(JString::strtolower($this->result->description), JString::strtolower($this->query->input)) : false;
 
 	// Find a potential start point
 	$start = ($pos && $pos > $pad_length) ? $pos - $pad_length : 0;


### PR DESCRIPTION
This PR avoids the mb_strpos empty delimiter warning that can occur when "Allow Empty Search" is used and no search term is entered.
#### Summary of Changes

The default Smart Search layout does not check for an empty search term before calling JString::strpos, which ultimately leads to a warning being thrown in mb_strpos.
#### Testing Instructions
- Make sure you have Smart Search set up and working with some content indexed.
- Add a menu item to point to the Smart Search results page.  Set "Allow Empty Search" to "Yes" in the menu item (setting this at global level doesn't produce the error (not sure why)).
- Set "Error Reporting" to "Development" in Global Configuration.
- Use your menu item to go to the search page.
- Use Advanced Search to select something from a dropdown.  For example, choose "Uncategorised" from the "Category" dropdown.
- Without entering any search terms, click the Search button.  You should see an error message like "Warning: mb_strpos(): Empty delimiter in /var/www/temp/joomla-mb-strpos/libraries/vendor/joomla/string/src/phputf8/mbstring/core.php on line 41"
- Apply this PR and try searching again.  The warning message should no longer appear.
