### PR TITLE
(Regression) [com_banners] clients view: Corrects input filters

### DIFF
--- a/administrator/components/com_banners/models/clients.php
+++ b/administrator/components/com_banners/models/clients.php
@@ -61,7 +61,7 @@ class BannersModelClients extends JModelList
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
 		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
-		$this->setState('filter.purchase_type', $this->getUserStateFromRequest($this->context . '.filter.purchase_type', 'filter_purchase_type', '', 'string'));
+		$this->setState('filter.purchase_type', $this->getUserStateFromRequest($this->context . '.filter.purchase_type', 'filter_purchase_type'));
 
 		// Load the parameters.
 		$this->setState('params', JComponentHelper::getParams('com_banners'));

--- a/administrator/components/com_banners/models/clients.php
+++ b/administrator/components/com_banners/models/clients.php
@@ -60,8 +60,8 @@ class BannersModelClients extends JModelList
 	{
 		// Load the filter state.
 		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', null, 'int'));
-		$this->setState('filter.purchase_type', $this->getUserStateFromRequest($this->context . '.filter.purchase_type', 'filter_purchase_type'));
+		$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
+		$this->setState('filter.purchase_type', $this->getUserStateFromRequest($this->context . '.filter.purchase_type', 'filter_purchase_type', '', 'string'));
 
 		// Load the parameters.
 		$this->setState('params', JComponentHelper::getParams('com_banners'));


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

After latest merging the state filter stop working in hathor.

This is because of the input filters that i forgot to change.
The state filter cannot be filtered by `'int'` because it contains `*` for `All` so it was to be filtered `'string'` (the same in other views for the language filter and other filters).

Don't know how it works on isis but on hathor doesn't work without this change.

There are some others with the same problem. Will make PR to correct them.
#### Testing Instructions

Code review, or:
1. Apply patch
2. Use hathor and select filter "All" in the state filter in the banners clients view.
