### PR TITLE
Tag blog layout (RFC)

### DIFF
--- a/components/com_contact/layouts/tagged_item/contact.php
+++ b/components/com_contact/layouts/tagged_item/contact.php
@@ -9,12 +9,13 @@
 
 defined('JPATH_BASE') or die;
 
-$item = $displayData['item'];
 JModelLegacy::addIncludePath('components/com_contact/models');
+
+$item    = $displayData['item'];
 $model   = JModelLegacy::getInstance('contact', 'ContactModel');
 $contact = $model->getItem($item->content_item_id);
+$lang    = JFactory::getLanguage()->load('com_contact');
 
-$lang = JFactory::getLanguage()->load('com_contact');
 ?>
 <h3>
 	<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
@@ -23,11 +24,11 @@ $lang = JFactory::getLanguage()->load('com_contact');
 </h3>
 <dl class="dl-horizontal">
 	<?php if ($contact->address) : ?>
-		<dt><?php echo JText::_('COM_CONTACT_ADDRESS') ?></dt>
+		<dt><?php echo JText::_('COM_CONTACT_ADDRESS'); ?></dt>
 		<dd><?php echo $contact->address; ?></dd>
 	<?php endif; ?>
 	<?php if ($contact->country) : ?>
-		<dt><?php echo JText::_('COM_CONTACT_COUNTRY') ?></dt>
+		<dt><?php echo JText::_('COM_CONTACT_COUNTRY'); ?></dt>
 		<dd><?php echo $contact->country; ?></dd>
 	<?php endif; ?>
 </dl>
@@ -35,4 +36,3 @@ $lang = JFactory::getLanguage()->load('com_contact');
 	<img src="<?php echo $item->core_images; ?>" class="ss-image pull-right img-polaroid">
 <?php endif; ?>
 <?php echo $item->core_body; ?>
-

--- a/components/com_contact/layouts/tagged_item/contact.php
+++ b/components/com_contact/layouts/tagged_item/contact.php
@@ -35,3 +35,4 @@ $lang = JFactory::getLanguage()->load('com_contact');
 	<img src="<?php echo $item->core_images; ?>" class="ss-image pull-right img-polaroid">
 <?php endif; ?>
 <?php echo $item->core_body; ?>
+

--- a/components/com_contact/layouts/tagged_item/contact.php
+++ b/components/com_contact/layouts/tagged_item/contact.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$item = $displayData['item'];
+JModelLegacy::addIncludePath('components/com_contact/models');
+$model   = JModelLegacy::getInstance('contact', 'ContactModel');
+$contact = $model->getItem($item->content_item_id);
+
+$lang = JFactory::getLanguage()->load('com_contact');
+?>
+<h3>
+	<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
+		<?php echo $this->escape($item->core_title); ?>
+	</a>
+</h3>
+<dl class="dl-horizontal">
+	<?php if ($contact->address) : ?>
+		<dt><?php echo JText::_('COM_CONTACT_ADDRESS') ?></dt>
+		<dd><?php echo $contact->address; ?></dd>
+	<?php endif; ?>
+	<?php if ($contact->country) : ?>
+		<dt><?php echo JText::_('COM_CONTACT_COUNTRY') ?></dt>
+		<dd><?php echo $contact->country; ?></dd>
+	<?php endif; ?>
+</dl>
+<?php if ($item->core_images) : ?>
+	<img src="<?php echo $item->core_images; ?>" class="ss-image pull-right img-polaroid">
+<?php endif; ?>
+<?php echo $item->core_body; ?>

