### PR TITLE
[com_tags] use the new treeprefix layout

### DIFF
--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -153,7 +153,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td>
-								<?php echo $item->level > 1 ? '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', $item->level - 2) . '</span>&ndash;' : ''; ?>
+								<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'tags.', $canCheckin); ?>
 								<?php endif; ?>


### PR DESCRIPTION
#### Summary of Changes

Now that https://github.com/joomla/joomla-cms/pull/10528 is merged, this a minor PR for com_tags to also use the new treeprefix layout.
#### Testing Instructions

Same as https://github.com/joomla/joomla-cms/pull/10526
1. Use latest staging
2. Apply patch
3. Go to Component -> Tags and create a tag structure with 3 or more levels.
4. Check the visual of the tree structure is the same as the image in "After"
