### PR TITLE
[mod_syndicate] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_syndicate/mod_syndicate.php
+++ b/modules/mod_syndicate/mod_syndicate.php
@@ -21,8 +21,7 @@ if (is_null($link))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
-
-$text = htmlspecialchars($params->get('text'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$text            = htmlspecialchars($params->get('text'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_syndicate', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_syndicate module to the frontend
- see that it works
- apply this patch
- see that it still works
