### PR TITLE
[com_finder] frontend: Add language titles to smart search frontend

### DIFF
--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -56,6 +56,35 @@ class FinderHelperLanguage
 	}
 
 	/**
+	 * Method to return the language name for a language taxonomy branch.
+	 *
+	 * @param   string  $branchName  Branch name.
+	 *
+	 * @return  string  The language title.
+	 *
+	 * @since   3.6.0
+	 */
+	public static function branchLanguageTitle($branchName)
+	{
+		$title = $branchName;
+
+		if ($branchName == '*')
+		{
+			$title = JText::_('JALL_LANGUAGE');
+		}
+		else
+		{
+			$languages = JLanguageHelper::getLanguages('lang_code');
+			if (isset($languages[$branchName]))
+			{
+				$title = $languages[$branchName]->title;
+			}
+		}
+
+		return $title;
+	}
+
+	/**
 	 * Method to load Smart Search component language file.
 	 *
 	 * @return  void

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -309,6 +309,10 @@ abstract class JHtmlFilter
 					->where('t.access IN (' . $groups . ')')
 					->order('t.ordering, t.title');
 
+				// Self-join to get the parent title.
+				$query->select('e.title AS parent_title')
+					->join('LEFT', $db->quoteName('#__finder_taxonomy', 'e') . ' ON ' . $db->quoteName('e.id') . ' = ' . $db->quoteName('t.parent_id'));
+
 				// Limit the nodes to a predefined filter.
 				if (!empty($filter->data))
 				{
@@ -331,11 +335,16 @@ abstract class JHtmlFilter
 				$language = JFactory::getLanguage();
 				foreach ($branches[$bk]->nodes as $node_id => $node)
 				{
-					$key = FinderHelperLanguage::branchPlural($node->title);
-					if ($language->hasKey($key))
+					if (trim($node->parent_title, '**') == 'Language')
 					{
-						$branches[$bk]->nodes[$node_id]->title = JText::_($key);
+						$title = FinderHelperLanguage::branchLanguageTitle($node->title);
 					}
+					else
+					{
+						$key = FinderHelperLanguage::branchPlural($node->title);
+						$title = $language->hasKey($key) ? JText::_($key) : $node->title;
+					}
+					$branches[$bk]->nodes[$node_id]->title = $title;
 				}
 
 				// Add the Search All option to the branch.


### PR DESCRIPTION
#### Summary of Changes

Following https://github.com/joomla/joomla-cms/pull/10266 and https://github.com/joomla/joomla-cms/pull/10267, that does the same for the backend, this PR adds the language title (instead of code and *) to the finder frontend search view.
##### Before Patch

![image](https://cloud.githubusercontent.com/assets/9630530/15088348/3e29503a-13ea-11e6-9c34-dbf19ed4ceba.png)
##### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/15088349/42e58684-13ea-11e6-9c76-6e103476dcca.png)
#### Testing Instructions

Note that for this test you have to have index in the Smart Seacrh (com_finder) in multiple langauges and the system language plugin disabled.
1. Apply patch
2. Go to frontend
3. Go to http://yourdomain.com/component/finder/
4. Click "Advanced Search" button, some filters will appear
5. Check the language filter

The languages titles should be exactly the same you have in Extensions -> Languages -> Content Languages.
