### PR TITLE
[cpanel modules] Align dates and add tooltips

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -895,6 +895,7 @@ DATE_FORMAT_LC1="l, d F Y"
 DATE_FORMAT_LC2="l, d F Y H:i"
 DATE_FORMAT_LC3="d F Y"
 DATE_FORMAT_LC4="Y-m-d"
+DATE_FORMAT_LC5="Y-m-d H:i:s"
 DATE_FORMAT_JS1="y-m-d"
 
 ; Months

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -895,7 +895,7 @@ DATE_FORMAT_LC1="l, d F Y"
 DATE_FORMAT_LC2="l, d F Y H:i"
 DATE_FORMAT_LC3="d F Y"
 DATE_FORMAT_LC4="Y-m-d"
-DATE_FORMAT_LC5="Y-m-d H:i:s"
+DATE_FORMAT_LC5="Y-m-d H:i"
 DATE_FORMAT_JS1="y-m-d"
 
 ; Months

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
 	<?php if (count($list)) : ?>
 		<?php foreach ($list as $i => $item) : ?>
 			<div class="row-fluid">
-				<div class="span9">
+				<div class="span8">
 					<?php echo JHtml::_('jgrid.published', $item->state, $i, '', false); ?>
 					<?php if ($item->checked_out) : ?>
 						<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
@@ -34,7 +34,7 @@ JHtml::_('bootstrap.tooltip');
 						<?php echo $item->author_name; ?>
 					</small>
 				</div>
-				<div class="span3">
+				<div class="span4">
 					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -35,7 +35,7 @@ JHtml::_('bootstrap.tooltip');
 					</small>
 				</div>
 				<div class="span4">
-					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
+					<div class="small pull-right hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -35,9 +35,9 @@ JHtml::_('bootstrap.tooltip');
 					</small>
 				</div>
 				<div class="span3">
-					<span class="small">
-						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</span>
+					<div class="small">
+						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
+					</div>
 				</div>
 			</div>
 		<?php endforeach; ?>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -35,7 +35,7 @@ JHtml::_('bootstrap.tooltip');
 					</small>
 				</div>
 				<div class="span3">
-					<div class="small">
+					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>
 		<div class="row-fluid">
-			<div class="span9">
+			<div class="span8">
 				<?php if ($user->client_id == 0) : ?>
 					<a class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini">
 						<span class="icon-remove icon-white" title="<?php echo JText::_('JLOGOUT'); ?>"></span>
@@ -38,7 +38,7 @@ JHtml::_('bootstrap.tooltip');
 					<?php endif; ?>
 				</small>
 			</div>
-			<div class="span3">
+			<div class="span4">
 				<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
 					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC5')); ?>
 				</div>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -39,7 +39,7 @@ JHtml::_('bootstrap.tooltip');
 				</small>
 			</div>
 			<div class="span4">
-				<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
+				<div class="small pull-right hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
 					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC5')); ?>
 				</div>
 			</div>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>
 		<div class="row-fluid">
-			<div class="span7">
+			<div class="span9">
 				<?php if ($user->client_id == 0) : ?>
 					<a class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini">
 						<span class="icon-remove icon-white" title="<?php echo JText::_('JLOGOUT'); ?>"></span>
@@ -38,10 +38,10 @@ JHtml::_('bootstrap.tooltip');
 					<?php endif; ?>
 				</small>
 			</div>
-			<div class="span5">
-				<span class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
-					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC2')); ?>
-				</span>
+			<div class="span3">
+				<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LAST_ACTIVITY'); ?>">
+					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC5')); ?>
+				</div>
 			</div>
 		</div>
 	<?php endforeach; ?>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -34,9 +34,8 @@ JHtml::_('bootstrap.tooltip');
 					</strong>
 				</div>
 				<div class="span3">
-					<div class="small">
-						<span class="icon-calendar"></span>
-						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
+					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
+						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>
 			</div>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -34,10 +34,10 @@ JHtml::_('bootstrap.tooltip');
 					</strong>
 				</div>
 				<div class="span3">
-					<span class="small">
+					<div class="small">
 						<span class="icon-calendar"></span>
-						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
-					</span>
+						<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
+					</div>
 				</div>
 			</div>
 		<?php endforeach; ?>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -18,7 +18,7 @@ JHtml::_('bootstrap.tooltip');
 			<?php $hits = (int) $item->hits; ?>
 			<?php $hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : ($hits >= 100 ? 'info' : ''))); ?>
 			<div class="row-fluid">
-				<div class="span9">
+				<div class="span8">
 					<span class="badge badge-<?php echo $hits_class; ?> hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_HITS'); ?>"><?php echo $item->hits; ?></span>
 					<?php if ($item->checked_out) : ?>
 							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
@@ -33,7 +33,7 @@ JHtml::_('bootstrap.tooltip');
 						<?php endif; ?>
 					</strong>
 				</div>
-				<div class="span3">
+				<div class="span4">
 					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -34,7 +34,7 @@ JHtml::_('bootstrap.tooltip');
 					</strong>
 				</div>
 				<div class="span4">
-					<div class="small hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
+					<div class="small pull-right hasTooltip" title="<?php echo JHtml::tooltipText('JGLOBAL_FIELD_CREATED_LABEL'); ?>">
 						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -293,7 +293,7 @@ DATE_FORMAT_LC1="l, d F Y"
 DATE_FORMAT_LC2="l, d F Y H:i"
 DATE_FORMAT_LC3="d F Y"
 DATE_FORMAT_LC4="Y-m-d"
-DATE_FORMAT_LC5="Y-m-d H:i:s"
+DATE_FORMAT_LC5="Y-m-d H:i"
 DATE_FORMAT_JS1="y-m-d"
 
 ; Months

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -293,6 +293,7 @@ DATE_FORMAT_LC1="l, d F Y"
 DATE_FORMAT_LC2="l, d F Y H:i"
 DATE_FORMAT_LC3="d F Y"
 DATE_FORMAT_LC4="Y-m-d"
+DATE_FORMAT_LC5="Y-m-d H:i:s"
 DATE_FORMAT_JS1="y-m-d"
 
 ; Months


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

In CPanel modules (mod_logged, mod_latest and mod_popular):
- Adds and uniformizes tooltip (indicating that is the created date) on dates.
- Uniformizes the modules alignment.
- Uniformizes the date format (added a new LC5 `Y-m-d H:i` date).
- Right align the dates

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15147802/767d45d6-16ba-11e6-9f96-040c508a56be.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15147805/78e79790-16ba-11e6-8358-96465b1db9ac.png)
#### Testing Instructions
1. Use joomla staging with test sample data
2. Go to CPanel check the align and the date tooltips in the 3 modules
3. Apply patch
4. Go to CPanel check the align and the date tooltips in the 3 modules

@brianteeman please check now
