### PR TITLE
[com_categories] modal: use the same tree level visual

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -200,7 +200,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&ndash;' : ''; ?>
+								<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'categories.', $canCheckin); ?>
 								<?php endif; ?>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -110,7 +110,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
 							</td>
 							<td>
-								<?php echo str_repeat('<span class="gi">&mdash;</span>', $item->level - 1); ?>
+								<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 								<a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 									<?php echo $this->escape($item->title); ?>
 								</a>


### PR DESCRIPTION
#### Summary of Changes

This PR does for categories modal, the same visual change as the other views.

After PR (example)
![image](https://cloud.githubusercontent.com/assets/9630530/15328082/9415c190-1c4b-11e6-877c-06149a5fd29c.png)
#### Testing Instructions
1. Use latest staging
2. Apply this patch
3. Access `/administrator/index.php?option=com_categories&view=categories&layout=modal&tmpl=component&extension=com_content`or have a multilanguage site with categories in different languages, edit one category assigned to a particular language, go to "Associations" tab and press "Select".
4. Check the tree view

Note: as you can check from the code diff this also changes the categories normal view (already merged) to use the layout from https://github.com/joomla/joomla-cms/pull/10528.
