### PR TITLE
removed unnecessary description fields in filter xml

### DIFF
--- a/administrator/components/com_banners/models/forms/filter_banners.xml
+++ b/administrator/components/com_banners/models/forms/filter_banners.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_BANNERS_BANNERS_FILTER_SEARCH_LABEL"
-			description="COM_BANNERS_BANNERS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			extension="com_banners"
 			onchange="this.form.submit();"
 			>
@@ -31,7 +28,6 @@
          	name="client_id"
 			type="bannerclient"
 			label="COM_BANNERS_FILTER_CLIENT"
-			description="COM_BANNERS_FILTER_CLIENT_DESC"
 			extension="com_content"
 			onchange="this.form.submit();"
 			>
@@ -41,7 +37,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,7 +46,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -67,7 +61,6 @@
 			type="list"
 			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -99,7 +92,6 @@
 			class="input-mini"
 			default="25"
 			label="COM_BANNERS_LIST_LIMIT"
-			description="COM_BANNERS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_banners/models/forms/filter_clients.xml
+++ b/administrator/components/com_banners/models/forms/filter_clients.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_BANNERS_CLIENTS_FILTER_SEARCH_LABEL"
-			description="COM_BANNERS_CLIENTS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="state"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="purchase_type"
 			type="list"
 			label="COM_BANNERS_FILTER_PURCHASETYPE_LABEL"
-			description="COM_BANNERS_FIELD_PURCHASETYPE_DESC"
 			default="0"
 			onchange="this.form.submit();"
 			>
@@ -39,7 +36,6 @@
 			type="list"
 			label="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -61,7 +57,6 @@
 			class="input-mini"
 			default="25"
 			label="COM_BANNERS_LIST_LIMIT"
-			description="COM_BANNERS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_banners/models/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/models/forms/filter_tracks.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_BANNERS_TRACKS_FILTER_SEARCH_LABEL"
-			description="COM_BANNERS_TRACKS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			extension="com_banners"
 			onchange="this.form.submit();"
 			>
@@ -22,7 +20,6 @@
 			name="client_id"
 			type="bannerclient"
 			label="COM_BANNERS_FILTER_CLIENT"
-			description="COM_BANNERS_FILTER_CLIENT_DESC"
 			extension="com_content"
 			onchange="this.form.submit();"
 			>
@@ -41,7 +38,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -54,7 +50,6 @@
 			name="begin"
 			type="calendar"
 			label="COM_BANNERS_BEGIN_LABEL"
-			description="COM_BANNERS_BEGIN_DESC"
 			hint="COM_BANNERS_BEGIN_HINT"
 			format="%Y-%m-%d"
 			size="10"
@@ -65,7 +60,6 @@
 			name="end"
 			type="calendar"
 			label="COM_BANNERS_END_LABEL"
-			description="COM_BANNERS_END_DESC"
 			hint="COM_BANNERS_END_HINT"
 			format="%Y-%m-%d"
 			size="10"
@@ -78,7 +72,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="b.name ASC"
 			>
@@ -98,7 +91,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="5"
 			onchange="this.form.submit();"

--- a/administrator/components/com_categories/models/forms/filter_categories.xml
+++ b/administrator/components/com_categories/models/forms/filter_categories.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_CATEGORIES_FILTER_SEARCH_LABEL"
-			description="COM_CATEGORIES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_CATEGORIES_FILTER_PUBLISHED"
-			description="COM_CATEGORIES_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -30,7 +27,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -40,7 +36,6 @@
 			name="tag"
 			type="tag"
 			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			mode="nested"
 			onchange="this.form.submit();"
 			>
@@ -50,7 +45,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -65,7 +59,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
@@ -88,7 +81,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_CATEGORIES_LIST_LIMIT"
-			description="COM_CATEGORIES_LIST_LIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_contact/models/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/models/forms/filter_contacts.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_CONTACT_FILTER_SEARCH_LABEL"
-			description="COM_CONTACT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			description="JOPTION_SELECT_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			extension="com_contact"
 			published="0,1,2"
 			onchange="this.form.submit();"
