### PR TITLE
Fix for some unsigned numeric types in mysql schema

### DIFF
--- a/libraries/cms/schema/changeitem/mysql.php
+++ b/libraries/cms/schema/changeitem/mysql.php
@@ -233,6 +233,10 @@ class JSchemaChangeitemMysql extends JSchemaChangeitem
 		{
 			$result = 'int(10) unsigned';
 		}
+		elseif (strtolower(substr($type2, 0, 8)) == 'unsigned')
+		{
+			$result = $type1 . ' unsigned';
+		}
 
 		return $result;
 	}


### PR DESCRIPTION
Pull Request for Issue where some mysql unsigned numeric types will throw  `table ___ does not have column ___ with type ___` in the Extensions: Database update checks.

Basically, the `fixInteger()` function makes an overly broad assumption that any type passed in `type1` either needs to be returned as that type or if it's the full word type `integer` that it should check if the `type2` is unsigned. 

In some cases unsigned numeric types were unaffected, but for select cases  `fixInteger()` method actually resulted in stripping out the `unsigned` designation for those numeric types during database updates.
#### Summary of Changes

Fixes all cases where the mysql numeric types are unsigned.

Prior to this patch, table changes to add `unsigned` to some numeric types would result in the the database check trowing an error `table ___ does not have column ___ with type ___` This typically happens with things like `int(10)`

With this patch all mysql numeric types retain the `unsigned` designation.
#### Testing Instructions

https://docs.joomla.org/Testing_Joomla!_patches
- Use this sample data schema change to get a database schema with unsigned types
  [3.6.0-2016-06-20.zip](https://github.com/joomla/joomla-cms/files/324726/3.6.0-2016-06-20.zip) 
  - place the sample data schema change file at `administrator/components/com_admin/sql/updates/mysql/`
  - (or create your own schema change with unsigned numeric types other than `integer`)
- go to  Extensions: Database and press the fix button
  - note: that some columns will continue to say `table ___ does not have column ___ with type int(10)`
  - note: although these columns say int(10) none say `unsigned`
- Now apply this patch
- go to  Extensions: Database
  - note: there should now be an additional notices for columns with int(11) and bigint(20) and all types stating unsigned
- press the fix button and you should get the notice `Database table structure is up to date.` for a successful test
