### PR TITLE
User group debug (complements #10008 - already merged)

### DIFF
--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -126,10 +126,10 @@ class UsersModelDebuggroup extends JModelList
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('group_id', $this->getUserStateFromRequest($this->context . '.group_id', 'group_id', 0, 'int', false));
 
-		$levelStart = $this->getUserStateFromRequest($this->context . '.filter.level_start', 'filter_level_start', 0, 'int');
+		$levelStart = $this->getUserStateFromRequest($this->context . '.filter.level_start', 'filter_level_start', '', 'cmd');
 		$this->setState('filter.level_start', $levelStart);
 
-		$value = $this->getUserStateFromRequest($this->context . '.filter.level_end', 'filter_level_end', 0, 'int');
+		$value = $this->getUserStateFromRequest($this->context . '.filter.level_end', 'filter_level_end', '', 'cmd');
 
 		if ($value > 0 && $value < $levelStart)
 		{

--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -65,7 +65,7 @@ class UsersModelDebuggroup extends JModelList
 	 */
 	public function getItems()
 	{
-		$groupId = $this->getState('filter.group_id');
+		$groupId = $this->getState('group_id');
 
 		if (($assets = parent::getItems()) && $groupId)
 		{
@@ -124,7 +124,7 @@ class UsersModelDebuggroup extends JModelList
 
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.group_id', $this->getUserStateFromRequest($this->context . '.filter.group_id', 'group_id', 0, 'int', false));
+		$this->setState('group_id', $this->getUserStateFromRequest($this->context . '.group_id', 'group_id', 0, 'int', false));
 
 		$levelStart = $this->getUserStateFromRequest($this->context . '.filter.level_start', 'filter_level_start', 0, 'int');
 		$this->setState('filter.level_start', $levelStart);
@@ -162,8 +162,8 @@ class UsersModelDebuggroup extends JModelList
 	protected function getStoreId($id = '')
 	{
 		// Compile the store id.
+		$id .= ':' . $this->getState('group_id');
 		$id .= ':' . $this->getState('filter.search');
-		$id .= ':' . $this->getState('filter.group_id');
 		$id .= ':' . $this->getState('filter.level_start');
 		$id .= ':' . $this->getState('filter.level_end');
 		$id .= ':' . $this->getState('filter.component');
@@ -180,7 +180,7 @@ class UsersModelDebuggroup extends JModelList
 	 */
 	public function getGroup()
 	{
-		$groupId = (int) $this->getState('filter.group_id');
+		$groupId = (int) $this->getState('group_id');
 
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -19,7 +19,7 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $colSpan   = 4 + count($this->actions);
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('filter.group_id')); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>

--- a/administrator/templates/hathor/html/com_users/debuggroup/default.php
+++ b/administrator/templates/hathor/html/com_users/debuggroup/default.php
@@ -18,7 +18,7 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=debuggroup&user_id='.(int) $this->state->get('filter.user_id'));?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=debuggroup&group_id='.(int) $this->state->get('group_id'));?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

This PR complements https://github.com/joomla/joomla-cms/pull/10008 (already merged) and does some corrections to searchtools pre-activated state and corrects hathor behaviour (was linking with user_id, instead of group_id ...).
#### Testing Instructions

This is a very simple test.
1. Use latest staging
2. Ativate debug in global config
3. Logout
4. Login and go directly to "Users" -> "User Groups"
5. Click a "Debug Permissions Report" link on any group and check the filter bar is not activated (blue).
6. Go to hathor and select some filter you will notice it will now work fine.

Without this patch the search tools filters bar is pre-ativated at beggining and hathor search/filters/pagination won't work at all.
