### PR TITLE
Correct isis message close buttons behaviour

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/system/message.php
+++ b/administrator/templates/isis/html/layouts/joomla/system/message.php
@@ -15,11 +15,11 @@ $alert = array('error' => 'alert-error', 'warning' => '', 'notice' => 'alert-inf
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && $msgList) : ?>
-		<button type="button" class="close" data-dismiss="alert">&times;</button>
 		<?php foreach ($msgList as $type => $msgs) : ?>
 			<div class="alert <?php echo isset($alert[$type]) ? $alert[$type] : 'alert-' . $type; ?>">
-				<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
-				<?php if ($msgs) : ?>
+				<button type="button" class="close" data-dismiss="alert">&times;</button>
+				<?php if (!empty($msgs)) : ?>
+					<h4 class="alert-heading"><?php echo JText::_($type); ?></h4>
 					<?php foreach ($msgs as $msg) : ?>
 						<div class="alert-message"><?php echo $msg; ?></div>
 					<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Small PR for solving the following issue.

Isis system message close buttons are wrongly placed with causes when you close a message to closes all the messages.

This PR will make isis system messages working like the other templates.
##### Before patch

![image](https://cloud.githubusercontent.com/assets/9630530/14589142/cb1a7216-04d2-11e6-950d-454b77456ec1.png)
##### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/14589135/aaaddef0-04d2-11e6-98ed-e2ec27db058d.png)
#### Testing Instructions

Very easy test. Just use the patchtester without github credentials.
1. Apply any other patch.
   
   Check the two messages that appear in the patch tester.
   
   You only have one close button that close both messages.
2. Apply this patch.
   
   Check the two messages that appear in the patch tester.
   
   You should have two close buttons, each close each message.
