### PR TITLE
tag options - showon

### DIFF
--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -34,6 +34,7 @@
 			label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
 			description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
 			default="5"
+			showon="save_history:1"
 		/>
 
 		<field 
@@ -168,7 +169,9 @@
 			type="text"
 			filter="integer"
 			label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
-			description="COM_TAGS_LIST_MAX_CHARACTERS_DESC">
+			description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
+			showon="tag_list_show_item_description:1"
+		>
 		</field>
 
 	</fieldset>
@@ -306,6 +309,7 @@
 			filter="integer"
 			label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
 			description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
+			showon="all_tags_show_tag_descripion:1"
 		/>
 		
 		<field 
@@ -369,6 +373,7 @@
 			default="1"
 			label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 			description="JGLOBAL_PAGINATION_RESULTS_DESC"
+			showon="show_pagination:1,2"
 		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the com_tags component options

Testing Instructions

This is only a cosmetic change
Go to the Options page for this component and try all the options on that page to ensure that the new show/hide functionality makes sense.

[Note this is part of a series of PR for each component options page and then the menu options]
