### PR TITLE
Allow the redirect plugin to proxy to the previously set exception handler

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -27,6 +27,14 @@ class PlgSystemRedirect extends JPlugin
 	protected $autoloadLanguage = false;
 
 	/**
+	 * The global exception handler registered before the plugin was instantiated
+	 *
+	 * @var    callable
+	 * @since  3.6
+	 */
+	private static $previousExceptionHandler;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe
@@ -38,9 +46,11 @@ class PlgSystemRedirect extends JPlugin
 	{
 		parent::__construct($subject, $config);
 
-		// Set the error handler for E_ERROR to be the class handleError method.
+		// Set the JError handler for E_ERROR to be the class' handleError method.
 		JError::setErrorHandling(E_ERROR, 'callback', array('PlgSystemRedirect', 'handleError'));
-		set_exception_handler(array('PlgSystemRedirect', 'handleException'));
+
+		// Register the previously defined exception handler so we can forward errors to it
+		self::$previousExceptionHandler = set_exception_handler(array('PlgSystemRedirect', 'handleException'));
 	}
 
 	/**
@@ -97,8 +107,15 @@ class PlgSystemRedirect extends JPlugin
 		// Make sure the error is a 404 and we are not in the administrator.
 		if ($app->isAdmin() || $error->getCode() != 404)
 		{
-			// Render the error page.
-			JErrorPage::render($error);
+			// Proxy to the previous exception handler if available, otherwise just render the error page
+			if (self::$previousExceptionHandler)
+			{
+				call_user_func_array(self::$previousExceptionHandler, array($error));
+			}
+			else
+			{
+				JErrorPage::render($error);
+			}
 		}
 
 		// Get the full current URI.


### PR DESCRIPTION
#### Summary of Changes

This PR makes it possible for the redirect plugin, when it is enabled and acting as the global exception handler, to proxy to a previously set exception handler for conditions where it isn't aiming to handle the exception (a 404 page on the site application).  This enables a custom exception handler to be used consistently regardless of whether the plugin is enabled or not (right now you could set a custom exception handler but when the redirect plugin is enabled it will only call to `JErrorPage::render()`.
#### Testing Instructions

Install the attached [exception.zip](https://github.com/joomla/joomla-cms/files/233589/exception.zip) package and enable the `plg_system_exception` plugin.  Also enable the `System - Redirect` plugin.  Ensure that the plugin is ordered before the redirect plugin.

Do something to cause an exception to be thrown.  Prior to the patch, you'll always get Joomla's error page.  After the patch you should get a "My custom error handler" page.
