### PR TITLE
Modal com_newsfeeds: improve Select & Edit Newsfeed

### DIFF
--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -19,7 +19,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
+	 * @var     string
 	 * @since   1.6
 	 */
 	protected $type = 'Modal_Newsfeed';
@@ -27,7 +27,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 	/**
 	 * Method to get the field input markup.
 	 *
-	 * @return  string	The field input markup.
+	 * @return  string  The field input markup.
 	 *
 	 * @since   1.6
 	 */
@@ -39,9 +39,6 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
-		// Load the javascript
-		JHtml::_('bootstrap.tooltip');
-
 		// Build the script.
 		$script = array();
 
@@ -52,7 +49,11 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		if (id == "' . (int) $this->value . '") {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
+			$script[] = '		} else {';
+			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
+			$script[] = '		}';
 		}
 
 		if ($allowClear)
@@ -60,7 +61,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
 		}
 
-		$script[] = '		jQuery("#modalNewsfeed' . $this->id . '").modal("hide");';
+		$script[] = '		jQuery("#newsfeedSelect' . $this->id . 'Modal").modal("hide");';
 
 		if ($this->required)
 		{
@@ -79,8 +80,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 			$script[] = '	function jClearNewsfeed(id) {';
 			$script[] = '		document.getElementById(id + "_id").value = "";';
-			$script[] = '		document.getElementById(id + "_name").value = "' .
-				htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '";';
+			$script[] = '		document.getElementById(id + "_name").value = "'
+				. htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
 			$script[] = '		if (document.getElementById(id + "_edit")) {';
 			$script[] = '			jQuery("#"+id + "_edit").addClass("hidden");';
@@ -94,17 +95,19 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		// Setup variables for display.
 		$html = array();
-		$link = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;function=jSelectNewsfeed_' . $this->id;
+
+		$linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;function=jSelectNewsfeed_' . $this->id;
+		$linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component&amp;task=newsfeed.edit';
 
 		if (isset($this->element['language']))
 		{
-			$link .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkNewsfeeds .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkNewsfeed  .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
 
-		// Get the title of the linked chart
 		if ((int) $this->value > 0)
 		{
-			$db = JFactory::getDbo();
+			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('name'))
 				->from($db->quoteName('#__newsfeeds'))
@@ -125,6 +128,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		{
 			$title = JText::_('COM_NEWSFEEDS_SELECT_A_FEED');
 		}
+
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
 		// The active newsfeed id field.
@@ -137,54 +141,93 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$value = (int) $this->value;
 		}
 
+		$urlSelect = $linkNewsfeeds . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkNewsfeed . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
+
 		// The current newsfeed display field.
 		$html[] = '<span class="input-append">';
-		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title .
-			'" disabled="disabled" size="35" />';
+		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
 
-		$html[] = '<a href="#modalNewsfeed' . $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"'
+		// Select newsfeed button
+		$html[] = '<a'
+			. ' class="btn hasTooltip"'
+			. ' data-toggle="modal"'
+			. ' role="button"'
+			. ' href="#newsfeedSelect' . $this->id . 'Modal"'
 			. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED_BUTTON') . '">'
 			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
 			. '</a>';
 
-		$html[] = JHtml::_(
-			'bootstrap.renderModal',
-			'modalNewsfeed' . $this->id,
-			array(
-				'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
-				'title' => JText::_('COM_NEWSFEEDS_CHANGE_FEED_BUTTON'),
-				'width' => '800px',
-				'height' => '300px',
-				'footer' => '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
-					. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-			)
-		);
-
 		// Edit newsfeed button
 		if ($allowEdit)
 		{
-			$html[] = '<a class="btn hasTooltip' . ($value ? '' : ' hidden') .
-				'" href="index.php?option=com_newsfeeds&layout=modal&tmpl=component&task=newsfeed.edit&id=' . $value .
-				'" target="_blank" title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') .
-				'" ><span class="icon-edit"></span>' . JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a'
+				. ' class="btn hasTooltip' . ($value ? '' : ' hidden') . '"'
+				. ' id="' . $this->id . '_edit"'
+				. ' data-toggle="modal"'
+				. ' role="button"'
+				. ' href="#newsfeedEdit' . $this->id . 'Modal"'
+				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') . '">'
+				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '</a>';
 		}
 
 		// Clear newsfeed button
 		if ($allowClear)
 		{
-			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearNewsfeed(\'' .
-				$this->id . '\')"><span class="icon-remove"></span>' . JText::_('JCLEAR') . '</button>';
+			$html[] = '<button'
+				. ' class="btn' . ($value ? '' : ' hidden') . '"'
+				. ' id="' . $this->id . '_clear"'
+				. ' onclick="return jClearNewsfeed(\'' . $this->id . '\')">'
+				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '</button>';
 		}
 
 		$html[] = '</span>';
 
-		// Add class='required' for client side validation
-		$class = '';
+		// Select newsfeed modal
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'newsfeedSelect' . $this->id . 'Modal',
+			array(
+				'url'         => $urlSelect,
+				'title'       => JText::_('COM_NEWSFEEDS_SELECT_A_FEED'),
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+			)
+		);
 
