### PR TITLE
Added Multilanguage associations to the TOS linked article in user profile…

### DIFF
--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -95,10 +95,14 @@ class JFormFieldTos extends JFormFieldRadio
 			$article = $db->loadObject();
 
 			if (JLanguageAssociations::isEnabled())
-				$tosassociated = JLanguageAssociations::getAssociations('com_content','#__content','com_content.item',$tosarticle);
+			{
+				$tosassociated = JLanguageAssociations::getAssociations('com_content', '#__content', 'com_content.item', $tosarticle);
+			}
 
 			$current_lang = JFactory::getLanguage()->getTag();
-			if ($current_lang != $article->language && array_key_exists($current_lang, $tosassociated)) {
+
+			if ($current_lang != $article->language && array_key_exists($current_lang, $tosassociated))
+			{
 				$url = ContentHelperRoute::getArticleRoute($tosassociated[$current_lang]->id, $tosassociated[$current_lang]->catid);
 			}
 			else

--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -88,13 +88,24 @@ class JFormFieldTos extends JFormFieldRadio
 
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true);
-			$query->select('id, alias, catid')
+			$query->select('id, alias, catid, language')
 				->from('#__content')
 				->where('id = ' . $tosarticle);
 			$db->setQuery($query);
 			$article = $db->loadObject();
-			$slug    = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
-			$url     = ContentHelperRoute::getArticleRoute($slug, $article->catid);
+
+			if (JLanguageAssociations::isEnabled())
+				$tosassociated = JLanguageAssociations::getAssociations('com_content','#__content','com_content.item',$tosarticle);
+
+			$current_lang = JFactory::getLanguage()->getTag();
+			if ($current_lang != $article->language && array_key_exists($current_lang, $tosassociated)) {
+				$url = ContentHelperRoute::getArticleRoute($tosassociated[$current_lang]->id, $tosassociated[$current_lang]->catid);
+			}
+			else
+			{
+				$slug = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
+				$url = ContentHelperRoute::getArticleRoute($slug, $article->catid);
+			}
 
 			$link = JHtml::_('link', JRoute::_($url . '&tmpl=component'), $text, $attribs);
 		}


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

The TOS field in the user profile plugin permits to link an article containing the TOS text. This feature does not include MultiLanguage support. With this PR now the plugin will select the right article for the  current used language between the available associated articles if the Language Associations option
is enabled.
#### Testing Instructions

Create a multisite web config
Enable the user profile plugin and its Language Associations option
Select an article for the TOS in the user profile plugin
Configure associated articles for the article selected before
