### PR TITLE
Replace isSSLConnection method by isHttpsConnection

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -962,14 +962,30 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
+	 * Determine if we are using a secure (HTTPS) connection.
+	 *
+	 * @return  boolean  True if using HTTPS, false if not.
+	 *
+	 * @since   12.2
+	 */
+	public function isHttpsConnection()
+	{
+		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
+	}
+
+	/**
 	 * Determine if we are using a secure (SSL) connection.
 	 *
 	 * @return  boolean  True if using SSL, false if not.
 	 *
 	 * @since   12.2
+	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use the isHttpsConnection() method.
 	 */
 	public function isSSLConnection()
 	{
+		JLog::add(__CLASS__ . '::isSSLConnection() is deprecated. Use the ' . __CLASS__ . '::isHttpsConnection() instead.',
+			JLog::WARNING, 'deprecated');
+
 		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 	}
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -983,8 +983,7 @@ class JApplicationWeb extends JApplicationBase
 	 */
 	public function isSSLConnection()
 	{
-		JLog::add(__CLASS__ . '::isSSLConnection() is deprecated. Use the ' . __CLASS__ . '::isHttpsConnection() instead.',
-			JLog::WARNING, 'deprecated');
+		JLog::add(__CLASS__ . '::isSSLConnection() is deprecated. Use the ' . __CLASS__ . '::isHttpsConnection() instead.', JLog::WARNING, 'deprecated');
 
 		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));
 	}

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -671,11 +671,11 @@ class JBrowser
 	 * @return  boolean  True if using SSL, false if not.
 	 *
 	 * @since   11.1
-	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use the isSSLConnection method on the application object.
+	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use the isHttpsConnection() method on the application object.
 	 */
 	public function isSSLConnection()
 	{
-		JLog::add('JBrowser::isSSLConnection() is deprecated. Use the isSSLConnection method on the application object instead.',
+		JLog::add('JBrowser::isSSLConnection() is deprecated. Use the isHttpsConnection method on the application object instead.',
 			JLog::WARNING, 'deprecated');
 
 		return ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION'));

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -1164,7 +1164,7 @@ class JApplication extends JApplicationBase
 	 * @return  boolean  True if using SSL, false if not.
 	 *
 	 * @since   12.2
-	 * @deprecated  4.0
+	 * @deprecated  4.0 - Use the isHttpsConnection() method instead.
 	 */
 	public function isSSLConnection()
 	{

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1337,6 +1337,7 @@ class JApplicationWebTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   12.2
+	 * @deprecated  4.0 - Replaced by isHttpsConnection().
 	 */
 	public function testIsSSLConnection()
 	{
@@ -1347,5 +1348,23 @@ class JApplicationWebTest extends TestCase
 		$_SERVER['HTTPS'] = 'on';
 
 		$this->assertTrue($this->class->isSSLConnection());
+	}
+
+	/**
+	 * Tests the isHttpsConnection method
+	 *
+	 * @return  void
+	 *
+	 * @since   12.2
+	 */
+	public function testIsHttpsConnection()
+	{
+		unset($_SERVER['HTTPS']);
+
+		$this->assertFalse($this->class->isHttpsConnection());
+
+		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertTrue($this->class->isHttpsConnection());
 	}
 }


### PR DESCRIPTION
#### Summary of Changes

This PR adds the new JApplicationWeb isHttpsConnection method and deprecates the isSSLConnection method.

This correction of the `SSL` term to the `HTTPS` term (the correct one, since HTTPS can use SSL or TLS) was done across Joomla and this PR makes this change in the application method too.
#### Testing Instructions

This has to be tested by code review.
You can also apply the patch and check everything works fine.
#### Observations

If someone can look if the unit tests are ok, it would be appreciated.
