### PR TITLE
Fix module copy. Fixes #4918

### DIFF
--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -254,13 +254,6 @@ class ModulesModelModule extends JModelAdmin
 
 				$table->position = $position;
 
-				// Alter the title if necessary
-				$data = $this->generateNewTitle(0, $table->title, $table->position);
-				$table->title = $data['0'];
-
-				// Unpublish the moved module
-				$table->published = 0;
-
 				if (!$table->store())
 				{
 					$this->setError($table->getError());


### PR DESCRIPTION
Pull Request for Issue #4918.
#### Summary of Changes

When moving a module it no longer unpublishes it or increments the title (because having a module in the same position with the same title is just fine)
#### Testing Instructions

See #4918
