### PR TITLE
Contact options - showon

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -47,6 +47,7 @@
 			label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
 			description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
 			default="5"
+			showon="save_history:1"
 		/>
 
 		<field name="show_contact_list"
@@ -225,6 +226,7 @@
 			type="media"
 			label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
 			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
+			showon="show_image:1"
 		>
 		</field>
 		<field name="allow_vcard"
@@ -253,7 +255,7 @@
 			type="list"
 			default="10"
 			label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
-			description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
+			showon="show_articles:1"
 		>
 			<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 			<option value="5">J5</option>
@@ -299,6 +301,7 @@
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				size="30"
+				showon="show_links:1"
 			/>
 
 			<field name="linkb_name"
@@ -306,17 +309,23 @@
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				size="30"
+				showon="show_links:1"
 			/>
 
-			<field name="linkc_name" type="text"
-				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL" description="COM_CONTACT_FIELD_LINK_NAME_DESC"
-				size="30" />
+			<field name="linkc_name" 
+				type="text"
+				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL" 
+				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
+				size="30" 
+				showon="show_links:1"
+			/>
 
 			<field name="linkd_name"
 				type="text"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				size="30"
+				showon="show_links:1"
 			/>
 
 			<field name="linke_name"
@@ -324,6 +333,7 @@
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				size="30"
+				showon="show_links:1"
 			/>
 
 		<field
@@ -360,35 +370,51 @@
 
 		<field name="icon_address"
 			type="media"
-			hide_none="1" label="COM_CONTACT_FIELD_ICONS_ADDRESS_LABEL"
-			description="COM_CONTACT_FIELD_ICONS_ADDRESS_DESC" />
+			hide_none="1" 
+			label="COM_CONTACT_FIELD_ICONS_ADDRESS_LABEL"
+			description="COM_CONTACT_FIELD_ICONS_ADDRESS_DESC"
+			showon="contact_icons:0"
+		 />
 
 		<field name="icon_email"
 			type="media"
-			hide_none="1" label="COM_CONTACT_FIELD_ICONS_EMAIL_LABEL"
-			description="COM_CONTACT_FIELD_ICONS_EMAIL_DESC" />
+			hide_none="1" 
+			label="COM_CONTACT_FIELD_ICONS_EMAIL_LABEL"
+			description="COM_CONTACT_FIELD_ICONS_EMAIL_DESC"
+			showon="contact_icons:0"
+		/>
 
 		<field name="icon_telephone"
 			type="media"
-			 hide_none="1"
+			hide_none="1"
 			label="COM_CONTACT_FIELD_ICONS_TELEPHONE_LABEL"
-			description="COM_CONTACT_FIELD_ICONS_TELEPHONE_DESC" />
+			description="COM_CONTACT_FIELD_ICONS_TELEPHONE_DESC" 
+			showon="contact_icons:0"
+		/>
 
 		<field name="icon_mobile"
 			type="media"
-			 hide_none="1"
-			label="COM_CONTACT_FIELD_ICONS_MOBILE_LABEL" description="COM_CONTACT_FIELD_ICONS_MOBILE_DESC" />
+			hide_none="1"
+			label="COM_CONTACT_FIELD_ICONS_MOBILE_LABEL" 
+			description="COM_CONTACT_FIELD_ICONS_MOBILE_DESC" 
+			showon="contact_icons:0"
+		/>
 
 		<field name="icon_fax"
 			type="media"
-			hide_none="1" label="COM_CONTACT_FIELD_ICONS_FAX_LABEL"
-			description="COM_CONTACT_FIELD_ICONS_FAX_DESC" />
+			hide_none="1" 
+			label="COM_CONTACT_FIELD_ICONS_FAX_LABEL"
+			description="COM_CONTACT_FIELD_ICONS_FAX_DESC" 
+			showon="contact_icons:0"
+		/>
 
 		<field name="icon_misc"
 			type="media"
 			hide_none="1"
 			label="COM_CONTACT_FIELD_ICONS_MISC_LABEL"
-			description="COM_CONTACT_FIELD_ICONS_MISC_DESC" />
+			description="COM_CONTACT_FIELD_ICONS_MISC_DESC" 
+			showon="contact_icons:0"
+		/>
 	</fieldset>
 
 	<fieldset name="Category"
@@ -449,21 +475,23 @@
 			<option value="5">J5</option>
 		</field>
 
