### PR TITLE
[com_modules] Add edit tooltip

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -147,7 +147,7 @@ if ($saveOrder)
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'modules.', $canCheckin); ?>
 								<?php endif; ?>
 								<?php if ($canEdit) : ?>
-									<a href="<?php echo JRoute::_('index.php?option=com_modules&task=module.edit&id=' . (int) $item->id); ?>">
+									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_modules&task=module.edit&id=' . (int) $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 										<?php echo $this->escape($item->title); ?></a>
 								<?php else : ?>
 									<?php echo $this->escape($item->title); ?>


### PR DESCRIPTION
#### Summary of Changes

Very simple PR just to add the "Edit" tooltip that is missing in com_modules.

After PR
![image](https://cloud.githubusercontent.com/assets/9630530/15095207/2a6ed50e-14b4-11e6-9e11-bbf7f8f40057.png)
#### Testing Instructions

Code review, or:
1. Apply patch
2. Go to Extensions -> Modules and check the toolip on overring the modules title.
