### PR TITLE
[mod_* templates] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/administrator/modules/mod_feed/mod_feed.php
+++ b/administrator/modules/mod_feed/mod_feed.php
@@ -26,6 +26,6 @@ if (empty ($rssurl))
 }
 
 $feed            = ModFeedHelper::getFeed($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/components/com_users/helpers/html/users.php
+++ b/components/com_users/helpers/html/users.php
@@ -39,7 +39,7 @@ abstract class JHtmlUsers
 
 		elseif (!is_array($value))
 		{
-			return htmlspecialchars($value);
+			return htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 		}
 	}
 
@@ -90,7 +90,7 @@ abstract class JHtmlUsers
 				}
 			}
 
-			$value = htmlspecialchars($value);
+			$value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 
 			if (substr($value, 0, 4) == "http")
 			{
@@ -130,7 +130,7 @@ abstract class JHtmlUsers
 
 			if ($title)
 			{
-				return htmlspecialchars($title);
+				return htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 			}
 			else
 			{
@@ -168,7 +168,7 @@ abstract class JHtmlUsers
 
 			if ($result)
 			{
-				return htmlspecialchars($result['name']);
+				return htmlspecialchars($result['name'], ENT_COMPAT, 'UTF-8');
 			}
 			else
 			{
@@ -206,7 +206,7 @@ abstract class JHtmlUsers
 
 			if ($result)
 			{
-				return htmlspecialchars($result['name']);
+				return htmlspecialchars($result['name'], ENT_COMPAT, 'UTF-8');
 			}
 			else
 			{

--- a/modules/mod_banners/mod_banners.php
+++ b/modules/mod_banners/mod_banners.php
@@ -18,6 +18,6 @@ $footerText = trim($params->get('footer_text'));
 require_once JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php';
 BannersHelper::updateReset();
 $list = &ModBannersHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_banners', $params->get('layout', 'default'));

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.php
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.php
@@ -18,6 +18,6 @@ $count = count($list);
 
 // Set the default separator
 $separator = ModBreadCrumbsHelper::setSeparator($params->get('separator'));
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_breadcrumbs', $params->get('layout', 'default'));

--- a/modules/mod_feed/mod_feed.php
+++ b/modules/mod_feed/mod_feed.php
@@ -26,6 +26,6 @@ if (empty ($rssurl))
 }
 
 $feed = ModFeedHelper::getFeed($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/modules/mod_footer/mod_footer.php
+++ b/modules/mod_footer/mod_footer.php
@@ -32,6 +32,6 @@ else
 	$lineone = $line1;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_footer', $params->get('layout', 'default'));

--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -20,7 +20,7 @@ $active_id  = $active->id;
 $default_id = $default->id;
 $path       = $base->tree;
 $showAll    = $params->get('showAllChildren');
-$class_sfx  = htmlspecialchars($params->get('class_sfx'));
+$class_sfx  = htmlspecialchars($params->get('class_sfx'), ENT_COMPAT, 'UTF-8');
 
 if (count($list))
 {

--- a/modules/mod_random_image/mod_random_image.php
+++ b/modules/mod_random_image/mod_random_image.php
@@ -23,6 +23,7 @@ if (!count($images))
 	return;
 }
 
-$image = ModRandomImageHelper::getRandomImage($params, $images);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$image           = ModRandomImageHelper::getRandomImage($params, $images);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+
 require JModuleHelper::getLayoutPath('mod_random_image', $params->get('layout', 'default'));

--- a/modules/mod_related_items/mod_related_items.php
+++ b/modules/mod_related_items/mod_related_items.php
@@ -26,7 +26,7 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
-$showDate = $params->get('showDate', 0);
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$showDate        = $params->get('showDate', 0);
 
 require JModuleHelper::getLayoutPath('mod_related_items', $params->get('layout', 'default'));

--- a/modules/mod_tags_similar/mod_tags_similar.php
+++ b/modules/mod_tags_similar/mod_tags_similar.php
@@ -26,6 +26,6 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_tags_similar', $params->get('layout', 'default'));

--- a/modules/mod_whosonline/mod_whosonline.php
+++ b/modules/mod_whosonline/mod_whosonline.php
@@ -25,6 +25,6 @@ if ($showmode > 0)
 }
 
 $linknames = $params->get('linknames', 0);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'));
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_whosonline', $params->get('layout', 'default'));

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -49,11 +49,11 @@ $this->direction = $doc->direction;
 		<link rel="stylesheet" href="<?php echo $file; ?>" type="text/css" />
 	<?php endforeach; ?>
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color); ?>.css" type="text/css" />
+	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color, ENT_COMPAT, 'UTF-8'); ?>.css" type="text/css" />
 	<?php if ($this->direction == 'rtl') : ?>
 		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/templates/<?php echo $this->template; ?>/css/template_rtl.css" type="text/css" />
 		<?php if (file_exists(JPATH_SITE . '/templates/' . $this->template . '/css/' . $color . '_rtl.css')) : ?>
-			<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo $color ?>_rtl.css" type="text/css" />
+			<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/<?php echo htmlspecialchars($color, ENT_COMPAT, 'UTF-8'); ?>_rtl.css" type="text/css" />
 		<?php endif; ?>
 	<?php endif; ?>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions

Please review or test all changed files
