### PR TITLE
Since tags: From 3.5.2 to 3.6.0

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -778,7 +778,7 @@ class ContentModelArticle extends JModelAdmin
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function hit()
 	{

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -284,7 +284,7 @@ class FinderModelIndex extends JModelList
 	 *
 	 * @return  int  The total of indexed items.
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function getTotalIndexed()
 	{

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -156,7 +156,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function upload()
 	{
@@ -191,7 +191,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	 *
 	 * @return  array
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function captive()
 	{
@@ -225,7 +225,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 	 *
 	 * @return  array
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function confirm()
 	{

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.5.2</version>
+	<version>3.6.0</version>
 	<description>COM_JOOMLAUPDATE_XML_DESCRIPTION</description>
 	<media destination="com_joomlaupdate" folder="media">
 		<folder>js</folder>

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -807,7 +807,7 @@ ENDDATA;
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function upload()
 	{
@@ -893,7 +893,7 @@ ENDDATA;
 	 *
 	 * @return  bool
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function captiveLogin($credentials)
 	{
@@ -931,7 +931,7 @@ ENDDATA;
 	 *
 	 * @return  bool
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function captiveFileExists()
 	{
@@ -952,7 +952,7 @@ ENDDATA;
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function removePackageFiles()
 	{

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -21,7 +21,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	 *
 	 * @var    array
 	 *
-	 * @since  3.5.2
+	 * @since  3.6.0
 	 */
 	protected $updateInfo = null;
 
@@ -30,7 +30,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	 *
 	 * @var    string
 	 *
-	 * @since  3.5.2
+	 * @since  3.6.0
 	 */
 	protected $methodSelect = null;
 
@@ -39,7 +39,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	 *
 	 * @var   string
 	 *
-	 * @since  3.5.2
+	 * @since  3.6.0
 	 */
 	protected $methodSelectUpload = null;
 

--- a/administrator/components/com_joomlaupdate/views/upload/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/upload/view.html.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Joomla! Update's Update View
  *
- * @since  3.5.2
+ * @since  3.6.0
  */
 class JoomlaupdateViewUpload extends JViewLegacy
 {
@@ -23,7 +23,7 @@ class JoomlaupdateViewUpload extends JViewLegacy
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function display($tpl = null)
 	{

--- a/administrator/components/com_messages/models/fields/messagestates.php
+++ b/administrator/components/com_messages/models/fields/messagestates.php
@@ -16,7 +16,7 @@ JLoader::register('MessagesHelper', JPATH_ADMINISTRATOR . '/components/com_messa
 /**
  * Form Field class for the Joomla Framework.
  *
- * @since  3.5.2
+ * @since  3.6.0
  */
 class JFormFieldMessageStates extends JFormFieldList
 {
@@ -24,7 +24,7 @@ class JFormFieldMessageStates extends JFormFieldList
 	 * The form field type.
 	 *
 	 * @var     string
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected $type = 'MessageStates';
 
@@ -33,7 +33,7 @@ class JFormFieldMessageStates extends JFormFieldList
 	 *
 	 * @return  array  The field option objects.
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected function getOptions()
 	{

--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -62,7 +62,7 @@ class RedirectControllerLinks extends JControllerAdmin
 	 *
 	 * @return  void.
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function duplicateUrls()
 	{

--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -207,7 +207,7 @@ class RedirectModelLink extends JModelAdmin
 	 *
 	 * @return  boolean  Returns true on success, false on failure.
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function duplicateUrls(&$pks, $url, $comment = null)
 	{

--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -24,7 +24,7 @@ class UsersModelDebuggroup extends JModelList
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
 	 * @see     JController
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function __construct($config = array())
 	{

--- a/administrator/components/com_users/models/debuguser.php
+++ b/administrator/components/com_users/models/debuguser.php
@@ -24,7 +24,7 @@ class UsersModelDebugUser extends JModelList
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 *
 	 * @see     JController
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function __construct($config = array())
 	{

--- a/administrator/components/com_users/models/fields/components.php
+++ b/administrator/components/com_users/models/fields/components.php
@@ -14,7 +14,7 @@ JFormHelper::loadFieldClass('list');
 /**
  * Form Field class for the Joomla Framework.
  *
- * @since  3.5.2
+ * @since  3.6.0
  */
 class JFormFieldComponents extends JFormFieldList
 {
@@ -22,7 +22,7 @@ class JFormFieldComponents extends JFormFieldList
 	 * The form field type.
 	 *
 	 * @var     string
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected $type = 'Components';
 
@@ -31,7 +31,7 @@ class JFormFieldComponents extends JFormFieldList
 	 *
 	 * @return  array  The field option objects
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected function getOptions()
 	{

--- a/administrator/components/com_users/models/fields/levels.php
+++ b/administrator/components/com_users/models/fields/levels.php
@@ -14,7 +14,7 @@ JFormHelper::loadFieldClass('list');
 /**
  * Form Field class for the Joomla Framework.
  *
- * @since  3.5.2
+ * @since  3.6.0
  */
 class JFormFieldLevels extends JFormFieldList
 {
@@ -22,7 +22,7 @@ class JFormFieldLevels extends JFormFieldList
 	 * The form field type.
 	 *
 	 * @var     string
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected $type = 'Levels';
 
@@ -31,7 +31,7 @@ class JFormFieldLevels extends JFormFieldList
 	 *
 	 * @return  array  The field option objects
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	protected function getOptions()
 	{

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -186,7 +186,7 @@ class ContentModelArchive extends ContentModelArticles
 	 *
 	 * @return   array
 	 * 
-	 * @since    3.5.2
+	 * @since    3.6.0
 	 */
 	public function getYears()
 	{

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -1225,7 +1225,7 @@ class JClientFtp
 	 *
 	 * @return  boolean  True if successful
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function append($remote, $buffer)
 	{
@@ -1311,7 +1311,7 @@ class JClientFtp
 	 *
 	 * @return  mixed  number of bytes or false on error
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function size($remote)
 	{

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -448,7 +448,7 @@ class JFile
 	 *
 	 * @return  boolean  True on success
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public static function append($file, &$buffer, $use_streams = false)
 	{

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -175,7 +175,7 @@ class JUpdater extends JAdapter
 	 *
 	 * @return  mixed
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	public function update($id)
 	{
@@ -199,7 +199,7 @@ class JUpdater extends JAdapter
 	 *
 	 * @return  array
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	private function getUpdateSites($eid = 0)
 	{
@@ -245,7 +245,7 @@ class JUpdater extends JAdapter
 	 *
 	 * @return  array  The update records. Empty array if no updates are found.
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	private function getUpdateObjectsForSite($updateSite, $minimum_stability = self::STABILITY_STABLE, $includeCurrent = false)
 	{
@@ -376,7 +376,7 @@ class JUpdater extends JAdapter
 	 *
 	 * @return  array  The IDs of the update sites with cached updates
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	private function getSitesWithUpdates($timestamp = 0)
 	{
@@ -414,7 +414,7 @@ class JUpdater extends JAdapter
 	 *
 	 * @return  void
 	 *
-	 * @since   3.5.2
+	 * @since   3.6.0
 	 */
 	private function updateLastCheckTimestamp($updateSiteId)
 	{


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

With the drop of 3.5.2 in favour of 3.6.0 we need to change the since tags that are 3.5.2.
This PR changes them.

Also changes com_joomlaupdate manifest file version from 3.5.2 to 3.6.0
#### Testing Instructions

Code review.
