### PR TITLE
Smart Search: utf8_strpos: Offset must be an integer

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -19,7 +19,7 @@ if ($show_description)
 	// Calculate number of characters to display around the result
 	$term_length = JString::strlen($this->query->input);
 	$desc_length = $this->params->get('description_length', 255);
-	$pad_length = $term_length < $desc_length ? floor(($desc_length - $term_length) / 2) : 0;
+	$pad_length = $term_length < $desc_length ? (int) floor(($desc_length - $term_length) / 2) : 0;
 
 	// Find the position of the search term
 	$pos = $term_length ? JString::strpos(JString::strtolower($this->result->description), JString::strtolower($this->query->input)) : false;


### PR DESCRIPTION
Under some circumstances a search for a word can result in a "PHP Fatal error:  utf8_strpos: Offset must be an integer".  This is because the floor function used to calculate the offset can sometimes return a float rather than an int.
#### Summary of Changes

The return value from the floor is now cast to an int to make sure that the offset (the 3rd argument) passed to JString::strpos, which becomes the offset argument to utf8_strpos, is always an int.
#### Testing Instructions

This may be tricky to replicate but this is how I encountered the problem in the first place...
1. Fresh install of Joomla with the Testing sample data set (the last option on the list).
2. Enable Smart Search and index the content.
3. From the front-end, go to the Smart Search search component page.
4. Enter "the" as the search term and click Search.

This should throw the error on one of the search results.  For me it happened on "Modules" and "Sample Sites".

Apply this PR and repeat the test.
