### PR TITLE
[JDocument render] Use real tabs for rendering tabs, not two spaces ...

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -749,7 +749,7 @@ abstract class JFactory
 		$attributes = array(
 			'charset'      => 'utf-8',
 			'lineend'      => 'unix',
-			'tab'          => "\t",
+			'tab'          => PHP_TAB,
 			'language'     => $lang->getTag(),
 			'direction'    => $lang->isRtl() ? 'rtl' : 'ltr',
 			'mediaversion' => $version->getMediaVersion()

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -747,11 +747,11 @@ abstract class JFactory
 		$version = new JVersion;
 
 		$attributes = array(
-			'charset' => 'utf-8',
-			'lineend' => 'unix',
-			'tab' => '  ',
-			'language' => $lang->getTag(),
-			'direction' => $lang->isRtl() ? 'rtl' : 'ltr',
+			'charset'      => 'utf-8',
+			'lineend'      => 'unix',
+			'tab'          => "\t",
+			'language'     => $lang->getTag(),
+			'direction'    => $lang->isRtl() ? 'rtl' : 'ltr',
 			'mediaversion' => $version->getMediaVersion()
 		);
 

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -749,7 +749,7 @@ abstract class JFactory
 		$attributes = array(
 			'charset'      => 'utf-8',
 			'lineend'      => 'unix',
-			'tab'          => PHP_TAB,
+			'tab'          => "\t",
 			'language'     => $lang->getTag(),
 			'direction'    => $lang->isRtl() ? 'rtl' : 'ltr',
 			'mediaversion' => $version->getMediaVersion()


### PR DESCRIPTION
#### Summary of Changes

Simple PR to use tabs for tabs instead of two spaces when rendering.

Note: don't know why the two spaces were there in the first place (since [6 Aug 2006](https://github.com/joomla/joomla-cms/blob/755d1705450a34810716ad246c7ce1ccb7137843/libraries/joomla/factory.php#L528))
#### Testing Instructions

Code review, or:
1. Go to any page and check the page source, check, for instance, the `<script...` starts after two spaces.
2. Apply patch
3. Repeat step 1 and check, for instance, the `<script...` starts after one tab.
