### PR TITLE
Rename update site names

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-01.sql
@@ -1,3 +1,7 @@
+-- Rename update site names
+UPDATE `#__update_sites` SET `name` = 'Joomla! Core' WHERE `name` = 'Joomla Core' AND `type` = 'collection';
+UPDATE `#__update_sites` SET `name` = 'Joomla! Extension Directory' WHERE `name` = 'Joomla Extension Directory' AND `type` = 'collection';
+
 UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/core/list.xml' WHERE `name` = 'Joomla! Core' AND `type` = 'collection';
 UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/jed/list.xml' WHERE `name` = 'Joomla! Extension Directory' AND `type` = 'collection';
 UPDATE `#__update_sites` SET `location` = 'https://update.joomla.org/language/translationlist_3.xml' WHERE `name` = 'Accredited Joomla! Translations' AND `type` = 'collection';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-01.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-01.sql
@@ -1,3 +1,7 @@
+-- Rename update site names
+UPDATE "#__update_sites" SET "name" = 'Joomla! Core' WHERE "name" = 'Joomla Core' AND "type" = 'collection';
+UPDATE "#__update_sites" SET "name" = 'Joomla! Extension Directory' WHERE "name" = 'Joomla Extension Directory' AND "type" = 'collection';
+
 UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/core/list.xml' WHERE "name" = 'Joomla! Core' AND "type" = 'collection';
 UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/jed/list.xml' WHERE "name" = 'Joomla! Extension Directory' AND "type" = 'collection';
 UPDATE "#__update_sites" SET "location" = 'https://update.joomla.org/language/translationlist_3.xml' WHERE "name" = 'Accredited Joomla! Translations' AND "type" = 'collection';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-01.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-01.sql
@@ -1,3 +1,7 @@
+-- Rename update site names
+UPDATE [#__update_sites] SET [name] = 'Joomla! Core' WHERE [name] = 'Joomla Core' AND [type] = 'collection';
+UPDATE [#__update_sites] SET [name] = 'Joomla! Extension Directory' WHERE [name] = 'Joomla Extension Directory' AND [type] = 'collection';
+
 UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/core/list.xml' WHERE [name] = 'Joomla! Core' AND [type] = 'collection';
 UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/jed/list.xml' WHERE [name] = 'Joomla! Extension Directory' AND [type] = 'collection';
 UPDATE [#__update_sites] SET [location] = 'https://update.joomla.org/language/translationlist_3.xml' WHERE [name] = 'Accredited Joomla! Translations' AND [type] = 'collection';


### PR DESCRIPTION
Pull Request for Issue #10611 
#### Summary of Changes

Old update site names renamed.
#### Testing Instructions

Install fresh Joomla 3.3.0
Update to Joomla 3.6.0
Go to database #__update_sites table

without PR we have:
![update_sites_j330-to-j360](https://cloud.githubusercontent.com/assets/1245155/15500098/eb9b4d4a-21af-11e6-9da3-29cb32065235.png)

after PR we have the same lines as in freshly installed Joomla 3.6.0:
![update_sites_j330-to-j360_pr](https://cloud.githubusercontent.com/assets/1245155/15500054/b0281c0c-21af-11e6-8d09-d769805645de.png)
