### PR TITLE
Throw an exception if the cache storage is unsupported (Ref #9426)

### DIFF
--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -143,6 +143,7 @@ class JCacheStorage
 		// We can't cache this since options may change...
 		$handler = strtolower(preg_replace('/[^A-Z0-9_\.-]/i', '', $handler));
 
+		/** @var JCacheStorage $class */
 		$class = 'JCacheStorage' . ucfirst($handler);
 
 		if (!class_exists($class))
@@ -164,6 +165,12 @@ class JCacheStorage
 			{
 				throw new RuntimeException(sprintf('Unable to load Cache Storage: %s', $handler));
 			}
+		}
+
+		// Validate the cache storage is supported on this platform
+		if (!$class::isSupported())
+		{
+			throw new RuntimeException(sprintf('The %s Cache Storage is not supported on this platform.', $handler));
 		}
 
 		return new $class($options);


### PR DESCRIPTION
#### Summary of Changes

A check is added to `JCacheStorage::getInstance()` to ensure the cache store that is about to be instantiated is supported on the platform and will throw a `RuntimeException` if not.  This should help prevent trying to use a storage class that isn't compatible with the platform and instead of possibly hitting PHP Fatal errors the app will more gracefully die with the Exception being thrown.
#### Testing Instructions

Set your configuration's `cache_handler` value to use a cache store that isn't supported on your platform.  Pre-patch it will most likely lead to a fatal error or some other kind of Exception/Throwable depending on your setup; post-patch you should get an error page telling you the cache store isn't supported.
