### PR TITLE
Dependency updates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d500f4784ce37841dad0b29e32660849",
+    "hash": "4b3569df296296de25e50ae830800393",
     "content-hash": "800b07fe877fd7416bf7c046ad42a55a",
     "packages": [
         {
@@ -51,16 +51,16 @@
         },
         {
             "name": "joomla/application",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/application.git",
-                "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0"
+                "reference": "2c2fb32553819f22ee15d4022dec805e750f43ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/application/zipball/9ac5463d5437759dc523bf02d59d279a43f361e0",
-                "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/2c2fb32553819f22ee15d4022dec805e750f43ce",
+                "reference": "2c2fb32553819f22ee15d4022dec805e750f43ce",
                 "shasum": ""
             },
             "require": {
@@ -88,8 +88,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Joomla\\Application\\": "src/",
-                    "Joomla\\Application\\Tests\\": "Tests/"
+                    "Joomla\\Application\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -103,7 +102,7 @@
                 "framework",
                 "joomla"
             ],
-            "time": "2016-03-18 15:08:10"
+            "time": "2016-04-09 03:08:55"
         },
         {
             "name": "joomla/compat",
@@ -338,32 +337,31 @@
         },
         {
             "name": "joomla/registry",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
-                "reference": "db55cf426bd27524557affbe95b18d6a2f959657"
+                "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/db55cf426bd27524557affbe95b18d6a2f959657",
-                "reference": "db55cf426bd27524557affbe95b18d6a2f959657",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+                "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9",
                 "shasum": ""
             },
             "require": {
                 "joomla/compat": "~1.0",
-                "joomla/string": "~1.3",
                 "joomla/utilities": "~1.0",
-                "php": ">=5.3.10"
+                "php": ">=5.3.10|>=7.0"
             },
             "require-dev": {
                 "joomla/test": "~1.0",
-                "phpunit/phpunit": "4.*",
+                "phpunit/phpunit": "~4.8|~5.0",
                 "squizlabs/php_codesniffer": "1.*",
-                "symfony/yaml": "~2.0"
+                "symfony/yaml": "~2.0|~3.0"
             },
             "suggest": {
-                "symfony/yaml": "Install 2.* if you require YAML support."
+                "symfony/yaml": "Install symfony/yaml if you require YAML support."
             },
             "type": "joomla-package",
             "extra": {
@@ -373,8 +371,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Joomla\\Registry\\": "src/",
-                    "Joomla\\Registry\\Tests\\": "Tests/"
+                    "Joomla\\Registry\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -388,7 +385,7 @@
                 "joomla",
                 "registry"
             ],