@@ -32,7 +29,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -41,7 +37,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -51,7 +46,6 @@
 			name="tag"
 			type="tag"
 			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			mode="nested"
 			onchange="this.form.submit();"
 			>
@@ -61,7 +55,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -76,7 +69,6 @@
 			name="fullordering"
 			type="list"
 			label="COM_CONTACT_LIST_FULL_ORDERING"
-			description="COM_CONTACT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -106,7 +98,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_CONTACT_LIST_LIMIT"
-			description="COM_CONTACT_LIST_LIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_CONTENT_FILTER_SEARCH_LABEL"
-			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_CONTENT_FILTER_PUBLISHED"
-			description="COM_CONTENT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -22,7 +20,6 @@
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
 			extension="com_content"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			published="0,1,2"
 			>
@@ -32,25 +29,22 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
 		</field>
 		<field
-                	name="author_id"
-                	type="author"
-                	label="COM_CONTENT_FILTER_AUTHOR"
-                	description="COM_CONTENT_FILTER_AUTHOR_DESC"
-                	onchange="this.form.submit();"
-                	>
-            		<option value="">JOPTION_SELECT_AUTHOR</option>
-        	</field>
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_AUTHOR</option>
+		</field>
 		<field
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -61,31 +55,28 @@
 			type="tag"
 			mode="nested"
 			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
 		</field>
-	        <field
-        	        name="level"
-        	        type="integer"
-        	        first="1"
-        	        last="10"
-        	        step="1"
-        	        label="JOPTION_FILTER_LEVEL"
-        	        languages="*"
-        	        description="JOPTION_FILTER_LEVEL_DESC"
-        	        onchange="this.form.submit();"
-        	        >
-        		<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-        	</field>
+		<field
+			name="level"
+			type="integer"
+			first="1"
+			last="10"
+			step="1"
+			label="JOPTION_FILTER_LEVEL"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+		<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+	</field>
 	</fields>
 	<fields name="list">
 		<field
 			name="fullordering"
 			type="list"
 			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.id DESC"
 			>
@@ -121,7 +112,6 @@
 			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_CONTENT_FILTER_SEARCH_LABEL"
-			description="COM_CONTENT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_CONTENT_FILTER_PUBLISHED"
-			description="COM_CONTENT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -22,7 +20,6 @@
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
 			extension="com_content"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_CATEGORY</option>
@@ -31,25 +28,22 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
 		</field>
 		<field
-                	name="author_id"
-                	type="author"
-                	label="COM_CONTENT_FILTER_AUTHOR"
-                	description="COM_CONTENT_FILTER_AUTHOR_DESC"
-                	onchange="this.form.submit();"
-                	>
-        		<option value="">JOPTION_SELECT_AUTHOR</option>
-        	</field>
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_AUTHOR</option>
+		</field>
 		<field
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -60,7 +54,6 @@
 			type="tag"
 			mode="nested"
 			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_TAG</option>
@@ -73,7 +66,6 @@
                 	step="1"
                 	label="JOPTION_FILTER_LEVEL"
                 	languages="*"
-                	description="JOPTION_FILTER_LEVEL_DESC"
                 	onchange="this.form.submit();"
                 	>
         		<option value="">JOPTION_SELECT_MAX_LEVELS</option>
@@ -84,7 +76,6 @@
 			name="fullordering"
 			type="list"
 			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.title ASC"
 			>
@@ -116,7 +107,6 @@
 			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>

--- a/administrator/components/com_finder/models/forms/filter_filters.xml
+++ b/administrator/components/com_finder/models/forms/filter_filters.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_FINDER_SEARCH_FILTER_SEARCH_LABEL"
-			description="COM_FINDER_SEARCH_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -13,7 +12,6 @@
 			type="status"
 			filter="0,1"
 			label="COM_FINDER_FILTER_PUBLISHED"
-			description="COM_FINDER_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_finder/models/forms/filter_index.xml
+++ b/administrator/components/com_finder/models/forms/filter_index.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_FINDER_INDEX_SEARCH_LABEL"
-			description="COM_FINDER_INDEX_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="state"
 			type="status"
 			label="COM_FINDER_FILTER_PUBLISHED"
