### PR TITLE
Fix Notice on mod_menu

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -54,7 +54,7 @@ class JAdminCssMenu extends JObject
 	 *
 	 * @return  void
 	 */
-	public function addChild(JMenuNode &$node, $setCurrent = false)
+	public function addChild(JMenuNode $node, $setCurrent = false)
 	{
 		$this->_current->addChild($node);
 

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -49,7 +49,7 @@ class JAdminCssMenu extends JObject
 	/**
 	 * Method to add a child
 	 *
-	 * @param   JMenuNode  $node       The node to process
+	 * @param   JMenuNode  $node        The node to process
 	 * @param   boolean    $setCurrent  True to set as current working node
 	 *
 	 * @return  void

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -49,7 +49,7 @@ class JAdminCssMenu extends JObject
 	/**
 	 * Method to add a child
 	 *
-	 * @param   JMenuNode  &$node       The node to process
+	 * @param   JMenuNode  $node       The node to process
 	 * @param   boolean    $setCurrent  True to set as current working node
 	 *
 	 * @return  void


### PR DESCRIPTION
Notice: Only variables should be passed by reference in C:\wamp\www\develop\administrator\modules\mod_menu\tmpl\default_enabled.php on line 23

and many more notices.
Discovered by the new PHP7.0.7 RC1 version

Before that version the notices where never showed.
