### PR TITLE
[html5] System frontend template

### DIFF
--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -9,13 +9,11 @@
 
 defined('_JEXEC') or die;
 
-$doc = JFactory::getDocument();
-
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Styles
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -8,12 +8,20 @@
  */
 
 defined('_JEXEC') or die;
+
+$doc = JFactory::getDocument();
+
+// Output as HTML5
+$doc->setHtml5(true);
+
+// Styles
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -20,19 +20,26 @@ $doc             = JFactory::getDocument();
 $app             = JFactory::getApplication();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
+
+// Output document as HTML5.
+if (is_callable(array($doc, 'setHtml5')))
+{
+	$doc->setHtml5(true);
+}
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<!DOCTYPE html>
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8" />
 	<title><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></title>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error.css" type="text/css" />
+	<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/error.css" rel="stylesheet" />
 	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/error_rtl.css" type="text/css" />
+		<link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/error_rtl.css" rel="stylesheet" />
 	<?php endif; ?>
 	<?php if ($app->get('debug_lang', '0') == '1' || $app->get('debug', '0') == '1') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl ?>/media/cms/css/debug.css" type="text/css" />
+		<link href="<?php echo JUri::root(true); ?>/media/cms/css/debug.css" rel="stylesheet" />
 	<?php endif; ?>
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
 	<div class="error">
@@ -51,7 +58,7 @@ $this->direction = $doc->direction;
 			</ol>
 			<p><strong><?php echo JText::_('JERROR_LAYOUT_PLEASE_TRY_ONE_OF_THE_FOLLOWING_PAGES'); ?></strong></p>
 			<ul>
-				<li><a href="<?php echo $this->baseurl; ?>/index.php" title="<?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?>"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
+				<li><a href="<?php echo JUri::root(true); ?>/index.php" title="<?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?>"><?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
 			</ul>
 			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 			<div id="techinfo">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -16,16 +16,7 @@ if (!isset($this->error))
 }
 
 // Get language and direction
-$doc             = JFactory::getDocument();
-$app             = JFactory::getApplication();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
-
-// Output document as HTML5.
-if (is_callable(array($doc, 'setHtml5')))
-{
-	$doc->setHtml5(true);
-}
+$app = JFactory::getApplication();
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -10,6 +10,20 @@
 defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
+$doc = JFactory::getDocument();
+
+// Output as HTML5
+$doc->setHtml5(true);
+
+// Styles
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline.css');
+
+if ($this->direction == 'rtl')
+{
+	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline_rtl.css');
+}
+
+$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
@@ -19,18 +33,14 @@ require_once JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php';
 $twofactormethods = UsersHelper::getTwoFactorMethods();
 ?>
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
+<html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline.css" type="text/css" />
-	<?php if ($this->direction == 'rtl') : ?>
-		<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/offline_rtl.css" type="text/css" />
-	<?php endif; ?>
-	<link rel="stylesheet" href="<?php echo $this->baseurl; ?>/templates/system/css/general.css" type="text/css" />
+	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
-<jdoc:include type="message" />
+	<jdoc:include type="message" />
 	<div id="frame" class="outline">
 		<?php if ($app->get('offline_image') && file_exists($app->get('offline_image'))) : ?>
 			<img src="<?php echo $app->get('offline_image'); ?>" alt="<?php echo htmlspecialchars($app->get('sitename'), ENT_COMPAT, 'UTF-8'); ?>" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -10,20 +10,19 @@
 defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
-$doc = JFactory::getDocument();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Styles
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline.css');
 
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/offline_rtl.css');
 }
 
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');


### PR DESCRIPTION
#### Summary of Changes

This is a redo of https://github.com/joomla/joomla-cms/pull/9842 for **system site** only.

This PR does a basic conversion of **system site** template to HTML5.
Also made some minor corrections:
- Use the API in inline css/js (except error page)
- Use ie9 or lower hml5.js in all files.
#### Testing Instructions
- Install patch
- Add the following code to force the system template in the frontend (before https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/application/site.php#L422) 

``` php
 $this->template = new stdClass;
 $this->template->template = 'system';
 $this->template->params   = new Registry;
```
- Go to frontend and check if the the following pages are working properly (they don't have style):
  - component popup (add `?tmpl=component&print=1` to an existent page)
  - error pages (test one non existent URL)
  - offline (set the site to offline and check the login page)
- Remove the code added in 2. and check all is again ok  and with style.

Check also the code changes.
#### Observations

All pages should now start with this code:

``` html
<!DOCTYPE html>
<html lang="en-gb" dir="ltr">
<head>
[...]
    <meta charset="utf-8" />
[...]
```
