### PR TITLE
Fix introtext treatment in single article view

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -134,7 +134,7 @@ JHtml::_('behavior.caption');
 	<?php // Optional teaser intro text for guests ?>
 	<?php elseif ($params->get('show_noauth') == true && $user->get('guest')) : ?>
 	<?php echo JLayoutHelper::render('joomla.content.intro_image', $this->item); ?>
-	<?php echo JHtml::_('content.prepare', $this->item->introtext); ?>	
+	<?php echo $this->item->text; ?>	
 	<?php // Optional link to let them register to see the whole article. ?>
 	<?php if ($params->get('show_readmore') && $this->item->fulltext != null) : ?>
 	<?php $menu = JFactory::getApplication()->getMenu(); ?>

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -169,8 +169,7 @@ class ContentViewArticle extends JViewLegacy
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
 		// Copy "text" to "introtext" for B/C (some templates might still use introtext...)
-		// but don't do that when introtex != text (there might be templates around using introtext when that's not supposed to happen)
-		// The introtext received by the above templates will not be processed by onContentPrepare: full B/C here!
+		// Don't do that when introtex != text, for full B/C with (non core) templates using introtext when that's not supposed to happen
 		if ($full_fix)
 		{
 			$item->introtext = $item->text;

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -139,7 +139,11 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		if ($item->params->get('show_intro', '1') == '1')
+		if (!$item->params->get('access-view') && $item->params->get('show_noauth', '0'))
+		{
+			$item->text = $item->introtext;
+		}
+		elseif ($item->params->get('show_intro', '1'))
 		{
 			$item->text = $item->introtext . ' ' . $item->fulltext;
 		}
@@ -159,6 +163,9 @@ class ContentViewArticle extends JViewLegacy
 
 		JPluginHelper::importPlugin('content');
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
+
+		// Copy "text" to "introtext" for B/C (some templates might still use introtext...)
+		$item->introtext = $item->text;
 
 		$item->event = new stdClass;
 		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, $offset));

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -130,6 +130,8 @@ class ContentViewArticle extends JViewLegacy
 
 		$offset = $this->state->get('list.offset');
 
+		$full_fix = true;
+
 		// Check the view access to the article (the model has already computed the values).
 		if ($item->params->get('access-view') == false && ($item->params->get('show_noauth', '0') == '0'))
 		{
@@ -146,10 +148,12 @@ class ContentViewArticle extends JViewLegacy
 		elseif ($item->fulltext && $item->params->get('show_intro', '1'))
 		{
 			$item->text = $item->introtext . ' ' . $item->fulltext;
+			$full_fix = false;
 		}
 		elseif ($item->fulltext)
 		{
 			$item->text = $item->fulltext;
+			$full_fix = false;
 		}
 		else
 		{
@@ -165,7 +169,12 @@ class ContentViewArticle extends JViewLegacy
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
 		// Copy "text" to "introtext" for B/C (some templates might still use introtext...)
-		$item->introtext = $item->text;
+		// but don't do that when introtex != text (there might be templates around using introtext when that's not supposed to happen)
+		// The introtext received by the above templates will not be processed by onContentPrepare: full B/C here!
+		if ($full_fix)
+		{
+			$item->introtext = $item->text;
+		}
 
 		$item->event = new stdClass;
 		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, $offset));

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -143,7 +143,7 @@ class ContentViewArticle extends JViewLegacy
 		{
 			$item->text = $item->introtext;
 		}
-		elseif ($item->params->get('show_intro', '1'))
+		elseif ($item->fulltext && $item->params->get('show_intro', '1'))
 		{
 			$item->text = $item->introtext . ' ' . $item->fulltext;
 		}


### PR DESCRIPTION
#### Summary of Changes

An issue emerged in #9830 and was partially fixed in  #9865 (_onContentPrepare plugins not acting on introtext_)

The underlying issue is that (_contrary to what is done in the "Category blog" view_) introtext is not "_treated_", even when it is the **only** text to be displayed due to the `show_noauth` option being in force and the user being guest.

This PR fixes the above issue.
#### Testing Instructions / Additional comments

Testing instructions for #9865 can be used.

Compared to current staging **nothing should change** when using the standard "Protostar" template and the single article view template is not overridden. This is because in #9865 a fix was incorporated in the single article **template** for the above behaviour.

This is not anyway correct: it shouldn't be a template's concern to "prepare" the item to be displayed: this is "view" territory. The same is done in the "Category Blog" view.

This PR fixes the issue at its roots so other (_old and/or overriden_) templates can benefit of it.

Also, there shouldn't be (_and with this fix there is none_) difference between "introtext" and "text", when used at the template level (_actually we should only use "text"_). Again, it is "view" territory to decide what should be displayed and what shouldn't.
