### PR TITLE
Fix #10520 (issue with "Save & Close" in modal) + function to update input title when changed

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -48,6 +48,16 @@ class JFormFieldModal_Category extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
 
+		// The active category id field.
+		if (0 == (int) $this->value)
+		{
+			$value = '';
+		}
+		else
+		{
+			$value = (int) $this->value;
+		}
+
 		// Build the script.
 		$script = array();
 
@@ -71,6 +81,11 @@ class JFormFieldModal_Category extends JFormField
 		}
 
 		$script[] = '		jQuery("#categorySelect' . $this->id . 'Modal").modal("hide");';
+		$script[] = '	}';
+
+		// Edit button script
+		$script[] = '	function jEditCategory_' . $value . '(title) {';
+		$script[] = '		document.getElementById("' . $this->id . '_name").value = title;';
 		$script[] = '	}';
 
 		// Clear button script
@@ -98,15 +113,22 @@ class JFormFieldModal_Category extends JFormField
 		// Setup variables for display.
 		$html = array();
 
-		$linkCategories = 'index.php?option=com_categories&amp;view=categories&amp;layout=modal&amp;tmpl=component&amp;extension='
-			. $extension . '&amp;function=jSelectCategory_' . $this->id;
-		$linkCategory   = 'index.php?option=com_categories&amp;view=category&amp;layout=modal&amp;tmpl=component&amp;task=category.edit';
+		$linkCategories = 'index.php?option=com_categories&amp;view=categories&amp;layout=modal&amp;tmpl=component'
+			. '&amp;extension=' . $extension
+			. '&amp;function=jSelectCategory_' . $this->id;
+
+		$linkCategory   = 'index.php?option=com_categories&amp;view=category&amp;layout=modal&amp;tmpl=component'
+			. '&amp;task=category.edit'
+			. '&amp;function=jEditCategory_' . $value;
 
 		if (isset($this->element['language']))
 		{
 			$linkCategories .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkCategory   .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
+
+		$urlSelect = $linkCategories . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkCategory . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
 		if ((int) $this->value > 0)
 		{
@@ -134,19 +156,6 @@ class JFormFieldModal_Category extends JFormField
 
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
-		// The active category id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
-
-		$urlSelect = $linkCategories . '&amp;' . JSession::getFormToken() . '=1';
-		$urlEdit   = $linkCategory . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
-
 		// The current category display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
@@ -169,7 +178,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#categoryEdit' . $this->value . 'Modal"'
+				. ' href="#categoryEdit' . $value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -207,7 +216,7 @@ class JFormFieldModal_Category extends JFormField
 		// Edit category modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'categoryEdit' . $this->value . 'Modal',
+			'categoryEdit' . $value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CATEGORIES_EDIT_CATEGORY'),
@@ -218,13 +227,13 @@ class JFormFieldModal_Category extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -49,14 +49,7 @@ class JFormFieldModal_Category extends JFormField
 		JFactory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
 
 		// The active category id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
+		$value = (int) $this->value > 0 ? (int) $this->value : '';
 
 		// Build the script.
 		$script = array();
@@ -130,13 +123,13 @@ class JFormFieldModal_Category extends JFormField
 		$urlSelect = $linkCategories . '&amp;' . JSession::getFormToken() . '=1';
 		$urlEdit   = $linkCategory . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
-		if ((int) $this->value > 0)
+		if ($value)
 		{
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('title'))
 				->from($db->quoteName('#__categories'))
-				->where($db->quoteName('id') . ' = ' . (int) $this->value);
+				->where($db->quoteName('id') . ' = ' . (int) $value);
 			$db->setQuery($query);
 
 			try

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -169,7 +169,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#categoryEdit' . $this->id . 'Modal"'
+				. ' href="#categoryEdit' . $this->value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -207,7 +207,7 @@ class JFormFieldModal_Category extends JFormField
 		// Edit category modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'categoryEdit' . $this->id . 'Modal',
+			'categoryEdit' . $this->value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CATEGORIES_EDIT_CATEGORY'),
@@ -218,13 +218,13 @@ class JFormFieldModal_Category extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#categoryEdit' . $this->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#categoryEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -31,6 +31,11 @@ JFactory::getDocument()->addScriptDeclaration('
 			jQuery("#permissions-sliders select").attr("disabled", "disabled");
 			' . $this->form->getField("description")->save() . '
 			Joomla.submitform(task, document.getElementById("item-form"));
+
+			if (task !== "category.apply")
+			{
+				window.parent.jQuery("#categoryEdit' . $this->item->id . 'Modal").modal("hide");
+			}
 		}
 	};
 ');

