### PR TITLE
core.edit.own permission doesn't allow to insert article link with a XTD "Article" button

### DIFF
--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -26,8 +26,8 @@ if ($input->get('view') === 'article' && $input->get('layout') === 'pagebreak')
 }
 elseif ($input->get('view') === 'articles' && $input->get('layout') === 'modal')
 {
-        if (!($user->authorise('core.edit', 'com_content') ||
-	    $user->authorise('core.edit.own', 'com_content')))
+	if (!($user->authorise('core.edit', 'com_content') 
+	|| $user->authorise('core.edit.own', 'com_content')))
 	{
 		JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
 

--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -26,8 +26,7 @@ if ($input->get('view') === 'article' && $input->get('layout') === 'pagebreak')
 }
 elseif ($input->get('view') === 'articles' && $input->get('layout') === 'modal')
 {
-	if (!($user->authorise('core.edit', 'com_content') 
-	|| $user->authorise('core.edit.own', 'com_content')))
+	if (!($user->authorise('core.edit', 'com_content') || $user->authorise('core.edit.own', 'com_content')))
 	{
 		JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
 

--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -26,7 +26,8 @@ if ($input->get('view') === 'article' && $input->get('layout') === 'pagebreak')
 }
 elseif ($input->get('view') === 'articles' && $input->get('layout') === 'modal')
 {
-	if (!$user->authorise('core.edit', 'com_content'))
+        if (!($user->authorise('core.edit', 'com_content') ||
+	    $user->authorise('core.edit.own', 'com_content')))
 	{
 		JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
 


### PR DESCRIPTION
Pull Request for Issue #10636 .
#### Summary of Changes

Allow user/group (that is not descendant of 'Editor' group) with core.edit.own permissions to add article link via XTD button.
#### Testing Instructions
1. Create user or user+group (add user to created group).
2. Go to Global Configuration -> Permissions, set 'Edit Own' permissions to 'Allow' for user/group.
3. Login to frontend;
4. Edit article content - use 'Article' XTD Button, this should bring form with articles list, create link;
5. Further testing for Edit and Edit Own permissions (Denied or Inheritance that gives Denied result):

| Edit | Edit Own | Result |
| --- | --- | --- |
| Denied | Denied | form with JERROR_ALERTNOAUTHOR message for both permissions |
| Allow | Denied | form with articles for Edit, form with JERROR_ALERTNOAUTHOR for Edit Own |
| Denied | Allow | form with JERROR_ALERTNOAUTHOR for Edit, form with articles for Edit Own |
| Allow | Allow | form with articles for both permissions; |
