### PR TITLE
[cpanel modules] Add tooltips to dates and align

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -35,9 +35,9 @@ JHtml::_('bootstrap.tooltip');
 					</small>
 				</div>
 				<div class="span3">
-					<span class="small">
+					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL') . '<br/>' . JHtml::_('date', $item->created, 'Y-m-d H:i:s'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</span>
+					</div>
 				</div>
 			</div>
 		<?php endforeach; ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>
 		<div class="row-fluid">
-			<div class="span7">
+			<div class="span9">
 				<?php if ($user->client_id == 0) : ?>
 					<a class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini">
 						<span class="icon-remove icon-white" title="<?php echo JText::_('JLOGOUT'); ?>"></span>
@@ -38,10 +38,10 @@ JHtml::_('bootstrap.tooltip');
 					<?php endif; ?>
 				</small>
 			</div>
-			<div class="span5">
-				<span class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
-					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC2')); ?>
-				</span>
+			<div class="span3">
+				<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY') . '<br/>' . JHtml::_('date', $user->time, 'Y-m-d H:i:s'); ?>">
+					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC4')); ?>
+				</div>
 			</div>
 		</div>
 	<?php endforeach; ?>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -34,10 +34,9 @@ JHtml::_('bootstrap.tooltip');
 					</strong>
 				</div>
 				<div class="span3">
-					<span class="small">
-						<span class="icon-calendar"></span>
-						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</span>
+					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL') . '<br/>' . JHtml::_('date', $item->created, 'Y-m-d H:i:s'); ?>">
+						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
+					</div>
 				</div>
 			</div>
 		<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

In CPanel modules:
- Adds and uniformizes tooltip (with date and hour) on dates. mod_logges, mod_latest and mod_popular.
- Uniformizes mod_logged alignment (to be like the others).

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15144655/c89097b8-16a8-11e6-948c-febf3b3db1c8.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15144658/cc93670a-16a8-11e6-900d-ff4290c7bcbe.png)
#### Testing Instructions
1. Use joomla staging with test sample data
2. Go to CPanel check the align and the date tooltips in the 3 modules
3. Apply patch
4. Go to CPanel check the align and the date tooltips in the 3 modules