-			description="COM_FINDER_FILTER_PUBLISHED_DESC"
 			filter="0,1"
 			onchange="this.form.submit();"
 			>
@@ -22,7 +20,6 @@
 			name="type"
 			type="sql"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			default="0"
 			query="SELECT id AS value, title AS type FROM #__finder_types ORDER BY title"
 			onchange="this.form.submit();"

--- a/administrator/components/com_finder/models/forms/filter_maps.xml
+++ b/administrator/components/com_finder/models/forms/filter_maps.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_FINDER_SEARCH_SEARCH_QUERY_LABEL"
-			description="COM_FINDER_SEARCH_SEARCH_QUERY_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -13,7 +12,6 @@
 			type="status"
 			filter="0,1"
 			label="COM_FINDER_FILTER_PUBLISHED"
-			description="COM_FINDER_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -28,7 +26,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="2"
 			step="1"

--- a/administrator/components/com_installer/models/forms/filter_discover.xml
+++ b/administrator/components/com_installer/models/forms/filter_discover.xml
@@ -7,7 +7,6 @@
 			name="search"
 			type="text"
 			label="COM_INSTALLER_DISCOVER_FILTER_SEARCH_LABEL"
-			description="COM_INSTALLER_DISCOVER_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -37,7 +36,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="name ASC"
 			>
@@ -57,7 +55,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_installer/models/forms/filter_languages.xml
+++ b/administrator/components/com_installer/models/forms/filter_languages.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_INSTALLER_LANGUAGES_FILTER_SEARCH_LABEL"
-			description="COM_INSTALLER_LANGUAGES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>
@@ -14,7 +13,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="name ASC"
 			>
@@ -30,7 +28,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_installer/models/forms/filter_manage.xml
+++ b/administrator/components/com_installer/models/forms/filter_manage.xml
@@ -7,14 +7,12 @@
 			name="search"
 			type="text"
 			label="COM_INSTALLER_MANAGE_FILTER_SEARCH_LABEL"
-			description="COM_INSTALLER_MANAGE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="status"
 			type="extensionstatus"
 			label="COM_PLUGINS_FILTER_PUBLISHED"
-			description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -46,7 +44,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="name ASC"
 			>
@@ -68,7 +65,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_installer/models/forms/filter_update.xml
+++ b/administrator/components/com_installer/models/forms/filter_update.xml
@@ -7,7 +7,6 @@
 			name="search"
 			type="text"
 			label="COM_INSTALLER_UPDATE_FILTER_SEARCH_LABEL"
-			description="COM_INSTALLER_UPDATE_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -37,7 +36,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="u.name ASC"
 			>
@@ -55,7 +53,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_installer/models/forms/filter_updatesites.xml
+++ b/administrator/components/com_installer/models/forms/filter_updatesites.xml
@@ -7,14 +7,12 @@
 			name="search"
 			type="text"
 			label="COM_INSTALLER_UPDATESITES_FILTER_SEARCH_LABEL"
-			description="COM_INSTALLER_UPDATESITES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="enabled"
 			type="list"
 			label="COM_PLUGINS_FILTER_PUBLISHED"
-			description="COM_PLUGINS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -48,7 +46,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="name ASC"
 			>
@@ -72,7 +69,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -4,7 +4,6 @@
 		name="menutype"
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
-		description="JOPTION_FILTER_CATEGORY_DESC"
 		onchange="this.form.submit();"
 		>
 		<option value="">COM_MENUS_SELECT_MENU</option>
@@ -14,14 +13,12 @@
 			name="search"
 			type="text"
 			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
-			description="COM_MENUS_ITEMS_SEARCH_FILTER"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_MENUS_FILTER_PUBLISHED"
-			description="COM_MENUS_FILTER_PUBLISHED_DESC"
 			filter="*,0,1,-2"
 			onchange="this.form.submit();"
 			>
