### PR TITLE
[com_menus] items view: cleaner tree prefix

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -169,7 +169,8 @@ $colSpan = ($assoc) ? 10 : 9;
 							<?php echo JHtml::_('MenusHtml.Menus.state', $item->published, $i, $canChange, 'cb'); ?>
 						</td>
 						<td>
-							<?php echo str_repeat('<span class="gi">|&mdash;</span>', $item->level - 1) ?>
+							<?php $prefix = JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
+							<?php echo $prefix; ?>
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'items.', $canCheckin); ?>
 							<?php endif; ?>
@@ -190,9 +191,9 @@ $colSpan = ($assoc) ? 10 : 9;
 								<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note));?>
 							<?php endif; ?>
 							</span>
-							<div class="small" title="<?php echo $this->escape($item->path);?>">
-								<?php echo str_repeat('<span class="gtr">&mdash;</span>', $item->level - 1) ?>
-								<span title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
+							<div title="<?php echo $this->escape($item->path); ?>">
+								<?php echo $prefix; ?>
+								<span class="small"  title="<?php echo isset($item->item_type_desc) ? htmlspecialchars($this->escape($item->item_type_desc), ENT_COMPAT, 'UTF-8') : ''; ?>">
 									<?php echo $this->escape($item->item_type); ?></span>
 							</div>
 						</td>

--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -22,5 +22,5 @@ extract($displayData);
 
 if ($level > 1)
 {
-	echo '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', (int) $level - 2) . '&#9482;</span>&nbsp;&nbsp;&nbsp;';
+	echo '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', (int) $level - 2) . '</span>&ndash;&nbsp;';
 }

--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -22,5 +22,5 @@ extract($displayData);
 
 if ($level > 1)
 {
-	echo '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', (int) $level - 2) . '</span>&ndash;&nbsp;';
+	echo '<span class="muted">' . str_repeat('&#9482;&nbsp;&nbsp;&nbsp;', (int) $level - 2) . '&#9482;</span>&nbsp;&nbsp;&nbsp;';
 }


### PR DESCRIPTION
#### Summary of Changes

This PR does for com_menus items view, the same visual change as the other views that have tree structures.

Also adjusted a little the tree prefix layout to be even more clean and be more adaptabe to multiline contexts.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15389735/37f841b0-1db0-11e6-8cb0-53e2cba5eea3.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15389655/e5ec597e-1daf-11e6-966a-8000a022bb6d.png)
#### Testing Instructions
1. Use latest staging and go to "Menus" -> (Any Menu with levels)
2. Check the "Before" scenario
3. Apply patch
4. Check the "After" scenario.
5. Check the adjusted tree layout in ACL Permissions, User Groups, Categories, Debug permission report, etc
