### PR TITLE
[mod_version] Remove deprecated html align attribute and replace it with CSS class

### DIFF
--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -10,5 +10,5 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($version)) : ?>
-	<p align="center"><?php echo $version; ?></p>
+	<p class="text-center"><?php echo $version; ?></p>
 <?php endif; ?>


### PR DESCRIPTION
#### Summary of Changes

Very simple PR to remove the align attribute in mod version for a CSS class.

Note the CSS class used is already in the admin templates 
The css class is already there.
- https://github.com/joomla/joomla-cms/blob/staging/administrator/templates/isis/css/template.css#L594
- https://github.com/joomla/joomla-cms/blob/staging/administrator/templates/hathor/css/template.css#L3786
#### Testing Instructions

Just a very simple change. Code review.
