### PR TITLE
Fallback to old cookie name if new isn't present.

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -57,6 +57,13 @@ class PlgAuthenticationCookie extends JPlugin
 		$cookieName  = 'joomla_remember_me_' . JUserHelper::getShortHashedUserAgent();
 		$cookieValue = $this->app->input->cookie->get($cookieName);
 
+		// Try with old cookieName (pre 3.6.0) if not found
+		if (!$cookieValue)
+		{
+			$cookieName  = JUserHelper::getShortHashedUserAgent();
+			$cookieValue = $this->app->input->cookie->get($cookieName);
+		}
+
 		if (!$cookieValue)
 		{
 			return false;
@@ -224,6 +231,17 @@ class PlgAuthenticationCookie extends JPlugin
 
 			// We need the old data to get the existing series
 			$cookieValue = $this->app->input->cookie->get($cookieName);
+
+			// Try with old cookieName (pre 3.6.0) if not found
+			if (!$cookieValue)
+			{
+				$oldCookieName = JUserHelper::getShortHashedUserAgent();
+				$cookieValue   = $this->app->input->cookie->get($oldCookieName);
+
+				// Destroy the old cookie in the browser
+				$this->app->input->cookie->set($oldCookieName, false, time() - 42000, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain'));
+			}
+
 			$cookieArray = explode('.', $cookieValue);
 
 			// Filter series since we're going to use it in the query
@@ -277,7 +295,7 @@ class PlgAuthenticationCookie extends JPlugin
 
 		// Get the parameter values
 		$lifetime = $this->params->get('cookie_lifetime', '60') * 24 * 60 * 60;
-		$length	  = $this->params->get('key_length', '16');
+		$length   = $this->params->get('key_length', '16');
 
 		// Generate new cookie
 		$token       = JUserHelper::genRandomPassword($length);

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -53,6 +53,12 @@ class PlgSystemRemember extends JPlugin
 		{
 			$cookieName = 'joomla_remember_me_' . JUserHelper::getShortHashedUserAgent();
 
+			// Try with old cookieName (pre 3.6.0) if not found
+			if (!$this->app->input->cookie->get($cookieName))
+			{
+				$cookieName = JUserHelper::getShortHashedUserAgent();
+			}
+
 			// Check for the cookie
 			if ($this->app->input->cookie->get($cookieName))
 			{


### PR DESCRIPTION
PR https://github.com/joomla/joomla-cms/pull/10373 changed the name of the remember me cookie so it can be detected by reverse caching proxies. This is fine but means that all existing remember me cookies don't work anymore and all users will have to login fresh after the update.
While this isn't that big of a deal, we can still do better :smile: 
#### Summary of Changes

This PR adds a fallback mechanism to the cookie plugins. If there is no cookie with the new name (prefixed with `joomla_remember_me_`), it will look for the old name and proceed with that one if found.
After a successfull login, the old cookie will be destroyed and a new one created with the prefixed name.
#### Testing Instructions

Ideally:
- take a 3.5.1 installation
- log in with remember me option activated
- update to latest staging and apply this PR
- close all browser windows to be sure all sessions are terminated
- open the site again. You should still be logged in. Without this PR you would be logged out.

Hackish way since the testing is a bit complex
- take latest staging and apply this PR
- change https://github.com/Bakual/joomla-cms/blob/CookieFallback/plugins/authentication/cookie/cookie.php#L254 from `$cookieName = 'joomla_remember_me_' . JUserHelper::getShortHashedUserAgent();` to `$cookieName = JUserHelper::getShortHashedUserAgent();`
- log in with the option "remember me" activated. This should create a cookie with the old name (without prefix)
- close all browser windows to kill all sessions
- open the site again. You should still be logged in and the cookie got renamed to the new name (with prefix).
