### PR TITLE
Fix string normalise toVariable

### DIFF
--- a/libraries/vendor/joomla/string/src/Normalise.php
+++ b/libraries/vendor/joomla/string/src/Normalise.php
@@ -130,7 +130,7 @@ abstract class Normalise
 		$input = self::toCamelCase($input);
 
 		// Remove leading digits.
-		$input = preg_replace('#^[0-9]+.*$#', '', $input);
+		$input = preg_replace('#^[0-9]+#', '', $input);
 
 		// Lowercase the first character.
 		$first = substr($input, 0, 1);


### PR DESCRIPTION
#### Summary of Changes

Currently `Joomla\String\Normalise::toVariable()` blanks out the whole string instead of just removing leading digits, if there is any leading digits.
#### Testing Instructions

Execute

``` php
$var = Joomla\String\Normalise::toVariable('1abc3def4');
```

Correct output => 'abc3def4'
Output before patch => ''
