### PR TITLE
Allow including of "parent" menu manifests

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1179,6 +1179,49 @@ class MenusModelItem extends JModelAdmin
 				throw new Exception(JText::_('JERROR_LOADFILE_FAILED'));
 			}
 
+			// Check for other forms to include
+			$include = $xml->xpath('/metadata/layout/include');
+
+			if ($include)
+			{
+				// Check to include the view manifest file
+				$includeView = (string) $include[0]['view'];
+
+				if ($includeView && $includeView != 'false')
+				{
+					$metadataFolders = array(
+						$base . '/view/' . $view,
+						$base . '/views/' . $view
+					);
+					$metaPath = JPath::find($metadataFolders, 'metadata.xml');
+
+					if (is_file($viewFormFile = JPath::clean($metaPath)))
+					{
+						if ($form->loadFile($viewFormFile, false, '/metadata') == false)
+						{
+							throw new Exception(JText::_('JERROR_LOADFILE_FAILED'));
+						}
+					}
+				}
+
+				// Check to include the component manifest file
+				$includeComponent = (string) $include[0]['component'];
+
+				if ($includeComponent &&  $includeComponent != 'false')
+				{
+					$componentFormFile = JPath::clean($base . '/metadata.xml');
+
+					if (is_file($componentFormFile))
+					{
+						if ($form->loadFile($componentFormFile, false, '/metadata') == false)
+						{
+							throw new Exception(JText::_('JERROR_LOADFILE_FAILED'));
+						}
+					}
+				}
+			}
+
+
 			// Get the help data from the XML file if present.
 			$help = $xml->xpath('/metadata/layout/help');
 		}

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1221,7 +1221,6 @@ class MenusModelItem extends JModelAdmin
 				}
 			}
 
-
 			// Get the help data from the XML file if present.
 			$help = $xml->xpath('/metadata/layout/help');
 		}

