### PR TITLE
Modify installer plugin interface and rewrite installer plugins

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -52,9 +52,9 @@ class InstallerModelInstall extends JModelLegacy
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
 
-		$show_info    = JComponentHelper::getParams('com_installer')->get('show_jed_info', 1);
-		$webinstaller = JPluginHelper::getPlugin('installer', 'webinstaller');
-		$this->state->set('install.show_jed_info', $show_info && !is_object($webinstaller));
+		$showInfo     = JComponentHelper::getParams('com_installer')->get('show_jed_info', 1);
+		$webInstaller = JPluginHelper::getPlugin('installer', 'webinstaller');
+		$this->state->set('install.show_jed_info', $showInfo && !is_object($webInstaller));
 
 		parent::populateState();
 	}
@@ -377,9 +377,11 @@ class InstallerModelInstall extends JModelLegacy
 	}
 
 	/**
-	 * Load the install methods with respective forms installer plugins
+	 * Load the install methods with respective forms from installer plugins
 	 *
 	 * @return  stdClass[]
+	 *
+	 * @since   3.6.0
 	 */
 	public function getInstallTypes()
 	{
@@ -392,7 +394,7 @@ class InstallerModelInstall extends JModelLegacy
 			$dispatcher = JEventDispatcher::getInstance();
 
 			/*
-			 * Those plugin  prior to J3.6 expect the tabSet initialized already, we won't break b/c but ignore returned html.
+			 * Those plugin prior to J3.6 expect the tabSet initialized already, we won't break b/c but ignore returned html.
 			 * Webinstaller is on of those, but it skips tabs on "hathor" template, but again others may not care!
 			 */
 			JHtml::_('bootstrap.startTabSet', 'myTab');

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -48,8 +48,13 @@ class InstallerModelInstall extends JModelLegacy
 
 		$this->setState('message', $app->getUserState('com_installer.message'));
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
+
 		$app->setUserState('com_installer.message', '');
 		$app->setUserState('com_installer.extension_message', '');
+
+		$show_info    = JComponentHelper::getParams('com_installer')->get('show_jed_info', 1);
+		$webinstaller = JPluginHelper::getPlugin('installer', 'webinstaller');
+		$this->state->set('install.show_jed_info', $show_info && !is_object($webinstaller));
 
 		parent::populateState();
 	}
@@ -369,5 +374,56 @@ class InstallerModelInstall extends JModelLegacy
 		$package = JInstallerHelper::unpack($tmp_dest . '/' . $p_file, true);
 
 		return $package;
+	}
+
+	/**
+	 * Load the install methods with respective forms installer plugins
+	 *
+	 * @return  stdClass[]
+	 */
+	public function getInstallTypes()
+	{
+		JPluginHelper::importPlugin('installer');
+
+		$types = array();
+
+		try
+		{
+			$dispatcher = JEventDispatcher::getInstance();
+
+			/*
+			 * Those plugin  prior to J3.6 expect the tabSet initialized already, we won't break b/c but ignore returned html.
+			 * Webinstaller is on of those, but it skips tabs on "hathor" template, but again others may not care!
+			 */
+			JHtml::_('bootstrap.startTabSet', 'myTab');
+
+			// Load before first tab for B/C prior to J3.6, output may be comprise or multiple plugins html
+			ob_start();
+			$dispatcher->trigger('onInstallerViewBeforeFirstTab');
+			$beforeTabs = ob_get_clean();
+
+			if (trim($beforeTabs) != '')
+			{
+				$types[] = (object) array('html' => $beforeTabs);
+			}
+
+			$dispatcher->trigger('onInstallerFetchInstallTypes', array(&$types, true));
+
+			// Load after last tab for B/C prior to J3.6, output may be comprise or multiple plugins html
+			ob_start();
+			$dispatcher->trigger('onInstallerViewAfterLastTab');
+			$afterTabs = ob_get_clean();
+
+			if (trim($afterTabs) != '')
+			{
+				$types[] = (object) array('html' => $afterTabs);
+			}
+		}
+		catch (Exception $e)
+		{
+			$this->setError($e->getMessage());
+		}
+
+		return $types;
 	}
 }

