### PR TITLE
[com_finder] filter view (new/edit): Use language title in language subbranch

### DIFF
--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -56,6 +56,35 @@ class FinderHelperLanguage
 	}
 
 	/**
+	 * Method to return the language name for a language taxonomy branch.
+	 *
+	 * @param   string  $branchName  Branch name.
+	 *
+	 * @return  string  The language title.
+	 *
+	 * @since   3.6.0
+	 */
+	public static function branchLanguageTitle($branchName)
+	{
+		$title = $branchName;
+
+		if ($branchName == '*')
+		{
+			$title = JText::_('JALL_LANGUAGE');
+		}
+		else
+		{
+			$languages = JLanguageHelper::getLanguages('lang_code');
+			if (isset($languages[$branchName]))
+			{
+				$title = $languages[$branchName]->title;
+			}
+		}
+
+		return $title;
+	}
+
+	/**
 	 * Method to load Smart Search component language file.
 	 *
 	 * @return  void

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -80,8 +80,6 @@ abstract class JHtmlFilter
 			->where('t.parent_id = 1')
 			->where('t.state = 1')
 			->where('t.access IN (' . $groups . ')')
-			->where('c.state = 1')
-			->where('c.access IN (' . $groups . ')')
 			->group('t.id, t.parent_id, t.state, t.access, t.ordering, t.title, c.parent_id')
 			->order('t.ordering, t.title');
 
@@ -134,6 +132,10 @@ abstract class JHtmlFilter
 				->where('t.access IN (' . $groups . ')')
 				->order('t.ordering, t.title');
 
+			// Self-join to get the parent title.
+			$query->select('e.title AS parent_title')
+				->join('LEFT', $db->quoteName('#__finder_taxonomy', 'e') . ' ON ' . $db->quoteName('e.id') . ' = ' . $db->quoteName('t.parent_id'));
+
 			// Load the branches.
 			$db->setQuery($query);
 
@@ -150,11 +152,16 @@ abstract class JHtmlFilter
 			$lang = JFactory::getLanguage();
 			foreach ($nodes as $nk => $nv)
 			{
-				$key = FinderHelperLanguage::branchPlural($nv->title);
-				if ($lang->hasKey($key))
+				if (trim($nv->parent_title, '**') == 'Language')
 				{
-					$nodes[$nk]->title = JText::_($key);
+					$title = FinderHelperLanguage::branchLanguageTitle($nv->title);
 				}
+				else
+				{
+					$key = FinderHelperLanguage::branchPlural($nv->title);
+					$title = $lang->hasKey($key) ? JText::_($key) : $nv->title;
+				}
+				$nodes[$nk]->title = $title;
 			}
 
 			// Adding slides


### PR DESCRIPTION
#### Summary of Changes

As done in https://github.com/joomla/joomla-cms/pull/10266 for the content maps list, this PR adds the language title (instead of code and *) to the new/edit filter view.

Also removed some duplicated query instructions.
##### Before Patch

![image](https://cloud.githubusercontent.com/assets/9630530/15087140/00c5cc2a-13de-11e6-9ede-134c4b3eaecd.png)
##### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/15087144/192efc3c-13de-11e6-8dfd-1c3747a8f421.png)
#### Testing Instructions

Note that for this test you have to have index in the Smart Search (com_finder) in multiple langauges and the system language plugin disabled.
1. Apply patch
2. Check the Language subbranches in Components -> Smart Search -> Search Filter, and then the "New" button

The languages titles should be exactly the same you have in Extensions -> Languages -> Content Languages.
