### PR TITLE
[com_checkin] - add creation date tag on manifest

### DIFF
--- a/administrator/components/com_checkin/checkin.xml
+++ b/administrator/components/com_checkin/checkin.xml
@@ -2,6 +2,7 @@
 <extension type="component" version="3.1" method="upgrade">
 	<name>com_checkin</name>
 	<author>Joomla! Project</author>
+	<creationDate>April 2006</creationDate>
 	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>


### PR DESCRIPTION
Pull Request for Issue #10661 .
#### Summary of Changes

added the creation date tag that was missed
#### Testing Instructions

code review 
or
Go to Administration panel > Extensions: Manage > Search Tool: Select type - Component
All components from Joomla Project have filled Date colum (month+ year)
