### PR TITLE
Regression: Solves searchtools filters bugs and regressions

### DIFF
--- a/administrator/components/com_banners/models/banners.php
+++ b/administrator/components/com_banners/models/banners.php
@@ -45,10 +45,9 @@ class BannersModelBanners extends JModelList
 				'clicks', 'a.clicks',
 				'publish_up', 'a.publish_up',
 				'publish_down', 'a.publish_down',
-				'state', 'sticky', 'a.sticky',
+				'sticky', 'a.sticky',
 				'client_id',
 				'category_id',
-				'published'
 			);
 		}
 
@@ -132,14 +131,14 @@ class BannersModelBanners extends JModelList
 		$query->select('cl.name AS client_name,cl.purchase_type as client_purchase_type')
 			->join('LEFT', '#__banner_clients AS cl ON cl.id = a.cid');
 
-		// Filter by published state
-		$published = $this->getState('filter.published');
+		// Filter by state
+		$state = $this->getState('filter.state');
 
-		if (is_numeric($published))
+		if (is_numeric($state))
 		{
-			$query->where('a.state = ' . (int) $published);
+			$query->where('a.state = ' . (int) $state);
 		}
-		elseif ($published === '')
+		elseif ($state === '')
 		{
 			$query->where('(a.state IN (0, 1))');
 		}
@@ -218,8 +217,7 @@ class BannersModelBanners extends JModelList
 	{
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
-		$id .= ':' . $this->getState('filter.access');
-		$id .= ':' . $this->getState('filter.published');
+		$id .= ':' . $this->getState('filter.state');
 		$id .= ':' . $this->getState('filter.category_id');
 		$id .= ':' . $this->getState('filter.language');
 

--- a/administrator/components/com_banners/models/banners.php
+++ b/administrator/components/com_banners/models/banners.php
@@ -48,6 +48,7 @@ class BannersModelBanners extends JModelList
 				'sticky', 'a.sticky',
 				'client_id',
 				'category_id',
+				'published',
 			);
 		}
 
@@ -131,14 +132,14 @@ class BannersModelBanners extends JModelList
 		$query->select('cl.name AS client_name,cl.purchase_type as client_purchase_type')
 			->join('LEFT', '#__banner_clients AS cl ON cl.id = a.cid');
 
-		// Filter by state
-		$state = $this->getState('filter.state');
+		// Filter by published state
+		$published = $this->getState('filter.published');
 
-		if (is_numeric($state))
+		if (is_numeric($published))
 		{
-			$query->where('a.state = ' . (int) $state);
+			$query->where('a.state = ' . (int) $published);
 		}
-		elseif ($state === '')
+		elseif ($published === '')
 		{
 			$query->where('(a.state IN (0, 1))');
 		}
