### PR TITLE
Smart Search PHP Notice when saving filter

### DIFF
--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -79,13 +79,19 @@ class FinderTableFilter extends JTable
 			$this->alias = JFactory::getDate()->format('Y-m-d-H-i-s');
 		}
 
-		// Check the end date is not earlier than start up.
-		if ($this->d2 > $this->_db->getNullDate() && $this->d2 < $this->d1)
+		$params = new Registry($this->params);
+
+		$nullDate = $this->_db->getNullDate();
+		$d1 = $params->get('d1', $nullDate);
+		$d2 = $params->get('d2', $nullDate);
+
+		// Check the end date is not earlier than the start date.
+		if ($d2 > $nullDate && $d2 < $d1)
 		{
 			// Swap the dates.
-			$temp = $this->d1;
-			$this->d1 = $this->d2;
-			$this->d2 = $temp;
+			$params->set('d1', $d2);
+			$params->set('d2', $d1);
+			$this->params = (string) $params;
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issue #10187  .
#### Summary of Changes

Start and end dates for filters are stored in params and not as individual table columns.
#### Testing Instructions
- Set error reporting to maximum.
- Create a new filter or modify an existing one.  You should see "PHP Notice: Undefined property: FinderTableFilter::$d2 in ROOT/administrator/components/com_finder/tables/filter.php on line 83"
- Apply this PR and try again.
- Also try entering a start date which is after the end date.  After saving the dates should be swapped.
