### PR TITLE
[comp & lib] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/components/com_content/views/categories/tmpl/default_items.php
+++ b/components/com_content/views/categories/tmpl/default_items.php
@@ -40,7 +40,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 				<?php endif;?>
 			</h3>
 			<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
-				<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt')); ?>" />
+				<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>" />
 			<?php endif; ?>
 			<?php if ($this->params->get('show_subcat_desc_cat') == 1) :?>
 				<?php if ($item->description) : ?>

--- a/components/com_tags/views/tag/tmpl/list.php
+++ b/components/com_tags/views/tag/tmpl/list.php
@@ -30,7 +30,7 @@ $n = count($this->items);
 		<div class="category-desc">
 			<?php $images = json_decode($this->item[0]->images); ?>
 			<?php if ($this->params->get('tag_list_show_tag_image', 1) == 1 && !empty($images->image_fulltext)) : ?>
-				<img src="<?php echo htmlspecialchars($images->image_fulltext); ?>">
+				<img src="<?php echo htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8'); ?>">
 			<?php endif; ?>
 			<?php if ($this->params->get('tag_list_show_tag_description') == 1 && $this->item[0]->description) : ?>
 				<?php echo JHtml::_('content.prepare', $this->item[0]->description, '', 'com_tags.tag'); ?>

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -60,7 +60,7 @@ class UsersViewRegistration extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/remind/view.html.php
+++ b/components/com_users/views/remind/view.html.php
@@ -55,7 +55,7 @@ class UsersViewRemind extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/reset/view.html.php
+++ b/components/com_users/views/reset/view.html.php
@@ -65,7 +65,7 @@ class UsersViewReset extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/libraries/joomla/application/route.php
+++ b/libraries/joomla/application/route.php
@@ -94,7 +94,7 @@ class JRoute
 
 		if ($xhtml)
 		{
-			$url = htmlspecialchars($url);
+			$url = htmlspecialchars($url, ENT_COMPAT, 'UTF-8');
 		}
 
 		return $url;

--- a/libraries/joomla/database/exporter/mysqli.php
+++ b/libraries/joomla/database/exporter/mysqli.php
@@ -74,7 +74,7 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 			{
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
-					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment) . '"' .
+					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' .
 					' />';
 			}
 

--- a/libraries/joomla/database/exporter/mysqli.php
+++ b/libraries/joomla/database/exporter/mysqli.php
@@ -74,8 +74,8 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 			{
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
-					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' .
-					' />';
+					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' .
+					' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' . ' />';
 			}
 
 			$buffer[] = '  </table_structure>';

--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -80,7 +80,7 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	{
 		if ($response->code != 200)
 		{
-			$error = htmlspecialchars($response->body);
+			$error = htmlspecialchars($response->body, ENT_COMPAT, 'UTF-8');
 
 			throw new DomainException($error, $response->code);
 		}

--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -65,7 +65,7 @@ if (!empty($list))
 	$grouped                    = false;
 	$article_grouping           = $params->get('article_grouping', 'none');
 	$article_grouping_direction = $params->get('article_grouping_direction', 'ksort');
-	$moduleclass_sfx            = htmlspecialchars($params->get('moduleclass_sfx'));
+	$moduleclass_sfx            = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 	$item_heading               = $params->get('item_heading');
 
 	if ($article_grouping !== 'none')


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions

Please do a code review or test all changed files.
