### PR TITLE
Fix for "one word aliases of categories treated as articles" with adv…

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -330,63 +330,63 @@ class ContentRouter extends JComponentRouterBase
 		}
 
 		/*
-		 * If there is only one segment, then it points to either an article or a category.
-		 * We test it first to see if it is a category.  If the id and alias match a category,
-		 * then we assume it is a category.  If they don't we assume it is an article
-		 */
-		if ($count == 1)
-		{
-			// We check to see if an alias is given.  If not, we assume it is an article
-			if (strpos($segments[0], ':') === false)
-			{
-				$vars['view'] = 'article';
-				$vars['id'] = (int) $segments[0];
-
-				return $vars;
-			}
-
-			list($id, $alias) = explode(':', $segments[0], 2);
-
-			// First we check if it is a category
-			$category = JCategories::getInstance('Content')->get($id);
-
-			if ($category && $category->alias == $alias)
-			{
-				$vars['view'] = 'category';
-				$vars['id'] = $id;
-
-				return $vars;
-			}
-			else
-			{
-				$query = $db->getQuery(true)
-					->select($db->quoteName(array('alias', 'catid')))
-					->from($db->quoteName('#__content'))
-					->where($db->quoteName('id') . ' = ' . (int) $id);
-				$db->setQuery($query);
-				$article = $db->loadObject();
-
-				if ($article)
-				{
-					if ($article->alias == $alias)
-					{
-						$vars['view'] = 'article';
-						$vars['catid'] = (int) $article->catid;
-						$vars['id'] = (int) $id;
-
-						return $vars;
-					}
-				}
-			}
-		}
-
-		/*
 		 * If there was more than one segment, then we can determine where the URL points to
 		 * because the first segment will have the target category id prepended to it.  If the
 		 * last segment has a number prepended, it is an article, otherwise, it is a category.
 		 */
 		if (!$advanced)
 		{
+			/*
+			 * If there is only one segment, then it points to either an article or a category.
+			 * We test it first to see if it is a category.  If the id and alias match a category,
+			 * then we assume it is a category.  If they don't we assume it is an article
+			 */
+			if ($count == 1)
+			{
+				// We check to see if an alias is given.  If not, we assume it is an article
+				if (strpos($segments[0], ':') === false)
+				{
+					$vars['view'] = 'article';
+					$vars['id'] = (int) $segments[0];
+
+					return $vars;
+				}
+
+				list($id, $alias) = explode(':', $segments[0], 2);
+
+				// First we check if it is a category
+				$category = JCategories::getInstance('Content')->get($id);
+
+				if ($category && $category->alias == $alias)
+				{
+					$vars['view'] = 'category';
+					$vars['id'] = $id;
+
+					return $vars;
+				}
+				else
+				{
+					$query = $db->getQuery(true)
+						->select($db->quoteName(array('alias', 'catid')))
+						->from($db->quoteName('#__content'))
+						->where($db->quoteName('id') . ' = ' . (int) $id);
+					$db->setQuery($query);
+					$article = $db->loadObject();
+
+					if ($article)
+					{
+						if ($article->alias == $alias)
+						{
+							$vars['view'] = 'article';
+							$vars['catid'] = (int) $article->catid;
+							$vars['id'] = (int) $id;
+
+							return $vars;
+						}
+					}
+				}
+			}
+		
 			$cat_id = (int) $segments[0];
 
 			$article_id = (int) $segments[$count - 1];

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -329,6 +329,11 @@ class ContentRouter extends JComponentRouterBase
 			return $vars;
 		}
 
+		/*
+		 * If there was more than one segment, then we can determine where the URL points to
+		 * because the first segment will have the target category id prepended to it.  If the
+		 * last segment has a number prepended, it is an article, otherwise, it is a category.
+		 */
 		if (!$advanced)
 		{
 			/*
@@ -381,13 +386,7 @@ class ContentRouter extends JComponentRouterBase
 					}
 				}
 			}
-			
-			/*
-			 * If there was more than one segment, then we can determine where the URL points to
-			 * because the first segment will have the target category id prepended to it.  If the
-			 * last segment has a number prepended, it is an article, otherwise, it is a category.
-			 */
-			 
+
 			$cat_id = (int) $segments[0];
 
 			$article_id = (int) $segments[$count - 1];

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -381,12 +381,13 @@ class ContentRouter extends JComponentRouterBase
 					}
 				}
 			}
-
+			
 			/*
 			 * If there was more than one segment, then we can determine where the URL points to
 			 * because the first segment will have the target category id prepended to it.  If the
 			 * last segment has a number prepended, it is an article, otherwise, it is a category.
 			 */
+			 
 			$cat_id = (int) $segments[0];
 
 			$article_id = (int) $segments[$count - 1];

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -329,11 +329,6 @@ class ContentRouter extends JComponentRouterBase
 			return $vars;
 		}
 
-		/*
-		 * If there was more than one segment, then we can determine where the URL points to
-		 * because the first segment will have the target category id prepended to it.  If the
-		 * last segment has a number prepended, it is an article, otherwise, it is a category.
-		 */
 		if (!$advanced)
 		{
 			/*
@@ -386,7 +381,12 @@ class ContentRouter extends JComponentRouterBase
 					}
 				}
 			}
-		
+
+			/*
+			 * If there was more than one segment, then we can determine where the URL points to
+			 * because the first segment will have the target category id prepended to it.  If the
+			 * last segment has a number prepended, it is an article, otherwise, it is a category.
+			 */
 			$cat_id = (int) $segments[0];
 
 			$article_id = (int) $segments[$count - 1];

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -386,7 +386,7 @@ class ContentRouter extends JComponentRouterBase
 					}
 				}
 			}
-		
+
 			$cat_id = (int) $segments[0];
 
 			$article_id = (int) $segments[$count - 1];

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -86,7 +86,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		}
 
 		// Attempt to connect to the server.
-		if (!($this->connection = @ mysql_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
+		if (!($this->connection = @ mysqli_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
 		{
 			throw new RuntimeException('Could not connect to MySQL.');
 		}

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -86,7 +86,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		}
 
 		// Attempt to connect to the server.
-		if (!($this->connection = @ mysqli_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
+		if (!($this->connection = @ mysql_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
 		{
 			throw new RuntimeException('Could not connect to MySQL.');
 		}


### PR DESCRIPTION
#### Summary of Changes

Include advanced SEF enabled check
#### Testing Instructions

Enable advanced SEF
Create Category
Create Sub-category (one word alias)
Create article in sub-category

Link menu Item to Category
#### Bug result

Category can be accessed
Article in sub-category can be accessed
Sub-category can't be accessed because it treated as article(while having one word alias) and article not found
#### Fix result

Category can be accessed
Sub-category can be accessed
Articles of all levels can be accessed