-            "time": "2015-10-14 17:01:46"
+            "time": "2016-04-18 23:57:43"
         },
         {
             "name": "joomla/session",

--- a/libraries/vendor/composer/LICENSE
+++ b/libraries/vendor/composer/LICENSE
@@ -1,5 +1,5 @@
 
-Copyright (c) 2015 Nils Adermann, Jordi Boggiano
+Copyright (c) 2016 Nils Adermann, Jordi Boggiano
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/libraries/vendor/composer/autoload_psr4.php
+++ b/libraries/vendor/composer/autoload_psr4.php
@@ -15,7 +15,6 @@ return array(
     'Joomla\\Uri\\' => array($vendorDir . '/joomla/uri/src'),
     'Joomla\\String\\Tests\\' => array($vendorDir . '/joomla/string/Tests'),
     'Joomla\\String\\' => array($vendorDir . '/joomla/string/src'),
-    'Joomla\\Registry\\Tests\\' => array($vendorDir . '/joomla/registry/Tests'),
     'Joomla\\Registry\\' => array($vendorDir . '/joomla/registry/src'),
     'Joomla\\Input\\Tests\\' => array($vendorDir . '/joomla/input/Tests'),
     'Joomla\\Input\\' => array($vendorDir . '/joomla/input/src'),
@@ -25,6 +24,5 @@ return array(
     'Joomla\\Event\\' => array($vendorDir . '/joomla/event/src'),
     'Joomla\\DI\\Tests\\' => array($vendorDir . '/joomla/di/Tests'),
     'Joomla\\DI\\' => array($vendorDir . '/joomla/di/src'),
-    'Joomla\\Application\\Tests\\' => array($vendorDir . '/joomla/application/Tests'),
     'Joomla\\Application\\' => array($vendorDir . '/joomla/application/src'),
 );

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -263,62 +263,6 @@
         ]
     },
     {
-        "name": "joomla/registry",
-        "version": "1.5.0",
-        "version_normalized": "1.5.0.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/registry.git",
-            "reference": "db55cf426bd27524557affbe95b18d6a2f959657"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/db55cf426bd27524557affbe95b18d6a2f959657",
-            "reference": "db55cf426bd27524557affbe95b18d6a2f959657",
-            "shasum": ""
-        },
-        "require": {
-            "joomla/compat": "~1.0",
-            "joomla/string": "~1.3",
-            "joomla/utilities": "~1.0",
-            "php": ">=5.3.10"
-        },
-        "require-dev": {
-            "joomla/test": "~1.0",
-            "phpunit/phpunit": "4.*",
-            "squizlabs/php_codesniffer": "1.*",
-            "symfony/yaml": "~2.0"
-        },
-        "suggest": {
-            "symfony/yaml": "Install 2.* if you require YAML support."
-        },
-        "time": "2015-10-14 17:01:46",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Registry\\": "src/",
-                "Joomla\\Registry\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Registry Package",
-        "homepage": "https://github.com/joomla-framework/registry",
-        "keywords": [
-            "framework",
-            "joomla",
-            "registry"
-        ]
-    },
-    {
         "name": "phpmailer/phpmailer",
         "version": "v5.2.14",
         "version_normalized": "5.2.14.0",
@@ -644,64 +588,6 @@
         ]
     },
     {
-        "name": "joomla/application",
-        "version": "1.5.1",
-        "version_normalized": "1.5.1.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/application.git",
-            "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/application/zipball/9ac5463d5437759dc523bf02d59d279a43f361e0",
-            "reference": "9ac5463d5437759dc523bf02d59d279a43f361e0",
-            "shasum": ""
-        },
-        "require": {
-            "joomla/input": "~1.2",
-            "joomla/registry": "~1.1",
-            "php": ">=5.3.10|>=7.0",
-            "psr/log": "~1.0"
-        },
-        "require-dev": {
-            "joomla/session": "^1.2.1",
-            "joomla/test": "~1.1",
-            "joomla/uri": "~1.1",
-            "phpunit/phpunit": "~4.8|~5.0",
-            "squizlabs/php_codesniffer": "1.*"
-        },
-        "suggest": {
-            "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
-            "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
-        },
-        "time": "2016-03-18 15:08:10",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Application\\": "src/",
-                "Joomla\\Application\\Tests\\": "Tests/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Application Package",
-        "homepage": "https://github.com/joomla-framework/application",
-        "keywords": [
-            "application",
-            "framework",
-            "joomla"
-        ]
-    },
-    {
         "name": "joomla/event",
         "version": "1.2.0",
         "version_normalized": "1.2.0.0",
@@ -960,6 +846,117 @@
             "compatibility",
             "polyfill",
             "shim"
+        ]
+    },
+    {
+        "name": "joomla/registry",
+        "version": "1.5.1",
+        "version_normalized": "1.5.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/registry.git",
+            "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+            "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/compat": "~1.0",
+            "joomla/utilities": "~1.0",
+            "php": ">=5.3.10|>=7.0"
+        },
+        "require-dev": {
+            "joomla/test": "~1.0",
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*",
+            "symfony/yaml": "~2.0|~3.0"
+        },
+        "suggest": {
+            "symfony/yaml": "Install symfony/yaml if you require YAML support."
+        },
+        "time": "2016-04-18 23:57:43",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Registry\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Registry Package",
+        "homepage": "https://github.com/joomla-framework/registry",
+        "keywords": [
+            "framework",
+            "joomla",
+            "registry"
+        ]
+    },
+    {
+        "name": "joomla/application",
+        "version": "1.6.0",
+        "version_normalized": "1.6.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/application.git",
+            "reference": "2c2fb32553819f22ee15d4022dec805e750f43ce"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/application/zipball/2c2fb32553819f22ee15d4022dec805e750f43ce",
+            "reference": "2c2fb32553819f22ee15d4022dec805e750f43ce",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/input": "~1.2",
+            "joomla/registry": "~1.1",
+            "php": ">=5.3.10|>=7.0",
+            "psr/log": "~1.0"
+        },
+        "require-dev": {
+            "joomla/session": "^1.2.1",
+            "joomla/test": "~1.1",
+            "joomla/uri": "~1.1",
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "suggest": {
+            "joomla/session": "To use AbstractWebApplication with session support, install joomla/session",
+            "joomla/uri": "To use AbstractWebApplication, install joomla/uri"
+        },
+        "time": "2016-04-09 03:08:55",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Application\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Application Package",
+        "homepage": "https://github.com/joomla-framework/application",
+        "keywords": [
+            "application",
+            "framework",
+            "joomla"
         ]
     }
 ]

