### PR TITLE
Switch HHVM off of container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - INSTALL_REDIS="yes"
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.3
       env: INSTALL_APC="yes"
@@ -23,6 +24,18 @@ matrix:
     - php: 7.0
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # until the next update
+      addons:
+        apt:
+          packages:
+            - mysql-server-5.6
+            - mysql-client-core-5.6
+            - mysql-client-5.6
+      services:
+        - mysql
+        - postgresql
       env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: hhvm
@@ -36,8 +49,10 @@ before_script:
   # Make sure all dev dependencies are installed
   - composer install
   # Set up databases for testing
-  - mysql -e 'create database joomla_ut;'
-  - mysql joomla_ut < tests/unit/schema/mysql.sql
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql -e 'create database joomla_ut;'; fi
+  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < tests/unit/schema/mysql.sql; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root -e 'create database joomla_ut;'; fi
+  - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < tests/unit/schema/mysql.sql; fi
   - psql -c 'create database joomla_ut;' -U postgres
   - psql -d joomla_ut -a -f tests/unit/schema/postgresql.sql
   # Set up Apache


### PR DESCRIPTION
Pull Request for hhvm is out of date and segfaulting with phpunit Issue.
#### Summary of Changes

Use Trusty build for HHVM to get HHVM 3.13.1 which solves a segfault issue in the HHVM 3.6.x testing
use **fast finish** to let allow failures continue to run yet still report the completed required tests on time. ([trusty builds can be slow](https://github.com/travis-ci/travis-ci/issues/5980))

Note: although this get's us testing on a supported HHVM version and solved the segfault issue, there is still a `Fatal error: request has exceeded memory limit` issue with a test. This test error should not hold back accepting this PR.
#### Testing Instructions

Merge by code review
