### PR TITLE
Fix padding for #9822 + minor changes for consistency of iframe modals

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/pagebreak.php
+++ b/administrator/components/com_content/views/article/tmpl/pagebreak.php
@@ -31,18 +31,20 @@ $script .= '}' . "\n";
 
 JFactory::getDocument()->addScriptDeclaration($script);
 ?>
-<form class="form-horizontal">
+<div class="container-popup">
+	<form class="form-horizontal">
 
-	<div class="control-group">
-		<label for="title" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TITLE'); ?></label>
-		<div class="controls"><input type="text" id="title" name="title" /></div>
-	</div>
+		<div class="control-group">
+			<label for="title" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TITLE'); ?></label>
+			<div class="controls"><input type="text" id="title" name="title" /></div>
+		</div>
 
-	<div class="control-group">
-		<label for="alias" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TOC'); ?></label>
-		<div class="controls"><input type="text" id="alt" name="alt" /></div>
-	</div>
+		<div class="control-group">
+			<label for="alias" class="control-label"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TOC'); ?></label>
+			<div class="controls"><input type="text" id="alt" name="alt" /></div>
+		</div>
 
-	<button onclick="insertPagebreak();" class="btn btn-primary"><?php echo JText::_('COM_CONTENT_PAGEBREAK_INSERT_BUTTON'); ?></button>
+		<button onclick="insertPagebreak();" class="btn btn-primary"><?php echo JText::_('COM_CONTENT_PAGEBREAK_INSERT_BUTTON'); ?></button>
 
-</form>
+	</form>
+</div>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -33,7 +33,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 		<div class="clearfix"></div>
-		<hr class="hr-condensed" />
 
 		<?php if (empty($this->items)) : ?>
 		<div class="alert alert-no-items">

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -27,109 +27,115 @@ $function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<div style="padding-top: 25px;"></div>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
-	<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-	<?php if (empty($this->items)) : ?>
-	<div class="alert alert-no-items">
-		<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-	</div>
-	<?php else : ?>
-		<table class="table table-striped table-condensed">
-			<thead>
-				<tr>
-					<th width="1%" class="center nowrap">
-						<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
-					</th>
-					<th class="title">
-						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
-					</th>
-					<th width="10%" class="nowrap">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="nowrap">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-					</th>
-					<th width="5%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
-					</th>
-					<th width="1%" class="nowrap">
+	<div class="container-popup">
+
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
+		<div class="clearfix"></div>
+		<hr class="hr-condensed" />
+
+		<?php if (empty($this->items)) : ?>
+		<div class="alert alert-no-items">
+			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+		</div>
+		<?php else : ?>
+			<table class="table table-striped table-condensed">
+				<thead>
+					<tr>
+						<th width="1%" class="center nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
+						</th>
+						<th class="title">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+						</th>
+						<th width="5%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
+						</th>
+						<th width="1%" class="nowrap">
 						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-					</th>
