### PR TITLE
Fix "Cancel" button not closing modal images

### DIFF
--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -56,7 +56,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				</div>
 				<div class="pull-right">
 					<button class="btn btn-success button-save-selected" type="button" onclick="<?php if ($this->state->get('field.id')):?>window.parent.jInsertFieldValue(document.getElementById('f_url').value,'<?php echo $this->state->get('field.id');?>');<?php else:?>ImageManager.onok();<?php endif;?>window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');" data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
-					<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
+					<button class="btn button-cancel" type="button" onclick="window.parent.jModalClose();window.parent.jQuery('.modal.in').modal('hide');<?php if (!$this->state->get('field.id')) :
 						// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
 				</div>
 			</div>


### PR DESCRIPTION
Pull Request for Issue reported (and confirmed in 3.5.1) by @roland-d : https://github.com/joomla/joomla-cms/pull/10522#issuecomment-220562095
#### Summary of Changes
- Add <code>window.parent.jModalClose()</code> to <code>onclick</code> for cancel button
#### Testing Instructions
- Open a select image modal (for example, in Article edit, intro image)
- Click on "Cancel" button.
- Before Patch: modal does not close
- After Patch: modal closes
