### PR TITLE
[com_plugins] plugins view: Add missing tooltip in search

### DIFF
--- a/administrator/components/com_plugins/models/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/models/forms/filter_plugins.xml
@@ -6,6 +6,8 @@
 		<field
 			name="search"
 			type="text"
+			label="JSEARCH_FILTER_LABEL"
+			description="COM_PLUGINS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 		/>
 


### PR DESCRIPTION
#### Summary of Changes

Simple PR to add missing tootip on the com_plugins search filter.
#### Testing Instructions

Code review.

or

Go to Extensions -> Plugins, check the tootip in the search field. Before patch no tootlip, After patch the tooltip is there.
