### PR TITLE
[com_menus] modal module edit: add viewport dimensions

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -135,19 +135,20 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					'bootstrap.renderModal',
 					'module' . $module->id . 'Modal',
 					array(
-						'url' => $link,
-						'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
-						'backdrop' => 'static',
+						'url'         => $link,
+						'title'       => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
+						'backdrop'    => 'static',
 						'closeButton' => false,
-						'height' => '400px',
-						'width' => '800px',
-						'closeButton' => false,
-						'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-							. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-							. '<button type="button" class="btn btn-success novalidate" data-dismiss="modal" aria-hidden="true"'
-							. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-							. JText::_("JSAVE") . '</button>'
+						'height'      => '400px',
+						'width'       => '800px',
+						'modalWidth'  => '80',
+						'bodyHeight'  => '70',
+						'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+								. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								. '<button type="button" class="btn btn-success novalidate" data-dismiss="modal" aria-hidden="true"'
+								. ' onclick="jQuery(\'#module' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+								. JText::_("JSAVE") . '</button>'
 					)
 				); ?>
 			</tr>


### PR DESCRIPTION
**To be tested on latest Staging (needs #10388 )**
#### Summary of Changes
- Add viewport dimensions to modal Module Edit (modal width: 80vw, modal body height: 70vh)
- Follow code style: Indent for array
- Remove dupplicated closeButton option (mine error in previous PR)
#### Testing Instructions

This modal could be tested in each menu item edition:
- Go to <code>Module Assignment</code> tab
- Click on any module title to open the module edition

**Before Patch**
![capture d ecran 2016-05-10 a 20 40 28](https://cloud.githubusercontent.com/assets/2385058/15158573/da5c2c26-16f0-11e6-8fa8-d83bbb898f73.png)

**After Patch**
![capture d ecran 2016-05-10 a 20 43 15](https://cloud.githubusercontent.com/assets/2385058/15158583/e3185e0c-16f0-11e6-90a7-a341fcc3fe34.png)