--- a/administrator/components/com_installer/views/default/view.php
+++ b/administrator/components/com_installer/views/default/view.php
@@ -17,6 +17,16 @@ defined('_JEXEC') or die;
 class InstallerViewDefault extends JViewLegacy
 {
 	/**
+	 * @var  bool
+	 */
+	protected $showMessage = false;
+
+	/**
+	 * @var  JObject
+	 */
+	protected $state;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  Configuration array

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -11,36 +11,18 @@ defined('_JEXEC') or die;
 
 // MooTools is loaded for B/C for extensions generating JavaScript in their install scripts, this call will be removed at 4.0
 JHtml::_('behavior.framework', true);
-JHtml::_('jquery.framework');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('script', 'com_installer/install.js', false, true);
 
-JFactory::getDocument()->addScriptDeclaration(
-	'
-	Joomla.submitbutton4 = function() {
-		var form = document.getElementById("adminForm");
-
-		// do field validation
-		if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
-			alert("' . JText::_('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL', true) . '");
-		} else {
-			jQuery("#loading").css("display", "block");
-			form.installtype.value = "url";
-			form.submit();
-		}
-	};
-
+JFactory::getDocument()->addScriptDeclaration('
+	// Keep for B/C. required for webInstaller updates
 	Joomla.submitbuttonInstallWebInstaller = function() {
-		var form = document.getElementById("adminForm");
-		
-		form.install_url.value = "https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml";
-		Joomla.submitbutton4();
+		Joomla.installer.installWebInstaller();
 	};
-
 	// Add spindle-wheel for installations:
 	jQuery(document).ready(function($) {
 		var outerDiv = $("#installer-install");
-		
+
 		$("#loading")
 		.css("top", outerDiv.position().top - $(window).scrollTop())
 		.css("left", "0")
@@ -49,11 +31,9 @@ JFactory::getDocument()->addScriptDeclaration(
 		.css("display", "none")
 		.css("margin-top", "-10px");
 	});
-	'
-);
+');
 
-JFactory::getDocument()->addStyleDeclaration(
-	'
+JFactory::getDocument()->addStyleDeclaration('
 	#loading {
 		background: rgba(255, 255, 255, .8) url(\'' . JHtml::_('image', 'jui/ajax-loader.gif', '', null, true, true) . '\') 50% 15% no-repeat;
 		position: fixed;
@@ -67,8 +47,7 @@ JFactory::getDocument()->addStyleDeclaration(
 		line-height: 2em;
 		color:#333333;
 	}
-	'
-);
+');
 ?>
 <script type="text/javascript">
 	// Set the first tab to active if there is no other active tab
@@ -113,22 +92,18 @@ JFactory::getDocument()->addStyleDeclaration(
 							&nbsp;&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
 						<input class="btn" type="button"
 							value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>"
-							onclick="Joomla.submitbuttonInstallWebInstaller()"/>
+							onclick="Joomla.installer.installWebInstaller()"/>
 					</div>
 				<?php endif; ?>
 
 				<?php echo JHtml::_('bootstrap.startTabSet', 'myTab'); ?>
-
-				<?php if (!count($this->installTypes)) : ?>
-					<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
-				<?php endif; ?>
 
 				<?php foreach ($this->installTypes as $tab) : ?>
 					<?php if (isset($tab->form) && $tab->form instanceof JForm): ?>
 						<?php echo JHtml::_('bootstrap.addTab', 'myTab', $tab->name, $tab->title); ?>
 						<div class="clr"></div>
 						<fieldset class="uploadform">
-							<legend><?php echo $tab->title; ?></legend>
+							<legend><?php echo $tab->description; ?></legend>
 							<?php foreach ($tab->form->getFieldset() as $field): ?>
 								<div class="control-group">
 									<div class="control-label"><?php echo $field->label; ?></div>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -11,7 +11,9 @@ defined('_JEXEC') or die;
 
 // MooTools is loaded for B/C for extensions generating JavaScript in their install scripts, this call will be removed at 4.0
 JHtml::_('behavior.framework', true);
+JHtml::_('jquery.framework');
 JHtml::_('bootstrap.tooltip');
+JHtml::_('script', 'com_installer/install.js', false, true);
 
 JFactory::getDocument()->addScriptDeclaration(
 	'
@@ -21,11 +23,8 @@ JFactory::getDocument()->addScriptDeclaration(
 		// do field validation
 		if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
 			alert("' . JText::_('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL', true) . '");
-		}
-		else
-		{
+		} else {
 			jQuery("#loading").css("display", "block");
-			
 			form.installtype.value = "url";
 			form.submit();
 		}
@@ -35,7 +34,6 @@ JFactory::getDocument()->addScriptDeclaration(
 		var form = document.getElementById("adminForm");
 		
 		form.install_url.value = "https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml";
-		
 		Joomla.submitbutton4();
 	};
 
@@ -64,7 +62,6 @@ JFactory::getDocument()->addStyleDeclaration(
 		filter: alpha(opacity = 80);
 		overflow: hidden;
 	}
-	
 	.j-jed-message {
 		margin-bottom: 40px;
 		line-height: 2em;
@@ -72,9 +69,7 @@ JFactory::getDocument()->addStyleDeclaration(
 	}
 	'
 );
-
 ?>
-
 <script type="text/javascript">
 	// Set the first tab to active if there is no other active tab
 	jQuery(document).ready(function($) {
@@ -83,7 +78,7 @@ JFactory::getDocument()->addStyleDeclaration(
 		};
 		if (!hasTab(localStorage.getItem('tab-href')))
 		{
-			var tabAnchor = $("#myTabTabs li:first a");
+			var tabAnchor = $("#myTabTabs").find("li:first a");
 			window.localStorage.setItem('tab-href', tabAnchor.attr('href'));
 			tabAnchor.click();
 		}
@@ -104,7 +99,7 @@ JFactory::getDocument()->addStyleDeclaration(
 				<!-- Render messages set by extension install scripts here -->
 				<?php if ($this->showMessage) : ?>
 					<?php echo $this->loadTemplate('message'); ?>
-				<?php elseif ($this->showJedAndWebInstaller) : ?>
+				<?php elseif ($this->state->get('install.show_jed_info')) : ?>
 					<div class="alert alert-info j-jed-message"
 						style="margin-bottom: 40px; line-height: 2em; color:#333333;">
 						<?php echo JHtml::_(
@@ -121,17 +116,35 @@ JFactory::getDocument()->addStyleDeclaration(
 							onclick="Joomla.submitbuttonInstallWebInstaller()"/>
 					</div>
 				<?php endif; ?>
+
 				<?php echo JHtml::_('bootstrap.startTabSet', 'myTab'); ?>
-				<?php // Show installation tabs at the start ?>
-				<?php $firstTab = JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
-				<?php // Show installation tabs ?>
-				<?php $tabs = JEventDispatcher::getInstance()->trigger('onInstallerAddInstallationTab', array()); ?>
-				<?php // Show installation tabs at the end ?>
-				<?php $lastTab = JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
-				<?php $tabs = array_merge($firstTab, $tabs, $lastTab); ?>
-				<?php if (!$tabs) : ?>
+
+				<?php if (!count($this->installTypes)) : ?>
 					<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), 'warning'); ?>
 				<?php endif; ?>
+
+				<?php foreach ($this->installTypes as $tab) : ?>
+					<?php if (isset($tab->form) && $tab->form instanceof JForm): ?>
+						<?php echo JHtml::_('bootstrap.addTab', 'myTab', $tab->name, $tab->title); ?>
+						<div class="clr"></div>
+						<fieldset class="uploadform">
+							<legend><?php echo $tab->title; ?></legend>
+							<?php foreach ($tab->form->getFieldset() as $field): ?>
+								<div class="control-group">
+									<div class="control-label"><?php echo $field->label; ?></div>
+									<div class="controls"><?php echo $field->input; ?></div>
+								</div>
+							<?php endforeach; ?>
+							<div class="form-actions">
+								<button type="button" class="btn btn-primary"
+								       onclick="Joomla.installer.submit('<?php echo $tab->name ?>');"><?php echo $tab->button; ?></button>
+							</div>
+						</fieldset>
+						<?php echo JHtml::_('bootstrap.endTab'); ?>
+					<?php else: // B/C for older plugins before Joomla 3.6.0 that echo html directly ?>
+						<?php echo $tab->html; ?>
+					<?php endif; ?>
+				<?php endforeach; ?>
 
 				<?php if ($this->ftp) : ?>
 					<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'ftp', JText::_('COM_INSTALLER_MSG_DESCFTPTITLE')); ?>

--- a/administrator/components/com_installer/views/install/view.html.php
+++ b/administrator/components/com_installer/views/install/view.html.php
@@ -62,7 +62,7 @@ class InstallerViewInstall extends InstallerViewDefault
 
 		if (count($this->installTypes) == 0)
 		{
-			JLog::add(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), JLog::INFO, 'jerror');
+			JLog::add(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), JLog::WARNING, 'jerror');
 		}
 
 		$show = $this->state->get('install.show_jed_info');
@@ -77,6 +77,8 @@ class InstallerViewInstall extends InstallerViewDefault
 		$this->state->set('install.show_jed_info', $show);
 
 		parent::display($tpl);
+
+		$dispatcher->trigger('onInstallerAfterDisplay');
 	}
 
 	/**

--- a/administrator/components/com_installer/views/install/view.html.php
+++ b/administrator/components/com_installer/views/install/view.html.php
@@ -63,8 +63,6 @@ class InstallerViewInstall extends InstallerViewDefault
 		if (count($this->installTypes) == 0)
 		{
 			JLog::add(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), JLog::INFO, 'jerror');
-
-			return;
 		}
 
 		$show = $this->state->get('install.show_jed_info');

--- a/administrator/components/com_installer/views/install/view.html.php
+++ b/administrator/components/com_installer/views/install/view.html.php
@@ -19,6 +19,23 @@ include_once __DIR__ . '/../default/view.php';
 class InstallerViewInstall extends InstallerViewDefault
 {
 	/**
+	 * @var  stdClass
+	 */
+	protected $paths;
+
+	/**
+	 * @var  bool
+	 *
+	 * @deprecated   Use $this->state->get('install.show_jed_info');
+	 */
+	protected $showJedAndWebInstaller;
+
+	/**
+	 * @var  stdClass[]
+	 */
+	protected $installTypes;
+
+	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  Template
@@ -31,17 +48,35 @@ class InstallerViewInstall extends InstallerViewDefault
 	{
 		$paths = new stdClass;
 		$paths->first = '';
-		$state = $this->get('state');
 
-		$this->paths = &$paths;
-		$this->state = &$state;
+		$this->paths        = $paths;
+		$this->state        = $this->get('state');
+		$this->installTypes = $this->get('InstallTypes');
 
-		$this->showJedAndWebInstaller = JComponentHelper::getParams('com_installer')->get('show_jed_info', 1);
+		if ($errors = $this->get('Errors'))
+		{
+			JLog::add(implode('<br>', $errors), JLog::WARNING, 'jerror');
+
+			return;
+		}
+
+		if (count($this->installTypes) == 0)
+		{
+			JLog::add(JText::_('COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND'), JLog::INFO, 'jerror');
+
+			return;
+		}
+
+		$show = $this->state->get('install.show_jed_info');
 
 		JPluginHelper::importPlugin('installer');
 
 		$dispatcher = JEventDispatcher::getInstance();
-		$dispatcher->trigger('onInstallerBeforeDisplay', array(&$this->showJedAndWebInstaller, $this));
+		$dispatcher->trigger('onInstallerBeforeDisplay', array(&$show, $this));
+
+		// Sync both the deprecated and new value
+		$this->showJedAndWebInstaller = $show;
+		$this->state->set('install.show_jed_info', $show);
 
 		parent::display($tpl);
 	}

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -12,62 +12,18 @@ defined('_JEXEC') or die;
 // MooTools is loaded for B/C for extensions generating JavaScript in their install scripts, this call will be removed at 4.0
 JHtml::_('behavior.framework', true);
 JHtml::_('bootstrap.tooltip');
+JHtml::_('script', 'com_installer/install.js', false, true);
 
 JFactory::getDocument()->addScriptDeclaration("
-	Joomla.submitbutton = function()
-	{
-		var form = document.getElementById('adminForm');
-
-		// do field validation
-		if (form.install_package.value == ''){
-			alert('" . JText::_('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true) . "');
-		}
-		else
-		{
-			form.installtype.value = 'upload';
-			form.submit();
-		}
-	};
-
-	Joomla.submitbutton3 = function()
-	{
-		var form = document.getElementById('adminForm');
-
-		// do field validation
-		if (form.install_directory.value == ''){
-			alert('" . JText::_('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_DIRECTORY', true) . "');
-		}
-		else
-		{
-			form.installtype.value = 'folder';
-			form.submit();
-		}
-	};
-
-	Joomla.submitbutton4 = function()
-	{
-		var form = document.getElementById('adminForm');
-
-		// do field validation
-		if (form.install_url.value == '' || form.install_url.value == 'http://' || form.install_url.value == 'https://'){
-			alert('" . JText::_('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL', true) . "');
-		}
-		else
-		{
-			form.installtype.value = 'url';
-			form.submit();
-		}
-	};
-
-	Joomla.submitbuttonInstallWebInstaller = function()
-	{
-		var form = document.getElementById('adminForm');
-
-		form.install_url.value = 'https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml';
-
-		Joomla.submitbutton4();
+	// Keep for B/C. required for webInstaller updates
+	Joomla.submitbuttonInstallWebInstaller = function() {
+		Joomla.installer.installWebInstaller();
 	};
 ");
+JFactory::getDocument()->addStyleDeclaration('
+	.control-label { display: block; min-width: 140px; float: left }
+	.form-action { padding-left: 138px; margin-top: 5px; }
+');
 ?>
 <form enctype="multipart/form-data" action="<?php echo JRoute::_('index.php?option=com_installer&view=install');?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
@@ -79,42 +35,36 @@ JFactory::getDocument()->addScriptDeclaration("
 	<div id="j-main-container">
 <?php endif;?>
 
-	<?php if ($this->showJedAndWebInstaller && !$this->showMessage) : ?>
+	<?php if ($this->state->get('install.show_jed_info') && !$this->showMessage) : ?>
 		<div class="alert j-jed-message" style="margin-bottom: 20px; line-height: 2em; color:#333333; clear:both;">
-			<a href="index.php?option=com_config&view=component&component=com_installer&path=&return=<?php echo urlencode(base64_encode(JUri::getInstance())); ?>" class="close hasTooltip" data-dismiss="alert" title="<?php echo str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')); ?>">&times;</a>
+			<a href="index.php?option=com_config&view=component&component=com_installer&path=&return=<?php echo urlencode(base64_encode(JUri::getInstance())); ?>"
+			   class="close hasTooltip" data-dismiss="alert" title="<?php echo str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')); ?>">&times;</a>
 			<p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>&nbsp;&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
-			<input class="btn" type="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>" onclick="Joomla.submitbuttonInstallWebInstaller()" />
+			<input class="btn" type="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>" onclick="Joomla.installer.installWebInstaller()" />
 		</div>
 	<?php endif; ?>
 
 	<?php if ($this->ftp) : ?>
 		<?php echo $this->loadTemplate('ftp'); ?>
 	<?php endif; ?>
+
 	<div class="width-70 fltlft">
-
-		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewBeforeFirstTab', array()); ?>
-
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_UPLOAD_PACKAGE_FILE'); ?></legend>
-			<label for="install_package"><?php echo JText::_('COM_INSTALLER_PACKAGE_FILE'); ?></label>
-			<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
-			<input class="button" type="button" value="<?php echo JText::_('COM_INSTALLER_UPLOAD_AND_INSTALL'); ?>" onclick="Joomla.submitbutton()" />
-		</fieldset>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_DIRECTORY'); ?></legend>
-			<label for="install_directory"><?php echo JText::_('COM_INSTALLER_INSTALL_DIRECTORY'); ?></label>
-			<input type="text" id="install_directory" name="install_directory" class="input_box" size="70" value="<?php echo $this->state->get('install.directory'); ?>" />			<input type="button" class="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton3()" />
-		</fieldset>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_URL'); ?></legend>
-			<label for="install_url"><?php echo JText::_('COM_INSTALLER_INSTALL_URL'); ?></label>
-			<input type="text" id="install_url" name="install_url" class="input_box" size="70" value="https://" />
-			<input type="button" class="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>" onclick="Joomla.submitbutton4()" />
-		</fieldset>
-
-		<?php JEventDispatcher::getInstance()->trigger('onInstallerViewAfterLastTab', array()); ?>
+		<?php foreach ($this->installTypes as $installType) : ?>
+			<?php if (isset($installType->form) && $installType->form instanceof JForm): ?>
+				<div class="clr"></div>
+				<fieldset class="uploadform">
+					<legend><?php echo $installType->title; ?></legend>
+					<?php foreach ($installType->form->getFieldset() as $field): ?>
+						<div class="control-label"><?php echo $field->label; ?></div>
+						<div class="control-input"><?php echo $field->input; ?></div>
+					<?php endforeach; ?>
+					<div class="form-action"><button type="button" class="btn btn-primary"
+					        onclick="Joomla.installer.submit('<?php echo $installType->name ?>');"><?php echo $installType->button; ?></button></div>
+				</fieldset>
+			<?php else: // B/C for older plugins before Joomla 3.6.0 that echo html directly ?>
+				<?php echo $installType->html; ?>
+			<?php endif; ?>
+		<?php endforeach; ?>
 
 		<input type="hidden" name="type" value="" />
 		<input type="hidden" name="installtype" value="upload" />

--- a/media/com_installer/js/install.js
+++ b/media/com_installer/js/install.js
@@ -1,0 +1,26 @@
+Joomla = Joomla || {};
+
+Joomla.installer = {
+	handlers: [],
+	addHandler: function (type, func) {
+		if (typeof func == 'function') {
+			this.handlers[type] = func;
+		}
+	},
+	triggerHandler: function (type, form) {
+		if (typeof this.handlers[type] == 'function') {
+			return this.handlers[type].apply(this, [form]);
+		}
+		console.log('Unknown install submit button handler: ' + type);
+		return false;
+	},
+	submit: function (type, form) {
+		form = form || document.getElementById('adminForm');
+		var valid = this.triggerHandler(type, form);
+
+		if (valid) {
+			jQuery('#loading').css('display', 'block');
+			form.submit();
+		}
+	}
+};

--- a/media/com_installer/js/install.js
+++ b/media/com_installer/js/install.js
@@ -22,5 +22,18 @@ Joomla.installer = {
 			jQuery('#loading').css('display', 'block');
 			form.submit();
 		}
+	},
+	installWebInstaller: function() {
+		var form = document.getElementById('adminForm');
+		if (typeof form.install_url == 'undefined') {
+			var install_url = document.createElement('input');
+			install_url.type = 'hidden';
+			install_url.name = 'install_url';
+			form.appendChild(install_url);
+		}
+		form.install_url.value = 'https://appscdn.joomla.org/webapps/jedapps/webinstaller.xml';
+		form.installtype.value = 'url';
+		jQuery('#loading').css('display', 'block');
+		form.submit();
 	}
 };

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -28,24 +28,30 @@ class PlgInstallerFolderInstaller  extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
-	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
+	 * @param   array  &$types    An array that will be appended with this plugin's install-type object
+	 *                            Properties of that object:
+	 *                            name: install type name,
+	 *                            title: Title of the install type,
+	 *                            description: Short description for the install type,
+	 *                            button: Submit Button label
+	 *                            form: The JForm instance for the install form OR the html
+	 * @param   bool   $withForm  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
+	public function onInstallerFetchInstallTypes(&$types, $withForm = false)
 	{
 		$app  = JFactory::getApplication('administrator');
 		$type = new stdClass;
 
 		$type->name        = 'folder';
-		$type->description = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
 		$type->title       = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
+		$type->description = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
 		$type->button      = JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON');
 
-		if ($with_form)
+		if ($withForm)
 		{
 			$form = JForm::getInstance('com_installer.install.folder', __DIR__ . '/form.xml');
 
@@ -78,7 +84,7 @@ class PlgInstallerFolderInstaller  extends JPlugin
 		JText::script('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH', true);
 
 		$script = '
-			jQuery(document).ready(function($){
+			jQuery(document).ready(function($) {
 				Joomla.installer.addHandler("folder", function(form) {
 					form = form || document.getElementById("adminForm");
 					// Do field validation 

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -18,78 +18,80 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerFolderInstaller  extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Affects constructor behavior. If true, language files will be loaded automatically.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.1
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
-	 * Textfield or Form of the Plugin.
+	 * Get the install type and the related form for this Plugin.
+	 *
+	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerAddInstallationTab()
+	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
-		$app = JFactory::getApplication('administrator');
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'folder', JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'));
-		?>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></legend>
-			<div class="control-group">
-				<label for="install_directory" class="control-label"><?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></label>
-				<div class="controls">
-					<input
-						type="text"
-						id="install_directory"
-						name="install_directory"
-						class="span5 input_box"
-						size="70"
-						value="<?php echo $app->input->get('install_directory', $app->get('tmp_path')); ?>" />
-				</div>
-			</div>
-			<div class="form-actions">
-				<input type="button" class="btn btn-primary" id="installbutton_directory"
-					value="<?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonfolder()"
-				/>
-			</div>
-		</fieldset>
+		$app  = JFactory::getApplication('administrator');
+		$type = new stdClass();
 
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$type->name        = 'folder';
+		$type->description = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
+		$type->title       = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
+		$type->button      = JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON');
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonfolder = function()
+		if ($with_form)
+		{
+			$form = JForm::getInstance('com_installer.install.folder', __DIR__ . '/form.xml');
+
+			if (!$form instanceof JForm)
 			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_directory.value == "")
-				{
-					alert("' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH') . '");
-				}
-				else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "folder"
-					form.submit();
-				}
-			};
-		');
+				// We cannot render the form so skip this.
+				return true;
+			}
+
+			$form->setFieldAttribute('install_directory', 'default', $app->get('tmp_path'));
+			$form->bind(array('install_directory' => $app->input->get('install_directory')));
+
+			$type->form = $form;
+
+			$this->addScript();
+		}
+
+		$types[] = $type;
 
 		return true;
+	}
+
+	/**
+	 * Add the install submit handler script to the page
+	 *
+	 * @return  void
+	 */
+	private function addScript()
+	{
+		JText::script('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH', true);
+
+		$script = '
+			jQuery(document).ready(function($){
+				Joomla.installer.addHandler("folder", function(form) {
+					form = form || document.getElementById("adminForm");
+					// Do field validation 
+					if (form.install_directory.value == "") {
+						alert(Joomla.JText._("PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH"));
+						return false;
+					}
+					form.installtype.value = "folder";
+					return true;
+				});
+			});
+		';
+
+		JFactory::getDocument()->addScriptDeclaration($script);
 	}
 }

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -28,7 +28,7 @@ class PlgInstallerFolderInstaller  extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
 	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
@@ -38,7 +38,7 @@ class PlgInstallerFolderInstaller  extends JPlugin
 	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
 		$app  = JFactory::getApplication('administrator');
-		$type = new stdClass();
+		$type = new stdClass;
 
 		$type->name        = 'folder';
 		$type->description = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');

--- a/plugins/installer/folderinstaller/folderinstaller.xml
+++ b/plugins/installer/folderinstaller/folderinstaller.xml
@@ -12,6 +12,7 @@
 
 	<files>
 		<filename plugin="folderinstaller">folderinstaller.php</filename>
+		<filename>form.xml</filename>
 	</files>
 
 	<languages>

--- a/plugins/installer/folderinstaller/form.xml
+++ b/plugins/installer/folderinstaller/form.xml
@@ -1,8 +1,8 @@
 <form>
 	<field
+		type="text"
 		name="install_directory"
 		label="PLG_INSTALLER_FOLDERINSTALLER_TEXT"
-		type="text"
 		class="span5 input_box"
 		size="70"
 	/>

--- a/plugins/installer/folderinstaller/form.xml
+++ b/plugins/installer/folderinstaller/form.xml
@@ -1,0 +1,9 @@
+<form>
+	<field
+		name="install_directory"
+		label="PLG_INSTALLER_FOLDERINSTALLER_TEXT"
+		type="text"
+		class="span5 input_box"
+		size="70"
+	/>
+</form>

--- a/plugins/installer/packageinstaller/form.xml
+++ b/plugins/installer/packageinstaller/form.xml
@@ -1,8 +1,8 @@
 <form>
 	<field
+		type="file"
 		name="install_package"
 		label="PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE"
-		type="file"
 		class="input_box"
 		size="57"
 	/>

--- a/plugins/installer/packageinstaller/form.xml
+++ b/plugins/installer/packageinstaller/form.xml
@@ -1,0 +1,9 @@
+<form>
+	<field
+		name="install_package"
+		label="PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE"
+		type="file"
+		class="input_box"
+		size="57"
+	/>
+</form>

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -29,14 +29,20 @@ class PlgInstallerPackageInstaller extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
-	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
+	 * @param   array  &$types    An array that will be appended with this plugin's install-type object
+	 *                            Properties of that object:
+	 *                            name: install type name,
+	 *                            title: Title of the install type,
+	 *                            description: Short description for the install type,
+	 *                            button: Submit Button label
+	 *                            form: The JForm instance for the install form OR the html
+	 * @param   bool   $withForm  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
+	public function onInstallerFetchInstallTypes(&$types, $withForm = false)
 	{
 		$type = new stdClass;
 
@@ -45,7 +51,7 @@ class PlgInstallerPackageInstaller extends JPlugin
 		$type->description = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION');
 		$type->button      = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL');
 
-		if ($with_form)
+		if ($withForm)
 		{
 			$form = JForm::getInstance('com_installer.install.package', __DIR__ . '/form.xml');
 
@@ -75,7 +81,7 @@ class PlgInstallerPackageInstaller extends JPlugin
 		JText::script('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE', true);
 
 		$script = '
-			jQuery(document).ready(function($){
+			jQuery(document).ready(function($) {
 				Joomla.installer.addHandler("package", function(form) {
 					form = form || document.getElementById("adminForm");
 					// Do field validation 

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -19,69 +19,76 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerPackageInstaller extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Affects constructor behavior. If true, language files will be loaded automatically.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.1
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
-	 * Textfield or Form of the Plugin.
+	 * Get the install type and the related form for this Plugin.
+	 *
+	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerAddInstallationTab()
+	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'package', JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE'));
-		?>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION'); ?></legend>
-			<div class="control-group">
-				<label for="install_package" class="control-label"><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE'); ?></label>
-				<div class="controls">
-					<input class="input_box" id="install_package" name="install_package" type="file" size="57" />
-				</div>
-			</div>
-			<div class="form-actions">
-				<button class="btn btn-primary" type="button" id="installbutton_package" onclick="Joomla.submitbuttonpackage()">
-					<?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL'); ?></button>
-			</div>
-		</fieldset>
+		$type = new stdClass();
 
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$type->name        = 'package';
+		$type->title       = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE');
+		$type->description = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION');
+		$type->button      = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_AND_INSTALL');
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonpackage = function()
+		if ($with_form)
+		{
+			$form = JForm::getInstance('com_installer.install.package', __DIR__ . '/form.xml');
+
+			if (!$form instanceof JForm)
 			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_package.value == "")
-				{
-					alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE') . '");
-				}
-				else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "upload"
-					form.submit();
-				}
-			};
-		');
+				// We cannot render the form so skip this.
+				return true;
+			}
+
+			$type->form = $form;
+
+			$this->addScript();
+		}
+
+		$types[] = $type;
 
 		return true;
+	}
+
+	/**
+	 * Add the install submit handler script to the page
+	 *
+	 * @return  void
+	 */
+	private function addScript()
+	{
+		JText::script('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE', true);
+
+		$script = '
+			jQuery(document).ready(function($){
+				Joomla.installer.addHandler("package", function(form) {
+					form = form || document.getElementById("adminForm");
+					// Do field validation 
+					if (form.install_package.value == "") {
+						alert(Joomla.JText._("PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE"));
+						return false;
+					}
+					form.installtype.value = "upload";
+					return true;
+				});
+			});
+		';
+
+		JFactory::getDocument()->addScriptDeclaration($script);
 	}
 }

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -29,7 +29,7 @@ class PlgInstallerPackageInstaller extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
 	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
@@ -38,7 +38,7 @@ class PlgInstallerPackageInstaller extends JPlugin
 	 */
 	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
-		$type = new stdClass();
+		$type = new stdClass;
 
 		$type->name        = 'package';
 		$type->title       = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE');

--- a/plugins/installer/packageinstaller/packageinstaller.xml
+++ b/plugins/installer/packageinstaller/packageinstaller.xml
@@ -12,6 +12,7 @@
 
 	<files>
 		<filename plugin="packageinstaller">packageinstaller.php</filename>
+		<filename>form.xml</filename>
 	</files>
 
 	<languages>

--- a/plugins/installer/urlinstaller/form.xml
+++ b/plugins/installer/urlinstaller/form.xml
@@ -1,8 +1,8 @@
 <form>
 	<field
+		type="text"
 		name="install_url"
 		label="PLG_INSTALLER_URLINSTALLER_TEXT"
-		type="text"
 		class="span5 input_box"
 		size="70"
 		hint="https://"

--- a/plugins/installer/urlinstaller/form.xml
+++ b/plugins/installer/urlinstaller/form.xml
@@ -1,0 +1,10 @@
+<form>
+	<field
+		name="install_url"
+		label="PLG_INSTALLER_URLINSTALLER_TEXT"
+		type="text"
+		class="span5 input_box"
+		size="70"
+		hint="https://"
+	/>
+</form>

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -28,14 +28,20 @@ class PlgInstallerUrlInstaller extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
-	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
+	 * @param   array  &$types    An array that will be appended with this plugin's install-type object
+	 *                            Properties of that object:
+	 *                            name: install type name,
+	 *                            title: Title of the install type,
+	 *                            description: Short description for the install type,
+	 *                            button: Submit Button label
+	 *                            form: The JForm instance for the install form OR the html
+	 * @param   bool   $withForm  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
+	public function onInstallerFetchInstallTypes(&$types, $withForm = false)
 	{
 		$type = new stdClass;
 
@@ -44,7 +50,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 		$type->description = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
 		$type->button      = JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON');
 
-		if ($with_form)
+		if ($withForm)
 		{
 			$form = JForm::getInstance('com_installer.install.url', __DIR__ . '/form.xml');
 
@@ -74,7 +80,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 		JText::script('PLG_INSTALLER_URLINSTALLER_NO_URL', true);
 
 		$script = '
-			jQuery(document).ready(function($){
+			jQuery(document).ready(function($) {
 				Joomla.installer.addHandler("url", function(form) {
 					form = form || document.getElementById("adminForm");
 					// Do field validation 

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -18,72 +18,76 @@ JHtml::_('bootstrap.tooltip');
 class PlgInstallerUrlInstaller extends JPlugin
 {
 	/**
-	 * Constructor
+	 * Affects constructor behavior. If true, language files will be loaded automatically.
 	 *
-	 * @param   object  &$subject  The object to observe
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *                             Recognized key values include 'name', 'group', 'params', 'language'
-	 *                             (this list is not meant to be comprehensive).
-	 *
-	 * @since   3.6.0
+	 * @var    boolean
+	 * @since  3.1
 	 */
-	public function __construct(&$subject, $config = array())
-	{
-		$this->autoloadLanguage = true;
-
-		parent::__construct($subject, $config);
-	}
+	protected $autoloadLanguage = true;
 
 	/**
-	 * Textfield or Form of the Plugin.
+	 * Get the install type and the related form for this Plugin.
+	 *
+	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
 	 *
 	 * @since   3.6.0
 	 */
-	public function onInstallerAddInstallationTab()
+	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'url', JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'));
-		?>
-		<div class="clr"></div>
-		<fieldset class="uploadform">
-			<legend><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></legend>
-			<div class="control-group">
-				<label for="install_url"
-				       class="control-label"><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></label>
-				<div class="controls">
-					<input type="text" id="install_url" name="install_url" class="span5 input_box" size="70" placeholder="https://"/>
-				</div>
-			</div>
-			<div class="form-actions">
-				<input type="button" class="btn btn-primary" id="installbutton_url"
-				       value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>"
-				       onclick="Joomla.submitbuttonurl()"
-				/>
-			</div>
-		</fieldset>
+		$type = new stdClass();
 
-		<?php
-		echo JHtml::_('bootstrap.endTab');
+		$type->name        = 'url';
+		$type->title       = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
+		$type->description = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
+		$type->button      = JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON');
 
-		JFactory::getDocument()->addScriptDeclaration('
-			Joomla.submitbuttonurl = function()
+		if ($with_form)
+		{
+			$form = JForm::getInstance('com_installer.install.url', __DIR__ . '/form.xml');
+
+			if (!$form instanceof JForm)
 			{
-				var form = document.getElementById("adminForm");
-		
-				// do field validation 
-				if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
-		            alert("' . JText::_('PLG_INSTALLER_URLINSTALLER_NO_URL', true) . '");
-		        }
-		        else
-				{
-					jQuery("#loading").css("display", "block");
-					form.installtype.value = "url"
-					form.submit();
-				}
-			};
-		');
+				// We cannot render the form so skip this.
+				return true;
+			}
+
+			$type->form = $form;
+
+			$this->addScript();
+		}
+
+		$types[] = $type;
 
 		return true;
+	}
+
+	/**
+	 * Add the install submit handler script to the page
+	 *
+	 * @return  void
+	 */
+	private function addScript()
+	{
+		JText::script('PLG_INSTALLER_URLINSTALLER_NO_URL', true);
+
+		$script = '
+			jQuery(document).ready(function($){
+				Joomla.installer.addHandler("url", function(form) {
+					form = form || document.getElementById("adminForm");
+					// Do field validation 
+					if (form.install_url.value == "" || form.install_url.value == "http://" || form.install_url.value == "https://") {
+						alert(Joomla.JText._("PLG_INSTALLER_URLINSTALLER_NO_URL"));
+						return false;
+					}
+					form.installtype.value = "url";
+					return true;
+				});
+			});
+		';
+
+		JFactory::getDocument()->addScriptDeclaration($script);
 	}
 }

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -28,7 +28,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 	/**
 	 * Get the install type and the related form for this Plugin.
 	 *
-	 * @param   array  $types      An array that will be appended with this plugin's install-type object
+	 * @param   array  &$types     An array that will be appended with this plugin's install-type object
 	 * @param   bool   $with_form  Whether to pass the install type information only or include relevant form/html also
 	 *
 	 * @return  bool  Always returns true
@@ -37,7 +37,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 	 */
 	public function onInstallerFetchInstallTypes(&$types, $with_form = false)
 	{
-		$type = new stdClass();
+		$type = new stdClass;
 
 		$type->name        = 'url';
 		$type->title       = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');

--- a/plugins/installer/urlinstaller/urlinstaller.xml
+++ b/plugins/installer/urlinstaller/urlinstaller.xml
@@ -12,6 +12,7 @@
 
 	<files>
 		<filename plugin="urlinstaller">urlinstaller.php</filename>
+		<filename>form.xml</filename>
 	</files>
 
 	<languages>


### PR DESCRIPTION
This PR decouples html rendering from the installer plugins.
#### Summary of Changes

Move plugin calls out of the layout to the model with appropriate b/c.
Show/hide 'install web installer' message logic is now in populateState method
Check for no plugin installed/enabled is now in the view itself.
Updated the new plugins in 3.6: packageinstaller, folderinstaller and urlinstaller  to new structure and events.
Layout for **isis** and **hathor** templates updated for new structure.

**Deprecating**:
InstallerViewInstall::$showJedAndWebInstaller
onInstallerViewBeforeFirstTab event
onInstallerViewAfterLastTab event

**New Event**:
onInstallerFetchInstallTypes

**Removed Event**:
onInstallerAddInstallationTab (not in public release yet, so no b/c concerns)
#### Testing Instructions

Enable all installer plugins, you should be able to see the relevant install tabs in the install page.
Disabling a plugin should hide the tab from install page.
Disable all plugins should show such message with link to plugin manager.
Reordering installer plugins from plugin manager should affect order of the tabs.
Submit buttons for each install type should perform relevant installation task as earlier.
#### Known Issue

Plugins created with old (now deprecating) triggers that directly echo the output are currently always rendered first on isis template. Internal ordering is still obeyed. (e.g. Install from Web)
