### PR TITLE
[com_checkin] add creationDate

### DIFF
--- a/administrator/components/com_checkin/checkin.xml
+++ b/administrator/components/com_checkin/checkin.xml
@@ -2,6 +2,7 @@
 <extension type="component" version="3.1" method="upgrade">
 	<name>com_checkin</name>
 	<author>Joomla! Project</author>
+	<creationDate>May 2016</creationDate>
 	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>


### PR DESCRIPTION
Pull Request for Issue #10661 
#### Summary of Changes

Just added missing creationDate string in
`/administrator/components/com_checkin/checkin.xml`
#### Testing Instructions

Go to Administration panel > Extensions: Manage > Search Tool: Select type - Component
All components from Joomla Project have filled Date column, with the exception for Check-in component.

before PR
Сomponent Check-in > Date: Unknown

after PR
Сomponent Check-in > Date: May 2016
