### PR TITLE
[com_neewsfeed] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -67,20 +67,20 @@ else
 	<!-- Show Images from Component -->
 	<?php  if (isset($images->image_first) and !empty($images->image_first)) : ?>
 	<?php $imgfloat = (empty($images->float_first)) ? $this->params->get('float_first') : $images->float_first; ?>
-	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>"> <img
+	<div class="img-intro-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?>"> <img
 		<?php if ($images->image_first_caption):
-			echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_first_caption) . '"';
+			echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_first_caption, ENT_COMPAT, 'UTF-8') . '"';
 		endif; ?>
-		src="<?php echo htmlspecialchars($images->image_first); ?>" alt="<?php echo htmlspecialchars($images->image_first_alt); ?>"/> </div>
+		src="<?php echo htmlspecialchars($images->image_first, ENT_COMPAT, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($images->image_first_alt, ENT_COMPAT, 'UTF-8'); ?>"/> </div>
 	<?php endif; ?>
 
 	<?php  if (isset($images->image_second) and !empty($images->image_second)) : ?>
 	<?php $imgfloat = (empty($images->float_second)) ? $this->params->get('float_second') : $images->float_second; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
+	<div class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image"> <img
 	<?php if ($images->image_second_caption):
 		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_second_caption) . '"';
 	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_second); ?>" alt="<?php echo htmlspecialchars($images->image_second_alt); ?>"/> </div>
+	src="<?php echo htmlspecialchars($images->image_second, ENT_COMPAT, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($images->image_second_alt, ENT_COMPAT, 'UTF-8'); ?>"/> </div>
 	<?php endif; ?>
 	<!-- Show Description from Component -->
 	<?php echo $this->item->description; ?>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Show a newsfeed to the frontend
- add a intro image
- see that it works
- apply this patch
- see that it still works
