### PR TITLE
[html5] Isis administrator template

### DIFF
--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -55,7 +55,7 @@ if ($this->params->get('linkColor'))
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane component">
 	<jdoc:include type="message" />

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -15,13 +15,16 @@ $lang            = JFactory::getLanguage();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
@@ -41,25 +44,18 @@ if (is_file($file))
 {
 	$doc->addStyleSheetVersion($file);
 }
-?>
 
+// Link color
+if ($this->params->get('linkColor'))
+{
+	$doc->addStyleDeclaration('a { color: ' . $this->params->get('linkColor') . '; }');
+}
+?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
-
-	<!-- Link color -->
-	<?php if ($this->params->get('linkColor')) : ?>
-		<style type="text/css">
-			a
-			{
-				color: <?php echo $this->params->get('linkColor'); ?>;
-			}
-		</style>
-	<?php endif; ?>
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane component">
 	<jdoc:include type="message" />

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -79,11 +79,11 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" rel="stylesheet" />
+		<link href="<?php echo JUri::root(true); ?>/media/cms/css/debug.css" rel="stylesheet" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" rel="stylesheet" />
+		<link href="<?php echo JUri::root(true); ?>/media/jui/css/bootstrap-rtl.css" rel="stylesheet" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>
@@ -123,11 +123,11 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 			}
 		</style>
 	<?php endif; ?>
-	<script src="<?php echo $this->baseurl; ?>/media/jui/js/jquery.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/jui/js/jquery-noconflict.js"></script>
-	<script src="<?php echo $this->baseurl; ?>/media/jui/js/bootstrap.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js"></script>
+	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js"></script>
 	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js"></script>
-	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="admin <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " ";?>" data-spy="scroll" data-target=".subhead" data-offset="87">
 	<!-- Top Navigation -->

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -22,9 +22,15 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
+
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
-$frontEndUri->setScheme(((int) JFactory::getApplication()->get('force_ssl', 0) === 2) ? 'https' : 'http');
+$frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');
 $mainPageUri = $frontEndUri->toString();
 
 // Detecting Active Variables
@@ -65,30 +71,30 @@ $statusFixed   = $params->get('statusFixed', '1');
 $stickyToolbar = $params->get('stickyToolbar', '1');
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<title><?php echo $this->title; ?> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
 		<!-- Load additional CSS styles for debug mode-->
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/cms/css/debug.css" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/media/cms/css/debug.css" rel="stylesheet" />
 	<?php endif; ?>
 	<?php // If Right-to-Left ?>
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo JUri::root(); ?>/media/jui/css/bootstrap-rtl.css" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/media/jui/css/bootstrap-rtl.css" rel="stylesheet" />
 	<?php endif; ?>
 	<?php // Load specific language related CSS ?>
 	<?php $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css'; ?>
 	<?php if (is_file($file)) : ?>
-		<link rel="stylesheet" href="<?php echo $file; ?>" type="text/css" />
+		<link href="<?php echo $file; ?>" rel="stylesheet" />
 	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template<?php echo ($this->direction == 'rtl' ? '-rtl' : ''); ?>.css" type="text/css" />
-	<link href="<?php echo $this->baseurl ?>/templates/<?php echo $this->template; ?>/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/template<?php echo ($this->direction == 'rtl' ? '-rtl' : ''); ?>.css" rel="stylesheet" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
 	<?php // Template color ?>
 	<?php if ($params->get('templateColor')) : ?>
