### PR TITLE
[com_menus] menus view: solve menus view link inconsistency

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -109,16 +109,16 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							<?php echo JHtml::_('grid.id', $i, $item->id); ?>
 						</td>
 						<td>
-							<?php if ($canManageItems) : ?>
-							<a href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype); ?>">
+							<?php if ($canEdit) : ?>
+							<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_menus&task=menu.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 								<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>
 							<div class="small">
 								<?php echo JText::_('COM_MENUS_MENU_MENUTYPE_LABEL'); ?>:
-								<?php if ($canEdit) : ?>
-									<a href="<?php echo JRoute::_('index.php?option=com_menus&task=menu.edit&id=' . $item->id); ?>" title="<?php echo $this->escape($item->description); ?>">
+								<?php if ($canManageItems) : ?>
+									<a href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype); ?>">
 									<?php echo $this->escape($item->menutype); ?></a>
 								<?php else : ?>
 									<?php echo $this->escape($item->menutype); ?>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

When we are in Menus -> Manage (com_menus, menus view) we have two links like this

![image](https://cloud.githubusercontent.com/assets/9630530/15095156/402dc8c0-14b2-11e6-965a-0bb5da8376d7.png)

But, the link behaviour is different from all other views. In all other views the title/name is the link to edit the item.

So this PR exchange the links for better UX and consistency. Also adds a "Edit" tooltip.
![image](https://cloud.githubusercontent.com/assets/9630530/15095159/6469fb0a-14b2-11e6-92aa-638dc6ac7291.png)
#### Testing Instructions
1. Apply patch in latest staging
2. Go to Menus -> Manage and check the links.
