### PR TITLE
Use JLayout for field file

### DIFF
--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -49,14 +49,15 @@ extract($displayData);
 JHtml::_('jquery.framework');
 JHtml::_('script', 'system/html5fallback.js', false, true);
 ?>
+Tste:
 <input type="file"
 	name="<?php echo $name; ?>"
 	id="<?php echo $id; ?>"
 	<?php echo !empty($size) ? ' size="' . $size . '"' : ''
 	. !empty($accept) ? ' accept="' . $accept . '"' : ''
 	. !empty($class) ? ' class="' . $class . '"' : ''
+	. !empty($multiple) ? ' multiple' : ''
 	. $disabled ? ' disabled' : ''
-	. $multiple ? ' multiple' : ''
 	. $autofocus ? ' autofocus' : ''
 	. $onchange ? ' onchange="' . $onchange . '"' : ''
 	. $required ? ' required aria-required="true"' : ''; ?> />

--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   array    $spellcheck      Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ */
+
+// Including fallback code for HTML5 non supported browsers.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
+?>
+<input type="file"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	<?php echo !empty($size) ? ' size="' . $size . '"' : ''
+	. !empty($accept) ? ' accept="' . $accept . '"' : ''
+	. !empty($class) ? ' class="' . $class . '"' : ''
+	. $disabled ? ' disabled' : ''
+	. $multiple ? ' multiple' : ''
+	. $autofocus ? ' autofocus' : ''
+	. $onchange ? ' onchange="' . $onchange . '"' : ''
+	. $required ? ' required aria-required="true"' : ''; ?> />

--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -49,15 +49,14 @@ extract($displayData);
 JHtml::_('jquery.framework');
 JHtml::_('script', 'system/html5fallback.js', false, true);
 ?>
-Tste:
 <input type="file"
 	name="<?php echo $name; ?>"
 	id="<?php echo $id; ?>"
-	<?php echo !empty($size) ? ' size="' . $size . '"' : ''
-	. !empty($accept) ? ' accept="' . $accept . '"' : ''
-	. !empty($class) ? ' class="' . $class . '"' : ''
-	. !empty($multiple) ? ' multiple' : ''
-	. $disabled ? ' disabled' : ''
-	. $autofocus ? ' autofocus' : ''
-	. $onchange ? ' onchange="' . $onchange . '"' : ''
-	. $required ? ' required aria-required="true"' : ''; ?> />
+	<?php echo !empty($size) ? ' size="' . $size . '"' : ''; ?>
+	<?php echo !empty($accept) ? ' accept="' . $accept . '"' : ''; ?>
+	<?php echo !empty($class) ? ' class="' . $class . '"' : ''; ?>
+	<?php echo !empty($multiple) ? ' multiple' : ''; ?>
+	<?php echo $disabled ? ' disabled' : ''; ?>
+	<?php echo $autofocus ? ' autofocus' : ''; ?>
+	<?php echo !empty($onchange) ? ' onchange="' . $onchange . '"' : ''; ?>
+	<?php echo $required ? ' required aria-required="true"' : ''; ?> />

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -138,13 +138,9 @@ class JFormFieldFile extends JFormField
 	{
 		$data = parent::getLayoutData();
 
-		// Initialize some field attributes.
-		$accept    = !empty($this->accept) ? ' accept="' . $this->accept . '"' : '';
-		$multiple  = $this->multiple ? ' multiple' : '';
-
 		$extraData = array(
-			'accept'   => $accept,
-			'multiple' => $multiple,
+			'accept'   => $this->accept,
+			'multiple' => $this->multiple,
 		);
 
 		return array_merge($data, $extraData);

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -35,6 +35,14 @@ class JFormFieldFile extends JFormField
 	protected $accept;
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.6
+	 */
+	protected $layout = 'joomla.form.field.file';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to the the value.
@@ -116,23 +124,29 @@ class JFormFieldFile extends JFormField
 	 */
 	protected function getInput()
 	{
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.6
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
+
 		// Initialize some field attributes.
 		$accept    = !empty($this->accept) ? ' accept="' . $this->accept . '"' : '';
-		$size      = !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$class     = !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$disabled  = $this->disabled ? ' disabled' : '';
-		$required  = $this->required ? ' required aria-required="true"' : '';
-		$autofocus = $this->autofocus ? ' autofocus' : '';
 		$multiple  = $this->multiple ? ' multiple' : '';
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
+		$extraData = array(
+			'accept'   => $accept,
+			'multiple' => $multiple,
+		);
 
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
-		return '<input type="file" name="' . $this->name . '" id="' . $this->id . '"' . $accept
-			. $disabled . $class . $size . $onchange . $required . $autofocus . $multiple . ' />';
+		return array_merge($data, $extraData);
 	}
 }


### PR DESCRIPTION
Separate Logic from output.
This is 100% B/C and allows templates to customise the core output of Joomla.
There shouldn't be any performance degradation since JLayouts are using caching.
It's a straight forward change, nothing magic here!

Response to the conversation: https://groups.google.com/forum/#!topic/joomla-dev-cms/I3onEgcwKZE

Notifying @chrisdavenport 

Testing
Try to upload a file in media manager or install a component/module/plugin by selecting a zip file
