### PR TITLE
[com_categories] Cleaner tree view

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -200,7 +200,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9478;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&#9495;' : ''; ?>
+								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&#8210;' : ''; ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'categories.', $canCheckin); ?>
 								<?php endif; ?>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -200,7 +200,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>
+								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9478;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&#9495;' : ''; ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'categories.', $canCheckin); ?>
 								<?php endif; ?>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -200,7 +200,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&#8210;' : ''; ?>
+								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&ndash;' : ''; ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'categories.', $canCheckin); ?>
 								<?php endif; ?>


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

This PR is a proposal to make a better visual to the trees in the list views of isis.

If accepted i can do in the other tree views (tags, menu items, etc).

As you can see from the code difference is just one line of code that changes.
###### Before PR (current scenario)

![image](https://cloud.githubusercontent.com/assets/9630530/14984924/1e3146f2-113d-11e6-8782-1528e84ea7a8.png)
###### After PR (proposed scenario)

![image](https://cloud.githubusercontent.com/assets/9630530/14984919/1a8e8190-113d-11e6-8372-425be9e6e13f.png)
#### Testing Instructions
1. Use latest staging (the difference is more visible)
2. Apply patch
3. Go to content categories and check the visual difference
4. Do also some searches (with and without patch to check the difference)
