### PR TITLE
Modal com_content: improve Select & Edit Article (Update)

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -19,7 +19,7 @@ class JFormFieldModal_Article extends JFormField
 	/**
 	 * The form field type.
 	 *
-	 * @var		string
+	 * @var     string
 	 * @since   1.6
 	 */
 	protected $type = 'Modal_Article';
@@ -27,7 +27,7 @@ class JFormFieldModal_Article extends JFormField
 	/**
 	 * Method to get the field input markup.
 	 *
-	 * @return  string	The field input markup.
+	 * @return  string  The field input markup.
 	 *
 	 * @since   1.6
 	 */
@@ -39,6 +39,9 @@ class JFormFieldModal_Article extends JFormField
 		// Load language
 		JFactory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
+		// The active article id field.
+		$value = (int) $this->value > 0 ? (int) $this->value : '';
+
 		// Build the script.
 		$script = array();
 
@@ -49,7 +52,7 @@ class JFormFieldModal_Article extends JFormField
 
 		if ($allowEdit)
 		{
-			$script[] = '		if (id == "' . (int) $this->value . '") {';
+			$script[] = '		if (id == "' . $value . '") {';
 			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
 			$script[] = '		} else {';
 			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
@@ -69,6 +72,11 @@ class JFormFieldModal_Article extends JFormField
 			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
 		}
 
+		$script[] = '	}';
+
+		// Edit button script
+		$script[] = '	function jEditArticle_' . $value . '(title) {';
+		$script[] = '		document.getElementById("' . $this->id . '_name").value = title;';
 		$script[] = '	}';
 
 		// Clear button script
@@ -95,22 +103,30 @@ class JFormFieldModal_Article extends JFormField
 
 		// Setup variables for display.
 		$html = array();
-		$linkArticles = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;function=jSelectArticle_' . $this->id;
-		$linkArticle = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component&amp;task=article.edit';
+
+		$linkArticles = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component'
+			. '&amp;function=jSelectArticle_' . $this->id;
+
+		$linkArticle  = 'index.php?option=com_content&amp;view=article&amp;layout=modal&amp;tmpl=component'
+			. '&amp;task=article.edit'
+			. '&amp;function=jEditArticle_' . $value;
 
 		if (isset($this->element['language']))
 		{
 			$linkArticles .= '&amp;forcedLanguage=' . $this->element['language'];
-			$linkArticle .= '&amp;forcedLanguage=' . $this->element['language'];
+			$linkArticle  .= '&amp;forcedLanguage=' . $this->element['language'];
 		}
 
-		if ((int) $this->value > 0)
+		$urlSelect = $linkArticles . '&amp;' . JSession::getFormToken() . '=1';
+		$urlEdit   = $linkArticle . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
+
+		if ($value)
 		{
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('title'))
 				->from($db->quoteName('#__content'))
-				->where($db->quoteName('id') . ' = ' . (int) $this->value);
+				->where($db->quoteName('id') . ' = ' . (int) $value);
 			$db->setQuery($query);
 
 			try
@@ -127,58 +143,51 @@ class JFormFieldModal_Article extends JFormField
 		{
 			$title = JText::_('COM_CONTENT_SELECT_AN_ARTICLE');
 		}
+
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-
-		// The active article id field.
-		if (0 == (int) $this->value)
-		{
-			$value = '';
-		}
-		else
-		{
-			$value = (int) $this->value;
-		}
-
-		$urlSelect = $linkArticles . '&amp;' . JSession::getFormToken() . '=1';
-		$urlEdit = $linkArticle . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
 
 		// The current article display field.
 		$html[] = '<span class="input-append">';
-		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
-		$html[] = '<a href="#articleSelect' . $this->id . 'Modal" class="btn hasTooltip" role="button" data-toggle="modal" title="'
-			. JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '">'
-			. '<span class="icon-file"></span> '
-			. JText::_('JSELECT') . '</a>';
+		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+
+		// Select article button
+		$html[] = '<a'
+			. ' class="btn hasTooltip"'
+			. ' data-toggle="modal"'
+			. ' role="button"'
+			. ' href="#articleSelect' . $this->id . 'Modal"'
+			. ' title="' . JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '">'
+			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+			. '</a>';
 
 		// Edit article button
 		if ($allowEdit)
 		{
-			$html[] = '<a id="' . $this->id . '_edit" href="#articleEdit' . $this->id . 'Modal" class="btn hasTooltip'
-				. ($value ? '' : ' hidden') . '" role="button" data-toggle="modal" title="'
-				. JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
-				. '<span class="icon-edit"></span> '
-				. JText::_('JACTION_EDIT') . '</a>';
+			$html[] = '<a'
+				. ' class="btn hasTooltip' . ($value ? '' : ' hidden') . '"'
+				. ' id="' . $this->id . '_edit"'
+				. ' data-toggle="modal"'
+				. ' role="button"'
+				. ' href="#articleEdit' . $value . 'Modal"'
+				. ' title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
+				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '</a>';
 		}
 
 		// Clear article button
 		if ($allowClear)
 		{
-			$html[] = '<button id="' . $this->id . '_clear" class="btn' . ($value ? '' : ' hidden') . '" onclick="return jClearArticle(\'' .
-				$this->id . '\')"><span class="icon-remove"></span>' . JText::_('JCLEAR') . '</button>';
+			$html[] = '<button'
+				. ' class="btn' . ($value ? '' : ' hidden') . '"'
+				. ' id="' . $this->id . '_clear"'
+				. ' onclick="return jClearArticle(\'' . $this->id . '\')">'
+				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '</button>';
 		}
 
 		$html[] = '</span>';
 
