### PR TITLE
[com_users] add searchtools to modal layout

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -11,9 +11,13 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.multiselect');
+
+// Special case for the search field tooltip.
+$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
+JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $app             = JFactory::getApplication();
 $input           = $app->input;

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -15,54 +15,54 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.multiselect');
 
-$input     = JFactory::getApplication()->input;
-$field     = $input->getCmd('field');
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
+$app             = JFactory::getApplication();
+$input           = $app->input;
+$field           = $input->getCmd('field');
+$listOrder       = $this->escape($this->state->get('list.ordering'));
+$listDirn        = $this->escape($this->state->get('list.direction'));
+$enabledStates   = array(0 => 'icon-publish', 1 => 'icon-unpublish');
+$activatedStates = array(0 => 'icon-publish', 1 => 'icon-unpublish');
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64'));?>" method="post" name="adminForm" id="adminForm">
-	<fieldset class="filter">
-		<div id="filter-bar" class="btn-toolbar">
-			<div class="filter-search btn-group pull-left">
-				<label for="filter_search" class="element-invisible"><?php echo JText::_('JSEARCH_FILTER'); ?></label>
-				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_USERS_SEARCH_IN_NAME'); ?>" data-placement="bottom"/>
-			</div>
-			<div class="btn-group pull-left">
-				<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_SUBMIT'); ?>" data-placement="bottom"><span class="icon-search"></span></button>
-				<button type="button" class="btn hasTooltip" title="<?php echo JHtml::tooltipText('JSEARCH_FILTER_CLEAR'); ?>" data-placement="bottom" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
-				<?php if ($input->get('required', 0, 'int') != 1 ) : ?>
-					<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
-						data-user-field="<?php echo $this->escape($field);?>"><?php echo JText::_('JOPTION_NO_USER'); ?></button>
-				<?php endif; ?>
-			</div>
-			<div class="btn-group pull-right hidden-phone">
-				<label for="filter_group_id" class="element-invisible"><?php echo JText::_('COM_USERS_FILTER_USER_GROUP'); ?></label>
-				<?php echo JHtml::_('access.usergroup', 'filter_group_id', $this->state->get('filter.group_id'), 'onchange="this.form.submit()"'); ?>
-			</div>
+<div class="container-popup">
+	<form action="<?php echo JRoute::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64')); ?>" method="post" name="adminForm" id="adminForm">
+		<?php if ($input->get('required', 0, 'int') != 1 ) : ?>
+		<div class="pull-left">
+			<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
+				data-user-field="<?php echo $this->escape($field);?>"><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
 		</div>
-	</fieldset>
-	<?php if (empty($this->items)) : ?>
+		<?php endif; ?>
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+		<?php if (empty($this->items)) : ?>
 		<div class="alert alert-no-items">
 			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
 		</div>
-	<?php else : ?>
+		<?php else : ?>
 		<table class="table table-striped table-condensed">
 			<thead>
 				<tr>
-					<th class="left">
-						<?php echo JHtml::_('grid.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
+					<th class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
 					</th>
-					<th class="nowrap" width="25%">
-						<?php echo JHtml::_('grid.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
+					<th width="25%" class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
 					</th>
-					<th class="nowrap" width="25%">
+					<th width="1%" class="nowrap center">
+						<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_ENABLED', 'a.block', $listDirn, $listOrder); ?>
+					</th>
+					<th width="1%" class="nowrap center">
+						<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_ACTIVATED', 'a.activation', $listDirn, $listOrder); ?>
+					</th>
+					<th width="25%" class="nowrap">
 						<?php echo JText::_('COM_USERS_HEADING_GROUPS'); ?>
+					</th>
+					<th width="1%" class="nowrap">
+						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
 				</tr>
 			</thead>
 			<tfoot>
 				<tr>
-					<td colspan="15">
+					<td colspan="6">
 						<?php echo $this->pagination->getListFooter(); ?>
 					</td>
 				</tr>
@@ -70,32 +70,37 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			<tbody>
 				<?php
 				$i = 0;
-
 				foreach ($this->items as $item) : ?>
-					<tr class="row<?php echo $i % 2; ?>">
-						<td>
-							<a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
-								data-user-field="<?php echo $this->escape($field);?>" onclick="if (window.parent) window.parent.jSelectUser(this);">
-								<?php echo $item->name; ?>
-							</a>
-						</td>
-						<td align="center">
-							<?php echo $item->username; ?>
-						</td>
-						<td align="left">
-							<?php echo nl2br($item->group_names); ?>
-						</td>
-					</tr>
+				<tr class="row<?php echo $i % 2; ?>">
+					<td>
+						<a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
+							data-user-field="<?php echo $this->escape($field);?>" onclick="if (window.parent) window.parent.jSelectUser(this);">
+							<?php echo $this->escape($item->name); ?>
+						</a>
+					</td>
+					<td>
+						<?php echo $this->escape($item->username); ?>
+					</td>
+					<td class="center">
+						<span class="<?php echo $enabledStates[(int) $this->escape($item->block)]; ?>"></span>
+					</td>
+					<td class="center">
+						<span class="<?php echo $activatedStates[(int) $this->escape($item->activation)]; ?>"></span>
+					</td>
+					<td>
+						<?php echo nl2br($item->group_names); ?>
+					</td>
+					<td>
+						<?php echo (int) $item->id; ?>
+					</td>
+				</tr>
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-	<?php endif; ?>
-	<div>
+		<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>" />
 		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
-	</div>
-</form>
+	</form>
+</div>


### PR DESCRIPTION
#### Description

This PR adds searchtools to com_users modal layout users view and does some minor visual improvements.
###### Before PR

![image](https://cloud.githubusercontent.com/assets/9630530/14766915/4e1f08f0-0a11-11e6-9e0f-cd2bc875465b.png)
###### After PR

![image](https://cloud.githubusercontent.com/assets/9630530/14766907/2e84e0dc-0a11-11e6-8e53-6ae6f5469a70.png)
#### How to test
1. Use latest staging and apply patch
2. Edit some article and go to "Publishing" tab
3. In the "Created by" press the user icon the modal will appear
4. Check if search, filters, ordering and pagination are working properly in modal.
5. Test selecting a user or "-No User -"

Note: You can test other "Select User" modals (ex: in a contact, user notes, messaging, or others)