--- a/components/com_content/views/category/metadata.xml
+++ b/components/com_content/views/category/metadata.xml
@@ -1,0 +1,528 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<view
+		title="Category">
+		<message><![CDATA[TYPECATEGLAYDESC]]></message>
+	</view>
+
+	<!-- Add fields to the request variables for the layout. -->
+	<fields name="request">
+		<fieldset name="request"
+			addfieldpath="/administrator/components/com_categories/models/fields"
+		>
+			<field
+				name="id"
+				type="modal_category"
+				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
+				extension="com_content"
+				required="true"
+				select="true"
+				new="true"
+				edit="true"
+				clear="true"
+			/>
+		</fieldset>
+	</fields>
+
+	<!-- Add fields to the parameters object for the layout. -->
+	<fields name="params">
+		<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
+			<field
+				name="show_category_title"
+				type="list"
+				label="JGLOBAL_SHOW_CATEGORY_TITLE"
+				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_description"
+				type="list"
+				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_description_image"
+				type="list"
+				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="maxLevel"
+				type="list"
+				label="JGLOBAL_MAXLEVEL_LABEL"
+				description="JGLOBAL_MAXLEVEL_DESC"
+				useglobal="true"
+				>
+				<option value="-1">JALL</option>
+				<option value="0">JNONE</option>
+				<option value="1">J1</option>
+				<option value="2">J2</option>
+				<option value="3">J3</option>
+				<option value="4">J4</option>
+				<option value="5">J5</option>
+			</field>
+
+			<field
+				name="show_empty_categories"
+				type="list"
+				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
+				description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_no_articles"
+				type="list"
+				label="COM_CONTENT_NO_ARTICLES_LABEL"
+				description="COM_CONTENT_NO_ARTICLES_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_category_heading_title_text"
+				type="list"
+				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
+				useglobal="true"
+			>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_subcat_desc"
+				type="list"
+				label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
+				description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_cat_num_articles"
+				type="list"
+				label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
+				description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_cat_tags"
+				type="list"
+				label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
+				description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="page_subheading"
+				type="text"
+				label="JGLOBAL_SUBHEADING_LABEL"
+				description="JGLOBAL_SUBHEADING_DESC"
+				size="20"
+			/>
+		</fieldset>
+
+		<fieldset name="advanced" label="foo">
+			<field
+				name="orderby_pri"
+				type="list"
+				label="JGLOBAL_CATEGORY_ORDER_LABEL"
+				description="JGLOBAL_CATEGORY_ORDER_DESC"
+				useglobal="true"
+				>
+				<option value="none">JGLOBAL_NO_ORDER</option>
+				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
+				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
+				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
+			</field>
+
+			<field
+				name="orderby_sec"
+				type="list"
+				label="JGLOBAL_ARTICLE_ORDER_LABEL"
+				description="JGLOBAL_ARTICLE_ORDER_DESC"
+				useglobal="true"
+				>
+				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
+				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
+				<option value="date">JGLOBAL_OLDEST_FIRST</option>
+				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
+				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
+				<option value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
+				<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
+				<option value="hits">JGLOBAL_MOST_HITS</option>
+				<option value="rhits">JGLOBAL_LEAST_HITS</option>
+				<option value="random">JGLOBAL_RANDOM_ORDER</option>
+				<option value="order">JGLOBAL_ORDERING</option>
+				<option value="vote" requires="vote">JGLOBAL_VOTES_DESC</option>
+				<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
+				<option value="rank" requires="vote"> JGLOBAL_RATINGS_DESC</option>
+				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
+			</field>
+
+			<field
+				name="order_date"
+				type="list"
+				label="JGLOBAL_ORDERING_DATE_LABEL"
+				description="JGLOBAL_ORDERING_DATE_DESC"
+				useglobal="true"
+				>
+				<option value="created">JGLOBAL_CREATED</option>
+				<option value="modified">JGLOBAL_MODIFIED</option>
+				<option value="published">JPUBLISHED</option>
+			</field>
+
+			<field
+				name="show_pagination"
+				type="list"
+				label="JGLOBAL_PAGINATION_LABEL"
+				description="JGLOBAL_PAGINATION_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+				<option value="2">JGLOBAL_AUTO</option>
+			</field>
+
+			<field
+				name="show_pagination_results"
+				type="list"
+				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_featured"
+				type="list"
+				label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
+				description="JGLOBAL_SHOW_FEATURED_ARTICLES_DESC"
+				useglobal="true"
+				>
+				<option value="show">JSHOW</option>
+				<option value="hide">JHIDE</option>
+				<option value="only">JONLY</option>
+			</field>
+		</fieldset>
+		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+			<field
+				name="show_title"
+				type="list"
+				label="JGLOBAL_SHOW_TITLE_LABEL"
+				description="JGLOBAL_SHOW_TITLE_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="link_titles"
+				type="list"
+				label="JGLOBAL_LINKED_TITLES_LABEL"
+				description="JGLOBAL_LINKED_TITLES_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+
+			<field
+				name="show_intro"
+				type="list"
+				label="JGLOBAL_SHOW_INTRO_LABEL"
+				description="JGLOBAL_SHOW_INTRO_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_category"
+				type="list"
+				label="JGLOBAL_SHOW_CATEGORY_LABEL"
+				description="JGLOBAL_SHOW_CATEGORY_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="link_category"
+				type="list"
+				label="JGLOBAL_LINK_CATEGORY_LABEL"
+				description="JGLOBAL_LINK_CATEGORY_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+
+			<field
+				name="show_parent_category"
+				type="list"
+				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
+				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="link_parent_category"
+				type="list"
+				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
+				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+
+			<field
+				name="show_associations"
+				type="list"
+				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
+				description="JGLOBAL_SHOW_ASSOCIATIONS_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_author"
+				type="list"
+				label="JGLOBAL_SHOW_AUTHOR_LABEL"
+				description="JGLOBAL_SHOW_AUTHOR_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="link_author"
+				type="list"
+				label="JGLOBAL_LINK_AUTHOR_LABEL"
+				description="JGLOBAL_LINK_AUTHOR_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JNo</option>
+				<option value="1">JYes</option>
+			</field>
+
+			<field
+				name="show_create_date"
+				type="list"
+				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
+				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_modify_date"
+				type="list"
+				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
+				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_publish_date"
+				type="list"
+				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
+				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_item_navigation"
+				type="list"
+				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
+				description="JGLOBAL_SHOW_NAVIGATION_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_vote"
+				type="list"
+				label="JGLOBAL_SHOW_VOTE_LABEL"
+				description="JGLOBAL_SHOW_VOTE_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_readmore"
+				type="list"
+				label="JGLOBAL_SHOW_READMORE_LABEL"
+				description="JGLOBAL_SHOW_READMORE_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_readmore_title"
+				type="list"
+				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
+				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_icons"
+				type="list"
+				label="JGLOBAL_SHOW_ICONS_LABEL"
+				description="JGLOBAL_SHOW_ICONS_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_print_icon"
+				type="list"
+				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
+				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_email_icon"
+				type="list"
+				label="JGLOBAL_Show_Email_Icon_Label"
+				description="JGLOBAL_Show_Email_Icon_Desc"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_hits"
+				type="list"
+				label="JGLOBAL_SHOW_HITS_LABEL"
+				description="JGLOBAL_SHOW_HITS_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_noauth"
+				type="list"
+				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
+				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
+				useglobal="true"
+				>
+				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
+		</fieldset>
+
+		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL">
+			<field
+				name="show_feed_link"
+				type="list"
+				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+				description="JGLOBAL_SHOW_FEED_LINK_DESC"
+				useglobal="true"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="feed_summary"
+				type="list"
+				label="JGLOBAL_FEED_SUMMARY_LABEL"
+				description="JGLOBAL_FEED_SUMMARY_DESC"
+				useglobal="true"
+				>
+				<option value="0">JGLOBAL_INTRO_TEXT</option>
+				<option value="1">JGLOBAL_FULL_TEXT</option>
+			</field>
+		</fieldset>
+	</fields>
+</metadata>

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
 	<layout title="COM_CONTENT_CATEGORY_VIEW_BLOG_TITLE" option="COM_CONTENT_CATEGORY_VIEW_BLOG_OPTION">
