### PR TITLE
[com_languages] Forgotten client_id filter

### DIFF
--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -326,7 +326,7 @@ class LanguagesModelInstalled extends JModelList
 		// Create a new db object.
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
-		$client = $this->getState('filter.client_id');
+		$client = $this->getState('client_id');
 		$type = "language";
 
 		// Select field element from the extensions table.


### PR DESCRIPTION
#### Summary of Changes

This changes a forgotten `filter.client_id` to `client_id`(the view selector).
#### Testing Instructions

Code review.
#### Observations

That i know of, this is not used in the core, but the way it is, this would not work properly if the selected client is "Administrator", because the `filter.client_id` state, since it doesn't exist, would always be 0.

Pinging @infograf768 
