### PR TITLE
[tests] Add html5 data- attribute to be used by acceptance tests

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -25,7 +25,7 @@ JHtml::_('formbehavior.chosen');
 							<?php echo JText::_('JGLOBAL_USERNAME'); ?>
 						</label>
 					</span>
-					<input name="username" tabindex="1" id="mod-login-username" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true" />
+					<input name="username" tabindex="1" id="mod-login-username" type="text" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true" data-tests="username" />
 					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_REMIND'); ?>">
 						<span class="icon-help"></span>
 					</a>
@@ -41,7 +41,7 @@ JHtml::_('formbehavior.chosen');
 							<?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 						</label>
 					</span>
-					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"/>
+					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15" data-tests="password"/>
 					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_RESET'); ?>">
 						<span class="icon-help"></span>
 					</a>
@@ -84,7 +84,7 @@ JHtml::_('formbehavior.chosen');
 		<div class="control-group">
 			<div class="controls">
 				<div class="btn-group">
-					<button tabindex="3" class="btn btn-primary btn-block btn-large">
+					<button tabindex="3" class="btn btn-primary btn-block btn-large" data-tests="log in">
 						<span class="icon-lock icon-white"></span> <?php echo JText::_('MOD_LOGIN_LOGIN'); ?>
 					</button>
 				</div>


### PR DESCRIPTION
This pull is created by for the works of the Automated Testing Working Group
#### Summary of Changes

Sometimes we need to write a very complex xpath to locate a element in the page, for example:

$I->click(['xpath' =>  "//*[@id=\"menuList\"]/tbody/tr/td[2]/a[contains(text(), 'weblink')"])

Instead of challenging the location abilities of the tester, is much easier to modify the output of the template by adding attributes that ease the location:

```
$I->fillField(['css' => 'input[data-tests="username"]'], $username);
```

note that is important that our tests are readable, and that has to do with using readable locators.

We came to the conclusion that using `data-` [html5 attribute](https://www.w3.org/TR/2011/WD-html5-20110525/elements.html#embedding-custom-non-visible-data-with-the-data-attributes) we will not affect the accessibility nor the functionality.

This element locators will allow us to make our tests not fail when the name of a button or a title changes like it happened in the past with: https://github.com/joomla-extensions/weblinks/issues/75.

I'm opening this pull request being a small example of the changes that we plan to do in the Joomla templates. We would like to get community feedback to ensure we will not affect anyone with them. 

We have had experiences in the past that this kind of changes can also improve the current output, see for example this issue: https://github.com/joomla/joomla-cms/issues/7207.
#### Testing Instructions
- You should be able to login in Joomla administrator without notice any change
# Notes

Note for Automated Testing Working Group: we originally planned to use css classes for this as we specified at https://docs.joomla.org/Testing_Joomla_Extensions_with_Codeception#Write_complex_locator_VS._modifying_the_output_of_the_tested_website, but after a small performance tests done by me, @yvesh and @810 we have concluded that the tests performance is not affected:

```
As a class: ✔ administrator login: Successful login (34.3448s) <= test repeated 10 times
As an attribute: ✔ administrator login: Successful login (32.3201s)  <= test repeated 10 times
```

And using a `data-tests attribute` make our tests more readable than using `css classes`. Therefore we plan to change the best practice from css classes into data- html5 attributes.
