### PR TITLE
[bump.php] Regex pattern match

### DIFF
--- a/build/bump.php
+++ b/build/bump.php
@@ -224,7 +224,7 @@ if (file_exists($rootPath . $languagePackXmlFile))
 if (file_exists($rootPath . $antJobFile))
 {
 	$fileContents = file_get_contents($rootPath . $antJobFile);
-	$fileContents = preg_replace('#<arg value="Joomla! CMS [^<]* API" />#', '<arg value="Joomla! CMS ' . $version['main'] . ' API" />', $fileContents);
+	$fileContents = preg_replace('#<arg value="Joomla! CMS [^ ]* API" />#', '<arg value="Joomla! CMS ' . $version['main'] . ' API" />', $fileContents);
 	file_put_contents($rootPath . $antJobFile, $fileContents);
 }
 


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

The new replace of bump.php uses a not so correct pattern match `[^<]*`. It should be `[^ ]*`, since where we want to end the pattern match (for replace) is a space character and not the less sign (`<`).
#### Testing Instructions

In joomla root dir, run CLI command `php build/bump.php -v 3.7.0`

And then check the `/build.xml` for `Joomla! CMS 3.7 API`

Then use `php build/bump.php -v 3.6.0-dev` to go back to previous state.

@mbabker @wilsonge 
