### PR TITLE
Make sure $tz is an instance of DateTimeZone before attempting to create DateTime

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -91,13 +91,13 @@ class JDate extends DateTime
 		// If the time zone object is not set, attempt to build it.
 		if (!($tz instanceof DateTimeZone))
 		{
-			if ($tz === null)
-			{
-				$tz = self::$gmt;
-			}
-			elseif (is_string($tz))
+			if (is_string($tz))
 			{
 				$tz = new DateTimeZone($tz);
+			}
+			else
+			{
+				$tz = self::$gmt;
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #10451 .
#### Summary of Changes

Slightly modified `libraries/joomla/date/date.php` to prevent PHP fatal error when creating `DateTime` objects when `$tz` isn't correctly instantiated as a `DateTimeZone` object.
#### Testing Instructions

```
$date = new JDate('now', (int)1);
```

Throws PHP error :

> DateTime::__construct() expects parameter 2 to be DateTimeZone, integer given