--- a/components/com_tags/views/tag/tmpl/blog.php
+++ b/components/com_tags/views/tag/tmpl/blog.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_tags
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+?>
+<div class="tag-category<?php echo $this->pageclass_sfx; ?>">
+	<?php if ($this->params->get('show_page_heading')) : ?>
+		<h1><?php echo $this->escape($this->params->get('page_heading')); ?></h1>
+	<?php endif; ?>
+	<?php if ($this->params->get('show_tag_title', 1)) : ?>
+		<h2><?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?></h2>
+	<?php endif; ?>
+	<?php // We only show a tag description if there is a single tag. ?>
+	<?php if (count($this->item) == 1 and ($this->params->get('tag_list_show_tag_image', 1) or $this->params->get('tag_list_show_tag_description', 1))) : ?>
+		<div class="category-desc">
+			<?php $images = json_decode($this->item[0]->images); ?>
+			<?php if ($this->params->get('tag_list_show_tag_image', 1) == 1 and !empty($images->image_fulltext)) : ?>
+				<img src="<?php echo htmlspecialchars($images->image_fulltext); ?>">
+			<?php endif; ?>
+			<?php if ($this->params->get('tag_list_show_tag_description') == 1 and $this->item[0]->description) : ?>
+				<?php echo JHtml::_('content.prepare', $this->item[0]->description, '', 'com_tags.tag'); ?>
+			<?php endif; ?>
+			<div class="clr"></div>
+		</div>
+	<?php endif; ?>
+	<?php if ($this->params->get('tag_list_show_tag_description', 1) or $this->params->get('show_description_image', 1)) : ?>
+		<?php if ($this->params->get('show_description_image', 1) == 1 and $this->params->get('tag_list_image')) : ?>
+			<img src="<?php echo $this->params->get('tag_list_image'); ?>">
+		<?php endif; ?>
+		<?php if ($this->params->get('tag_list_description', '') > '') : ?>
+			<?php echo JHtml::_('content.prepare', $this->params->get('tag_list_description'), '', 'com_tags.tag'); ?>
+		<?php endif; ?>
+	<?php endif; ?>
+
+	<?php echo $this->loadTemplate('items'); ?>
+	<?php if (($this->params->def('show_pagination', 1) == 1 or ($this->params->get('show_pagination') == 2)) and ($this->pagination->get('pages.total') > 1)) : ?>
+		<div class="pagination">
+			<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+				<p class="counter pull-right"> <?php echo $this->pagination->getPagesCounter(); ?> </p>
+			<?php endif; ?>
+			<?php echo $this->pagination->getPagesLinks(); ?>
+		</div>
+	<?php endif; ?>
+</div>

