### PR TITLE
solve issue with clicking x on JED install

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -109,7 +109,7 @@ JFactory::getDocument()->addStyleDeclaration(
 						 style="margin-bottom: 40px; line-height: 2em; color:#333333;">
 					<?php echo JHtml::_(
 						'link',
-						JRoute::_('index.php?option=com_installer&view=discover' . urlencode(base64_encode(JUri::getInstance()))),
+						JRoute::_('index.php?option=com_config&view=component&component=com_installer&path=&return=' . urlencode(base64_encode(JUri::getInstance()))),
 						'&times;',
 						'class="close hasTooltip" data-dismiss="alert" title="' . str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '"'
 					);


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Click on JED message "X" button

![image](https://cloud.githubusercontent.com/assets/9630530/15099176/68877818-1546-11e6-8701-bf93ba4a7b86.png)

Result:
![image](https://cloud.githubusercontent.com/assets/9630530/15099178/7f91880a-1546-11e6-8fba-bf67d7601ad8.png)

This PR solves it
#### Testing Instructions
1. Use latest staging
2. Apply patch
3. Go to Extensions -> Manage -> Install
4. Click on the "X" in the JED message. You should now be redirect to the oprions to disable the message.
