### PR TITLE
Important! Change pkg_en-GB id to 802, since 801 can be used by pkg_weblinks

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
@@ -6,9 +6,9 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 UPDATE `#__update_sites_extensions`
 SET `extension_id` = 802
 WHERE `update_site_id` IN (
-						SELECT `update_site_id`
-						FROM `#__update_sites`
-						WHERE `name` = 'Accredited Joomla! Translations'
-						AND `type` = 'collection'
-						)
+			SELECT `update_site_id`
+			FROM `#__update_sites`
+			WHERE `name` = 'Accredited Joomla! Translations'
+			AND `type` = 'collection'
+			)
 AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
@@ -1,6 +1,6 @@
 -- Insert the missing en-GB package extension.
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`)
- VALUES (801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+ VALUES (802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- Change update site extension id to the new extension.
-UPDATE `#__update_sites_extensions` SET `extension_id` = 801 WHERE `update_site_id` = 3 AND `extension_id` = 600;
+UPDATE `#__update_sites_extensions` SET `extension_id` = 802 WHERE `name` = 'Accredited Joomla! Translations' AND `type` = 'collection' AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-08.sql
@@ -3,4 +3,12 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
  VALUES (802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- Change update site extension id to the new extension.
-UPDATE `#__update_sites_extensions` SET `extension_id` = 802 WHERE `name` = 'Accredited Joomla! Translations' AND `type` = 'collection' AND `extension_id` = 600;
+UPDATE `#__update_sites_extensions`
+SET `extension_id` = 802
+WHERE `update_site_id` IN (
+						SELECT `update_site_id`
+						FROM `#__update_sites`
+						WHERE `name` = 'Accredited Joomla! Translations'
+						AND `type` = 'collection'
+						)
+AND `extension_id` = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
@@ -1,4 +1,4 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
-UPDATE "#__update_sites_extensions" SET "extension_id" = 801 WHERE "update_site_id" = 3 AND "extension_id" = 600;
+UPDATE "#__update_sites_extensions" SET "extension_id" = 802 WHERE "name" = 'Accredited Joomla! Translations' AND "type" = 'collection' AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
@@ -4,9 +4,9 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 UPDATE "#__update_sites_extensions"
 SET "extension_id" = 802
 WHERE "update_site_id" IN (
-						SELECT "update_site_id"
-						FROM "#__update_sites"
-						WHERE "name" = 'Accredited Joomla! Translations'
-						AND "type" = 'collection'
-						)
+			SELECT "update_site_id"
+			FROM "#__update_sites"
+			WHERE "name" = 'Accredited Joomla! Translations'
+			AND "type" = 'collection'
+			)
 AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-08.sql
@@ -1,4 +1,12 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
-UPDATE "#__update_sites_extensions" SET "extension_id" = 802 WHERE "name" = 'Accredited Joomla! Translations' AND "type" = 'collection' AND "extension_id" = 600;
+UPDATE "#__update_sites_extensions"
+SET "extension_id" = 802
+WHERE "update_site_id" IN (
+						SELECT "update_site_id"
+						FROM "#__update_sites"
+						WHERE "name" = 'Accredited Joomla! Translations'
+						AND "type" = 'collection'
+						)
+AND "extension_id" = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
@@ -8,9 +8,9 @@ SET IDENTITY_INSERT [#__extensions]  OFF;
 UPDATE [#__update_sites_extensions]
 SET [extension_id] = 802
 WHERE [update_site_id] IN (
-						SELECT [update_site_id]
-						FROM [#__update_sites]
-						WHERE [name] = 'Accredited Joomla! Translations'
-						AND [type] = 'collection'
-						)
+			SELECT [update_site_id]
+			FROM [#__update_sites]
+			WHERE [name] = 'Accredited Joomla! Translations'
+			AND [type] = 'collection'
+			)
 AND [extension_id] = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
@@ -1,8 +1,8 @@
 SET IDENTITY_INSERT [#__extensions]  ON;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions]  OFF;
 
-UPDATE [#__update_sites_extensions] SET [extension_id] = 801 WHERE [update_site_id] = 3 AND [extension_id] = 600;
+UPDATE [#__update_sites_extensions] SET [extension_id] = 802 WHERE [name] = 'Joomla! Update Component Update Site' AND [type] = 'extension' AND [extension_id] = 600;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-08.sql
@@ -5,4 +5,12 @@ SELECT 802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, 
 
 SET IDENTITY_INSERT [#__extensions]  OFF;
 
-UPDATE [#__update_sites_extensions] SET [extension_id] = 802 WHERE [name] = 'Joomla! Update Component Update Site' AND [type] = 'extension' AND [extension_id] = 600;
+UPDATE [#__update_sites_extensions]
+SET [extension_id] = 802
+WHERE [update_site_id] IN (
+						SELECT [update_site_id]
+						FROM [#__update_sites]
+						WHERE [name] = 'Accredited Joomla! Translations'
+						AND [type] = 'collection'
+						)
+AND [extension_id] = 600;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -621,7 +621,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+(802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- --------------------------------------------------------
 
@@ -1813,7 +1813,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites_extensions` (
 INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
 (1, 700),
 (2, 700),
-(3, 801),
+(3, 802),
 (4, 28);
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -633,7 +633,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 
 -- Packages
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 SELECT setval('#__extensions_extension_id_seq', 10000, false);
 
@@ -1740,7 +1740,7 @@ COMMENT ON TABLE "#__update_sites_extensions" IS 'Links extensions to update sit
 INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
 (1, 700),
 (2, 700),
-(3, 801),
+(3, 802),
 (4, 28);
 
 --

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1027,7 +1027,7 @@ INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [cl
 SELECT 700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 801, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions]  OFF;
 
@@ -2748,7 +2748,7 @@ SELECT 1, 700
 UNION ALL
 SELECT 2, 700
 UNION ALL
-SELECT 3, 801
+SELECT 3, 802
 UNION ALL
 SELECT 4, 28;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10352.
#### Summary of Changes

Change new pkg_en-GB id to 802 since some sites can be using 801 for pkg_weblinks.
Also changed the sql to not use the update_site_id.
#### Testing Instructions

Two tests needed:
###### New Install
- Download https://github.com/andrepereiradasilva/joomla-cms/archive/patch-8.zip
- Install as normal install
- Do the tests described in the test section
###### Upgrade
- Use latest staging
- Download https://github.com/andrepereiradasilva/update.joomla.org/raw/master/joomla-cms-patch-8-update.zip
- Now upgrade: Go to Components -> Joomla! Update ("Upload and update" tab) and upload the downlaoded package
- Do the tests described in the test section

Note: This update package changes version to 3.6.1-dev and adds a weblinks id 801 and after do the changes in this PR (you can check that by unzipping this small package).
###### Tests
1. After install  go to Extensions -> Manage -> Install Languages (Find Languages button) and check the languages are there
2. Go to Extensions -> Manage -> Update Sites and check there is a English language package update site
3. Go to Extensions -> Manage -> Manage and check there is a "Package" extension called "English language package"
#### Observation

Please confirm 802 has never been used by other package in joomla history.
