### PR TITLE
Add simplify plugin

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -213,9 +213,9 @@ class UsersModelUser extends JModelAdmin
 		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
 
 		$result = parent::validate($form, $data, $group);
-		
+
 		$dispatcher->trigger('onUserAfterDataValidation', array($form, &$data, &$result));
-		
+
 		return $result;
 	}
 

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -191,6 +191,35 @@ class UsersModelUser extends JModelAdmin
 	}
 
 	/**
+	 * Method to validate the form data.
+	 *
+	 * @param   JForm   $form   The form to validate against.
+	 * @param   array   $data   The data to validate.
+	 * @param   string  $group  The name of the field group to validate.
+	 *
+	 * @return  mixed  Array of filtered data if valid, false otherwise.
+	 *
+	 * @see     JFormRule
+	 * @see     JFilterInput
+	 * @since   3.6
+	 */
+	public function validate($form, $data, $group = null)
+	{
+		// Load the users plugin group.
+		JPluginHelper::importPlugin('user');
+
+		$dispatcher = JEventDispatcher::getInstance();
+
+		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
+
+		$result = parent::validate($form, $data, $group);
+		
+		$dispatcher->trigger('onUserAfterDataValidation', array($form, &$data, &$result));
+		
+		return $result;
+	}
+
+	/**
 	 * Method to save the form data.
 	 *
 	 * @param   array  $data  The form data.

--- a/administrator/language/en-GB/en-GB.plg_user_simplify.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_simplify.ini
@@ -1,0 +1,14 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_USER_SIMPLIFY="User - Simplify"
+PLG_USER_SIMPLIFY_EMAIL1="Email (username)"
+PLG_USER_SIMPLIFY_EMAIL2="Confirm Email (username)"
+PLG_USER_SIMPLIFY_EMAIL="Email (username)"
+PLG_USER_SIMPLIFY_USERNAME="Email"
+PLG_USER_SIMPLIFY_FIELD_REMOVENAME_DESC="Remove name field from forms."
+PLG_USER__SIMPLIFY_FIELD_REMOVENAME_LABEL="Remove Name"
+PLG_USER_SIMPLIFY_XML_DESCRIPTION="Simplify the user registration, allows registration only with email address"
+

--- a/administrator/language/en-GB/en-GB.plg_user_simplify.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_simplify.ini
@@ -9,6 +9,6 @@ PLG_USER_SIMPLIFY_EMAIL2="Confirm Email (username)"
 PLG_USER_SIMPLIFY_EMAIL="Email (username)"
 PLG_USER_SIMPLIFY_USERNAME="Email"
 PLG_USER_SIMPLIFY_FIELD_REMOVENAME_DESC="Remove name field from forms."
-PLG_USER__SIMPLIFY_FIELD_REMOVENAME_LABEL="Remove Name"
-PLG_USER_SIMPLIFY_XML_DESCRIPTION="Simplify the user registration, allows registration only with email address"
+PLG_USER_SIMPLIFY_FIELD_REMOVENAME_LABEL="Remove Name"
+PLG_USER_SIMPLIFY_XML_DESCRIPTION="Simplify the user registration process. This allows registration only with email address."
 

--- a/administrator/language/en-GB/en-GB.plg_user_simplify.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_simplify.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_USER_SIMPLIFY="User - Simplify"
-PLG_USER_SIMPLIF_XML_DESCRIPTION="Simplify the user registration, allows registration only with email address"
+PLG_USER_SIMPLIF_XML_DESCRIPTION="Simplify the user registration process. This allows registration only with email address."

--- a/administrator/language/en-GB/en-GB.plg_user_simplify.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_simplify.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_USER_SIMPLIFY="User - Simplify"
+PLG_USER_SIMPLIF_XML_DESCRIPTION="Simplify the user registration, allows registration only with email address"

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -276,6 +276,35 @@ class UsersModelProfile extends JModelForm
 	}
 
 	/**
+	 * Method to validate the form data.
+	 *
+	 * @param   JForm   $form   The form to validate against.
+	 * @param   array   $data   The data to validate.
+	 * @param   string  $group  The name of the field group to validate.
+	 *
+	 * @return  mixed  Array of filtered data if valid, false otherwise.
+	 *
+	 * @see     JFormRule
+	 * @see     JFilterInput
+	 * @since   3.6
+	 */
+	public function validate($form, $data, $group = null)
+	{
+		// Load the users plugin group.
+		JPluginHelper::importPlugin('user');
+
+		$dispatcher = JEventDispatcher::getInstance();
+
+		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
+
+		$result = parent::validate($form, $data, $group);
+
+		$dispatcher->trigger('onUserAfterDataValidation', array($form, &$data, &$result));
+
+		return $result;
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -331,6 +331,35 @@ class UsersModelRegistration extends JModelForm
 	}
 
 	/**
+	 * Method to validate the form data.
+	 *
+	 * @param   JForm   $form   The form to validate against.
+	 * @param   array   $data   The data to validate.
+	 * @param   string  $group  The name of the field group to validate.
+	 *
+	 * @return  mixed  Array of filtered data if valid, false otherwise.
+	 *
+	 * @see     JFormRule
+	 * @see     JFilterInput
+	 * @since   3.6
+	 */
+	public function validate($form, $data, $group = null)
+	{
+		// Load the users plugin group.
+		JPluginHelper::importPlugin('user');
+
+		$dispatcher = JEventDispatcher::getInstance();
+
+		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
+
+		$result = parent::validate($form, $data, $group);
+
+		$dispatcher->trigger('onUserAfterDataValidation', array($form, &$data, &$result));
+
+		return $result;
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * Note. Calling getState in this method will result in recursion.

--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -94,10 +94,12 @@ JHtml::_('behavior.formvalidator');
 			<a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
 			<?php echo JText::_('COM_USERS_LOGIN_RESET'); ?></a>
 		</li>
+		<?php if ( ! JPluginHelper::isEnabled('user', 'simplify')) :?>
 		<li>
 			<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
 			<?php echo JText::_('COM_USERS_LOGIN_REMIND'); ?></a>
 		</li>
+		<?php endif; ?>
 		<?php
 		$usersConfig = JComponentHelper::getParams('com_users');
 		if ($usersConfig->get('allowUserRegistration')) : ?>

--- a/components/com_users/views/profile/tmpl/default_core.php
+++ b/components/com_users/views/profile/tmpl/default_core.php
@@ -9,6 +9,20 @@
 
 defined('_JEXEC') or die;
 
+$showname     = true;
+$showusername = true;
+
+if (JPluginHelper::isEnabled('user', 'simplify'))
+{
+	$showusername = false;
+
+	$plugin = JPluginHelper::getPlugin('user', 'simplify');
+
+	$params = (new JRegistry)->loadString($plugin->params);
+
+	$showname = $params->get('remove_name_field', 1) == 0;
+}
+
 ?>
 
 <fieldset id="users-profile-core">
@@ -16,18 +30,22 @@ defined('_JEXEC') or die;
 		<?php echo JText::_('COM_USERS_PROFILE_CORE_LEGEND'); ?>
 	</legend>
 	<dl class="dl-horizontal">
-		<dt>
-			<?php echo JText::_('COM_USERS_PROFILE_NAME_LABEL'); ?>
-		</dt>
-		<dd>
-			<?php echo $this->data->name; ?>
-		</dd>
-		<dt>
-			<?php echo JText::_('COM_USERS_PROFILE_USERNAME_LABEL'); ?>
-		</dt>
-		<dd>
-			<?php echo htmlspecialchars($this->data->username); ?>
-		</dd>
+		<?php if ( $showname) :?>
+			<dt>
+				<?php echo JText::_('COM_USERS_PROFILE_NAME_LABEL'); ?>
+			</dt>
+			<dd>
+				<?php echo $this->data->name; ?>
+			</dd>
+		<?php endif; ?>
+		<?php if ( $showusername) :?>
+			<dt>
+				<?php echo JText::_('COM_USERS_PROFILE_USERNAME_LABEL'); ?>
+			</dt>
+			<dd>
+				<?php echo htmlspecialchars($this->data->username); ?>
+			</dd>
+		<?php endif; ?>
 		<dt>
 			<?php echo JText::_('COM_USERS_PROFILE_REGISTERED_DATE_LABEL'); ?>
 		</dt>

--- a/components/com_users/views/profile/tmpl/default_core.php
+++ b/components/com_users/views/profile/tmpl/default_core.php
@@ -18,7 +18,8 @@ if (JPluginHelper::isEnabled('user', 'simplify'))
 
 	$plugin = JPluginHelper::getPlugin('user', 'simplify');
 
-	$params = (new JRegistry)->loadString($plugin->params);
+	$params = new JRegistry;
+	$params->loadString($plugin->params);
 
 	$showname = $params->get('remove_name_field', 1) == 0;
 }

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -954,6 +954,7 @@ class JForm
 	 * @param   SimpleXMLElement  $element  The XML element object representation of the form field.
 	 * @param   string            $group    The optional dot-separated form group path on which to set the field.
 	 * @param   boolean           $replace  True to replace an existing field if one already exists.