@@ -217,7 +218,7 @@ class BannersModelBanners extends JModelList
 	{
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
-		$id .= ':' . $this->getState('filter.state');
+		$id .= ':' . $this->getState('filter.published');
 		$id .= ':' . $this->getState('filter.category_id');
 		$id .= ':' . $this->getState('filter.language');
 
@@ -256,7 +257,7 @@ class BannersModelBanners extends JModelList
 	{
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search'));
-		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
+		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', ''));
 		$this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', ''));
 		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', ''));

--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -10,7 +10,7 @@
 			class="js-stools-search-string"
 		/>
 		<field
-			name="state"
+			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
 			description="JOPTION_SELECT_PUBLISHED_DESC"

--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -10,7 +10,7 @@
 			class="js-stools-search-string"
 		/>
 		<field
-			name="published"
+			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
 			description="JOPTION_SELECT_PUBLISHED_DESC"
@@ -29,15 +29,15 @@
 			<option value="">JOPTION_SELECT_CATEGORY</option>
 		</field>
 		<field
-         		name="client_id"
-                	type="bannerclient"
-                	label="COM_BANNERS_FILTER_CLIENT"
-                	extension="com_content"
-                	description="COM_BANNERS_FILTER_CLIENT_DESC"
-                	onchange="this.form.submit();"
-                	>
-            		<option value="">COM_BANNERS_SELECT_CLIENT</option>
-        	</field>
+			name="client_id"
+			type="bannerclient"
+			label="COM_BANNERS_FILTER_CLIENT"
+			extension="com_content"
+			description="COM_BANNERS_FILTER_CLIENT_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">COM_BANNERS_SELECT_CLIENT</option>
+		</field>
 		<field
 			name="language"
 			type="contentlanguage"

--- a/administrator/components/com_banners/models/tracks.php
+++ b/administrator/components/com_banners/models/tracks.php
@@ -67,9 +67,9 @@ class BannersModelTracks extends JModelList
 	{
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', null, 'int'));
+		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', '', 'cmd'));
 		$this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', '', 'cmd'));
-		$this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', null, 'int'));
+		$this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'cmd'));
 		$this->setState('filter.begin', $this->getUserStateFromRequest($this->context . '.filter.begin', 'filter_begin', '', 'string'));
 		$this->setState('filter.end', $this->getUserStateFromRequest($this->context . '.filter.end', 'filter_end', '', 'string'));
 

--- a/administrator/components/com_banners/models/tracks.php
+++ b/administrator/components/com_banners/models/tracks.php
@@ -68,7 +68,7 @@ class BannersModelTracks extends JModelList
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', null, 'int'));
-		$this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', null, 'int'));
+		$this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', '', 'cmd'));
 		$this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', null, 'int'));
 		$this->setState('filter.begin', $this->getUserStateFromRequest($this->context . '.filter.begin', 'filter_begin', '', 'string'));
 		$this->setState('filter.end', $this->getUserStateFromRequest($this->context . '.filter.end', 'filter_end', '', 'string'));

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -93,8 +93,8 @@ class CategoriesModelCategories extends JModelList
 
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.search', 'filter_search', '', 'string'));
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
-		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
 		$this->setState('filter.level', $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', '', 'string'));
 

--- a/administrator/components/com_contact/models/contacts.php
+++ b/administrator/components/com_contact/models/contacts.php
@@ -95,8 +95,8 @@ class ContactModelContacts extends JModelList
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', '', 'string'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
-		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
 
 		// List state information.

--- a/administrator/components/com_languages/models/languages.php
+++ b/administrator/components/com_languages/models/languages.php
@@ -61,7 +61,7 @@ class LanguagesModelLanguages extends JModelList
 	{
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 
 		// Load the parameters.

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -94,7 +94,7 @@ class ModulesModelModules extends JModelList
 		else
 		{
 			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
-			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
+			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
 		}
 
 		// Special case for the client id.

--- a/administrator/components/com_modules/models/modules.php
+++ b/administrator/components/com_modules/models/modules.php
@@ -93,7 +93,7 @@ class ModulesModelModules extends JModelList
 		// If in backend (modal or not) we get the same fields from the user request.
 		else
 		{
-			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
+			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
 			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
 		}
 

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -92,7 +92,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', null, 'int'));
 		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
-		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
+		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
 
 		// Load the parameters.

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -90,7 +90,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
-		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', null, 'int'));
+		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', '', 'cmd'));
 		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
 		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -91,7 +91,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', null, 'int'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
 		$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'cmd'));
 		$this->setState('filter.tag', $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '', 'string'));
 

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -64,7 +64,7 @@ class PluginsModelPlugins extends JModelList
 		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
 		$this->setState('filter.search', $search);
 
-		$accessId = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', null, 'int');
+		$accessId = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd');
 		$this->setState('filter.access', $accessId);
 
 		$state = $this->getUserStateFromRequest($this->context . '.filter.enabled', 'filter_enabled', '', 'string');

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -100,7 +100,7 @@ class PluginsModelPlugins extends JModelList
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
 		$id .= ':' . $this->getState('filter.access');
-		$id .= ':' . $this->getState('filter.state');
+		$id .= ':' . $this->getState('filter.enabled');
 		$id .= ':' . $this->getState('filter.folder');
 		$id .= ':' . $this->getState('filter.language');
 

