### PR TITLE
User options - showon

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -17,7 +17,8 @@
 			type="usergrouplist"
 			default="2"
 			label="COM_USERS_CONFIG_FIELD_NEW_USER_TYPE_LABEL"
-			description="COM_USERS_CONFIG_FIELD_NEW_USER_TYPE_DESC">
+			description="COM_USERS_CONFIG_FIELD_NEW_USER_TYPE_DESC"
+			showon="allowUserRegistration:1">
 		</field>
 
 		<field
@@ -94,7 +95,9 @@
 			class="btn-group btn-group-yesno"
 			default="0"
 			label="COM_USERS_CONFIG_FIELD_FRONTEND_LANG_LABEL"
-			description="COM_USERS_CONFIG_FIELD_FRONTEND_LANG_DESC">
+			description="COM_USERS_CONFIG_FIELD_FRONTEND_LANG_DESC"
+			showon="frontend_userparams:1"
+		>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
@@ -196,6 +199,7 @@
 			label="JGLOBAL_HISTORY_LIMIT_OPTIONS_LABEL"
 			description="JGLOBAL_HISTORY_LIMIT_OPTIONS_DESC"
 			default="5"
+			showon="save_history:1"
 		/>
 	</fieldset>
 


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the users component options

Testing Instructions

This is only a cosmetic change
Go to the Options page for this component and try all the options on that page to ensure that the new show/hide functionality makes sense.

[Note this is part of a series of PR for each component options page and then the menu options]
