### PR TITLE
Add 'Search' & 'Clear text' buttons to compact list of tagged items view

### DIFF
--- a/components/com_tags/views/tag/tmpl/list_items.php
+++ b/components/com_tags/views/tag/tmpl/list_items.php
@@ -15,7 +15,11 @@ JHtml::_('formbehavior.chosen', 'select');
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-
+JFactory::getDocument()->addScriptDeclaration("
+		var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+");
 ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
@@ -27,6 +31,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
 				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+				<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
+					<span class="icon-search"></span>
+				</button>
+				<button type="reset" name="filter-clear-button" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn" onclick="resetFilter(); document.adminForm.submit();">
+					<span class="icon-remove"></span>
+				</button>
 			</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/9899#issuecomment-210413765
#### Summary of Changes

Add 'Search' & 'Clear text' buttons to compact list of tagged items view
#### Testing Instructions
- Install the current staging with testing sample data.
- Install the patch tester component.
- Add Yellow tag to some articles.
- Go to Front End and click on the link Compact tagged from All Front End Views menu .
- Note that the next search does not have a buttons 'Search' & 'Clear text'
- Go to Back End apply the patch.
- Go to the Front End, refresh the page and note that the button 'Search' & 'Clear text' appeared.
- Check whether the buttons work.