-				</tr>
-			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="6">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
-			<tbody>
-			<?php
-			$iconStates = array(
-				-2 => 'icon-trash',
-				0 => 'icon-unpublish',
-				1 => 'icon-publish',
-				2 => 'icon-archive',
-			);
-			?>
-			<?php foreach ($this->items as $i => $item) : ?>
-				<?php if ($item->language && JLanguageMultilang::isEnabled())
-				{
-					$tag = strlen($item->language);
-					if ($tag == 5)
+						</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="6">
+							<?php echo $this->pagination->getListFooter(); ?>
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>
+				<?php
+				$iconStates = array(
+					-2 => 'icon-trash',
+					0 => 'icon-unpublish',
+					1 => 'icon-publish',
+					2 => 'icon-archive',
+				);
+				?>
+				<?php foreach ($this->items as $i => $item) : ?>
+					<?php if ($item->language && JLanguageMultilang::isEnabled())
 					{
-						$lang = substr($item->language, 0, 2);
+						$tag = strlen($item->language);
+						if ($tag == 5)
+						{
+							$lang = substr($item->language, 0, 2);
+						}
+						elseif ($tag == 6)
+						{
+							$lang = substr($item->language, 0, 3);
+						}
+						else {
+							$lang = "";
+						}
 					}
-					elseif ($tag == 6)
+					elseif (!JLanguageMultilang::isEnabled())
 					{
-						$lang = substr($item->language, 0, 3);
-					}
-					else {
 						$lang = "";
 					}
-				}
-				elseif (!JLanguageMultilang::isEnabled())
-				{
-					$lang = "";
-				}
-				?>
-				<tr class="row<?php echo $i % 2; ?>">
-					<td class="center">
-						<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
-					</td>
-					<td>
-						<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-							<?php echo $this->escape($item->title); ?></a>
-						<div class="small">
-							<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
-						</div>
-					</td>
-					<td class="small hidden-phone">
-						<?php echo $this->escape($item->access_level); ?>
-					</td>
-					<td class="small hidden-phone">
-						<?php if ($item->language == '*'): ?>
-							<?php echo JText::alt('JALL', 'language'); ?>
-						<?php else:?>
-							<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-						<?php endif;?>
-					</td>
-					<td class="nowrap small hidden-phone">
-						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</td>
-					<td>
-						<?php echo (int) $item->id; ?>
-					</td>
-				</tr>
-			<?php endforeach; ?>
-			</tbody>
-		</table>
-	<?php endif; ?>
+					?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td class="center">
+							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
+						</td>
+						<td>
+							<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+								<?php echo $this->escape($item->title); ?></a>
+							<div class="small">
+								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+							</div>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="small hidden-phone">
+							<?php if ($item->language == '*'): ?>
+								<?php echo JText::alt('JALL', 'language'); ?>
+							<?php else:?>
+								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+							<?php endif;?>
+						</td>
+						<td class="nowrap small hidden-phone">
+							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+						</td>
+						<td>
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
 
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="boxchecked" value="0" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
-	<?php echo JHtml::_('form.token'); ?>
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+	</div>
 </form>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -35,122 +35,128 @@ JFactory::getDocument()->addScriptDeclaration(
 	"
 );
 ?>
-<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
-	<div id="messages" style="display: none;">
-		<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
-	</div>
-	<div class="well">
-		<div class="row">
-			<div class="span12 control-group">
-				<div class="control-label">
-					<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY') ?></label>
-				</div>
-				<div class="controls">
-					<?php echo $this->folderList; ?>
-					<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP') ?>"><?php echo JText::_('COM_MEDIA_UP') ?></button>
-				</div>
-			</div>
-			<div class="pull-right">
-				<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
-				<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
-					// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
-			</div>
+<div class="container-popup">
+
+	<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
+
+		<div id="messages" style="display: none;">
+			<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
 		</div>
-	</div>
 
-	<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
-
-	<div class="well">
-		<div class="row">
-			<div class="span6 control-group">
-				<div class="control-label">
-					<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
-				</div>
-				<div class="controls">
-					<input type="text" id="f_url" value="" />
-				</div>
-			</div>
-			<?php if (!$this->state->get('field.id')):?>
-				<div class="span6 control-group">
+		<div class="well">
+			<div class="row">
+				<div class="span12 control-group">
 					<div class="control-label">
-						<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
+						<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY') ?></label>
 					</div>
 					<div class="controls">
-						<select size="1" id="f_align">
-							<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET') ?></option>
-							<option value="left"><?php echo JText::_('JGLOBAL_LEFT') ?></option>
-							<option value="center"><?php echo JText::_('JGLOBAL_CENTER') ?></option>
-							<option value="right"><?php echo JText::_('JGLOBAL_RIGHT') ?></option>
-						</select>
+						<?php echo $this->folderList; ?>
+						<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP') ?>"><?php echo JText::_('COM_MEDIA_UP') ?></button>
+					</div>
+				</div>
+				<div class="pull-right">
+					<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+					<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
+						// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
+				</div>
+			</div>
+		</div>
+
+		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
+
+		<div class="well">
+			<div class="row">
+				<div class="span6 control-group">
+					<div class="control-label">
+						<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
+					</div>
+					<div class="controls">
+						<input type="text" id="f_url" value="" />
+					</div>
+				</div>
+				<?php if (!$this->state->get('field.id')):?>
+					<div class="span6 control-group">
+						<div class="control-label">
+							<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
+						</div>
+						<div class="controls">
+							<select size="1" id="f_align">
+								<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET') ?></option>
+								<option value="left"><?php echo JText::_('JGLOBAL_LEFT') ?></option>
+								<option value="center"><?php echo JText::_('JGLOBAL_CENTER') ?></option>
+								<option value="right"><?php echo JText::_('JGLOBAL_RIGHT') ?></option>
+							</select>
+						</div>
+					</div>
+				<?php endif;?>
+			</div>
+			<?php if (!$this->state->get('field.id')):?>
+				<div class="row">
+					<div class="span6 control-group">
+						<div class="control-label">
+							<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
+						</div>
+						<div class="controls">
+							<input type="text" id="f_alt" value="" />
+						</div>
+					</div>
+					<div class="span6 control-group">
+						<div class="control-label">
+							<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE') ?></label>
+						</div>
+						<div class="controls">
+							<input type="text" id="f_title" value="" />
+						</div>
+					</div>
+				</div>
+				<div class="row">
+					<div class="span6 control-group">
+						<div class="control-label">
+							<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>
+						</div>
+						<div class="controls">
+							<input type="text" id="f_caption" value="" />
+						</div>
+					</div>
+					<div class="span6 control-group">
+						<div class="control-label">
+							<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL') ?></label>
+						</div>
+						<div class="controls">
+							<input type="text" list="d_caption_class" id="f_caption_class" value="" />
+							<datalist id="d_caption_class">
+								<option value="text-left">
+								<option value="text-center">
+								<option value="text-right">
+							</datalist>
+						</div>
 					</div>
 				</div>
 			<?php endif;?>
