### PR TITLE
[com_content] modal articles & article edit : add viewport dimensions

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -196,18 +196,20 @@ class JFormFieldModal_Article extends JFormField
 			'bootstrap.renderModal',
 			'articleEdit' . $this->id . 'Modal',
 			array(
-				'url' => $urlEdit,
-				'title' => JText::_('COM_CONTENT_EDIT_ARTICLE'),
-				'backdrop' => 'static',
+				'url'         => $urlEdit,
+				'title'       => JText::_('COM_CONTENT_EDIT_ARTICLE'),
+				'backdrop'    => 'static',
 				'closeButton' => false,
-				'width' => '800px',
-				'height' => '400px',
-				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-					. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-					. '<button type="button" class="btn btn-success" data-dismiss="modal" aria-hidden="true"'
-					. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-					. JText::_("JSAVE") . '</button>'
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. '<button type="button" class="btn btn-success" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. JText::_("JSAVE") . '</button>'
 			)
 		);
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -183,12 +183,14 @@ class JFormFieldModal_Article extends JFormField
 			'bootstrap.renderModal',
 			'articleSelect' . $this->id . 'Modal',
 			array(
-				'url' => $urlSelect,
-				'title' => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
-				'width' => '800px',
-				'height' => '400px',
-				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				'url'         => $urlSelect,
+				'title'       => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 


### PR DESCRIPTION
**To be tested on latest Staging (needs #10388 )**
#### Summary of Changes
- Add viewport dimensions to modal Article Select and Edit (modal width: 80vw, modal body height: 70vh)
- Follow code style: Indent for array
#### Testing Instructions

This modal could be tested by creating a new menu item:
- Select type = single article
- First Modal using viewport units of this PR : select an article (Select button)
- Then save the menu to be able to view the edit button
- Second Modal using viewport units of this PR : edit article (Edit button)
- You can test too the 2 modals in Article Edition > Associations

**Before Patch**
![capture d ecran 2016-05-10 a 20 28 53](https://cloud.githubusercontent.com/assets/2385058/15157935/0b62a622-16ee-11e6-835a-421e81dc8277.png)

**After Patch**
![capture d ecran 2016-05-10 a 20 29 52](https://cloud.githubusercontent.com/assets/2385058/15157946/158c959a-16ee-11e6-9d8a-a1900fb9c7d5.png)
