### PR TITLE
Usage of proper class inheritance check for limiting query

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -566,7 +566,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$query = $this->replacePrefix((string) $this->sql);
 
-		if (!($this->sql instanceof JDatabaseQuery) && ($this->limit > 0 || $this->offset > 0))
+		if (!($this->sql instanceof JDatabaseQueryLimitable) && ($this->limit > 0 || $this->offset > 0))
 		{
 			$query .= ' LIMIT ' . $this->offset . ', ' . $this->limit;
 		}


### PR DESCRIPTION
Pull Request for Issue #10108 
(Its a PR against the request at https://github.com/joomla/joomla-cms/pull/10138)
#### Summary of Changes

While adding support for limitable interface.The checking of query objects type should be consistent.
#### Testing Instructions

extend a sample class MyQuery from JDatabaseQuery.
Use a simple select statement on $query = new MyQuery(); $query->select('user_id'); $query->where("1"); $query->limit(5,10); $results = JFactory::getDbo()->setQuery($query)->loadAssoclist();
Should get limited records.
