### PR TITLE
Displaying correct itemprop language when modified by the languagecode plugin

### DIFF
--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -85,6 +85,20 @@ class PlgSystemLanguagecode extends JPlugin
 				}
 			}
 
+			// Replace codes in itemprop content
+			preg_match_all(chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")([0-9A-Za-z\-]*)(".*/>)' . chr(1) . 'i', $body, $matches);
+
+			foreach ($matches[2] as $match)
+			{
+				$new_code = $this->params->get(strtolower($match));
+
+				if ($new_code)
+				{
+					$patterns[] = chr(1) . '(<meta.*\s+itemprop="inLanguage".*\s+content=")(' . $match . ')(".*/>)' . chr(1) . 'i';
+					$replace[] = '${1}' . $new_code . '${3}';
+				}
+			}
+
 			$app->setBody(preg_replace($patterns, $replace, $body));
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue #10540

This does not need to be tested on a multilang site.
Test instructions:

Edit the System Language Code plugin and enable it, save.
After save, a new tab "Language Codes" will show.
Enter `fr-CA` for example (if your default site language is fr-FR) 

![screen shot 2016-05-18 at 08 49 11](https://cloud.githubusercontent.com/assets/869724/15349748/777d5fc2-1cd5-11e6-9729-44315f0eda69.png)

Save and close.

Display an article in frontend and look at source:

Instead of
`<meta itemprop="inLanguage" content="fr-FR" />`
you will now correctly get
`<meta itemprop="inLanguage" content="fr-CA" />`
