### PR TITLE
Update cog icon to user icon in administrator template index.php

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -192,7 +192,7 @@ $doc->addScriptDeclaration(
 				<jdoc:include type="modules" name="menu" style="none" />
 				<ul class="nav nav-user<?php echo ($this->direction == 'rtl') ? ' pull-left' : ' pull-right'; ?>">
 					<li class="dropdown">
-						<a class="<?php echo ($hidden ? ' disabled' : 'dropdown-toggle'); ?>" data-toggle="<?php echo ($hidden ? '' : 'dropdown'); ?>" <?php echo ($hidden ? '' : 'href="#"'); ?>><span class="icon-cog"></span>
+						<a class="<?php echo ($hidden ? ' disabled' : 'dropdown-toggle'); ?>" data-toggle="<?php echo ($hidden ? '' : 'dropdown'); ?>" <?php echo ($hidden ? '' : 'href="#"'); ?>><span class="icon-user"></span>
 							<span class="caret"></span></a>
 						<ul class="dropdown-menu">
 							<?php if (!$hidden) : ?>


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

I propose changing the gear icon to a user icon for the user menu at the top right of the admin template. While I know the user icon is also used in the subsequent drop down, that gear never made sense to me as this is a user menu. There's nothing in that menu that's NOT user related (unless you argue that a log out option isn't user related).

In many other systems, that sort of menu is denoted by a user or head icon. This would just bring a bit more clarity to that menu.

To test the change, log into the admin and see if the cog icon is now a user icon.
