### PR TITLE
[mod_multilangstatus] add modal viewport dimensions + Code Style

### DIFF
--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.6.0</version>
+	<version>3.0.0</version>
 	<description>MOD_MULTILANGSTATUS_XML_DESCRIPTION</description>
 
 	<files>

--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -7,8 +7,9 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.0.0</version>
+	<version>3.6.0</version>
 	<description>MOD_MULTILANGSTATUS_XML_DESCRIPTION</description>
+
 	<files>
 		<filename module="mod_multilangstatus">mod_multilangstatus.php</filename>
 		<folder>tmpl</folder>
@@ -19,30 +20,37 @@
 		<language tag="en-GB">language/en-GB/en-GB.mod_multilangstatus.ini</language>
 		<language tag="en-GB">language/en-GB/en-GB.mod_multilangstatus.sys.ini</language>
 	</languages>
+
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_ADMIN_MULTILANG" />
+
 	<config>
+
 		<fields name="params">
+
 			<fieldset name="advanced">
+
 				<field
 					name="layout"
 					type="modulelayout"
 					label="JFIELD_ALT_LAYOUT_LABEL"
-					description="JFIELD_ALT_MODULE_LAYOUT_DESC" />
+					description="JFIELD_ALT_MODULE_LAYOUT_DESC"
+				/>
 
 				<field
 					name="moduleclass_sfx"
 					type="textarea" rows="3"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
-					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
+					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
+				/>
 
 				<field
 					name="cache"
 					type="list"
-					default="0"
 					label="COM_MODULES_FIELD_CACHING_LABEL"
-					description="COM_MODULES_FIELD_CACHING_DESC">
-					<option
-						value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
+					description="COM_MODULES_FIELD_CACHING_DESC"
+					default="0"
+					>
+					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -20,11 +20,8 @@ JFactory::getDocument()->addScriptDeclaration("
 		$('body').append(multilangueModal);
 	});
 ");
-
-$link   = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
-$footer = '<button class="btn" data-dismiss="modal" type="button" aria-hidden="true">'
-		. JText::_('JTOOLBAR_CLOSE') . '</button>';
 ?>
+
 <div class="btn-group multilanguage">
 	<a class="btn btn-link"
 		data-toggle="modal"
@@ -41,11 +38,12 @@ $footer = '<button class="btn" data-dismiss="modal" type="button" aria-hidden="t
 	array(
 		'title'       => JText::_('MOD_MULTILANGSTATUS'),
 		'backdrop'    => 'static',
-		'url'         => $link,
+		'url'         => JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component'),
 		'height'      => '400px',
 		'width'       => '800px',
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => $footer,
+		'footer'      => '<button class="btn" data-dismiss="modal" type="button" aria-hidden="true">'
+				. JText::_('JTOOLBAR_CLOSE') . '</button>',
 	)
 );

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -14,17 +14,23 @@ JHtml::_('jquery.framework');
 
 // Use javascript to remove the modal added below from the current div and add it to the end of html body tag.
 JFactory::getDocument()->addScriptDeclaration("
-jQuery(document).ready(function($) {
-	var multilangueModal = $('#multiLangModal').clone();
-	$('#multiLangModal').remove();
-	$('body').append(multilangueModal);
-});");
+	jQuery(document).ready(function($) {
+		var multilangueModal = $('#multiLangModal').clone();
+		$('#multiLangModal').remove();
+		$('body').append(multilangueModal);
+	});
+");
 
-$link = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
-$footer = '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">' . JText::_('JTOOLBAR_CLOSE') . '</button>';
+$link   = JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component');
+$footer = '<button class="btn" data-dismiss="modal" type="button" aria-hidden="true">'
+		. JText::_('JTOOLBAR_CLOSE') . '</button>';
 ?>
 <div class="btn-group multilanguage">
-	<a href="#multiLangModal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('MOD_MULTILANGSTATUS'); ?>">
+	<a class="btn btn-link"
+		data-toggle="modal"
+		href="#multiLangModal"
+		title="<?php echo JText::_('MOD_MULTILANGSTATUS'); ?>"
+		role="button">
 		<span class="icon-comment"></span><?php echo JText::_('MOD_MULTILANGSTATUS'); ?>
 	</a>
 </div>
@@ -33,13 +39,13 @@ $footer = '<button class="btn" type="button" data-dismiss="modal" aria-hidden="t
 	'bootstrap.renderModal',
 	'multiLangModal',
 	array(
-		'title' => JText::_('MOD_MULTILANGSTATUS'),
-		'backdrop' => 'static',
-		'keyboard' => true,
-		'closeButton' => true,
-		'footer' => $footer,
-		'url' => $link,
-		'height' => '300px',
-		'width' => '500px'
-		)
-	);
+		'title'       => JText::_('MOD_MULTILANGSTATUS'),
+		'backdrop'    => 'static',
+		'url'         => $link,
+		'height'      => '400px',
+		'width'       => '800px',
+		'bodyHeight'  => '70',
+		'modalWidth'  => '80',
+		'footer'      => $footer,
+	)
+);

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -37,7 +37,6 @@ JFactory::getDocument()->addScriptDeclaration("
 	'multiLangModal',
 	array(
 		'title'       => JText::_('MOD_MULTILANGSTATUS'),
-		'backdrop'    => 'static',
 		'url'         => JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component'),
 		'height'      => '400px',
 		'width'       => '800px',


### PR DESCRIPTION
**To be tested on 3.6.0-alpha or latest Staging (needs #10388 )**
#### Summary of Changes
- Add viewport dimensions to modal multilanguage status (modal width: 80vw, modal body height: 70vh)
- Code Style cc/ @wojsmol @andrepereiradasilva 
- Update version number to 3.6.0 (But, should this be done for core extensions, as none are updated ?... cc/ @wilsonge )
#### Testing Instructions
- Enable Admin module Multilanguage status
- Click on footer "Multilingual Status" button (bottom left of admin)
- Check modal dimensions

**Before Patch**
![capture d ecran 2016-05-28 a 13 45 45](https://cloud.githubusercontent.com/assets/2385058/15627169/1d443742-24dc-11e6-90b5-57ceca848fa0.png)

**After Patch**
![capture d ecran 2016-05-28 a 13 52 08](https://cloud.githubusercontent.com/assets/2385058/15627171/267e219c-24dc-11e6-85b4-964b70c7d75f.png)
