### PR TITLE
[url install] Back to https, this time use a placeholder

### DIFF
--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -52,7 +52,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 				<label for="install_url"
 				       class="control-label"><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></label>
 				<div class="controls">
-					<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" value="http://"/>
+					<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>
 				</div>
 			</div>
 			<div class="form-actions">


### PR DESCRIPTION
#### Summary of Changes

Go back to `https://` (removed in recent comment)
See https://github.com/joomla/joomla-cms/pull/9383

This time i used a placeholder as suggested by @bembelimen

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15099505/fd4ea914-154e-11e6-87d6-6339d4decbea.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15099502/dbbcaf80-154e-11e6-99f4-a6df703a107a.png)
#### Testing Instructions

Code review
