### PR TITLE
Catch Exception from JHttpFactory::getHttp()

### DIFF
--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -42,8 +42,6 @@ abstract class JInstallerHelper
 		$version = new JVersion;
 		ini_set('user_agent', $version->getUserAgent('Installer'));
 
-		$http = JHttpFactory::getHttp();
-
 		// Load installer plugins, and allow url and headers modification
 		$headers = array();
 		JPluginHelper::importPlugin('installer');
@@ -52,7 +50,7 @@ abstract class JInstallerHelper
 
 		try
 		{
-			$response = $http->get($url, $headers);
+			$response = JHttpFactory::getHttp()->get($url, $headers);
 		}
 		catch (Exception $exception)
 		{


### PR DESCRIPTION
#### Summary of Changes

`JHttpFactory::getHttp()` throws a RuntimeException if there aren't any available transports, so it is better to catch that exception since we are already handling other error conditions in this method versus letting it bubble up.  Since the returned `JHttp` object is only used once, we also don't need to assign it to a variable.  The call to `JHttpFactory::getHttp()` is therefore moved into the try/catch where we attempt to make the remote GET call to download the package so that the error condition is gracefully handled.
#### Testing Instructions

Make `JHttpFactory::getHttp()` throw an Exception and try installing an extension via URL.  You should get an error with whatever the `JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT` key translates into as the message instead of it potentially bubbling up to the global exception handler (I don't know if there are any try/catch in the call chain going this way, so something may already be catching exceptions at a higher level; either way this is a semantically correct change).