--- a/components/com_tags/views/tag/tmpl/blog.xml
+++ b/components/com_tags/views/tag/tmpl/blog.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="com_tags_tag_view_blog_title" option="com_tags_tag_view_blog_option">
+		<help
+			key="JHELP_MENUS_MENU_ITEM_TAGS_ITEMS_LIST"
+		/>
+		<message>
+			<![CDATA[com_tags_tag_view_blog_desc]]>
+		</message>
+	</layout>
+
+	<!-- Add fields to the request variables for the layout. -->
+	<fields name="request">
+		<fieldset name="request">
+
+			<field
+				name="id"
+				type="tag"
+				label="COM_TAGS_FIELD_TAG_LABEL"
+				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
+				custom="deny"
+				required="true"
+				multiple="true"
+			/>
+
+			<field
+				name="types"
+				type="contenttype"
+				label="COM_TAGS_FIELD_TYPE_LABEL"
+				description="COM_TAGS_FIELD_TYPE_DESC"
+				multiple="true"
+			/>
+
+			<field
+				name="tag_list_language_filter"
+				type="contentlanguage"
+				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
+				description="COM_TAGS_FIELD_LANGUAGE_FILTER_DESC"
+				default=""
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="all">JALL</option>
+				<option value="current_language">JCURRENT</option>
+			</field>
+
+		</fieldset>
+	</fields>
+
+	<!-- Add fields to the parameters object for the layout. -->
+	<fields name="params">
+		<fieldset name="basic" label="COM_TAGS_OPTIONS">
+
+			<field
+				name="show_tag_title"
+				type="list"
+				label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
+				description="COM_TAGS_SHOW_TAG_TITLE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_show_tag_image"
+				type="list"
+				label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
+				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_show_tag_description"
+				type="list"
+				label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
+				description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_image"
+				type="media"
+				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
+				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
+			/>
+
+			<field
+				name="tag_list_description"
+				type="textarea"
+				class="inputbox"
+				label="COM_TAGS_SHOW_TAG_LIST_DESCRIPTION_LABEL"
+				description="COM_TAGS_TAG_LIST_DESCRIPTION_DESC"
+				rows="3"
+				cols="30"
+				filter="safehtml"
+			/>
+
+			<field
+				name="show_tag_num_items"
+				type="list"
+				label="COM_TAGS_NUMBER_TAG_ITEMS_LABEL"
+				description="COM_TAGS_NUMBER_TAG_ITEMS_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_orderby"
+				type="list"
+				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
+				description="JGLOBAL_FIELD_FIELD_ORDERING_DESC"
+				default=""
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="c.core_title">JGLOBAL_TITLE</option>
+				<option value="match_count">COM_TAGS_MATCH_COUNT</option>
+				<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
+				<option value="c.core_modified_time">JGLOBAL_MODIFIED_DATE</option>
+				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
+			</field>
+
+			<field
+				name="tag_list_orderby_direction"
+				type="list"
+				label="JGLOBAL_ORDER_DIRECTION_LABEL"
+				description="JGLOBAL_ORDER_DIRECTION_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="ASC">JGLOBAL_ORDER_ASCENDING</option>
+				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
+			</field>
+
+		</fieldset>
+
+		<fieldset name="advanced" label="COM_TAGS_ITEM_OPTIONS">
+
+			<field
+				name="spacer2"
+				type="spacer"
+				class="text"
+				label="COM_TAGS_SUBSLIDER_DRILL_TAG_LIST_LABEL"
+			/>
+
+			<field
+				name="tag_list_show_item_image"
+				type="list"
+				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"
+				description="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_show_item_description"
+				type="list"
+				label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
+				description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="tag_list_item_maximum_characters"
+				type="text"
+				filter="integer"
+				label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
+				description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
+			/>
+
+			<field
+				name="filter_field"
+				type="list"
+				default=""
+				label="JGLOBAL_FILTER_FIELD_LABEL"
+				description="JGLOBAL_FILTER_FIELD_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+		</fieldset>
+
+		<fieldset name="pagination" label="COM_TAGS_PAGINATION_OPTIONS">
+
+			<field
+				name="show_pagination_limit"
+				type="list"
+				label="JGLOBAL_DISPLAY_SELECT_LABEL"
+				description="JGLOBAL_DISPLAY_SELECT_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_pagination"
+				type="list"
+				label="JGLOBAL_PAGINATION_LABEL"
+				description="JGLOBAL_PAGINATION_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+				<option value="2">JGLOBAL_AUTO</option>
+			</field>
+
+			<field
+				name="show_pagination_results"
+				type="list"
+				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+				description="JGLOBAL_PAGINATION_RESULTS_DESC">
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+		</fieldset>
+
+		<fieldset name="selection" label="COM_TAGS_LIST_SELECTION_OPTIONS">
+
+			<field
+				name="return_any_or_all"
+				type="list"
+				label="COM_TAGS_SEARCH_TYPE_LABEL"
+				description="COM_TAGS_SEARCH_TYPE_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">COM_TAGS_ALL</option>
+				<option value="1">COM_TAGS_ANY</option>
+			</field>
+
+			<field
+				name="include_children"
+				type="list"
+				label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
+				description="COM_TAGS_INCLUDE_CHILDREN_DESC"
+				default=""
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">COM_TAGS_EXCLUDE</option>
+				<option value="1">COM_TAGS_INCLUDE</option>
+			</field>
+
+			<field
+				name="maximum"
+				type="text"
+				default="200"
+				filter="integer"
+				label="COM_TAGS_LIST_MAX_LABEL"
+				description="COM_TAGS_LIST_MAX_DESC">
+			</field>
+
+		</fieldset>
+
+		<fieldset name="integration">
+
+			<field
+				name="show_feed_link"
+				type="list"
+				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+				description="JGLOBAL_SHOW_FEED_LINK_DESC"
+			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+		</fieldset>
+	</fields>
+</metadata>

