### PR TITLE
Modal com_categories: improve Select & Edit Category

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -163,11 +163,13 @@ class JFormFieldModal_Category extends JFormField
 			'modalCategory-' . $this->id,
 			array(
 				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-				'title' => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
-				'width' => '800px',
-				'height' => '300px',
-				'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
+				'width'       => '800px',
+				'height'      => '300px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
 		);
 

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -19,7 +19,7 @@ class JFormFieldModal_Category extends JFormField
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
+	 * @var     string
 	 * @since   1.6
 	 */
 	protected $type = 'Modal_Category';
@@ -27,7 +27,7 @@ class JFormFieldModal_Category extends JFormField
 	/**
 	 * Method to get the field input markup.
 	 *
-	 * @return  string	The field input markup.
+	 * @return  string  The field input markup.
 	 *
 	 * @since   1.6
 	 */
@@ -58,7 +58,11 @@ class JFormFieldModal_Category extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		if (id == "' . (int) $this->value . '") {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		} else {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
+			$script[] = '		}';
 		}
 
 		if ($allowClear)
@@ -66,7 +70,7 @@ class JFormFieldModal_Category extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jQuery("#modalCategory-' . $this->id . '").modal("hide");';
+		$script[] = '		jQuery("#categorySelect' . $this->id . 'Modal").modal("hide");';
 		$script[] = '	}';
 
 		// Clear button script
@@ -93,12 +97,15 @@ class JFormFieldModal_Category extends JFormField
 
 		// Setup variables for display.
 		$html = array();
-		$link = 'index.php?option=com_categories&amp;view=categories&amp;layout=modal&amp;tmpl=component&amp;extension='
+
+		$linkCategories = 'index.php?option=com_categories&amp;view=categories&amp;layout=modal&amp;tmpl=component&amp;extension='
 			. $extension . '&amp;function=jSelectCategory_' . $this->id;
+		$linkCategory   = 'index.php?option=com_categories&amp;view=category&amp;layout=modal&amp;tmpl=component&amp;task=category.edit';
 
 		if (isset($this->element['language']))
 		{
-			$link .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkCategories .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkCategory   .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
 
 		if ((int) $this->value > 0)
@@ -137,11 +144,19 @@ class JFormFieldModal_Category extends JFormField
 			$value = (int) $this->value;
 		}
 
+		$urlSelect = $linkCategories . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkCategory . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
+
 		// The current category display field.
 		$html[] = '<span class="input-append">';
-		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a href="#modalCategory-'
-			. $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"'
+		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+
+		// Select category button
+		$html[] = '<a'
+			. ' class="btn hasTooltip"'
+			. ' data-toggle="modal"'
+			. ' role="button"'
+			. ' href="#categorySelect' . $this->id . 'Modal"'
 			. ' title="' . JHtml::tooltipText('COM_CATEGORIES_CHANGE_CATEGORY') . '">'
 			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
 			. '</a>';
