### PR TITLE
New installer plugins: remove the dot in the plugin name and other language review

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.ini
@@ -3,9 +3,9 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_INSTALLER_PACKAGEINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Package (zip) Upload' tab."
 PLG_INSTALLER_PACKAGEINSTALLER="Installer - Upload from a Package Zip"
+PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE="Extension package file"
+PLG_INSTALLER_PACKAGEINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Package (zip) Upload' tab."
 PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION="Upload & Install Joomla Extension"
 PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE="Upload Package File"
-PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE="Extension package file"
 PLG_INSTALLER_PACKAGEINSTALLER__UPLOAD_AND_INSTALL="Upload & Install"

--- a/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_packageinstaller.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_INSTALLER_PACKAGEINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Package (zip) Upload' tab."
 PLG_INSTALLER_PACKAGEINSTALLER="Installer - Upload from a Package Zip"
+PLG_INSTALLER_PACKAGEINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Package (zip) Upload' tab."

--- a/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_INSTALLER_URLFOLDERINSTALLER="Installer - Install from URL or Path Folder"
-PLG_INSTALLER_URLFOLDERINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Install from URL or Path Folder' tab."
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLALL_TEXT="Install from URL or Path Folder"
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLALL_BUTTON="Check and Install"
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLALL_NO_INSTALL_PATH="Please enter a URL or Path Folder."
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLER_URLFOLDERINSTALLER="Installer - Install from URL or Path Folder."
+PLG_INSTALLER_URLFOLDERINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Install from URL or Path Folder' tab."

--- a/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.ini
@@ -3,6 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+PLG_INSTALLER_URLFOLDERINSTALLER="Installer - Install from URL or Path Folder"
 PLG_INSTALLER_URLFOLDERINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Install from URL or Path Folder' tab."
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLALL_TEXT="Install from URL or Path Folder"
 PLG_INSTALLER_URLFOLDERINSTALLER_INSTALLALL_BUTTON="Check and Install"

--- a/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_installer_urlfolderinstaller.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+PLG_INSTALLER_URLFOLDERINSTALLER="Installer - Install from URL or Path Folder"
 PLG_INSTALLER_URLFOLDERINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin offers functionality for the 'Install from URL or Path Folder' tab."
-PLG_INSTALLER_URLFOLDERINSTALLER="Installer - Install from URL or Path Folder."


### PR DESCRIPTION
#### Summary of Changes

Small changes in the new "Install from URL or Path Folder" plugin language file.
- Removes the dot in the plugin name (for consistency with all others)
- Add the plugin name in the main language file 
- Alpha order the language strings
#### Testing Instructions

Code review.
