### PR TITLE
Rewrite installation plugins and add them to Hathor

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -126,6 +126,13 @@ JFactory::getDocument()->addStyleDeclaration(
 				<?php $firstTab = JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
 				<?php // Show installation tabs ?>
 				<?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
+				<?php foreach ($tabs as $tab) : ?>
+					<?php echo JHtml::_('bootstrap.addTab', 'myTab', $tab['name'], $tab['label']); ?>
+					<fieldset class="uploadform">
+						<?php echo $tab['content']; ?>
+					</fieldset>
+					<?php echo JHtml::_('bootstrap.endTab'); ?>
+				<?php endforeach; ?>
 				<?php // Show installation tabs at the end ?>
 				<?php $lastTab = JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
 				<?php $tabs = array_merge($firstTab, $tabs, $lastTab); ?>

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3454,6 +3454,10 @@ fieldset.uploadform {
 	margin-top: 10px;
 	margin-bottom: 10px;
 }
+fieldset.uploadform .control-group,
+fieldset.uploadform .form-actions {
+	display: inline-block;
+}
 #installer-database,
 #installer-discover,
 #installer-update,

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -92,7 +92,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<?php endif; ?>
 	<div class="width-70 fltlft">
 
-		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
+		<?php $firstTab = JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
 
 		<?php // Show installation fieldsets ?>
 		<?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
@@ -102,7 +102,13 @@ JFactory::getDocument()->addScriptDeclaration("
 			</fieldset>
 		<?php endforeach; ?>
 
-		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
+		<?php $lastTab = JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
+
+		<?php $tabs = array_merge($firstTab, $tabs, $lastTab); ?>
+		<?php if (!$tabs) : ?>
+			<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
+		<?php endif; ?>
+
 
 		<input type="hidden" name="type" value="" />
 		<input type="hidden" name="installtype" value="upload" />

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -94,25 +94,13 @@ JFactory::getDocument()->addScriptDeclaration("
 
 		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
 
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_UPLOAD_PACKAGE_FILE'); ?></legend>
-			<label for="install_package"><?php echo JText::_('COM_INSTALLER_PACKAGE_FILE'); ?></label>
-			<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
-			<input class="button" type="button" value="<?php echo JText::_('COM_INSTALLER_UPLOAD_AND_INSTALL'); ?>" onclick="Joomla.submitbutton()" />
-		</fieldset>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY'); ?></legend>
-			<label for="install_directory"><?php echo JText::_('COM_INSTALLER_INSTALL_DIRECTORY'); ?></label>
-			<input type="text" id="install_directory" name="install_directory" class="input_box" size="70" value="<?php echo $this->state->get('install.directory'); ?>" />			<input type="button" class="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton3()" />
-		</fieldset>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_URL'); ?></legend>
-			<label for="install_url"><?php echo JText::_('COM_INSTALLER_INSTALL_URL'); ?></label>
-			<input type="text" id="install_url" name="install_url" class="input_box" size="70" value="https://" />
-			<input type="button" class="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton4()" />
-		</fieldset>
+		<?php // Show installation fieldsets ?>
+		<?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
+		<?php foreach ($tabs as $tab) : ?>
+			<fieldset class="uploadform">
+				<?php echo $tab['content']; ?>
+			</fieldset>
+		<?php endforeach; ?>
 
 		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
 

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -34,42 +34,14 @@ class PlgInstallerFolderInstaller extends JPlugin
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		$app = JFactory::getApplication('administrator');
-
 		$tab            = array();
 		$tab['name']    = 'folder';
 		$tab['label']   = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
-		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT') . '</legend>'
-			. '<div class="control-group">'
-				. '<label for="install_directory" class="control-label">' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT') . '</label>'
-				. '<div class="controls">'
-					. '<input type="text" id="install_directory" name="install_directory" class="span5 input_box" size="70" value="'
-						. $app->input->get('install_directory', $app->get('tmp_path')) . '" />'
-				. '</div>'
-			. '</div>'
-			. '<div class="form-actions">'
-				. '<input type="button" class="btn btn-primary" id="installbutton_directory"
-					value="' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON') . '" onclick="Joomla.submitbuttonfolder()" />'
-			. '</div>';
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonfolder = function()
-			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_directory.value == "")
-				{
-					alert("' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH') . '");
-				}
-				else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "folder"
-					form.submit();
-				}
-			};
-		');
+		// Render the input
+		ob_start();
+		include JPluginHelper::getLayoutPath('installer', 'folderinstaller');
+		$tab['content'] = ob_get_clean();
 
 		return $tab;
 	}

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
  *
  * @since  3.6.0
  */
