### PR TITLE
[mod_* frontend & protostar] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/modules/mod_articles_archive/mod_articles_archive.php
+++ b/modules/mod_articles_archive/mod_articles_archive.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $params->def('count', 10);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $list            = ModArchiveHelper::getList($params);
 
 require JModuleHelper::getLayoutPath('mod_articles_archive', $params->get('layout', 'default'));

--- a/modules/mod_articles_latest/mod_articles_latest.php
+++ b/modules/mod_articles_latest/mod_articles_latest.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $list            = ModArticlesLatestHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_latest', $params->get('layout', 'default'));

--- a/modules/mod_articles_news/mod_articles_news.php
+++ b/modules/mod_articles_news/mod_articles_news.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $list            = ModArticlesNewsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_news', $params->get('layout', 'horizontal'));

--- a/modules/mod_articles_popular/mod_articles_popular.php
+++ b/modules/mod_articles_popular/mod_articles_popular.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 require_once __DIR__ . '/helper.php';
 
 $list = ModArticlesPopularHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_popular', $params->get('layout', 'default'));

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -59,7 +59,7 @@ class ModBreadCrumbsHelper
 		if ($params->get('showHome', 1))
 		{
 			$item = new stdClass;
-			$item->name = htmlspecialchars($params->get('homeText', JText::_('MOD_BREADCRUMBS_HOME')));
+			$item->name = htmlspecialchars($params->get('homeText', JText::_('MOD_BREADCRUMBS_HOME')), ENT_COMPAT, 'UTF-8');
 			$item->link = JRoute::_('index.php?Itemid=' . $home->id);
 			array_unshift($crumbs, $item);
 		}
@@ -96,7 +96,7 @@ class ModBreadCrumbsHelper
 		}
 		else
 		{
-			$_separator = htmlspecialchars($custom);
+			$_separator = htmlspecialchars($custom, ENT_COMPAT, 'UTF-8');
 		}
 
 		return $_separator;

--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 // Include the languages functions only once
 require_once __DIR__ . '/helper.php';
 
-$headerText	     = $params->get('header_text');
-$footerText	     = $params->get('footer_text');
+$headerText      = $params->get('header_text');
+$footerText      = $params->get('footer_text');
 $list            = ModLanguagesHelper::getList($params);
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 

--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -12,11 +12,9 @@ defined('_JEXEC') or die;
 // Include the languages functions only once
 require_once __DIR__ . '/helper.php';
 
-$headerText	= $params->get('header_text');
-$footerText	= $params->get('footer_text');
-
-$list = ModLanguagesHelper::getList($params);
-
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$headerText	     = $params->get('header_text');
+$footerText	     = $params->get('footer_text');
+$list            = ModLanguagesHelper::getList($params);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_languages', $params->get('layout', 'default'));

--- a/modules/mod_stats/mod_stats.php
+++ b/modules/mod_stats/mod_stats.php
@@ -15,6 +15,6 @@ require_once __DIR__ . '/helper.php';
 $serverinfo      = $params->get('serverinfo');
 $siteinfo        = $params->get('siteinfo');
 $list            = ModStatsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_stats', $params->get('layout', 'default'));

--- a/templates/protostar/html/modules.php
+++ b/templates/protostar/html/modules.php
@@ -39,12 +39,12 @@ function modChrome_well($module, &$params, &$attribs)
 	$moduleTag     = $params->get('module_tag', 'div');
 	$bootstrapSize = (int) $params->get('bootstrap_size', 0);
 	$moduleClass   = $bootstrapSize != 0 ? ' span' . $bootstrapSize : '';
-	$headerTag     = htmlspecialchars($params->get('header_tag', 'h3'));
-	$headerClass   = htmlspecialchars($params->get('header_class', 'page-header'));
+	$headerTag     = htmlspecialchars($params->get('header_tag', 'h3'), ENT_COMPAT, 'UTF-8');
+	$headerClass   = htmlspecialchars($params->get('header_class', 'page-header'), ENT_COMPAT, 'UTF-8');
 
 	if ($module->content)
 	{
-		echo '<' . $moduleTag . ' class="well ' . htmlspecialchars($params->get('moduleclass_sfx')) . $moduleClass . '">';
+		echo '<' . $moduleTag . ' class="well ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8') . $moduleClass . '">';
 
 			if ($module->showtitle)
 			{


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions

Please review the changes or test all change modules / templates
