### PR TITLE
Enable HTTPs detection for the server scheme "frontend-backend"

### DIFF
--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -63,8 +63,8 @@ class JUri extends Uri
 			if ($uri == 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off')) || 
-					isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
+				if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+					|| isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 				{
 					$https = 's://';
 				}

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -63,7 +63,8 @@ class JUri extends Uri
 			if ($uri == 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if ((isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off')) || 
+					isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https'))
 				{
 					$https = 's://';
 				}


### PR DESCRIPTION
Pull Request for Issue # Redirect loop in servers with the scheme "frontend-backend"
#### Summary of Changes

The problem appears when using NGINX as the front-end and Apache as the back-end. If NGINX does SSL/TLS encryption, Apache might not see the variable $_SERVER['HTTPS']. In fact, it might be empty, while the URL contains a protocol HTTPs. This commit can help server administrators to handle such a configuration. If they set a variable before the back-end, for example `proxy_set_header  X-Forwarded-Proto https;`, Joomla! will see the HTTPs.
