### PR TITLE
Regression: com_modules batch positions and hathor client select

### DIFF
--- a/administrator/components/com_modules/models/select.php
+++ b/administrator/components/com_modules/models/select.php
@@ -34,7 +34,7 @@ class ModulesModelSelect extends JModelList
 
 		// Load the filter state.
 		$clientId = $app->getUserState('com_modules.modules.client_id', 0);
-		$this->setState('filter.client_id', (int) $clientId);
+		$this->setState('client_id', (int) $clientId);
 
 		// Load the parameters.
 		$params = JComponentHelper::getParams('com_modules');
@@ -61,7 +61,7 @@ class ModulesModelSelect extends JModelList
 	protected function getStoreId($id = '')
 	{
 		// Compile the store id.
-		$id .= ':' . $this->getState('filter.client_id');
+		$id .= ':' . $this->getState('client_id');
 
 		return parent::getStoreId($id);
 	}
@@ -90,7 +90,7 @@ class ModulesModelSelect extends JModelList
 		$query->where('a.type = ' . $db->quote('module'));
 
 		// Filter by client.
-		$clientId = $this->getState('filter.client_id');
+		$clientId = $this->getState('client_id');
 		$query->where('a.client_id = ' . (int) $clientId);
 
 		// Filter by enabled
@@ -112,7 +112,7 @@ class ModulesModelSelect extends JModelList
 		// Get the list of items from the database.
 		$items = parent::getItems();
 
-		$client = JApplicationHelper::getClientInfo($this->getState('filter.client_id', 0));
+		$client = JApplicationHelper::getClientInfo($this->getState('client_id', 0));
 		$lang = JFactory::getLanguage();
 
 		// Loop through the results to add the XML metadata,

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch.php
@@ -11,7 +11,7 @@
 
 defined('_JEXEC') or die;
 
-$clientId  = $this->state->get('filter.client_id');
+$clientId  = $this->state->get('client_id');
 
 // Show only Module Positions of published Templates
 $published = 1;

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-$clientId  = $this->state->get('filter.client_id');
+$clientId  = $this->state->get('client_id');
 
 // Show only Module Positions of published Templates
 $published = 1;

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.modal');
 
-$client    = $this->state->get('filter.client_id') ? 'administrator' : 'site';
+$client    = $this->state->get('client_id') ? 'administrator' : 'site';
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -46,7 +46,7 @@ $saveOrder = $listOrder == 'ordering';
 				<?php echo JText::_('JGLOBAL_FILTER_CLIENT'); ?>
 			</label>
 			<select name="client_id" id="client_id">
-				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('filter.client_id'));?>
+				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('client_id'));?>
 			</select>
 
             <label class="selectlabel" for="filter_state">
@@ -62,7 +62,7 @@ $saveOrder = $listOrder == 'ordering';
 			</label>
 			<select name="filter_position" id="filter_position">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION');?></option>
-				<?php echo JHtml::_('select.options', ModulesHelper::getPositions($this->state->get('filter.client_id')), 'value', 'text', $this->state->get('filter.position'));?>
+				<?php echo JHtml::_('select.options', ModulesHelper::getPositions($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.position'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_module">
@@ -70,7 +70,7 @@ $saveOrder = $listOrder == 'ordering';
 			</label>
 			<select name="filter_module" id="filter_module">
 				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_MODULE');?></option>
-				<?php echo JHtml::_('select.options', ModulesHelper::getModules($this->state->get('filter.client_id')), 'value', 'text', $this->state->get('filter.module'));?>
+				<?php echo JHtml::_('select.options', ModulesHelper::getModules($this->state->get('client_id')), 'value', 'text', $this->state->get('filter.module'));?>
 			</select>
 
 			<label class="selectlabel" for="filter_access">


### PR DESCRIPTION
#### Summary of Changes

Solves regressions:
- In batch modal the positions are not selected based on the client id
- In hathor we can't select the client in modules view (it always goes back to Site)
#### Testing Instructions
1. Apply this patch in latest staging
2. Do a batch with client site in modules (check the positions in batch are from site templates)
3. Do a batch with admins site in modules (check the positions in batch are from admin templates)
4. Change the admin template to hathor. Try to change between client and admin modules.

Note: you can check that without the patch they are incorrect.
