### PR TITLE
inadequate filtering of user-name during installation process

### DIFF
--- a/installation/form/rule/username.php
+++ b/installation/form/rule/username.php
@@ -9,7 +9,7 @@ defined('JPATH_BASE') or die;
 /**
  * Form Rule class for the admin_user field.
  *
- * @since  3.5
+ * @since  3.7
  */
 class InstallationFormRuleUsername extends JFormRule
 {
@@ -17,14 +17,16 @@ class InstallationFormRuleUsername extends JFormRule
 	 * The regular expression to use in testing a form field value.
 	 *
 	 * @var    string
-	 * @since  3.6
+	 * @since  3.7
 	 */
 	protected $regex = '^[^<>"\'%;()&\\\\]*$';
+
 	/**
 	 * The regular expression modifiers to use when testing a form field value.
 	 *
 	 * @var    string
-	 * @since  3.6
+	 * @since  3.7
 	 */
 	protected $modifiers = 'i';
+
 }

--- a/installation/form/rule/username.php
+++ b/installation/form/rule/username.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @package    Joomla.Installation
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('JPATH_BASE') or die;
+/**
+ * Form Rule class for the admin_user field.
+ *
+ * @since  3.5
+ */
+class InstallationFormRuleUsername extends JFormRule
+{
+	/**
+	 * The regular expression to use in testing a form field value.
+	 *
+	 * @var    string
+	 * @since  3.6
+	 */
+	protected $regex = '^[^<>"\'%;()&\\\\]*$';
+	/**
+	 * The regular expression modifiers to use when testing a form field value.
+	 *
+	 * @var    string
+	 * @since  3.6
+	 */
+	protected $modifiers = 'i';
+}

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -19,9 +19,10 @@
 			required="true"
 		/>
 
-		<field name="admin_user" type="username" id="admin_user" class="inputbox"
+		<field name="admin_user" type="text" id="admin_user" class="inputbox"
 			label="INSTL_ADMIN_USER_LABEL"
 			required="true"
+			filter="username"
 		/>
 
 		<field name="admin_password" type="password" id="admin_password" class="inputbox"

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -19,7 +19,7 @@
 			required="true"
 		/>
 
-		<field name="admin_user" type="text" id="admin_user" class="inputbox"
+		<field name="admin_user" type="username" id="admin_user" class="inputbox"
 			label="INSTL_ADMIN_USER_LABEL"
 			required="true"
 		/>

--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -19,7 +19,7 @@
 			required="true"
 		/>
 
-		<field name="admin_user" type="text" id="admin_user" class="inputbox"
+		<field name="admin_user" type="text" id="admin_user" class="inputbox validate-username"
 			label="INSTL_ADMIN_USER_LABEL"
 			required="true"
 			filter="username"


### PR DESCRIPTION
#### Steps to reproduce the issue

Install Joomla! and use in the user-name a "forbidden character like:
< > \ " ' % ; ( ) &

In my case the credentials where:
Admin-User: S9nFA7N7x7tL}jXOJqIx&vQk3jSF
JAdmin-Pass: msevXL0Stl,BV7szpufhMwo10^IV8SRs

In the installation process this user/password combination was accepted, installation went fine, but one could not log-in any more.

After I changed the username in the Database login was possible again.
#### Expected result

I would expect that during installation there would be a warning, that prevented me from choosing an username that renders the Superadministrator Login useless. Like the one that is used if one registers a new user in the backend.
#### Actual result

Installation with unusable username is possible. Therefore creating a not usable SuperAdmin account on installation
#### Testing

Install this as new branch https://github.com/dgt41/joomla-cms/archive/admin_username.zip
try to enter username containing < > \ " ' % ; ( ) &
