### PR TITLE
Allow users to pass in a custom color for background fill

### DIFF
--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -432,7 +432,9 @@ class JImage
 		if ($this->isTransparent())
 		{
 			// Get the transparent color values for the current image.
-			$rgba  = $this->getColorForIndex($this->handle);
+			// $rgba  = $this->getColorForIndex($this->handle);
+			// FIXME: Discuss whether a desired fillColor should go over transparency?
+			$rgba  = &$fillColor;
 			$color = imagecolorallocatealpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 
 			// Set the transparent color values for the new image.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1232,6 +1232,20 @@ class JImage
 	}
 
 	/**
+	 * Method to get the type of image currently loaded.
+	 *
+	 * @return  int  The image type (IMAGETYPE_GIF, IMAGETYPE_JPEG, etc.)
+	 *
+	 * @since   11.3
+	 *
+	 * @see     http://php.net/manual/de/function.imagetypes.php
+	 */
+	public function getType()
+	{
+		return $this->type;
+	}
+
+	/**
 	 * Method to set the background fill color to use for non-transparent images.
 	 *
 	 * @param   array  $color  The RGBA values defining the color to use for background fill
@@ -1264,6 +1278,23 @@ class JImage
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Method to get the background fill color.
+	 *
+	 * @return  array  The RGBA values defining the color to use for background fill
+	 *
+	 * @since   11.3
+	 */
+	public function getFillColor()
+	{
+		if (!isset($this->fillColor))
+		{
+			$this->setFillColor(array());
+		}
+
+		return $this->fillColor;
 	}
 
 	/**
@@ -1324,23 +1355,6 @@ class JImage
 	}
 
 	/**
-	 * Method to get the background fill color.
-	 *
-	 * @return  array  The RGBA values defining the color to use for background fill
-	 *
-	 * @since   11.3
-	 */
-	public function getFillColor()
-	{
-		if (!isset($this->fillColor))
-		{
-			$this->setFillColor(array());
-		}
-
-		return $this->fillColor;
-	}
-
-	/**
 	 * Method to ensure the color index for a given resource is within valid range.
 	 *
 	 * Under some circumstance attempting calling {@link imagecolorsforindex()} on a GIF image
@@ -1391,19 +1405,5 @@ class JImage
 		}
 
 		return $rgba;
-	}
-
-	/**
-	 * Method to get the type of image currently loaded.
-	 *
-	 * @return  int  The image type (IMAGETYPE_GIF, IMAGETYPE_JPEG, etc.)
-	 *
-	 * @since   11.3
-	 *
-	 * @see     http://php.net/manual/de/function.imagetypes.php
-	 */
-	public function getType()
-	{
-		return $this->type;
 	}
 }

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1254,7 +1254,7 @@ class JImage
 			'red'   => 0,
 			'green' => 0,
 			'blue'  => 0,
-			'alpha' => 127
+			'alpha' => 0
 		);
 
 		// If custom color definition has been passed, replace default color.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -432,8 +432,9 @@ class JImage
 		if ($this->isTransparent())
 		{
 			// Get the transparent color values for the current image.
-			// $rgba  = $this->getColorForIndex($this->handle);
-			// FIXME: Discuss whether a desired fillColor should go over transparency?
+			//$rgba  = $this->getColorForIndex($this->handle);
+
+			// FIXME: Consider there's a desired fillColor - shouldn't this goes over transparency?
 			$rgba  = &$fillColor;
 			$color = imagecolorallocatealpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -140,7 +140,7 @@ class JImage
 			$this->loadFile($source);
 		}
 