-		if ($this->required)
-		{
-			$class = ' class="required modal-value"';
-		}
+		// Edit newsfeed modal
+		$html[] = JHtml::_(
+			'bootstrap.renderModal',
+			'newsfeedEdit' . $this->id . 'Modal',
+			array(
+				'url'         => $urlEdit,
+				'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
+				'backdrop'    => 'static',
+				'closeButton' => false,
+				'width'       => '800px',
+				'height'      => '400px',
+				'modalWidth'  => '80',
+				'bodyHeight'  => '70',
+				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. JText::_("JSAVE") . '</button>'
+						. '<button type="button" class="btn btn-success" aria-hidden="true"'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. JText::_("JAPPLY") . '</button>'
+			)
+		);
+
+		// Add class='required' for client side validation
+		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -9,15 +9,16 @@
 
 defined('_JEXEC') or die;
 
-// Include the HTML helpers.
+// Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app = JFactory::getApplication();
+$app   = JFactory::getApplication();
 $input = $app->input;
+
 $assoc = JLanguageAssociations::isEnabled();
 
 JFactory::getDocument()->addScriptDeclaration("
@@ -32,8 +33,13 @@ JFactory::getDocument()->addScriptDeclaration("
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('images', 'jbasic', 'jmetadata', 'item_associations');
 
+// In case of modal
+$isModal = $input->get('layout') == 'modal' ? true : false;
+$layout  = $isModal ? 'modal' : 'edit';
+$tmpl    = $isModal ? '&tmpl=component' : '';
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="newsfeed-form" class="form-validate">
+
+<form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="newsfeed-form" class="form-validate">
 
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
@@ -76,18 +82,18 @@ $this->ignore_fieldsets = array('images', 'jbasic', 'jmetadata', 'item_associati
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-jbasic', JText::_('JGLOBAL_FIELDSET_DISPLAY_OPTIONS')); ?>
 		<?php echo $this->loadTemplate('display'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
-
-		<?php if ($assoc) : ?>
+		<?php if ( ! $isModal && $assoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
+		<?php elseif ($isModal && $assoc) : ?>
+			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -6,6 +6,7 @@
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -6,103 +6,15 @@
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
-
 defined('_JEXEC') or die;
 
-// Include the HTML helpers.
-JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
-
-JHtml::_('behavior.formvalidator');
-JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select');
-
-$app = JFactory::getApplication();
-$input = $app->input;
-$assoc = JLanguageAssociations::isEnabled();
-
-JFactory::getDocument()->addScriptDeclaration("
-	Joomla.submitbutton = function(task)
-	{
-		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.getElementById('newsfeed-form')))
-		{
-			if (window.opener && (task == 'newsfeed.save' || task == 'newsfeed.cancel'))
-			{
-				window.opener.document.closeEditWindow = self;
-				window.opener.setTimeout('window.document.closeEditWindow.close()', 1000);
-			}
-
-			Joomla.submitform(task, document.getElementById('newsfeed-form'));
-		}
-	};
-");
-
-$this->ignore_fieldsets = array('jbasic', 'item_associations');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.apply');"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.save');"></button>
+<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.cancel');"></button>
+
 <div class="container-popup">
-
-<div class="pull-right">
-	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('newsfeed.apply');"><?php echo JText::_('JTOOLBAR_APPLY') ?></button>
-	<button class="btn btn-primary" type="button" onclick="Joomla.submitbutton('newsfeed.save');"><?php echo JText::_('JTOOLBAR_SAVE') ?></button>
-	<button class="btn" type="button" onclick="Joomla.submitbutton('newsfeed.cancel');"><?php echo JText::_('JCANCEL') ?></button>
+	<?php $this->setLayout('edit'); ?>
+	<?php echo $this->loadTemplate(); ?>
 </div>
-
-<div class="clearfix"> </div>
-<hr class="hr-condensed" />
-
-<form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&layout=modal&tmpl=component&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="newsfeed-form" class="form-validate form-horizontal">
-	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
-
-	<div class="form-horizontal">
-		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', empty($this->item->id) ? JText::_('COM_NEWSFEEDS_NEW_NEWSFEED') : JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED')); ?>
-		<div class="row-fluid">
-			<div class="span9">
-				<div class="form-vertical">
-					<?php echo $this->form->getControlGroup('link'); ?>
-					<?php echo $this->form->getControlGroup('description'); ?>
-				</div>
-			</div>
-			<div class="span3">
-				<?php echo JLayoutHelper::render('joomla.edit.global', $this); ?>
-			</div>
-		</div>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS')); ?>
-		<div class="row-fluid">
-			<div class="span6">
-					<?php echo $this->form->getControlGroup('images'); ?>
-					<?php foreach ($this->form->getGroup('images') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
-					<?php endforeach; ?>
-				</div>
-			</div>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
-		<div class="row-fluid form-horizontal-desktop">
-			<div class="span6">
-				<?php echo JLayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-			</div>
-			<div class="span6">
-				<?php echo JLayoutHelper::render('joomla.edit.metadata', $this); ?>
-			</div>
-		</div>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-jbasic', JText::_('JGLOBAL_FIELDSET_DISPLAY_OPTIONS')); ?>
-		<?php echo $this->loadTemplate('display'); ?>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-
-		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
-
-		<?php if ($assoc) : ?>
-			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
-		<?php endif; ?>
-
-		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-	</div>
-	<input type="hidden" name="task" value="" />
-	<?php echo JHtml::_('form.token'); ?>
-</form>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -14,8 +14,12 @@ require_once JPATH_ROOT . '/components/com_newsfeeds/helpers/route.php';
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
+
+// Special case for the search field tooltip.
+$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
+JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $app = JFactory::getApplication();
 
@@ -23,102 +27,108 @@ $function  = $app->input->getCmd('function', 'jSelectNewsfeed');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
-<div style="padding-top: 25px;"></div>
-<form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds&layout=modal&tmpl=component&function=' . $function);?>" method="post" name="adminForm" id="adminForm" class="form-inline">
-	<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
-	<?php else : ?>
-		<table class="table table-striped table-condensed">
-			<thead>
-				<tr>
-					<th width="1%" class="nowrap center">
-						<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
-					</th>
-					<th class="nowrap title">
-						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
-					</th>
-					<th width="15%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-					</th>
-					<th width="1%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-					</th>
-				</tr>
-			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="5">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
-			<tbody>
-			<?php
-			$iconStates = array(
-				-2 => 'icon-trash',
-				0 => 'icon-unpublish',
-				1 => 'icon-publish',
-				2 => 'icon-archive',
-			);
-			?>
-			<?php foreach ($this->items as $i => $item) : ?>
-				<?php if ($item->language && JLanguageMultilang::isEnabled())
-				{
-					$tag = strlen($item->language);
-					if ($tag == 5)
+<div class="container-popup">
+
+	<form action="<?php echo JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds&layout=modal&tmpl=component&function=' . $function);?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
+			<table class="table table-striped table-condensed">
+				<thead>
+					<tr>
+						<th width="1%" class="nowrap center">
+							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
+						</th>
+						<th class="nowrap title">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="1%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+						</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="5">
+							<?php echo $this->pagination->getListFooter(); ?>
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>
+				<?php
+				$iconStates = array(
+					-2 => 'icon-trash',
+					0 => 'icon-unpublish',
+					1 => 'icon-publish',
+					2 => 'icon-archive',
+				);
+				?>
+				<?php foreach ($this->items as $i => $item) : ?>
+					<?php if ($item->language && JLanguageMultilang::isEnabled())
 					{
-						$lang = substr($item->language, 0, 2);
+						$tag = strlen($item->language);
+						if ($tag == 5)
+						{
+							$lang = substr($item->language, 0, 2);
+						}
+						elseif ($tag == 6)
+						{
+							$lang = substr($item->language, 0, 3);
+						}
+						else {
+							$lang = "";
+						}
 					}
-					elseif ($tag == 6)
+					elseif (!JLanguageMultilang::isEnabled())
 					{
-						$lang = substr($item->language, 0, 3);
-					}
-					else {
 						$lang = "";
 					}
-				}
-				elseif (!JLanguageMultilang::isEnabled())
-				{
-					$lang = "";
-				}
-				?>
-				<tr class="row<?php echo $i % 2; ?>">
-					<td class="center">
-						<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
-					</td>
-					<td>
-						<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(NewsfeedsHelperRoute::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
-						<?php echo $this->escape($item->name); ?></a>
-						<div class="small">
-							<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
-						</div>
-					</td>
-					<td class="small hidden-phone">
-						<?php echo $this->escape($item->access_level); ?>
-					</td>
-					<td class="small hidden-phone">
-						<?php if ($item->language == '*'):?>
-							<?php echo JText::alt('JALL', 'language'); ?>
-						<?php else:?>
-							<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-						<?php endif;?>
-					</td>
-					<td class="hidden-phone">
-						<?php echo (int) $item->id; ?>
-					</td>
-				</tr>
-			<?php endforeach; ?>
-			</tbody>
-		</table>
-	<?php endif; ?>
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="boxchecked" value="0" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
-	<?php echo JHtml::_('form.token'); ?>
-</form>
+					?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td class="center">
+							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
+						</td>
+						<td>
+							<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(NewsfeedsHelperRoute::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<?php echo $this->escape($item->name); ?></a>
+							<div class="small">
+								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+							</div>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="small hidden-phone">
+							<?php if ($item->language == '*'):?>
+								<?php echo JText::alt('JALL', 'language'); ?>
+							<?php else:?>
+								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+							<?php endif;?>
+						</td>
+						<td class="hidden-phone">
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+
+	</form>
+</div>


### PR DESCRIPTION
Improve modals to select and to edit a news feed.
**Note: to be testing on staging.**
#### Summary of Changes
- When Bootstrap modal loads an iframe, BS tooltips with placement top are truncated at the top border of the iframe. (no auto placement in BS2). This PR sets the tooltip placement to bottom to fix this issue.
- Remove inline CSS
- Content is embedded in a container div (using already existing container-popup class for modal.php)
- Add empty lines to improve the readability
- Add viewport dimensions (new <code>3.6.0-dev</code>)
- News feed edit modal is simplified (load edit layout, so no dupplicated code)
- Fix Edit button when current associated news feed in data is not the selected news feed
- Control if modal, in edit layout
- Add <code>Save</code> (keep modal open), <code>Save & Close</code> and <code>Close</code> button to the footer of the modal
- Fix Edit modal not opening as a modal (missing bootstrap.renderModal for Edit modal)
- Fix consistency of fieldsets <code>$this->ignore_fieldsets</code>, and add missing tabs, and remove dupplicated fieldset metadata (as using now correct edit view inside the modal)
#### Testing Instructions (Staging + Multilanguages enabled!)
- Go to Components > News Feeds > open a news feed, and go to <code>Associations</code> tab to select associated news feed to open the modal.
- Verify tooltip placement is bottom, and not truncated
- Verify the modal size now is proportionnal to viewport (modal is 80/100th viewport width, and modal-body is 70/100th viewport height)
- Select an associated news feed and save the news feed to show edit button
- Open Edit modal and play with it ;-)
- Do the same in a menu item type "Single news feed", for Select and Edit news feed.

Same rendering as for Categories in PR #10441 (screenshots)
