### PR TITLE
Module - language switcher showon options

### DIFF
--- a/modules/mod_languages/mod_languages.xml
+++ b/modules/mod_languages/mod_languages.xml
@@ -58,16 +58,14 @@
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
-				<field name="spacer1" type="spacer" class="text"
-					label="MOD_LANGUAGES_SPACERDROP_LABEL"
-				/>
 				<field
 					name="image"
 					type="radio"
 					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_LANGUAGES_FIELD_USEIMAGE_LABEL"
-					description="MOD_LANGUAGES_FIELD_USEIMAGE_DESC" >
+					description="MOD_LANGUAGES_FIELD_USEIMAGE_DESC"
+					showon="dropdown:0" >
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
@@ -77,7 +75,8 @@
 					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_LANGUAGES_FIELD_INLINE_LABEL"
-					description="MOD_LANGUAGES_FIELD_INLINE_DESC" >
+					description="MOD_LANGUAGES_FIELD_INLINE_DESC"
+					showon="dropdown:0" >
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
@@ -87,20 +86,19 @@
 					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_LANGUAGES_FIELD_ACTIVE_LABEL"
-					description="MOD_LANGUAGES_FIELD_ACTIVE_DESC" >
+					description="MOD_LANGUAGES_FIELD_ACTIVE_DESC"
+					showon="dropdown:0" >
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
-				<field name="spacer2" type="spacer" class="text"
-					label="MOD_LANGUAGES_SPACERNAME_LABEL"
-				/>
 				<field
 					name="full_name"
 					type="radio"
 					class="btn-group btn-group-yesno"
 					default="1"
 					label="MOD_LANGUAGES_FIELD_FULL_NAME_LABEL"
-					description="MOD_LANGUAGES_FIELD_FULL_NAME_DESC" >
+					description="MOD_LANGUAGES_FIELD_FULL_NAME_DESC"
+					showon="dropdown:0[AND]image:1" >
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>


### PR DESCRIPTION
Summary of Changes

Use the showon functionality now available in forms to simplify/reduce the options displayed in the module options - note that this also removes some text that explains not so use things etc

Testing Instructions

This is only a cosmetic change
Go to the module and try all the options on that page to ensure that the new show/hide functionality makes sense.
