### PR TITLE
Only convert to an array when it is a string for mssql.

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -373,7 +373,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	public function group($columns)
 	{
 		// Transform $columns into an array for filtering purposes
-		$columns = explode(',', str_replace(" ", "", $columns));
+		is_string($columns) && $columns = explode(',', str_replace(" ", "", $columns));
 
 		// Get the _formatted_ FROM string and remove everything except `table AS alias`
 		$fromStr = str_replace(array("[","]"), "", str_replace("#__", $this->db->getPrefix(), str_replace("FROM ", "", (string) $this->from)));


### PR DESCRIPTION
Pull Request for Issue 10327 .
#### Summary of Changes

Only convert to an array when it is a string. The method can be called with either a string or an array. When calling with an array it produces 4 warnings, see issue!
#### Testing Instructions

Use joomla on mssql.