-		<field name="show_empty_categories" type="radio"
-			default="0"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-			description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
-		>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
 		<field name="show_subcat_desc" type="radio"
 			default="1"
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+			showon="maxLevel:-1,1,2,3,4,5"
+		>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+
+		<field name="show_empty_categories" type="radio"
+			default="0"
+			class="btn-group btn-group-yesno"
+			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+			description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
+			showon="maxLevel:-1,1,2,3,4,5"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -510,6 +538,7 @@
 			label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
 		>
 			<option value="-1">JALL</option>
+			<option value="0">JNONE</option>
 			<option value="1">J1</option>
 			<option value="2">J2</option>
 			<option value="3">J3</option>
@@ -517,21 +546,23 @@
 			<option value="5">J5</option>
 		</field>
 
-		<field name="show_empty_categories_cat" type="radio"
-			default="0"
-			class="btn-group btn-group-yesno"
-			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-			description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
-		>
-			<option value="1">JSHOW</option>
-			<option value="0">JHIDE</option>
-		</field>
-
 		<field name="show_subcat_desc_cat" type="radio"
 			default="1"
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 			description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+			showon="maxLevelcat:-1,1,2,3,4,5"
+		>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+		
+		<field name="show_empty_categories_cat" type="radio"
+			default="0"
+			class="btn-group btn-group-yesno"
+			label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+			description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
+			showon="maxLevelcat:-1,1,2,3,4,5"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -590,6 +621,7 @@
 			class="btn-group btn-group-yesno"
 			label="COM_CONTACT_FIELD_CONFIG_POSITION_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_POSITION_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -600,6 +632,7 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_EMAIL"
 			description="COM_CONTACT_FIELD_CONFIG_EMAIL_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -611,6 +644,7 @@
 			default="1"
 			label="COM_CONTACT_FIELD_CONFIG_PHONE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_PHONE_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -622,6 +656,7 @@
 			default="0"
 			label="COM_CONTACT_FIELD_CONFIG_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_MOBILE_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -633,6 +668,7 @@
 			default="0"
 			label="COM_CONTACT_FIELD_CONFIG_FAX_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_FAX_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -643,6 +679,7 @@
 			class="btn-group btn-group-yesno"
 			label="COM_CONTACT_FIELD_CONFIG_SUBURB_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SUBURB_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -654,6 +691,7 @@
 			default="0"
 			label="COM_CONTACT_FIELD_CONFIG_STATE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_STATE_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -665,6 +703,7 @@
 			default="0"
 			label="COM_CONTACT_FIELD_CONFIG_COUNTRY_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_COUNTRY_DESC"
+			showon="show_headings:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -688,6 +727,7 @@
 				default="1"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				showon="show_pagination:1,2"
 			>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
@@ -741,6 +781,7 @@
 			default="1"
 			label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
 			description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
+			showon="show_email_form:1"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -752,6 +793,7 @@
 			rows="3"
 			cols="30"
 			description="COM_CONTACT_FIELD_CONFIG_BANNED_EMAIL_DESC"
+			showon="show_email_form:1"
 		/>
 
 		<field name="banned_subject"
@@ -760,6 +802,7 @@
 			rows="3"
 			cols="30"
 			description="COM_CONTACT_FIELD_CONFIG_BANNED_SUBJECT_DESC"
+			showon="show_email_form:1"
 		/>
 
 		<field name="banned_text"
@@ -768,6 +811,7 @@
 			rows="3"
 			cols="30"
 			description="COM_CONTACT_FIELD_CONFIG_BANNED_TEXT_DESC"
+			showon="show_email_form:1"
 		/>
 
 		<field name="validate_session"
@@ -776,6 +820,7 @@
 			default="1"
 			label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
+			showon="show_email_form:1"
 		>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
@@ -787,6 +832,7 @@
 			default="0"
 			label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
+			showon="show_email_form:1"
 		>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
@@ -796,7 +842,9 @@
 			type="text"
 			size="30"
 			label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"
-			description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC" />
+			description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC" 
+			showon="show_email_form:1"
+		/>
 	</fieldset>
 
 	<fieldset name="integration"

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -255,6 +255,7 @@
 			type="list"
 			default="10"
 			label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
+			description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
 			showon="show_articles:1"
 		>
 			<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the com_contact component options

Testing Instructions

This is only a cosmetic change
Go to the Options page for this component and try all the options on that page to ensure that the new show/hide functionality makes sense.

[Note this is part of a series of PR for each component options page and then the menu options]