--- a/components/com_tags/views/tag/tmpl/blog_items.php
+++ b/components/com_tags/views/tag/tmpl/blog_items.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_tags
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$columns = 2;
+
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
+
+JFactory::getDocument()->addScriptDeclaration("
+		var resetFilter = function() {
+		document.getElementById('filter-search').value = '';
+	}
+");
+?>
+<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm"
+	  id="adminForm" class="form-inline">
+	<?php if ($this->params->get('show_headings') || $this->params->get('filter_field') || $this->params->get('show_pagination_limit')) : ?>
+		<fieldset class="filters btn-toolbar">
+			<?php if ($this->params->get('filter_field')) : ?>
+				<div class="btn-group">
+					<label class="filter-search-lbl element-invisible" for="filter-search">
+						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
+					</label>
+					<input type="text" name="filter-search" id="filter-search"
+						   value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox"
+						   onchange="document.getElementById('adminForm').submit();"
+						   title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>"
+						   placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>"/>
+					<button type="button" name="filter-search-button"
+							title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>"
+							onclick="document..getElementById('adminForm').submit();" class="btn">
+						<span class="icon-search"></span>
+					</button>
+					<button type="reset" name="filter-clear-button"
+							title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>" class="btn"
+							onclick="resetFilter(); document.getElementById('adminForm').submit();">
+						<span class="icon-remove"></span>
+					</button>
+				</div>
+			<?php endif; ?>
+			<?php if ($this->params->get('show_pagination_limit')) : ?>
+				<div class="btn-group pull-right">
+					<label for="limit" class="element-invisible">
+						<?php echo JText::_('JGLOBAL_DISPLAY_NUM'); ?>
+					</label>
+					<?php echo $this->pagination->getLimitBox(); ?>
+				</div>
+			<?php endif; ?>
+
+			<input type="hidden" name="filter_order" value=""/>
+			<input type="hidden" name="filter_order_Dir" value=""/>
+			<input type="hidden" name="limitstart" value=""/>
+			<input type="hidden" name="task" value=""/>
+			<div class="clearfix"></div>
+		</fieldset>
+	<?php endif; ?>
+
+	<?php if (!$this->items) : ?>
+		<p> <?php echo JText::_('COM_TAGS_NO_ITEMS'); ?></p>
+	<?php else : ?>
+		<?php $counter = 0; ?>
+		<?php foreach ($this->items as $i => $item) : ?>
+			<?php $rowcount = ((int) $i % (int) $columns) + 1; ?>
+			<?php $type_alias = explode('.', $item->type_alias); ?>
+			<?php if ($rowcount == 1) : ?>
+				<?php $row = $counter / $columns; ?>
+				<div class="items-row cols-<?php echo (int) $columns; ?> <?php echo 'row-' . $row; ?> row-fluid clearfix">
+			<?php endif; ?>
+			<div class="span<?php echo round((12 / $columns)); ?>">
+				<div
+					class="item column-<?php echo $rowcount; ?><?php echo $item->core_state == 0 ? ' system-unpublished' : ''; ?>">
+					<?php $layout = new JLayoutFile('tagged_item.' . $type_alias[1], null, array('component' => $type_alias[0])); ?>
+					<?php if (!$output = $layout->render(array('item' => $item))) : ?>
+						<?php $output = JLayoutHelper::render('joomla.content.tagged_item', array('item' => $item)); ?>
+					<?php endif; ?>
+					<?php echo $output; ?>
+				</div>
+				<?php $counter++; ?>
+			</div>
+			<?php if (($rowcount == $columns) or ($counter == count($this->items))) : ?>
+				</div>
+			<?php endif; ?>
+		<?php endforeach; ?>
+	<?php endif; ?>
+</form>

--- a/layouts/joomla/content/tagged_item.php
+++ b/layouts/joomla/content/tagged_item.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$item = $displayData['item'];
+?>
+<h3>
+	<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
+		<?php echo $this->escape($item->core_title); ?>
+	</a>
+</h3>
+<?php echo $item->core_body; ?>

--- a/layouts/joomla/content/tagged_item.php
+++ b/layouts/joomla/content/tagged_item.php
@@ -17,3 +17,4 @@ $item = $displayData['item'];
 	</a>
 </h3>
 <?php echo $item->core_body; ?>
+

--- a/layouts/joomla/content/tagged_item.php
+++ b/layouts/joomla/content/tagged_item.php
@@ -10,6 +10,7 @@
 defined('JPATH_BASE') or die;
 
 $item = $displayData['item'];
+
 ?>
 <h3>
 	<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
@@ -17,4 +18,3 @@ $item = $displayData['item'];
 	</a>
 </h3>
 <?php echo $item->core_body; ?>
-


### PR DESCRIPTION
This is a proof of concept PR based on a discussion in the Google Group (https://groups.google.com/d/msg/joomla-dev-cms/YVwuuNYHFUQ/hHs7_kaFAgAJ)
#### Summary of Changes

This PR would add a new layout to the tag view of com_tags which shows the items in a similar way the com_content blog layout does.
Since com_tags doesn't have all needed data for some extensions (like for com_contact) and since the various content types need different designs (eg a contact is different from an article) the layout uses content type specific JLayouts to render the items. If an extension doesn't provide a specific JLayout for its content type(s), a default fallback JLayout is used.
The JLayout for a contact will fetch the additional data using the components model. Imho, this isn't really nice from an architectural point of view but I don't see a simpler approach.
#### Testing Instructions

Create a new menu item for the new layout (currently untranslated, just take the ugly one) and tag content from various extensions (eg some contacts and articles) and see how they render.
#### Known issues

This PR is far from ready. Most menu parameters will not work and it is hardcoded to use two columns.
It is mainly meant to show how it could work and to open the discussion.