@@ -31,7 +28,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,7 +36,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -50,7 +45,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -65,7 +59,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			statuses="*,0,1,2,-2"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
@@ -94,7 +87,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_MENUS_LIST_LIMIT"
-			description="COM_MENUS_LIST_LIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_menus/models/forms/filter_menus.xml
+++ b/administrator/components/com_menus/models/forms/filter_menus.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_MENUS_MENUS_FILTER_SEARCH_LABEL"
-			description="COM_MENUS_MENUS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>
@@ -14,7 +13,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.title ASC"
 			>
@@ -28,7 +26,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="5"
 			onchange="this.form.submit();"

--- a/administrator/components/com_messages/models/forms/filter_messages.xml
+++ b/administrator/components/com_messages/models/forms/filter_messages.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_MESSAGES_FILTER_SEARCH_LABEL"
-			description="COM_MESSAGES_SEARCH_IN_SUBJECT"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="state"
 			type="messagestates"
 			label="COM_MESSAGES_FILTER_STATES_LABEL"
-			description="COM_MESSAGES_FILTER_STATES_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -24,7 +22,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.date_time DESC"
 			>
@@ -42,7 +39,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="5"
 			onchange="this.form.submit();"

--- a/administrator/components/com_modules/models/forms/filter_modules.xml
+++ b/administrator/components/com_modules/models/forms/filter_modules.xml
@@ -16,7 +16,6 @@
 			name="search"
 			type="text"
 			label="COM_MODULES_MODULES_FILTER_SEARCH_LABEL"
-			description="COM_MODULES_MODULES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -48,7 +47,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -57,7 +55,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -69,7 +66,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			statuses="*,0,1,-2"
 			onchange="this.form.submit();"
 			default="a.position ASC"
@@ -98,7 +94,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_MODULES_LIST_LIMIT"
-			description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/models/forms/filter_newsfeeds.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_NEWSFEEDS_FILTER_SEARCH_LABEL"
-			description="COM_NEWSFEEDS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_NEWSFEEDS_FILTER_PUBLISHED"
-			description="COM_NEWSFEEDS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			extension="com_newsfeeds"
 			onchange="this.form.submit();"
 			>
@@ -31,7 +28,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -40,7 +36,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -50,7 +45,6 @@
 			name="tag"
 			type="tag"
 			label="JOPTION_FILTER_TAG"
-			description="JOPTION_FILTER_TAG_DESC"
 			mode="nested"
 			onchange="this.form.submit();"
 			>
@@ -60,7 +54,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -75,7 +68,6 @@
 			name="fullordering"
 			type="list"
 			label="COM_NEWSFEEDS_LIST_FULL_ORDERING"
-			description="COM_NEWSFEEDS_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -105,7 +97,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_NEWSFEEDS_LIST_LIMIT"
-			description="COM_NEWSFEEDS_LIST_LIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_plugins/models/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/models/forms/filter_plugins.xml
@@ -7,7 +7,6 @@
 			name="search"
 			type="text"
 			label="COM_PLUGINS_FILTER_SEARCH_LABEL"
-			description="COM_PLUGINS_SEARCH_IN_TITLE"
 			hint="JSEARCH_FILTER"
 		/>
 
@@ -31,7 +30,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 		>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -43,7 +41,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="folder ASC"
 		>

--- a/administrator/components/com_redirect/models/forms/filter_links.xml
+++ b/administrator/components/com_redirect/models/forms/filter_links.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_REDIRECT_FILTER_SEARCH_LABEL"
-			description="COM_REDIRECT_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="state"
 			type="status"
 			label="COM_REDIRECT_FILTER_PUBLISHED"
-			description="COM_REDIRECT_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -23,7 +21,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.old_url ASC"
 			>
@@ -47,7 +44,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="5"
 			onchange="this.form.submit();"

--- a/administrator/components/com_search/models/forms/filter_searches.xml
+++ b/administrator/components/com_search/models/forms/filter_searches.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_SEARCH_SEARCH_IN_PHRASE"
-			description="COM_SEARCH_SEARCH_IN_PHRASE"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>

--- a/administrator/components/com_tags/models/forms/filter_tags.xml
+++ b/administrator/components/com_tags/models/forms/filter_tags.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_TAGS_FILTER_SEARCH_LABEL"
-			description="COM_TAGS_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="published"
 			type="status"
 			label="COM_TAGS_FILTER_PUBLISHED"
