### PR TITLE
Fix Notice error for undefined array and avoid 404 when associations are disabled

### DIFF
--- a/plugins/user/profile/fields/tos.php
+++ b/plugins/user/profile/fields/tos.php
@@ -101,17 +101,17 @@ class JFormFieldTos extends JFormFieldRadio
 
 			$current_lang = JFactory::getLanguage()->getTag();
 
-			if ($current_lang != $article->language && array_key_exists($current_lang, $tosassociated))
+			if (isset($tosassociated) && $current_lang != $article->language && array_key_exists($current_lang, $tosassociated))
 			{
 				$url = ContentHelperRoute::getArticleRoute($tosassociated[$current_lang]->id, $tosassociated[$current_lang]->catid);
+				$link = JHtml::_('link', JRoute::_($url . '&tmpl=component&lang=' . $tosassociated[$current_lang]->language), $text, $attribs);
 			}
 			else
 			{
 				$slug = $article->alias ? ($article->id . ':' . $article->alias) : $article->id;
 				$url = ContentHelperRoute::getArticleRoute($slug, $article->catid);
+				$link = JHtml::_('link', JRoute::_($url . '&tmpl=component&lang=' . $article->language), $text, $attribs);
 			}
-
-			$link = JHtml::_('link', JRoute::_($url . '&tmpl=component'), $text, $attribs);
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Fix Notice error for undefined array and avoid 404 using the TOS with original language in case of multi-language association is disabled and an article from a different language than the current used is configured.
#### Testing Instructions

No Error Fix
Create a single language website environment and enable the profile plugins in order to request the custom TOS field in the user registration form
Check that no PHP Notice errors raise.

No Association Fix
Create a multi language website environment and enable the profile plugins in order to request the custom TOS field in the user registration form. 
Select an article.
In the Language Filter plugin disable the Item Associations
Try to register using a different front end language than the one associated to the TOS article previously chosen.
Check that the TOS is correctly linked to the article originally selected, despite the current language is different (so avoiding 404)
