### PR TITLE
[com_menus] menus view: solves some bugs in new acl

### DIFF
--- a/administrator/components/com_menus/views/menu/view.html.php
+++ b/administrator/components/com_menus/views/menu/view.html.php
@@ -52,7 +52,7 @@ class MenusViewMenu extends JViewLegacy
 		$this->item	 = $this->get('Item');
 		$this->state = $this->get('State');
 
-		$this->canDo = JHelperContent::getActions('com_menus');
+		$this->canDo = JHelperContent::getActions('com_menus', 'menu', $this->item->id);
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -99,9 +99,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) :
-					$canCreate = $user->authorise('core.create',     'com_menus');
-					$canEdit   = $user->authorise('core.edit',       'com_menus');
-					$canChange = $user->authorise('core.edit.state', 'com_menus');
+					$canEdit        = $user->authorise('core.edit',   'com_menus.menu.' . (int) $item->id);
 					$canManageItems = $user->authorise('core.manage', 'com_menus.menu.' . (int) $item->id);
 				?>
 					<tr class="row<?php echo $i % 2; ?>">
@@ -126,16 +124,31 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							</div>
 						</td>
 						<td class="center btns">
-							<a class="badge<?php if ($item->count_published > 0) echo ' badge-success'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=1'); ?>">
-								<?php echo $item->count_published; ?></a>
+							<?php if ($canManageItems) : ?>
+								<a class="badge<?php if ($item->count_published > 0) echo ' badge-success'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=1'); ?>">
+									<?php echo $item->count_published; ?></a>
+							<?php else : ?>
+								<span class="badge<?php if ($item->count_published > 0) echo ' badge-success'; ?>">
+									<?php echo $item->count_published; ?></span>
+							<?php endif; ?>
 						</td>
 						<td class="center btns">
-							<a class="badge<?php if ($item->count_unpublished > 0) echo ' badge-important'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=0'); ?>">
-								<?php echo $item->count_unpublished; ?></a>
+							<?php if ($canManageItems) : ?>
+								<a class="badge<?php if ($item->count_unpublished > 0) echo ' badge-important'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=0'); ?>">
+									<?php echo $item->count_unpublished; ?></a>
+							<?php else : ?>
+								<span class="badge<?php if ($item->count_unpublished > 0) echo ' badge-important'; ?>">
+									<?php echo $item->count_unpublished; ?></span>
+							<?php endif; ?>
 						</td>
 						<td class="center btns">
-							<a class="badge<?php if ($item->count_trashed > 0) echo ' badge-inverse'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=-2'); ?>">
-								<?php echo $item->count_trashed; ?></a>
+							<?php if ($canManageItems) : ?>
+								<a class="badge<?php if ($item->count_trashed > 0) echo ' badge-inverse'; ?>" href="<?php echo JRoute::_('index.php?option=com_menus&view=items&menutype=' . $item->menutype . '&filter[published]=-2'); ?>">
+									<?php echo $item->count_trashed; ?></a>
+							<?php else : ?>
+								<span class="badge<?php if ($item->count_trashed > 0) echo ' badge-inverse'; ?>">
+									<?php echo $item->count_trashed; ?></span>
+							<?php endif; ?>
 						</td>
 						<td class="center">
 							<?php if (isset($this->modules[$item->menutype])) : ?>


### PR DESCRIPTION
#### Summary of Changes

Some ACL in the menus list view aren't working quite right:
- If the user can't edit a particular menu type it should not have a link to it.
- Also if a user can't view the menu "Access Administration Interface" for a particular menu it shouldn't have links in the count buttons.
- Also if a user can't edit the menu "Edit" for a particular menu it shouldn't have the options to edit inside the edit screen.

This PR solves this issues.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15369658/8237f962-1d2b-11e6-950c-e7c666108740.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15369665/8d4d7c14-1d2b-11e6-9ced-454390d17a65.png)
#### Testing Instructions
1. Create a user groups "testgroup" (child of "Administrator" user group)
2. Go to Menus -> Manager, edit a particular menu and set the "testgroup" group to have no permission (Denied) in "Edit" and "Access Administration Interface"
3. Create a user "testuser" and add it only to "testgroup"
4. Open a new private browser window and login to backend with "testuser".
5. Go to menu Menus -> Manage
6. You can see the user can view the edit link for the menu type (and if you click on it, it can edit the menu type) and also has a link in the  published/unpublished/trashed count.
   
   It shouldn't since you removed those permission in "2."
7. Apply patch. Repeat step 6. all good.

@bembelimen @infograf768 please test
