### PR TITLE
Missing "header" field added in database query

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -127,7 +127,7 @@ class PlgSystemRedirect extends JPlugin
 		{
 			$currRel = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
 			$query = $db->getQuery(true)
-				->select($db->quoteName('new_url'))
+				->select($db->quoteName(array('new_url', 'header')))
 				->select($db->quoteName('published'))
 				->from($db->quoteName('#__redirect_links'))
 				->where($db->quoteName('old_url') . ' = ' . $db->quote($currRel));


### PR DESCRIPTION
If a full URL is redirected the fields selected from the database are "new_url", "header" and "published" but if a server-relative URL is redirected only the fields "new_url" and "published" are selected from the database.

This has two implications:
- you will find an error message in your webserver error log file whenever a server-relative URL is redirected, this error message looks like: `PHP Notice:  Undefined property: stdClass::$header in .../plugins/system/redirect/redirect.php on line 142`
- if you enable the advanced feature for setting redirection codes and if you use this feature with server-relative redirections it is not working since the database field "header" holding this redirection code isn't selected from the database

This pull request changes the select with the server-relative URL such that in this case the "header" field is selected too.

How to test:
- define a server-relative redirection and set the redirection code to 307
- open the redirected URL either with your browser or with e.g. `wget` (for `wget` see below)
- check for the redirection and the redirection code - the code is 301

Now apply the change and repeat the test, the redirection code is now 307.

Since browsers tend to cache redirections they got from a web server it is not easy to test the redirection plugin. One way is to completely clean the browser cache prior to the next test (or to remove at least all objects cached from the server used for testing).

The other way is to use the tool `wget` as follows:

`wget -O - --max-redirect 0 <URL>`

For <URL> please substitute the redirected URL. The relevant output of this tool will look like:

`HTTP request sent, awaiting response... 307 Temporary Redirect`
`Location: <new URL>`
