### PR TITLE
[com_categories] Solve checkin wrong redirect (bug)

### DIFF
--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -147,7 +147,7 @@ class CategoriesControllerCategories extends JControllerAdmin
 	 *
 	 * @return  boolean  True on success
 	 *
-	 * @since   3.6
+	 * @since   3.6.0
 	 */
 	public function checkin()
 	{

--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -139,4 +139,25 @@ class CategoriesControllerCategories extends JControllerAdmin
 
 		$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&extension=' . $extension, false));
 	}
+
+	/**
+	 * Check in of one or more records.
+	 *
+	 * Overrides JControllerAdmin::checkin to redirect to URL with extension.
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   3.6
+	 */
+	public function checkin()
+	{
+		// Process parent checkin method.
+		$result = parent::checkin();
+
+		// Overrride the redirect Uri.
+		$redirectUri = 'index.php?option=' . $this->option . '&view=' . $this->view_list . '&extension=' . $this->input->get('extension', '', 'CMD');
+		$this->setRedirect(JRoute::_($redirectUri, false), $this->message, $this->messageType);
+
+		return $result;
+	}
 }


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

When we check in a category item we are always redirect to com_content categories after the checkin action, no matter in what category context we are.

We could be in com_contact, com_newsletters, com_banners, com_users, com_weblinks, com_content or third party extension categories. No matter where we are, if we checkin a category item, after the checkin action it always redirects to com_content categories.

This PR solves that bug.
#### Testing Instructions

Very simple test.
1. Use latest staging and go to Components -> Contacts -> Categories
2. Edit a category and DON'T save or close, use the browser back button.
3. In the contacts category list view you'll now have a checkin button. Press the button, you'll be redirected to com_content categories
4. Apply the patch and repeat the process. You are now redirected to com_contact categories as you should.

You can do similiar tests in other categories contexts if you want.
