### PR TITLE
Archived articles view year selection hardcoded

### DIFF
--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -185,6 +185,7 @@ class ContentModelArchive extends ContentModelArticles
 	 * Gets the archived articles years
 	 *
 	 * @return   array
+	 * 
 	 * @since    3.5.2
 	 */
 	public function getYears()
@@ -192,8 +193,8 @@ class ContentModelArchive extends ContentModelArticles
 		$db = $this->getDbo();
 
 		$query = $db->getQuery(true);
-		$years  =  $query->year($db->qn('created'));
-		$query->select('DISTINCT (' . $years . ')' )
+		$years = $query->year($db->qn('created'));
+		$query->select('DISTINCT (' . $years . ')')
 			->from($db->qn('#__content'))
 			->where($db->qn('state') . '= 2')
 			->order('1 ASC');

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -180,4 +180,25 @@ class ContentModelArchive extends ContentModelArticles
 
 		return $result;
 	}
+
+	/**
+	 * Gets the archived articles years
+	 *
+	 * @return   array
+	 * @since    3.5.2
+	 */
+	public function getYears()
+	{
+		$db = $this->getDbo();
+
+		$query = $db->getQuery(true);
+		$years  =  $query->year($db->qn('created'));
+		$query->select('DISTINCT (' . $years . ')' )
+			->from($db->qn('#__content'))
+			->where($db->qn('state') . '= 2')
+			->order('1 ASC');
+
+		$db->setQuery($query);
+		return $db->loadColumn();
+	}
 }

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -191,12 +191,16 @@ class ContentModelArchive extends ContentModelArticles
 	public function getYears()
 	{
 		$db = $this->getDbo();
+		$nullDate = $db->quote($db->getNullDate());
+		$nowDate  = $db->quote(JFactory::getDate()->toSql());
 
 		$query = $db->getQuery(true);
 		$years = $query->year($db->qn('created'));
 		$query->select('DISTINCT (' . $years . ')')
 			->from($db->qn('#__content'))
 			->where($db->qn('state') . '= 2')
+			->where('(publish_up = ' . $nullDate . ' OR publish_up <= ' . $nowDate . ')')
+			->where('(publish_down = ' . $nullDate . ' OR publish_down >= ' . $nowDate . ')')
 			->order('1 ASC');
 
 		$db->setQuery($query);

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -114,7 +114,7 @@ class ContentViewArchive extends JViewLegacy
 		$years = array();
 		$years[] = JHtml::_('select.option', null, JText::_('JYEAR'));
 
-		for ($i = 0 ; $i < count($this->years); $i++)
+		for ($i = 0; $i < count($this->years); $i++)
 		{
 			$years[] = JHtml::_('select.option', $this->years[$i], $this->years[$i]);
 		}

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -24,6 +24,8 @@ class ContentViewArchive extends JViewLegacy
 
 	protected $pagination = null;
 
+	protected $years = null;
+
 	/**
 	 * Execute and display a template script.
 	 *
@@ -108,12 +110,13 @@ class ContentViewArchive extends JViewLegacy
 		);
 
 		// Year Field
+		$this->years = $this->getModel()->getYears();
 		$years = array();
 		$years[] = JHtml::_('select.option', null, JText::_('JYEAR'));
 
-		for ($year = date('Y'), $i = $year - 10; $i <= $year; $i++)
+		for ($i = 0 ; $i < count($this->years); $i++)
 		{
-			$years[] = JHtml::_('select.option', $i, $i);
+			$years[] = JHtml::_('select.option', $this->years[$i], $this->years[$i]);
 		}
 
 		$form->yearField = JHtml::_(


### PR DESCRIPTION
Pull Request for Issue #6754 .
![archived articles](https://cloud.githubusercontent.com/assets/181681/14760822/f60e1af2-094d-11e6-993d-45b2a7009b26.png)
#### Summary of Changes

Added a getYears() function to retrive only archived content items years
to the archived model class
and the call in the view class
#### Testing Instructions

from backend set the state of some articles to archived (choose from different created year)
you should notice in the frontend that 
Archieved articles view year selection must cointain only  the archived year  and not 
the hardcode (now - 10 year) 
 see #6754 for more infoe
#### Comments

should be done better using ajax for dynamically select the relative months based on the selectecd year ....
