### PR TITLE
[com_menus] items view: Force redirect to menu items list view after creating menu item with "Add new Menu Item" or direct URL (solves #10458 - redirect part)

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -923,9 +923,12 @@ class MenusModelItem extends JModelAdmin
 
 		$menuType = $app->getUserState('com_menus.edit.item.menutype');
 
-		if ($app->input->getString('menutype', false))
+		if ($forcedMenuType = $app->input->get('menutype', '', 'string'))
 		{
-			$menuType = $app->input->getString('menutype', 'mainmenu');
+			$menuType = $forcedMenuType;
+
+			// Set the menu type on the list view state, so we return to this menu after saving.
+			$app->setUserState('com_menus.items.menutype', $forcedMenuType);
 		}
 
 		$this->setState('item.menutype', $menuType);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10458 (wrong redirect after save menu item).
#### Summary of Changes

This issue exists at least in 3.5.1 (didn't check older versions).

When we create a menu item by selecting "Add new Menu Item" in the admin menu. After we create and save the menu item, the system in not redirecting to the list of menu items of the menu where we created the menu item.

This PR solves that.
#### Testing Instructions

You check that issue with this:
1. Use latest staging
2. Logout from backend
3. Login in the backend
4. Go directly to the admin menu Menus -> (Any Menu you want) -> Add new menu item
6. Now create the menu item as ususal. Save and close
7 .Notice you are redirect to the "All Menu Items" menu items list view, not the list view of the menu you created the menu item.
8. Now select a list of menu items of another menu.
9. Go again to admin menu Menus -> (Any Menu you want except the one you are in) -> Add new menu item
10. Now create the menu item as ususal. Save and close
11 .Notice you are redirect to the old menu you here menu items list view, not the list view of the menu you created the menu item.
12. Apply patch, repeat tests and notice the redirect is now ok.
