### PR TITLE
[layouts/intro_image.php] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -8,23 +8,23 @@
  */
 
 defined('JPATH_BASE') or die;
-$params  = $displayData->params;
+$params = $displayData->params;
 ?>
 <?php $images = json_decode($displayData->images); ?>
 <?php if (isset($images->image_intro) && !empty($images->image_intro)) : ?>
 	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> 
+	<div class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image"> 
 	<?php if ($params->get('link_titles') && $params->get('access-view')) : ?>
-	<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"><img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="thumbnailUrl"/></a>
+		<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"><img
+		<?php if ($images->image_intro_caption) : ?>
+			<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_intro, ENT_COMPAT, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt, ENT_COMPAT, 'UTF-8'); ?>" itemprop="thumbnailUrl"/></a>
 	<?php else : ?><img
-	<?php if ($images->image_intro_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_intro); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>" itemprop="thumbnailUrl"/>
+		<?php if ($images->image_intro_caption) : ?>
+			<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption, ENT_COMPAT, 'UTF-8') . '"'; ?>
+		<?php endif; ?>
+		src="<?php echo htmlspecialchars($images->image_intro, ENT_COMPAT, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt, ENT_COMPAT, 'UTF-8'); ?>" itemprop="thumbnailUrl"/>
 	<?php endif; ?> 
-</div>
+	</div>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Add an intro image to an article
- access that article to the frontend
- see that it works
- apply this patch
- see that it still works
