### PR TITLE
[com_languages ] - added the month  on creationDate tag on manifest

### DIFF
--- a/administrator/components/com_languages/languages.xml
+++ b/administrator/components/com_languages/languages.xml
@@ -2,7 +2,7 @@
 <extension type="component" version="3.1" method="upgrade">
 	<name>com_languages</name>
 	<author>Joomla! Project</author>
-	<creationDate>2006</creationDate>
+	<creationDate>April 2006</creationDate>
 	<copyright>(C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>


### PR DESCRIPTION
Pull Request for Issue #10661 .
#### Summary of Changes

added the month  creationDate tag that was missed
#### Testing Instructions

code review
or
Go to Administration panel > Extensions: Manage > Search Tool: Select type - Component
All components from Joomla Project have filled Date colum (month year)
