### PR TITLE
[com_users] levels view: hide id rows on mobile

### DIFF
--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -57,7 +57,7 @@ if ($saveOrder)
 						<th>
 							<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_LEVEL_NAME', 'a.title', $listDirn, $listOrder); ?>
 						</th>
-						<th width="5%" class="nowrap hidden-phone">
+						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
 					</tr>
@@ -108,7 +108,7 @@ if ($saveOrder)
 								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>
 						</td>
-						<td>
+						<td class="hidden-phone">
 							<?php echo (int) $item->id; ?>
 						</td>
 					</tr>


### PR DESCRIPTION
#### Summary of Changes

The heading ID does no show on mobile, but it's rows are there, and they shouldn't.

![image](https://cloud.githubusercontent.com/assets/9630530/15030283/4b5c0b1e-1249-11e6-8a05-21bbcb164271.png)
#### Testing Instructions
1. Apply patch
2. Go to Users -> Access Levels on mobile view (reduce browser width) the Id column should not be there now.