+	 * @param   string            $path	    Tree elements a doc separated list where we add the node.
 	 *
 	 * @return  boolean  True on success.
 	 *
@@ -2102,9 +2103,11 @@ class JForm
 	/**
 	 * Adds a new child SimpleXMLElement node to the source.
 	 *
-	 * @param   SimpleXMLElement $source  The source element on which to append.
-	 * @param   SimpleXMLElement $new     The new element to append.
-	 * @param   string           $path	  Tree elements a doc separated list where we add the node
+	 * @param   SimpleXMLElement  $source  The source element on which to append.
+	 * @param   SimpleXMLElement  $new     The new element to append.
+	 * @param   string            $path	   Tree elements a doc separated list where we add the node
+	 *
+	 * @return  void
 	 *
 	 * @since   11.1
 	 */
@@ -2114,13 +2117,13 @@ class JForm
 		if ($path != '')
 		{
 			$pathElements = explode('.', $path);
-			
+
 			foreach ($pathElements as $element)
 			{
 				$source = $source->{$element};
 			}	
 		}
-		
+
 		// Add the new child node.
 		$node = $source->addChild($new->getName(), htmlspecialchars(trim($new)));
 

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -960,7 +960,7 @@ class JForm
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
-	public function setField(SimpleXMLElement $element, $group = null, $replace = true)
+	public function setField(SimpleXMLElement $element, $group = null, $replace = true, $path = '')
 	{
 		// Make sure there is a valid JForm XML document.
 		if (!($this->xml instanceof SimpleXMLElement))
@@ -999,7 +999,7 @@ class JForm
 		else
 		{
 			// Set the new field to the form.
-			self::addNode($this->xml, $element);
+			self::addNode($this->xml, $element, $path);
 		}
 
 		// Synchronize any paths found in the load.
@@ -2102,15 +2102,25 @@ class JForm
 	/**
 	 * Adds a new child SimpleXMLElement node to the source.
 	 *
-	 * @param   SimpleXMLElement  $source  The source element on which to append.
-	 * @param   SimpleXMLElement  $new     The new element to append.
-	 *
-	 * @return  void
+	 * @param   SimpleXMLElement $source  The source element on which to append.
+	 * @param   SimpleXMLElement $new     The new element to append.
+	 * @param   string           $path	  Tree elements a doc separated list where we add the node
 	 *
 	 * @since   11.1
 	 */
-	protected static function addNode(SimpleXMLElement $source, SimpleXMLElement $new)
+	protected static function addNode(SimpleXMLElement $source, SimpleXMLElement $new, $path = '')
 	{
+		// Get the right parent element
+		if ($path != '')
+		{
+			$pathElements = explode('.', $path);
+			
+			foreach ($pathElements as $element)
+			{
+				$source = $source->{$element};
+			}	
+		}
+		
 		// Add the new child node.
 		$node = $source->addChild($new->getName(), htmlspecialchars(trim($new)));
 
@@ -2264,5 +2274,20 @@ class JForm
 	public function getXml()
 	{
 		return $this->xml;
+	}
+
+	/**
+	 * Method to get a form field represented as an XML element object.
+	 *
+	 * @param   string  $name   The name of the form field.
+	 * @param   string  $group  The optional dot-separated form group path on which to find the field.
+	 *
+	 * @return  SimpleXMLElement|boolean  The XML element object for the field or boolean false on error.
+	 *
+	 * @since   3.6
+	 */
+	public function getFieldXml($name, $group = null)
+	{
+		return self::findField($name, $group);
 	}
 }

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -2291,6 +2291,6 @@ class JForm
 	 */
 	public function getFieldXml($name, $group = null)
 	{
-		return self::findField($name, $group);
+		return $this->findField($name, $group);
 	}
 }

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -2105,7 +2105,7 @@ class JForm
 	 *
 	 * @param   SimpleXMLElement  $source  The source element on which to append.
 	 * @param   SimpleXMLElement  $new     The new element to append.
