### PR TITLE
module syndicate options showon

### DIFF
--- a/modules/mod_syndicate/mod_syndicate.xml
+++ b/modules/mod_syndicate/mod_syndicate.xml
@@ -39,7 +39,8 @@
 					name="text"
 					type="text"
 					label="MOD_SYNDICATE_FIELD_TEXT_LABEL"
-					description="MOD_SYNDICATE_FIELD_TEXT_DESC" />
+					description="MOD_SYNDICATE_FIELD_TEXT_DESC"
+					showon="display_text:1" />
 				<field
 					name="format"
 					type="list"


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the module options. In this case the show text option

Testing Instructions

This is only a cosmetic change
Go to the module and try all the options on that page to ensure that the new show/hide functionality makes sense.
