### PR TITLE
fix so "int(11) unsigned" - will not trigger check fail

### DIFF
--- a/libraries/cms/schema/changeitem/mysql.php
+++ b/libraries/cms/schema/changeitem/mysql.php
@@ -229,9 +229,9 @@ class JSchemaChangeitemMysql extends JSchemaChangeitem
 	{
 		$result = $type1;
 
-		if (strtolower($type1) == "integer" && strtolower(substr($type2, 0, 8)) == 'unsigned')
+		if ((strpos(strtolower($type1), "integer")!==false || strpos(strtolower($type1), "int(")!==false) && strtolower(substr($type2, 0, 8)) == 'unsigned')
 		{
-			$result = 'int(10) unsigned';
+			$result = $type1.' unsigned';
 		}
 
 		return $result;


### PR DESCRIPTION
Pull Request for Issue "Custom DB fix".

ALTER TABLE `#__quiz_r_student_hotspot` CHANGE `c_select_x` `c_select_x` int(11) unsigned NOT NULL  DEFAULT "0";
#### Summary of Changes

Fixing DB check always show errors.
#### Testing Instructions

**Before:**
check provided SQL with SchemaChangesetItem - it gives error, as column is 'int(11) unsigned' and it tries to check for 'int(11)'
**After:**
check Query looking for 'int(11) unsigned'