--- a/administrator/components/com_categories/views/category/tmpl/modal.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal.php
@@ -10,9 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+
+$function  = JFactory::getApplication()->input->getCmd('function', 'jEditCategory_' . (int) $this->item->id);
+
+// Function to update input title when changed
+JFactory::getDocument()->addScriptDeclaration('
+	function jEditCategoryModal() {
+		if (window.parent && document.formvalidator.isValid(document.getElementById("item-form"))) {
+			return window.parent.' . $this->escape($function) . '(document.getElementById("jform_title").value);
+		}
+	}
+');
 ?>
-<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.apply');"></button>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.save');"></button>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.apply'); jEditCategoryModal();"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.save'); jEditCategoryModal();"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('category.cancel');"></button>
 
 <div class="container-popup">

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -39,6 +39,16 @@ class JFormFieldModal_Contact extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
+		// The active contact id field.
+		if (0 == (int) $this->value)
+		{
+			$value = '';
+		}
+		else
+		{
+			$value = (int) $this->value;
+		}
+
 		// Build the script.
 		$script = array();
 
@@ -71,6 +81,11 @@ class JFormFieldModal_Contact extends JFormField
 
 		$script[] = '	}';
 
+		// Edit button script
+		$script[] = '	function jEditContact_' . $value . '(name) {';
+		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
+		$script[] = '	}';
+
 		// Clear button script
 		static $scriptClear;
 
@@ -96,14 +111,21 @@ class JFormFieldModal_Contact extends JFormField
 		// Setup variables for display.
 		$html = array();
 
