### PR TITLE
RTL: Align correctly the modal footer buttons

### DIFF
--- a/administrator/templates/hathor/css/template_rtl.css
+++ b/administrator/templates/hathor/css/template_rtl.css
@@ -1301,3 +1301,6 @@ div.toggle-editor {
 div.toggle-editor {
 	margin-top: 14px;
 }
+.modal-footer button {
+	float: left;
+}

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9103,3 +9103,6 @@ a.grid_true {
 .js-pstats-data-details dd {
 	margin-right: 240px;
 }
+.modal-footer button {
+	float: left;
+}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -275,3 +275,8 @@ a.grid_true {
 .js-pstats-data-details dd {
 	margin-right: 240px;
 }
+
+/* Modal footer */
+.modal-footer button {
+	float: left;
+}

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -175,6 +175,9 @@ textarea {
 .rtl .categories-list .collapse {
 	margin: 0 20px 0 0;
 }
+.rtl .modal-footer button {
+	float: left;
+}
 .clearfix {
 	*zoom: 1;
 }

--- a/templates/protostar/less/template_rtl.less
+++ b/templates/protostar/less/template_rtl.less
@@ -18,3 +18,8 @@
 .rtl .categories-list .collapse {
 	margin: 0 20px 0 0;
 }
+
+// Modal footer
+.rtl .modal-footer button {
+	float: left;
+}


### PR DESCRIPTION
Before patch, buttons  are aligned in the same way as LTR

![screen shot 2016-05-21 at 10 51 19](https://cloud.githubusercontent.com/assets/869724/15447453/2820e514-1f43-11e6-89d8-28f6451d52a0.png)

Corrected after Patch:

![screen shot 2016-05-21 at 10 49 15](https://cloud.githubusercontent.com/assets/869724/15447456/35e79288-1f43-11e6-9ddf-80ba4ecd032d.png)

To test, see instructions to display modal 
https://github.com/joomla/joomla-cms/pull/10557
or
https://github.com/joomla/joomla-cms/pull/10522

Set en-gb.xml to `1`  `<rtl>1</rtl>`

@JoomliC @andrepereiradasilva @roland-d 