-		<help key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG" />
+		<include view="true" />
+		<help key="JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_BLOG" />
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_BLOG_DESC]]>
 		</message>
@@ -10,20 +11,7 @@
 	<!-- Add fields to the request variables for the layout. -->
 	<fields name="request">
 		<fieldset name="request"
-			addfieldpath="/administrator/components/com_categories/models/fields"
 		>
-			<field
-				name="id"
-				type="modal_category"
-				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
-				extension="com_content"
-				required="true"
-				select="true"
-				new="true"
-				edit="true"
-				clear="true"
-			/>
 
 			<field
 				name="filter_tag"
@@ -39,338 +27,92 @@
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">
 		<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
-				<field
-					name="layout_type"
-					type="hidden"
-					default="blog"
-				/>
-
-				<field
-					name="show_category_heading_title_text"
-					type="list"
-	 				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-					description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_category_title"
-					type="list"
-					label="JGLOBAL_SHOW_CATEGORY_TITLE"
-					description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_description"
-					type="list"
-					label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-					description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_description_image"
-					type="list"
-					label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-					description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="maxLevel"
-					type="list"
-					label="JGLOBAL_MAXLEVEL_LABEL"
-					description="JGLOBAL_MAXLEVEL_DESC"
-					useglobal="true"
-					>
-					<option value="-1">JALL</option>
-					<option value="0">JNONE</option>
-					<option value="1">J1</option>
-					<option value="2">J2</option>
-					<option value="3">J3</option>
-					<option value="4">J4</option>
-					<option value="5">J5</option>
-				</field>
-
-				<field
-					name="show_empty_categories"
-					type="list"
-					label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-					description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_no_articles"
-					type="list"
-					label="COM_CONTENT_NO_ARTICLES_LABEL"
-					description="COM_CONTENT_NO_ARTICLES_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_subcat_desc"
-					type="list"
-					label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-					description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_cat_num_articles"
-					type="list"
-					label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-					description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field 
-					name="show_cat_tags"
-					type="list"
-					label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
-					description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="page_subheading"
-					type="text"
-					label="JGLOBAL_SUBHEADING_LABEL"
-					description="JGLOBAL_SUBHEADING_DESC"
-					size="20"
-				/>
+			<field
+				name="layout_type"
+				type="hidden"
+				default="blog"
+			/>
 		</fieldset>
 
 		<fieldset name="advanced" label="JGLOBAL_BLOG_LAYOUT_OPTIONS">