-	 * @param   string            $path	   Tree elements a doc separated list where we add the node
+	 * @param   string            $path	   Tree elements a dot separated list where we add the node.
 	 *
 	 * @return  void
 	 *
@@ -2121,7 +2121,7 @@ class JForm
 			foreach ($pathElements as $element)
 			{
 				$source = $source->{$element};
-			}	
+			}
 		}
 
 		// Add the new child node.

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -14,6 +14,13 @@ require_once JPATH_SITE . '/components/com_users/helpers/route.php';
 JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
+// Load the users plugin group.
+JPluginHelper::importPlugin('user');
+
+$simplify = JPluginHelper::isEnabled('user', 'simplify');
+
+$usernameTag = $simplify ? 'PLG_USER_SIMPLIFY_USERNAME' : 'MOD_LOGIN_VALUE_USERNAME';
+
 ?>
 <form action="<?php echo JRoute::_(htmlspecialchars(JUri::getInstance()->toString()), true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
 	<?php if ($params->get('pretext')) : ?>
@@ -27,14 +34,14 @@ JHtml::_('bootstrap.tooltip');
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend">
 						<span class="add-on">
-							<span class="icon-user hasTooltip" title="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>"></span>
-							<label for="modlgn-username" class="element-invisible"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
+							<span class="icon-user hasTooltip" title="<?php echo JText::_($usernameTag) ?>"></span>
+							<label for="modlgn-username" class="element-invisible"><?php echo JText::_($usernameTag); ?></label>
 						</span>
