### PR TITLE
Fix APC for when internal key name is entry_name

### DIFF
--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -57,7 +57,7 @@ class JCacheStorageApc extends JCacheStorage
 			}
 			elseif (isset($key['entry_name']))
 			{
-				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				// Some APC modules changed the internal key name from key to entry_name, HHVM is one such case
 				$name = $key['entry_name'];
 			}
 			else
@@ -149,7 +149,7 @@ class JCacheStorageApc extends JCacheStorage
 			}
 			elseif (isset($key['entry_name']))
 			{
-				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				// Some APC modules changed the internal key name from key to entry_name, HHVM is one such case
 				$internalKey = $key['entry_name'];
 			}
 			else
@@ -189,7 +189,7 @@ class JCacheStorageApc extends JCacheStorage
 			}
 			elseif (isset($key['entry_name']))
 			{
-				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				// Some APC modules changed the internal key name from key to entry_name, HHVM is one such case
 				$internalKey = $key['entry_name'];
 			}
 			else

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -50,8 +50,22 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
-			$name    = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+				$name = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				$name = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$name = $key['key'];
+			}
+
 			$namearr = explode('-', $name);
 
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
@@ -128,8 +142,21 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
-			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+				$internalKey = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				$internalKey = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$internalKey = $key['key'];
+			}
 
 			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
@@ -155,8 +182,21 @@ class JCacheStorageApc extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
-			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// If APCu is being used for this adapter, the internal key name changed with APCu 4.0.7 from key to info
+				$internalKey = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APC modules changed the internal key name from key to entry_name, HHMV is one such case
+				$internalKey = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$internalKey = $key['key'];
+			}
 
 			if (strpos($internalKey, $secret . '-cache-'))
 			{

--- a/libraries/joomla/cache/storage/apcu.php
+++ b/libraries/joomla/cache/storage/apcu.php
@@ -50,8 +50,22 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// The internal key name changed with APCu 4.0.7 from key to info
-			$name    = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// The internal key name changed with APCu 4.0.7 from key to info
+				$name = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APCu modules changed the internal key name from key to entry_name
+				$name = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$name = $key['key'];
+			}
+
 			$namearr = explode('-', $name);
 
 			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
@@ -136,8 +150,21 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// The internal key name changed with APCu 4.0.7 from key to info
-			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// The internal key name changed with APCu 4.0.7 from key to info
+				$internalKey = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APCu modules changed the internal key name from key to entry_name
+				$internalKey = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$internalKey = $key['key'];
+			}
 
 			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
 			{
@@ -163,8 +190,21 @@ class JCacheStorageApcu extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			// The internal key name changed with APCu 4.0.7 from key to info
-			$internalKey = isset($key['info']) ? $key['info'] : $key['key'];
+			if (isset($key['info']))
+			{
+				// The internal key name changed with APCu 4.0.7 from key to info
+				$internalKey = $key['info'];
+			}
+			elseif (isset($key['entry_name']))
+			{
+				// Some APCu modules changed the internal key name from key to entry_name
+				$internalKey = $key['entry_name'];
+			}
+			else
+			{
+				// A fall back for the old internal key name
+				$internalKey = $key['key'];
+			}
 
 			if (strpos($internalKey, $secret . '-cache-'))
 			{


### PR DESCRIPTION
Pull Request for Part of Issue #10220 
#### Summary of Changes

Some APC(u) modules changed the internal key name from `key` to `entry_name`. HHVM is one such case where the APC module uses a different naming.

This addresses the 3 known types of keys for APC(u)
#### Testing Instructions

Merge by code review. 

Passing test with var_dump of the entries in our unit tests showing HHVM apc key name is `entry_name` https://travis-ci.org/photodude/joomla-cms/jobs/132170969
