### PR TITLE
[com_modules] modal module edit: Fix for TypeError: window.parent is null

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/modal.php
+++ b/administrator/components/com_modules/views/module/tmpl/modal.php
@@ -10,15 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-// This code is needed for proper check out in case of modal close
-JFactory::getDocument()->addScriptDeclaration('
-	window.parent.jQuery(".modal").on("hidden", function () {
-	if (typeof window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn") !== "undefined") {
-		window.parent.jQuery("#module' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
-		}
-	});
-');
 ?>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/9935#issuecomment-218548301 .
#### Summary of Changes
- Close control was added in bootstrap.renderModal in PR https://github.com/joomla/joomla-cms/pull/10317 : https://github.com/joomla/joomla-cms/pull/10317/files#diff-7488449cc92aded23bb5f4abdac5ca91R146
- For this reason, this PR removes script to control close inside the modal.php view (not needed anymore, and duplicated task)
- In the same time, fix the already existed TypeError returned by console! ;-)
#### Testing Instructions

With console error opened, on latest staging.
- Go to menus, and open one menu item
- Click on one of the module in "Module Assignment" tab, to open the module edition
- Then click CLOSE button of the modal
-  Go to Modules Manager : Check that now the module is not locked (the module edition was well closed)