-class PlgInstallerFolderInstaller  extends JPlugin
+class PlgInstallerFolderInstaller extends JPlugin
 {
 	/**
 	 * Load the language file on instantiation.

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -18,58 +18,39 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerFolderInstaller  extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Load the language file on instantiation.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.6.0
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
 	 * Textfield or Form of the Plugin.
 	 *
-	 * @return  bool  Always returns true
+	 * @return  array  Returns an array with the tab information
 	 *
 	 * @since   3.6.0
 	 */
 	public function onInstallerAddInstallationTab()
 	{
 		$app = JFactory::getApplication('administrator');
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'folder', JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'));
-		?>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></legend>
-			<div class="control-group">
-				<label for="install_directory" class="control-label"><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></label>
-				<div class="controls">
-					<input
-						type="text"
-						id="install_directory"
-						name="install_directory"
-						class="span5 input_box"
-						size="70"
-						value="<?php echo $app->input->get('install_directory', $app->get('tmp_path')); ?>" />
-				</div>
-			</div>
-			<div class="form-actions">
-				<input type="button" class="btn btn-primary" id="installbutton_directory"
-					value="<?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonfolder()"
-				/>
-			</div>
-		</fieldset>
 
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$tab            = array();
+		$tab['name']    = 'folder';
+		$tab['label']   = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
+		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT') . '</legend>'
+			. '<div class="control-group">'
+				. '<label for="install_directory" class="control-label">' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT') . '</label>'
+				. '<div class="controls">'
+					. '<input type="text" id="install_directory" name="install_directory" class="span5 input_box" size="70" value="'
+						. $app->input->get('install_directory', $app->get('tmp_path')) . '" />'
+				. '</div>'
+			. '</div>'
+			. '<div class="form-actions">'
+				. '<input type="button" class="btn btn-primary" id="installbutton_directory"
+					value="' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON') . '" onclick="Joomla.submitbuttonfolder()" />'
+			. '</div>';
 
 		JFactory::getDocument()->addScriptDeclaration('
 			Joomla.submitbuttonfolder = function()
@@ -90,6 +71,6 @@ class PlgInstallerFolderInstaller  extends JPlugin
 			};
 		');
 
-		return true;
+		return $tab;
 	}
 }

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Installer.folderinstaller
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$app = JFactory::getApplication('administrator');
+
+JFactory::getDocument()->addScriptDeclaration('
+	Joomla.submitbuttonfolder = function()
+	{
+		var form = document.getElementById("adminForm");
+
+		// do field validation 
+		if (form.install_directory.value == "")
+		{
+			alert("' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH') . '");
+		}
+		else
+		{
+			jQuery("#loading").css("display", "block");
+			form.installtype.value = "folder"
+			form.submit();
+		}
+	};
+');
+?>
+<legend><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></legend>
+<div class="control-group">
+	<label for="install_directory" class="control-label"><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></label>
+	<div class="controls">
+		<input type="text" id="install_directory" name="install_directory" class="span5 input_box" size="70"
+			value="<?php echo $app->input->get('install_directory', $app->get('tmp_path')); ?>" />
+	</div>
+</div>
+<div class="form-actions">
+	<input type="button" class="btn btn-primary" id="installbutton_directory"
+		value="<?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonfolder()" />
+</div>

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -38,36 +38,11 @@ class PlgInstallerPackageInstaller extends JPlugin
 		$tab            = array();
 		$tab['name']    = 'package';
 		$tab['label']   = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE');
-		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION') . '</legend>'
-			. '<div class="control-group">'
-				. '<label for="install_package" class="control-label">' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE') . '</label>'
-				. '<div class="controls">'
-					. '<input class="input_box" id="install_package" name="install_package" type="file" size="57" />'
-				. '</div>'
-			. '</div>'
-			. '<div class="form-actions">'
-				. '<button class="btn btn-primary" type="button" id="installbutton_package" onclick="Joomla.submitbuttonpackage()">'
-					. JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL') . '</button>'
-			. '</div>';
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonpackage = function()
-			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_package.value == "")
-				{
-					alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE') . '");
-				}
-				else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "upload"
-					form.submit();
-				}
-			};
-		');
+		// Render the input
+		ob_start();
+		include JPluginHelper::getLayoutPath('installer', 'packageinstaller');
+		$tab['content'] = ob_get_clean();
 
 		return $tab;
 	}

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -19,49 +19,36 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerPackageInstaller extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Load the language file on instantiation.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.6.0
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
 	 * Textfield or Form of the Plugin.
 	 *
