### PR TITLE
[3.6.0 Alpha1] fix language access inconsistency

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-06.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-04-06.sql
@@ -1,1 +1,2 @@
 ALTER TABLE `#__redirect_links` MODIFY `new_url` VARCHAR(2048);
+UPDATE `#__languages` SET `access` = 1 WHERE `title` = 'English (UK)' AND `access` = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-06.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-04-06.sql
@@ -1,0 +1,1 @@
+UPDATE "#__languages" SET "access" = 1 WHERE "title" = 'English (UK)' AND "access" = 0;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-06.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-04-06.sql
@@ -1,1 +1,2 @@
 ALTER TABLE [#__redirect_links] ALTER COLUMN [new_url] [nvarchar](2048);
+UPDATE [#__languages] SET [access] = 1 WHERE [title] = 'English (UK)' AND [access] = 0;


### PR DESCRIPTION
One more inconsistency between updated Joomla site and freshly installed Joomla site.
#### Testing Instructions

1) Install Joomla 3.2.0 or earlier version.
2) Update to Joomla 3.6.0
3) Go to Extensions > Languages > Content Languages
##### Expected result

We must see Access: Public (as in freshly installed Joomla 3.6.0).
![languages-english-access-j360-clean-install](https://cloud.githubusercontent.com/assets/1245155/15604548/b328f01e-2409-11e6-9f21-c87b01f59ee1.png)
##### Actual result

But we see Access: not set
![languages-english-access-j320-to-j360](https://cloud.githubusercontent.com/assets/1245155/15604556/bbc07152-2409-11e6-8dda-b9fefdb6c494.png)

This PR fixes this inconsistency for English language access field.
Exploring the problem I discovered when this inconsistency was made #2714