@@ -151,34 +166,21 @@ class JFormFieldModal_Category extends JFormField
 		{
 			$html[] = '<a'
 				. ' class="btn hasTooltip' . ($value ? '' : ' hidden') . '"'
-				. ' href="index.php?option=com_categories&layout=modal&tmpl=component&task=category.edit&id=' . $value . '"'
-				. ' target="_blank"'
-				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '" >'
-				. '<span class="icon-edit"></span>' . JText::_('JACTION_EDIT')
+				. ' id="' . $this->id . '_edit"'
+				. ' data-toggle="modal"'
+				. ' role="button"'
+				. ' href="#categoryEdit' . $this->id . 'Modal"'
+				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '">'
+				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
-
-		$html[] = JHtml::_(
-			'bootstrap.renderModal',
-			'modalCategory-' . $this->id,
-			array(
-				'url'         => $link . '&amp;' . JSession::getFormToken() . '=1',
-				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
-				'width'       => '800px',
-				'height'      => '300px',
-				'modalWidth'  => '80',
-				'bodyHeight'  => '70',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-			)
-		);
 
 		// Clear category button
 		if ($allowClear)
 		{
 			$html[] = '<button'
-				. ' id="' . $this->id . '_clear"'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
+				. ' id="' . $this->id . '_clear"'
 				. ' onclick="return jClearCategory(\'' . $this->id . '\')">'
 				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
 				. '</button>';
@@ -186,13 +188,49 @@ class JFormFieldModal_Category extends JFormField
 
 		$html[] = '</span>';
 
-		// Note: class='required' for client side validation
-		$class = '';
+		// Select category modal
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'categorySelect' . $this->id . 'Modal',
+			array(
+				'url'         => $urlSelect,
+				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
 
-		if ($this->required)
-		{
-			$class = ' class="required modal-value"';
-		}
+		// Edit category modal
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'categoryEdit' . $this->id . 'Modal',
+			array(
+				'url'         => $urlEdit,
+				'title'       => JText::_('COM_CATEGORIES_EDIT_CATEGORY'),
+				'backdrop'    => 'static',
+				'closeButton' => false,
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. JText::_("JSAVE") . '</button>'
+						. '<button type="button" class="btn btn-success" aria-hidden="true"'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. JText::_("JAPPLY") . '</button>'
+			)
+		);
+
+		// Note: class='required' for client side validation
+		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -162,7 +162,7 @@ class JFormFieldModal_Category extends JFormField
 			'bootstrap.renderModal',
 			'modalCategory-' . $this->id,
 			array(
-				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+				'url' => $link . '&amp;' . JSession::getFormToken() . '=1',
 				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
 				'width'       => '800px',
 				'height'      => '300px',

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -162,7 +162,7 @@ class JFormFieldModal_Category extends JFormField
 			'bootstrap.renderModal',
 			'modalCategory-' . $this->id,
 			array(
-				'url' => $link . '&amp;' . JSession::getFormToken() . '=1',
+				'url'         => $link . '&amp;' . JSession::getFormToken() . '=1',
 				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
 				'width'       => '800px',
 				'height'      => '300px',

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -20,113 +20,125 @@ require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
+
+// Special case for the search field tooltip.
+$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
+JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $extension = $this->escape($this->state->get('filter.extension'));
 $function  = $app->input->getCmd('function', 'jSelectCategory');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<div style="padding-top: 25px;"></div>
-<form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
-	<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
-	<?php else : ?>
-		<table class="table table-striped" id="categoryList">
-			<thead>
-				<tr>
-					<th width="1%" class="nowrap center">
-						<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
-					</th>
-					<th class="nowrap">
-						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
-					</th>
-					<th width="10%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder);	?>
-					</th>
-					<th width="1%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-					</th>
-				</tr>
-			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="5">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
-			<tbody>
-				<?php
-				$iconStates = array(
-					-2 => 'icon-trash',
-					0 => 'icon-unpublish',
-					1 => 'icon-publish',
-					2 => 'icon-archive',
-				);
-				?>
-				<?php foreach ($this->items as $i => $item) : ?>
-					<?php if ($item->language && JLanguageMultilang::isEnabled())
-					{
-						$tag = strlen($item->language);
-						if ($tag == 5)
+<div class="container-popup">
+
+	<form action="<?php echo JRoute::_('index.php?option=com_categories&view=categories&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
+
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
+		<div class="clearfix"></div>
+
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
+			<table class="table table-striped" id="categoryList">
+				<thead>
+					<tr>
+						<th width="1%" class="nowrap center">
+							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
+						</th>
+						<th class="nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder);	?>
+						</th>
+						<th width="1%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+						</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="5">
+							<?php echo $this->pagination->getListFooter(); ?>
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>
+					<?php
+					$iconStates = array(
+						-2 => 'icon-trash',
+						0 => 'icon-unpublish',
+						1 => 'icon-publish',
+						2 => 'icon-archive',
+					);
+					?>
+					<?php foreach ($this->items as $i => $item) : ?>
+						<?php if ($item->language && JLanguageMultilang::isEnabled())
 						{
-							$lang = substr($item->language, 0, 2);
+							$tag = strlen($item->language);
+							if ($tag == 5)
+							{
+								$lang = substr($item->language, 0, 2);
+							}
+							elseif ($tag == 6)
+							{
+								$lang = substr($item->language, 0, 3);
+							}
+							else
+							{
+								$lang = "";
+							}
 						}
-						elseif ($tag == 6)
-						{
-							$lang = substr($item->language, 0, 3);
-						}
-						else
+						elseif (!JLanguageMultilang::isEnabled())
 						{
 							$lang = "";
 						}
-					}
-					elseif (!JLanguageMultilang::isEnabled())
-					{
-						$lang = "";
-					}
-					?>
-					<tr class="row<?php echo $i % 2; ?>">
-						<td class="center">
-							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
-						</td>
-						<td>
-							<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1); ?>
-							<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-								<?php echo $this->escape($item->title); ?>
-							</a>
-						</td>
-						<td class="small hidden-phone">
-							<?php echo $this->escape($item->access_level); ?>
-						</td>
-						<td class="small hidden-phone">
-							<?php if ($item->language == '*') : ?>
-								<?php echo JText::alt('JALL', 'language'); ?>
-							<?php else: ?>
-								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-							<?php endif; ?>
-						</td>
-						<td class="hidden-phone">
-							<?php echo (int) $item->id; ?>
-						</td>
-					</tr>
-				<?php endforeach; ?>
-			</tbody>
-		</table>
-	<?php endif; ?>
-	<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="boxchecked" value="0" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
-	<?php echo JHtml::_('form.token'); ?>
+						?>
+						<tr class="row<?php echo $i % 2; ?>">
+							<td class="center">
+								<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
+							</td>
+							<td>
+								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1); ?>
+								<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+									<?php echo $this->escape($item->title); ?>
+								</a>
+							</td>
+							<td class="small hidden-phone">
+								<?php echo $this->escape($item->access_level); ?>
+							</td>
+							<td class="small hidden-phone">
+								<?php if ($item->language == '*') : ?>
+									<?php echo JText::alt('JALL', 'language'); ?>
+								<?php else: ?>
+									<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+								<?php endif; ?>
+							</td>
+							<td class="hidden-phone">
+								<?php echo (int) $item->id; ?>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
 
-</form>
+		<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+
+	</form>
+</div>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -111,7 +111,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</td>
 							<td>
 								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1); ?>
-								<a href="javascript:void()" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+								<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 									<?php echo $this->escape($item->title); ?>
 								</a>
 							</td>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -38,9 +38,13 @@ JFactory::getDocument()->addScriptDeclaration('
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
+// In case of modal
+$isModal = $input->get('layout') == 'modal' ? true : false;
+$layout = $isModal ? 'modal' : 'edit';
+$tmpl = $isModal ? '&tmpl=component' : '';
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
@@ -70,10 +74,12 @@ $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php if ($assoc && $extensionassoc) : ?>
+		<?php if ( ! $isModal && $assoc && $extensionassoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
+		<?php elseif ($isModal && $assoc && $extensionassoc) : ?>
+			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
 		<?php if ($this->canDo->get('core.admin')) : ?>

--- a/administrator/components/com_categories/views/category/tmpl/modal.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal.php
@@ -9,96 +9,13 @@
 
 defined('_JEXEC') or die;
 
-// Include the component HTML helpers.
-JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-
-JHtml::_('behavior.formvalidator');
-JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select');
-
-$app = JFactory::getApplication();
-$input = $app->input;
-
-$assoc = JLanguageAssociations::isEnabled();
-
-JFactory::getDocument()->addScriptDeclaration("
-	Joomla.submitbutton = function(task)
-	{
-		if (task == 'category.cancel' || document.formvalidator.isValid(document.getElementById('item-form')))
-		{
-			" . $this->form->getField('description')->save() . "
-
-			if (window.opener && (task == 'category.save' || task == 'category.cancel'))
-			{
-				window.opener.document.closeEditWindow = self;
-				window.opener.setTimeout('window.document.closeEditWindow.close()', 1000);
-			}
-
-			Joomla.submitform(task, document.getElementById('item-form'));
-		}
-	};
-");
-
-// Fieldsets to not automatically render by /layouts/joomla/edit/params.php
-$this->ignore_fieldsets = array('jmetadata', 'item_associations');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.apply');"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.save');"></button>
+<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.cancel');"></button>
+
 <div class="container-popup">
-
-	<div class="pull-right">
-		<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('category.apply');"><?php echo JText::_('JTOOLBAR_APPLY') ?></button>
-		<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('category.save');"><?php echo JText::_('JTOOLBAR_SAVE') ?></button>
-		<button class="btn" type="button" onclick="Joomla.submitbutton('category.cancel');"><?php echo JText::_('JCANCEL') ?></button>
-	</div>
-
-	<div class="clearfix"></div>
-	<hr class="hr-condensed" />
-
-	<form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=modal&tmpl=component&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate form-horizontal">
-		<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
-
-		<div class="form-horizontal">
-			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'general')); ?>
-
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'general', JText::_('JCATEGORY')); ?>
-			<div class="row-fluid">
-				<div class="span9">
-					<?php echo $this->form->getLabel('description'); ?>
-					<?php echo $this->form->getInput('description'); ?>
-				</div>
-				<div class="span3">
-					<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
-				</div>
-			</div>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CATEGORIES_FIELDSET_PUBLISHING')); ?>
-			<div class="row-fluid form-horizontal-desktop">
-				<div class="span6">
-					<?php echo JLayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-				</div>
-				<div class="span6">
-					<?php echo JLayoutHelper::render('joomla.edit.metadata', $this); ?>
-				</div>
-			</div>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-			<?php if ($assoc) : ?>
-				<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
-			<?php endif; ?>
-
-			<?php if ($this->canDo->get('core.admin')) : ?>
-				<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'rules', JText::_('COM_CATEGORIES_FIELDSET_RULES')); ?>
-				<?php echo $this->form->getInput('rules'); ?>
-				<?php echo JHtml::_('bootstrap.endTab'); ?>
-			<?php endif; ?>
-
-			<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
-
-			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-
-			<?php echo $this->form->getInput('extension'); ?>
-			<input type="hidden" name="task" value="" />
-			<?php echo JHtml::_('form.token'); ?>
-		</div>
-	</form>
+	<?php $this->setLayout('edit'); ?>
+	<?php echo $this->loadTemplate(); ?>
 </div>