-				<field 
-					name="bloglayout"
-					type="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
-					class="text"
-				/>
+			<field
+				name="bloglayout"
+				type="spacer"
+				label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
+				class="text"
+			/>
 
-				<field
-					name="num_leading_articles"
-					type="text"
-					label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
-					description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
-					useglobal="true"
-					size="3"
-				/>
+			<field
+				name="num_leading_articles"
+				type="text"
+				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
+				description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
+				useglobal="true"
+				size="3"
+			/>
 
-				<field
-					name="num_intro_articles"
-					type="text"
-					label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
-					description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
-					useglobal="true"
-					size="3"
-				/>
+			<field
+				name="num_intro_articles"
+				type="text"
+				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
+				description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
+				useglobal="true"
+				size="3"
+			/>
 
-				<field
-					name="num_columns"
-					type="text"
-					label="JGLOBAL_NUM_COLUMNS_LABEL"
-					description="JGLOBAL_NUM_COLUMNS_DESC"
-					useglobal="true"
-					size="3"
-				/>
+			<field
+				name="num_columns"
+				type="text"
+				label="JGLOBAL_NUM_COLUMNS_LABEL"
+				description="JGLOBAL_NUM_COLUMNS_DESC"
+				useglobal="true"
+				size="3"
+			/>
 
-				<field
-					name="num_links"
-					type="text"
-					label="JGLOBAL_NUM_LINKS_LABEL"
-					description="JGLOBAL_NUM_LINKS_DESC"
-					useglobal="true"
-					size="3"
-				/>
+			<field
+				name="num_links"
+				type="text"
+				label="JGLOBAL_NUM_LINKS_LABEL"
+				description="JGLOBAL_NUM_LINKS_DESC"
+				useglobal="true"
+				size="3"
+			/>
 
-				<field
-					name="multi_column_order"
-					type="list"
-					label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-					description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
-					useglobal="true"
-					>
-					<option value="0">JGLOBAL_DOWN</option>
-					<option value="1">JGLOBAL_ACROSS</option>
-				</field>
+			<field
+				name="multi_column_order"
+				type="list"
+				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+				description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
+				useglobal="true"
+				>
+				<option value="0">JGLOBAL_DOWN</option>
+				<option value="1">JGLOBAL_ACROSS</option>
+			</field>
 
-				<field
-					name="show_subcategory_content"
-					type="list"
-					label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
-					description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
-					useglobal="true"
-					>
-					<option value="0">JNONE</option>
-					<option value="-1">JALL</option>
-					<option value="1">J1</option>
-					<option value="2">J2</option>
-					<option value="3">J3</option>
-					<option value="4">J4</option>
-					<option value="5">J5</option>
-				</field>
+			<field
+				name="show_subcategory_content"
+				type="list"
+				label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
+				description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"
+				useglobal="true"
+				>
+				<option value="0">JNONE</option>
+				<option value="-1">JALL</option>
+				<option value="1">J1</option>
+				<option value="2">J2</option>
+				<option value="3">J3</option>
+				<option value="4">J4</option>
+				<option value="5">J5</option>
+			</field>
 
