### PR TITLE
[com_newsfeeds] newsfeeds view: Add max level filter

### DIFF
--- a/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
@@ -55,6 +55,19 @@
 			>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field

--- a/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
@@ -55,19 +55,6 @@
 			>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
-		<field
-			name="level"
-			type="integer"
-			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
-			first="1"
-			last="10"
-			step="1"
-			languages="*"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
 	</fields>
 	<fields name="list">
 		<field

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -225,7 +225,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		{
 			$query->where($db->quoteName('c.level') . ' <= ' . (int) $level);
 		}
- 
+
 		// Filter by search in title
 		$search = $this->getState('filter.search');
 

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -45,6 +45,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 				'cache_time', 'a.cache_time',
 				'numarticles',
 				'tag',
+				'level', 'c.level',
 			);
 
 			$assoc = JLanguageAssociations::isEnabled();
@@ -94,6 +95,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
 		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
+		$this->setState('filter.level', $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', null, 'int'));
 
 		// Load the parameters.
 		$params = JComponentHelper::getParams('com_newsfeeds');
@@ -129,6 +131,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		$id .= ':' . $this->getState('filter.access');
 		$id .= ':' . $this->getState('filter.language');
 		$id .= ':' . $this->getState('filter.tag');
+		$id .= ':' . $this->getState('filter.level');
 
 		return parent::getStoreId($id);
 	}
@@ -155,30 +158,30 @@ class NewsfeedsModelNewsfeeds extends JModelList
 					' a.published, a.access, a.ordering, a.language, a.publish_up, a.publish_down'
 			)
 		);
-		$query->from($db->quoteName('#__newsfeeds') . ' AS a');
+		$query->from($db->quoteName('#__newsfeeds', 'a'));
 
 		// Join over the language
 		$query->select('l.title AS language_title, l.image AS language_image')
-			->join('LEFT', $db->quoteName('#__languages') . ' AS l ON l.lang_code = a.language');
+			->join('LEFT', $db->quoteName('#__languages', 'l') . ' ON l.lang_code = a.language');
 
 		// Join over the users for the checked out user.
 		$query->select('uc.name AS editor')
-			->join('LEFT', '#__users AS uc ON uc.id=a.checked_out');
+			->join('LEFT', $db->quoteName('#__users', 'uc') . ' ON uc.id=a.checked_out');
 
 		// Join over the asset groups.
 		$query->select('ag.title AS access_level')
-			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
+			->join('LEFT', $db->quoteName('#__viewlevels', 'ag') . ' ON ag.id = a.access');
 
 		// Join over the categories.
 		$query->select('c.title AS category_title')
-			->join('LEFT', '#__categories AS c ON c.id = a.catid');
+			->join('LEFT', $db->quoteName('#__categories', 'c') . ' ON c.id = a.catid');
 
 		// Join over the associations.
 		$assoc = JLanguageAssociations::isEnabled();
 
 		if ($assoc)
 		{
-			$query->select('COUNT(asso2.id)>1 as association')
+			$query->select('COUNT(asso2.id)>1 AS association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_newsfeeds.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
 				->group('a.id, l.title, l.image, uc.name, ag.title, c.title');
@@ -187,14 +190,14 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		// Filter by access level.
 		if ($access = $this->getState('filter.access'))
 		{
-			$query->where('a.access = ' . (int) $access);
+			$query->where($db->quoteName('a.access') . ' = ' . (int) $access);
 		}
 
 		// Implement View Level Access
 		if (!$user->authorise('core.admin'))
 		{
 			$groups = implode(',', $user->getAuthorisedViewLevels());
-			$query->where('a.access IN (' . $groups . ')');
+			$query->where($db->quoteName('a.access') . ' IN (' . $groups . ')');
 		}
 
 		// Filter by published state.
@@ -202,11 +205,11 @@ class NewsfeedsModelNewsfeeds extends JModelList
 
 		if (is_numeric($published))
 		{
-			$query->where('a.published = ' . (int) $published);
+			$query->where($db->quoteName('a.published') . ' = ' . (int) $published);
 		}
 		elseif ($published === '')
 		{
-			$query->where('(a.published IN (0, 1))');
+			$query->where($db->quoteName('a.published') . ' IN (0, 1)');
 		}
 
 		// Filter by category.
@@ -214,9 +217,15 @@ class NewsfeedsModelNewsfeeds extends JModelList
 
 		if (is_numeric($categoryId))
 		{
-			$query->where('a.catid = ' . (int) $categoryId);
+			$query->where($db->quoteName('a.catid') . ' = ' . (int) $categoryId);
 		}
 
+		// Filter on the level.
+		if ($level = $this->getState('filter.level'))
+		{
+			$query->where($db->quoteName('c.level') . ' <= ' . (int) $level);
+		}
+ 
 		// Filter by search in title
 		$search = $this->getState('filter.search');
 
@@ -224,7 +233,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		{
 			if (stripos($search, 'id:') === 0)
 			{
-				$query->where('a.id = ' . (int) substr($search, 3));
+				$query->where($db->quoteName('a.id') . ' = ' . (int) substr($search, 3));
 			}
 			else
 			{
@@ -236,7 +245,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		// Filter on the language.
 		if ($language = $this->getState('filter.language'))
 		{
-			$query->where('a.language = ' . $db->quote($language));
+			$query->where($db->quoteName('a.language') . ' = ' . $db->quote($language));
 		}
 
 		// Filter by a single tag.
@@ -253,8 +262,8 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$orderCol = $this->state->get('list.ordering');
-		$orderDirn = $this->state->get('list.direction');
+		$orderCol = $this->state->get('list.ordering', 'a.name');
+		$orderDirn = $this->state->get('list.direction', 'ASC');
 
 		if ($orderCol == 'a.ordering' || $orderCol == 'category_title')
 		{


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

All backend views that are or are associated with tree like structures (e.g. menus, categories) should have a max level filter.

This is valid currently for:
- com_menus items view
- com_content articles view
- com_content featured view
- com_tags tags view

So, this PR is a part of series of PR to add that filter in the views that use categories:
- com_contacts contacts view (RTC https://github.com/joomla/joomla-cms/pull/9975)
- com_banners banners view (RTC https://github.com/joomla/joomla-cms/pull/9977)
- com_newsfeeds newsfeeds view (**this PR**)
- com_notes notes view (RTC https://github.com/joomla/joomla-cms/pull/9984)
- com_banners tracks view (https://github.com/joomla/joomla-cms/pull/10009)

![image](https://cloud.githubusercontent.com/assets/9630530/14611926/8be00e7a-058c-11e6-88fb-9f761264bf09.png)
#### Testing Instructions
1. Use latest staging and apply this patch
2. Create some newsffeds categories with at least two levels
3. Create some newsffeds and associate them to the categories created in 2..
4. Test the new max levels filter.
