### PR TITLE
Exit if the session storage is unsupported

### DIFF
--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -52,21 +52,34 @@ abstract class JSessionStorage
 
 		if (empty(self::$instances[$name]))
 		{
+			/** @var JSessionStorage $class */
 			$class = 'JSessionStorage' . ucfirst($name);
 
 			if (!class_exists($class))
 			{
 				$path = __DIR__ . '/storage/' . $name . '.php';
 
-				if (file_exists($path))
-				{
-					require_once $path;
-				}
-				else
+				if (!file_exists($path))
 				{
 					// No attempt to die gracefully here, as it tries to close the non-existing session
 					jexit('Unable to load session storage class: ' . $name);
 				}
+
+				require_once $path;
+
+				// The class should now be loaded
+				if (!class_exists($class))
+				{
+					// No attempt to die gracefully here, as it tries to close the non-existing session
+					jexit('Unable to load session storage class: ' . $name);
+				}
+			}
+
+			// Validate the session storage is supported on this platform
+			if (!$class::isSupported())
+			{
+				// No attempt to die gracefully here, as it tries to close the non-existing session
+				jexit(sprintf('The %s Session Storage is not supported on this platform.', $name));
 			}
 
 			self::$instances[$name] = new $class($options);


### PR DESCRIPTION
#### Summary of Changes

A check is added to `JSessionStorage::getInstance()` to ensure the session store that is about to be instantiated is supported on the platform and will gracefully exit the app if not.
#### Testing Instructions

Set your configuration's `session_handler` value to use a session store that isn't supported on your platform. Pre-patch it will most likely lead to a fatal error or some other kind of Exception/Throwable depending on your setup; post-patch you should get a white page telling you the session store isn't supported.