-		$linkContacts = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;function=jSelectContact_' . $this->id;
-		$linkContact  = 'index.php?option=com_contact&amp;view=contact&amp;layout=modal&amp;tmpl=component&amp;task=contact.edit';
+		$linkContacts = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component'
+			. '&amp;function=jSelectContact_' . $this->id;
+
+		$linkContact  = 'index.php?option=com_contact&amp;view=contact&amp;layout=modal&amp;tmpl=component'
+			. '&amp;task=contact.edit'
+			. '&amp;function=jEditContact_' . $value;
 
 		if (isset($this->element['language']))
 		{
 			$linkContacts .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkContact  .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
+
+		$urlSelect = $linkContacts . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkContact . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
 		if ((int) $this->value > 0)
 		{
@@ -131,19 +153,6 @@ class JFormFieldModal_Contact extends JFormField
 
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
-		// The active contact id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
-
-		$urlSelect = $linkContacts . '&amp;' . JSession::getFormToken() . '=1';
-		$urlEdit   = $linkContact . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
-
 		// The current contact display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
@@ -166,7 +175,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#contactEdit' . $this->value . 'Modal"'
+				. ' href="#contactEdit' . $value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -204,7 +213,7 @@ class JFormFieldModal_Contact extends JFormField
 		// Edit contact modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'contactEdit' . $this->value . 'Modal',
+			'contactEdit' . $value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CONTACT_EDIT_CONTACT'),
@@ -215,13 +224,13 @@ class JFormFieldModal_Contact extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -166,7 +166,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#contactEdit' . $this->id . 'Modal"'
+				. ' href="#contactEdit' . $this->value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -204,7 +204,7 @@ class JFormFieldModal_Contact extends JFormField
 		// Edit contact modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'contactEdit' . $this->id . 'Modal',
+			'contactEdit' . $this->value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CONTACT_EDIT_CONTACT'),
@@ -215,13 +215,13 @@ class JFormFieldModal_Contact extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
+						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#contactEdit' . $this->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#contactEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -40,14 +40,7 @@ class JFormFieldModal_Contact extends JFormField
 		JFactory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
 		// The active contact id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
+		$value = (int) $this->value > 0 ? (int) $this->value : '';
 
 		// Build the script.
 		$script = array();
@@ -127,13 +120,13 @@ class JFormFieldModal_Contact extends JFormField
 		$urlSelect = $linkContacts . '&amp;' . JSession::getFormToken() . '=1';
 		$urlEdit   = $linkContact . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
-		if ((int) $this->value > 0)
+		if ($value)
 		{
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('name'))
 				->from($db->quoteName('#__contact_details'))
-				->where($db->quoteName('id') . ' = ' . (int) $this->value);
+				->where($db->quoteName('id') . ' = ' . (int) $value);
 			$db->setQuery($query);
 
 			try

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -28,6 +28,11 @@ JFactory::getDocument()->addScriptDeclaration('
 		{
 			' . $this->form->getField("misc")->save() . '
 			Joomla.submitform(task, document.getElementById("contact-form"));
+
+			if (task !== "contact.apply")
+			{
+				window.parent.jQuery("#contactEdit' . $this->item->id . 'Modal").modal("hide");
+			}
 		}
 	};
 ');

--- a/administrator/components/com_contact/views/contact/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contact/tmpl/modal.php
@@ -10,9 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+
+$function  = JFactory::getApplication()->input->getCmd('function', 'jEditContact_' . (int) $this->item->id);
+
+// Function to update input title when changed
+JFactory::getDocument()->addScriptDeclaration('
+	function jEditContactModal() {
+		if (window.parent && document.formvalidator.isValid(document.getElementById("contact-form"))) {
+			return window.parent.' . $this->escape($function) . '(document.getElementById("jform_name").value);
+		}
+	}
+');
 ?>
-<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('contact.apply');"></button>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('contact.save');"></button>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('contact.apply'); jEditContactModal();"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('contact.save'); jEditContactModal();"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('contact.cancel');"></button>
 
 <div class="container-popup">

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -40,14 +40,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
 		// The active newsfeed id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
+		$value = (int) $this->value > 0 ? (int) $this->value : '';
 
 		// Build the script.
 		$script = array();
@@ -127,13 +120,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 		$urlSelect = $linkNewsfeeds . '&amp;' . JSession::getFormToken() . '=1';
 		$urlEdit   = $linkNewsfeed . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
-		if ((int) $this->value > 0)
+		if ($value)
 		{
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('name'))
 				->from($db->quoteName('#__newsfeeds'))
-				->where($db->quoteName('id') . ' = ' . (int) $this->value);
+				->where($db->quoteName('id') . ' = ' . (int) $value);
 			$db->setQuery($query);
 
 			try

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -39,6 +39,16 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
+		// The active newsfeed id field.
+		if (0 == (int) $this->value)
+		{
+			$value = '';
+		}
+		else
+		{
+			$value = (int) $this->value;
+		}
+
 		// Build the script.
 		$script = array();
 
@@ -71,6 +81,11 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		$script[] = '	}';
 
+		// Edit button script
+		$script[] = '	function jEditNewsfeed_' . $value . '(name) {';
+		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
+		$script[] = '	}';
+
 		// Clear button script
 		static $scriptClear;
 
@@ -96,14 +111,21 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Setup variables for display.
 		$html = array();
 
-		$linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;function=jSelectNewsfeed_' . $this->id;
-		$linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component&amp;task=newsfeed.edit';
+		$linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component'
+			. '&amp;function=jSelectNewsfeed_' . $this->id;
+
+		$linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component'
+			. '&amp;task=newsfeed.edit'
+			. '&amp;function=jEditNewsfeed_' . $value;
 
 		if (isset($this->element['language']))
 		{
 			$linkNewsfeeds .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkNewsfeed  .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
+
+		$urlSelect = $linkNewsfeeds . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkNewsfeed . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
 		if ((int) $this->value > 0)
 		{
@@ -131,19 +153,6 @@ class JFormFieldModal_Newsfeed extends JFormField
 
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
-		// The active newsfeed id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
-
-		$urlSelect = $linkNewsfeeds . '&amp;' . JSession::getFormToken() . '=1';
-		$urlEdit   = $linkNewsfeed . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
-
 		// The current newsfeed display field.
 		$html[] = '<span class="input-append">';
 		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
@@ -166,7 +175,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#newsfeedEdit' . $this->value . 'Modal"'
+				. ' href="#newsfeedEdit' . $value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -204,7 +213,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Edit newsfeed modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'newsfeedEdit' . $this->value . 'Modal',
+			'newsfeedEdit' . $value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
@@ -215,13 +224,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -166,7 +166,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#newsfeedEdit' . $this->id . 'Modal"'
+				. ' href="#newsfeedEdit' . $this->value . 'Modal"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -204,7 +204,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Edit newsfeed modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'newsfeedEdit' . $this->id . 'Modal',
+			'newsfeedEdit' . $this->value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
@@ -215,13 +215,13 @@ class JFormFieldModal_Newsfeed extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						. '<button type="button" class="btn btn-primary" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $this->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. ' onclick="jQuery(\'#newsfeedEdit' . $this->value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
 						. JText::_("JAPPLY") . '</button>'
 			)
 		);

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -21,14 +21,19 @@ $input = $app->input;
 
 $assoc = JLanguageAssociations::isEnabled();
 
-JFactory::getDocument()->addScriptDeclaration("
+JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)
 	{
-		if (task == 'newsfeed.cancel' || document.formvalidator.isValid(document.getElementById('newsfeed-form'))) {
-			Joomla.submitform(task, document.getElementById('newsfeed-form'));
+		if (task == "newsfeed.cancel" || document.formvalidator.isValid(document.getElementById("newsfeed-form"))) {
+			Joomla.submitform(task, document.getElementById("newsfeed-form"));
+
+			if (task !== "newsfeed.apply")
+			{
+				window.parent.jQuery("#newsfeedEdit' . $this->item->id . 'Modal").modal("hide");
+			}
 		}
 	};
-");
+');
 
 // Fieldsets to not automatically render by /layouts/joomla/edit/params.php
 $this->ignore_fieldsets = array('images', 'jbasic', 'jmetadata', 'item_associations');

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -10,9 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+
+$function  = JFactory::getApplication()->input->getCmd('function', 'jEditNewsfeed_' . (int) $this->item->id);
+
+// Function to update input title when changed
+JFactory::getDocument()->addScriptDeclaration('
+	function jEditNewsfeedModal() {
+		if (window.parent && document.formvalidator.isValid(document.getElementById("newsfeed-form"))) {
+			return window.parent.' . $this->escape($function) . '(document.getElementById("jform_name").value);
+		}
+	}
+');
 ?>
-<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.apply');"></button>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.save');"></button>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.apply'); jEditNewsfeedModal();"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.save'); jEditNewsfeedModal();"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('newsfeed.cancel');"></button>
 
 <div class="container-popup">


### PR DESCRIPTION
Pull Request for Issue #10520.
#### Summary of Changes
- Fix modal closing for already reviewed and refactoried edit modals.
- Article and module Select and Edit modals will be reviewed soon with the same improvements and fixes as already merged for com_categories, com_newsfeeds and com_contact, and i will add then this patch in the same time of those upcoming PRs.
- **EDIT:** add function to update input title when changed
#### Testing Instructions
- Test with edit modal : <code>newsfeed</code>, <code>contact</code> and <code>categories</code>
- Click on <code>Save</code> and <code>Save & Close</code> with a correct edition (no error), and then with an empty title, or any other possible error (not filled required field).
- Expected behavior: If an error, <code>Save & Close</code> won't close the modal, and <code>Save</code> will never close the modal (close only when requested, and on successful edition)
- More detailled testing intructions for reviewed modals here: https://github.com/joomla/joomla-cms/pull/10441
- **EDIT:** Edit a contact, news feed and/or category, change title, and save and close : this title in the input should be then updated with the new title.
