### PR TITLE
[com_content] Fix modal article edit & simplify modal layout

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -49,7 +49,11 @@ class JFormFieldModal_Article extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		jQuery("#' . $this->id . '_Edit").addClass("hidden");';
+			$script[] = '		if (id == ' . $this->value . ') {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		} else {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
+			$script[] = '		}';
 		}
 
 		if ($allowClear)
@@ -149,7 +153,7 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a id="' . $this->id . '_Edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
+			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
 				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
 				. '<span class="icon-edit"></span> '
 				. JText::_('JACTION_EDIT') . '</a>';

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -71,11 +71,6 @@ class JFormFieldModal_Article extends JFormField
 
 		$script[] = '	}';
 
-		$script[] = '	function jEditArticle_' . $this->id . '(id, title, catid, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
-		$script[] = '		document.getElementById("' . $this->id . '_name").value = title;';
-		$script[] = '	}';
-
 		// Clear button script
 		static $scriptClear;
 
@@ -101,7 +96,7 @@ class JFormFieldModal_Article extends JFormField
 		// Setup variables for display.
 		$html = array();
 		$linkArticles = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
-		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit&amp;function=jEditArticle_' . $this->id;
+		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit;
 
 		if (isset($this->element['language']))
 		{

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -96,7 +96,7 @@ class JFormFieldModal_Article extends JFormField
 		// Setup variables for display.
 		$html = array();
 		$linkArticles = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
-		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit;
+		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit';
 
 		if (isset($this->element['language']))
 		{

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -49,7 +49,8 @@ class JFormFieldModal_Article extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		if (id == ' . $this->value . ') {';
+			$script[] = '		var currentValue = "' . $this->value . '";';
+			$script[] = '		if (id == currentValue) {';
 			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
 			$script[] = '		} else {';
 			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
@@ -153,7 +154,7 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
+			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip' . ($value ? '' : ' hidden') . '" role="button" data-toggle="modal" title="'
 				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
 				. '<span class="icon-edit"></span> '
 				. JText::_('JACTION_EDIT') . '</a>';

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -153,8 +153,8 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
-				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
+			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal"'
+				. ' title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
 				. '<span class="icon-edit"></span> '
 				. JText::_('JACTION_EDIT') . '</a>';
 		}

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -49,7 +49,7 @@ class JFormFieldModal_Article extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		jQuery("#' . $this->id . '_Edit").addClass("hidden");';
 		}
 
 		if ($allowClear)
@@ -57,7 +57,7 @@ class JFormFieldModal_Article extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jQuery("#modalArticle' . $this->id . '").modal("hide");';
+		$script[] = '		jQuery("#articleSelect' . $this->id . 'Modal").modal("hide");';
 
 		if ($this->required)
 		{
@@ -91,11 +91,13 @@ class JFormFieldModal_Article extends JFormField
 
 		// Setup variables for display.
 		$html = array();
-		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
+		$linkArticles = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
+		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit';
 
 		if (isset($this->element['language']))
 		{
-			$link .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkArticles .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkArticle .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
 
 		if ((int) $this->value > 0)
@@ -133,12 +135,13 @@ class JFormFieldModal_Article extends JFormField
 			$value = (int) $this->value;
 		}
 
-		$url = $link . '&amp;' . JSession::getFormToken() . '=1';
+		$urlSelect = $linkArticles . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit = $linkArticle . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
 		// The current article display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a href="#modalArticle' . $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal" title="'
+		$html[] = '<a href="#articleSelect' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
 			. JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '">'
 			. '<span class="icon-file"></span> '
 			. JText::_('JSELECT') . '</a>';
@@ -146,9 +149,10 @@ class JFormFieldModal_Article extends JFormField
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden')
-				. '" href="index.php?option=com_content&layout=modal&tmpl=component&task=article.edit&id=' . $value . '" target="_blank" title="'
-				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '" ><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a id="' . $this->id . '_Edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
+				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
+				. '<span class="icon-edit"></span> '
+				. JText::_('JACTION_EDIT') . '</a>';
 		}
 
 		// Clear article button
@@ -172,16 +176,34 @@ class JFormFieldModal_Article extends JFormField
 
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'modalArticle' . $this->id,
+			'articleSelect' . $this->id . 'Modal',
 			array(
-				'url' => $url,
+				'url' => $urlSelect,
 				'title' => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
 				'width' => '800px',
-				'height' => '300px',
+				'height' => '400px',
 				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
 					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
+
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'articleEdit' . $this->id . 'Modal',
+			array(
+				'url' => $urlEdit,
+				'title' => JText::_('COM_CONTENT_EDIT_ARTICLE'),
+				'width' => '800px',
+				'height' => '400px',
+				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+					. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+					. '<button type="button" class="btn btn-success" data-dismiss="modal" aria-hidden="true"'
+					. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+					. JText::_("JSAVE") . '</button>'
+			)
+		);
+
 		return implode("\n", $html);
 	}
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -198,6 +198,8 @@ class JFormFieldModal_Article extends JFormField
 			array(
 				'url' => $urlEdit,
 				'title' => JText::_('COM_CONTENT_EDIT_ARTICLE'),
+				'backdrop' => 'static',
+				'closeButton' => false,
 				'width' => '800px',
 				'height' => '400px',
 				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -127,7 +127,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
-		<?php if ($assoc) : ?>
+		<?php if ($assoc && $input->get('layout') != 'modal') : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS', true)); ?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -9,163 +9,21 @@
 
 defined('_JEXEC') or die;
 
-// Include the component HTML helpers.
-JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 
-
-JHtml::_('behavior.formvalidator');
-JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select');
-
-$this->configFieldsets  = array('editorConfig');
-$this->hiddenFieldsets  = array('basic-limited');
-$this->ignore_fieldsets = array('jmetadata', 'item_associations');
-
-// Create shortcut to parameters.
-$params = $this->state->get('params');
-
-$app = JFactory::getApplication();
-$input = $app->input;
-$assoc = JLanguageAssociations::isEnabled();
-
-// This checks if the config options have ever been saved. If they haven't they will fall back to the original settings.
-$params = json_decode($params);
-$editoroptions = isset($params->show_publishing_options);
-
-if (!$editoroptions)
-{
-	$params->show_publishing_options = '1';
-	$params->show_article_options = '1';
-	$params->show_urls_images_backend = '0';
-	$params->show_urls_images_frontend = '0';
-}
-
-// Check if the article uses configuration settings besides global. If so, use them.
-if (isset($this->item->attribs['show_publishing_options']) && $this->item->attribs['show_publishing_options'] != '')
-{
-	$params->show_publishing_options = $this->item->attribs['show_publishing_options'];
-}
-
-if (isset($this->item->attribs['show_article_options']) && $this->item->attribs['show_article_options'] != '')
-{
-	$params->show_article_options = $this->item->attribs['show_article_options'];
-}
-
-if (isset($this->item->attribs['show_urls_images_frontend']) && $this->item->attribs['show_urls_images_frontend'] != '')
-{
-	$params->show_urls_images_frontend = $this->item->attribs['show_urls_images_frontend'];
-}
-
-if (isset($this->item->attribs['show_urls_images_backend']) && $this->item->attribs['show_urls_images_backend'] != '')
-{
-	$params->show_urls_images_backend = $this->item->attribs['show_urls_images_backend'];
-}
-
+// This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
-	Joomla.submitbutton = function(task)
-	{
-		if (task == "article.cancel" || document.formvalidator.isValid(document.getElementById("item-form")))
-		{
-			' . $this->form->getField('articletext')->save() . '
-			if (window.opener && (task == "article.save" || task == "article.cancel"))
-			{
-				window.opener.document.closeEditWindow = self;
-				window.opener.setTimeout("window.document.closeEditWindow.close()", 1000);
-			}
-
-		Joomla.submitform(task, document.getElementById("item-form"));
+	window.parent.jQuery(".modal").on("hidden", function () {
+	if (typeof window.parent.jQuery("#articleEdit' . $this->item->id . 'Modal iframe").contents().find("#closeBtn") !== "undefined") {
+		window.parent.jQuery("#articleEdit' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
 		}
-	};
+	});
 ');
-
 ?>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.save');"></button>
+<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.cancel');"></button>
 
 <div class="container-popup">
-
-<div class="pull-right">
-	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.apply');"><?php echo JText::_('JTOOLBAR_APPLY') ?></button>
-	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('article.save');"><?php echo JText::_('JTOOLBAR_SAVE') ?></button>
-	<button class="btn" type="button" onclick="Joomla.submitbutton('article.cancel');"><?php echo JText::_('JCANCEL') ?></button>
+	<?php $this->setLayout('edit'); ?>
+	<?php echo $this->loadTemplate(); ?>
 </div>
-
-<div class="clearfix"> </div>
-<hr class="hr-condensed" />
-
-<form action="<?php echo JRoute::_('index.php?option=com_content&layout=modal&tmpl=component&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
-<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
-
-	<div class="form-horizontal">
-		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'general', JText::_('COM_CONTENT_ARTICLE_CONTENT', true)); ?>
-		<div class="row-fluid">
-			<div class="span9">
-				<fieldset class="adminform">
-					<?php echo $this->form->getInput('articletext'); ?>
-				</fieldset>
-			</div>
-			<div class="span3">
-				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
-			</div>
-		</div>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-		<?php // Do not show the publishing options if the edit form is configured not to. ?>
-		<?php if ($params->show_publishing_options == 1) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CONTENT_FIELDSET_PUBLISHING', true)); ?>
-			<div class="row-fluid form-horizontal-desktop">
-				<div class="span6">
-					<?php echo JLayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-				</div>
-				<div class="span6">
-					<?php echo JLayoutHelper::render('joomla.edit.metadata', $this); ?>
-				</div>
-			</div>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php endif; ?>
-
-		<?php // Do not show the images and links options if the edit form is configured not to. ?>
-		<?php if ($params->show_urls_images_backend == 1) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('COM_CONTENT_FIELDSET_URLS_AND_IMAGES', true)); ?>
-			<div class="row-fluid form-horizontal-desktop">
-				<div class="span6">
-					<?php echo $this->form->getControlGroup('images'); ?>
-					<?php foreach ($this->form->getGroup('images') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
-					<?php endforeach; ?>
-				</div>
-				<div class="span6">
-					<?php foreach ($this->form->getGroup('urls') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
-					<?php endforeach; ?>
-				</div>
-			</div>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php endif; ?>
-
-		<?php if (isset($assoc)) : ?>
-			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
-		<?php endif; ?>
-
-		<?php $this->show_options = $params->show_article_options; ?>
-		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
-
-		<?php if ($this->canDo->get('core.admin')) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'editor', JText::_('COM_CONTENT_SLIDER_EDITOR_CONFIG', true)); ?>
-			<?php echo $this->form->renderFieldset('editorConfig'); ?>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php endif; ?>
-
-		<?php if ($this->canDo->get('core.admin')) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'permissions', JText::_('COM_CONTENT_FIELDSET_RULES', true)); ?>
-				<?php echo $this->form->getInput('rules'); ?>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php endif; ?>
-
-		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>" />
-		<?php echo JHtml::_('form.token'); ?>
-	</div>
-</form>


### PR DESCRIPTION
To reproduce issue before applying this patch, create a **new menu item**, select **type "single article"**, and **save** this menu item.
Then, click **"Edit"** button to edit the article from the menu item.

**Current behavior (before patch) :**
- Open the article edition page (modal) in a new browser window or tab (!!!), and NOT inside a Bootstrap modal :-|

![capture d ecran 2016-05-07 a 22 43 12](https://cloud.githubusercontent.com/assets/2385058/15094490/f19ea2ee-14a5-11e6-9b83-c7077d92fb86.png)
![capture d ecran 2016-05-07 a 22 43 26](https://cloud.githubusercontent.com/assets/2385058/15094493/f82bfd0a-14a5-11e6-9f42-036454ad7305.png)

**Expected behavior :**
- Open the article edition page inside a modal, with <code>close</code> and <code>save & close</code> buttons
- Same behavior as current one for Edition of modules from the menu item (in Module Assignment tab) when clicking on the name of each modules.

![capture d ecran 2016-05-07 a 22 45 08](https://cloud.githubusercontent.com/assets/2385058/15094496/032bc64a-14a6-11e6-8eda-5e80c598f3e5.png)
#### Summary of Changes
- Open the Article Edition modal inside a bootstrap modal
- Simplify the modal.php view (loading directly the edit.php view)
- Change in edit.php to not load Articles Association tab when inside a modal (previous behavior and expected one).
- Fix tooltip placement inside modal-body loading an iframe
#### Testing Instructions
- Test in Menus > Menu Item type "single article" > Edit article to open the modal to edit article
- Test in Articles > Article Edition > Associations > Select an associated article, save and then try to edit this article associated with Edit button (should open the modal).

**If it's ok for this one (modal edit article) i will do the same for all menu item type "single item" : Newsfeed modal (menu item type single newsfeed), Contact modal (type single contact), etc...**
