### PR TITLE
Database connection problems on CLI

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -148,7 +148,7 @@ abstract class JFactory
 		{
 			if ($file === null)
 			{
-				$file = JPATH_PLATFORM . '/config.php';
+				$file = JPATH_ROOT . '/configuration.php';
 			}
 
 			self::$config = self::createConfig($file, $type, $namespace);

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -148,7 +148,7 @@ abstract class JFactory
 		{
 			if ($file === null)
 			{
-				$file = JPATH_ROOT . '/configuration.php';
+				$file = JPATH_CONFIGURATION . '/configuration.php';
 			}
 
 			self::$config = self::createConfig($file, $type, $namespace);


### PR DESCRIPTION
#### Summary of Changes

A wrong path for the main configuration file prevents the database from open a connection under CLI scripts.
#### Testing Instructions

Create and run a typical CLI script from scratch as described in the documentation
[Example 1: Hello World Command Line Interface (CLI) App](https://docs.joomla.org/How_to_create_a_stand-alone_application_using_the_Joomla!_Platform)

In JFilterInput::__construct() an attempt to connect to the database with `$db->connect();`
fails because the configuration files has not been read yet
(it will be read afterwards, but it is too late and the invalid database connection is cached and served to subsequent calls)

No matter whether you have a valid configuration.php or not, this always raises an exception and makes
absolutely unreachable the recent code added to handle UTF8mb4 
`// And now we can decide if we should strip USCs`
`$this->stripUSC = $db->hasUTF8mb4Support() ? 0 : 1;`

the instruction within the catch block will be always executed instead
`// Could not connect to MySQL. Strip USC to be on the safe side.`
`$this->stripUSC = 1;`

Since the exception is caught and the program flux continues, I think that the only way to inspect this behaviour is using a breakpoint to follow the execution.
