### PR TITLE
Article Association Modal Mobile

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -55,7 +55,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<th class="title">
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
-						<th width="10%" class="nowrap">
+						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
 						<th width="15%" class="nowrap">
@@ -64,7 +64,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<th width="5%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
 						</th>
-						<th width="1%" class="nowrap">
+						<th width="1%" class="nowrap hidden-phone">
 						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
 					</tr>
@@ -120,7 +120,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<td class="small hidden-phone">
+						<td class="small">
 							<?php if ($item->language == '*'): ?>
 								<?php echo JText::alt('JALL', 'language'); ?>
 							<?php else:?>
@@ -130,7 +130,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td class="nowrap small hidden-phone">
 							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 						</td>
-						<td>
+						<td class="nowrap small hidden-phone">
 							<?php echo (int) $item->id; ?>
 						</td>
 					</tr>


### PR DESCRIPTION
#### Summary of Changes

Correct display in modal - on mobile devices and display language instead of id
#### Testing Instructions

enable system language plugin for association
make sure you have some articles tagged for a language
go to an article and select associations tab and then select the select an article for editing button to open the modal
Go to a mobile view and you will see that the headers and columns do not match
Apply the patch and the columns match and language column is displayed instead of the id
