### PR TITLE
Solve issues with item state dropdowns

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -20,8 +20,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $canOrder  = $user->authorise('core.edit.state', 'com_banners.category');
-$archived  = $this->state->get('filter.state') == 2 ? true : false;
-$trashed   = $this->state->get('filter.state') == -2 ? true : false;
 $saveOrder = $listOrder == 'a.ordering';
 
 if ($saveOrder)
@@ -30,7 +28,6 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'articleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
 ?>
-
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -123,16 +120,13 @@ if ($saveOrder)
 							<td class="center">
 								<div class="btn-group">
 									<?php echo JHtml::_('jgrid.published', $item->state, $i, 'banners.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-									<?php
-									// Create dropdown items
-									$action = $archived ? 'unarchive' : 'archive';
-									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'banners');
-
-									$action = $trashed ? 'untrash' : 'trash';
-									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'banners');
-
-									// Render dropdown list
-									echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+									<?php // Create dropdown items and render the dropdown list.
+									if ($canChange)
+									{
+										JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'banners');
+										JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'banners');
+										echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+									}
 									?>
 								</div>
 							</td>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -20,10 +20,7 @@ $userId     = $user->get('id');
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $params     = (isset($this->state->params)) ? $this->state->params : new JObject;
-$archived   = $this->state->get('filter.state') == 2 ? true : false;
-$trashed    = $this->state->get('filter.state') == -2 ? true : false;
 ?>
-
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=clients'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -85,16 +82,13 @@ $trashed    = $this->state->get('filter.state') == -2 ? true : false;
 							<td class="center">
 								<div class="btn-group">
 									<?php echo JHtml::_('jgrid.published', $item->state, $i, 'clients.', $canChange); ?>
-									<?php
-									// Create dropdown items
-									$action = $archived ? 'unarchive' : 'archive';
-									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'clients');
-
-									$action = $trashed ? 'untrash' : 'trash';
-									JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'clients');
-
-									// Render dropdown list
-									echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+									<?php // Create dropdown items and render the dropdown list.
+									if ($canChange)
+									{
+										JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'clients');
+										JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'clients');
+										echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+									}
 									?>
 								</div>
 							</td>

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -19,8 +19,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$archived  = $this->state->get('filter.published') == 2 ? true : false;
-$trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 
@@ -129,16 +127,13 @@ if ($saveOrder)
 						<td class="center">
 							<div class="btn-group">
 								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'contacts.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								<?php
-								// Create dropdown items
-								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'contacts');
-
-								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'contacts');
-
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+								<?php // Create dropdown items and render the dropdown list.
+								if ($canChange)
+								{
+									JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'contacts');
+									JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'contacts');
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+								}
 								?>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -134,14 +134,11 @@ $assoc = JLanguageAssociations::isEnabled();
 							<div class="btn-group">
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
-								<?php
+								<?php // Create dropdown items and render the dropdown list.
 								if ($canChange)
 								{
-									// Create dropdown items
 									JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'articles');
 									JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'articles');
-
-									// Render dropdown list
 									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
 								}
 								?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -20,8 +20,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$archived  = $this->state->get('filter.published') == 2 ? true : false;
-$trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder == 'a.ordering';
 $columns   = 10;
 

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -137,15 +137,15 @@ $assoc = JLanguageAssociations::isEnabled();
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 								<?php
-								// Create dropdown items
-								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
+								if ($canChange)
+								{
+									// Create dropdown items
+									JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'articles');
+									JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'articles');
 
-								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
-
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									// Render dropdown list
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+								}
 								?>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -20,8 +20,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $canOrder  = $user->authorise('core.edit.state', 'com_content.article');
-$archived  = $this->state->get('filter.published') == 2 ? true : false;
-$trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $saveOrder = $listOrder == 'fp.ordering';
 ?>
 

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -108,15 +108,15 @@ $saveOrder = $listOrder == 'fp.ordering';
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 								<?php
-								// Create dropdown items
-								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
+								if ($canChange)
+								{
+									// Create dropdown items
+									JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'articles');
+									JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'articles');
 
-								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'articles');
-
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									// Render dropdown list
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+								}
 								?>
 							</div>
 						</td>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -105,14 +105,11 @@ $saveOrder = $listOrder == 'fp.ordering';
 							<div class="btn-group">
 								<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 								<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
