### PR TITLE
Fix UNC path test on windows installations

### DIFF
--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -206,7 +206,7 @@ class JPath
 		}
 		// Remove double slashes and backslashes and convert all slashes and backslashes to DIRECTORY_SEPARATOR
 		// If dealing with a UNC path don't forget to prepend the path with a backslash.
-		elseif (($ds == '\\') && ($path[0] == '\\' ) && ( $path[1] == '\\' ))
+		elseif (($ds == '\\') && substr($path, 0, 2) == '\\\\')
 		{
 			$path = "\\" . preg_replace('#[/\\\\]+#', $ds, $path);
 		}


### PR DESCRIPTION
#### Summary of Changes

Previously it would raise undefined string offset error when the passed value is  "\" only, as there was no length check for the `$path` variable.
#### Testing Instructions

**If testing on Windows:**

``` php
    JPath::clean('\\');
```

**If testing on any OS, including Windows:**

``` php
    JPath::clean('\\', '\\');
```

You can see the php error message: _undefined string offset 1_

Make sure you have error reporting enabled when you test this.
