### PR TITLE
Create a valid HTML id value for lists

### DIFF
--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -118,7 +118,7 @@ abstract class JHtmlSelect
 		}
 
 		$id = $options['id'] !== false ? $options['id'] : $name;
-		$id = str_replace(array('[', ']'), '', $id);
+		$id = str_replace(array('[', ']', ' '), '', $id);
 
 		$baseIndent = str_repeat($options['format.indent'], $options['format.depth']++);
 		$html = $baseIndent . '<select' . ($id !== '' ? ' id="' . $id . '"' : '') . ' name="' . $name . '"' . $attribs . '>' . $options['format.eol']
@@ -243,7 +243,7 @@ abstract class JHtmlSelect
 		}
 
 		$id = $options['id'] !== false ? $options['id'] : $name;
-		$id = str_replace(array('[', ']'), '', $id);
+		$id = str_replace(array('[', ']', ' '), '', $id);
 
 		// Disable groups in the options.
 		$options['groups'] = false;


### PR DESCRIPTION
#### Summary of Changes

When we do not provide an ID for a select or grouped select list Joomla will create the ID based on the name of the field. The name is more permissive than an ID. We already remove brackets from the name but spaces are also not allowed in IDs. This pull request removes the spaces from the generated ID value.
#### Testing Instructions
1. Add the following code to the file administrator/components/com_banners/views/banner/tmpl/edit.php after line 49

``` php
<?php echo JHtml::_(
'select.genericlist',
array(1,2),
'Desc. field',
);
?>
```
1. Go to Components -> Banners
2. Click on New
3. Open the browser console by pressing F12 or right click and select Inspect
4. Click on the Console tab in the Inspector
5. Click on Save
6. It is expected you get an error that the Name field is required but nothing happens.
7. Look at the Console tab in Inspector and you will see the following error:
   `
   Uncaught Error: Syntax error, unrecognized expression: #Desc. field-lbl
   `
8. Apply the patch
9. Reload the page
10. Click on Save
11. You will now get the error that the Name field is required.
12. Change is successful
