### PR TITLE
Dont hard code the name of the first user (installation)

### DIFF
--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -280,7 +280,7 @@ class InstallationModelConfiguration extends JModelBase
 		{
 			$query->clear()
 				->update($db->quoteName('#__users'))
-				->set($db->quoteName('name') . ' = ' . $db->quote('Super User'))
+				->set($db->quoteName('name') . ' = ' . $db->quote(trim($options->admin_user)))
 				->set($db->quoteName('username') . ' = ' . $db->quote(trim($options->admin_user)))
 				->set($db->quoteName('email') . ' = ' . $db->quote($options->admin_email))
 				->set($db->quoteName('password') . ' = ' . $db->quote($cryptpass))
@@ -295,7 +295,8 @@ class InstallationModelConfiguration extends JModelBase
 		else
 		{
 			$columns = array(
-				$db->quoteName('id'), $db->quoteName('name'),
+				$db->quoteName('id'),
+				$db->quoteName('name'),
 				$db->quoteName('username'),
 				$db->quoteName('email'),
 				$db->quoteName('password'),
@@ -310,7 +311,7 @@ class InstallationModelConfiguration extends JModelBase
 				->insert('#__users', true)
 				->columns($columns)
 				->values(
-					$db->quote($userId) . ', ' . $db->quote('Super User') . ', ' . $db->quote(trim($options->admin_user)) . ', ' .
+					$db->quote($userId) . ', ' . $db->quote(trim($options->admin_user)) . ', ' . $db->quote(trim($options->admin_user)) . ', ' .
 					$db->quote($options->admin_email) . ', ' . $db->quote($cryptpass) . ', ' .
 					$db->quote('0') . ', ' . $db->quote('1') . ', ' . $db->quote($installdate) . ', ' . $db->quote($nullDate) . ', ' .
 					$db->quote('0') . ', ' . $db->quote('')


### PR DESCRIPTION
#### Summary of Changes

Currently we hard code the first user name to `Super User`. This PR moves it to use the real admin User name `$options->admin_user`.
#### Testing Instructions
- Install this branch: https://github.com/zero-24/joomla-cms/archive/createcorrectuser.zip
- Confirn that the first user has the correct name (that you have set on the installation) and not `Super User`
