### PR TITLE
regression: re-adding tos and dob in front-end

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -45,6 +45,7 @@ class PlgUserProfile extends JPlugin
 	public function __construct(& $subject, $config)
 	{
 		parent::__construct($subject, $config);
+		JFormHelper::addFieldPath(__DIR__ . '/field');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for a regression, 3.6.0-alpha TOS do not show-up properly anymore
![capture](https://cloud.githubusercontent.com/assets/5349333/15506530/483a0556-21c8-11e6-8155-6f6fd58154c2.PNG)
#### Summary of Changes

Recent update in file "plugins\user\profile\profile.php" renamed the "fields" directory in "field" and removed the JFormHelper::addFieldPath. Re-added back that line with proper directory.

JFormHelper::addFieldPath(**DIR** . '/field');
#### Testing Instructions

Ensure TOS is working with e.g captcha, association...
