### PR TITLE
Trigger onContentAfterTitle event, display afterDisplayContent correct

### DIFF
--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -102,11 +102,14 @@ abstract class ModArticlesNewsHelper
 				$item->introtext = preg_replace('/<img[^>]*>/', '', $item->introtext);
 			}
 
-			$results                 = $app->triggerEvent('onContentAfterDisplay', array('com_content.article', &$item, &$params, 1));
+			$results                 = $app->triggerEvent('onContentAfterTitle', array('com_content.article', &$item, &$params, 1));
 			$item->afterDisplayTitle = trim(implode("\n", $results));
 
 			$results                    = $app->triggerEvent('onContentBeforeDisplay', array('com_content.article', &$item, &$params, 1));
 			$item->beforeDisplayContent = trim(implode("\n", $results));
+
+			$results                 = $app->triggerEvent('onContentAfterDisplay', array('com_content.article', &$item, &$params, 1));
+			$item->afterDisplayContent = trim(implode("\n", $results));
 		}
 
 		return $items;

--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -33,6 +33,8 @@ $item_heading = $params->get('item_heading', 'h4');
 
 <?php echo $item->introtext; ?>
 
+<?php echo $item->afterDisplayContent; ?>
+
 <?php if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) : ?>
 	<?php echo '<a class="readmore" href="' . $item->link . '">' . $item->linkText . '</a>'; ?>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

The **Articles - Newsflash** module triggers the _onContentAfterDisplay_ event and displays the result after the title of the article. The _onContentAfterTitle_ event result should be displayed there instead and the result from the _onContentAfterDisplay_ event should be displayed after the intro text of the article.

This can easily be reproduced with DPAttachments as it's content plugin is only listening to the event _onContentAfterDisplay_ as can be seen here https://github.com/Digital-Peak/DPAttachments/blob/master/plg_content_dpattachments/dpattachments.php#L21
#### Testing Instructions
- Create an article
- Install DPAttachments from here https://joomla.digital-peak.com/download/dpattachments
- Create an _Articles - Newsflash_ module and publish it to _position-1_
- Upload an attachment trough the new module
### Expected result with patch

The attachment is displayed after the description.
### Result without patch

The attachment is displayed after the title, bevore the intro text, despite the onContentAfterDisplay event is triggered.