-			description="COM_TAGS_FILTER_PUBLISHED_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -21,7 +19,6 @@
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_ACCESS</option>
@@ -30,7 +27,6 @@
 			name="language"
 			type="contentlanguage"
 			label="JOPTION_FILTER_LANGUAGE"
-			description="JOPTION_FILTER_LANGUAGE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
@@ -40,7 +36,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -54,7 +49,6 @@
             name="fullordering"
 			type="list"
 			label="COM_TAGS_LIST_FULL_ORDERING"
-			description="COM_TAGS_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
 			>
@@ -76,7 +70,6 @@
 			name="limit"
 			type="limitbox"
 			label="COM_TAGS_LIST_LIMIT"
-			description="COM_TAGS_LIST_LIMIT_DESC"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_templates/models/forms/filter_styles.xml
+++ b/administrator/components/com_templates/models/forms/filter_styles.xml
@@ -14,7 +14,6 @@
 			name="search"
 			type="text"
 			label="JSEARCH_FILTER"
-			description="COM_TEMPLATES_STYLES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -41,7 +40,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.template ASC"
 			>
@@ -59,7 +57,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_templates/models/forms/filter_templates.xml
+++ b/administrator/components/com_templates/models/forms/filter_templates.xml
@@ -14,7 +14,6 @@
 			name="search"
 			type="text"
 			label="JSEARCH_FILTER"
-			description="COM_TEMPLATES_TEMPLATES_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>
@@ -23,7 +22,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.element ASC"
 			>
@@ -35,7 +33,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_users/models/forms/filter_debuggroup.xml
+++ b/administrator/components/com_users/models/forms/filter_debuggroup.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_ASSETS"
-			description="COM_USERS_SEARCH_IN_ASSETS"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="component"
 			type="Components"
 			label="COM_USERS_FILTER_COMPONENT_LABEL"
-			description="COM_USERS_FILTER_COMPONENT_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_COMPONENT</option>
@@ -21,7 +19,6 @@
 			name="level_start"
 			type="Levels"
 			label="COM_USERS_FILTER_LEVEL_START_LABEL"
-			description="COM_USERS_FILTER_LEVEL_START_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_LEVEL_START</option>
@@ -30,7 +27,6 @@
 			name="level_end"
 			type="Levels"
 			label="COM_USERS_FILTER_LEVEL_END_LABEL"
-			description="COM_USERS_FILTER_LEVEL_END_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_LEVEL_END</option>

--- a/administrator/components/com_users/models/forms/filter_debuguser.xml
+++ b/administrator/components/com_users/models/forms/filter_debuguser.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_ASSETS"
-			description="COM_USERS_SEARCH_IN_ASSETS"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="component"
 			type="Components"
 			label="COM_USERS_FILTER_COMPONENT_LABEL"
-			description="COM_USERS_FILTER_COMPONENT_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_COMPONENT</option>
@@ -21,7 +19,6 @@
 			name="level_start"
 			type="Levels"
 			label="COM_USERS_FILTER_LEVEL_START_LABEL"
-			description="COM_USERS_FILTER_LEVEL_START_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_LEVEL_START</option>
@@ -30,7 +27,6 @@
 			name="level_end"
 			type="Levels"
 			label="COM_USERS_FILTER_LEVEL_END_LABEL"
-			description="COM_USERS_FILTER_LEVEL_END_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_SELECT_LEVEL_END</option>

--- a/administrator/components/com_users/models/forms/filter_groups.xml
+++ b/administrator/components/com_users/models/forms/filter_groups.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_GROUPS_LABEL"
-			description="COM_USERS_SEARCH_IN_GROUPS"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>
@@ -14,7 +13,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.lft ASC"
 			>
@@ -30,7 +28,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_users/models/forms/filter_levels.xml
+++ b/administrator/components/com_users/models/forms/filter_levels.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_ACCESS_LEVELS"
-			description="COM_USERS_SEARCH_IN_LEVEL_NAME"
 			hint="JSEARCH_FILTER"
 		/>
 	</fields>
