### PR TITLE
Catch more specific Exception classes as practical

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -84,6 +84,10 @@ class JErrorPage
 				// This return is needed to ensure the test suite does not trigger the non-Exception handling below
 				return;
 			}
+			catch (Throwable $e)
+			{
+				// Pass the error down
+			}
 			catch (Exception $e)
 			{
 				// Pass the error down

--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -52,7 +52,7 @@ abstract class JInstallerHelper
 		{
 			$response = JHttpFactory::getHttp()->get($url, $headers);
 		}
-		catch (Exception $exception)
+		catch (RuntimeException $exception)
 		{
 			JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT', $exception->getMessage()), JLog::WARNING, 'jerror');
 

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -80,7 +80,7 @@ class JSchemaChangeset
 				{
 					$this->db->setQuery($changeItem->updateQuery)->execute();
 				}
-				catch (Exception $e)
+				catch (RuntimeException $e)
 				{
 					JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 				}

--- a/libraries/joomla/cache/storage/redis.php
+++ b/libraries/joomla/cache/storage/redis.php
@@ -84,7 +84,7 @@ class JCacheStorageRedis extends JCacheStorage
 				$connection = static::$_redis->pconnect($server['host'], $server['port']);
 				$auth       = (!empty($server['auth'])) ? static::$_redis->auth($server['auth']) : true;
 			}
-			catch (Exception $e)
+			catch (RedisException $e)
 			{
 				JLog::add($e->getMessage(), JLog::DEBUG);
 			}
@@ -96,7 +96,7 @@ class JCacheStorageRedis extends JCacheStorage
 				$connection = static::$_redis->connect($server['host'], $server['port']);
 				$auth       = (!empty($server['auth'])) ? static::$_redis->auth($server['auth']) : true;
 			}
-			catch (Exception $e)
+			catch (RedisException $e)
 			{
 				JLog::add($e->getMessage(), JLog::DEBUG);
 			}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -73,7 +73,7 @@ class JFilterInput extends InputFilter
 				// And now we can decide if we should strip USCs
 				$this->stripUSC = $db->hasUTF8mb4Support() ? 0 : 1;
 			}
-			catch (Exception $e)
+			catch (RuntimeException $e)
 			{
 				// Could not connect to MySQL. Strip USC to be on the safe side.
 				$this->stripUSC = 1;

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -47,7 +47,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return $result;
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
 			return false;
 		}
@@ -91,7 +91,7 @@ class JSessionStorageDatabase extends JSessionStorage
 			*/
 			return true;
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
 			return false;
 		}
@@ -122,7 +122,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return (boolean) $db->execute();
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
 			return false;
 		}
@@ -156,7 +156,7 @@ class JSessionStorageDatabase extends JSessionStorage
 
 			return (boolean) $db->execute();
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
 			return false;
 		}

--- a/libraries/joomla/updater/updateadapter.php
+++ b/libraries/joomla/updater/updateadapter.php
@@ -152,7 +152,7 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		{
 			$db->execute();
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
 			// Do nothing
 		}
@@ -187,9 +187,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		{
 			$name = $db->loadResult();
 		}
-		catch (Exception $e)
+		catch (RuntimeException $e)
 		{
-
+			// Do nothing
 		}
 
 		return $name;


### PR DESCRIPTION
Generally, catching the top level `Exception` class should only be done when required (i.e. a global exception handler or circumstances where `Exception` (not one of its subclasses) are thrown.  This PR tries to catch more specific Exception objects as logical.
#### Why Change?

Generally, code should only try to catch and handle errors it expects.  In the case of catching the top level `Exception` class, basically all errors will be caught and processed by the catch portion of the try/catch, even if it's an error condition that the code making the call wasn't expecting.  One could argue it's better to catch more errors than expected but it's really kind of a bad practice.
#### Summary of Changes
- `JErrorPage::render()` will now also catch a PHP 7 `Throwable` if one is thrown while rendering the error page (this is an extra step to help prevent possible WSOD or PHP Fatal conditions)
- `JInstallerHelper::downloadPackage()` will only catch thrown `RuntimeException` objects as that is all that is expected from the `JHttp` API
- The constructor of `JSchemaChangeset` will only catch thrown `RuntimeException` objects as that is all that is expected from the database API
- `JCacheStorageRedis::getConnection()` will only catch thrown `RedisException` objects as that is what the underlying PHP code throws
- The constructor of `JFilterInput` will only catch thrown `RuntimeException` objects as that is all that is expected from the database API
- `JSessionStorageDatabase` will only catch thrown `RuntimeException` objects as that is all that is expected from the database API
- `JUpdateAdapter` will only catch thrown `RuntimeException` objects as that is all that is expected from the database API
#### Testing Instructions

This is mostly going to be PLT review/decision.  If you wanted to test some of the changes, the easiest one will be to throw `Exception` from the `JHttp` API when installing an extension via URL. Pre-patch, it'll be caught and gracefully handled because the catch is for all `Exception` objects and post-patch that should bubble up to either something which is catching all `Exception` objects or hit the global handler and cause an error page to be displayed.
