### PR TITLE
Type hint in Redirect plugin causes Catchable Error

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -46,15 +46,18 @@ class PlgSystemRedirect extends JPlugin
 	/**
 	 * Method to handle an error condition from JError.
 	 *
-	 * @param   JException  &$error  The JException object to be handled.
+	 * @param   Exception  &$error  The Exception object passed from JError to be handled.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public static function handleError(JException &$error)
+	public static function handleError(&$error)
 	{
-		self::doErrorHandling($error);
+		if (is_object($error) && ($error instanceof Exception))
+		{
+			self::handleException($error);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions
# How to reproduce

Publish the Redirect plugin. Access a _front-end_ component page which throws an exception.

Expected result: Joomla!'s error page with error details and error message.

Actual result (BUG!): PHP throws a Fatal Error such as this: `Catchable fatal error: Argument 1 passed to PlgSystemRedirect::handleError() must be an instance of JException, instance of FOF30\Factory\Exception\ControllerNotFound given in /XXXXXXXXXXX/plugins/system/redirect/redirect.php on line 55`
# Explanation (for developers)

JError is the default exception error handler. As a result JError calls PlgSystemRedirect::handleError as a callback error handler before PHP SPL has the chance to call PlgSystemRedirect::handleException

This doesn't even require testing. It's a very simple, obvious bug. /cc @wilsonge @mbabker
