### PR TITLE
[com_users] notes view: cannot delete note (bug) - solves issue

### DIFF
--- a/administrator/components/com_users/views/notes/view.html.php
+++ b/administrator/components/com_users/views/notes/view.html.php
@@ -126,7 +126,7 @@ class UsersViewNotes extends JViewLegacy
 			JToolbarHelper::checkin('notes.checkin');
 		}
 
-		if ($this->state->get('filter.state') == -2 && $canDo->get('core.delete'))
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'notes.delete', 'JTOOLBAR_EMPTY_TRASH');
 			JToolbarHelper::divider();


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Wit the lateste changes, the delete note button disappeared.
This PR corrects that.
#### Testing Instructions
1. Go to Users -> User notes and create a note
2. Now set it to trashed
3. Set the filter state to trashed so you cn delete notes
4. You'll notice you have a "Trash" button in the toolbar, not a "Delete" button
5. Apply patch, you can now delete
