### PR TITLE
Do not hard load the language filter plugin

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -586,7 +586,7 @@ final class JApplicationSite extends JApplicationCms
 		}
 
 		// If a language was specified it has priority, otherwise use user or default language settings
-		JPluginHelper::importPlugin('system', 'languagefilter');
+		JPluginHelper::importPlugin('system');
 
 		if (empty($options['language']))
 		{


### PR DESCRIPTION
Loading the language filter plug-in specifically (before any other plug-in) also loads the menu items which prevents hooking into the menu's using onAfterInitialize with a system plug-in even when it is prioritized (sorted) higher than the languagefilter plugin.

This prevents creating a system plug-in that for example intercepts database calls to Joomla menu items (Needed for translation extensions). 

There are 3 possible solutions to this as I see it:
- Fix this file so it loads all system plugins in the order they are supposed to
- Come up with a solution that does not need loading the languagefilter plugin here
- Change the importPlugin() method to allow calling it without caching it (or similar) so what when all system plugins are called later in execution they will be loaded in the correct order.

This pull request is mainly aimed at starting a discussion for the correct approach. If the supplied patch will work, then great. We have a solution. But I am not 100% sure that loading all system plugins this early in execution is the correct approach.
