### PR TITLE
[com_redirect] links view: change purge icon to "X"

### DIFF
--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -143,7 +143,7 @@ class RedirectViewLinks extends JViewLegacy
 		}
 		elseif ($canDo->get('core.edit.state'))
 		{
-			JToolbarHelper::custom('links.purge', 'purge', 'purge', 'COM_REDIRECT_TOOLBAR_PURGE', false);
+			JToolbarHelper::custom('links.purge', 'delete', 'delete', 'COM_REDIRECT_TOOLBAR_PURGE', false);
 			JToolbarHelper::trash('links.trash');
 			JToolbarHelper::divider();
 		}


### PR DESCRIPTION
#### Summary of Changes

Purge is deleting permanently, so we should use the "X" not the trash can.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15030645/70bfdd8e-124b-11e6-84e9-a55e25cc3501.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15030636/59a4f0f8-124b-11e6-8118-514ef1cf2204.png)
#### Testing Instructions

Code review, or:
1. Apply patch
2. Go to Components -> Redirects and check the purge icon in the actions toolbar.