-	<style type="text/css">
+	<style>
 		.navbar-inner, .navbar-inverse .navbar-inner, .nav-list > .active > a, .nav-list > .active > a:hover, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle
 		{
 			background: <?php echo $params->get('templateColor');?>;
@@ -102,7 +108,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // Template header color ?>
 	<?php if ($params->get('headerColor')) : ?>
-	<style type="text/css">
+	<style>
 		.header
 		{
 			background: <?php echo $params->get('headerColor');?>;
@@ -111,21 +117,18 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 	<?php endif; ?>
 	<?php // Sidebar background color ?>
 	<?php if ($params->get('sidebarColor')) : ?>
-		<style type="text/css">
+		<style>
 			.nav-list > .active > a, .nav-list > .active > a:hover {
 				background: <?php echo $params->get('sidebarColor'); ?>;
 			}
 		</style>
 	<?php endif; ?>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery.js" type="text/javascript"></script>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/jquery-noconflict.js" type="text/javascript"></script>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/bootstrap.js" type="text/javascript"></script>
-	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js" type="text/javascript"></script>
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<script src="<?php echo $this->baseurl; ?>/media/jui/js/jquery.js"></script>
+	<script src="<?php echo $this->baseurl; ?>/media/jui/js/jquery-noconflict.js"></script>
+	<script src="<?php echo $this->baseurl; ?>/media/jui/js/bootstrap.js"></script>
+	<script src="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/js/template.js"></script>
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="admin <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " ";?>" data-spy="scroll" data-target=".subhead" data-offset="87">
 	<!-- Top Navigation -->
 	<nav class="navbar navbar-inverse navbar-fixed-top">

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -175,7 +175,7 @@ if ($this->params->get('linkColor'))
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>" data-basepath="<?php echo JURI::root(true); ?>">
 <!-- Top Navigation -->

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -17,9 +17,12 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
-$frontEndUri->setScheme(((int) JFactory::getApplication()->get('force_ssl', 0) === 2) ? 'https' : 'http');
+$frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');
 $mainPageUri = $frontEndUri->toString();
 
 // Add JavaScript Frameworks
@@ -55,7 +58,7 @@ $itemid   = $input->get('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename', ''), ENT_QUOTES, 'UTF-8');
 $cpanel   = ($option === 'com_cpanel');
 
-$hidden = JFactory::getApplication()->input->get('hidemainmenu');
+$hidden = $app->input->get('hidemainmenu');
 
 $showSubmenu          = false;
 $this->submenumodules = JModuleHelper::getModules('submenu');
@@ -119,55 +122,61 @@ if ($stickyToolbar)
 {
 	$stickyBar = 'true';
 }
+
+// Template color
+if ($navbar_color)
+{
+	$doc->addStyleDeclaration("
+	.navbar-inner,
+	.navbar-inverse .navbar-inner,
+	.dropdown-menu li > a:hover,
+	.dropdown-menu .active > a,
+	.dropdown-menu .active > a:hover,
+	.navbar-inverse .nav li.dropdown.open > .dropdown-toggle,
+	.navbar-inverse .nav li.dropdown.active > .dropdown-toggle,
+	.navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle,
+	#status.status-top {
+		background: " . $navbar_color . ";
+	}");
+}
+
+// Template header color
+if ($header_color)
+{
+	$doc->addStyleDeclaration("
+	.header {
+		background: " . $header_color . ";
+	}");
+}
+
+// Sidebar background color
+if ($this->params->get('sidebarColor'))
+{
+	$doc->addStyleDeclaration("
+	.nav-list > .active > a,
+	.nav-list > .active > a:hover {
+		background: " . $this->params->get('sidebarColor') . ";
+	}");
+}
+
+// Link color
+if ($this->params->get('linkColor'))
+{
+	$doc->addStyleDeclaration("
+	a,
+	.j-toggle-sidebar-button {
+		color: " . $this->params->get('linkColor') . ";
+	}");
+}
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-
-	<!-- Template color -->
-	<?php if ($navbar_color) : ?>
-		<style type="text/css">
-			.navbar-inner, .navbar-inverse .navbar-inner, .dropdown-menu li > a:hover, .dropdown-menu .active > a, .dropdown-menu .active > a:hover, .navbar-inverse .nav li.dropdown.open > .dropdown-toggle, .navbar-inverse .nav li.dropdown.active > .dropdown-toggle, .navbar-inverse .nav li.dropdown.open.active > .dropdown-toggle, #status.status-top {
-				background: <?php echo $navbar_color; ?>;
-			}
-		</style>
-	<?php endif; ?>
-	<!-- Template header color -->
-	<?php if ($header_color) : ?>
-		<style type="text/css">
-			.header {
-				background: <?php echo $header_color; ?>;
-			}
-		</style>
-	<?php endif; ?>
-
-	<!-- Sidebar background color -->
-	<?php if ($this->params->get('sidebarColor')) : ?>
-		<style type="text/css">
-			.nav-list > .active > a, .nav-list > .active > a:hover {
-				background: <?php echo $this->params->get('sidebarColor'); ?>;
-			}
-		</style>
-	<?php endif; ?>
-
-	<!-- Link color -->
-	<?php if ($this->params->get('linkColor')) : ?>
-		<style type="text/css">
-			a, .j-toggle-sidebar-button
-			{
-				color: <?php echo $this->params->get('linkColor'); ?>;
-			}
-		</style>
-	<?php endif; ?>
-
-	<!--[if lt IE 9]>
-	<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>" data-basepath="<?php echo JURI::root(true); ?>">
 <!-- Top Navigation -->
 <nav class="navbar<?php echo $navbar_is_light ? '' : ' navbar-inverse'; ?> navbar-fixed-top">
@@ -285,7 +294,7 @@ if ($stickyToolbar)
 
 	<?php if (!$this->countModules('status') || (!$statusFixed && $this->countModules('status'))) : ?>
 		<footer class="footer">
-			<p align="center">
+			<p class="text-center">
 				<jdoc:include type="modules" name="footer" style="no" />
 				&copy; <?php echo $sitename; ?> <?php echo date('Y'); ?></p>
 		</footer>

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -110,7 +110,7 @@ if ($app->get('debug_lang', 1) || $app->get('debug', 1))
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " "; ?>">
 	<!-- Container -->

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -13,9 +13,12 @@ $app  = JFactory::getApplication();
 $doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
+// Output as HTML5
+$doc->setHtml5(true);
+
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
-$frontEndUri->setScheme(((int) JFactory::getApplication()->get('force_ssl', 0) === 2) ? 'https' : 'http');
+$frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');
 
 // Color Params
 $background_color = $this->params->get('loginBackgroundColor') ? $this->params->get('loginBackgroundColor') : '';
@@ -26,7 +29,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
 // Add Stylesheets
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
+$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
@@ -64,48 +67,51 @@ function colorIsLight($color)
 
 	return $yiq >= 200;
 }
+
+// Background color
+if ($background_color)
+{
+	$doc->addStyleDeclaration("
+	.view-login {
+		background-color: " . $background_color . ";
+	}");
+}
+
+// Responsive Styles
+$doc->addStyleDeclaration("
+	@media (max-width: 480px) {
+		.view-login .container {
+			margin-top: -170px;
+		}
+		.btn {
+			font-size: 13px;
+			padding: 4px 10px 4px;
+		}
+	}");
+
+// Check if debug is on
+if ($app->get('debug_lang', 1) || $app->get('debug', 1))
+{
+	$doc->addStyleDeclaration("
+	.view-login .container {
+		position: static;
+		margin-top: 20px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.view-login .navbar-fixed-bottom {
+		display: none;
+	}");
+}
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<style type="text/css">
-		/* Background color */
-		<?php if($background_color): ?>
-		.view-login {
-			background-color: <?php echo $background_color; ?>;
-		}
-		<?php endif; ?>
-		/* Responsive Styles */
-		@media (max-width: 480px) {
-			.view-login .container {
-				margin-top: -170px;
-			}
-			.btn {
-				font-size: 13px;
-				padding: 4px 10px 4px;
-			}
-		}
-		<?php // Check if debug is on ?>
-		<?php if ($app->get('debug_lang', 1) || $app->get('debug', 1)) : ?>
-		.view-login .container {
-			position: static;
-			margin-top: 20px;
-			margin-left: auto;
-			margin-right: auto;
-		}
-		.view-login .navbar-fixed-bottom {
-			display: none;
-		}
-		<?php endif; ?>
-	</style>
-	<!--[if lt IE 9]>
-		<script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script>
-	<![endif]-->
+	<!--[if lt IE 9]><script src="<?php echo $this->baseurl; ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
-
 <body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " "; ?>">
 	<!-- Container -->
 	<div class="container">


### PR DESCRIPTION
#### Summary of Changes

This is a redo of https://github.com/joomla/joomla-cms/pull/9842 for **isis** only.

This PR does a basic conversion of **isis** template to HTML5.
Also made some minor corrections:
- Use script/style version for template js/css
- Use the API in inline JS/CSS (except in error pages)
- Use html5.js for browser lower than IE9 in all files.
#### Testing Instructions
1. Install patch
2. Set the admin template as "Isis" (if not yet)
3. Go to admin and check if the the following pages are working properly:
   - normal page (test any existent URL)
   - component popup (add `&tmpl=component&print=1` to an existent page)
   - error pages (test one non existent URL)
   - login (logoff and check the login page)

Check also the code changes.
#### Observations

All pages should now start with this code:

``` html
<!DOCTYPE html>
<html lang="en-gb" dir="ltr">
<head>
[...]
    <meta charset="utf-8" />
[...]
```
