### PR TITLE
[plg_captcha_recaptcha] Fix for displaying the captcha with Internet Explorer

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -58,9 +58,11 @@ class PlgCaptchaRecaptcha extends JPlugin
 		}
 		else
 		{
-			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
-			JFactory::getDocument()->addScript($file, "text/javascript", true);
+			// Load callback first for browser compatibility
 			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
+			
+			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
+			JHtml::_('script', $file);
 		}
 
 		return true;

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -60,7 +60,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		{
 			// Load callback first for browser compatibility
 			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
-			
+
 			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
 			JHtml::_('script', $file);
 		}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -59,7 +59,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		else
 		{
 			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
-			JHtml::_('script', $file);
+			JFactory::getDocument()->addScript($file, "text/javascript", true);
 			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #9623  .
#### Summary of Changes

Defer implementation of the script google recaptcha.
### Before patch

When you go to single contact page with Internet Explorer, Google Recaptcha does not display all the time.
#### Testing Instructions
1. Install joomla 3.5.1 with sample data for testing, apply patch
2. Publish and configure recaptcha plugin
   ![2016-05-23 13_41_41-joomla 3 - administration - plug-ins _ captcha - recaptcha](https://cloud.githubusercontent.com/assets/5129879/15469645/e72f8fd8-20eb-11e6-8d4f-f88e867c638a.png)
3. Set "Captcha - ReCaptcha" in general configuration, default captcha
   ![2016-05-23 13_43_49-joomla 3 - administration - configuration](https://cloud.githubusercontent.com/assets/5129879/15469684/2784cc1a-20ec-11e6-9198-b0aa1cc4ba73.png)
4. With Internet Explorer, go to home page and navigate to "Single contact"
   ![2016-05-23 13_51_26-single contact](https://cloud.githubusercontent.com/assets/5129879/15469857/3b604d8a-20ed-11e6-9558-ea117523d3cb.png)
5. Google Recaptcha must be display on contact form after multiple refresh or click on menu.
