### PR TITLE
Fall back to index.php if file not found.

### DIFF
--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -619,6 +619,11 @@ class JDocumentHtml extends JDocument
 			$template = 'system';
 		}
 
+		if (!file_exists($directory . '/' . $template . '/' . $file))
+		{
+			$file = 'index.php';
+		}
+
 		// Load the language file for the template
 		$lang = JFactory::getLanguage();
 


### PR DESCRIPTION
Pull Request for Issue #10207 .
#### Summary of Changes

This PR simply adds a fallback to index.php in case the requested file isn't present neither in the active template nor in the system template
#### Testing Instructions

Test by adding `?tmpl=` or `?tmpl=foo` to the URL. Without this PR you will get a blank page, with this PR the page will be rendered with the system/index,php file (looks ugly but it renders).
