### PR TITLE
joomlaupdate options - showon

### DIFF
--- a/administrator/components/com_joomlaupdate/config.xml
+++ b/administrator/components/com_joomlaupdate/config.xml
@@ -29,6 +29,7 @@
 			length="50"
 			label="COM_JOOMLAUPDATE_CONFIG_CUSTOMURL_LABEL"
 			description="COM_JOOMLAUPDATE_CONFIG_CUSTOMURL_DESC"
+			showon="updatesource:custom"
 			/>
 	</fieldset>
 


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the com_joomlaupdate component options

Testing Instructions

This is only a cosmetic change
Go to the Options page for this component and try all the options on that page to ensure that the new show/hide functionality makes sense.

[Note this is part of a series of PR for each component options page and then the menu options]
