### PR TITLE
Fix #6178 (Isis template)

### DIFF
--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -269,11 +269,6 @@ if ($stickyToolbar)
 				<div class="span12">
 					<?php endif; ?>
 					<jdoc:include type="message" />
-					<?php
-					// Show the page title here if the header is hidden
-					if (!$displayHeader) : ?>
-						<h1 class="content-title"><?php echo JHtml::_('string.truncate', $app->JComponentTitle, 0, false, false); ?></h1>
-					<?php endif; ?>
 					<jdoc:include type="component" />
 				</div>
 			</div>


### PR DESCRIPTION
Pull Request for Issue #6178.
cc/ @roland-d @brianteeman @ChristopherRaymond
#### Summary of Changes
- Remove Page Title if "Display Header" is on "No"
#### Testing Instructions
- See : https://github.com/joomla/joomla-cms/issues/6178#issuecomment-220103829 (Option 1 confirmed)
- Go to Isis Template options, and disable the header (Display Header = No)

**Before Patch:**
![capture d ecran 2016-05-18 a 19 38 43](https://cloud.githubusercontent.com/assets/2385058/15368864/527ccc66-1d30-11e6-8fcb-d0b2fd54270b.png)

**After Patch:**
![capture d ecran 2016-05-18 a 19 36 30](https://cloud.githubusercontent.com/assets/2385058/15368810/0cfc0eae-1d30-11e6-857d-96aa235c0c90.png)