--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -61,19 +61,19 @@ class PluginsModelPlugins extends JModelList
 	protected function populateState($ordering = null, $direction = null)
 	{
 		// Load the filter state.
-		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+		$search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string');
 		$this->setState('filter.search', $search);
 
 		$accessId = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd');
 		$this->setState('filter.access', $accessId);
 
-		$state = $this->getUserStateFromRequest($this->context . '.filter.enabled', 'filter_enabled', '', 'string');
+		$state = $this->getUserStateFromRequest($this->context . '.filter.enabled', 'filter_enabled', '', 'cmd');
 		$this->setState('filter.enabled', $state);
 
-		$folder = $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', null, 'cmd');
+		$folder = $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string');
 		$this->setState('filter.folder', $folder);
 
-		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
+		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string');
 		$this->setState('filter.language', $language);
 
 		// Load the parameters.

--- a/administrator/components/com_users/models/notes.php
+++ b/administrator/components/com_users/models/notes.php
@@ -39,6 +39,7 @@ class UsersModelNotes extends JModelList
 				'review_time', 'a.review_time',
 				'publish_up', 'a.publish_up',
 				'publish_down', 'a.publish_down',
+				'published',
 			);
 		}
 
@@ -152,7 +153,7 @@ class UsersModelNotes extends JModelList
 	{
 		// Compile the store id.
 		$id .= ':' . $this->getState('filter.search');
-		$id .= ':' . $this->getState('filter.state');
+		$id .= ':' . $this->getState('filter.published');
 		$id .= ':' . $this->getState('filter.category_id');
 		$id .= ':' . $this->getState('filter.user_id');
 
@@ -202,11 +203,8 @@ class UsersModelNotes extends JModelList
 		}
 
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search'));
-
-		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_published', '', 'string'));
-
+		$this->setState('filter.published', $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '', 'string'));
 		$this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id'));
-
 		$this->setState('filter.user_id', $this->getUserStateFromRequest($this->context . '.filter.user_id', 'filter_user_id'));
 
 		parent::populateState($ordering, $direction);

--- a/administrator/components/com_users/models/users.php
+++ b/administrator/components/com_users/models/users.php
@@ -74,8 +74,8 @@ class UsersModelUsers extends JModelList
 
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.active', $this->getUserStateFromRequest($this->context . '.filter.active', 'filter_active', null, 'int'));
-		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', null, 'int'));
+		$this->setState('filter.active', $this->getUserStateFromRequest($this->context . '.filter.active', 'filter_active', '', 'cmd'));
+		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
 		$this->setState('filter.group_id', $this->getUserStateFromRequest($this->context . '.filter.group_id', 'filter_group_id', null, 'int'));
 		$this->setState('filter.range', $this->getUserStateFromRequest($this->context . '.filter.range', 'filter_range', '', 'cmd'));
 

--- a/administrator/templates/hathor/html/com_banners/banners/default.php
+++ b/administrator/templates/hathor/html/com_banners/banners/default.php
@@ -39,12 +39,12 @@ $saveOrder = $listOrder == 'ordering';
 		</div>
 
 		<div class="filter-select">
-			<label class="selectlabel" for="filter_state">
+			<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" id="filter_state">
+			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
 			<label class="selectlabel" for="filter_client_id">

--- a/administrator/templates/hathor/html/com_banners/tracks/default.php
+++ b/administrator/templates/hathor/html/com_banners/tracks/default.php
@@ -97,7 +97,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php foreach ($this->items as $i => $item) :?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<td>
-					<?php echo $item->name;?>
+					<?php echo $item->banner_name;?>
 				</td>
 				<td>
 					<?php echo $item->client_name;?>

--- a/administrator/templates/hathor/html/com_installer/manage/default_filter.php
+++ b/administrator/templates/hathor/html/com_installer/manage/default_filter.php
@@ -32,7 +32,7 @@ defined('_JEXEC') or die;
 			</label>
 			<select name="filter_status" id="filter_status">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.status'), true);?>