-		// The class='required' for client side validation
-		$class = '';
-
-		if ($this->required)
-		{
-			$class = ' class="required modal-value"';
-		}
-
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
-
+		// Select article modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
 			'articleSelect' . $this->id . 'Modal',
@@ -194,9 +203,10 @@ class JFormFieldModal_Article extends JFormField
 			)
 		);
 
+		// Edit article modal
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',
-			'articleEdit' . $this->id . 'Modal',
+			'articleEdit' . $value . 'Modal',
 			array(
 				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CONTENT_EDIT_ARTICLE'),
@@ -207,13 +217,21 @@ class JFormFieldModal_Article extends JFormField
 				'modalWidth'  => '80',
 				'bodyHeight'  => '70',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-						. '<button type="button" class="btn btn-success" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#articleEdit' . $this->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
+						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
+						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
+						. '<button type="button" class="btn btn-success" aria-hidden="true"'
+						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
+						. JText::_("JAPPLY") . '</button>'
 			)
 		);
+
+		// Note: class='required' for client side validation.
+		$class = $this->required ? ' class="required modal-value"' : '';
+
+		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -25,6 +25,7 @@ $params = $this->state->get('params');
 
 $app = JFactory::getApplication();
 $input = $app->input;
+
 $assoc = JLanguageAssociations::isEnabled();
 
 // This checks if the config options have ever been saved. If they haven't they will fall back to the original settings.
@@ -68,13 +69,22 @@ JFactory::getDocument()->addScriptDeclaration('
 			jQuery("#permissions-sliders select").attr("disabled", "disabled");
 			' . $this->form->getField('articletext')->save() . '
 			Joomla.submitform(task, document.getElementById("item-form"));
+
+			if (task !== "article.apply")
+			{
+				window.parent.jQuery("#articleEdit' . (int) $this->item->id . 'Modal").modal("hide");
+			}
 		}
 	};
 ');
 
+// In case of modal
+$isModal = $input->get('layout') == 'modal' ? true : false;
+$layout = $isModal ? 'modal' : 'edit';
+$tmpl = $isModal ? '&tmpl=component' : '';
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_content&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php?option=com_content&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
 	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
@@ -127,10 +137,12 @@ JFactory::getDocument()->addScriptDeclaration('
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
-		<?php if ($assoc && $input->get('layout') != 'modal') : ?>
+		<?php if ( ! $isModal && $assoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
-				<?php echo $this->loadTemplate('associations'); ?>
+			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
+		<?php elseif ($isModal && $assoc) : ?>
+			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
 		<?php $this->show_options = $params->show_article_options; ?>
@@ -153,7 +165,5 @@ JFactory::getDocument()->addScriptDeclaration('
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>" />
 		<?php echo JHtml::_('form.token'); ?>
-
-
-		</div>
+	</div>
 </form>

--- a/administrator/components/com_content/views/article/tmpl/modal.php
+++ b/administrator/components/com_content/views/article/tmpl/modal.php
@@ -10,8 +10,20 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+
+$function  = JFactory::getApplication()->input->getCmd('function', 'jEditArticle_' . (int) $this->item->id);
+
+// Function to update input title when changed
+JFactory::getDocument()->addScriptDeclaration('
+	function jEditArticleModal() {
+		if (window.parent && document.formvalidator.isValid(document.getElementById("item-form"))) {
+			return window.parent.' . $this->escape($function) . '(document.getElementById("jform_title").value);
+		}
+	}
+');
 ?>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.save');"></button>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.apply'); jEditArticleModal();"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.save'); jEditArticleModal();"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('article.cancel');"></button>
 
 <div class="container-popup">

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -18,7 +18,9 @@ if ($app->isSite())
 
 require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
+// Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
@@ -40,9 +42,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<div class="clearfix"></div>
 
 		<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
-		</div>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
 		<?php else : ?>
 			<table class="table table-striped table-condensed">
 				<thead>


### PR DESCRIPTION
Improve modals to select and to edit an article. (Update for PR #10292 (merged in staging) + patch PR 10522)
**Note: to be testing on staging.**
#### Summary of Changes
- Control if modal, in edit layout
- Add <code>Save</code> (keep modal open), <code>Save & Close</code> and <code>Close</code> button to the footer of the modal
- Fix closing of Modal when edit validation returns an error (does not close the modal, and display alert message in modal)
- Add function to update input title when changed
- A few code improvements (simplify)
#### Testing Instructions (Staging + Multilanguages enabled!)
- Go to Content > Articles > open an article, and go to <code>Associations</code> tab to select associated article to open the modal.
- Select an associated article and save the article to show edit button
- Click on Save and Save & Close with a correct edition (no error), and then with an empty title, or any other possible error (not filled required field).
- Expected behavior: If an error, Save & Close won't close the modal, and Save will never close the modal (close only when requested, and on successful edition)
- Edit an article in modal, change title, and save and close : the title in the input field should be then updated with the new title.
- Do the same in a menu item type "Single Article", for Select and Edit article.

Same rendering as for Categories in PR #10441 (screenshots)
