### PR TITLE
Add dropdown tasks items to categories

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -18,23 +18,17 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app        = JFactory::getApplication();
-$user       = JFactory::getUser();
-$userId     = $user->get('id');
-$extension  = $this->escape($this->state->get('filter.extension'));
-$listOrder  = $this->escape($this->state->get('list.ordering'));
-$listDirn   = $this->escape($this->state->get('list.direction'));
-$saveOrder  = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$parts      = explode('.', $extension);
-$component  = $parts[0];
-$section    = null;
-$columns    = 7;
-$stateTasks = array(
-	1  => 'publish',
-	0  => 'unpublish',
-	2  => 'archive',
-	-2 => 'trash',
-);
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$extension = $this->escape($this->state->get('filter.extension'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$parts     = explode('.', $extension);
+$component = $parts[0];
+$section   = null;
+$columns   = 7;
 
 if (count($parts) > 1)
 {
@@ -196,13 +190,8 @@ if ($saveOrder)
 									if ($canChange)
 									{
 										// Create dropdown items
-										foreach ($stateTasks as $state => $task)
-										{
-											if ((int) $item->published !== $state)
-											{
-												JHtml::_('actionsdropdown.' . $task, 'cb' . $i, 'categories');
-											}
-										}
+										JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'categories');
+										JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'categories');
 
 										// Render dropdown list
 										echo JHtml::_('actionsdropdown.render', $this->escape($item->title));

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -193,17 +193,20 @@ if ($saveOrder)
 								<div class="btn-group">
 									<?php echo JHtml::_('jgrid.published', $item->published, $i, 'categories.', $canChange); ?>
 									<?php
-									// Create dropdown items
-									foreach ($stateTasks as $state => $task)
+									if ($canChange)
 									{
-										if ((int) $item->published !== $state)
+										// Create dropdown items
+										foreach ($stateTasks as $state => $task)
 										{
-											JHtml::_('actionsdropdown.' . $task, 'cb' . $i, 'categories');
+											if ((int) $item->published !== $state)
+											{
+												JHtml::_('actionsdropdown.' . $task, 'cb' . $i, 'categories');
+											}
 										}
-									}
 
-									// Render dropdown list
-									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+										// Render dropdown list
+										echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									}
 									?>
 								</div>
 							</td>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -18,16 +18,23 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app		= JFactory::getApplication();
-$user		= JFactory::getUser();
-$userId		= $user->get('id');
-$extension	= $this->escape($this->state->get('filter.extension'));
-$listOrder	= $this->escape($this->state->get('list.ordering'));
-$listDirn	= $this->escape($this->state->get('list.direction'));
-$saveOrder 	= ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$parts		= explode('.', $extension);
-$component	= $parts[0];
-$section	= null;
+$app        = JFactory::getApplication();
+$user       = JFactory::getUser();
+$userId     = $user->get('id');
+$extension  = $this->escape($this->state->get('filter.extension'));
+$listOrder  = $this->escape($this->state->get('list.ordering'));
+$listDirn   = $this->escape($this->state->get('list.direction'));
+$saveOrder  = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$parts      = explode('.', $extension);
+$component  = $parts[0];
+$section    = null;
+$columns    = 7;
+$stateTasks = array(
+	1  => 'publish',
+	0  => 'unpublish',
+	2  => 'archive',
+	-2 => 'trash',
+);
 
 if (count($parts) > 1)
 {
@@ -40,8 +47,6 @@ if (count($parts) > 1)
 		$section = $inflector->toPlural($section);
 	}
 }
-
-$columns	= 7;
 
 if ($saveOrder)
 {
@@ -185,7 +190,22 @@ if ($saveOrder)
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 							</td>
 							<td class="center">
-								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'categories.', $canChange); ?>
+								<div class="btn-group">
+									<?php echo JHtml::_('jgrid.published', $item->published, $i, 'categories.', $canChange); ?>
+									<?php
+									// Create dropdown items
+									foreach ($stateTasks as $state => $task)
+									{
+										if ((int) $item->published !== $state)
+										{
+											JHtml::_('actionsdropdown.' . $task, 'cb' . $i, 'categories');
+										}
+									}
+
+									// Render dropdown list
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									?>
+								</div>
 							</td>
 							<td>
 								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>


### PR DESCRIPTION
Pull Request for Improvements.
#### Summary of Changes

This PR adds state tasks dropdown actions to categories.
##### Before PR

![image](https://cloud.githubusercontent.com/assets/9630530/14758007/d69ef2ce-08f1-11e6-89e2-2eaa767abe2a.png)
##### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/14761067/2a041e98-094d-11e6-9542-410879d49d5b.png)
#### Testing Instructions
1. Use latest staging and apply patch 
2. Test the new dropdown menu in all possible category states (published, unpublished, archived and trash)
