### PR TITLE
Bad var name due to too much copy/paste

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -756,7 +756,7 @@ class JMail extends PHPMailer
 		$message = sprintf(JText::_('JLIB_MAIL_MSG_ADMIN'), $adminName, $type, $title, $author, $url, $url, 'administrator', $type);
 		$message .= JText::_('JLIB_MAIL_MSG') . "\n";
 
-		if ($this->addRecipient($recipient) === false)
+		if ($this->addRecipient($adminEmail) === false)
 		{
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue #9881
#### Summary of Changes

Too much copy/pasting led to the wrong variable being used in the `sendAdminMail()` method.  This fixes it.
#### Testing Instructions

Code review.  See https://github.com/joomla/joomla-cms/commit/7fcf7f6d0327976e49704e1f25fc9da2a8f199b7#diff-98e863dabf8033c2313bc92e9c99cc2fL615 to see how the variable changed and how this corrects it back.
