### PR TITLE
Use showon in article options

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -100,7 +100,7 @@
 			label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 			description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
 			default="1"
-			showon="show_category:1">
+			showon="show_parent_category:1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -217,7 +217,7 @@
 			label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
 			description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
 			default="100"
-			showon="show_readmore_title:1"
+			showon="show_readmore:1[AND]show_readmore_title:1"
 		/>
 
 		<field

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -345,6 +345,7 @@
 			label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
 			description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
 			default="10"
+			showon="save_history:1"
 		/>
 		<field
 			name="show_urls_images_frontend"
@@ -380,6 +381,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
+			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -393,6 +395,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
+			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -406,6 +409,7 @@
 			description="COM_CONTENT_URL_FIELD_BROWSERNAV_DESC"
 			default="Parent"
 			filter="int"
+			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			>
 				<option value="0">JBROWSERTARGET_PARENT</option>
 				<option value="1">JBROWSERTARGET_NEW</option>
@@ -422,7 +426,9 @@
 			name="float_intro"
 			type="list"
 			label="COM_CONTENT_FLOAT_INTRO_LABEL"
-			description="COM_CONTENT_FLOAT_DESC">
+			description="COM_CONTENT_FLOAT_DESC"
+			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			>
 				<option value="right">COM_CONTENT_RIGHT</option>
 				<option value="left">COM_CONTENT_LEFT</option>
 				<option value="none">COM_CONTENT_NONE</option>
@@ -431,7 +437,9 @@
 			name="float_fulltext"
 			type="list"
 			label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
-			description="COM_CONTENT_FLOAT_DESC">
+			description="COM_CONTENT_FLOAT_DESC"
+			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
+			>
 				<option value="right">COM_CONTENT_RIGHT</option>
 				<option value="left">COM_CONTENT_LEFT</option>
 				<option value="none">COM_CONTENT_NONE</option>
@@ -584,6 +592,7 @@
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 		>
 			<option value="-1">JALL</option>
+			<option value="0">JNONE</option>
 			<option value="1">J1</option>
 			<option value="2">J2</option>
 			<option value="3">J3</option>
@@ -597,6 +606,7 @@
 			default="0"
 			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
 			description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+			showon="maxLevelcat:-1,1,2,3,4,5"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -608,6 +618,7 @@
 			default="1"
 			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+			showon="maxLevelcat:-1,1,2,3,4,5"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -744,7 +755,9 @@
 			type="text"
 			size="15"
 			label="JGLOBAL_DATE_FORMAT_LABEL"
-			description="JGLOBAL_DATE_FORMAT_DESC" />
+			description="JGLOBAL_DATE_FORMAT_DESC" 
+			showon="list_show_date:created,modified,published"
+		/>
 
 		<field name="list_show_hits"
 			type="radio"
@@ -837,7 +850,9 @@
 			class="btn-group btn-group-yesno"
 			default="1"
 			label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-			description="JGLOBAL_PAGINATION_RESULTS_DESC">
+			description="JGLOBAL_PAGINATION_RESULTS_DESC"
+			showon="show_pagination:1,2"
+			>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
 		</field>
@@ -874,7 +889,9 @@
 			type="list"
 			label="JGLOBAL_FEED_SUMMARY_LABEL"
 			description="JGLOBAL_FEED_SUMMARY_DESC"
-			default="0">
+			default="0"
+			showon="show_feed_link:1"
+		>
 			<option
 				value="0">JGLOBAL_INTRO_TEXT</option>
 			<option
@@ -887,7 +904,9 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_FEED_SHOW_READMORE_LABEL"
 			description="JGLOBAL_FEED_SHOW_READMORE_DESC"
-			default="0">
+			default="0"
+			showon="show_feed_link:1[AND]feed_summary:0"
+		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -31,7 +31,8 @@
 			class="btn-group btn-group-yesno"
 			default="1"
 			label="JGLOBAL_LINKED_TITLES_LABEL"
-			description="JGLOBAL_LINKED_TITLES_DESC">
+			description="JGLOBAL_LINKED_TITLES_DESC"
+			showon="show_title:1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
@@ -75,7 +76,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_LINK_CATEGORY_LABEL"
 			description="JGLOBAL_LINK_CATEGORY_DESC"
-			default="1">
+			default="1"
+			showon="show_category:1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
@@ -97,7 +99,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 			description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-			default="1">
+			default="1"
+			showon="show_category:1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
@@ -125,7 +128,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_LINK_AUTHOR_LABEL"
 			description="JGLOBAL_LINK_AUTHOR_DESC"
-			default="0">
+			default="0"
+			showon="show_author:1">
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
@@ -201,7 +205,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
 			description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-			default="1">
+			default="1"
+			showon="show_readmore:1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
@@ -212,6 +217,7 @@
 			label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
 			description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
 			default="100"
+			showon="show_readmore_title:1"
 		/>
 
 		<field
@@ -248,7 +254,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 			description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-			default="1">
+			default="1"
+			showon="show_icons:1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
@@ -259,7 +266,8 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
 			description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-			default="1">
+			default="1"
+			showon="show_icons:1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -591,8 +591,8 @@
 			description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 		>
-			<option value="-1">JALL</option>
 			<option value="0">JNONE</option>
+			<option value="-1">JALL</option>
 			<option value="1">J1</option>
 			<option value="2">J2</option>
 			<option value="3">J3</option>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -829,6 +829,7 @@
 				default="published"
 				description="JGLOBAL_ORDERING_DATE_DESC"
 				label="JGLOBAL_ORDERING_DATE_LABEL"
+				showon="orderby_sec:rdate,date"
 			>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>


### PR DESCRIPTION
#### Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in article options
#### Testing Instructions

This is only a cosmetic change
Go to the Options page for com_content and try all the show/hide options on that page to ensure they make sense.

If this is accepted we can look to do this for all config screens
