### PR TITLE
Update router.php

### DIFF
--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -319,16 +319,6 @@ class ContentRouter extends JComponentRouterBase
 			return $vars;
 		}
 
-		// First handle archive view
-		if ($item->query['view'] == 'archive')
-		{
-			$vars['year']  = $count >= 2 ? $segments[$count - 2] : null;
-			$vars['month'] = $segments[$count - 1];
-			$vars['view']  = 'archive';
-
-			return $vars;
-		}
-
 		/*
 		 * If there is only one segment, then it points to either an article or a category.
 		 * We test it first to see if it is a category.  If the id and alias match a category,


### PR DESCRIPTION
Pull Request for Issue #9566 .
#### Summary of Changes

eliminated code in router.php that didn't let display single archived articles view
#### Testing Instructions

SEF should be ON.

```
Create several articles: some of them assign to category that has a menu item, some of them assign to category that DOES NOT have a menu item.
Change the state of created articles to "Archive".
Proceed to archive articles view.
Proceed to every article to read them.
```

Expected result
Archive articles should always open normally.

Actual result before patch
Archive articles does not display if no menu item for category exists.
