### PR TITLE
[mod_tags_similar] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -18,13 +18,13 @@ defined('_JEXEC') or die;
 		<li>
 			<?php if (($item->type_alias == 'com_users.category') || ($item->type_alias == 'com_banners.category')) : ?>
 				<?php if (!empty($item->core_title)) :
-					echo htmlspecialchars($item->core_title);
+					echo htmlspecialchars($item->core_title, ENT_COMPAT, 'UTF-8');
 				endif; ?>
 			<?php else: ?>
 				<?php $item->route = new JHelperRoute; ?>
 				<a href="<?php echo JRoute::_(TagsHelperRoute::getItemRoute($item->content_item_id, $item->core_alias, $item->core_catid, $item->core_language, $item->type_alias, $item->router)); ?>">
 					<?php if (!empty($item->core_title)) :
-						echo htmlspecialchars($item->core_title);
+						echo htmlspecialchars($item->core_title, ENT_COMPAT, 'UTF-8');
 					endif; ?>
 				</a>
 			<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_tags_similar module to the frontend
- see that it works
- apply this patch
- see that it still works