-		</div>
-		<?php if (!$this->state->get('field.id')):?>
-			<div class="row">
-				<div class="span6 control-group">
-					<div class="control-label">
-						<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
-					</div>
-					<div class="controls">
-						<input type="text" id="f_alt" value="" />
-					</div>
-				</div>
-				<div class="span6 control-group">
-					<div class="control-label">
-						<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE') ?></label>
-					</div>
-					<div class="controls">
-						<input type="text" id="f_title" value="" />
-					</div>
-				</div>
-			</div>
-			<div class="row">
-				<div class="span6 control-group">
-					<div class="control-label">
-						<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>
-					</div>
-					<div class="controls">
-						<input type="text" id="f_caption" value="" />
-					</div>
-				</div>
-				<div class="span6 control-group">
-					<div class="control-label">
-						<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL') ?></label>
-					</div>
-					<div class="controls">
-						<input type="text" list="d_caption_class" id="f_caption_class" value="" />
-						<datalist id="d_caption_class">
-							<option value="text-left">
-							<option value="text-center">
-							<option value="text-right">
-						</datalist>
-					</div>
-				</div>
-			</div>
-		<?php endif;?>
 
-		<input type="hidden" id="dirPath" name="dirPath" />
-		<input type="hidden" id="f_file" name="f_file" />
-		<input type="hidden" id="tmpl" name="component" />
+			<input type="hidden" id="dirPath" name="dirPath" />
+			<input type="hidden" id="f_file" name="f_file" />
+			<input type="hidden" id="tmpl" name="component" />
 
-	</div>
-</form>
-<?php if ($user->authorise('core.create', 'com_media')) : ?>
-	<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
-		<div id="uploadform" class="well">
-			<fieldset id="upload-noflash" class="actions">
-				<div class="control-group">
-					<div class="control-label">
-						<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
-					</div>
-					<div class="controls">
-						<input type="file" id="upload-file" name="Filedata[]" multiple /><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
-						<p class="help-block"><?php echo $this->config->get('upload_maxsize') == '0' ? JText::_('COM_MEDIA_UPLOAD_FILES_NOLIMIT') : JText::sprintf('COM_MEDIA_UPLOAD_FILES', $this->config->get('upload_maxsize')); ?></p>
-					</div>
-				</div>
-			</fieldset>
-			<?php JFactory::getSession()->set('com_media.return_url', 'index.php?option=com_media&view=images&tmpl=component&fieldid=' . $input->getCmd('fieldid', '') . '&e_name=' . $input->getCmd('e_name') . '&asset=' . $input->getCmd('asset') . '&author=' . $input->getCmd('author')); ?>
 		</div>
 	</form>
-<?php endif; ?>
+
+	<?php if ($user->authorise('core.create', 'com_media')) : ?>
+		<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
+			<div id="uploadform" class="well">
+				<fieldset id="upload-noflash" class="actions">
+					<div class="control-group">
+						<div class="control-label">
+							<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
+						</div>
+						<div class="controls">
+							<input type="file" id="upload-file" name="Filedata[]" multiple /><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
+							<p class="help-block"><?php echo $this->config->get('upload_maxsize') == '0' ? JText::_('COM_MEDIA_UPLOAD_FILES_NOLIMIT') : JText::sprintf('COM_MEDIA_UPLOAD_FILES', $this->config->get('upload_maxsize')); ?></p>
+						</div>
+					</div>
+				</fieldset>
+				<?php JFactory::getSession()->set('com_media.return_url', 'index.php?option=com_media&view=images&tmpl=component&fieldid=' . $input->getCmd('fieldid', '') . '&e_name=' . $input->getCmd('e_name') . '&asset=' . $input->getCmd('asset') . '&author=' . $input->getCmd('author')); ?>
+			</div>
+		</form>
+	<?php endif; ?>
+</div>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -36,9 +36,9 @@ modulePosIns = function(position) {
 	window.parent.jModalClose();
 };');
 ?>
