### PR TITLE
[tags & users & libs & beez] Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')

### DIFF
--- a/components/com_tags/views/tag/tmpl/default.php
+++ b/components/com_tags/views/tag/tmpl/default.php
@@ -29,7 +29,7 @@ $isSingleTag = (count($this->item) == 1);
 		<div class="category-desc">
 			<?php $images = json_decode($this->item[0]->images); ?>
 			<?php if ($this->params->get('tag_list_show_tag_image', 1) == 1 && !empty($images->image_fulltext)) : ?>
-				<img src="<?php echo htmlspecialchars($images->image_fulltext); ?>">
+				<img src="<?php echo htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8'); ?>">
 			<?php endif; ?>
 			<?php if ($this->params->get('tag_list_show_tag_description') == 1 && $this->item[0]->description) : ?>
 				<?php echo JHtml::_('content.prepare', $this->item[0]->description, '', 'com_tags.tag'); ?>

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -62,7 +62,7 @@ class UsersViewLogin extends JViewLegacy
 		$this->tfa = is_array($tfa) && count($tfa) > 1;
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -49,7 +49,7 @@ $tagsData = $displayData->get('category')->tags->itemTags;
 		<?php if ($params->get('show_description', 1) || $params->def('show_description_image', 1)) : ?>
 			<div class="category-desc">
 				<?php if ($params->get('show_description_image') && $displayData->get('category')->getParams()->get('image')) : ?>
-					<img src="<?php echo $displayData->get('category')->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($displayData->get('category')->getParams()->get('image_alt')); ?>"/>
+					<img src="<?php echo $displayData->get('category')->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($displayData->get('category')->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>"/>
 				<?php endif; ?>
 				<?php if ($params->get('show_description') && $displayData->get('category')->description) : ?>
 					<?php echo JHtml::_('content.prepare', $displayData->get('category')->description, '', $extension . '.category.description'); ?>

--- a/libraries/joomla/database/exporter/pdomysql.php
+++ b/libraries/joomla/database/exporter/pdomysql.php
@@ -76,8 +76,8 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 			{
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
-					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' .
-					' />';
+					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' .
+					' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' . ' />';
 			}
 
 			$buffer[] = '  </table_structure>';

--- a/libraries/joomla/database/exporter/pdomysql.php
+++ b/libraries/joomla/database/exporter/pdomysql.php
@@ -76,7 +76,7 @@ class JDatabaseExporterPdomysql extends JDatabaseExporter
 			{
 				$buffer[] = '   <key Table="' . $table . '"' . ' Non_unique="' . $key->Non_unique . '"' . ' Key_name="' . $key->Key_name . '"' .
 					' Seq_in_index="' . $key->Seq_in_index . '"' . ' Column_name="' . $key->Column_name . '"' . ' Collation="' . $key->Collation . '"' .
-					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment) . '"' .
+					' Null="' . $key->Null . '"' . ' Index_type="' . $key->Index_type . '"' . ' Comment="' . htmlspecialchars($key->Comment, ENT_COMPAT, 'UTF-8') . '"' .
 					' />';
 			}
 

--- a/libraries/joomla/openstreetmap/object.php
+++ b/libraries/joomla/openstreetmap/object.php
@@ -119,7 +119,7 @@ abstract class JOpenstreetmapObject
 		// Validate the response code.
 		if ($response->code != 200)
 		{
-			$error = htmlspecialchars($response->body);
+			$error = htmlspecialchars($response->body, ENT_COMPAT, 'UTF-8');
 
 			throw new DomainException($error, $response->code);
 		}

--- a/libraries/legacy/view/categories.php
+++ b/libraries/legacy/view/categories.php
@@ -84,7 +84,7 @@ class JViewCategories extends JViewLegacy
 		$items = array($parent->id => $items);
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 		$this->maxLevelcat = $params->get('maxLevelcat', -1) < 0 ? PHP_INT_MAX : $params->get('maxLevelcat', PHP_INT_MAX);
 		$this->params      = &$params;

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -22,7 +22,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 <?php endif; ?>
 
 <?php if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0)) : ?>
-	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current()); ?>">
+	<form name="lang" method="post" action="<?php echo htmlspecialchars(JUri::current(), ENT_COMPAT, 'UTF-8'); ?>">
 	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
 		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo $language->link; ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>

--- a/templates/beez3/html/com_newsfeeds/category/default_items.php
+++ b/templates/beez3/html/com_newsfeeds/category/default_items.php
@@ -17,7 +17,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 
 <?php if (empty($this->items)) : ?>
-	<p> <?php echo JText::_('COM_NEWSFEEDS_NO_ARTICLES'); ?>	 </p>
+	<p><?php echo JText::_('COM_NEWSFEEDS_NO_ARTICLES'); ?></p>
 <?php else : ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString(), ENT_COMPAT, 'UTF-8'); ?>" method="post" name="adminForm" id="adminForm">

--- a/templates/beez3/html/com_newsfeeds/category/default_items.php
+++ b/templates/beez3/html/com_newsfeeds/category/default_items.php
@@ -20,7 +20,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<p> <?php echo JText::_('COM_NEWSFEEDS_NO_ARTICLES'); ?>	 </p>
 <?php else : ?>
 
-<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo htmlspecialchars(JUri::getInstance()->toString(), ENT_COMPAT, 'UTF-8'); ?>" method="post" name="adminForm" id="adminForm">
 	<fieldset class="filters">
 	<legend class="hidelabeltxt"><?php echo JText::_('JGLOBAL_FILTER_LABEL'); ?></legend>
 	<?php if ($this->params->get('show_pagination_limit')) : ?>
@@ -90,14 +90,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	</table>
 
 	<?php if ($this->params->get('show_pagination')) : ?>
-	<div class="pagination">
-	<?php if ($this->params->def('show_pagination_results', 1)) : ?>
-		<p class="counter">
-			<?php echo $this->pagination->getPagesCounter(); ?>
-		</p>
-	<?php endif; ?>
-	<?php echo $this->pagination->getPagesLinks(); ?>
-	</div>
+		<div class="pagination">
+		<?php if ($this->params->def('show_pagination_results', 1)) : ?>
+			<p class="counter">
+				<?php echo $this->pagination->getPagesCounter(); ?>
+			</p>
+		<?php endif; ?>
+		<?php echo $this->pagination->getPagesLinks(); ?>
+		</div>
 	<?php endif; ?>
 
 </form>


### PR DESCRIPTION
Pull Request for Issue #10399 .
#### Summary of Changes

Always use htmlspecialchars($str, ENT_COMPAT, 'UTF-8')
#### Testing Instructions

Please do a code review or test all changed files.