+				<?php echo JHtml::_('select.options', InstallerHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.status'), true);?>
 			</select>
 
             <label class="selectlabel" for="filter_type">
@@ -43,12 +43,12 @@ defined('_JEXEC') or die;
 				<?php echo JHtml::_('select.options', InstallerHelper::getExtensionTypes(), 'value', 'text', $this->state->get('filter.type'), true);?>
 			</select>
 
-			<label class="selectlabel" for="filter_group">
+			<label class="selectlabel" for="filter_folder">
 				<?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT'); ?>
 			</label>
-			<select name="filter_group" id="filter_group">
+			<select name="filter_folder" id="filter_folder">
 				<option value=""><?php echo JText::_('COM_INSTALLER_VALUE_FOLDER_SELECT');?></option>
-				<?php echo JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.group'), true);?>
+				<?php echo JHtml::_('select.options', array_merge(InstallerHelper::getExtensionGroupes(), array('*' => JText::_('COM_INSTALLER_VALUE_FOLDER_NONAPPLICABLE'))), 'value', 'text', $this->state->get('filter.folder'), true);?>
 			</select>
 
 			<button type="submit" id="filter-go">

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -48,7 +48,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 			</label>
 			<select name="filter_published" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.state'), true);?>
+				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions'), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
 			<label class="selectlabel" for="filter_category_id">

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -39,12 +39,12 @@ $saveOrder = $listOrder == 'ordering';
 		</div>
 
 		<div class="filter-select">
-			<label class="selectlabel" for="filter_state">
+			<label class="selectlabel" for="filter_enabled">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_state" id="filter_state">
+			<select name="filter_enabled" id="filter_enabled">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', PluginsHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.state'), true);?>
+				<?php echo JHtml::_('select.options', PluginsHelper::publishedOptions(), 'value', 'text', $this->state->get('filter.enabled'), true);?>
 			</select>
 
 			<label class="selectlabel" for="filter_folder">

--- a/administrator/templates/hathor/html/com_users/notes/default.php
+++ b/administrator/templates/hathor/html/com_users/notes/default.php
@@ -55,7 +55,7 @@ $canEdit = $user->authorise('core.edit', 'com_users');
 				<?php
 				echo JHtml::_(
 					'select.options', JHtml::_('jgrid.publishedOptions'),
-					'value', 'text', $this->state->get('filter.state'), true
+					'value', 'text', $this->state->get('filter.published'), true
 				); ?>
 			</select>
 


### PR DESCRIPTION
Pull Request for **Regression** and several bugs.
#### Summary of Changes

With all the changes in searchtools some filters have a wrong input filtering. Some were caused by my PRs, and many other were already there. 

Anyhow, most of this problems only manifests itself in hathor.

As you see from the code changes, besides the input filtering, there are a series of inconsistencies in the filters names (and other) that cause this bugs.
#### Testing Instructions

First test on isis to confirm they are all working properly:
1. Use latest staging and apply this PR
2. Go to "Users" -> "Manage" and test the "state" and "activated" filters
3. Go to "Users" -> "User notes" and test the "state" filter
4. Go to "Content" -> "Categories" and test the "access" and the "language" filter (the "All" value in particular).
5. Go to "Components" -> "Banners" -> "Banners" and test the "state" filter.
6. Go to "Components" -> "Banners" -> "Tracks" and test the "type", the "client" and "category" filter.
7. Go to "Components" -> "Contacts" -> "Contacts" and test the "access" and the "language" filter (the "All" value in particular).
8. Go to "Components" -> "Newsfeeds" -> "Newsfeeds" and test the "category id", "access" and the "language" filter (the "All" value in particular).
9. Go to "Extensions" -> "Modules" and test the "state" (the "All" value in particular) "language" filter (the "All" value in particular).
10. Go to "Extensions" -> "Plugins" and test the "status" filter.
11. Go to "Extensions" -> "Languages" -> "Content Languages" and test the "state" filter (the "All" value in particular).
12. Go to "Extensions" -> "Manage" -> "Manage" and test all the filters.

Now change the template to hathor and do the same tests.

Notes:
- In the tests above i only say to test the filters i corrected, but if you find more problems with filters please report.
