### PR TITLE
Alternative approach to #9999 to deal with hardcoded import of plugins

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -585,8 +585,21 @@ final class JApplicationSite extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		// If a language was specified it has priority, otherwise use user or default language settings
-		JPluginHelper::importPlugin('system', 'languagefilter');
+		/*
+		 * If a language was specified it has priority, otherwise use user or default language settings
+		 * Check this only if the languagefilter plugin is enabled
+		 *
+		 * @TODO - Remove the hardcoded dependency to the languagefilter plugin
+		 */
+		if (JPluginHelper::isEnabled('system', 'languagefilter'))
+		{
+			$plugin = JPluginHelper::getPlugin('system', 'languagefilter');
+
+			$pluginParams = new Registry($plugin->params);
+
+			$this->setLanguageFilter(true);
+			$this->setDetectBrowser($pluginParams->get('detect_browser', '1') == '1');
+		}
 
 		if (empty($options['language']))
 		{
@@ -600,7 +613,7 @@ final class JApplicationSite extends JApplicationCms
 			}
 		}
 
-		if ($this->_language_filter && empty($options['language']))
+		if ($this->getLanguageFilter() && empty($options['language']))
 		{
 			// Detect cookie language
 			$lang = $this->input->cookie->get(md5($this->get('secret') . 'language'), null, 'string');
@@ -624,7 +637,7 @@ final class JApplicationSite extends JApplicationCms
 			}
 		}
 
-		if ($this->_detect_browser && empty($options['language']))
+		if ($this->getDetectBrowser() && empty($options['language']))
 		{
 			// Detect browser language
 			$lang = JLanguageHelper::detectLanguage();

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -75,11 +75,6 @@ class PlgSystemLanguageFilter extends JPlugin
 					unset($this->sefs[$language->sef]);
 				}
 			}
-
-			$this->app->setLanguageFilter(true);
-
-			// Detect browser feature.
-			$this->app->setDetectBrowser($this->params->get('detect_browser', '1') == '1');
 		}
 	}
 


### PR DESCRIPTION
This is the implementation of the alternative approach to #9999 I suggested.

To be quite frank, I don't work with the multilingual system so I don't know if this will have unintended side effects, someone more familiar than me on that will need to guide on this.

In essence, instead of importing the languagefilter plugin (which seems to hardcode it as the first plugin to be executed because the event dispatcher doesn't have an internal handling for event priorities), the plugin data is only loaded from the database and the params extracted out to set the application vars.

This defers importing of the plugin until the point when the system plugin group is imported to trigger the `onAfterInitialise` event and should cause the configured plugin ordering to be respected when importing and dispatching events. 
