### PR TITLE
Don't hardcode language strings for Sysinfo Output

### DIFF
--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -168,7 +168,7 @@ class AdminViewSysinfo extends JViewLegacy
 	{
 		foreach ($sectionData as $directory => $data)
 		{
-			$sectionData[$directory] = $data['writable'] ? ' writable' : ' NOT writable';
+			$sectionData[$directory] = $data['writable'] ? JText::_('COM_ADMIN_WRITABLE') : JText::_('COM_ADMIN_UNWRITABLE');
 		}
 
 		return $this->renderSection($sectionName, $sectionData, $level);


### PR DESCRIPTION
#### Summary of Changes

Insted of the hardcoded english `writable` & `NOT writable` we now use the language constants:

`COM_ADMIN_WRITABLE` & `COM_ADMIN_UNWRITABLE` that we also use for the GUI in the text download too. The JSON Output handed it different and should not changed.
#### Testing Instructions
- Go to the System Information
- Use the system Information Download button for text
- see that we have on the directory secten have allways `writable` & `NOT writable`
- apply this patch
- try it again
- see that we now have the same textes as we have in the GUI
