### PR TITLE
Add viewport units options for modals

### DIFF
--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -90,12 +90,14 @@ class JFormFieldMenutype extends JFormFieldList
 			'bootstrap.renderModal',
 			'menuTypeModal',
 			array(
-				'url'    => $link,
-				'title'  => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
-				'width'  => '800px',
-				'height' => '300px',
-				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				'url'        => $link,
+				'title'      => JText::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
+				'width'      => '800px',
+				'height'     => '300px',
+				'modalWidth' => '80',
+				'bodyHeight' => '70',
+				'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -97,7 +97,7 @@ class JFormFieldMenutype extends JFormFieldList
 				'modalWidth' => '80',
 				'bodyHeight' => '70',
 				'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				                . JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -97,7 +97,7 @@ class JFormFieldMenutype extends JFormFieldList
 				'modalWidth' => '80',
 				'bodyHeight' => '70',
 				'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -97,7 +97,7 @@ class JFormFieldMenutype extends JFormFieldList
 				'modalWidth' => '80',
 				'bodyHeight' => '70',
 				'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-				                . JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6234,6 +6234,80 @@ div.modal.fade.in {
 .modal-batch {
 	overflow-y: visible;
 }
+.modal-body[class^="jviewport-height"],
+.modal-body[class*="jviewport-height"] {
+	max-height: none;
+}
+.jviewport-height10 {
+	height: 10vh;
+}
+.jviewport-height20 {
+	height: 20vh;
+}
+.jviewport-height30 {
+	height: 30vh;
+}
+.jviewport-height40 {
+	height: 40vh;
+}
+.jviewport-height50 {
+	height: 50vh;
+}
+.jviewport-height60 {
+	height: 60vh;
+}
+.jviewport-height70 {
+	height: 70vh;
+}
+.jviewport-height80 {
+	height: 80vh;
+}
+.jviewport-height90 {
+	height: 90vh;
+}
+.jviewport-height100 {
+	height: 100vh;
+}
+div.modal.jviewport-width10 {
+	width: 10vw;
+	margin-left: -5vw;
+}
+div.modal.jviewport-width20 {
+	width: 20vw;
+	margin-left: -10vw;
+}
+div.modal.jviewport-width30 {
+	width: 30vw;
+	margin-left: -15vw;
+}
+div.modal.jviewport-width40 {
+	width: 40vw;
+	margin-left: -20vw;
+}
+div.modal.jviewport-width50 {
+	width: 50vw;
+	margin-left: -25vw;
+}
+div.modal.jviewport-width60 {
+	width: 60vw;
+	margin-left: -30vw;
+}
+div.modal.jviewport-width70 {
+	width: 70vw;
+	margin-left: -35vw;
+}
+div.modal.jviewport-width80 {
+	width: 80vw;
+	margin-left: -40vw;
+}
+div.modal.jviewport-width90 {
+	width: 90vw;
+	margin-left: -45vw;
+}
+div.modal.jviewport-width100 {
+	width: 100vw;
+	margin-left: -50vw;
+}
 @media (max-width: 767px) {
 	div.modal {
 		position: fixed;
@@ -6248,6 +6322,10 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+	}
+	div.modal[class*="jviewport-width"] {
+		width: auto;
+		margin: 0;
 	}
 }
 @media (max-width: 480px) {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6234,6 +6234,80 @@ div.modal.fade.in {
 .modal-batch {
 	overflow-y: visible;
 }
+.modal-body[class^="jviewport-height"],
+.modal-body[class*="jviewport-height"] {
+	max-height: none;
+}
+.jviewport-height10 {
+	height: 10vh;
+}
+.jviewport-height20 {
+	height: 20vh;
+}
+.jviewport-height30 {
+	height: 30vh;
+}
+.jviewport-height40 {
+	height: 40vh;
+}
+.jviewport-height50 {
+	height: 50vh;
+}
+.jviewport-height60 {
+	height: 60vh;
+}
+.jviewport-height70 {
+	height: 70vh;
+}
+.jviewport-height80 {
+	height: 80vh;
+}
+.jviewport-height90 {
+	height: 90vh;
+}
+.jviewport-height100 {
+	height: 100vh;
+}
+div.modal.jviewport-width10 {
+	width: 10vw;
+	margin-left: -5vw;
+}
+div.modal.jviewport-width20 {
+	width: 20vw;
+	margin-left: -10vw;
+}
+div.modal.jviewport-width30 {
+	width: 30vw;
+	margin-left: -15vw;
+}
+div.modal.jviewport-width40 {
+	width: 40vw;
+	margin-left: -20vw;
+}
+div.modal.jviewport-width50 {
+	width: 50vw;
+	margin-left: -25vw;
+}
+div.modal.jviewport-width60 {
+	width: 60vw;
+	margin-left: -30vw;
+}
+div.modal.jviewport-width70 {
+	width: 70vw;
+	margin-left: -35vw;
+}
+div.modal.jviewport-width80 {
+	width: 80vw;
+	margin-left: -40vw;
+}
+div.modal.jviewport-width90 {
+	width: 90vw;
+	margin-left: -45vw;
+}
+div.modal.jviewport-width100 {
+	width: 100vw;
+	margin-left: -50vw;
+}
 @media (max-width: 767px) {
 	div.modal {
 		position: fixed;
@@ -6248,6 +6322,10 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+	}
+	div.modal[class*="jviewport-width"] {
+		width: auto;
+		margin: 0;
 	}
 }
 @media (max-width: 480px) {

--- a/layouts/joomla/modal/body.php
+++ b/layouts/joomla/modal/body.php
@@ -26,10 +26,21 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
+ *                             - bodyHeight   int      height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */
+
+$bodyClass = 'modal-body';
+
+$bodyHeight = isset($params['bodyHeight']) ? round((int) $params['bodyHeight'], -1) : '';
+
+if ($bodyHeight && $bodyHeight >= 20 && $bodyHeight < 90)
+{
+	$bodyClass.= ' jviewport-height' . $bodyHeight;
+}
 ?>
-<div class="modal-body">
+<div class="<?php echo $bodyClass; ?>">
 	<?php echo $body; ?>
 </div>

--- a/layouts/joomla/modal/body.php
+++ b/layouts/joomla/modal/body.php
@@ -38,7 +38,7 @@ $bodyHeight = isset($params['bodyHeight']) ? round((int) $params['bodyHeight'], 
 
 if ($bodyHeight && $bodyHeight >= 20 && $bodyHeight < 90)
 {
-	$bodyClass.= ' jviewport-height' . $bodyHeight;
+	$bodyClass .= ' jviewport-height' . $bodyHeight;
 }
 ?>
 <div class="<?php echo $bodyClass; ?>">

--- a/layouts/joomla/modal/body.php
+++ b/layouts/joomla/modal/body.php
@@ -26,8 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- *                             - bodyHeight   int      height of the modal body in viewport units (vh)
- *                             - modalWidth   int      width of the modal in viewport units (vh)
+ *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/footer.php
+++ b/layouts/joomla/modal/footer.php
@@ -26,6 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
+ *                             - bodyHeight   int      height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/footer.php
+++ b/layouts/joomla/modal/footer.php
@@ -26,8 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- *                             - bodyHeight   int      height of the modal body in viewport units (vh)
- *                             - modalWidth   int      width of the modal in viewport units (vh)
+ *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/header.php
+++ b/layouts/joomla/modal/header.php
@@ -26,6 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
+ *                             - bodyHeight   int      height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/header.php
+++ b/layouts/joomla/modal/header.php
@@ -26,8 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- *                             - bodyHeight   int      height of the modal body in viewport units (vh)
- *                             - modalWidth   int      width of the modal in viewport units (vh)
+ *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -38,7 +38,7 @@ $bodyHeight = isset($params['bodyHeight']) ? round((int) $params['bodyHeight'], 
 
 if ($bodyHeight && $bodyHeight >= 20 && $bodyHeight < 90)
 {
-	$iframeClass.= ' jviewport-height' . $bodyHeight;
+	$iframeClass .= ' jviewport-height' . $bodyHeight;
 }
 
 $iframeAttributes = array(

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -26,8 +26,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- *                             - bodyHeight   int      height of the modal body in viewport units (vh)
- *                             - modalWidth   int      width of the modal in viewport units (vh)
+ *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -26,12 +26,23 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
+ *                             - bodyHeight   int      height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */
 
+$iframeClass = 'iframe';
+
+$bodyHeight = isset($params['bodyHeight']) ? round((int) $params['bodyHeight'], -1) : '';
+
+if ($bodyHeight && $bodyHeight >= 20 && $bodyHeight < 90)
+{
+	$iframeClass.= ' jviewport-height' . $bodyHeight;
+}
+
 $iframeAttributes = array(
-	'class' => 'iframe',
+	'class' => $iframeClass,
 	'src'   => $params['url']
 );
 

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -29,8 +29,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
- *                             - bodyHeight   int      height of the modal body in viewport units (vh)
- *                             - modalWidth   int      width of the modal in viewport units (vh)
+ *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -29,6 +29,8 @@ extract($displayData);
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
+ *                             - bodyHeight   int      height of the modal body in viewport units (vh)
+ *                             - modalWidth   int      width of the modal in viewport units (vh)
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */
@@ -38,6 +40,13 @@ $modalClasses = array('modal', 'hide');
 if (!isset($params['animation']) || $params['animation'])
 {
 	array_push($modalClasses, 'fade');
+}
+
+$modalWidth = isset($params['modalWidth']) ? round((int) $params['modalWidth'], -1) : '';
+
+if ($modalWidth && $modalWidth > 0 && $modalWidth <= 100)
+{
+	array_push($modalClasses, 'jviewport-width' . $modalWidth);
 }
 
 $modalAttributes = array(

--- a/media/jui/less/modals.joomla.less
+++ b/media/jui/less/modals.joomla.less
@@ -33,4 +33,33 @@ div.modal {
 .modal-batch {
   overflow-y: visible;
 }
+// Modal viewport dimensions
+.modal-body[class^="jviewport-height"],
+.modal-body[class*="jviewport-height"] {
+  max-height: none;
+}
+.jviewport-height {
+  &10 { height: 10vh; }
+  &20 { height: 20vh; }
+  &30 { height: 30vh; }
+  &40 { height: 40vh; }
+  &50 { height: 50vh; }
+  &60 { height: 60vh; }
+  &70 { height: 70vh; }
+  &80 { height: 80vh; }
+  &90 { height: 90vh; }
+  &100 { height: 100vh; }
+}
+div.modal.jviewport-width {
+  &10 { width: 10vw; margin-left: -5vw; }
+  &20 { width: 20vw; margin-left: -10vw; }
+  &30 { width: 30vw; margin-left: -15vw; }
+  &40 { width: 40vw; margin-left: -20vw; }
+  &50 { width: 50vw; margin-left: -25vw; }
+  &60 { width: 60vw; margin-left: -30vw; }
+  &70 { width: 70vw; margin-left: -35vw; }
+  &80 { width: 80vw; margin-left: -40vw; }
+  &90 { width: 90vw; margin-left: -45vw; }
+  &100 { width: 100vw; margin-left: -50vw; }
+}
 // < Joomla JUI

--- a/media/jui/less/responsive-767px-max.joomla.less
+++ b/media/jui/less/responsive-767px-max.joomla.less
@@ -19,6 +19,12 @@
     &.fade.in { top: 20px; }
   }
 
+  // Modals viewport width
+  div.modal[class*="jviewport-width"] {
+    width: auto;
+    margin: 0;
+  }
+
 }
 
 // UP TO LANDSCAPE PHONE

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -6220,6 +6220,80 @@ div.modal.fade.in {
 .modal-batch {
 	overflow-y: visible;
 }
+.modal-body[class^="jviewport-height"],
+.modal-body[class*="jviewport-height"] {
+	max-height: none;
+}
+.jviewport-height10 {
+	height: 10vh;
+}
+.jviewport-height20 {
+	height: 20vh;
+}
+.jviewport-height30 {
+	height: 30vh;
+}
+.jviewport-height40 {
+	height: 40vh;
+}
+.jviewport-height50 {
+	height: 50vh;
+}
+.jviewport-height60 {
+	height: 60vh;
+}
+.jviewport-height70 {
+	height: 70vh;
+}
+.jviewport-height80 {
+	height: 80vh;
+}
+.jviewport-height90 {
+	height: 90vh;
+}
+.jviewport-height100 {
+	height: 100vh;
+}
+div.modal.jviewport-width10 {
+	width: 10vw;
+	margin-left: -5vw;
+}
+div.modal.jviewport-width20 {
+	width: 20vw;
+	margin-left: -10vw;
+}
+div.modal.jviewport-width30 {
+	width: 30vw;
+	margin-left: -15vw;
+}
+div.modal.jviewport-width40 {
+	width: 40vw;
+	margin-left: -20vw;
+}
+div.modal.jviewport-width50 {
+	width: 50vw;
+	margin-left: -25vw;
+}
+div.modal.jviewport-width60 {
+	width: 60vw;
+	margin-left: -30vw;
+}
+div.modal.jviewport-width70 {
+	width: 70vw;
+	margin-left: -35vw;
+}
+div.modal.jviewport-width80 {
+	width: 80vw;
+	margin-left: -40vw;
+}
+div.modal.jviewport-width90 {
+	width: 90vw;
+	margin-left: -45vw;
+}
+div.modal.jviewport-width100 {
+	width: 100vw;
+	margin-left: -50vw;
+}
 @media (max-width: 767px) {
 	div.modal {
 		position: fixed;
@@ -6234,6 +6308,10 @@ div.modal.fade.in {
 	}
 	div.modal.fade.in {
 		top: 20px;
+	}
+	div.modal[class*="jviewport-width"] {
+		width: auto;
+		margin: 0;
 	}
 }
 @media (max-width: 480px) {


### PR DESCRIPTION
Pull Request for Issue #10070 .

Based on idea by @RoterNagel about using viewport units for modals, and the proposal of @andrepereiradasilva to create special classes for viewport units.

This PR is full B/C as this one is not changing current behavior. It adds new optional options <code>modalWidth</code> and <code>bodyHeight</code> to be able to set viewport units in the modal constructor.
_Note: for old browsers with no viewport unit support, it will just displayed the modal as before._

The Options for modals are then these ones:
- <code>title</code> (string) : The modal title
- <code>backdrop</code> (mixed) : A boolean select if a modal-backdrop element should be included (default = true)
   The string 'static' includes a backdrop which doesn't close the modal on click.
- <code>keyboard</code> (boolean) : Closes the modal when escape key is pressed (default = true)
- <code>closeButton</code> (boolean) : Display modal close button (default = true)
- <code>animation</code> (boolean) : Fade in from the top of the page (default = true)
- <code>footer</code> (string) : Optional markup for the modal footer
- <code>url</code> (string) : URL of a resource to be inserted as an <code>iframe</code> inside the modal body
- <code>height</code> (string) : height of the <code>iframe</code> containing the remote resource
- <code>width</code> (string) : width of the <code>iframe</code> containing the remote resource
- NEW **<code>bodyHeight</code> (int) : Optional height of the modal body in viewport units (vh)**
- NEW **<code>modalWidth</code> (int) : Optional width of the modal in viewport units (vh)**
#### Summary of Changes
- Changes done on latest Staging (to get the previous modal changes already merged in 3.6.0-dev)
- New modal options: <code>modalWidth</code> and <code>bodyHeight</code>
- Add <code>jviewport</code> classes to <code>modals.joomla.less</code>
- Update <code>responsive-767px-max.joomla.less</code>
- Run generatecss
- Integrate new options in the modal layouts (with control for a correct vh value)
- Add those 2 new options in the <code>menuTypeModal</code> for test and demonstrate B/C

**Note:** i added viewport options here only for Menu Item Type select for testing purpose. If this PR is accepted, i will then be able to add this to other modals (already updated and merged, and the ones i'm working on and not yet improved). My goal is all modals reviewed for 3.6.0 ;-)
#### Testing Instructions
- Apply patch on latest <code>staging</code>
- Clean cache (to clean template.css in cache)
- Go to **menus** > **new menu item** > click to select a **Menu Item Type**
- Verify that now the modal is higher (<code>bodyHeight</code> 70vh) as expected in PR #10070 
- _Note: I have set <code>modalWidth</code> to 80vw as the default modal width was already 80% (and in this modal <code>menu-type</code>, seems to be a good width)_

**Before Patch**
![Menu Item Type select modal before patch](https://cloud.githubusercontent.com/assets/2385058/15150460/933eaf12-16cd-11e6-901e-bda9b69e9c18.png)

**After Patch**
![Menu Item Type select modal before patch with viewport units](https://cloud.githubusercontent.com/assets/2385058/15150603/31708110-16ce-11e6-8b83-093f53f0701a.png)
- Test other modals (Batch, Messaging > Settings, ...) to confirm B/C, and nothing change for other modals where modalWidth and bodyHeight not specified.
