### PR TITLE
JBrowser Opera 15+ detection - redo of #8449

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -245,6 +245,13 @@ class JBrowser
 					$this->identifyBrowserVersion();
 				}
 			}
+			
+			 // Opera 15+
+			elseif (preg_match('|OPR[/ ]([0-9.]+)|', $this->agent, $version))
+			{
+				$this->setBrowser('opera');
+				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+			}
 			elseif (preg_match('|Chrome[/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('chrome');

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -245,7 +245,7 @@ class JBrowser
 					$this->identifyBrowserVersion();
 				}
 			}
-			
+
 			 // Opera 15+
 			elseif (preg_match('|OPR[/ ]([0-9.]+)|', $this->agent, $version))
 			{

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -246,7 +246,7 @@ class JBrowser
 				}
 			}
 
-			 // Opera 15+
+			// Opera 15+
 			elseif (preg_match('|OPR[/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('opera');


### PR DESCRIPTION
Redo of #8449 by @sergey-zero
#### Summary of Changes

Opera 15+ browsers detection in JBrowser.
#### Testing Instructions

You can use this code snippet for test of detection

``` php
jimport('joomla.environment.browser');
$browser = JBrowser::getInstance();
$browserType = $browser->getBrowser();
$browserVersion = $browser->getMajor();
var_dump($browserType, $browserVersion);
```
