### PR TITLE
Wrong context used to fetch component parameters

### DIFF
--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -1068,7 +1068,7 @@ class FinderModelSearch extends JModelList
 		// Get the configuration options.
 		$app = JFactory::getApplication();
 		$input = $app->input;
-		$params = $app->getParams();
+		$params = $app->getParams('com_finder');
 		$user = JFactory::getUser();
 		$filter = JFilterInput::getInstance();
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

When inheriting the model from within a custom component the inherited model `FinderModelSearch` when populating its state requires its components parameters. To fetch them it utilises `JApplication::getParams()`. However, if that model is inherited by a custom components model, which overrides `populateState` like so

```
protected function populateState($ordering = null, $direction = null)
{
   // Call parent for initial setup.
   parent::populateState($ordering, $direction);

   ...
}
```

then the context used by `JApplication::getParams()` is that of the custom component and the parameters returned are not those of `com_finder`. For that reason `JApplication::getParams()` must be passed the component name and correctly be `JApplication::getParams('com_finder')`.
#### Testing Instructions
1. From within any other component that is not com_finder create a model class that extends `FinderModelSearch`.
2. In the inheriting model override `populateState` as described above.
3. In your custom component create a view that inherits `FinderViewSearch` and override its `display` method the same way we override the model's `populateState` - just call `parent::display($tpl)` in there. This will call the parent view's display method where the model is called to return some data. That call will trigger the `populateState` method using the context of the custom component thus returning the wrong parameters.
4. Create two menu items - one using com_finder's search view and another one using your component's search view, which inherits com_finder's view. Then open every view in the browser.
5. In `FinderModelSearch::populateState` just var_dump() the parameters to see what is returned.
   Do it one time using the original code `$params = $app->getParams()`.
   Then change the code to `$params = $app->getParams('com_finder')` and reload.