-				<field
-					name="spacer1"
-					type="spacer"
-					hr="true"
-				/>
-
-				<field
-					name="orderby_pri"
-					type="list"
-					label="JGLOBAL_CATEGORY_ORDER_LABEL"
-					description="JGLOBAL_CATEGORY_ORDER_DESC"
-					useglobal="true"
-					>
-					<option value="none">JGLOBAL_NO_ORDER</option>
-					<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-					<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-					<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
-				</field>
-
-				<field
-					name="orderby_sec"
-					type="list"
-					label="JGLOBAL_ARTICLE_ORDER_LABEL"
-					description="JGLOBAL_ARTICLE_ORDER_DESC"
-					useglobal="true"
-					>
-					<option value="front">COM_CONTENT_FEATURED_ORDER</option>
-					<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
-					<option value="date">JGLOBAL_OLDEST_FIRST</option>
-					<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-					<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-					<option value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
-					<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
-					<option value="hits">JGLOBAL_MOST_HITS</option>
-					<option value="rhits">JGLOBAL_LEAST_HITS</option>
-					<option value="random">JGLOBAL_RANDOM_ORDER</option>
-					<option value="order">JGLOBAL_ORDERING</option>
-					<option	value="rorder">JGLOBAL_REVERSE_ORDERING</option>
-					<option value="vote" requires="vote">JGLOBAL_VOTES_DESC</option>
-					<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
-					<option value="rank" requires="vote">JGLOBAL_RATINGS_DESC</option>
-					<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
-				</field>
-
-				<field
-					name="order_date"
-					type="list"
-					label="JGLOBAL_ORDERING_DATE_LABEL"
-					description="JGLOBAL_ORDERING_DATE_DESC"
-					useglobal="true"
-					>
-					<option value="created">JGLOBAL_CREATED</option>
-					<option value="modified">JGLOBAL_MODIFIED</option>
-					<option value="published">JPUBLISHED</option>
-					<option value="unpublished">JUNPUBLISHED</option>
-				</field>
-
-				<field
-					name="show_pagination"
-					type="list"
-					label="JGLOBAL_PAGINATION_LABEL"
-					description="JGLOBAL_PAGINATION_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-					<option value="2">JGLOBAL_AUTO</option>
-				</field>
-
-				<field
-					name="show_pagination_results"
-					type="list"
-					label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-					description="JGLOBAL_PAGINATION_RESULTS_DESC"
-					useglobal="true"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
-					name="show_featured"
-					type="list"
-					default=""
-					label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
-					description="JGLOBAL_SHOW_FEATURED_ARTICLES_DESC"
-					useglobal="true"
-					>
-					<option value="show">JSHOW</option>
-					<option value="hide">JHIDE</option>
-					<option value="only">JONLY</option>
-				</field>
+			<field
+				name="spacer1"
+				type="spacer"
+				hr="true"
+			/>
 		</fieldset>
 
 		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field
-				name="show_title"
-				type="list"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-				description="JGLOBAL_SHOW_TITLE_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="link_titles"
-				type="list"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-				description="JGLOBAL_LINKED_TITLES_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field
-				name="show_intro"
-				type="list"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-				description="JGLOBAL_SHOW_INTRO_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
 			<field
 				name="info_block_position"
 				type="list"
@@ -398,220 +140,6 @@
 			</field>
 
 			<field
-				name="show_category"
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="link_category"
-				type="list"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field
-				name="show_parent_category"
-				type="list"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="link_parent_category"
-				type="list"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field
-				name="show_associations"
-				type="list"
-				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
-				description="JGLOBAL_SHOW_ASSOCIATIONS_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_author"
-				type="list"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="link_author"
-				type="list"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field
-				name="show_create_date"
-				type="list"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_modify_date"
-				type="list"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_publish_date"
-				type="list"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_item_navigation"
-				type="list"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_vote"
-				type="list"
-				label="JGLOBAL_SHOW_VOTE_LABEL"
-				description="JGLOBAL_SHOW_VOTE_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option	value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_readmore"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_readmore_title"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_icons"
-				type="list"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_print_icon"
-				type="list"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_email_icon"
-				type="list"
-				label="JGLOBAL_Show_Email_Icon_Label"
-				description="JGLOBAL_Show_Email_Icon_Desc"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_hits"
-				type="list"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
 				name="show_tags"
 				type="list"
 				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
@@ -621,42 +149,6 @@
 				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_noauth"
-				type="list"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
-				useglobal="true"
-				>
-				<option value="use_article">COM_CONTENT_FIELD_VALUE_USE_ARTICLE_SETTINGS</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-		</fieldset>
-
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL">
-			<field
-				name="show_feed_link"
-				type="list"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="feed_summary"
-				type="list"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JGLOBAL_INTRO_TEXT</option>
-				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -1,166 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
 	<layout title="COM_CONTENT_CATEGORY_VIEW_DEFAULT_TITLE" option="COM_CONTENT_CATEGORY_VIEW_DEFAULT_OPTION">