@@ -14,7 +13,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.ordering ASC"
 			>
@@ -30,7 +28,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_users/models/forms/filter_notes.xml
+++ b/administrator/components/com_users/models/forms/filter_notes.xml
@@ -5,7 +5,6 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_USER_NOTES"
-			description="COM_USERS_SEARCH_IN_NOTE_TITLE"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
@@ -19,7 +18,6 @@
 			name="category_id"
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
-			description="JOPTION_FILTER_CATEGORY_DESC"
 			extension="com_users"
 			onchange="this.form.submit();"
 			>
@@ -29,7 +27,6 @@
 			name="level"
 			type="integer"
 			label="JOPTION_FILTER_LEVEL"
-			description="JOPTION_FILTER_LEVEL_DESC"
 			first="1"
 			last="10"
 			step="1"
@@ -44,7 +41,6 @@
 			name="fullordering"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			description="JGLOBAL_SORT_BY"
 			onchange="this.form.submit();"
 			default="a.review_time DESC"
 			>
@@ -66,7 +62,6 @@
 			name="limit"
 			type="limitbox"
 			label="JGLOBAL_LIMIT"
-			description="JGLOBAL_LIMIT"
 			class="input-mini"
 			default="25"
 			onchange="this.form.submit();"

--- a/administrator/components/com_users/models/forms/filter_users.xml
+++ b/administrator/components/com_users/models/forms/filter_users.xml
@@ -5,14 +5,12 @@
 			name="search"
 			type="text"
 			label="COM_USERS_SEARCH_USERS"
-			description="COM_USERS_SEARCH_IN_NAME"
 			hint="JSEARCH_FILTER"
 		/>
 		<field
 			name="state"
 			type="userstate"
 			label="COM_USERS_FILTER_STATE"
-			description="COM_USERS_FILTER_STATE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_STATE</option>
@@ -21,7 +19,6 @@
 			name="active"
 			type="useractive"
 			label="COM_USERS_FILTER_ACTIVE"
-			description="COM_USERS_FILTER_ACTIVE_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_ACTIVE</option>
@@ -30,25 +27,22 @@
 			name="group_id"
 			type="usergrouplist"
 			label="COM_USERS_FILTER_GROUP"
-			description="COM_USERS_FILTER_GROUP_DESC"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_FILTER_USERGROUP</option>
 		</field>
 		<field
-				name="lastvisitrange"
-				type="lastvisitdaterange"
-				label="COM_USERS_OPTION_FILTER_LAST_VISIT_DATE"
-				description="COM_USERS_OPTION_FILTER_LAST_VISIT_DATE"
-				onchange="this.form.submit();"
-		>
+			name="lastvisitrange"
+			type="lastvisitdaterange"
+			label="COM_USERS_OPTION_FILTER_LAST_VISIT_DATE"
+			onchange="this.form.submit();"
+			>
 			<option value="">COM_USERS_OPTION_FILTER_LAST_VISIT_DATE</option>
 		</field>
 		<field
 			name="range"
 			type="registrationdaterange"
 			label="COM_USERS_OPTION_FILTER_DATE"
-			description="COM_USERS_OPTION_FILTER_DATE"
 			onchange="this.form.submit();"
 			>
 			<option value="">COM_USERS_OPTION_FILTER_DATE</option>
@@ -59,7 +53,6 @@
 			name="fullordering"
 			type="list"
 			label="COM_CONTENT_LIST_FULL_ORDERING"
-			description="COM_CONTENT_LIST_FULL_ORDERING_DESC"
 			onchange="this.form.submit();"
 			default="a.name ASC"
 			>
@@ -87,7 +80,6 @@
 			class="input-mini"
 			default="25"
 			label="COM_CONTENT_LIST_LIMIT"
-			description="COM_CONTENT_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>


### PR DESCRIPTION
Pull Request for Issue #8336. I've redone this with the current Joomla! 3.6.0-dev code base.
#### Summary of Changes

I've **removed** all the **description fields** from the filter_.xml files used by the Search Tools filters.
This time I've kept all the **label fields** for future use regarding accessibility (for use with "titles"). 
