### PR TITLE
Displaying existing tip in com_redirect Bulk Import

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -10,6 +10,7 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
+<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
 <div class="row-fluid">
 	<div class="control-group span12">
 		<div class="controls">


### PR DESCRIPTION
See remaining issue here:
https://github.com/joomla/joomla-cms/pull/10016

Before patch only the Title is displayed.

after patch, one should get:
![screen shot 2016-04-21 at 15 18 55](https://cloud.githubusercontent.com/assets/869724/14710157/8a8615b6-07d4-11e6-90f1-5e7e6adb0896.png)