-								<?php
+								<?php // Create dropdown items and render the dropdown list.
 								if ($canChange)
 								{
-									// Create dropdown items
 									JHtml::_('actionsdropdown.' . ((int) $item->state === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'articles');
 									JHtml::_('actionsdropdown.' . ((int) $item->state === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'articles');
-
-									// Render dropdown list
 									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
 								}
 								?>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -16,7 +16,6 @@ JHtml::_('formbehavior.chosen', 'select');
 $user		= JFactory::getUser();
 $listOrder	= $this->escape($this->state->get('list.ordering'));
 $listDirn	= $this->escape($this->state->get('list.direction'));
-$trashed	= $this->state->get('filter.state') == -2 ? true : false;
 $saveOrder	= ($listOrder == 'a.ordering');
 if ($saveOrder)
 {
@@ -122,12 +121,21 @@ if ($saveOrder)
 							<?php // Check if extension is enabled ?>
 							<?php if ($item->enabled > 0) : ?>
 								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								<?php // Create dropdown items ?>
-								<?php JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules'); ?>
-								<?php $action = $trashed ? 'untrash' : 'trash'; ?>
-								<?php JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'modules'); ?>
-								<?php // Render dropdown list ?>
-								<?php echo JHtml::_('actionsdropdown.render', $this->escape($item->title)); ?>
+								<?php
+								// Create dropdown items and render the dropdown list.
+								if ($canCreate)
+								{
+									JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');
+								}
+								if ($canChange)
+								{
+									JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'modules');
+								}
+								if ($canCreate || $canChange)
+								{
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+								}
+								?>
 							<?php else : ?>
 								<?php // Extension is not enabled, show a message that indicates this. ?>
 								<button class="btn-micro hasTooltip" title="<?php echo JText::_('COM_MODULES_MSG_MANAGE_EXTENSION_DISABLED'); ?>"><i class="icon-ban-circle"></i></button>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -121,8 +121,7 @@ if ($saveOrder)
 							<?php // Check if extension is enabled ?>
 							<?php if ($item->enabled > 0) : ?>
 								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'modules.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								<?php
-								// Create dropdown items and render the dropdown list.
+								<?php // Create dropdown items and render the dropdown list.
 								if ($canCreate)
 								{
 									JHtml::_('actionsdropdown.duplicate', 'cb' . $i, 'modules');

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -21,8 +21,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$archived  = $this->state->get('filter.published') == 2 ? true : false;
-$trashed   = $this->state->get('filter.published') == -2 ? true : false;
 $canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
@@ -127,16 +125,13 @@ if ($saveOrder)
 						<td class="center">
 							<div class="btn-group">
 								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'newsfeeds.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
-								<?php
-								// Create dropdown items
-								$action = $archived ? 'unarchive' : 'archive';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'newsfeeds');
-
-								$action = $trashed ? 'untrash' : 'trash';
-								JHtml::_('actionsdropdown.' . $action, 'cb' . $i, 'newsfeeds');
-
-								// Render dropdown list
-								echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
+								<?php // Create dropdown items and render the dropdown list.
+								if ($canChange)
+								{
+									JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'newsfeeds');
+									JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'newsfeeds');
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+								}
 								?>
 							</div>
 						</td>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -130,7 +130,7 @@ if ($saveOrder)
 								{
 									JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'newsfeeds');
 									JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'newsfeeds');
-									echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									echo JHtml::_('actionsdropdown.render', $this->escape($item->name));
 								}
 								?>
 							</div>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

As refered in https://github.com/joomla/joomla-cms/pull/10056, there are some bugs in the current implementations of the dropdown box in state column.
1. Doesn't check if the user can change the item state
   ![image](https://cloud.githubusercontent.com/assets/9630530/14761225/1e71cab2-0952-11e6-890c-085ddc00a078.png)
2. The dropdown is currently generated based on the `- Select Status -` filter state and not on the item state, as it should.
   This creates some problems, for instance, if you select, in the state filter, "All", an item in a trashed state has a trash option ... similiar, an article in archived state has the archive option.
   ![image](https://cloud.githubusercontent.com/assets/9630530/14761214/c5e850d2-0951-11e6-80cd-6b94e2e4fffa.png)

This PR corrects this two bugs in all this views:
- com_content articles
- com_content featured
- com_contact contacts
- com_newsfeeds newsfeeds
- com_banners banners
- com_banners clients
- com_modules modules
#### Testing Instructions
1. Apply patch
2. Test the dropdowns with all states in this views.

Note: You can check by the code changes that the code changes are the same in all views (except the modules that have a "Duplicate" and don't have archived)
