### PR TITLE
Support a new plugin group: pagecache

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -65,8 +65,14 @@ class PlgSystemCache extends JPlugin
 			$this->app = JFactory::getApplication();
 		}
 
-		$this->_cache     = JCache::getInstance('page', $options);
-		$this->_cache_key = JUri::getInstance()->toString();
+		$this->_cache = JCache::getInstance('page', $options);
+
+		JPluginHelper::importPlugin('pagecache');
+
+		$parts = JEventDispatcher::getInstance()->trigger('onPageCacheGetKey');
+		$parts[] = JUri::getInstance()->toString();
+
+		$this->_cache_key = serialize($parts);
 	}
 
 	/**

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -114,7 +114,7 @@ class PlgSystemCache extends JPlugin
 			return;
 		}
 
-		// If any pagecache plugins return false for onPageCacheSetCaching, do not cache.
+		// If any pagecache plugins return false for onPageCacheSetCaching, do not use the cache.
 		JPluginHelper::importPlugin('pagecache');
 
 		$results = JEventDispatcher::getInstance()->trigger('onPageCacheSetCaching');

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -86,7 +86,7 @@ class PlgSystemCache extends JPlugin
 			$parts = JEventDispatcher::getInstance()->trigger('onPageCacheGetKey');
 			$parts[] = JUri::getInstance()->toString();
 
-			$key = serialize($parts);
+			$key = md5(serialize($parts));
 		}
 
 		return $key;


### PR DESCRIPTION
This PR introduces a new plugin group `pagecache` which is used by the `System - Cache` plugin. 

Currently, the page URI (and only the page URI) is used as the cache key. With this change, by using a plugin in the `pagecache` group, the key can be made more complex. An event `onPageCacheGetKey` will be triggered and any return values from `pagecache` plugins will be added to the key. This means the cache key could be based on any number of additional factors including but not limited to:
- Cookie values
- Visitor's IP address
- Time of day
- External data of some kind
#### Testing Instructions

The most basic test is to turn on page caching and see that it still works as usual. With no `pagecache` plugins installed, there should be no change in the functionality of the `System - Cache` plugin. 

For a more complete test, you will need one or more `pagecache` plugins that respond to the `onPageCacheGetKey` event. 
#### Next Step

There's obviously a bit more that can be done here. Plugins in the `pagecache` group should be able to do a little more such as to determine whether or not a page should be cached at all or, if there is cached data for the current key, whether or not to actually use it. These and other events can easily be added if there is any interest in something like this. 
