### PR TITLE
Add dropdown tasks items to com_tags

### DIFF
--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -140,7 +140,17 @@ if ($saveOrder)
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 							</td>
 							<td class="center">
-								<?php echo JHtml::_('jgrid.published', $item->published, $i, 'tags.', $canChange);?>
+								<div class="btn-group">
+									<?php echo JHtml::_('jgrid.published', $item->published, $i, 'tags.', $canChange); ?>
+									<?php // Create dropdown items and render the dropdown list.
+									if ($canChange)
+									{
+										JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'tags');
+										JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'tags');
+										echo JHtml::_('actionsdropdown.render', $this->escape($item->title));
+									}
+									?>
+								</div>
 							</td>
 							<td>
 								<?php if ($item->level > 0): ?>


### PR DESCRIPTION
Pull Request for Improvements.
#### Summary of Changes

This PR adds state tasks dropdown actions to tags component.
##### Before PR

![image](https://cloud.githubusercontent.com/assets/9630530/14761365/f17a574a-0956-11e6-9eee-24eca0a8735d.png)
##### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/14761360/de0ac55a-0956-11e6-9200-46d6b45f7397.png)
#### Testing Instructions
1. Use latest staging and apply patch 
2. Test the new dropdown menu in all possible tags states (published, unpublished, archived and trash)
