### PR TITLE
Add htaccess authentification to the http transports

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -63,6 +63,8 @@ class JHttpTransportCurl implements JHttpTransport
 		// Setup the cURL handle.
 		$ch = curl_init();
 
+		$options = array();
+
 		// Set the request method.
 		switch (strtoupper($method))
 		{
@@ -186,6 +188,13 @@ class JHttpTransportCurl implements JHttpTransport
 
 		// Set the cURL options.
 		curl_setopt_array($ch, $options);
+
+		// Authentification, if needed
+		if ($this->options->get('userauth') && $this->options->get('passwordauth'))
+		{
+			$options[CURLOPT_USERPWD] = $this->options->get('userauth') . ':' . $this->options->get('passwordauth');
+			$options[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
+		}
 
 		// Execute the request and close the connection.
 		$content = curl_exec($ch);

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -186,15 +186,15 @@ class JHttpTransportCurl implements JHttpTransport
 			$options[$key] = $value;
 		}
 
-		// Set the cURL options.
-		curl_setopt_array($ch, $options);
-
 		// Authentification, if needed
 		if ($this->options->get('userauth') && $this->options->get('passwordauth'))
 		{
 			$options[CURLOPT_USERPWD] = $this->options->get('userauth') . ':' . $this->options->get('passwordauth');
 			$options[CURLOPT_HTTPAUTH] = CURLAUTH_BASIC;
 		}
+
+		// Set the cURL options.
+		curl_setopt_array($ch, $options);
 
 		// Execute the request and close the connection.
 		$content = curl_exec($ch);

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -137,6 +137,12 @@ class JHttpTransportSocket implements JHttpTransport
 			$request[] = $data;
 		}
 
+		// Authentification, if needed
+		if ($this->options->get('userauth') && $this->options->get('passwordauth'))
+		{
+			$request[] = 'Authorization: Basic ' . base64_encode($this->options->get('userauth') . ':' . $this->options->get('passwordauth'));
+		}
+
 		// Send the request to the server.
 		fwrite($connection, implode("\r\n", $request) . "\r\n\r\n");
 

--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -142,6 +142,13 @@ class JHttpTransportStream implements JHttpTransport
 			)
 		);
 
+		// Authentification, if needed
+		if ($this->options->get('userauth') && $this->options->get('passwordauth'))
+		{
+			$uri->setUser($this->options->get('userauth'));
+			$uri->setPass($this->options->get('passwordauth'));
+		}
+
 		// Capture PHP errors
 		$php_errormsg = '';
 		$track_errors = ini_get('track_errors');


### PR DESCRIPTION
#### Summary of Changes

At the moments it's not possible to connect to urls, which has a htaccess password protection. With this patch, you can provide login credentials
#### Testing Instructions
1. Protect a url with a htaccess password
2. call: (set the correct url instead of "http://your-url.tld")

```
$options = new \Joomla\Registry\Registry();

$http = JHttpFactory::getHttp($options);

$url = 'http://your-url.tld';
$result = $http->get($url);

print_r($result);
```
1. The result code should be "401"
2. Apply path
3. call: (replace htaccessuser + htaccesspassword with your credentials + set the correct url)

```
$credentials = array('userauth' => 'htaccessuser', 'passwordauth' => 'htaccesspassword');
$options = new \Joomla\Registry\Registry($credentials);

$http = JHttpFactory::getHttp($options);

$url = 'http://your-url.tld';
$result = $http->get($url);

print_r($result);
```
1. The result code should be "200"
