### PR TITLE
Changes Styles from Modals for higher "Shadowbox"-Modals

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -3911,12 +3911,13 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
+	max-height: none;
 	padding: 1%;
 }
 .modal-body iframe {
 	width: 100%;
 	max-height: none;
+	height: 70vh;
 	border: 0 !important;
 }
 .modal-form {
@@ -6221,6 +6222,7 @@ div.modal.fade {
 }
 div.modal.fade.in {
 	top: 5%;
+	top: 5vh;
 }
 .modal-batch {
 	overflow-y: visible;
@@ -6239,6 +6241,10 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+		top: 2vh;
+	}
+	.modal-body {
+		height: 79vh;
 	}
 }
 @media (max-width: 480px) {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6243,6 +6243,9 @@ div.modal.fade.in {
 		top: 20px;
 		top: 2vh;
 	}
+	.modal-body {
+		height: 79vh;
+	}
 }
 @media (max-width: 480px) {
 	div.modal {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -3911,12 +3911,13 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
+	max-height: none;
 	padding: 1%;
 }
 .modal-body iframe {
 	width: 100%;
 	max-height: none;
+	height: 70vh;
 	border: 0 !important;
 }
 .modal-form {
@@ -6221,6 +6222,7 @@ div.modal.fade {
 }
 div.modal.fade.in {
 	top: 5%;
+	top: 5vh;
 }
 .modal-batch {
 	overflow-y: visible;
@@ -6239,6 +6241,7 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+		top: 2vh;
 	}
 }
 @media (max-width: 480px) {

--- a/media/jui/less/modals.joomla.less
+++ b/media/jui/less/modals.joomla.less
@@ -27,7 +27,10 @@ div.modal {
     .transition(e('opacity .3s linear, top .3s ease-out'));
     top: -25%;
   }
-  &.fade.in { top: 5%; }
+  &.fade.in {
+    top: 5%; // for old browser without Viewport height(vh)-Support
+    top: 5vh;
+  }
 }
 //Modal for Batch views
 .modal-batch {

--- a/media/jui/less/modals.less
+++ b/media/jui/less/modals.less
@@ -41,13 +41,14 @@
 .modal-body {
   width: 98%;
   position: relative;
-  max-height: 400px;
+  max-height: none;
   padding: 1%;
 }
 // Remove border and scrollbar from iframe modal
 .modal-body iframe {
   width: 100%;
   max-height: none;
+  height: 70vh; //overrides browser standard (300px)
   border: 0 !important;
 }
 // Remove bottom margin if need be

--- a/media/jui/less/responsive-767px-max.joomla.less
+++ b/media/jui/less/responsive-767px-max.joomla.less
@@ -16,7 +16,10 @@
     width: auto;
     margin: 0;
     &.fade  { top: -100px; }
-    &.fade.in { top: 20px; }
+    &.fade.in {
+      top: 20px;
+      top: 2vh;
+    }
   }
 
 }

--- a/media/jui/less/responsive-767px-max.joomla.less
+++ b/media/jui/less/responsive-767px-max.joomla.less
@@ -22,6 +22,10 @@
     }
   }
 
+  .modal-body {
+    height: 79vh;
+  }
+
 }
 
 // UP TO LANDSCAPE PHONE

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -3926,12 +3926,13 @@ input[type="submit"].btn.btn-mini {
 .modal-body {
 	width: 98%;
 	position: relative;
-	max-height: 400px;
+	max-height: none;
 	padding: 1%;
 }
 .modal-body iframe {
 	width: 100%;
 	max-height: none;
+	height: 70vh;
 	border: 0 !important;
 }
 .modal-form {
@@ -6207,6 +6208,7 @@ div.modal.fade {
 }
 div.modal.fade.in {
 	top: 5%;
+	top: 5vh;
 }
 .modal-batch {
 	overflow-y: visible;
@@ -6225,6 +6227,10 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+		top: 2vh;
+	}
+	.modal-body {
+		height: 79vh;
 	}
 }
 @media (max-width: 480px) {


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

When you need to choose for example what kind of menu item you want an modals box appears (like Shadobox and Fanzybox do).
The iframe in that box had a `height` of 300px by (browser) default. I changed the default height to 70vh (Viewport height). Old Browser which doesn't support the vh-unit still get the default 300px.
I had to remove the max-height of the `.modal-body` and modified the responsive behavior, too.
#### Testing Instructions

Create for Example a new menu item an choose the type. Check if you are able see the hole modals-box.
Old:
![old-css-for-modals-in-joomla-backend_042416_110238_am](https://cloud.githubusercontent.com/assets/6461465/14766481/0f02c31e-0a0c-11e6-83ac-8d97f6dd50d0.jpg)

New:
![joomla-backend-modal-menu-item_042416_110004_am](https://cloud.githubusercontent.com/assets/6461465/14766476/c4fadc70-0a0b-11e6-8c8d-80503c8cc5a7.jpg)
