### PR TITLE
Set correct sendmail path (Fix #10032)

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -558,6 +558,30 @@ class JMail extends PHPMailer
 	}
 
 	/**
+	 * Send messages using $Sendmail.
+	 *
+	 * This overrides the parent class to remove the restriction on the executable's name containing the word "sendmail"
+	 *
+	 * @return  void
+	 *
+	 * @since   11.1
+	 */
+	public function isSendmail()
+	{
+		// Prefer the Joomla configured sendmail path and default to the configured PHP path otherwise
+		$sendmail = JFactory::getConfig()->get('sendmail', ini_get('sendmail_path'));
+
+		// And if we still don't have a path, then use the system default for Linux
+		if (empty($sendmail))
+		{
+			$sendmail = '/usr/sbin/sendmail';
+		}
+
+		$this->Sendmail = $sendmail;
+		$this->Mailer   = 'sendmail';
+	}
+
+	/**
 	 * Use sendmail for sending the email
 	 *
 	 * @param   string  $sendmail  Path to sendmail [optional]


### PR DESCRIPTION
Pull Request for Issue #10032
#### Summary of Changes

Overrides the `PHPMailer::isSendmail()` method to remove the restriction on the name of the sendmail binary's name and to read the sendmail path configured in the global configuration (defaulting to PHP's `sendmail_path` if something isn't set in the global config and ultimately defaulting to `/usr/sbin/sendmail` if neither of those give a path).
#### Testing Instructions

Set a custom sendmail path in the global config, send a message using it, and ensure PHPMailer uses the correct binary path.
