### PR TITLE
[plg_system_sef] Add sef URI when using srcset attribute

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -110,7 +110,7 @@ class PlgSystemSef extends JPlugin
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
 		$protocols  = '[a-zA-Z0-9\-]+:';
-		$attributes = array('href=', 'src=', 'poster=');
+		$attributes = array('href=', 'src=', 'srcset=', 'poster=');
 
 		foreach ($attributes as $attribute)
 		{

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -50,6 +50,7 @@ class PlgSystemSef extends JPlugin
 
 		// Check if a canonical html tag already exists (for instance, added by a component).
 		$canonical = '';
+
 		foreach ($doc->_links as $linkUrl => $link)
 		{
 			if (isset($link['relation']) && $link['relation'] === 'canonical')
@@ -98,16 +99,19 @@ class PlgSystemSef extends JPlugin
 		if (strpos($buffer, 'href="index.php?') !== false)
 		{
 			preg_match_all('#href="index.php\?([^"]+)"#m', $buffer, $matches);
+
 			foreach ($matches[1] as $urlQueryString)
 			{
 				$buffer = str_replace('href="index.php?' . $urlQueryString . '"', 'href="' . JRoute::_('index.php?' . $urlQueryString) . '"', $buffer);
 			}
+
 			$this->checkBuffer($buffer);
 		}
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
-		$protocols = '[a-zA-Z0-9\-]+:';
-		$attributes = array('href=', 'src=', 'srcset=', 'poster=');
+		$protocols  = '[a-zA-Z0-9\-]+:';
+		$attributes = array('href=', 'src=', 'poster=');
+
 		foreach ($attributes as $attribute)
 		{
 			if (strpos($buffer, $attribute) !== false)
@@ -128,6 +132,7 @@ class PlgSystemSef extends JPlugin
 
 		// Replace all unknown protocols in onmouseover and onmouseout attributes.
 		$attributes = array('onmouseover=', 'onmouseout=');
+
 		foreach ($attributes as $attribute)
 		{
 			if (strpos($buffer, $attribute) !== false)

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -107,7 +107,7 @@ class PlgSystemSef extends JPlugin
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
 		$protocols = '[a-zA-Z0-9\-]+:';
-		$attributes = array('href=', 'src=', 'poster=');
+		$attributes = array('href=', 'src=', 'srcset=', 'poster=');
 		foreach ($attributes as $attribute)
 		{
 			if (strpos($buffer, $attribute) !== false)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10463.
#### Summary of Changes

See https://github.com/joomla/joomla-cms/issues/10463
#### Testing Instructions
- Use SEF URL (global config + sef system plugin)
- Add an image in an article with this html (or equivalent)

``` html
<img src="images/sampledata/parks/banner_cradle.jpg" srcset="images/sampledata/parks/banner_cradle.jpg" alt="yyy" />
```
- Check in the frontend the srcset attribute URL is NOT converted to SEF URL (misses the base path).
- Apply patch
- Check in the frontend the srcset attribute URL is converted to SEF URL (in this example, should be `/images/sampledata/parks/banner_cradle.jpg` or `/<sitepath>/images/sampledata/parks/banner_cradle.jpg`)

Please note this will not solve all `srcset` possibilities, only for cases like the one described in the issue (path to one image).
