### PR TITLE
Isis: fixed height for header logo

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7235,8 +7235,9 @@ body .navbar-fixed-top {
 	text-align: right;
 }
 .logo {
-	width: 100%;
-	max-width: 143px;
+	width: auto;
+	max-width: 100%;
+	max-height: 36px;
 	height: auto;
 }
 .page-title {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7235,8 +7235,9 @@ body .navbar-fixed-top {
 	text-align: right;
 }
 .logo {
-	width: 100%;
-	max-width: 143px;
+	width: auto;
+	max-width: 100%;
+	max-height: 36px;
 	height: auto;
 }
 .page-title {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -317,9 +317,10 @@ body .navbar-fixed-top {
 }
 
 .logo {
-	width: 100%;
-	max-width: 143px;
-	height: auto;
+    width: auto;
+    max-width: 100%;
+    max-height: 36px;
+    height: auto;
 }
 
 /* Page Title */


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

The logo in the header has a new max-height instead of max-width. Before the changes a huge logo changed the appearance of the followiing elements.
![old-header-logo_042516_063757_pm_042516_070611_pm](https://cloud.githubusercontent.com/assets/6461465/14792260/c423c582-0b19-11e6-98e3-b49d13644615.jpg)

Now the logo doesn't influence the content after it because it's not possible that the logo is to high.
![new-header-logo_042516_070433_pm](https://cloud.githubusercontent.com/assets/6461465/14792355/27571aa0-0b1a-11e6-9b2b-5af0b1d261ef.jpg)
#### Testing Instructions

Go to Extensions > Templates > Styles click at isis-Default.
Tab "Advanced" > Logo
Use a logo with a height over 36px, for example 150px.

Logo shouldn't change the height of the content after it because it shouldn't float underneath the following content.
