### PR TITLE
Incorrect DELETE query when using setLimit()

### DIFF
--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -43,9 +43,13 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
-		if ($limit > 0 || $offset > 0)
+		if ($limit > 0 && $offset > 0)
 		{
 			$query .= ' LIMIT ' . $offset . ', ' . $limit;
+		}
+		elseif ($limit > 0)
+		{
+			$query .= ' LIMIT ' . $limit;
 		}
 
 		return $query;


### PR DESCRIPTION
#### Issue

Using a delete() query:

``` php
$db     = JFactory::getDbo();
$query  = $db->getQuery(true);
$query->delete('#__session')
    ->where($db->qn('time').' < '.$db->q(JFactory::getDate()->modify('-30 days')->toUnix()))
    ->setLimit(1);

echo $query->dump();
```

Produces this:

``` sql
DELETE 
FROM kfdcs_session
WHERE `time` < '1459851698' LIMIT 0, 1
```

The query is incorrect - DELETE doesn't use an offset http://dev.mysql.com/doc/refman/5.7/en/delete.html
#### Summary of Changes

Because specifying an offset is optional in MySQL, `LIMIT 0, 1` is the equivalent of `LIMIT 1` so changing the `processLimit()` function shouldn't cause any issues with existing code. The output should now be:

``` sql
DELETE 
FROM kfdcs_session
WHERE `time` < '1459851698' LIMIT 1
```
#### Testing Instructions

Just use the above code to test - you can add it in a component (eg. open /administrator/components/com_content/content.php and add it after `defined('_JEXEC') or die;`. Going to Articles will show the query.

**Make sure no other SQL errors are present - pagination should still work, deleting items etc**
