### PR TITLE
Remove extra spacing caused by paragraphs inside tables (part 1 - articles)

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -187,7 +187,7 @@ $assoc = JLanguageAssociations::isEnabled();
 							<?php if ($item->created_by_alias) : ?>
 								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
 								<?php echo $this->escape($item->author_name); ?></a>
-								<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
+								<div class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
 							<?php else : ?>
 								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
 								<?php echo $this->escape($item->author_name); ?></a>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

The Created by alias in com_content articles view is using a `p` tag inside the results table.

The usage of `p`adds an extra spacing to the bottom of the row.
###### Before patch

![image](https://cloud.githubusercontent.com/assets/9630530/14749771/5427a18e-08b9-11e6-8d15-8256828713e2.png)
###### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/14749810/88cd5faa-08b9-11e6-9b9c-b3e9507a7214.png)
#### Testing Instructions

Very simple
1. To Content -> Articles
2. Check the row bottom spacing of an article with created by user alias
3. Apply patch
4. Repeat step 2. the space is gone.
