### PR TITLE
[com_content] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/components/com_content/views/article/tmpl/default_links.php
+++ b/components/com_content/views/article/tmpl/default_links.php
@@ -48,27 +48,27 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// Open in a new window
-							echo '<a href="' . htmlspecialchars($link) . '" target="_blank"  rel="nofollow">' .
-								htmlspecialchars($label) . '</a>';
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow">' .
+								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 
 						case 2:
 							// Open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link) . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\">" .
-								htmlspecialchars($label) . '</a>';
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\">" .
+								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 						case 3:
 							// Open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link) . '"  rel="{handler: \'iframe\', size: {x:600, y:600}}">' .
-								htmlspecialchars($label) . ' </a>';
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}}">' .
+								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 
 						default:
 							// Open in parent window
-							echo '<a href="' . htmlspecialchars($link) . '" rel="nofollow">' .
-								htmlspecialchars($label) . ' </a>';
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" rel="nofollow">' .
+								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 					}
 				?>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- show an article to the frontend and show the links
- see that it works
- apply this patch
- see that it still works
