### PR TITLE
[com_contacts] contacts view: Adds max level filter

### DIFF
--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -49,6 +49,7 @@ class ContactModelContacts extends JModelList
 				'publish_down', 'a.publish_down',
 				'ul.name', 'linked_user',
 				'tag',
+				'level', 'c.level',
 			);
 
 			$assoc = JLanguageAssociations::isEnabled();
@@ -98,6 +99,7 @@ class ContactModelContacts extends JModelList
 		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
 		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
+		$this->setState('filter.level', $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', null, 'int'));
 
 		// List state information.
 		parent::populateState($ordering, $direction);
@@ -131,6 +133,7 @@ class ContactModelContacts extends JModelList
 		$id .= ':' . $this->getState('filter.access');
 		$id .= ':' . $this->getState('filter.language');
 		$id .= ':' . $this->getState('filter.tag');
+		$id .= ':' . $this->getState('filter.level');
 
 		return parent::getStoreId($id);
 	}
@@ -244,7 +247,8 @@ class ContactModelContacts extends JModelList
 							'l.image' ,
 							'uc.name' ,
 							'ag.title' ,
-							'c.title'
+							'c.title',
+							'c.level'
 						)
 					)
 				);
@@ -330,6 +334,12 @@ class ContactModelContacts extends JModelList
 					. ' ON ' . $db->quoteName('tagmap.content_item_id') . ' = ' . $db->quoteName('a.id')
 					. ' AND ' . $db->quoteName('tagmap.type_alias') . ' = ' . $db->quote('com_contact.contact')
 				);
+		}
+
+		// Filter on the level.
+		if ($level = $this->getState('filter.level'))
+		{
+			$query->where('c.level <= ' . (int) $level);
 		}
 
 		// Add the list ordering clause.

--- a/administrator/components/com_contact/models/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/models/forms/filter_contacts.xml
@@ -57,6 +57,19 @@
 			>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

All backend views that are or are associated with tree like structures (e.g. menus, categories) should have a max level filter.

This is valid currently for:
- com_menus items view
- com_content articles view
- com_content featured view
- com_tags tags view

So, this PR is a part of series of PR to add that filter in the views that use categories:
- com_contacts contacts view (**this PR**)
- com_banners banners view (RTC https://github.com/joomla/joomla-cms/pull/9977)
- com_newsfeeds newsfeeds view (RTC https://github.com/joomla/joomla-cms/pull/9978)
- com_notes notes view (RTC https://github.com/joomla/joomla-cms/pull/9984)
- com_banners tracks view (https://github.com/joomla/joomla-cms/pull/10009)

![image](https://cloud.githubusercontent.com/assets/9630530/14609301/275dca6a-0581-11e6-9176-149cf002e0ec.png)
#### Testing Instructions
1. Use latest staging and apply this patch
2. Create some contact categories with at least two levels
3. Create some contacts and associate them to the categories created in 2..
4. Test the new max levels filter.
