### PR TITLE
Remove extra spacing caused by paragraphs inside tables (part 2 - featured articles)

### DIFF
--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -166,7 +166,7 @@ $saveOrder = $listOrder == 'fp.ordering';
 						<td class="small hidden-phone">
 							<?php if ($item->created_by_alias) : ?>
 								<?php echo $this->escape($item->author_name); ?>
-								<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
+								<div class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
 							<?php else : ?>
 								<?php echo $this->escape($item->author_name); ?>
 							<?php endif; ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

The Created by alias in com_content articles view is using a `p` tag inside the results table.

The usage of `p`adds an extra spacing to the bottom of the row.
###### Before patch

![image](https://cloud.githubusercontent.com/assets/9630530/14749771/5427a18e-08b9-11e6-8d15-8256828713e2.png)
###### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/14749810/88cd5faa-08b9-11e6-9b9c-b3e9507a7214.png)
#### Testing Instructions

Very simple
1. To Content -> Featured
2. Check the row bottom spacing of an article with created by user alias
3. Apply patch
4. Repeat step 2. the space is gone.
