### PR TITLE
Remove com_ajax debug output

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -158,13 +158,6 @@ switch ($format)
 
 		break;
 
-	// Human-readable format
-	case 'debug' :
-		echo '<pre>' . print_r($results, true) . '</pre>';
-		$app->close();
-
-		break;
-
 	// Handle as raw format
 	default :
 		// Output exception


### PR DESCRIPTION
This PR removes developers debug output that should never have been committed in the first place. 
