### PR TITLE
[com_installer] updatesites view: Correct language variable (bug)

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -203,7 +203,7 @@ class InstallerModelUpdatesites extends InstallerModel
 
 		if ($count > 0)
 		{
-			$app->enqueueMessage(JText::plural('COM_INSTALLER_MSG_UPDATESITES_DELETE_N_UPDATESITES_DELETED', $count), 'message');
+			$app->enqueueMessage(JText::plural('COM_INSTALLER_MSG_UPDATESITES_N_DELETE_UPDATESITES_DELETED', $count), 'message');
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

After the latest merge from of https://github.com/joomla/joomla-cms/pull/9744, one language variable is not correctly called.

You can see the correct language variable https://github.com/joomla/joomla-cms/blob/staging/administrator/language/en-GB/en-GB.com_installer.ini#L139

In other words is called:
`COM_INSTALLER_MSG_UPDATESITES_DELETE_N_UPDATESITES_DELETED`
When it should be:
`COM_INSTALLER_MSG_UPDATESITES_N_DELETE_UPDATESITES_DELETED`.

This PR correct that.
#### Testing Instructions

Code review. Or delete an extension update site (before and after patch).
