### PR TITLE
Add enabled or disabled message to the sysinfo export

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -464,7 +464,7 @@ class AdminModelSysInfo extends JModelLegacy
 			$installed[$extension->name] = array(
 				'name'         => $extension->name,
 				'type'         => $extension->type,
-				'enabled'      => $extension->enabled ? JText::_('JENABLED') : JText::_('JDISABLED'),
+				'state'        => $extension->enabled ? JText::_('JENABLED') : JText::_('JDISABLED'),
 				'author'       => 'unknown',
 				'version'      => 'unknown',
 				'creationDate' => 'unknown',

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -464,10 +464,11 @@ class AdminModelSysInfo extends JModelLegacy
 			$installed[$extension->name] = array(
 				'name'         => $extension->name,
 				'type'         => $extension->type,
+				'enabled'      => $extension->enabled ? JText::_('JENABLED') : JText::_('JDISABLED'),
 				'author'       => 'unknown',
 				'version'      => 'unknown',
 				'creationDate' => 'unknown',
-				'authorUrl'    => 'unknown'
+				'authorUrl'    => 'unknown',
 			);
 
 			$manifest = json_decode($extension->manifest_cache);
@@ -481,7 +482,7 @@ class AdminModelSysInfo extends JModelLegacy
 				'author'       => $manifest->author,
 				'version'      => $manifest->version,
 				'creationDate' => $manifest->creationDate,
-				'authorUrl'    => $manifest->authorUrl
+				'authorUrl'    => $manifest->authorUrl,
 			);
 
 			$installed[$extension->name] = array_merge($installed[$extension->name], $extraData);


### PR DESCRIPTION
#### Summary of Changes

This adds the state of the extension Enabled / Disabled to the Systeminfo Download.
#### Testing Instructions
- Go to the System Information
- Use the system Information Download button
- see that for the extensions you have no info about enabled or disabled
- apply this patch
- try it again
- see that we have the info now for the extensions.
