### PR TITLE
[com_users] modal: Does not mantain required user (bug) - solves this issue

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -26,10 +26,11 @@ $listOrder       = $this->escape($this->state->get('list.ordering'));
 $listDirn        = $this->escape($this->state->get('list.direction'));
 $enabledStates   = array(0 => 'icon-publish', 1 => 'icon-unpublish');
 $activatedStates = array(0 => 'icon-publish', 1 => 'icon-unpublish');
+$userRequired    = (int) $input->get('required', 0, 'int');
 ?>
 <div class="container-popup">
 	<form action="<?php echo JRoute::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64')); ?>" method="post" name="adminForm" id="adminForm">
-		<?php if ($input->get('required', 0, 'int') != 1 ) : ?>
+		<?php if (!$userRequired) : ?>
 		<div class="pull-left">
 			<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
 				data-user-field="<?php echo $this->escape($field);?>"><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
@@ -105,6 +106,7 @@ $activatedStates = array(0 => 'icon-publish', 1 => 'icon-unpublish');
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>" />
 		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="required" value="<?php echo $userRequired; ?>" />
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 </div>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

There is a bug on users modal that is not forcing to select an user when it should.
![image](https://cloud.githubusercontent.com/assets/9630530/14956054/b1ccf046-1075-11e6-80f7-5b5b890936e6.png)
#### Testing Instructions
1. Create a New user note (the note needs an user). So click on the user button to select a user.
2. Notice there is no "No User" button because a user is required.
3. Now press "Clear" in the search filter. Notice that on page reload the "No User" button appears. (Bug)
4. Now apply this patch
5. Repeat test and you'll notice the "No User" button never appears.
