### PR TITLE
redis is valid for hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ matrix:
       services:
         - mysql
         - postgresql
-      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled items that currently do not work in travis-ci hhvm
+        - redis-server
+      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: hhvm
 
@@ -64,7 +65,8 @@ before_script:
   - if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
   - if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
   - if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
-  - if [[ $INSTALL_REDIS == "yes" ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
+  - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
+  - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat build/travis/phpenv/redis.ini >> /etc/hhvm/php.ini; fi
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml


### PR DESCRIPTION
Pull Request for one of the failures in Issue #10220 .
#### Summary of Changes

removes redis exclusion from hhvm testing

fixes unit test failure

``` php
JCacheStorageTest::testGetInstance with data set "defaultredis" ('redis', array(null, 'en-GB', true, null, 1462454997), 'JCacheStorageRedis')
Undefined variable: connection
/tests/unit/core/helper/helper.php:52
/libraries/joomla/cache/storage/redis.php:105
/libraries/joomla/cache/storage/redis.php:48
/libraries/joomla/cache/storage.php:169
/tests/unit/suites/libraries/joomla/cache/JCacheStorageTest.php:238
```
#### Testing Instructions

merge on review

Since hhvm is failing with memory I have a patch where I filtered for just the cache tests
before patch error (showing just redis cache test failures)
https://travis-ci.org/photodude/joomla-cms/jobs/127977188

after patch the redis error is gone (showing all cache tests, redis is no longer in the list)
https://travis-ci.org/photodude/joomla-cms/jobs/129048590
