### PR TITLE
[minor fixes] modal module edition

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -137,7 +137,9 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					array(
 						'url' => $link,
 						'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-						'height' => '300px',
+						'backdrop' => 'static',
+						'closeButton' => false,
+						'height' => '400px',
 						'width' => '800px',
 						'closeButton' => false,
 						'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -140,9 +140,11 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 						'height' => '300px',
 						'width' => '800px',
 						'closeButton' => false,
-						'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+							. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-							. '<button type="button" class="btn btn-success novalidate" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+							. '<button type="button" class="btn btn-success novalidate" data-dismiss="modal" aria-hidden="true"'
+							. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 							. JText::_("JSAVE") . '</button>'
 					)
 				); ?>

--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+
 // This code is needed for proper check out in case of modal close
 JFactory::getDocument()->addScriptDeclaration('
 	window.parent.jQuery(".modal").on("hidden", function () {
@@ -21,6 +23,7 @@ JFactory::getDocument()->addScriptDeclaration('
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
 
-<?php
-$this->setLayout('edit');
-echo $this->loadTemplate();
+<div class="container-popup">
+	<?php $this->setLayout('edit'); ?>
+	<?php echo $this->loadTemplate(); ?>
+</div>


### PR DESCRIPTION
A few minor fixes for modal module edit (in menu item edition)
#### Summary of Changes
- Fix Close button not handling module edit close button (after close of the modal, the module was locked)
- Fix Tooltip placement (truncated at top)
- Add Container for iframe content
- Allow close only if click on Close or Save&Close buttons (to prevent accidental close while editing)
#### Testing Instructions

Before apply the patch:
- Go to menus, and open one menu item
- Click on one of the module in "Module Assignment" tab, to open the module edition
- Then check Tooltip for title (truncated)
- Then click with changing nothing, on the bottom CLOSE button of the modal
- Go to Modules Manager : the module is locked
  Example of "close" button issue with module named here "Archived Articles"
  ![capture d ecran 2016-05-08 a 16 27 14](https://cloud.githubusercontent.com/assets/2385058/15098320/c51c76e8-153a-11e6-8b2f-cb3439bee30f.png)
  ![capture d ecran 2016-05-08 a 16 27 57](https://cloud.githubusercontent.com/assets/2385058/15098322/cf86e6c2-153a-11e6-8ba7-61ae9195f845.png)

Apply patch, and : 
- verify tooltip placement
- test as above, and check that now the module is not locked (the module edition was well closed)
