### PR TITLE
Component config: Improve and fix code style, hidden field + Add style for fieldset description

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -37,14 +37,16 @@ JFactory::getDocument()->addScriptDeclaration(
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" id="component-form" method="post" name="adminForm" autocomplete="off" class="form-validate form-horizontal">
 	<div class="row-fluid">
+
 		<!-- Begin Sidebar -->
-		<div id="sidebar" class="span2">
+		<div class="span2" id="sidebar">
 			<div class="sidebar-nav">
 				<?php echo $this->loadTemplate('navigation'); ?>
 			</div>
-		</div>
-		<!-- End Sidebar -->
-		<div class="span10">
+		</div><!-- End Sidebar -->
+
+		<div class="span10" id="config">
+
 			<ul class="nav nav-tabs" id="configTabs">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
 					<?php $rel = ''; ?>
@@ -53,7 +55,7 @@ JFactory::getDocument()->addScriptDeclaration(
 						<?php JHtml::_('script', 'jui/cms.js', false, true); ?>
 						<?php $showonarr = array(); ?>
 						<?php foreach (preg_split('%\[AND\]|\[OR\]%', $fieldSet->showon) as $showonfield) : ?>
-							<?php $showon   = explode(':', $showonfield, 2); ?>
+							<?php $showon = explode(':', $showonfield, 2); ?>
 							<?php $showonarr[] = array(
 								'field'  => $this->form->getFormControl() . '[' . $showon[0] . ']',
 								'values' => explode(',', $showon[1]),
@@ -63,55 +65,55 @@ JFactory::getDocument()->addScriptDeclaration(
 						<?php $rel = ' data-showon=\'' . json_encode($showonarr) . '\''; ?>
 					<?php endif; ?>
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
-					<li<?php echo $rel; ?>><a href="#<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($label); ?></a></li>
+					<li<?php echo $rel; ?>><a data-toggle="tab" href="#<?php echo $name; ?>"><?php echo JText::_($label); ?></a></li>
 				<?php endforeach; ?>
-			</ul>
-			<div class="tab-content">
+			</ul><!-- /configTabs -->
+
+			<div class="tab-content" id="configContent">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
 					<div class="tab-pane" id="<?php echo $name; ?>">
-						<?php
-						if (isset($fieldSet->description) && !empty($fieldSet->description))
-						{
-							echo '<p class="tab-description alert alert-info"><span class="icon-info"></span> ' . JText::_($fieldSet->description) . '</p>';
-						}
-						?>
+						<?php if (isset($fieldSet->description) && !empty($fieldSet->description)) : ?>
+							<div class="tab-description alert alert-info">
+								<span class="icon-info"></span> <?php echo JText::_($fieldSet->description); ?>
+							</div>
+						<?php endif; ?>
 						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-							<?php
-							$datashowon = '';
-							if ($showonstring = $field->getAttribute('showon'))							{
-								JHtml::_('jquery.framework');
-								JHtml::_('script', 'jui/cms.js', false, true);
-								$showonarr = array();
-
-								foreach (preg_split('%\[AND\]|\[OR\]%', $showonstring) as $showonfield)
-								{
-									$showon   = explode(':', $showonfield, 2);
-									$showonarr[] = array(
+							<?php $datashowon = ''; ?>
+							<?php if ($showonstring = $field->getAttribute('showon')) : ?>
+								<?php JHtml::_('jquery.framework'); ?>
+								<?php JHtml::_('script', 'jui/cms.js', false, true); ?>
+								<?php $showonarr = array(); ?>
+								<?php foreach (preg_split('%\[AND\]|\[OR\]%', $showonstring) as $showonfield) : ?>
+									<?php $showon = explode(':', $showonfield, 2); ?>
+									<?php $showonarr[] = array(
 										'field'  => $this->form->getFormControl() . '[' . $this->form->getFieldAttribute($showon[0], 'name') . ']',
 										'values' => explode(',', $showon[1]),
 										'op'     => (preg_match('%\[(AND|OR)\]' . $showonfield . '%', $showonstring, $matches)) ? $matches[1] : ''
-									);
-								}
-								$datashowon = ' data-showon=\'' . json_encode($showonarr) . '\'';
-							}
-							?>
-							<div class="control-group"<?php echo $datashowon; ?>>
-								<?php if (!$field->hidden && $name != "permissions") : ?>
-									<div class="control-label">
-										<?php echo $field->label; ?>
+									); ?>
+								<?php endforeach; ?>
+								<?php $datashowon = ' data-showon=\'' . json_encode($showonarr) . '\''; ?>
+							<?php endif; ?>
+							<?php if ($field->hidden) : ?>
+								<?php echo $field->input; ?>
+							<?php else : ?>
+								<div class="control-group"<?php echo $datashowon; ?>>
+									<?php if ($name != "permissions") : ?>
+										<div class="control-label">
+											<?php echo $field->label; ?>
+										</div>
+									<?php endif; ?>
+									<div class="<?php if ($name != "permissions") : ?>controls<?php endif; ?>">
+										<?php echo $field->input; ?>
 									</div>
-								<?php endif; ?>
-								<div class="<?php if ($name != "permissions") : ?>controls<?php endif; ?>">
-									<?php echo $field->input; ?>
 								</div>
-							</div>
+							<?php endif; ?>
 						<?php endforeach; ?>
 					</div>
 				<?php endforeach; ?>
-			</div>
-		</div>
-	</div>
-	<div>
+			</div><!-- /configContent -->
+
+		</div><!-- /config -->
+
 		<input type="hidden" name="id" value="<?php echo $this->component->id; ?>" />
 		<input type="hidden" name="component" value="<?php echo $this->component->option; ?>" />
 		<input type="hidden" name="return" value="<?php echo $this->return; ?>" />

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -72,7 +72,7 @@ JFactory::getDocument()->addScriptDeclaration(
 						<?php
 						if (isset($fieldSet->description) && !empty($fieldSet->description))
 						{
-							echo '<p class="tab-description">' . JText::_($fieldSet->description) . '</p>';
+							echo '<p class="tab-description alert alert-info"><span class="icon-info"></span> ' . JText::_($fieldSet->description) . '</p>';
 						}
 						?>
 						<?php foreach ($this->form->getFieldset($name) as $field) : ?>


### PR DESCRIPTION
#### Summary of Changes
- Fix code style
- Fix hidden field (no html to be rendered when field is hidden, to prevent empty lines (due to css classes for fields)
- Add style alert-info + icon for the description of a fieldset (description in top of each tab, when filled)
#### Testing Instructions

**Test for fieldset description style:**
- Go to any component configuration page (Options) and check description has now an alert-info look

**Before Patch**:
![capture d ecran 2016-05-24 a 01 07 00](https://cloud.githubusercontent.com/assets/2385058/15537750/69c0c09c-2278-11e6-9056-4fa174745c43.png)

**After Patch**:
![capture d ecran 2016-05-24 a 01 07 30](https://cloud.githubusercontent.com/assets/2385058/15537763/7a143776-2278-11e6-8a05-d9849c795b6d.png)

**Test for hidden fields fix:**
- To test fix for hidden fields, add in a config.xml those lines : 

```
        <field
            name="hidden1"
            type="hidden"
            default="1"
        />

        <field
            name="hidden2"
            type="hidden"
            default="1"
        />

        <field
            name="hidden3"
            type="hidden"
            default="1"
        />

        <field
            name="hidden4"
            type="hidden"
            default="1"
        />
```

**Before Patch**:
![capture d ecran 2016-05-25 a 12 47 05](https://cloud.githubusercontent.com/assets/2385058/15537645/f5342b56-2277-11e6-942d-08207d01bdcb.png)

**After Patch**:
![capture d ecran 2016-05-25 a 12 47 37](https://cloud.githubusercontent.com/assets/2385058/15537661/035877be-2278-11e6-9d6d-f959ae7010c8.png)
- You can control after save, that hidden fields are saved in the database (#__extensions > component params)
