### PR TITLE
[com_templates] styles/templates views: Add missing tooltip in search

### DIFF
--- a/administrator/components/com_templates/models/forms/filter_styles.xml
+++ b/administrator/components/com_templates/models/forms/filter_styles.xml
@@ -7,7 +7,7 @@
 			name="search"
 			type="text"
 			label="JSEARCH_FILTER"
-			description="JSEARCH_FILTER"
+			description="COM_TEMPLATES_STYLES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field

--- a/administrator/components/com_templates/models/forms/filter_templates.xml
+++ b/administrator/components/com_templates/models/forms/filter_templates.xml
@@ -7,7 +7,7 @@
 			name="search"
 			type="text"
 			label="JSEARCH_FILTER"
-			description="JSEARCH_FILTER"
+			description="COM_TEMPLATES_TEMPLATES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
         <field


### PR DESCRIPTION
#### Summary of Changes

Simple PR to add missing tootip on the com_templates search filters.
#### Testing Instructions

Code review.

or

Go to Extensions -> Templates -> Styles, check the tootip in the search field. Before patch "Search", After patch "Search in style description.".
Go to Extensions -> Templates -> Templates, check the tootip in the search field. Before patch "Search", After patch "Search in template name or folder name.".
