### PR TITLE
Normalising sprintf in debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1782,13 +1782,13 @@ class PlgSystemDebug extends JPlugin
 
 		$showEverything = $this->params->get('log-everything', 0);
 
-		$out .= '<h4>' . JText::sprintf(JText::_('PLG_DEBUG_LOGS_LOGGED'), $logEntriesTotal) . '</h4><br />';
+		$out .= '<h4>' . JText::sprintf('PLG_DEBUG_LOGS_LOGGED', $logEntriesTotal) . '</h4><br />';
 
 		if ($showDeprecated && $logEntriesDeprecated > 0)
 		{
 			$out .= '
 			<div class="alert alert-warning">
-				<h4>' . sprintf(JText::_('PLG_DEBUG_LOGS_DEPRECATED_FOUND_TITLE'), $logEntriesDeprecated) . '</h4>
+				<h4>' . JText::sprintf('PLG_DEBUG_LOGS_DEPRECATED_FOUND_TITLE', $logEntriesDeprecated) . '</h4>
 				<div>' . JText::_('PLG_DEBUG_LOGS_DEPRECATED_FOUND_TEXT') . '</div>
 			</div>
 			<br />';


### PR DESCRIPTION
Pull Request for Issue #10626 (See there for instructions)
Enable Debug System and Debug language in Global configuration.
Set Log Deprecated API to Yes in System debug plugin.

Patch and test again, make sure you get this:
![screen shot 2016-05-26 at 08 17 20](https://cloud.githubusercontent.com/assets/869724/15565543/b8f225a4-231b-11e6-98d9-1680fe3217f3.png)
