### PR TITLE
[com_template] style: add tree to template menu assigment

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Initiasile related data.
 require_once JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php';
 $menuTypes = MenusHelper::getMenuLinks();
-$user = JFactory::getUser();
+$user      = JFactory::getUser();
 ?>
 <label id="jform_menuselect-lbl" for="jform_menuselect"><?php echo JText::_('JGLOBAL_MENU_SELECTION'); ?></label>
 <div class="btn-toolbar">
@@ -26,19 +26,21 @@ $user = JFactory::getUser();
 		<?php foreach ($menuTypes as &$type) : ?>
 			<li class="span3">
 				<div class="thumbnail">
-				<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery('.<?php echo $type->menutype; ?>').attr('checked', !jQuery('.<?php echo $type->menutype; ?>').attr('checked'));">
-					<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?>
-				</button>
-				<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
+					<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery('.<?php echo $type->menutype; ?>').attr('checked', !jQuery('.<?php echo $type->menutype; ?>').attr('checked'));">
+						<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?>
+					</button>
+					<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
+	
+					<?php foreach ($type->links as $link) : ?>
+						<label class="checkbox small" for="link<?php echo (int) $link->value;?>" >
+						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value;?>" id="link<?php echo (int) $link->value;?>"<?php if ($link->template_style_id == $this->item->id):?> checked="checked"<?php endif;?><?php if ($link->checked_out && $link->checked_out != $user->id):?> disabled="disabled"<?php else:?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif;?> />
+						<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
+						</label>
+					<?php endforeach; ?>
 
-				<?php foreach ($type->links as $link) : ?>
-					<label class="checkbox small" for="link<?php echo (int) $link->value;?>" >
-					<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value;?>" id="link<?php echo (int) $link->value;?>"<?php if ($link->template_style_id == $this->item->id):?> checked="checked"<?php endif;?><?php if ($link->checked_out && $link->checked_out != $user->id):?> disabled="disabled"<?php else:?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif;?> />
-					<?php echo $link->text; ?>
-					</label>
-				<?php endforeach; ?>
 				</div>
 			</li>
 		<?php endforeach; ?>
+
 	</ul>
 </div>

--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -32,8 +32,8 @@ $user      = JFactory::getUser();
 					<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
 	
 					<?php foreach ($type->links as $link) : ?>
-						<label class="checkbox small" for="link<?php echo (int) $link->value;?>" >
-						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value;?>" id="link<?php echo (int) $link->value;?>"<?php if ($link->template_style_id == $this->item->id):?> checked="checked"<?php endif;?><?php if ($link->checked_out && $link->checked_out != $user->id):?> disabled="disabled"<?php else:?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif;?> />
+						<label class="checkbox small" for="link<?php echo (int) $link->value; ?>" >
+						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif; ?> />
 						<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
 						</label>
 					<?php endforeach; ?>


### PR DESCRIPTION
#### Summary of Changes

This PR does for com_templates style "Menu assigments", the same visual change as the other views.

After PR (example)
![image](https://cloud.githubusercontent.com/assets/9630530/15328808/2370a74a-1c4e-11e6-93a8-691d3cdcba9f.png)
#### Testing Instructions
1. Use latest staging
2. Apply this patch
3. Go to Extensions -> Templates -> Styles, edit one template style and go to "Menus assignment"
4. Check the tree view

Note: that this view didn't have a tree structure, but it should have. Also did some code style.
For viewing the code without the code style spaces difference use this link https://github.com/joomla/joomla-cms/pull/10534/files?w=1
