### PR TITLE
Fix loading iframe in modal (issue reported here https://github.com/j…

### DIFF
--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -81,9 +81,31 @@ if (isset($params['keyboard']))
  * Specific hack for Bootstrap 2.3.x
  */
 $script[] = "jQuery(document).ready(function($) {";
-$script[] = "   $('#" . $selector . "').on('shown.bs.modal', function() {";
+$script[] = "   $('#" . $selector . "').on('show.bs.modal', function() {";
 
 $script[] = "       $('body').addClass('modal-open');";
+
+if (isset($params['url']))
+{
+	$iframeHtml = JLayoutHelper::render('joomla.modal.iframe', $displayData);
+
+	// Script for destroying and reloading the iframe
+	$script[] = "       var modalBody = $(this).find('.modal-body');";
+	$script[] = "       modalBody.find('iframe').remove();";
+	$script[] = "       modalBody.prepend('" . trim($iframeHtml) . "');";
+}
+else
+{
+	// Set modalTooltip container to modal ID (selector), and placement to top-left if no data attribute (bootstrap-tooltip-extended.js)
+	$script[] = "       $('.modalTooltip').each(function(){;";
+	$script[] = "           var attr = $(this).attr('data-placement');";
+	$script[] = "           if ( attr === undefined || attr === false ) $(this).attr('data-placement', 'auto-dir top-left')";
+	$script[] = "       });";
+	$script[] = "       $('.modalTooltip').tooltip({'html': true, 'container': '#" . $selector . "'});";
+}
+
+// Adapt modal body max-height to window viewport if needed, when the modal has been made visible to the user.
+$script[] = "   }).on('shown.bs.modal', function() {";
 
 // Get height of the modal elements.
 $script[] = "       var modalHeight = $('div.modal:visible').outerHeight(true),";
@@ -104,13 +126,6 @@ $script[] = "           maxModalBodyHeight = maxModalHeight-(modalHeaderHeight+m
 
 if (isset($params['url']))
 {
-	$iframeHtml = JLayoutHelper::render('joomla.modal.iframe', $displayData);
-
-	// Script for destroying and reloading the iframe
-	$script[] = "       var modalBody = $(this).find('.modal-body');";
-	$script[] = "       modalBody.find('iframe').remove();";
-	$script[] = "       modalBody.prepend('" . trim($iframeHtml) . "');";
-
 	// Set max-height for iframe if needed, to adapt to viewport height.
 	$script[] = "       var iframeHeight = $('.iframe').height();";
 	$script[] = "       if (iframeHeight > maxModalBodyHeight){;";
@@ -120,13 +135,6 @@ if (isset($params['url']))
 }
 else
 {
-	// Set modalTooltip container to modal ID (selector), and placement to top-left if no data attribute (bootstrap-tooltip-extended.js)
-	$script[] = "       $('.modalTooltip').each(function(){;";
-	$script[] = "           var attr = $(this).attr('data-placement');";
-	$script[] = "           if ( attr === undefined || attr === false ) $(this).attr('data-placement', 'auto-dir top-left')";
-	$script[] = "       });";
-	$script[] = "       $('.modalTooltip').tooltip({'html': true, 'container': '#" . $selector . "'});";
-
 	// Set max-height for modal-body if needed, to adapt to viewport height.
 	$script[] = "       if (modalHeight > maxModalHeight){;";
 	$script[] = "           $('.modal-body').css({'max-height': maxModalBodyHeight, 'overflow-y': 'auto'});";


### PR DESCRIPTION
Pull Request for Issue reported by @roland-d : https://github.com/joomla/joomla-cms/pull/10557#issuecomment-220568181.

> When I click the Edit button the modal comes up and I first see the article list which then changes to the edit page.
> Why is the article list shown before the edit screen? I would expect the edit screen without seeing the article list first.
#### Summary of Changes
- When an iframe is loaded inside a modal, this one is destroyed first and then reloaded to use then Jlayout modal iframe, but it could return the issue reported (see Testing Instructions before patch, or @roland-d comment above) when the script is included in modal event handler "shown".
- Adding the iframe rendering inside a "show" event (before the modal has been made visible to the user), solves this issue.
#### Testing Instructions

**Before Patch:**
- Open any Edit modal (article, category, module, contact, newsfeed) : can be found in menu item type "Single ****" or in association tab of article, category, newsfeed, contact edit page
- After click on "Edit" button (the layout loads directly) click on "Close"
- Then click again on "Edit" button, and you may see the list view 1/2 second before the edit layout loads.

**After Patch:**
- Do the same: the edit layout loads each time directly, and the list (contacts, articles...) does not show up anymore before edit view