### PR DESCRIPTION
Improve modals to select and to edit a category.
**Note: to be testing on staging.**
#### Summary of Changes
- When Bootstrap modal loads an iframe, BS tooltips with placement top are truncated at the top border of the iframe. (no auto placement in BS2). This PR sets the tooltip placement to bottom to fix this issue.
- Remove inline CSS
- Content is embedded in a container div (using already existing container-popup class for modal.php)
- Add empty lines to improve the readability
- Add viewport dimensions (new <code>3.6.0-dev</code>)
- Category edit modal is simplify (loading edit layout, so no dupplicated code)
- Fix Edit button when current associated category in data is not the category selected
- Control if modal, in edit layout
- Add Save, Save & Close and Close button to the footer of the modal
- Fix Edit modal not opening as a modal (missing bootstrap.renderModal for Edit modal)
- Fix <code>Uncaught SyntaxError: Unexpected token )</code> in select category modal
#### Testing Instructions (Staging + Multilanguages enabled!)
- Go to Contents > Categories > open a categorie, and go to <code>Associations</code> tab to select associated category to open the modal.
- Verify tooltip placement is bottom, and not truncated
- Verify the modal size now is proportionnal to viewport (width 80/100th viewport width, and modal-body is 70/100th viewport height)
- Select an associated category and save the category to show edit button
- Open Edit modal and play with it ;-)

**Select Category Before Patch**
![capture d ecran 2016-05-12 a 16 43 11](https://cloud.githubusercontent.com/assets/2385058/15218966/5d7c6bf8-1862-11e6-9732-3a4faa7391b8.png)

**Select Category After Patch**
![capture d ecran 2016-05-12 a 16 42 16](https://cloud.githubusercontent.com/assets/2385058/15218999/756f9cb2-1862-11e6-84b0-140d2bfc9fef.png)

**Edit Category Before Patch**
Open in a new window...
![capture d ecran 2016-05-13 a 18 57 41](https://cloud.githubusercontent.com/assets/2385058/15255586/250bbcac-193d-11e6-8787-5c4642eee23d.png)

**Edit Category After Patch**
Open in a modal
![capture d ecran 2016-05-13 a 18 58 39](https://cloud.githubusercontent.com/assets/2385058/15255592/31c2e146-193d-11e6-8114-fcb22d57cd76.png)
