### PR TITLE
[com_content] modal article edit: Fix for TypeError: window.parent is null

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -10,15 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-// This code is needed for proper check out in case of modal close
-JFactory::getDocument()->addScriptDeclaration('
-	window.parent.jQuery(".modal").on("hidden", function () {
-	if (typeof window.parent.jQuery("#articleEdit' . $this->item->id . 'Modal iframe").contents().find("#closeBtn") !== "undefined") {
-		window.parent.jQuery("#articleEdit' . $this->item->id . 'Modal iframe").contents().find("#closeBtn").click();
-		}
-	});
-');
 ?>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.save');"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.cancel');"></button>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/9935#issuecomment-218548301 .
#### Summary of Changes
- Close control was added in bootstrap.renderModal in PR #10292 : https://github.com/joomla/joomla-cms/pull/10292/files#diff-cbe64e5e6a231b8b275d55b5c6c00942R206
- For this reason, this PR removes script to control close inside the modal.php view (not needed anymore, and duplicated task)
- In the same time, fix the TypeError returned by console
#### Testing Instructions

With console error opened, on latest staging.
- Test in Menus > Menu Item type "single article" > Edit article to open the modal to edit article
- Then click CLOSE button of the modal
-  Go to Articles : Check that the article is not locked (the article edition was well closed)
