### PR TITLE
[com_config] filters tab: use the same tree level visual

### DIFF
--- a/administrator/components/com_config/model/field/filters.php
+++ b/administrator/components/com_config/model/field/filters.php
@@ -79,9 +79,9 @@ class JFormFieldFilters extends JFormField
 			$group_filter['filter_attributes'] = !empty($group_filter['filter_attributes']) ? $group_filter['filter_attributes'] : '';
 
 			$html[] = '	<tr>';
-			$html[] = '		<th class="acl-groups left">';
-			$html[] = '			' . str_repeat('<span class="gi">|&mdash;</span>', $group->level) . $group->text;
-			$html[] = '		</th>';
+			$html[] = '		<td class="acl-groups left">';
+			$html[] = '			' . JLayoutHelper::render('joomla.html.treeprefix', array('level' => $group->level + 1)) . $group->text;
+			$html[] = '		</td>';
 			$html[] = '		<td>';
 			$html[] = '				<select'
 				. ' name="' . $this->name . '[' . $group->value . '][filter_type]"'


### PR DESCRIPTION
#### Summary of Changes

This PR does for com_config filters tab, the same visual change in the tree structure as done:
- for categories https://github.com/joomla/joomla-cms/pull/10213
- for tags https://github.com/joomla/joomla-cms/pull/10526
- for user group https://github.com/joomla/joomla-cms/pull/10528
- for debug user & debug group https://github.com/joomla/joomla-cms/pull/10530

After PR (example)
![image](https://cloud.githubusercontent.com/assets/9630530/15326933/ab2750dc-1c47-11e6-92c6-39bd959373c8.png)
#### Testing Instructions
1. Use latest staging
2. Apply patch https://github.com/joomla/joomla-cms/pull/10528 (to have the layout) and then this patch
3. Go to Global config "Text Filters" tab  and check the tree structure visual
