### PR TITLE
hathor/layout/title] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/administrator/templates/hathor/html/layouts/joomla/toolbar/title.php
+++ b/administrator/templates/hathor/html/layouts/joomla/toolbar/title.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 $class = 'pagetitle';
+
 if (!empty($displayData['icon']))
 {
 	// Strip the extension.
@@ -19,7 +20,7 @@ if (!empty($displayData['icon']))
 	{
 		$icons[$i] = 'icon-48-' . preg_replace('#\.[^.]*$#', '', $icon);
 	}
-	$class .= ' ' . htmlspecialchars(implode(' ', $icons));
+	$class .= ' ' . htmlspecialchars(implode(' ', $icons), ENT_COMPAT, 'UTF-8');
 }
 ?>
 <div class="<?php echo $class; ?>">


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions

Please do a quick code review. I have no idea how to test this file
