### PR TITLE
Fix modal header alignment if parent is centered

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8288,6 +8288,9 @@ body.modal-open {
 .modal-footer {
 	clear: both;
 }
+.modal-header {
+	text-align: left;
+}
 .pull-right {
 	float: left;
 }
@@ -9105,4 +9108,7 @@ a.grid_true {
 }
 .modal-footer button {
 	float: left;
+}
+.modal-header {
+	text-align: right;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8288,3 +8288,6 @@ body.modal-open {
 .modal-footer {
 	clear: both;
 }
+.modal-header {
+	text-align: left;
+}

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -280,3 +280,8 @@ a.grid_true {
 .modal-footer button {
 	float: left;
 }
+
+/* Modal Header text align right even if parent container centered */
+.modal-header {
+	text-align: right;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1336,8 +1336,8 @@ textarea.noResize {
 
 /* Prevent scrolling on the parent window of a modal */
 body.modal-open {
-  overflow: hidden;
-  -ms-overflow-style: none;
+	overflow: hidden;
+	-ms-overflow-style: none;
 }
 
 /* Corrects the modals padding */

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1358,3 +1358,8 @@ body.modal-open {
 .modal-footer {
 	clear: both;
 }
+
+/* Modal Header text align left even if parent container centered */
+.modal-header {
+	text-align: left;
+}


### PR DESCRIPTION
When the parent container has class center, where a modal is rendered, the modal-header is centered too (and should be left on LTR and right on RTL).
#### Summary of Changes
- Add text-align in Isis template and rtl less files
#### Testing Instructions
- Go to <code>Menus</code> > <code>Manage</code>
- Click on "Module" button to select a module to be edited (open a modal).
- The Modal Header should be now aligned left (right on RTL).

**Before Patch:**
![capture d ecran 2016-05-23 a 18 20 03](https://cloud.githubusercontent.com/assets/2385058/15477059/19292766-2113-11e6-9545-855cc410fee1.png)

**After Patch:**
![capture d ecran 2016-05-23 a 18 20 37](https://cloud.githubusercontent.com/assets/2385058/15477069/2077872e-2113-11e6-9723-6ead044981b5.png)

cc/ @infograf768 @andrepereiradasilva 
