### PR TITLE
[com_menus] Re-add the th css classes removed by #10190

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -58,7 +58,7 @@ $colSpan = ($assoc) ? 9 : 8;
 				<thead>
 					<tr>
 						<?php if (!empty($menuType)) : ?>
-							<th width="1%" class="hidden-phone">
+							<th width="1%" class="nowrap center hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', '', 'a.lft', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
 							</th>
 						<?php endif; ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Very small PR.
PR  https://github.com/joomla/joomla-cms/pull/10190 merged today removed the css classes applied by https://github.com/joomla/joomla-cms/pull/9988. This PR re-adds them.
#### Testing Instructions

 Code review, or see https://github.com/joomla/joomla-cms/pull/9988 for test instructions.
