### PR TITLE
[acl permission] use the same tree level visual

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -217,7 +217,7 @@ class JFormFieldRules extends JFormField
 
 			$html[] = '<li class="' . $active . '">';
 			$html[] = '<a href="#permission-' . $group->value . '" data-toggle="tab">';
-			$html[] = str_repeat('<span class="level">&ndash;</span> ', $curLevel = $group->level) . $group->text;
+			$html[] = JLayoutHelper::render('joomla.html.treeprefix', array('level' => $group->level + 1)) . $group->text;
 			$html[] = '</a>';
 			$html[] = '</li>';
 		}


### PR DESCRIPTION
#### Summary of Changes

This PR does for acl permission, the same visual change in the tree structure as done:

After PR (example)
![image](https://cloud.githubusercontent.com/assets/9630530/15327557/c6fa53de-1c49-11e6-8f3f-fffb317a5f2e.png)
#### Testing Instructions
1. Use latest staging
2. Apply this patch
3. Go to Global config, any component permissions tab and check the tree structure visual
