### PR TITLE
[com_redirect] links view: do not show archived items by default

### DIFF
--- a/administrator/components/com_redirect/models/links.php
+++ b/administrator/components/com_redirect/models/links.php
@@ -149,7 +149,7 @@ class RedirectModelLinks extends JModelList
 		}
 		elseif ($state === '')
 		{
-			$query->where($db->quoteName('a.published') . ' IN (0,1,2)');
+			$query->where($db->quoteName('a.published') . ' IN (0,1)');
 		}
 
 		// Filter the items over the search string if set.


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Agains all other views, com_redirect list view is showing archived items by default.
All other views only show Published and Unpublished.
This PR corrects that.

![image](https://cloud.githubusercontent.com/assets/9630530/15030796/565e5afa-124c-11e6-92ff-2cf412458073.png)
#### Testing Instructions

Code review, or:
1. Apply patch
2. Go to Componets -> Redirects
3. Create an item and put it Archived status.
4. Check it doesn't appear in the list, except when selected "All" or "Archived" in the state filter.
