### PR TITLE
[com_tags] use the same visual level structure as categories

### DIFF
--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -153,9 +153,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php if ($item->level > 0): ?>
-								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1) ?>
-								<?php endif; ?>
+								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&ndash;' : ''; ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'tags.', $canCheckin); ?>
 								<?php endif; ?>


### PR DESCRIPTION
#### Summary of Changes

This PR does for tags, the same visual change in the tree structure as done for categories (in https://github.com/joomla/joomla-cms/pull/10213).
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/15322242/717da0b6-1c33-11e6-9b90-d934fd829696.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/15322244/741416c0-1c33-11e6-8161-99c4c9c04fc2.png)
#### Testing Instructions
1. Use latest staging
2. Apply patch
3. Go to Component -> Tags and create a tag structure with 3 or more levels.
4. Check the visual of the tree structure is the same as the image in "After"