-	 * @return  bool  Always returns true
+	 * @return  array  Returns an array with the tab information
 	 *
 	 * @since   3.6.0
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'package', JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE'));
-		?>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION'); ?></legend>
-			<div class="control-group">
-				<label for="install_package" class="control-label"><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE'); ?></label>
-				<div class="controls">
-					<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
-				</div>
-			</div>
-			<div class="form-actions">
-				<button class="btn btn-primary" type="button" id="installbutton_package" onclick="Joomla.submitbuttonpackage()">
-					<?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL'); ?></button>
-			</div>
-		</fieldset>
-
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$tab            = array();
+		$tab['name']    = 'package';
+		$tab['label']   = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE');
+		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION') . '</legend>'
+			. '<div class="control-group">'
+				. '<label for="install_package" class="control-label">' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE') . '</label>'
+				. '<div class="controls">'
+					. '<input class="input_box" id="install_package" name="install_package" type="file" size="57" />'
+				. '</div>'
+			. '</div>'
+			. '<div class="form-actions">'
+				. '<button class="btn btn-primary" type="button" id="installbutton_package" onclick="Joomla.submitbuttonpackage()">'
+					. JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL') . '</button>'
+			. '</div>';
 
 		JFactory::getDocument()->addScriptDeclaration('
 			Joomla.submitbuttonpackage = function()
@@ -82,6 +69,6 @@ class PlgInstallerPackageInstaller extends JPlugin
 			};
 		');
 
