### PR TITLE
[mod_users_latest] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_users_latest/mod_users_latest.php
+++ b/modules/mod_users_latest/mod_users_latest.php
@@ -12,9 +12,9 @@ defined('_JEXEC') or die;
 // Include the latest functions only once
 require_once __DIR__ . '/helper.php';
 
-$shownumber = $params->get('shownumber', 5);
-$names = ModUsersLatestHelper::getUsers($params);
-$linknames = $params->get('linknames', 0);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$shownumber      = $params->get('shownumber', 5);
+$names           = ModUsersLatestHelper::getUsers($params);
+$linknames       = $params->get('linknames', 0);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_users_latest', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_users_latest module to the frontend
- see that it works
- apply this patch
- see that it still works
