### PR TITLE
[mod_stats_admin] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/administrator/modules/mod_stats_admin/mod_stats_admin.php
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.php
@@ -15,6 +15,6 @@ require_once __DIR__ . '/helper.php';
 $serverinfo      = $params->get('serverinfo');
 $siteinfo        = $params->get('siteinfo');
 $list            = ModStatsHelper::getStats($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_stats_admin', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions
- Enable the mod_stats_admin module to the backend
- see that it works
- apply this patch
- see that it still works
