### PR TITLE
Remove label tag margins if inside tables

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7847,6 +7847,9 @@ ul.treeselect ul.dropdown-menu li {
 	padding: 0 5px;
 	border: none;
 }
+table label {
+	margin: 0;
+}
 td.has-context {
 	height: 23px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7847,6 +7847,9 @@ ul.treeselect ul.dropdown-menu li {
 	padding: 0 5px;
 	border: none;
 }
+table label {
+	margin: 0;
+}
 td.has-context {
 	height: 23px;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1055,6 +1055,10 @@ ul.treeselect ul.dropdown-menu li {
 	border: none;
 }
 /* Tables */
+table label {
+	margin: 0;
+}
+
 td.has-context {
 	// Fixes difference in height between normal and hover on cell with context
 	height: 23px;


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

The `label` tags inside the tables have a 5px margin where they shouldn't.
This small PR corrects that.

Before

![image](https://cloud.githubusercontent.com/assets/9630530/14755057/5966c7ec-08d7-11e6-8607-fe6d3d885913.png)

After 

![image](https://cloud.githubusercontent.com/assets/9630530/14755065/75e00ea6-08d7-11e6-838b-f4d20c082dff.png)
#### Testing Instructions

Very simple test.

Code review or:
1. Use latest staging
2. Go to Extensions -> Manage -> Install languages (or any view that have labels inside table rows), Compare the margin above the language name and the margin below.
3. Apply patch
4. The extra spacing is removed.
