### PR TITLE
Converts slow and not-indexable COUNT(*) to COUNT(id)

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.5.1-2016-03-29.sql
@@ -4,4 +4,4 @@
 --
 
 UPDATE `#__utf8_conversion` SET `converted` = 0
- WHERE (SELECT COUNT(*) FROM `#__schemas` WHERE `extension_id`=700 AND `version_id` LIKE '3.5.0%') = 1;
+ WHERE (SELECT COUNT(`extension_id`) FROM `#__schemas` WHERE `extension_id`=700 AND `version_id` LIKE '3.5.0%') = 1;

--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -205,7 +205,7 @@ class BannersHelper extends JHelperContent
 			$item->count_unpublished = 0;
 			$item->count_published = 0;
 			$query = $db->getQuery(true);
-			$query->select('state, count(*) AS count')
+			$query->select('state, COUNT(id) AS count')
 				->from($db->qn('#__banners'))
 				->where('catid = ' . (int) $item->id)
 				->group('state');

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -60,7 +60,7 @@ class ContactHelper extends JHelperContent
 			$item->count_unpublished = 0;
 			$item->count_published = 0;
 			$query = $db->getQuery(true);
-			$query->select('published AS state, count(*) AS count')
+			$query->select('published AS state, COUNT(id) AS count')
 				->from($db->qn('#__contact_details'))
 				->where('catid = ' . (int) $item->id)
 				->group('published');

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -81,7 +81,7 @@ class ContentHelper extends JHelperContent
 			$item->count_unpublished = 0;
 			$item->count_published = 0;
 			$query = $db->getQuery(true);
-			$query->select('state, count(*) AS count')
+			$query->select('state, COUNT(id) AS count')
 				->from($db->qn('#__content'))
 				->where('catid = ' . (int) $item->id)
 				->group('state');

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -410,7 +410,7 @@ class InstallerModelDatabase extends InstallerModel
 
 		$db->setQuery($creaTabSql)->execute();
 
-		$db->setQuery('SELECT COUNT(*) FROM ' . $db->quoteName('#__utf8_conversion') . ';');
+		$db->setQuery('SELECT COUNT(' . $db->quoteName('converted') . ') FROM ' . $db->quoteName('#__utf8_conversion') . ';');
 
 		$count = $db->loadResult();
 

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -232,7 +232,7 @@ class InstallerModelUpdate extends JModelList
 		$db = $this->getDbo();
 
 		$query = $db->getQuery(true)
-			->select('COUNT(*)')
+			->select('COUNT(' . $db->quoteName('update_site_id') . ')')
 			->from($db->quoteName('#__update_sites'))
 			->where($db->quoteName('enabled') . ' = 0');
 

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -26,7 +26,7 @@ abstract class MultilangstatusHelper
 		// Check for multiple Home pages.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('COUNT(*)')
+			->select('COUNT(' . $db->quoteName('id') . ')')
 			->from($db->quoteName('#__menu'))
 			->where('home = 1')
 			->where('published = 1')
@@ -46,7 +46,7 @@ abstract class MultilangstatusHelper
 		// Check if switcher is published.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('COUNT(*)')
+			->select('COUNT(' . $db->quoteName('id') . ')')
 			->from($db->quoteName('#__modules'))
 			->where('module = ' . $db->quote('mod_languages'))
 			->where('published = 1')
@@ -147,7 +147,7 @@ abstract class MultilangstatusHelper
 
 		// Get the number of contact with all as language
 		$alang = $db->getQuery(true)
-			->select('count(*)')
+			->select('COUNT(cd.id)')
 			->from('#__contact_details AS cd')
 			->where('cd.user_id=u.id')
 			->where('cd.published=1')
@@ -155,7 +155,7 @@ abstract class MultilangstatusHelper
 
 		// Get the number of languages for the contact
 		$slang = $db->getQuery(true)
-			->select('count(distinct(l.lang_code))')
+			->select('COUNT(distinct(l.lang_code))')
 			->from('#__languages as l')
 			->join('LEFT', '#__contact_details AS cd ON cd.language=l.lang_code')
 			->where('cd.user_id=u.id')
@@ -164,14 +164,14 @@ abstract class MultilangstatusHelper
 
 		// Get the number of multiple contact/language
 		$mlang = $db->getQuery(true)
-			->select('count(*)')
+			->select('COUNT(l.lang_id)')
 			->from('#__languages as l')
 			->join('LEFT', '#__contact_details AS cd ON cd.language=l.lang_code')
 			->where('cd.user_id=u.id')
 			->where('cd.published=1')
 			->where('l.published=1')
 			->group('l.lang_code')
-			->having('count(*) > 1');
+			->having('COUNT(l.lang_id) > 1');
 
 		// Get the contacts
 		$query = $db->getQuery(true)

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -739,7 +739,7 @@ class MenusModelItem extends JModelAdmin
 		$query->select('a.id, a.title, a.position, a.published, map.menuid')
 			->from('#__modules AS a')
 			->join('LEFT', sprintf('#__modules_menu AS map ON map.moduleid = a.id AND map.menuid IN (0, %1$d, -%1$d)', $this->getState('item.id')))
