### PR TITLE
[com_finder] index view: Language codes to content languages in contentmap filter

### DIFF
--- a/administrator/components/com_finder/models/fields/contentmap.php
+++ b/administrator/components/com_finder/models/fields/contentmap.php
@@ -11,6 +11,8 @@ defined('JPATH_PLATFORM') or die;
 
 JFormHelper::loadFieldClass('groupedlist');
 
+JLoader::register('FinderHelperLanguage', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/language.php');
+
 /**
  * Form Field class for the Joomla CMS.
  * Supports a select grouped list of finder content map.
@@ -80,6 +82,8 @@ class JFormFieldContentMap extends JFormFieldGroupedList
 		// Build the grouped list array.
 		if ($contentMap)
 		{
+			$lang = JFactory::getLanguage();
+
 			foreach ($contentMap as $branch)
 			{
 				if ((int) $branch->level === 1)
@@ -90,7 +94,15 @@ class JFormFieldContentMap extends JFormFieldGroupedList
 				{
 					$levelPrefix = str_repeat('- ', max(0, $branch->level - 1));
 
-					$text = $branch->text == '*' ? 'JALL_LANGUAGE' : $branch->text;
+					if (trim($name, '**') == 'Language')
+					{
+						$text = FinderHelperLanguage::branchLanguageTitle($branch->text);
+					}
+					else
+					{
+						$key = FinderHelperLanguage::branchSingular($branch->text);
+						$text = $lang->hasKey($key) ? JText::_($key) : $branch->text;
+					}
 
 					// Initialize the group if necessary.
 					if (!isset($groups[$name]))
@@ -98,7 +110,7 @@ class JFormFieldContentMap extends JFormFieldGroupedList
 						$groups[$name] = array();
 					}
 
-					$groups[$name][] = JHtml::_('select.option', $branch->value, $levelPrefix . JText::_($text));
+					$groups[$name][] = JHtml::_('select.option', $branch->value, $levelPrefix . $text);
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

This is the same thing that was done in https://github.com/joomla/joomla-cms/pull/10267, but now for the new content map filter.
##### Before Patch

![image](https://cloud.githubusercontent.com/assets/9630530/15117438/73560732-15ff-11e6-9274-b1f979841630.png)
##### After patch

![image](https://cloud.githubusercontent.com/assets/9630530/15117434/6fc25f08-15ff-11e6-933d-3765b132ca88.png)
#### Testing Instructions

Note that for this test you have to have index in the Smart Search (com_finder) in multiple langauges and the system language plugin disabled.
1. Apply patch
2. Check the Language subbranches in Components -> Smart Search -> Indexed Content, and then the `- Select Content Map -` filter.

The languages titles should be exactly the same you have in Extensions -> Languages -> Content Languages.
