### PR TITLE
[com_menus] items view: Remove extra th (HTML error)

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -62,8 +62,7 @@ $colSpan = ($assoc) ? 9 : 8;
 								<?php echo JHtml::_('searchtools.sort', '', 'a.lft', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
 							</th>
 						<?php endif; ?>
-						</th>
-						<th width="1%" class="center">
+						<th width="1%" class="nowrap center">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
 						<th width="1%" class="nowrap center">


### PR DESCRIPTION
#### Summary of Changes

There is an extra `th`tag in com_menus items view heading.
This PR removes it.
#### Testing Instructions

Check code difference.