-		// NEW - Init background fill color with default color 'black'.
+		// Init background fill color with default color 'black'.
 		if (is_null($this->fillColor) || (is_array($this->fillColor) && count($this->fillColor !== 4)))
 		{
 			$this->getFillColor();
@@ -432,7 +432,6 @@ class JImage
 		if ($this->isTransparent())
 		{
 			// Get the transparent color values for the current image.
-			// MOD: Fetch rgba data from new function ensuring the calculation is color range safe.
 			$rgba  = $this->getColorForIndex($this->handle);
 			$color = imageColorAllocateAlpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 
@@ -610,7 +609,7 @@ class JImage
 		// Get the image properties.
 		$properties = self::getImageFileProperties($path);
 
-		// NEW: Prepare background fill color.
+		// Prepare background fill color.
 		$fillColor  = $this->getFillColor();
 
 		// Attempt to load the image based on the MIME-Type
@@ -640,7 +639,7 @@ class JImage
 
 				$this->handle = $handle;
 
-				// NEW
+				// Keep track of image type. This information is required.
 				$this->type = IMAGETYPE_GIF;
 				break;
 
@@ -668,7 +667,7 @@ class JImage
 
 				$this->handle = $handle;
 
-				// NEW
+				// Keep track of image type. This information is required.
 				$this->type = IMAGETYPE_JPEG;
 				break;
 
@@ -700,13 +699,12 @@ class JImage
 				if (!$this->isTransparent())
 				{
 					// Assign to black which is default for transparent PNGs
-					// MOD: Replace hardcoded 0 by configured fillColor value
 					$background = imagecolorAllocateAlpha($handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
 
 					imageColorTransparent($handle, $background);
 				}
 
-				// NEW
+				// Keep track of image type. This information is required.
 				$this->type = IMAGETYPE_PNG;
 				break;
 
@@ -755,7 +753,7 @@ class JImage
 		$offset    = new stdClass;
 		$offset->x = $offset->y = 0;
 
-		// NEW: Prepare background fill color.
+		// Prepare background fill color.
 		$fillColor = $this->getFillColor();
 
 		// Center image if needed and create the new truecolor image handle.
@@ -771,7 +769,6 @@ class JImage
 			if (!$this->isTransparent())
 			{
 				// Assign to black which is default for transparent PNGs
-				// MOD: Replace hardcoded 0 by configured fillColor value
 				$background = imagecolorAllocateAlpha($this->handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
 
 				imagecolorTransparent($this->handle, $background);
@@ -789,7 +786,6 @@ class JImage
 		if ($this->isTransparent())
 		{
 			// Get the transparent color values for the current image.
-			// MOD: Fetch rgba data from new function ensuring the calculation is color range safe.
 			$rgba  = $this->getColorForIndex($this->handle);
 			$color = imageColorAllocateAlpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 
@@ -1018,27 +1014,27 @@ class JImage
 			throw new LogicException('No valid image was loaded.');
 		}
 
-		// NEW: Ensure a passed in quality factor is within the valid range (0-100 for JPEG, but 0-9 for GIF and PNG).
+		// Ensure a passed in quality factor is within the valid range (0-100 for JPEG, but 0-9 for GIF and PNG).
+		// This is not something everybody knows. So we must take care of it.
 		$q = array_key_exists('quality', $options) ? (int) $options['quality'] : 100;
 
 		switch ($type)
 		{
 			case IMAGETYPE_GIF:
-				// NEW: Adjust quality factor for this specific image type.
+				// Adjust quality factor for this specific image type.
 				$q = $q >= 9 ? 9 : $q;
 				return imagegif($this->handle, $path);
 				break;
 
 			case IMAGETYPE_PNG:
-				// NEW: Adjust quality factor for this specific image type.
+				// Adjust quality factor for this specific image type.
 				$q = $q >= 9 ? 9 : $q;
-				// return imagepng($this->handle, $path, (array_key_exists('quality', $options)) ? $options['quality'] : 0);
 				return imagepng($this->handle, $path, $q);
 				break;
 
 			case IMAGETYPE_JPEG:
 			default:
-				// NEW: Adjust quality factor for this specific image type.
+				// Adjust quality factor for this specific image type.
 				$q = $q >= 100 ? 100 : $q;
 				return imagejpeg($this->handle, $path, $q);
 		}

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1285,26 +1285,30 @@ class JImage
 		}
 
 		// Sanitize color values.
-		array_walk($color, function(&$val) {
-			$val = (int) $val;
-		}
+		array_walk(
+			$color,
+			function(&$val) {
+				$val = (int) $val;
+			}
 		);
 
 		// Ensure passed in values are valid
-		$color = array_filter($color, function(&$val, $key) use(&$defaultColor) {
-			if ($key === 'alpha')
-			{
-				$val = $val > 127 ? 127 : $val;
-			}
-			else
-			{
-				$val = $val > 255 ? 255 : $val;
-			}
+		$color = array_filter(
+			$color,
+			function(&$val, $key) use(&$defaultColor) {
+				if ($key === 'alpha')
+				{
+					$val = $val > 127 ? 127 : $val;
+				}
+				else
+				{
+					$val = $val > 255 ? 255 : $val;
+				}
 
-			return true;
+				return true;
 
-		},
-		ARRAY_FILTER_USE_BOTH
+			},
+			ARRAY_FILTER_USE_BOTH
 		);
 
 		// Fill up missing values from the default color.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -71,7 +71,7 @@ class JImage
 	const ORIENTATION_SQUARE = 'square';
 
 	/**
-	 * @var    string  The image type (jpeg, png, gif, etc).
+	 * @var    int  The image type (IMAGETYPE_GIF, IMAGETYPE_JPEG, etc.)
 	 * @since  11.3
 	 */
 	protected $type = null;
@@ -433,10 +433,10 @@ class JImage
 		{
 			// Get the transparent color values for the current image.
 			$rgba  = $this->getColorForIndex($this->handle);
-			$color = imageColorAllocateAlpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
+			$color = imagecolorallocatealpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 
 			// Set the transparent color values for the new image.
-			imageColorTransparent($handle, $color);
+			imagecolortransparent($handle, $color);
 			imagefill($handle, 0, 0, $color);
 
 			imagecopyresized($handle, $this->handle, 0, 0, $left, $top, $width, $height, $width, $height);
@@ -581,7 +581,7 @@ class JImage
 			throw new LogicException('No valid image was loaded.');
 		}
 
-		return (imageColorTransparent($this->handle) >= 0);
+		return (imagecolortransparent($this->handle) >= 0);
 	}
 
 	/**
@@ -701,7 +701,7 @@ class JImage
 					// Assign to black which is default for transparent PNGs
 					$background = imagecolorAllocateAlpha($handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
 
-					imageColorTransparent($handle, $background);
+					imagecolortransparent($handle, $background);
 				}
 
 				// Keep track of image type. This information is required.
@@ -787,10 +787,10 @@ class JImage
 		{
 			// Get the transparent color values for the current image.
 			$rgba  = $this->getColorForIndex($this->handle);
-			$color = imageColorAllocateAlpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
+			$color = imagecolorallocatealpha($handle, $rgba['red'], $rgba['green'], $rgba['blue'], $rgba['alpha']);
 
 			// Set the transparent color values for the new image.
-			imageColorTransparent($handle, $color);
+			imagecolortransparent($handle, $color);
 			imagefill($handle, 0, 0, $color);
 
 			imagecopyresized(
@@ -1343,7 +1343,7 @@ class JImage
 	/**
 	 * Method to ensure the color index for a given resource is within valid range.
 	 *
-	 * Under some circumstance attempting calling {@link imageColorsForIndex()} on a GIF image
+	 * Under some circumstance attempting calling {@link imagecolorsforindex()} on a GIF image
 	 * fails causing a 'Color index out of range' error to be thrown.  This method circumvents
 	 * that issue because the native implementation doesn't check and catch it.
 	 *
@@ -1364,15 +1364,15 @@ class JImage
 			throw InvalidArgumentException('Argument must be a valid resource handle.');
 		}
 
-		$transparency = imageColorTransparent($resource);
-		$palletsize   = imageColorsTotal($resource);
+		$transparency = imagecolortransparent($resource);
+		$palletsize   = imagecolorstotal($resource);
 
 		if (($this->type === IMAGETYPE_GIF) || ($this->type === IMAGETYPE_PNG))
 		{
 			// Transparency is within valid range.
 			if ($transparency >= 0 && $transparency < $palletsize)
 			{
-				$rgba = imageColorsForIndex($resource, $transparency);
+				$rgba = imagecolorsforindex($resource, $transparency);
 			}
 			// Transparency is outside valid range - assign maximum.
 			else
@@ -1387,9 +1387,23 @@ class JImage
 		}
 		else
 		{
-			$rgba = imageColorsForIndex($resource, $transparency);
+			$rgba = imagecolorsforindex($resource, $transparency);
 		}
 
 		return $rgba;
+	}
+
+	/**
+	 * Method to get the type of image currently loaded.
+	 *
+	 * @return  int  The image type (IMAGETYPE_GIF, IMAGETYPE_JPEG, etc.)
+	 *
+	 * @since   11.3
+	 *
+	 * @see     http://php.net/manual/de/function.imagetypes.php
+	 */
+	public function getType()
+	{
+		return $this->type;
 	}
 }

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1274,7 +1274,7 @@ class JImage
 		// If custom color definition has been passed, replace default color.
 		if (count($color))
 		{
-			$this->fillColor = $this->fixFillColor($color);
+			$this->fillColor = $this->sanitizeFillColor($color);
 		}
 
 		return $this;
@@ -1306,7 +1306,7 @@ class JImage
 	 *
 	 * @since   11.3
 	 */
-	protected function fixFillColor($color = array())
+	protected function sanitizeFillColor($color = array())
 	{
 		if (!count($color))
 		{

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -70,13 +70,13 @@ class JImage
 	 */
 	const ORIENTATION_SQUARE = 'square';
 
-	/** NEW
+	/**
 	 * @var    string  The image type (jpeg, png, gif, etc).
 	 * @since  11.3
 	 */
 	protected $type = null;
 
-	/** NEW
+	/**
 	 * @var    array  The red, green and blue values for the background fill color
 	 * @since  11.3
 	 */
@@ -100,7 +100,7 @@ class JImage
 	 */
 	protected static $formats = array();
 
-	/** MOD
+	/**
 	 * Class constructor.
 	 *
 	 * @param   mixed  $source  Either a file path for a source image or a GD resource handler for an image.
@@ -376,7 +376,7 @@ class JImage
 		return $thumbsCreated;
 	}
 
-	/** MOD
+	/**
 	 * Method to crop the current image.
 	 *
 	 * @param   mixed    $width      The width of the image section to crop in pixels or a percentage.
@@ -584,7 +584,7 @@ class JImage
 		return (imageColorTransparent($this->handle) >= 0);
 	}
 
-	/** MOD - STEP 1
+	/**
 	 * Method to load a file into the JImage object as the resource.
 	 *
 	 * @param   string  $path  The filesystem path to load as an image.
@@ -718,7 +718,7 @@ class JImage
 		$this->path = $path;
 	}
 
-	/** MOD - STEP 1
+	/**
 	 * Method to resize the current image.
 	 *
 	 * @param   mixed    $width        The width of the resized image in pixels or a percentage.
@@ -876,7 +876,7 @@ class JImage
 		return $this->resize($resizewidth, $resizeheight, $createNew)->crop($width, $height, null, null, false);
 	}
 
-	/** MOD
+	/**
 	 * Method to rotate the current image.
 	 *
 	 * @param   mixed    $angle       The angle of rotation for the image
@@ -993,7 +993,7 @@ class JImage
 		return $this;
 	}
 
-	/** MOD - STEP 3
+	/**
 	 * Method to write the current image out to a file.
 	 *
 	 * @param   string   $path     The filesystem path to save the image.
@@ -1233,7 +1233,7 @@ class JImage
 		$this->destroy();
 	}
 
-	/** NEW
+	/**
 	 * Method to set the background fill color to use for non-transparent images.
 	 *
 	 * @param   array   $color   The RGBA values defining the color to use for background fill
@@ -1268,7 +1268,7 @@ class JImage
 		return $this;
 	}
 
-	/** NEW
+	/**
 	 * Method to properly set a passed background fill color.
 	 *
 	 * @param   array   The RGBA values defining the color to use fix
@@ -1320,7 +1320,7 @@ class JImage
 		return $color;
 	}
 
-	/** NEW
+	/**
 	 * Method to get the background fill color.
 	 *
 	 * @return  array   The RGBA values defining the color to use for background fill
@@ -1337,7 +1337,7 @@ class JImage
 		return $this->fillColor;
 	}
 
-	/** NEW
+	/**
 	 * Method to ensure the color index for a given resource is within valid range.
 	 *
 	 * Under some circumstance attempting calling {@link imageColorsForIndex()} on a GIF image

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -432,7 +432,7 @@ class JImage
 		if ($this->isTransparent())
 		{
 			// Get the transparent color values for the current image.
-			//$rgba  = $this->getColorForIndex($this->handle);
+			// $rgba  = $this->getColorForIndex($this->handle);
 
 			// FIXME: Consider there's a desired fillColor - shouldn't this goes over transparency?
 			$rgba  = &$fillColor;

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1021,14 +1021,12 @@ class JImage
 		switch ($type)
 		{
 			case IMAGETYPE_GIF:
-				// Adjust quality factor for this specific image type.
-				$q = $q >= 9 ? 9 : $q;
 				return imagegif($this->handle, $path);
 				break;
 
 			case IMAGETYPE_PNG:
 				// Adjust quality factor for this specific image type.
-				$q = $q >= 9 ? 9 : $q;
+				$q = $q >= 9 ? 0 : $q;
 				return imagepng($this->handle, $path, $q);
 				break;
 
@@ -1277,7 +1275,7 @@ class JImage
 	 *
 	 * @since   11.3
 	 */
-	public function fixFillColor($color = array())
+	protected function fixFillColor($color = array())
 	{
 		if (!count($color))
 		{
@@ -1359,7 +1357,7 @@ class JImage
 	 *
 	 * @see     http://stackoverflow.com/q/3874533
 	 */
-	public function getColorForIndex($resource = null)
+	protected function getColorForIndex($resource = null)
 	{
 		if (!is_resource($resource))
 		{

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -699,7 +699,7 @@ class JImage
 				if (!$this->isTransparent())
 				{
 					// Assign to black which is default for transparent PNGs
-					$background = imagecolorAllocateAlpha($handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
+					$background = imagecolorallocatealpha($handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
 
 					imagecolortransparent($handle, $background);
 				}
@@ -769,7 +769,7 @@ class JImage
 			if (!$this->isTransparent())
 			{
 				// Assign to black which is default for transparent PNGs
-				$background = imagecolorAllocateAlpha($this->handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
+				$background = imagecolorallocatealpha($this->handle, $fillColor['red'], $fillColor['green'], $fillColor['blue'], $fillColor['alpha']);
 
 				imagecolorTransparent($this->handle, $background);
 			}
@@ -910,7 +910,7 @@ class JImage
 			imagealphablending($handle, false);
 			imagesavealpha($handle, true);
 
-			$background = imagecolorAllocateAlpha($handle, 0, 0, 0, 127);
+			$background = imagecolorallocatealpha($handle, 0, 0, 0, 127);
 		}
 
 		// Copy the image

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -1236,11 +1236,11 @@ class JImage
 	/**
 	 * Method to set the background fill color to use for non-transparent images.
 	 *
-	 * @param   array   $color   The RGBA values defining the color to use for background fill
+	 * @param   array  $color  The RGBA values defining the color to use for background fill
 	 *
 	 * @return  JImage
 	 *
-	 * @throws  InvalidArgumentException   If argument is not an array
+	 * @throws  InvalidArgumentException  If argument is not an array
 	 *
 	 * @since   11.3
 	 */
@@ -1271,9 +1271,9 @@ class JImage
 	/**
 	 * Method to properly set a passed background fill color.
 	 *
-	 * @param   array   The RGBA values defining the color to use fix
+	 * @param   array  $color  The RGBA values defining the color to use fix
 	 *
-	 * @return  array   The fixed RGBA values defining the color to use as background fill color
+	 * @return  array  The fixed RGBA values defining the color to use as background fill color
 	 *
 	 * @since   11.3
 	 */
@@ -1285,14 +1285,13 @@ class JImage
 		}
 
 		// Sanitize color values.
-		array_walk($color, function(&$val)
-		{
+		array_walk($color, function(&$val) {
 			$val = (int) $val;
-		});
+		}
+		);
 
 		// Ensure passed in values are valid
-		$color = array_filter($color, function(&$val, $key) use(&$defaultColor)
-		{
+		$color = array_filter($color, function(&$val, $key) use(&$defaultColor) {
 			if ($key === 'alpha')
 			{
 				$val = $val > 127 ? 127 : $val;
@@ -1304,7 +1303,9 @@ class JImage
 
 			return true;
 
-		}, ARRAY_FILTER_USE_BOTH);
+		},
+		ARRAY_FILTER_USE_BOTH
+		);
 
 		// Fill up missing values from the default color.
 		if (count($color) < 4)
@@ -1323,7 +1324,7 @@ class JImage
 	/**
 	 * Method to get the background fill color.
 	 *
-	 * @return  array   The RGBA values defining the color to use for background fill
+	 * @return  array  The RGBA values defining the color to use for background fill
 	 *
 	 * @since   11.3
 	 */
@@ -1344,11 +1345,11 @@ class JImage
 	 * fails causing a 'Color index out of range' error to be thrown.  This method circumvents
 	 * that issue because the native implementation doesn't check and catch it.
 	 *
-	 * @param   array   An image resource handle
+	 * @param   array  $resource  An image resource handle
 	 *
-	 * @return  array   The fixed RGBA values defining the color to use as background fill color
+	 * @return  array  The fixed RGBA values defining the color to use as background fill color
 	 *
-	 * @throws  InvalidArgumentException   If argument is not a valid resource handle
+	 * @throws  InvalidArgumentException  If argument is not a valid resource handle
 	 *
 	 * @since   11.3
 	 *

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -699,7 +699,7 @@ class JImage
 
 			// Ensure passed in values are valid
 			$color = array_filter(
-				$color, 
+				$color,
 				function(&$value, $i) use(&$defaultColor)
 				{
 					if ($i === 3)
@@ -710,7 +710,7 @@ class JImage
 					{
 						$value = $value > 255 ? 255 : $value;
 					}
-	
+
 					return true;
 				},
 				ARRAY_FILTER_USE_BOTH

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -698,20 +698,22 @@ class JImage
 			JArrayHelper::toInteger($color);
 
 			// Ensure passed in values are valid
-			$color = array_filter($color, function(&$value, $i) use(&$defaultColor) {
-				if ($i === 3)
+			$color = array_filter(
+				$color, 
+				function(&$value, $i) use(&$defaultColor)
 				{
-					$value = $value > 127 ? 127 : $value;
-				}
-				else
-				{
-					$value = $value > 255 ? 255 : $value;
-				}
-
-				return true;
-
-			},
-			ARRAY_FILTER_USE_BOTH
+					if ($i === 3)
+					{
+						$value = $value > 127 ? 127 : $value;
+					}
+					else
+					{
+						$value = $value > 255 ? 255 : $value;
+					}
+	
+					return true;
+				},
+				ARRAY_FILTER_USE_BOTH
 			);
 
 			// Add missing values from the default color.

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -681,6 +681,71 @@ class JImage
 	}
 
 	/**
+	 * Method to set the background fill color to use for non-transparent images.
+	 *
+	 * @param   array   $color   The RGBA values defining the color to use for background fill
+	 *
+	 * @return  JImage
+	 *
+	 * @since   11.3
+	 */
+	public function setFillColor(array $color = array())
+	{
+		$this->fillColor = array(0, 0, 0, 127);
+
+		if (count($color))
+		{
+			JArrayHelper::toInteger($color);
+
+			// Ensure passed in values are valid
+			$color = array_filter($color, function(&$value, $i) use(&$defaultColor)
+			{
+				if ($i === 3)
+				{
+					$value = $value > 127 ? 127 : $value;
+				}
+				else
+				{
+					$value = $value > 255 ? 255 : $value;
+				}
+
+				return true;
+
+			}, ARRAY_FILTER_USE_BOTH);
+
+			// Add missing values from the default color.
+			$len = count($color);
+
+			if ($len < 4)
+			{
+				for ($i = $len; $i < 4; $i += 1)
+				{
+					array_push($color, $this->fillColor[$i]);
+				}
+
+				// Ensure the value for the alpha channel is valid.
+				$color[3] = $color[3] > 127 ? 127 : $color[3];
+			}
+
+			$this->fillColor = $color;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Method to get the background fill color.
+	 *
+	 * @return  array   The RGBA values defining the color to use for background fill
+	 *
+	 * @since   11.3
+	 */
+	public function getFillColor()
+	{
+		return $this->fillColor;
+	}
+
+	/**
 	 * Method to resize the current image.
 	 *
 	 * @param   mixed    $width        The width of the resized image in pixels or a percentage.
@@ -727,7 +792,10 @@ class JImage
 			// Make image transparent, otherwise cavas outside initial image would default to black
 			if (!$this->isTransparent())
 			{
-				$transparency = imagecolorAllocateAlpha($this->handle, 0, 0, 0, 127);
+				// Get fill color.
+				$fillColor = $this->getFillColor();
+
+				$transparency = imagecolorAllocateAlpha($this->handle, $fillColor[0], $fillColor[1], $fillColor[2], $fillColor[3]);
 				imagecolorTransparent($this->handle, $transparency);
 			}
 		}

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -683,7 +683,7 @@ class JImage
 	/**
 	 * Method to set the background fill color to use for non-transparent images.
 	 *
-	 * @param   array   $color   The RGBA values defining the color to use for background fill
+	 * @param   array  $color  The RGBA values defining the color to use for background fill
 	 *
 	 * @return  JImage
 	 *
@@ -698,8 +698,7 @@ class JImage
 			JArrayHelper::toInteger($color);
 
 			// Ensure passed in values are valid
-			$color = array_filter($color, function(&$value, $i) use(&$defaultColor)
-			{
+			$color = array_filter($color, function(&$value, $i) use(&$defaultColor) {
 				if ($i === 3)
 				{
 					$value = $value > 127 ? 127 : $value;
@@ -711,14 +710,16 @@ class JImage
 
 				return true;
 
-			}, ARRAY_FILTER_USE_BOTH);
+			},
+			ARRAY_FILTER_USE_BOTH
+			);
 
 			// Add missing values from the default color.
 			$len = count($color);
 
 			if ($len < 4)
 			{
-				for ($i = $len; $i < 4; $i += 1)
+				for ($i = $len; $i < 4; $i++)
 				{
 					array_push($color, $this->fillColor[$i]);
 				}


### PR DESCRIPTION
##### This patch currently works, but is work in progress.

Please follow the discussion below!
#### Summary of Changes

Currently the color to use for non-transparent images' background fill is hardcoded to `black` which provides no flexibility. Allowing the users to define a desired background color fixes this.
This PR adds two new functions `setFillColor` and `getFillColor` as well as two new helper functions and changes the functions `resize` and  `rotate` to use the desired fillColor, which defaults to `black` preserving BC.
#### Testing Instructions
- [ ] Create a footage array of test files for each image file type.
  I recomment downloading my test files from the links shown below into a folder named 'testfiled' in your Joomla installation's tmp directory. These are specially prepared for this test scenario.
- [ ] Copy and paste the code below to whichever file you'd like to use for running the test. I used my component's entry file.

Example:

```
$files  = array(
   'GIF' => array(
      'NO transparency in input file'   => JPATH_ROOT . '/tmp/testfiles/koZs44Z.gif',  // http://i.imgur.com/koZs44Z.gif
      'WITH transparency in input file' => JPATH_ROOT . '/tmp/testfiles/kyxRLmz.gif'  // http://i.imgur.com/kyxRLmz.gif
   ),
   'PNG' => array(
      'NO transparency in input file'   => JPATH_ROOT . '/tmp/testfiles/FcoS851.png',  // http://i.imgur.com/FcoS851.png
      'WITH transparency in input file' => JPATH_ROOT . '/tmp/testfiles/VL9BgDi.png'  // http://i.imgur.com/VL9BgDi.png
   ),
   'JPG' => array(
      'NO transparency in input file'   => JPATH_ROOT . '/tmp/testfiles/TFnVnnF.jpg'   // http://i.imgur.com/TFnVnnF.jpg
   )
);

// Font styles for the renderer
$ftColors = array(
   'none'        => 'rgb(0,0,0)',
   'red'         => 'rgb(255,0,0)',
   'green'       => 'rgb(0,255,0)',
   'blue'        => 'rgb(0,0,255)',
   'azure'       => 'rgb(0,255,255)',
   'pink'        => 'rgb(255,0,255)',
   'yellow'      => 'rgb(255,255,0)',
   'white'       => 'rgb(255,255,255)',
   'transparent' => 'rgb(0,0,0)',
   // 'nonsense' => 'rgb(0,0,0)'
);

// Fill colors to pass to JImage
$bgColors = array(
   'none'        => array(),
   'red'         => array('red'   =>    255,                                   'alpha' =>  33),
   'green'       => array(                   'green' => 255,                   'alpha' =>  66),
   'blue'        => array(                                    'blue' =>  255,  'alpha' =>  99),
   'azure'       => array(                   'green' => 255,  'blue' =>  255,  'alpha' =>  33),
   'pink'        => array('red'   =>    255,                  'blue' =>  255,  'alpha' =>  66),
   'yellow'      => array('red'   =>    255, 'green' => 255,                   'alpha' =>  99),
   'white'       => array('red'   =>    255, 'green' => 255,  'blue' =>  255),
   'transparent' => array(                                                     'alpha' =>  99),
   // 'nonsense' => array('red'   => 'this', 'green' => 'is', 'blue' => 'all', 'alpha' => 'nonsense, but it works')
);

// Render image
$render = function($path, $extension, $title)
{
   // Define neutral background color for every image to show the different fill colors don't apply when there's transparency
   $neutral = 'rgb(128,128,128)';

   echo '<div style="height:310px; background:' . $neutral . '; border:1px solid black; float:left;">';
   echo $title;
   echo '<img src="' . $path . '" alt="New Image" style="border-top:1px solid black;" />';
   echo '</div>';
};

array_walk($files, function(&$inFiles, $type) use(&$render, &$bgColors, &$ftColors)
{
   array_walk($inFiles, function(&$inFile, &$transparencyType) use(&$type, &$render, &$bgColors, &$ftColors)
   {
      echo '<h2 style="clear:both; padding-top:1em">Testing image type ' . $type . ' <small>(' . $transparencyType . ')</small></h2>';

      $pathinfo = pathinfo($inFile);

      $scaleFmt = JImage::SCALE_FIT;
      $outPath  = JPATH_ROOT . '/tmp/';
      $outFile  = null;
      $outExt   = $pathinfo['extension'];
      $outType  = explode('/', getimagesize($inFile)['mime']);
      $outType  = strtoupper( array_pop($outType) );
      $outType  = $outType === 'GIF' ? IMAGETYPE_GIF : ($outType === 'PNG' ? IMAGETYPE_PNG : IMAGETYPE_JPEG);
      $outFmt   = array('width' => '420', 'height' => '240');
      $outOpts  = array('quality' => 100);

      $i = 1;
      foreach ($bgColors as $color => &$rgb)
      {
         // Resize image defining no fill color (should fall back to BLACK):
         $outFile = "{$outPath}{$pathinfo['filename']}-{$outFmt['width']}x{$outFmt['height']}-{$color}.{$outExt}";
         $jimage  = new JImage($inFile);
         $jimage
         ->setFillColor($rgb)
         ->resize($outFmt['width'], $outFmt['height'], true, $scaleFmt)
         ->toFile($outFile, $outType, $outOpts);

         $render(
            str_replace(JPATH_ROOT, '', $outFile),
            $outExt,
           '<pre style="width:100%; text-align:center; color:' . $ftColors[$color] . '"><strong>' .
            print_r("TEST {$i} ==> " . strtoupper($color) . (in_array($color, array('none','nonsense')) ? ' (falls back to BLACK)' : ''), true) .
            '</strong></pre>' .
            '<pre style="width:100%; text-align:center; color:' . $ftColors[$color] . '"><strong>fillColor: ' .
            preg_replace('/(\}|\{)/', '', str_replace(',', ', ', str_replace('"', '', json_encode($jimage->getFillColor())))) .
            '<strong></pre>'
         );

         $i += 1;
      }
   });
});

echo '<pre style="clear:both; padding-top:1em">' . print_r('Imagetest done!', true) . '</pre>';
jexit();
```

This will render a collection of files for every image from the footage collection.

Please report issues and code improvement suggestions!
