### PR TITLE
[searchtools] Do not throw php notice if activeFilters is not set

### DIFF
--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -31,7 +31,7 @@ $formSelector = !empty($data['options']['formSelector']) ? $data['options']['for
 // Load search tools
 JHtml::_('searchtools.form', $formSelector, $data['options']);
 
-$filtersClass = $data['view']->activeFilters ? ' js-stools-container-filters-visible' : '';
+$filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilters ? ' js-stools-container-filters-visible' : '';
 ?>
 <div class="js-stools clearfix">
 	<div class="clearfix">


### PR DESCRIPTION
#### Summary of Changes

If the activeFilters object is not set in the `view.html.php` file, searchtools is throwing a PHP Notice.
`Notice: Undefined property: InstallerViewLanguages::$activeFilters in /path/to/joomla-staging/layouts/joomla/searchtools/default.php on line 34`

This PR solves that.
#### Testing Instructions

Mainly code review (just a isset()...).

1 But if you want to simulate the problem remove this line: https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_installer/views/languages/view.html.php#L54 (or the same line in any view) and set the error reporting to maximum.
2. Go to Extensions -> Manage -> Install Languages
3. Before patch, PHP Notice. After patch, all fine.
