### PR TITLE
Custom serialise JUser object without breaking B/C

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -909,6 +909,8 @@ class JUser extends JObject
 	/**
 	 * Method to recover the full object on unserialize.
 	 *
+	 * @return  void
+	 *
 	 * @since   3.6.0
 	 */
 	public function __wakeup()

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -16,7 +16,7 @@ use Joomla\Registry\Registry;
  *
  * @since  11.1
  */
-class JUser extends JObject implements Serializable
+class JUser extends JObject
 {
 	/**
 	 * A cached switch for if this user has root access rights.
@@ -895,39 +895,32 @@ class JUser extends JObject implements Serializable
 	}
 
 	/**
-	 * Method to serialize the input.
+	 * Method to allow serialize the object with minimal properties.
 	 *
-	 * @return  string  The serialized input.
+	 * @return  array  The names of the properties to include in serialization.
 	 *
 	 * @since   3.6.0
 	 */
-	public function serialize()
+	public function __sleep()
 	{
-		return serialize(array($this->id));
+		return array('id');
 	}
 
 	/**
-	 * Method to unserialize the user object.
-	 *
-	 * @param   string  $input  The serialized input.
-	 *
-	 * @return  JUser
+	 * Method to recover the full object on unserialize.
 	 *
 	 * @since   3.6.0
 	 */
-	public function unserialize($input)
+	public function __wakeup()
 	{
-		// Get the user id from the serialized data.
-		list($id) = unserialize($input);
-
 		// Initialise some variables
 		$this->userHelper = new JUserWrapperHelper;
 		$this->_params    = new Registry;
 
 		// Load the user if it exists
-		if (!empty($id))
+		if (!empty($this->id))
 		{
-			$this->load($id);
+			$this->load($this->id);
 		}
 		else
 		{


### PR DESCRIPTION
This PR is in continuation with #8805. Thanks @wilsonge.

This is to fix the B/C break that was caused by the serialized data not matching the new class prototype for the JUser.

The serialized output has a slight change with this PR. Such as current output is `C:5:"JUser":20:{a:1:{i:0;s:3:"256";}}` whereas the new output would be `O:5:"JUser":1:{s:2:"id";s:3:"256";}` for `JUser` with user id _256_ but I think that is not any issue, right?

I am intentionally leaving out the description and test instruction here so that you could have a look at the original PR and understand any negative/positive implications with my proposition.

See details here [#8805 Serialize the user object](https://github.com/joomla/joomla-cms/pull/8805)
### Additional Test Instructions
- Start without this patch AND also without #8805 (Preferably over a public release version like 3.5.1)
- Login to front-end and/or back-end
- Apply this patch
- Try to navigate to various pages in front-end and/or back-end.

**Expected result:** Nothing should break and you should be able to work seamlessly.
