### PR TITLE
Regression: Redirect to profile when Register to Read More

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -141,7 +141,7 @@ JHtml::_('behavior.caption');
 	<?php $active = $menu->getActive(); ?>
 	<?php $itemId = $active->id; ?>
 	<?php $link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false)); ?>
-	<?php $link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language), false))); ?>
+	<?php $link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language))); ?>
 	<p class="readmore">
 		<a href="<?php echo $link; ?>" class="register">
 		<?php $attribs = json_decode($this->item->attribs); ?>

--- a/components/com_content/views/category/tmpl/blog_item.php
+++ b/components/com_content/views/category/tmpl/blog_item.php
@@ -62,7 +62,7 @@ $info    = $params->get('info_block_position', 0);
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-		$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language), false)));
+		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
 	endif; ?>
 
 	<?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -135,7 +135,7 @@ if (!empty($this->items))
 							$active = $menu->getActive();
 							$itemId = $active->id;
 							$link   = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-							$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false)));
+							$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)));
 							?>
 							<a href="<?php echo $link; ?>" class="register">
 								<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>

--- a/components/com_content/views/featured/tmpl/default_item.php
+++ b/components/com_content/views/featured/tmpl/default_item.php
@@ -87,7 +87,7 @@ $info    = $this->item->params->get('info_block_position', 0);
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-		$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language), false)));
+		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
 	endif; ?>
 
 	<?php echo JLayoutHelper::render('joomla.content.readmore', array('item' => $this->item, 'params' => $params, 'link' => $link)); ?>

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -91,7 +91,7 @@ abstract class ModArticlesNewsHelper
 			else
 			{
 				$item->link = new JUri(JRoute::_('index.php?option=com_users&view=login', false));
-				$item->link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language), false)));
+				$item->link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)));
 				$item->linkText = JText::_('MOD_ARTICLES_NEWS_READMORE_REGISTER');
 			}
 

--- a/templates/beez3/html/com_content/article/default.php
+++ b/templates/beez3/html/com_content/article/default.php
@@ -185,11 +185,38 @@ if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item-
 
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
+<?php if ($params->get('show_readmore') && $this->item->fulltext != null) :
+	if ($params->get('access-view')) :
+		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
+	else :
+		$menu = JFactory::getApplication()->getMenu();
+		$active = $menu->getActive();
+		$itemId = $active->id;
+		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
+		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
+	endif;
+?>
+		<p class="readmore">
+				<a href="<?php echo $link; ?>">
+					<?php $attribs = json_decode($this->item->attribs); ?>
+					<?php if ($attribs->alternative_readmore == null) :
+						echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
+					elseif ($readmore = $this->item->alternative_readmore) :
+						echo $readmore;
+						if ($params->get('show_readmore_title', 0) != 0) :
+							echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+						endif;
+					elseif ($params->get('show_readmore_title', 0) == 0) :
+						echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
+					else :
+						echo JText::_('COM_CONTENT_READ_MORE');
+						echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+					endif; ?></a>
+		</p>
+<?php endif; ?>
 <?php
 if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND $this->item->paginationrelative):
 	echo $this->item->pagination;?>
 <?php endif; ?>
 	<?php echo $this->item->event->afterDisplayContent; ?>
 </article>
-
-

--- a/templates/beez3/html/com_content/article/default.php
+++ b/templates/beez3/html/com_content/article/default.php
@@ -185,35 +185,6 @@ if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item-
 
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
-<?php if ($params->get('show_readmore') && $this->item->fulltext != null) :
-	if ($params->get('access-view')) :
-		$link = JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language));
-	else :
-		$menu = JFactory::getApplication()->getMenu();
-		$active = $menu->getActive();
-		$itemId = $active->id;
-		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
-	endif;
-?>
-		<p class="readmore">
-				<a href="<?php echo $link; ?>">
-					<?php $attribs = json_decode($this->item->attribs); ?>
-					<?php if ($attribs->alternative_readmore == null) :
-						echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-					elseif ($readmore = $this->item->alternative_readmore) :
-						echo $readmore;
-						if ($params->get('show_readmore_title', 0) != 0) :
-							echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-						endif;
-					elseif ($params->get('show_readmore_title', 0) == 0) :
-						echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-					else :
-						echo JText::_('COM_CONTENT_READ_MORE');
-						echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
-					endif; ?></a>
-		</p>
-<?php endif; ?>
 <?php
 if (!empty($this->item->pagination) AND $this->item->pagination AND $this->item->paginationposition AND $this->item->paginationrelative):
 	echo $this->item->pagination;?>

--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -140,7 +140,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-		$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language), false)));
+		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
 	endif;
 ?>
 		<p class="readmore">

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -141,7 +141,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						$active = $menu->getActive();
 						$itemId = $active->id;
 						$link   = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-						$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language), false)));
+						$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($article->slug, $article->catid, $article->language)));
 					?>
 					<a href="<?php echo $link; ?>" class="register">
 					<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?></a>

--- a/templates/beez3/html/com_content/featured/default_item.php
+++ b/templates/beez3/html/com_content/featured/default_item.php
@@ -146,7 +146,7 @@ $templateparams = $app->getTemplate(true)->params;
 		$active = $menu->getActive();
 		$itemId = $active->id;
 		$link = new JUri(JRoute::_('index.php?option=com_users&view=login&Itemid=' . $itemId, false));
-		$link->setVar('return', base64_encode(JRoute::_(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language), false)));
+		$link->setVar('return', base64_encode(ContentHelperRoute::getArticleRoute($this->item->slug, $this->item->catid, $this->item->language)));
 	endif;
 ?>
 		<p class="readmore">


### PR DESCRIPTION
Pull Request for Issue #9846

This is a redo of https://github.com/joomla/joomla-cms/pull/8698 , which there are typos.

Create an article set as Registered with a Read More.
Create a menu item of type category blog displaying the category of the article. Make sure `Show Unauthorised Links` is set to Yes.
Display the menu item in frontend and click on the Read More for that article. 
Log in.

Before patch: the user is redirected to the user profile.
After patch: the article displays in full.
Test with Protostar and Beez3 (for which the ReadMore part was totally absent from default.php)

This is due to the changes in `JUri::isInternal()` since 3.4.6.

As no one has proposed a solution in that method, the only way to get this to work is to take off the JRoute for the return links.

IMPORTANT INFORMATION:
This will work for Core templates and 3rd party templates where there are no overrides for the com_content views concerned. 
I suggest to PLT to make a specific announcement on this.
