### PR TITLE
[com_plugins] plugins view: corrects some minor bugs

### DIFF
--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -27,28 +27,7 @@ if ($saveOrder)
 	$saveOrderingUrl = 'index.php?option=com_plugins&task=plugins.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'pluginList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
-
-$sortFields = $this->getSortFields();
-
-JFactory::getDocument()->addScriptDeclaration('
-	Joomla.orderTable = function()
-	{
-		table = document.getElementById("list_sortTable");
-		direction = document.getElementById("list_directionTable");
-		order = table.options[table.selectedIndex].value;
-		if (order != "' . $listOrder . '")
-		{
-			dirn = "asc";
-		}
-		else
-		{
-			dirn = direction.options[direction.selectedIndex].value;
-		}
-		Joomla.tableOrdering(order, dirn, "");
-	};
-');
 ?>
-
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
@@ -68,7 +47,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			<table class="table table-striped" id="pluginList">
 				<thead>
 					<tr>
-						<th width="1%" class="hidden-phone">
+						<th width="1%" class="nowrap center hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', '', 'ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
 						</th>
 						<th width="1%" class="hidden-phone">
@@ -96,7 +75,7 @@ JFactory::getDocument()->addScriptDeclaration('
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="12">
+						<td colspan="8">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>
@@ -108,7 +87,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
 					$canChange  = $user->authorise('core.edit.state', 'com_plugins') && $canCheckin;
 					?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->folder?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->folder; ?>">
 						<td class="order nowrap center hidden-phone">
 							<?php
 							$iconClass = '';
@@ -121,11 +100,11 @@ JFactory::getDocument()->addScriptDeclaration('
 								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
 							}
 							?>
-							<span class="sortable-handler<?php echo $iconClass ?>">
+							<span class="sortable-handler<?php echo $iconClass; ?>">
 								<span class="icon-menu"></span>
 							</span>
 							<?php if ($canChange && $saveOrder) : ?>
-								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering;?>" class="width-20 text-area-order " />
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
 							<?php endif; ?>
 						</td>
 						<td class="center hidden-phone">
@@ -146,16 +125,16 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php endif; ?>
 						</td>
 						<td class="nowrap small hidden-phone">
-							<?php echo $this->escape($item->folder);?>
+							<?php echo $this->escape($item->folder); ?>
 						</td>
 						<td class="nowrap small hidden-phone">
-							<?php echo $this->escape($item->element);?>
+							<?php echo $this->escape($item->element); ?>
 						</td>
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
 						<td class="hidden-phone">
-							<?php echo (int) $item->extension_id;?>
+							<?php echo (int) $item->extension_id; ?>
 						</td>
 					</tr>
 				<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for New issue.
#### Summary of Changes

Simple PR to solve minor issues.
- Corrects the missing nowrap in the ordering column.
- Corrects the table footer colspan.
- Removes some leftovers from the old filters
- Minor code style changes
#### Testing Instructions
- Use latest staging
- Go to Extensions -> Plugins
- Click the ordering column. You will see something like this:
  ![image](https://cloud.githubusercontent.com/assets/9630530/14643544/b04dd84a-0646-11e6-8f76-636f01ac0213.png)
- Apply patch
- Click the ordering column. You will see something like this:
  ![image](https://cloud.githubusercontent.com/assets/9630530/14643528/a008fc3a-0646-11e6-9567-1ba51b264bcd.png)