-						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>" />
+						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_($usernameTag) ?>" />
 					</div>
 				<?php else: ?>
-					<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?></label>
-					<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?>" />
+					<label for="modlgn-username"><?php echo JText::_($usernameTag) ?></label>
+					<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_($usernameTag) ?>" />
 				<?php endif; ?>
 			</div>
 		</div>
@@ -102,10 +109,12 @@ JHtml::_('bootstrap.tooltip');
 					<?php echo JText::_('MOD_LOGIN_REGISTER'); ?> <span class="icon-arrow-right"></span></a>
 				</li>
 			<?php endif; ?>
-				<li>
-					<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind&Itemid=' . UsersHelperRoute::getRemindRoute()); ?>">
-					<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
-				</li>
+				<?php if (! $simplify) : ?>
+					<li>
+						<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind&Itemid=' . UsersHelperRoute::getRemindRoute()); ?>">
+						<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
+					</li>
+				<?php endif; ?>
 				<li>
 					<a href="<?php echo JRoute::_('index.php?option=com_users&view=reset&Itemid=' . UsersHelperRoute::getResetRoute()); ?>">
 					<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>

--- a/plugins/user/simplify/simplify.php
+++ b/plugins/user/simplify/simplify.php
@@ -18,187 +18,185 @@ use Joomla\Registry\Registry;
  */
 class PlgUserSimplify extends JPlugin
 {
-    /**
-     * Load the language file on instantiation.
-     *
-     * @var    boolean
-     */
-    protected $autoloadLanguage = true;
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 */
+	protected $autoloadLanguage = true;
 
-    /**
-     * Application object
-     *
-     * @var    JApplicationCms
-     */
-    protected $app;
-    
-    /**
-     * Manipulate the user forms
-     *
-     * @param   JForm  $form  The form to be altered.
-     * @param   mixed  $data  The associated data for the form.
-     *
-     * @return  boolean
-     *
-     * @since   3.6
-     */
-    public function onContentPrepareForm($form, $data)
-    {
-        if (!($form instanceof JForm))
-        {
-            $this->_subject->setError('JERROR_NOT_A_FORM');
-            
-            return false;
-        }
-        
-        // Check we are manipulating a valid form.
-        $name = $form->getName();
-        
-        if (!in_array($name,
-            array('com_users.user', 'com_users.login', 'com_users.registration', 'com_users.profile'))
-        )
-        {
-            return true;
-        }
+	/**
+	 * Application object
+	 *
+	 * @var    JApplicationCms
+	 */
+	protected $app;
 
-        /*
-         * Check if we in right process step, we have a couple of options here to detect where we are. It is important
-         * to only manipulate the JForm object we use to display the form. For validation we need all fields because
-         * of the JTable checks, if name and username are filled and validation only works on fields that are part
-         * of the JForm object.
-         */
+	/**
+	 * Manipulate the user forms
+	 *
+	 * @param   JForm  $form  The form to be altered.
+	 * @param   mixed  $data  The associated data for the form.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.6
+	 */
+	public function onContentPrepareForm($form, $data)
+	{
+		if (!($form instanceof JForm))
+		{
+			$this->_subject->setError('JERROR_NOT_A_FORM');
 
-        if ($this->app->input->get('task') != '')
-        {
-            return true;
-        }
+			return false;
+		}
 
-        if ($name == 'com_users.profile')
-        {
-            // We resort the fields and change the label a bit so that it makes more sense
-            $fields   = array('id', 'name', 'username', 'password1', 'password2', 'email1', 'email2');
-            $newOrder = array('email1', 'email2', 'password1', 'password2');
+		// Check we are manipulating a valid form.
+		$name = $form->getName();
 
-            if ($this->params->get('remove_name_field', 1) == 0)
-            {
-                $newOrder = array_merge(array('name'), $newOrder);
-            }
+		if (!in_array($name, array('com_users.user', 'com_users.login', 'com_users.registration', 'com_users.profile')))
+		{
+			return true;
+		}
 
-            $newOrder = array_merge(array('id'), $newOrder);
+		/*
+		 * Check if we in right process step, we have a couple of options here to detect where we are. It is important
+		 * to only manipulate the JForm object we use to display the form. For validation we need all fields because
+		 * of the JTable checks, if name and username are filled and validation only works on fields that are part
+		 * of the JForm object.
+		 */
 
-            $this->reorderFormFields($form, $fields, $newOrder);
+		if ($this->app->input->get('task') != '')
+		{
+			return true;
+		}
 
-            $form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
-            $form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
-        }
+		if ($name == 'com_users.profile')
+		{
+			// We resort the fields and change the label a bit so that it makes more sense
+			$fields   = array('id', 'name', 'username', 'password1', 'password2', 'email1', 'email2');
+			$newOrder = array('email1', 'email2', 'password1', 'password2');
 
-        if ($name == 'com_users.registration')
-        {
-            // We resort the fields and change the label a bit so that it makes more sense
-            $fields   = array('spacer', 'name', 'username', 'password1', 'password2', 'email1', 'email2', 'captcha');
-            $newOrder = array('email1', 'email2', 'password1', 'password2', 'captcha');
+			if ($this->params->get('remove_name_field', 1) == 0)
+			{
+				$newOrder = array_merge(array('name'), $newOrder);
+			}
 
-            if ($this->params->get('remove_name_field', 1) == 0)
-            {
-                $newOrder = array_merge(array('name'), $newOrder);
-            }
+			$newOrder = array_merge(array('id'), $newOrder);
 
-            $newOrder = array_merge(array('spacer'), $newOrder);
+			$this->reorderFormFields($form, $fields, $newOrder);
 
-            $this->reorderFormFields($form, $fields, $newOrder);
+			$form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
+			$form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
+		}
 
-            $form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
-            $form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
-        }
+		if ($name == 'com_users.registration')
+		{
+			// We resort the fields and change the label a bit so that it makes more sense
+			$fields   = array('spacer', 'name', 'username', 'password1', 'password2', 'email1', 'email2', 'captcha');
+			$newOrder = array('email1', 'email2', 'password1', 'password2', 'captcha');
 
-        if ($name == 'com_users.user')
-        {
-            // We resort the fields and change the label a bit so that it makes more sense
-            $fields   = array('name', 'username', 'password', 'password2', 'email', 'registerDate', 'lastvisitDate',
-                             'lastResetTime', 'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
-            );
-            $newOrder = array('email', 'password', 'password2', 'registerDate', 'lastvisitDate', 'lastResetTime',
-                                'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
-            );
+			if ($this->params->get('remove_name_field', 1) == 0)
+			{
+				$newOrder = array_merge(array('name'), $newOrder);
+			}
 
-            if ($this->params->get('remove_name_field', 1) == 0)
-            {
-                $newOrder = array_merge(array('name'), $newOrder);
-            }
+			$newOrder = array_merge(array('spacer'), $newOrder);
 
-            $this->reorderFormFields($form, $fields, $newOrder);
+			$this->reorderFormFields($form, $fields, $newOrder);
 
-            $form->setFieldAttribute('email', 'label', 'PLG_USER_SIMPLIFY_EMAIL');
-        }
+			$form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
+			$form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
+		}
 
-        if ($name == 'com_users.login')
-        {
-            $form->setFieldAttribute('username', 'label', 'PLG_USER_SIMPLIFY_USERNAME');
-        }
+		if ($name == 'com_users.user')
+		{
+			// We resort the fields and change the label a bit so that it makes more sense
+			$fields   = array('name', 'username', 'password', 'password2', 'email', 'registerDate', 'lastvisitDate',
+							 'lastResetTime', 'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
+			);
+			$newOrder = array('email', 'password', 'password2', 'registerDate', 'lastvisitDate', 'lastResetTime',
+								'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
+			);
 
-        return true;
-    }
-    
-    /**
-     * Method is called before user data is validated
-     *
-     * @param   JForm  $form  The form to be altered.
-     * @param   mixed  $data  The associated data for the form.
-     *
-     * @return  boolean
-     *
-     * @since   3.6
-     */
-    public function onUserBeforeDataValidation($form, &$data)
-    {
-        if (array_key_exists('email', $data))
-        {
-            $value = $data['email'];
-        }    
-        
-        if (array_key_exists('email1', $data))
-        {
-            $value = $data['email1'];
-        }    
-        
-        if ($this->params->get('remove_name_field', 1) == 1)
-        {
-            $data['name'] = $value;
-        }
+			if ($this->params->get('remove_name_field', 1) == 0)
+			{
+				$newOrder = array_merge(array('name'), $newOrder);
+			}
 
-        if ($this->params->get('remove_username_field', 1) == 1)
-        {
-            $data['username'] = $value;
-        }
+			$this->reorderFormFields($form, $fields, $newOrder);
 
-        return true;
-    }
+			$form->setFieldAttribute('email', 'label', 'PLG_USER_SIMPLIFY_EMAIL');
+		}
 
-    /**
-     * Reorder fields of the form
-     *
-     * @param   JForm  $form      The form to be altered.
-     * @param   array  $fields    The fields of the form
-     * @param   array  $newOrder  The new ordering for the fields
-     *
-     * @return void
-     *
-     * @since   3.6
-     */
-    private function reorderFormFields($form, $fields, $newOrder)
-    {
-        $formFields = array();
+		if ($name == 'com_users.login')
+		{
+			$form->setFieldAttribute('username', 'label', 'PLG_USER_SIMPLIFY_USERNAME');
+		}
 
-        foreach ($fields AS $field)
-        {
-            $formFields[$field] = $form->getFieldXml($field);
+		return true;
+	}
 
-            $form->removeField($field);
-        }
+	/**
+	 * Method is called before user data is validated
+	 *
+	 * @param   JForm  $form   The form to be altered.
+	 * @param   mixed  &$data  The associated data for the form.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.6
+	 */
+	public function onUserBeforeDataValidation($form, &$data)
+	{
+		if (array_key_exists('email', $data))
+		{
+			$value = $data['email'];
+		}
 
-        foreach ($newOrder AS $field)
-        {
-            $form->setField($formFields[$field], null, false, 'fieldset');
-        }
-    }
+		if (array_key_exists('email1', $data))
+		{
+			$value = $data['email1'];
+		}
+
+		if ($this->params->get('remove_name_field', 1) == 1)
+		{
+			$data['name'] = $value;
+		}
+
+		if ($this->params->get('remove_username_field', 1) == 1)
+		{
+			$data['username'] = $value;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Reorder fields of the form
+	 *
+	 * @param   JForm  $form      The form to be altered.
+	 * @param   array  $fields    The fields of the form
+	 * @param   array  $newOrder  The new ordering for the fields
+	 *
+	 * @return void
+	 *
+	 * @since   3.6
+	 */
+	private function reorderFormFields($form, $fields, $newOrder)
+	{
+		$formFields = array();
+
+		foreach ($fields AS $field)
+		{
+			$formFields[$field] = $form->getFieldXml($field);
+
+			$form->removeField($field);
+		}
+
+		foreach ($newOrder AS $field)
+		{
+			$form->setField($formFields[$field], null, false, 'fieldset');
+		}
+	}
 }

--- a/plugins/user/simplify/simplify.php
+++ b/plugins/user/simplify/simplify.php
@@ -113,7 +113,7 @@ class PlgUserSimplify extends JPlugin
 		{
 			// We resort the fields and change the label a bit so that it makes more sense
 			$fields   = array('name', 'username', 'password', 'password2', 'email', 'registerDate', 'lastvisitDate',
-							 'lastResetTime', 'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
+								'lastResetTime', 'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
 			);
 			$newOrder = array('email', 'password', 'password2', 'registerDate', 'lastvisitDate', 'lastResetTime',
 								'resetCount', 'sendEmail', 'block', 'requireReset', 'id'

--- a/plugins/user/simplify/simplify.php
+++ b/plugins/user/simplify/simplify.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  User.joomla
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Simplify User plugin
+ *
+ * @since  3.6
+ */
+class PlgUserSimplify extends JPlugin
+{
+    /**
+     * Load the language file on instantiation.
+     *
+     * @var    boolean
+     */
+    protected $autoloadLanguage = true;
+
+    /**
+     * Application object
+     *
+     * @var    JApplicationCms
+     */
+    protected $app;
+    
+    /**
+     * Manipulate the user forms
+     *
+     * @param   JForm  $form  The form to be altered.
+     * @param   mixed  $data  The associated data for the form.
+     *
+     * @return  boolean
+     *
+     * @since   3.6
+     */
+    public function onContentPrepareForm($form, $data)
+    {
+        if (!($form instanceof JForm))
+        {
+            $this->_subject->setError('JERROR_NOT_A_FORM');
+            
+            return false;
+        }
+        
+        // Check we are manipulating a valid form.
+        $name = $form->getName();
+        
+        if (!in_array($name,
+            array('com_users.user', 'com_users.login', 'com_users.registration', 'com_users.profile'))
+        )
+        {
+            return true;
+        }
+
+        /*
+         * Check if we in right process step, we have a couple of options here to detect where we are. It is important
+         * to only manipulate the JForm object we use to display the form. For validation we need all fields because
+         * of the JTable checks, if name and username are filled and validation only works on fields that are part
+         * of the JForm object.
+         */
+
+        if ($this->app->input->get('task') != '')
+        {
+            return true;
+        }
+
+        if ($name == 'com_users.profile')
+        {
+            // We resort the fields and change the label a bit so that it makes more sense
+            $fields   = array('id', 'name', 'username', 'password1', 'password2', 'email1', 'email2');
+            $newOrder = array('email1', 'email2', 'password1', 'password2');
+
+            if ($this->params->get('remove_name_field', 1) == 0)
+            {
+                $newOrder = array_merge(array('name'), $newOrder);
+            }
+
+            $newOrder = array_merge(array('id'), $newOrder);
+
+            $this->reorderFormFields($form, $fields, $newOrder);
+
+            $form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
+            $form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
+        }
+
+        if ($name == 'com_users.registration')
+        {
+            // We resort the fields and change the label a bit so that it makes more sense
+            $fields   = array('spacer', 'name', 'username', 'password1', 'password2', 'email1', 'email2', 'captcha');
+            $newOrder = array('email1', 'email2', 'password1', 'password2', 'captcha');
+
+            if ($this->params->get('remove_name_field', 1) == 0)
+            {
+                $newOrder = array_merge(array('name'), $newOrder);
+            }
+
+            $newOrder = array_merge(array('spacer'), $newOrder);
+
+            $this->reorderFormFields($form, $fields, $newOrder);
+
+            $form->setFieldAttribute('email1', 'label', 'PLG_USER_SIMPLIFY_EMAIL1');
+            $form->setFieldAttribute('email2', 'label', 'PLG_USER_SIMPLIFY_EMAIL2');
+        }
+
+        if ($name == 'com_users.user')
+        {
+            // We resort the fields and change the label a bit so that it makes more sense
+            $fields   = array('name', 'username', 'password', 'password2', 'email', 'registerDate', 'lastvisitDate',
+                             'lastResetTime', 'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
+            );
+            $newOrder = array('email', 'password', 'password2', 'registerDate', 'lastvisitDate', 'lastResetTime',
+                                'resetCount', 'sendEmail', 'block', 'requireReset', 'id'
+            );
+
+            if ($this->params->get('remove_name_field', 1) == 0)
+            {
+                $newOrder = array_merge(array('name'), $newOrder);
+            }
+
+            $this->reorderFormFields($form, $fields, $newOrder);
+
+            $form->setFieldAttribute('email', 'label', 'PLG_USER_SIMPLIFY_EMAIL');
+        }
+
+        if ($name == 'com_users.login')
+        {
+            $form->setFieldAttribute('username', 'label', 'PLG_USER_SIMPLIFY_USERNAME');
+        }
+
+        return true;
+    }
+    
+    /**
+     * Method is called before user data is validated
+     *
+     * @param   JForm  $form  The form to be altered.
+     * @param   mixed  $data  The associated data for the form.
+     *
+     * @return  boolean
+     *
+     * @since   3.6
+     */
+    public function onUserBeforeDataValidation($form, &$data)
+    {
+        if (array_key_exists('email', $data))
+        {
+            $value = $data['email'];
+        }    
+        
+        if (array_key_exists('email1', $data))
+        {
+            $value = $data['email1'];
+        }    
+        
+        if ($this->params->get('remove_name_field', 1) == 1)
+        {
+            $data['name'] = $value;
+        }
+
+        if ($this->params->get('remove_username_field', 1) == 1)
+        {
+            $data['username'] = $value;
+        }
+
+        return true;
+    }
+
+    /**
+     * Reorder fields of the form
+     *
+     * @param   JForm  $form      The form to be altered.
+     * @param   array  $fields    The fields of the form
+     * @param   array  $newOrder  The new ordering for the fields
+     *
+     * @return void
+     *
+     * @since   3.6
+     */
+    private function reorderFormFields($form, $fields, $newOrder)
+    {
+        $formFields = array();
+
+        foreach ($fields AS $field)
+        {
+            $formFields[$field] = $form->getFieldXml($field);
+
+            $form->removeField($field);
+        }
+
+        foreach ($newOrder AS $field)
+        {
+            $form->setField($formFields[$field], null, false, 'fieldset');
+        }
+    }
+}

--- a/plugins/user/simplify/simplify.xml
+++ b/plugins/user/simplify/simplify.xml
@@ -24,7 +24,7 @@
 					   class="btn-group btn-group-yesno"
 					   default="1"
 					   description="PLG_USER_SIMPLIFY_FIELD_REMOVENAME_DESC"
-					   label="PLG_USER__SIMPLIFY_FIELD_REMOVENAME_LABEL"
+					   label="PLG_USER_SIMPLIFY_FIELD_REMOVENAME_LABEL"
 				>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>

--- a/plugins/user/simplify/simplify.xml
+++ b/plugins/user/simplify/simplify.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.6" type="plugin" group="user" method="upgrade">
+	<name>plg_user_simplify</name>
+	<author>Joomla! Project</author>
+	<creationDate>May 2016</creationDate>
+	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.0.0</version>
+	<description>PLG_USER_SIMPLIFY_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="simplify">simplify.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_user_simplify.ini</language>
+		<language tag="en-GB">en-GB.plg_user_simplify.sys.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+				<field name="remove_name_field"
+					   type="radio"
+					   class="btn-group btn-group-yesno"
+					   default="1"
+					   description="PLG_USER_SIMPLIFY_FIELD_REMOVENAME_DESC"
+					   label="PLG_USER__SIMPLIFY_FIELD_REMOVENAME_LABEL"
+				>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
+				</field>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/templates/beez3/html/mod_login/default.php
+++ b/templates/beez3/html/mod_login/default.php
@@ -11,6 +11,14 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
+
+// Load the users plugin group.
+JPluginHelper::importPlugin('user');
+
+$simplify = JPluginHelper::isEnabled('user', 'simplify');
+
+$usernameTag = $simplify ? 'PLG_USER_SIMPLIFY_USERNAME' : 'MOD_LOGIN_VALUE_USERNAME';
+
 ?>
 <?php if ($type == 'logout') : ?>
 	<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form">
@@ -40,7 +48,7 @@ JHtml::_('behavior.keepalive');
 	<?php endif; ?>
 	<fieldset class="userdata">
 	<p id="form-login-username">
-		<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?></label>
+		<label for="modlgn-username"><?php echo JText::_($usernameTag) ?></label>
 		<input id="modlgn-username" type="text" name="username" class="inputbox"  size="18" />
 	</p>
 	<p id="form-login-password">
@@ -78,10 +86,12 @@ JHtml::_('behavior.keepalive');
 			<a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
 			<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>
 		</li>
-		<li>
-			<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
-			<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
-		</li>
+		<?php if (! $simplify) : ?>
+			<li>
+				<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
+				<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
+			</li>
+		<?php endif; ?>
 		<?php $usersConfig = JComponentHelper::getParams('com_users'); ?>
 		<?php if ($usersConfig->get('allowUserRegistration')) : ?>
 			<li>

--- a/tests/unit/stubs/FormInspectors.php
+++ b/tests/unit/stubs/FormInspectors.php
@@ -28,12 +28,13 @@ class JFormInspector extends JForm
 	 *
 	 * @param   SimpleXMLElement  $source  The source element on which to append.
 	 * @param   SimpleXMLElement  $new     The new element to append.
+	 * @param   string            $path	   Tree elements a dot separated list where we add the node.
 	 *
 	 * @return  void
 	 */
-	public static function addNode(SimpleXMLElement $source, SimpleXMLElement $new)
+	public static function addNode(SimpleXMLElement $source, SimpleXMLElement $new, $path = '')
 	{
-		return parent::addNode($source, $new);
+		return parent::addNode($source, $new, $path);
 	}
 
 	/**


### PR DESCRIPTION
# Executive summary

This new plugin allow registration of a user only with an email address. If the plugin is enabled the username field is not available in forms. As default also the name field isn’t available but this can be configured.
# Backwards compatibility

Problems can occur when a template overwrite has changed one of the following views:
- com_users/views/login/default_login.php
- com_users/views/profile/default_core.php
- com_users/views/registration/default.php

Same is possible for the login module.

A small problem can be if someone has a direct link to the „Username Reminder Request“ as we have in our test data. This doesn’t makes sense in this configuration.
# Translation impact

Two new language files with 8 new language tags.
# Core changes
- New User Plugin Event „onUserBeforeDataValidation“
- New User Plugin Event „onUserAfterDataValidation“
- New JForm Class method getFieldXml as public getter for the protected method findField
- New parameter path for the setField method of JForm, allows to add a field at a specific place in the xml tree. 

All core changes are only additions and full B/C, even if the plugin isn’t accepted these changes allow more flexibility for JForm.
# Testing instruction
- Apply the patch
- Go to extensions and discover install the new plugin
- Enable the plugin
- Enable user registration

1) Test registration process
2) Test login
3) Test profile edit frontend
4) Test user data change backend