-<div style="padding-top: 25px;"></div>
 <form action="<?php echo JRoute::_('index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
-	<div id="j-main-container">
+	<div class="container-popup">
+
 		<div class="well">
 			<div class="control-group">
 				<div class="control-label">
@@ -51,8 +51,12 @@ modulePosIns = function(position) {
 				</div>
 			</div>
 		</div>
+
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
 		<div class="clearfix"></div>
+		<hr class="hr-condensed" />
+
 		<?php if (empty($this->items)) : ?>
 		<div class="alert alert-no-items">
 			<?php echo JText::_('COM_MODULES_MSG_MANAGE_NO_MODULES'); ?>
@@ -144,8 +148,10 @@ modulePosIns = function(position) {
 			</tbody>
 		</table>
 		<?php endif;?>
+
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>
+
 	</div>
 </form>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -55,7 +55,6 @@ modulePosIns = function(position) {
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 		<div class="clearfix"></div>
-		<hr class="hr-condensed" />
 
 		<?php if (empty($this->items)) : ?>
 		<div class="alert alert-no-items">

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7886,7 +7886,7 @@ th .tooltip-inner {
 	position: absolute;
 }
 .container-popup {
-	padding: 15px;
+	padding: 28px 10px 10px 10px;
 }
 .controls .btn-group > .btn {
 	min-width: 50px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7886,7 +7886,7 @@ th .tooltip-inner {
 	position: absolute;
 }
 .container-popup {
-	padding: 15px;
+	padding: 28px 10px 10px 10px;
 }
 .controls .btn-group > .btn {
 	min-width: 50px;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1106,7 +1106,7 @@ th .tooltip-inner {
 }
 /* Component pop-up */
 .container-popup {
-	padding: 15px;
+	padding: 28px 10px 10px 10px;
 }
 /* Min-width on buttons */
 .controls .btn-group > .btn {

--- a/templates/beez3/css/general.css
+++ b/templates/beez3/css/general.css
@@ -470,3 +470,8 @@ body input[type="text"].search-query {
 .text-center {
 	text-align: center;
 }
+
+/* Component pop-up */
+.container-popup {
+	padding: 28px 10px 10px 10px;
+}

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7521,3 +7521,6 @@ body.modal-open {
 .well .chzn-container {
 	max-width: 100%;
 }
+.container-popup {
+	padding: 28px 10px 10px 10px;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -652,3 +652,8 @@ body.modal-open {
 		max-width: 100%;
 	}
 }
+
+/* Component pop-up */
+.container-popup {
+	padding: 28px 10px 10px 10px;
+}


### PR DESCRIPTION
Pull Request for Issue #9822 .
#### Summary of Changes
- content is embedded in a container div (using already existing container-popup class for modal.php)
- add a few empty lines to improve the readability
- adjust <code>.container-popup</code> padding
#### Testing Instructions
- Test with TinyMCE editor
- Go to: Content > article, and edit an article
- clic on editor toolbar buttons: module, article, image and pagebreak
- control if padding is ok, as well as tooltip visible
- verify if issue #9822 for Page break is fixed

**Example with Modules modal:**
Before Patch
![capture d ecran 2016-04-20 a 17 30 22](https://cloud.githubusercontent.com/assets/2385058/14684837/1a69bea6-0732-11e6-9e26-3fac4dd8383f.png)

After Patch
![capture d ecran 2016-04-21 a 00 56 58](https://cloud.githubusercontent.com/assets/2385058/14693057/186ced74-075c-11e6-9366-c5b0b6aa70fb.png)

**Page Break issue #9822 solved:**
Before Patch
![capture d ecran 2016-04-20 a 19 58 22](https://cloud.githubusercontent.com/assets/2385058/14684903/69805aae-0732-11e6-976c-8e6f9873f7a5.png)

After Patch
![capture d ecran 2016-04-20 a 19 59 59](https://cloud.githubusercontent.com/assets/2385058/14684931/7e6cbac0-0732-11e6-811b-2c34b88e851a.png)
