### PR TITLE
Fix unknown column 'alias'

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -854,7 +854,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 					$asset->rules = (string) $this->_rules;
 				}
 
-				if (!$asset->check() || !$asset->store($updateNulls))
+				if (!$asset->check() || !$asset->store())
 				{
 					$this->setError($asset->getError());
 


### PR DESCRIPTION
Pull Request for Issue that leads to a problem for some developers.
Here you are more information.
https://groups.google.com/forum/#!topic/joomla-dev-general/KZFM8yKZYpg
http://forum.joomla.org/viewtopic.php?f=615&t=775779
#### Summary of Changes

This PR fixes an issue that causes an error when someone would like to store NULL value to table columns, using JTable.
I removed the variable _$updateNulls_ because JTableAsset causing the error. Furthermore, the object does not need this variable because there are no columns in _#__assets_ where you can store NULL value.
#### Testing Instructions
1. Change the default value of _$updateNulls_ to **true** on **line 309** in file **_libraries/legacy/table/content.php_**.
2. Save an existing article via the content manager.
3. That results to an error _Unknown column 'alias' in 'field list'_, caught on **line 1204** in **_libraries/legacy/model/admin.php_**.

![change_update_nulls](https://cloud.githubusercontent.com/assets/1272206/14818667/033db040-0bc7-11e6-8924-55e54c2c14db.png)

![unknown_column_alias](https://cloud.githubusercontent.com/assets/1272206/14818597/b9b3b6a4-0bc6-11e6-8799-ed78d8ddef27.png)