-		<help
-			key = "JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_LIST"
-		/>
+		<include view="true" />
+		<help key="JHELP_MENUS_MENU_ITEM_ARTICLE_CATEGORY_LIST" />
 		<message>
 			<![CDATA[COM_CONTENT_CATEGORY_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
 
-	<!-- Add fields to the request variables for the layout. -->
-	<fields name="request">
-		<fieldset name="request"
-			addfieldpath="/administrator/components/com_categories/models/fields"
-		>
-			<field 
-				name="id"
-				type="modal_category"
-				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
-				extension="com_content"
-				required="true"
-				select="true"
-				new="true"
-				edit="true"
-				clear="true"
-			/>
-		</fieldset>
-	</fields>
-
 	<!-- Add fields to the parameters object for the layout. -->
 	<fields name="params">
+		<!-- Empty fieldset so it appears in correct order -->
 		<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
-
-			<field 
-				name="show_category_title" 
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_TITLE"
-				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_description" 
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_description_image" 
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="maxLevel" 
-				type="list"
-				label="JGLOBAL_MAXLEVEL_LABEL"
-				description="JGLOBAL_MAXLEVEL_DESC"
-				useglobal="true"
-				>
-				<option value="-1">JALL</option>
-				<option value="0">JNONE</option>
-				<option value="1">J1</option>
-				<option value="2">J2</option>
-				<option value="3">J3</option>
-				<option value="4">J4</option>
-				<option value="5">J5</option>
-			</field>
-
-			<field 
-				name="show_empty_categories" 
-				type="list"
-				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
-				description="COM_CONTENT_SHOW_EMPTY_CATEGORIES_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_no_articles" 
-				type="list"
-				label="COM_CONTENT_NO_ARTICLES_LABEL"
-				description="COM_CONTENT_NO_ARTICLES_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_category_heading_title_text"
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_subcat_desc" 
-				type="list"
-				label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
-				description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_cat_num_articles" 
-				type="list"
-				label="COM_CONTENT_NUMBER_CATEGORY_ITEMS_LABEL"
-				description="COM_CONTENT_NUMBER_CATEGORY_ITEMS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_cat_tags" 
-				type="list"
-				label="COM_CONTENT_FIELD_SHOW_CAT_TAGS_LABEL"
-				description="COM_CONTENT_FIELD_SHOW_CAT_TAGS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="page_subheading" 
-				type="text"
-				label="JGLOBAL_SUBHEADING_LABEL"
-				description="JGLOBAL_SUBHEADING_DESC"
-				size="20"
-			/>
-
 		</fieldset>
 
 		<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
-			<field 
-				name="show_pagination_limit" 
+			<field
+				name="show_pagination_limit"
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
@@ -170,8 +26,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="filter_field" 
+			<field
+				name="filter_field"
 				type="list"
 				label="JGLOBAL_FILTER_FIELD_LABEL"
 				description="JGLOBAL_FILTER_FIELD_DESC"
@@ -181,11 +37,11 @@
 				<option value="title">JGLOBAL_TITLE</option>
 				<option value="author">JAUTHOR</option>
 				<option value="hits">JGLOBAL_HITS</option>
-	 			<option value="tag">JTAG</option>
+				<option value="tag">JTAG</option>
 			</field>
 
-			<field 
-				name="show_headings" 
+			<field
+				name="show_headings"
 				type="list"
 				label="JGLOBAL_SHOW_HEADINGS_LABEL"
 				description="JGLOBAL_SHOW_HEADINGS_DESC"
@@ -195,8 +51,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="list_show_date" 
+			<field
+				name="list_show_date"
 				type="list"
 				label="JGLOBAL_SHOW_DATE_LABEL"
 				description="JGLOBAL_SHOW_DATE_DESC"
@@ -208,8 +64,8 @@
 				<option value="published">JPUBLISHED</option>
 			</field>
 
-			<field 
-				name="date_format" 
+			<field
+				name="date_format"
 				type="text"
 				label="JGLOBAL_DATE_FORMAT_LABEL"
 				description="JGLOBAL_DATE_FORMAT_DESC"
@@ -217,8 +73,8 @@
 				useglobal="true"
 			/>
 
-			<field 
-				name="list_show_hits" 
+			<field
+				name="list_show_hits"
 				type="list"
 				label="JGLOBAL_LIST_HITS_LABEL"
 				description="JGLOBAL_LIST_HITS_DESC"
@@ -228,8 +84,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="list_show_author" 
+			<field
+				name="list_show_author"
 				type="list"
 				label="JGLOBAL_LIST_AUTHOR_LABEL"
 				description="JGLOBAL_LIST_AUTHOR_DESC"
@@ -269,81 +125,8 @@
 				hr="true"
 			/>
 
-			<field 
-				name="orderby_pri" 
-				type="list"
-				label="JGLOBAL_CATEGORY_ORDER_LABEL"
-				description="JGLOBAL_CATEGORY_ORDER_DESC"
-				useglobal="true"
-				>
-				<option value="none">JGLOBAL_NO_ORDER</option>
-				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
-			</field>
-
-			<field 
-				name="orderby_sec" 
-				type="list"
-				label="JGLOBAL_ARTICLE_ORDER_LABEL"
-				description="JGLOBAL_ARTICLE_ORDER_DESC"
-				useglobal="true"
-				>
-				<option value="front">COM_CONTENT_FEATURED_ORDER</option>
-				<option value="rdate">JGLOBAL_MOST_RECENT_FIRST</option>
-				<option value="date">JGLOBAL_OLDEST_FIRST</option>
-				<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
-				<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
-				<option value="author">JGLOBAL_AUTHOR_ALPHABETICAL</option>
-				<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
-				<option value="hits">JGLOBAL_MOST_HITS</option>
-				<option value="rhits">JGLOBAL_LEAST_HITS</option>
-				<option value="random">JGLOBAL_RANDOM_ORDER</option>
-				<option value="order">JGLOBAL_ORDERING</option>
-				<option	value="rorder">JGLOBAL_REVERSE_ORDERING</option>
-				<option value="vote" requires="vote">JGLOBAL_VOTES_DESC</option>
-				<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
-				<option value="rank" requires="vote"> JGLOBAL_RATINGS_DESC</option>
-				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
-			</field>
-
-			<field 
-				name="order_date" 
-				type="list"
-				label="JGLOBAL_ORDERING_DATE_LABEL"
-				description="JGLOBAL_ORDERING_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="created">JGLOBAL_CREATED</option>
-				<option value="modified">JGLOBAL_MODIFIED</option>
-				<option value="published">JPUBLISHED</option>
-			</field>
-
-			<field 
-				name="show_pagination" 
-				type="list"
-				label="JGLOBAL_PAGINATION_LABEL"
-				description="JGLOBAL_PAGINATION_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-				<option value="2">JGLOBAL_AUTO</option>
-			</field>
-
-			<field 
-				name="show_pagination_results" 
-				type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="display_num" 
+			<field
+				name="display_num"
 				type="list"
 				label="JGLOBAL_NUMBER_ITEMS_LIST_LABEL"
 				description="JGLOBAL_NUMBER_ITEMS_LIST_DESC"
@@ -358,287 +141,6 @@
 				<option value="50">J50</option>
 				<option value="100">J100</option>
 				<option value="0">JALL</option>
-			</field>
-
-			<field 
-				name="show_featured" 
-				type="list" 
-				label="JGLOBAL_SHOW_FEATURED_ARTICLES_LABEL"
-				description="JGLOBAL_SHOW_FEATURED_ARTICLES_DESC"
-				useglobal="true"
-				default=""
-				>
-				<option value="show">JSHOW</option>
-				<option value="hide">JHIDE</option>
-				<option value="only">JONLY</option>
-			</field>
-		</fieldset>
-
-		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field 
-				name="show_title" 
-				type="list"
-				label="JGLOBAL_SHOW_TITLE_LABEL"
-				description="JGLOBAL_SHOW_TITLE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="link_titles" 
-				type="list"
-				label="JGLOBAL_LINKED_TITLES_LABEL"
-				description="JGLOBAL_LINKED_TITLES_DESC"
-				useglobal="true"
-				>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field 
-				name="show_intro" 
-				type="list"
-				label="JGLOBAL_SHOW_INTRO_LABEL"
-				description="JGLOBAL_SHOW_INTRO_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_category" 
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="link_category" 
-				type="list"
-				label="JGLOBAL_LINK_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-
-			<field 
-				name="show_parent_category" 
-				type="list"
-				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="link_parent_category" 
-				type="list"
-				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
-				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-			
-			<field
-				name="show_associations"
-				type="list"
-				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
-				description="JGLOBAL_SHOW_ASSOCIATIONS_DESC"
-				useglobal="true"
-				>
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-			</field>
-
-			<field 
-				name="show_author" 
-				type="list"
-				label="JGLOBAL_SHOW_AUTHOR_LABEL"
-				description="JGLOBAL_SHOW_AUTHOR_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="link_author" 
-				type="list"
-				label="JGLOBAL_LINK_AUTHOR_LABEL"
-				description="JGLOBAL_LINK_AUTHOR_DESC"
-				useglobal="true"
-				>
-				<option value="0">JNo</option>
-				<option value="1">JYes</option>
-			</field>
-
-			<field 
-				name="show_create_date" 
-				type="list"
-				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
-				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_modify_date" 
-				type="list"
-				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
-				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_publish_date" 
-				type="list"
-				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
-				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_item_navigation" 
-				type="list"
-				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
-				description="JGLOBAL_SHOW_NAVIGATION_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_vote" 
-				type="list"
-				label="JGLOBAL_SHOW_VOTE_LABEL"
-				description="JGLOBAL_SHOW_VOTE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option	value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_readmore"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
-				name="show_readmore_title"
-				type="list"
-				label="JGLOBAL_SHOW_READMORE_TITLE_LABEL"
-				description="JGLOBAL_SHOW_READMORE_TITLE_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_icons" 
-				type="list"
-				label="JGLOBAL_SHOW_ICONS_LABEL"
-				description="JGLOBAL_SHOW_ICONS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_print_icon" 
-				type="list"
-				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
-				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_email_icon" 
-				type="list"
-				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
-				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_hits" 
-				type="list"
-				label="JGLOBAL_SHOW_HITS_LABEL"
-				description="JGLOBAL_SHOW_HITS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="show_noauth" 
-				type="list"
-				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
-				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
-				useglobal="true"
-				>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
-		</fieldset>
-		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL">
-
-			<field 
-				name="show_feed_link" 
-				type="list"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
-				description="JGLOBAL_SHOW_FEED_LINK_DESC"
-				useglobal="true"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field 
-				name="feed_summary" 
-				type="list"
-				label="JGLOBAL_FEED_SUMMARY_LABEL"
-				description="JGLOBAL_FEED_SUMMARY_DESC"
-				useglobal="true"
-				>
-				<option value="0">JGLOBAL_INTRO_TEXT</option>
-				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
When we have multiple layouts (menu item types) for the same component view, we more or less copy the whole manifest and just add or remove a few parameters from it. The rest is duplicated code.
This can be seen for example when looking at the manifests for the com_content category view and its two layouts ([blog](https://github.com/joomla/joomla-cms/blob/staging/components/com_content/views/category/tmpl/blog.xml) and [list/default](https://github.com/joomla/joomla-cms/blob/staging/components/com_content/views/category/tmpl/default.xml)).
When we add a new feature to the view itself, we have to maintain the parameters in both layout manifests.
#### Summary of Changes

This PR makes use of the existing (probably not very well known) view and component manifest feature. Instead of duplicating the parameters in each layout manifest, we now can just specify to include the view and/or component manifest file and put the shared parameters into those manifests.
With this PR Joomla will now first load the layout manifest file (eg the default.xml one) and if it specifies to load one of the "parent" files it will load the view and/or the component one (metadata.xml).

When parameters are specified in multiple files, then the layout file takes precedence over the view file over the component file.
Also parameters specified in the "parent" files will appear _after_ the parameters defined in the layout file.

This PR changes the menu item model to load those option files and moves the shared parameters from the com_content category view to the view manfiest file so we have a good test case :smile: 
#### Testing Instructions
- Check the parameters in the category view of com_content (`category list` and `category blog`) and verify that all are still there after applying the PR
- Check the functionality of the parameters, there should be no change at all.
#### Side Effects

When working on this PR I detected a few inconsistencies between the two layouts:
- The blog layout has an additional option for the parameters in the "Options" tab called "Use Article Settings". That option was missing in the list layout. It's now available in both layouts.
- The blog layout has two additional parameters in the "Options" tab called `Position of Article Info` and `Show Tags`. Those are used in the blog layout itself (and not in the list layout), however in the single article view they exist as well. We could move them to the view file as well but I left it for now since it is a good showcase for how it will work :smile: 