--- a/libraries/vendor/joomla/application/src/AbstractApplication.php
+++ b/libraries/vendor/joomla/application/src/AbstractApplication.php
@@ -62,6 +62,11 @@ abstract class AbstractApplication implements LoggerAwareInterface
 		$this->input = $input instanceof Input ? $input : new Input;
 		$this->config = $config instanceof Registry ? $config : new Registry;
 
+		// Set the execution datetime and timestamp;
+		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));
+		$this->set('execution.timestamp', time());
+		$this->set('execution.microtimestamp', microtime(true));
+
 		$this->initialise();
 	}
 

--- a/libraries/vendor/joomla/application/src/AbstractCliApplication.php
+++ b/libraries/vendor/joomla/application/src/AbstractCliApplication.php
@@ -8,9 +8,8 @@
 
 namespace Joomla\Application;
 
-use Joomla\Registry\Registry;
 use Joomla\Input;
-use Joomla\Application\Cli\CliOutput;
+use Joomla\Registry\Registry;
 
 /**
  * Base class for a Joomla! command line application.
@@ -20,26 +19,36 @@ use Joomla\Application\Cli\CliOutput;
 abstract class AbstractCliApplication extends AbstractApplication
 {
 	/**
-	 * @var    CliOutput  Output object
+	 * Output object
+	 *
+	 * @var    Cli\CliOutput
 	 * @since  1.0
 	 */
 	protected $output;
 
 	/**
+	 * CLI Input object
+	 *
+	 * @var    Cli\CliInput
+	 * @since  1.6.0
+	 */
+	protected $cliInput;
+
+	/**
 	 * Class constructor.
 	 *
-	 * @param   Input\Cli  $input   An optional argument to provide dependency injection for the application's
-	 *                              input object.  If the argument is a InputCli object that object will become
-	 *                              the application's input object, otherwise a default input object is created.
-	 * @param   Registry   $config  An optional argument to provide dependency injection for the application's
-	 *                              config object.  If the argument is a Registry object that object will become
-	 *                              the application's config object, otherwise a default config object is created.
-	 *
-	 * @param   CliOutput  $output  The output handler.
+	 * @param   Input\Cli      $input     An optional argument to provide dependency injection for the application's
+	 *                                    input object.  If the argument is a InputCli object that object will become
+	 *                                    the application's input object, otherwise a default input object is created.
+	 * @param   Registry       $config    An optional argument to provide dependency injection for the application's
+	 *                                    config object.  If the argument is a Registry object that object will become
+	 *                                    the application's config object, otherwise a default config object is created.
+	 * @param   Cli\CliOutput  $output    The output handler.
+	 * @param   Cli\CliInput   $cliInput  The CLI input handler.
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Input\Cli $input = null, Registry $config = null, CliOutput $output = null)
+	public function __construct(Input\Cli $input = null, Registry $config = null, Cli\CliOutput $output = null, Cli\CliInput $cliInput = null)
 	{
 		// Close the application if we are not executed from the command line.
 		// @codeCoverageIgnoreStart
@@ -50,14 +59,13 @@ abstract class AbstractCliApplication extends AbstractApplication
 
 		// @codeCoverageIgnoreEnd
 
-		$this->output = ($output instanceof CliOutput) ? $output : new Cli\Output\Stdout;
+		$this->output = ($output instanceof Cli\CliOutput) ? $output : new Cli\Output\Stdout;
+
+		// Set the CLI input object.
+		$this->cliInput = ($cliInput instanceof Cli\CliInput) ? $cliInput : new Cli\CliInput;
 
 		// Call the constructor as late as possible (it runs `initialise`).
 		parent::__construct($input instanceof Input\Input ? $input : new Input\Cli, $config);
-
-		// Set the execution datetime and timestamp;
-		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));
-		$this->set('execution.timestamp', time());
 
 		// Set the current directory.
 		$this->set('cwd', getcwd());
@@ -66,13 +74,25 @@ abstract class AbstractCliApplication extends AbstractApplication
 	/**
 	 * Get an output object.
 	 *
-	 * @return  CliOutput
+	 * @return  Cli\CliOutput
 	 *
 	 * @since   1.0
 	 */
 	public function getOutput()
 	{
 		return $this->output;
+	}
+
+	/**
+	 * Get a CLI input object.
+	 *
+	 * @return  Cli\CliInput
+	 *
+	 * @since   1.6.0
+	 */
+	public function getCliInput()
+	{
+		return $this->cliInput;
 	}
 
 	/**
@@ -102,6 +122,6 @@ abstract class AbstractCliApplication extends AbstractApplication
 	 */
 	public function in()
 	{
-		return rtrim(fread(STDIN, 8192), "\n\r");
+		return $this->getCliInput()->in();
 	}
 }

