### PR TITLE
[JDocumentRendererHtmlHead] only add the type attribute in the new script options if it's not an html5 page

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -214,7 +214,14 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if (!empty($scriptOptions))
 		{
-			$buffer .= $tab . '<script type="text/javascript">' . $lnEnd;
+			$buffer .= $tab . '<script';
+
+			if (!$document->isHtml5())
+			{
+				$buffer .= ' type="text/javascript"';
+			}
+
+			$buffer .= '>' . $lnEnd;
 
 			// This is for full XHTML support.
 			if ($document->_mime != 'text/html')


### PR DESCRIPTION
#### Summary of Changes

https://github.com/joomla/joomla-cms/pull/9843 removed all the `type` attributes in html5 pages if they are the default html5 types for js/css.

But https://github.com/joomla/joomla-cms/pull/3072 added a new script options render to JDocument renderer for HTML head.

For consistency, this simple PR does the same for the new script options.
#### Testing Instructions

Very simple PR. Code review.
Or ... you can follow the same test instructions as https://github.com/joomla/joomla-cms/pull/9843 and https://github.com/joomla/joomla-cms/pull/3072.
