### PR TITLE
Change scheme for the google maps api call to https and include an api key if one was set

### DIFF
--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -782,7 +782,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function geocodeAddress($address)
 	{
-		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
+		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
 
 		$uri->setVar('address', $address);
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -782,16 +782,16 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function geocodeAddress($address)
 	{
-		$this->uri->parse('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
+		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
 
-		$this->uri->setVar('address', $address);
+		$uri->setVar('address', $address);
 
 		if (($key = $this->getKey()))
 		{
-			$this->uri->setVar('key', $key);
+			$uri->setVar('key', $key);
 		}
 
-		$response = $this->http->get($this->uri->toString());
+		$response = $this->http->get($uri->toString());
 
 		if ($response->code < 200 || $response->code >= 300)
 		{

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -784,7 +784,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	{
 		$this->uri->parse('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
 
-		$this->uri->setVar('address', urlencode($address));
+		$this->uri->setVar('address', $address);
 
 		if (($key = $this->getKey()))
 		{

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -782,7 +782,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function geocodeAddress($address)
 	{
-		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
+		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
 
 		$uri->setVar('address', urlencode($address));
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -782,8 +782,16 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function geocodeAddress($address)
 	{
-		$url = 'http://maps.googleapis.com/maps/api/geocode/json?sensor=false&address=' . urlencode($address);
-		$response = $this->http->get($url);
+		$this->uri->parse('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
+
+		$this->uri->setVar('address', urlencode($address));
+
+		if (($key = $this->getKey()))
+		{
+			$this->uri->setVar('key', $key);
+		}
+
+		$response = $this->http->get($this->uri->toString());
 
 		if ($response->code < 200 || $response->code >= 300)
 		{

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -782,7 +782,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	 */
 	public function geocodeAddress($address)
 	{
-		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
+		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json?sensor=false');
 
 		$uri->setVar('address', urlencode($address));
 

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -784,7 +784,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 	{
 		$uri = JUri::getInstance('https://maps.googleapis.com/maps/api/geocode/json');
 
-		$uri->setVar('address', $address);
+		$uri->setVar('address', urlencode($address));
 
 		if (($key = $this->getKey()))
 		{

--- a/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleEmbedMapsTest.php
@@ -733,7 +733,10 @@ class JGoogleEmbedMapsTest extends TestCase
  */
 function mapsGeocodeCallback($url, array $headers = null, $timeout = null)
 {
-	parse_str($url, $params);
+	$query = parse_url($url, PHP_URL_QUERY);
+	
+	parse_str($query, $params);
+	
 	$address = strtolower($params['address']);
 
 	switch ($address)


### PR DESCRIPTION
#### Summary of Changes

This PR changes the api scheme / protocol for the geocodeAddress call to https instead of http. Currently the JGoogleEmbedMaps::geocodeAddress() api call uses http.

Though, e.g. if you call the api url directly, google redirects you to https, an exception will be returned from google when using the api together with an api key without using https.

> object(JHttpResponse)[1247]
>   public 'code' => int 200
>   public 'headers' =>
>     array (size=12)
>       'Content-Type' => string 'application/json; charset=UTF-8' (length=31)
>       'Date' => string 'Thu, 12 May 2016 10:18:22 GMT' (length=29)
>       'Pragma' => string 'no-cache' (length=8)
>       'Expires' => string 'Fri, 01 Jan 1990 00:00:00 GMT' (length=29)
>       'Cache-Control' => string 'no-cache, must-revalidate' (length=25)
>       'Access-Control-Allow-Origin' => string '*' (length=1)
>       'Server' => string 'mafe' (length=4)
>       'X-XSS-Protection' => string '1; mode=block' (length=13)
>       'X-Frame-Options' => string 'SAMEORIGIN' (length=10)
>       'Accept-Ranges' => string 'none' (length=4)
>       'Vary' => string 'Accept-Language,Accept-Encoding' (length=31)
>       'Transfer-Encoding' => string 'chunked' (length=7)
>   public 'body' => string '{
>    "error_message" : "Requests to this API must be over SSL. Load the API with \"https://\" instead of \"http://\".",
>    "results" : [],
>    "status" : "REQUEST_DENIED"
> }
> ' (length=172)

Speaking of the api key; The google library allows you to set an api key that will be used in the javascript rendering part but not in the geocodeAddress() method. This PR also adds a key to the request if present so that you won't run into your quota limit any time soon.
#### Testing Instructions

Download and install the test modul I attached to this PR. Enable the module, assign it to e.g. the position-3 of the protostar template. Don't forget to set the module to show on all pages.

Depending on the settings (key, address) you've made, you will see a debug message with information about the last request. Now, there aren't really that much visible errors to indicate something not working correctly. The debug message in the module only show that the request works as before.

You can provoke the exception mentioned above by applying the patch and changing the https back to http on line 785 in /libraries/joomla/google/embed/maps.php. Given you've provided an api key you would see a message similar to this one:
![api_key_exception](https://cloud.githubusercontent.com/assets/1304616/15217884/ce56c7ce-185d-11e6-8d63-6501c8fb6474.jpg)
#### Attachment

[mod_geocodepr.zip](https://github.com/joomla/joomla-cms/files/261518/mod_geocodepr.zip)