--- a/libraries/vendor/joomla/application/src/AbstractWebApplication.php
+++ b/libraries/vendor/joomla/application/src/AbstractWebApplication.php
@@ -69,6 +69,25 @@ abstract class AbstractWebApplication extends AbstractApplication
 	private $session;
 
 	/**
+	 * A map of integer HTTP 1.1 response codes to the full HTTP Status for the headers.
+	 *
+	 * @var    array
+	 * @since  1.6.0
+	 * @see    https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 */
+	private $responseMap = array(
+		300 => 'HTTP/1.1 300 Multiple Choices',
+		301 => 'HTTP/1.1 301 Moved Permanently',
+		302 => 'HTTP/1.1 302 Found',
+		303 => 'HTTP/1.1 303 See other',
+		304 => 'HTTP/1.1 304 Not Modified',
+		305 => 'HTTP/1.1 305 Use Proxy',
+		306 => 'HTTP/1.1 306 (Unused)',
+		307 => 'HTTP/1.1 307 Temporary Redirect',
+		308 => 'HTTP/1.1 308 Permanent Redirect'
+	);
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   Input          $input   An optional argument to provide dependency injection for the application's
@@ -98,10 +117,6 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 		// Set the system URIs.
 		$this->loadSystemUris();
-
-		// Set the execution datetime and timestamp;
-		$this->set('execution.datetime', gmdate('Y-m-d H:i:s'));
-		$this->set('execution.timestamp', time());
 	}
 
 	/**
@@ -257,14 +272,15 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 * or "303 See Other" code in the header pointing to the new location. If the headers have already been
 	 * sent this will be accomplished using a JavaScript statement.
 	 *
-	 * @param   string   $url    The URL to redirect to. Can only be http/https URL
-	 * @param   boolean  $moved  True if the page is 301 Permanently Moved, otherwise 303 See Other is assumed.
+	 * @param   string   $url     The URL to redirect to. Can only be http/https URL
+	 * @param   integer  $status  The HTTP 1.1 status code to be provided. 303 is assumed by default.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.0
+	 * @throws  \InvalidArgumentException
 	 */
