### PR TITLE
Fix background on loading joomlaupdate

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
@@ -50,7 +50,7 @@ $css             = <<< CSS
 	#loading {
 		background: rgba(255, 255, 255, .8) url('$ajaxLoaderImage') 50% 15% no-repeat;
 		position: fixed;
-		opacity: 0.8;
+		opacity: 1;
 		-ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity = 80);
 		filter: alpha(opacity = 80);
 		overflow: hidden;

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
@@ -34,10 +34,11 @@ $js               = <<< JS
 
 		$("#loading")
 		.css("top", outerDiv.position().top - $(window).scrollTop())
-		.css("left", outerDiv.position().left - $(window).scrollLeft())
-		.css("width", outerDiv.width())
-		.css("height", outerDiv.height())
+		.css("left", "0")
+		.css("width", "100%")
+		.css("height", "100%")
 		.css("display", "none")
+		.css("margin-top", "-10px");
 	});
 
 JS;
@@ -52,7 +53,6 @@ $css             = <<< CSS
 		opacity: 0.8;
 		-ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity = 80);
 		filter: alpha(opacity = 80);
-		margin: -10px -50px 0 -50px;
 		overflow: hidden;
 	}
 CSS;


### PR DESCRIPTION
#### Issue

When you install the update package you see a spinner with a background, only
the height and weight are wrong
#### Test instructions

•Go to Components > Joomla Update, Select "Upload & Update" tab and send a big file (any file with 1MB, for instance, works). You'll notice the white layer with joomla logo it's cropped (not full height). Press Cancel on next screen.

or use developer tools to disable  `display:none;` class
