### PR TITLE
Fix onContentPrepare event in contact view to trigger on correct text

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -238,7 +238,7 @@ class ContactViewContact extends JViewLegacy
 		$offset = $state->get('list.offset');
 
 		// Fix for where some plugins require a text attribute
-		!empty($item->description)? $item->text = $item->description : $item->text = null;
+		!empty($item->misc)? $item->text = $item->misc : $item->text = null;
 		$dispatcher->trigger('onContentPrepare', array ('com_contact.contact', &$item, &$this->params, $offset));
 
 		// Store the events for later
@@ -254,7 +254,7 @@ class ContactViewContact extends JViewLegacy
 
 		if ($item->text)
 		{
-			$item->description = $item->text;
+			$item->misc = $item->text;
 		}
 
 		// Escape strings for HTML output


### PR DESCRIPTION
#### Issue

The onContentPrepare event triggering on the contact view has no effect
#### Summary of Changes

Trigger onContentPrepare event on proper property  ($item->misc)
#### Testing Instructions
1. Edit a contact
2. Go to "Miscellaneous Information" TAB
3. Add plugin text of some content plugin that does not limit itself into some specific component / view
4. View the contact in frontend , the plugin text is replaced ...