-		return true;
+		return $tab;
 	}
 }

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Installer.packageinstaller
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+JFactory::getDocument()->addScriptDeclaration('
+	Joomla.submitbuttonpackage = function()
+	{
+		var form = document.getElementById("adminForm");
+
+		// do field validation 
+		if (form.install_package.value == "")
+		{
+			alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE') . '");
+		}
+		else
+		{
+			jQuery("#loading").css("display", "block");
+			form.installtype.value = "upload"
+			form.submit();
+		}
+	};
+');
+?>
+<legend><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION'); ?></legend>
+<div class="control-group">
+	<label for="install_package" class="control-label"><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE'); ?></label>
+	<div class="controls">
+		<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
+	</div>
+</div>
+<div class="form-actions">
+	<button class="btn btn-primary" type="button" id="installbutton_package" onclick="Joomla.submitbuttonpackage()">
+		<?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL'); ?>
+	</button>
+</div>

--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Installer.urlinstaller
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+JFactory::getDocument()->addScriptDeclaration('
+	Joomla.submitbuttonurl = function()
+	{
+		var form = document.getElementById("adminForm");
+
+		// do field validation 
+		if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
+			alert("' . JText::_('PLG_INSTALLER_URLINSTALLER_NO_URL', true) . '");
+		}
+		else
+		{
+			jQuery("#loading").css("display", "block");
+			form.installtype.value = "url"
+			form.submit();
+		}
+	};
+');
+?>
+<legend><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></legend>
+<div class="control-group">
+	<label for="install_url" class="control-label"><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></label>
+	<div class="controls">
+		<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>
+	</div>
+</div>
+<div class="form-actions">
+	<input type="button" class="btn btn-primary" id="installbutton_url"
+		value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonurl()" />'
+</div>

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -37,35 +37,11 @@ class PlgInstallerUrlInstaller extends JPlugin
 		$tab            = array();
 		$tab['name']    = 'url';
 		$tab['label']   = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
-		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_URLINSTALLER_TEXT') . '</legend>'
-			. '<div class="control-group">'
-				. '<label for="install_url" class="control-label">' . JText::_('PLG_INSTALLER_URLINSTALLER_TEXT') . '</label>'
-				. '<div class="controls">'
-					. '<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>'
-				. '</div>'
-			. '</div>'
-			. '<div class="form-actions">'
-				. '<input type="button" class="btn btn-primary" id="installbutton_url" value="'
-					. JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON') . '" onclick="Joomla.submitbuttonurl()" />'
-			. '</div>';
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonurl = function()
-			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
-		            alert("' . JText::_('PLG_INSTALLER_URLINSTALLER_NO_URL', true) . '");
-		        }
-		        else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "url"
-					form.submit();
-				}
-			};
-		');
+		// Render the input
+		ob_start();
+		include JPluginHelper::getLayoutPath('installer', 'urlinstaller');
+		$tab['content'] = ob_get_clean();
 
 		return $tab;
 	}

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -18,53 +18,36 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerUrlInstaller extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Load the language file on instantiation.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.6.0
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
 	 * Textfield or Form of the Plugin.
 	 *
-	 * @return  bool  Always returns true
+	 * @return  array  Returns an array with the tab information
 	 *
 	 * @since   3.6.0
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'url', JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'));
-		?>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></legend>
-			<div class="control-group">
-				<label for="install_url"
-				       class="control-label"><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></label>
-				<div class="controls">
-					<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>
-				</div>
-			</div>
-			<div class="form-actions">
-				<input type="button" class="btn btn-primary" id="installbutton_url"
-				       value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>"
-				       onclick="Joomla.submitbuttonurl()"
-				/>
-			</div>
-		</fieldset>
-
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$tab            = array();
+		$tab['name']    = 'url';
+		$tab['label']   = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
+		$tab['content'] = '<legend>' . JText::_('PLG_INSTALLER_URLINSTALLER_TEXT') . '</legend>'
+			. '<div class="control-group">'
+				. '<label for="install_url" class="control-label">' . JText::_('PLG_INSTALLER_URLINSTALLER_TEXT') . '</label>'
+				. '<div class="controls">'
+					. '<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>'
+				. '</div>'
+			. '</div>'
+			. '<div class="form-actions">'
+				. '<input type="button" class="btn btn-primary" id="installbutton_url" value="'
+					. JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON') . '" onclick="Joomla.submitbuttonurl()" />'
+			. '</div>';
 
 		JFactory::getDocument()->addScriptDeclaration('
 			Joomla.submitbuttonurl = function()
@@ -84,6 +67,6 @@ class PlgInstallerUrlInstaller extends JPlugin
 			};
 		');
 
-		return true;
+		return $tab;
 	}
 }


### PR DESCRIPTION
With 3.6.0, the installer tabs are generated by plugins similar how the install from web tab is done.
However this wasn't done for Hathor.

The way the plugins generated the output, it wasn't also possible to do proper overwrites for Hathor. The tabs and fieldsets were generated by the plugins, however Hathor doesn't use tabs.
#### Summary of Changes

This PR rewrites the plugins so they return the data instead of directly outputting the tab. The tab is then generated by the Isis layout file.
This PR also adds the functionality (plugin trigger) to Hathor.
#### Testing Instructions
- Test in Isis and Hathor that the various extension install ways still work.
- Try enabling/disabling the plugins and check that they properly show/hide in the installer view
- Try rearranging the plugins and see that they follow the ordering set in the plugin manager (except the install from web one).
