### PR TITLE
[Proposal] list views: Move ordering column to last

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -53,9 +53,6 @@ $assoc = JLanguageAssociations::isEnabled();
 			<table class="table table-striped" id="articleList">
 				<thead>
 					<tr>
-						<th width="1%" class="nowrap center hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', '', 'a.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
-						</th>
 						<th width="1%" class="center">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
@@ -89,6 +86,9 @@ $assoc = JLanguageAssociations::isEnabled();
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
+						<th width="1%" class="nowrap center hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', '', 'a.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-menu-2'); ?>
+						</th>
 					</tr>
 				</thead>
 				<tfoot>
@@ -108,25 +108,6 @@ $assoc = JLanguageAssociations::isEnabled();
 					$canChange  = $user->authorise('core.edit.state', 'com_content.article.' . $item->id) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
-						<td class="order nowrap center hidden-phone">
-							<?php
-							$iconClass = '';
-							if (!$canChange)
-							{
-								$iconClass = ' inactive';
-							}
-							elseif (!$saveOrder)
-							{
-								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
-							}
-							?>
-							<span class="sortable-handler<?php echo $iconClass ?>">
-								<span class="icon-menu"></span>
-							</span>
-							<?php if ($canChange && $saveOrder) : ?>
-								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
-							<?php endif; ?>
-						</td>
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 						</td>
@@ -203,6 +184,25 @@ $assoc = JLanguageAssociations::isEnabled();
 						</td>
 						<td class="hidden-phone">
 							<?php echo (int) $item->id; ?>
+						</td>
+						<td class="order nowrap center hidden-phone">
+							<?php
+							$iconClass = '';
+							if (!$canChange)
+							{
+								$iconClass = ' inactive';
+							}
+							elseif (!$saveOrder)
+							{
+								$iconClass = ' inactive tip-top hasTooltip" title="' . JHtml::tooltipText('JORDERINGDISABLED');
+							}
+							?>
+							<span class="sortable-handler<?php echo $iconClass ?>">
+								<span class="icon-menu"></span>
+							</span>
+							<?php if ($canChange && $saveOrder) : ?>
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+							<?php endif; ?>
 						</td>
 					</tr>
 					<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

This PR is a proposal to move the ordering column in all views to the last.

In this PR i make that simple change in com_content articles.

This would make:
- views more consistent (all list views start with checkbox, status and then item) - except the ones with ordering ...
- more easy to view what item we are draging
- IMO, ordering is not a primary action we need to do everytime . So it doesn't need that highlight (being the first column of the views). I find it rather confusing

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15020058/6dae0194-1218-11e6-88b0-95cbdd3bd171.png)

After

![image](https://cloud.githubusercontent.com/assets/9630530/15020034/5236dfe4-1218-11e6-9b83-43035fc2f795.png)
#### Testing Instructions
1. Apply patch
2. Go to Content -> Articles (check the ordering column)
3. Use the ordering drag before and after the patch.
#### Observations

If accepted i can make this change (and the ordering select box ordering change to) across all views.
