### PR TITLE
[com_config] text filters: Add chosen style

### DIFF
--- a/administrator/components/com_config/model/field/filters.php
+++ b/administrator/components/com_config/model/field/filters.php
@@ -86,7 +86,7 @@ class JFormFieldFilters extends JFormField
 			$html[] = '				<select'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_type]"'
 				. ' id="' . $this->id . $group->value . '_filter_type"'
-				. ' class="novalidate" data-chosen="true"'
+				. ' class="novalidate"'
 				. '>';
 			$html[] = '					<option value="BL"' . ($group_filter['filter_type'] == 'BL' ? ' selected="selected"' : '') . '>'
 				. JText::_('COM_CONFIG_FIELD_FILTERS_DEFAULT_BLACK_LIST') . '</option>';


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Chosen style disapeared from the the global config text filters select boxes in latest staging.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15024948/f053794c-122e-11e6-8a1f-0406d7d60705.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15024930/dedff370-122e-11e6-8185-f66d9327e883.png)
#### Testing Instructions
1. Apply patch
2. Go to Global config - text filters tab. check the styled select boxes.
