### PR TITLE
[Regression] Pagination not working in menu items

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
 		description="JOPTION_FILTER_CATEGORY_DESC"
-		onchange="jQuery('input[name=limitstart]').val('0');this.form.submit();"
+		onchange="this.form.submit();"
 		accesstype="manage"
 		>
 		<option value="">COM_MENUS_SELECT_MENU</option>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
 		description="JOPTION_FILTER_CATEGORY_DESC"
-		onchange="this.form.submit();"
+		onchange="jQuery('input[name=limitstart').val('0');this.form.submit();"
 		accesstype="manage"
 		>
 		<option value="">COM_MENUS_SELECT_MENU</option>

--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -5,7 +5,7 @@
 		type="menu"
 		label="COM_MENUS_FILTER_CATEGORY"
 		description="JOPTION_FILTER_CATEGORY_DESC"
-		onchange="jQuery('input[name=limitstart').val('0');this.form.submit();"
+		onchange="jQuery('input[name=limitstart]').val('0');this.form.submit();"
 		accesstype="manage"
 		>
 		<option value="">COM_MENUS_SELECT_MENU</option>

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -115,7 +115,6 @@ class MenusModelItems extends JModelList
 			elseif ($user->authorise('core.manage', 'com_menus.menu.' . $menuTypeItem->id))
 			{
 				$app->setUserState($this->context . '.menutype', $menuType);
-				$app->input->set('limitstart', 0);
 				$this->setState('menutypetitle', !empty($menuTypeItem->title) ? $menuTypeItem->title : '');
 				$this->setState('menutypeid', !empty($menuTypeItem->id) ? $menuTypeItem->id : '');
 			}

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -94,10 +94,11 @@ class MenusModelItems extends JModelList
 		$level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
 		$this->setState('filter.level', $level);
 
-		$menuType = $app->input->getString('menutype', $app->getUserState($this->context . '.menutype', ''));
+		$currentMenuType = $app->getUserState($this->context . '.menutype', '');
+		$menuType        = $app->input->getString('menutype', $currentMenuType);
 
 		// If selected menu type different from current menu type reset pagination to 0
-		if ($menuType != $app->getUserState($this->context . '.menutype', ''))
+		if ($menuType != $currentMenuType)
 		{
 			$app->input->set('limitstart', 0);
 		}

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -96,6 +96,12 @@ class MenusModelItems extends JModelList
 
 		$menuType = $app->input->getString('menutype', $app->getUserState($this->context . '.menutype', ''));
 
+		// If selected menu type different from current menu type reset pagination to 0
+		if ($menuType != $app->getUserState($this->context . '.menutype', ''))
+		{
+			$app->input->set('limitstart', 0);
+		}
+
 		if ($menuType)
 		{
 			$db = $this->getDbo();


### PR DESCRIPTION
Pull Request for New Issue (Regression).
#### Summary of Changes

When selecting a menu (besides the `- Select Menu -` option) the pagination is not working.
#### Testing Instructions
1. Use latest staging
2. Go to Menus -> (Any menu with several pages)
3. Check the pagination is not working (hint set pagination to 5 items)
4. Apply patch
5. Repeat test and check the pagination is working now.
6. Check also that when moving from one menu to another the pagination always resets to 1.

@infograf768 @bembelimen please check.
