### PR TITLE
Fix for #9832 + content embedded in a container div

### DIFF
--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -14,6 +14,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 
 JFactory::getDocument()->addScriptDeclaration(
 	"
@@ -27,14 +28,16 @@ JFactory::getDocument()->addScriptDeclaration(
 	"
 );
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
-	<fieldset>
-		<?php echo $this->form->renderField('lock'); ?>
-		<?php echo $this->form->renderField('mail_on_new'); ?>
-		<?php echo $this->form->renderField('auto_purge'); ?>
-	</fieldset>
-	<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
+<div class="container-popup">
+	<form action="<?php echo JRoute::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form" class="form-validate form-horizontal">
+		<fieldset>
+			<?php echo $this->form->renderField('lock'); ?>
+			<?php echo $this->form->renderField('mail_on_new'); ?>
+			<?php echo $this->form->renderField('auto_purge'); ?>
+		</fieldset>
+		<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
 
-	<input type="hidden" name="task" value="" />
-	<?php echo JHtml::_('form.token'); ?>
-</form>
+		<input type="hidden" name="task" value="" />
+		<?php echo JHtml::_('form.token'); ?>
+	</form>
+</div>


### PR DESCRIPTION
Pull Request for Issue #9832 .
#### Summary of Changes

When Bootstrap modal loads an iframe, BS tooltips with placement top are truncated at the top border of the iframe. (no auto placement in BS2)
This PR sets the tooltip placement to bottom.
In the same time, content is embedded in a container div (using already existing container-popup class for modal.php)
#### Testing Instructions

Go to: Components > Messaging > click on Settings button to open this modal.

**Before Patch:**
![capture d ecran 2016-04-19 a 17 11 43](https://cloud.githubusercontent.com/assets/2385058/14645329/80a112ba-0655-11e6-99fd-854f02300f17.png)

**After Patch:**
![capture d ecran 2016-04-19 a 17 38 26](https://cloud.githubusercontent.com/assets/2385058/14645343/93ceae7e-0655-11e6-8cc6-68c726ee130c.png)
