### PR TITLE
[com_finder] filters view: missing checkin button

### DIFF
--- a/administrator/components/com_finder/views/filters/view.html.php
+++ b/administrator/components/com_finder/views/filters/view.html.php
@@ -78,6 +78,7 @@ class FinderViewFilters extends JViewLegacy
 		{
 			JToolbarHelper::publishList('filters.publish');
 			JToolbarHelper::unpublishList('filters.unpublish');
+			JToolbarHelper::checkin('filters.checkin');
 			JToolbarHelper::divider();
 		}
 


### PR DESCRIPTION
#### Summary of Changes

The checkin toolbar button in com_finder filters button is missing.
This PR adds it.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15032169/2d93fd0a-1256-11e6-904d-a3634ebc0d34.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15032159/1a7d0dc4-1256-11e6-909d-85dc03860fb1.png)
#### Testing Instructions
1. Go to Smart Search -> Filters
2. Create a filter
3. Now edit it and don't save or close , use browser back button
4. You'll see the checkin button in the list view.
5. You'll also notice the Checkin button is not in action toolbar
6. Apply patch. The button is there.
