### PR TITLE
[mod_custom] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_custom/mod_custom.php
+++ b/modules/mod_custom/mod_custom.php
@@ -15,6 +15,6 @@ if ($params->def('prepare_content', 1))
 	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_custom.content');
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_custom', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_custom module to the frontend
- see that it works
- apply this patch
- see that it still works