-	public function redirect($url, $moved = false)
+	public function redirect($url, $status = 303)
 	{
 		// Check for relative internal links.
 		if (preg_match('#^index\.php#', $url))
@@ -323,8 +339,20 @@ abstract class AbstractWebApplication extends AbstractApplication
 			}
 			else
 			{
+				// Check if we have a boolean for the status variable for compatability with v1 of the framework
+				// @deprecated 3.0
+				if (is_bool($status))
+				{
+					$status = $status ? 301 : 303;
+				}
+
+				if (!is_int($status) && !isset($this->responseMap[$status]))
+				{
+					throw new \InvalidArgumentException('You have not supplied a valid HTTP 1.1 status code');
+				}
+
 				// All other cases use the more efficient HTTP header for redirection.
-				$this->header($moved ? 'HTTP/1.1 301 Moved Permanently' : 'HTTP/1.1 303 See other');
+				$this->header($this->responseMap[$status]);
 				$this->header('Location: ' . $url);
 				$this->header('Content-Type: text/html; charset=' . $this->charSet);
 

--- a/libraries/vendor/joomla/application/src/Cli/CliInput.php
+++ b/libraries/vendor/joomla/application/src/Cli/CliInput.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Part of the Joomla Framework Application Package
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Application\Cli;
+
+/**
+ * Class CliInput
+ *
+ * @since  1.6.0
+ */
+class CliInput
+{
+	/**
+	 * Get a value from standard input.
+	 *
+	 * @return  string  The input string from standard input.
+	 *
+	 * @codeCoverageIgnore
+	 * @since   1.6.0
+	 */
+	public function in()
+	{
+		return rtrim(fread(STDIN, 8192), "\n\r");
+	}
+}

--- a/libraries/vendor/joomla/registry/src/Format/Json.php
+++ b/libraries/vendor/joomla/registry/src/Format/Json.php
@@ -9,7 +9,6 @@
 namespace Joomla\Registry\Format;
 
 use Joomla\Registry\AbstractRegistryFormat;
-use Joomla\String\StringHelper;
 
 /**
  * JSON format handler for Registry.
@@ -30,7 +29,17 @@ class Json extends AbstractRegistryFormat
 	 */
 	public function objectToString($object, $options = array())
 	{
-		return StringHelper::unicode_to_utf8(json_encode($object));
+		$bitmask = isset($options['bitmask']) ? $options['bitmask'] : 0;
+
+		// The depth parameter is only present as of PHP 5.5
+		if (version_compare(PHP_VERSION, '5.5', '>='))
+		{
+			$depth = isset($options['depth']) ? $options['depth'] : 512;
+
+			return json_encode($object, $bitmask, $depth);
+		}
+
+		return json_encode($object, $bitmask);
 	}
 
 	/**
@@ -51,14 +60,9 @@ class Json extends AbstractRegistryFormat
 
 		if ((substr($data, 0, 1) != '{') && (substr($data, -1, 1) != '}'))
 		{
-			$ini = AbstractRegistryFormat::getInstance('Ini');
-			$obj = $ini->stringToObject($data, $options);
-		}
-		else
-		{
-			$obj = json_decode($data);
+			return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
 		}
 
-		return $obj;
+		return json_decode($data);
 	}
 }

--- a/libraries/vendor/joomla/registry/src/Format/Php.php
+++ b/libraries/vendor/joomla/registry/src/Format/Php.php
@@ -30,6 +30,9 @@ class Php extends AbstractRegistryFormat
 	 */
 	public function objectToString($object, $params = array())
 	{
+		// A class must be provided
+		$class = !empty($params['class']) ? $params['class'] : 'Registry';
+
 		// Build the object variables string
 		$vars = '';
 
@@ -53,7 +56,7 @@ class Php extends AbstractRegistryFormat
 			$str .= "namespace " . $params['namespace'] . ";\n\n";
 		}
 
-		$str .= "class " . $params['class'] . " {\n";
+		$str .= "class " . $class . " {\n";
 		$str .= $vars;
 		$str .= "}";
 

--- a/libraries/vendor/joomla/registry/src/Format/Yaml.php
+++ b/libraries/vendor/joomla/registry/src/Format/Yaml.php
@@ -22,8 +22,7 @@ class Yaml extends AbstractRegistryFormat
 	/**
 	 * The YAML parser class.
 	 *
-	 * @var    \Symfony\Component\Yaml\Parser;
-	 *
+	 * @var    \Symfony\Component\Yaml\Parser
 	 * @since  1.0
 	 */
 	private $parser;
@@ -31,8 +30,7 @@ class Yaml extends AbstractRegistryFormat
 	/**
 	 * The YAML dumper class.
 	 *
-	 * @var    \Symfony\Component\Yaml\Dumper;
-	 *
+	 * @var    \Symfony\Component\Yaml\Dumper
 	 * @since  1.0
 	 */
 	private $dumper;

--- a/libraries/vendor/joomla/registry/src/Registry.php
+++ b/libraries/vendor/joomla/registry/src/Registry.php
@@ -58,11 +58,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		if (is_array($data) || is_object($data))
 		{
 			$this->bindData($this->data, $data);
-
-			return;
 		}
-
-		if (!empty($data) && is_string($data))
+		elseif (!empty($data) && is_string($data))
 		{
 			$this->loadString($data);
 		}
@@ -252,8 +249,8 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 *
 	 * @return  Registry  The Registry object.
 	 *
-	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 * @since   1.0
+	 * @deprecated  2.0  Instantiate a new Registry instance instead
 	 */
 	public static function getInstance($id)
 	{


### PR DESCRIPTION
#### Summary of Changes

The following production dependencies are updated:
- Updating joomla/registry (1.5.0) to joomla/registry (1.5.1) ([Diff](https://github.com/joomla-framework/registry/compare/1.5.0...1.5.1))
- Updating joomla/application (1.5.1) to joomla/application (1.6.0) ([Diff](https://github.com/joomla-framework/application/compare/1.5.1...1.6.0))
#### Testing Instructions

The CMS continues to function normally.  Operations affected by these updates include:
- Upstream fix for https://github.com/joomla/joomla-cms/pull/9922
