### PR TITLE
Add link to Article in Article Edit

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -90,6 +90,13 @@ JFactory::getDocument()->addScriptDeclaration('
 			</div>
 			<div class="span3">
 				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
+				<?php
+				if ((int) $this->item->id > 0 )
+				{
+					echo '<a href="' . JRoute::_( JURI::root() . 'index.php?option=com_content&view=article&id='
+							. (int) $this->item->id ). '" target="_blank">link to article</a>';
+				}
+				?>
 			</div>
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>


### PR DESCRIPTION
Pull Request for Issue #10191. This PR adds a **link to the front-end view** of a single article **in the Article: Edit view**. It only works for saved articles (that have an ID) and the links are non-SEF links.

**Note** as it's a proof-of-concept PR, I did not add a Language String but used the hardcoded label "link to article".

@sanek4life Is this the functionality that you were asking for in issue #10191? 
Could you please test it?
# Testing Instructions
## Before the PR

Go to Content > Articles > open an article
![article-edit-before](https://cloud.githubusercontent.com/assets/1217850/15093147/b0b6d962-147e-11e6-9e4e-eaffb7992746.png)
## Before the PR

Go to Content > Articles > open an article, on the bottom right you'll have a non-SEF link to the front-end view of an article.
![article-edit-after](https://cloud.githubusercontent.com/assets/1217850/15093148/b0b9427e-147e-11e6-9c3d-1e5e1fe1189a.png)
