### PR TITLE
[menuitem field] Use the menu title instead of the menu type

### DIFF
--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -165,9 +165,9 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			// If the menutype is empty, group the items by menutype.
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true)
-				->select('title')
-				->from('#__menu_types')
-				->where('menutype = ' . $db->quote($menuType));
+				->select($db->quoteName('title'))
+				->from($db->quoteName('#__menu_types'))
+				->where($db->quoteName('menutype') . ' = ' . $db->quote($menuType));
 			$db->setQuery($query);
 
 			try

--- a/libraries/cms/form/field/menuitem.php
+++ b/libraries/cms/form/field/menuitem.php
@@ -162,8 +162,25 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 		// Build group for a specific menu type.
 		if ($menuType)
 		{
+			// If the menutype is empty, group the items by menutype.
+			$db    = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select('title')
+				->from('#__menu_types')
+				->where('menutype = ' . $db->quote($menuType));
+			$db->setQuery($query);
+
+			try
+			{
+				$menuTitle = $db->loadResult();
+			}
+			catch (RuntimeException $e)
+			{
+				$menuTitle = $menuType;
+			}
+
 			// Initialize the group.
-			$groups[$menuType] = array();
+			$groups[$menuTitle] = array();
 
 			// Build the options array.
 			foreach ($items as $link)
@@ -180,7 +197,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 					$lang = '';
 				}
 
-				$groups[$menuType][] = JHtml::_('select.option',
+				$groups[$menuTitle][] = JHtml::_('select.option',
 								$link->value, $levelPrefix . $link->text . $lang,
 								'value',
 								'text',
@@ -195,7 +212,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 			foreach ($items as $menu)
 			{
 				// Initialize the group.
-				$groups[$menu->menutype] = array();
+				$groups[$menu->title] = array();
 
 				// Build the options array.
 				foreach ($menu->links as $link)
@@ -212,7 +229,7 @@ class JFormFieldMenuitem extends JFormFieldGroupedList
 						$lang = '';
 					}
 
-					$groups[$menu->menutype][] = JHtml::_('select.option',
+					$groups[$menu->title][] = JHtml::_('select.option',
 										$link->value, $levelPrefix . $link->text . $lang,
 										'value',
 										'text',


### PR DESCRIPTION
#### Summary of Changes

As discussed in https://github.com/joomla/joomla-cms/pull/9987#issuecomment-221629798 this PR changes the menu type to the menu title in the menuitem form field.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/15550316/ba2af432-22a8-11e6-8df3-1de5f61c44e4.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/15550284/a46532fc-22a8-11e6-879d-ebfacdb397cc.png)
#### Testing Instructions
1. Add this to one of the xmls (this will create 5 fields with menu items selector):

``` xml
<field name="test1" type="menuitem"></field>
<field name="test2" type="menuitem" menu_type="aboutjoomla"></field>
<field name="test3" type="menuitem" language="*"></field>
<field name="test4" type="menuitem" disable="separator,alias,heading,url"></field>
<field name="test5" type="menuitem" published="0,1"></field>
```
1. Check the fields show the menu type and not the menu title
2. Apply patch
3. Check they now show the menu title and work as before.
