### PR TITLE
Redo PR #9379 (fix batch tooltip when mod multilanguage status enabled)

### DIFF
--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '#collapseModal'));
 
 ?>
 

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
 
 ?>
 

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '#collapseModal'));
 
 JFactory::getDocument()->addScriptDeclaration(
 	'

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '#collapseModal'));
 ?>
 <label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip" title="<?php
 echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC'); ?>">

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
  * None
  */
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
 ?>
 <label id="batch-tag-lbl" for="batch-tag-id" class="modalTooltip" title="<?php
 echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_LABEL_DESC'); ?>">

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -18,7 +18,7 @@ defined('JPATH_BASE') or die;
 
 extract($displayData);
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '#collapseModal'));
 
 $optionNo = '';
 

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -18,7 +18,7 @@ defined('JPATH_BASE') or die;
 
 extract($displayData);
 
-JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal'));
 
 $optionNo = '';
 


### PR DESCRIPTION
EDIT: REDO PR #9379 
This PR has fixed tooltip not visible in batch modal.
But tooltip are not displayed (since 3.5.0 or before...) if module multilanguage status is enabled
#### Testing Instructions
- Open batch modals (articles, menus...)
- hover the labels and be sure the tooltip is always visible (as describe in this issue #9363 screenshots)
- Test with and without admin module multilanguage status enabled
