### PR TITLE
Fatal error when user can't create menus (solves #10544)

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -127,7 +127,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true);
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), true);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu);
 	$menu->addSeparator();
 
 	if ($createMenu)
@@ -136,7 +136,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 		$menu->getParent();
 	}
 
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=*', 'class:menumgr'));
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=*', 'class:allmenu'));
 	$menu->addSeparator();
 
 	// Menu Types

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -127,7 +127,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true);
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'));
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), true);
 	$menu->addSeparator();
 
 	if ($createMenu)

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -127,7 +127,8 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS'), '#'), true);
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu);
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'));
+	$menu->addSeparator();
 
 	if ($createMenu)
 	{
@@ -135,10 +136,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 		$menu->getParent();
 	}
 
-	$menu->addSeparator();
-
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=*', 'class:menumgr'), $createMenu);
-	$menu->getParent();
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=*', 'class:menumgr'));
 	$menu->addSeparator();
 
 	// Menu Types

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -128,7 +128,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu);
-	
+
 	if ($createMenu)
 	{
 		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit', 'class:newarticle'));

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -128,13 +128,14 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$createMenu = $shownew && $user->authorise('core.create', 'com_menus');
 
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER'), 'index.php?option=com_menus&view=menus', 'class:menumgr'), $createMenu);
-	$menu->addSeparator();
-
+	
 	if ($createMenu)
 	{
 		$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENU_MANAGER_NEW_MENU'), 'index.php?option=com_menus&view=menu&layout=edit', 'class:newarticle'));
 		$menu->getParent();
 	}
+
+	$menu->addSeparator();
 
 	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=*', 'class:allmenu'));
 	$menu->addSeparator();


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10544.
#### Summary of Changes

Solves fatal error when user can't create menus.
#### Testing Instructions
1. Create a user groups "testgroup" (child of "Administrator" user group)
2. Go to Menus -> Manager (Options button) and set that group to have no permission to create Menu type: Created: Denied
3. Create a user "testuser" and add only to "testgroup"
4. Open a new private browser window and login to backend with "testuser". Result: fatal error
5. Apply patch. Repeat step 4. all good.

More info, see https://github.com/joomla/joomla-cms/issues/10544