-			->select('(SELECT COUNT(*) FROM #__modules_menu WHERE moduleid = a.id AND menuid < 0) AS ' . $db->quoteName('except'));
+			->select('(SELECT COUNT(moduleid) FROM #__modules_menu WHERE moduleid = a.id AND menuid < 0) AS ' . $db->quoteName('except'));
 
 		// Join on the asset groups table.
 		$query->select('ag.title AS access_title')

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -60,7 +60,7 @@ class NewsfeedsHelper extends JHelperContent
 			$item->count_unpublished = 0;
 			$item->count_published = 0;
 			$query = $db->getQuery(true);
-			$query->select('published AS state, count(*) AS count')
+			$query->select('published AS state, COUNT(id) AS count')
 				->from($db->qn('#__newsfeeds'))
 				->where('catid = ' . (int) $item->id)
 				->group('state');

--- a/administrator/components/com_templates/models/template.php
+++ b/administrator/components/com_templates/models/template.php
@@ -230,7 +230,7 @@ class TemplatesModelTemplate extends JModelForm
 	{
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)
-			->select('COUNT(*)')
+			->select('COUNT(' . $db->quoteName('extension_id') . ')')
 			->from('#__extensions')
 			->where('name = ' . $db->quote($this->getState('new_name')));
 		$db->setQuery($query);
@@ -374,7 +374,7 @@ class TemplatesModelTemplate extends JModelForm
 		// Codemirror or Editor None should be enabled
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)
-			->select('COUNT(*)')
+			->select('COUNT(' . $db->quoteName('extension_id') . ')')
 			->from('#__extensions as a')
 			->where(
 				'(a.name =' . $db->quote('plg_editors_codemirror') .

--- a/administrator/modules/mod_status/mod_status.php
+++ b/administrator/modules/mod_status/mod_status.php
@@ -17,7 +17,7 @@ $input  = JFactory::getApplication()->input;
 
 // Get the number of unread messages in your inbox.
 $query = $db->getQuery(true)
-	->select('COUNT(*)')
+	->select('COUNT(' . $db->quoteName('message_id') . ')')
 	->from('#__messages')
 	->where('state = 0 AND user_id_to = ' . (int) $user->get('id'));
 

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -436,7 +436,7 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 
 		// Deny remove default template
 		$db = $this->parent->getDbo();
-		$query = "SELECT COUNT(*) FROM #__template_styles WHERE home = '1' AND template = " . $db->quote($name);
+		$query = "SELECT COUNT(id) FROM #__template_styles WHERE home = '1' AND template = " . $db->quote($name);
 		$db->setQuery($query);
 
 		if ($db->loadResult() != 0)

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -541,7 +541,7 @@ class JDocumentHtml extends JDocument
 			if ($active)
 			{
 				$query = $db->getQuery(true)
-					->select('COUNT(*)')
+					->select('COUNT(' . $db->quoteName('id') . ')')
 					->from('#__menu')
 					->where('parent_id = ' . $active->id)
 					->where('published = 1');

--- a/libraries/joomla/form/rule/email.php
+++ b/libraries/joomla/form/rule/email.php
@@ -101,7 +101,7 @@ class JFormRuleEmail extends JFormRule
 			$query = $db->getQuery(true);
 
 			// Build the query.
-			$query->select('COUNT(*)')
+			$query->select('COUNT(' . $db->quoteName('id') . ')')
 				->from('#__users')
 				->where('email = ' . $db->quote($value));
 

--- a/libraries/joomla/form/rule/username.php
+++ b/libraries/joomla/form/rule/username.php
@@ -40,7 +40,7 @@ class JFormRuleUsername extends JFormRule
 		$query = $db->getQuery(true);
 
 		// Build the query.
-		$query->select('COUNT(*)')
+		$query->select('COUNT(' . $db->quoteName('id') . ')')
 			->from('#__users')
 			->where('username = ' . $db->quote($value));
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -786,7 +786,7 @@ abstract class JModelAdmin extends JModelForm
 
 						$db = JFactory::getDbo();
 						$query = $db->getQuery(true)
-							->select('COUNT(*) as count, ' . $db->quoteName('as1.key'))
+							->select('COUNT(' . $db->quoteName('id') . ') as count, ' . $db->quoteName('as1.key'))
 							->from($db->quoteName('#__associations') . ' AS as1')
 							->join('LEFT', $db->quoteName('#__associations') . ' AS as2 ON ' . $db->quoteName('as1.key') . ' =  ' . $db->quoteName('as2.key'))
 							->where($db->quoteName('as1.context') . ' = ' . $db->quote($this->associationsContext))

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -40,7 +40,7 @@ abstract class ModTagsPopularHelper
 			->select(
 				array(
 					'MAX(' . $db->quoteName('tag_id') . ') AS tag_id',
-					' COUNT(*) AS count', 'MAX(t.title) AS title',
+					' COUNT(' . $db->quoteName('tag_id') . ') AS count', 'MAX(t.title) AS title',
 					'MAX(' . $db->quoteName('t.access') . ') AS access',
 					'MAX(' . $db->quoteName('t.alias') . ') AS alias'
 				)


### PR DESCRIPTION
The `COUNT(*)` used in database queries is slow because it cannot use any indexes on the table.

This PR replaces these with a `COUNT` on the primary key where possible.

There are still some other occurrences of `COUNT(*)` in core, but these are in functions where the table is variable. So no (fast) way of knowing the primary key.

The changes in this PR are all pretty straightforward and can be reviewed by looking over the code changes.
