### PR TITLE
getCache should link to JCacheController

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -254,7 +254,7 @@ abstract class JFactory
 	/**
 	 * Get a cache object
 	 *
-	 * Returns the global {@link JCache} object
+	 * Returns the global {@link JCacheController} object
 	 *
 	 * @param   string  $group    The cache group name
 	 * @param   string  $handler  The handler to use


### PR DESCRIPTION
Pull Request for Issue #10112 .
#### Summary of Changes

Corrects the link for `JFactory::getCache()` this method uses `JCache::getInstance()` which returns a `JCacheController` instance "decorating" `JCache`
#### Testing Instructions

Merge by code review
