### PR TITLE
[mod_wrapper] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -15,12 +15,12 @@ require_once __DIR__ . '/helper.php';
 $params = ModWrapperHelper::getParams($params);
 
 $load            = $params->get('load');
-$url             = htmlspecialchars($params->get('url'));
-$target          = htmlspecialchars($params->get('target'));
-$width           = htmlspecialchars($params->get('width'));
-$height          = htmlspecialchars($params->get('height'));
-$scroll          = htmlspecialchars($params->get('scrolling'));
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
-$frameborder     = htmlspecialchars($params->get('frameborder'));
+$url             = htmlspecialchars($params->get('url'), ENT_COMPAT, 'UTF-8');
+$target          = htmlspecialchars($params->get('target'), ENT_COMPAT, 'UTF-8');
+$width           = htmlspecialchars($params->get('width'), ENT_COMPAT, 'UTF-8');
+$height          = htmlspecialchars($params->get('height'), ENT_COMPAT, 'UTF-8');
+$scroll          = htmlspecialchars($params->get('scrolling'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$frameborder     = htmlspecialchars($params->get('frameborder'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_wrapper', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_wrapper module to the frontend
- see that it works
- apply this patch
- see that it still works
