### PR TITLE
Module breadcrumbs - showon

### DIFF
--- a/modules/mod_breadcrumbs/mod_breadcrumbs.xml
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.xml
@@ -46,7 +46,8 @@
 					name="homeText"
 					type="text"
 					label="MOD_BREADCRUMBS_FIELD_HOMETEXT_LABEL"
-					description="MOD_BREADCRUMBS_FIELD_HOMETEXT_DESC" />
+					description="MOD_BREADCRUMBS_FIELD_HOMETEXT_DESC"
+					showon="showHome:1" />
 				<field
 					name="showLast"
 					type="radio"


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the module options in this case for the Show home

Testing Instructions

This is only a cosmetic change
Go to the module and try all the options on that page to ensure that the new show/hide functionality makes sense.
