### PR TITLE
[FIX 3.6.0-alpha] Do not close edit modal when escape key is pressed (Thanks @andrepereiradasilva !)

### DIFF
--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -195,14 +195,14 @@ class JFormFieldModal_Category extends JFormField
 			'bootstrap.renderModal',
 			'categorySelect' . $this->id . 'Modal',
 			array(
-				'url'         => $urlSelect,
 				'title'       => JText::_('COM_CATEGORIES_SELECT_A_CATEGORY'),
-				'width'       => '800px',
+				'url'         => $urlSelect,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
 			)
 		);
 
@@ -211,14 +211,15 @@ class JFormFieldModal_Category extends JFormField
 			'bootstrap.renderModal',
 			'categoryEdit' . $value . 'Modal',
 			array(
-				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CATEGORIES_EDIT_CATEGORY'),
 				'backdrop'    => 'static',
+				'keyboard'    => false,
 				'closeButton' => false,
-				'width'       => '800px',
+				'url'         => $urlEdit,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -227,7 +228,7 @@ class JFormFieldModal_Category extends JFormField
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
 						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-						. JText::_("JAPPLY") . '</button>'
+						. JText::_("JAPPLY") . '</button>',
 			)
 		);
 

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -209,10 +209,10 @@ class JFormFieldModal_Contact extends JFormField
 			'contactEdit' . $value . 'Modal',
 			array(
 				'title'       => JText::_('COM_CONTACT_EDIT_CONTACT'),
-				'url'         => $urlEdit,
 				'backdrop'    => 'static',
 				'keyboard'    => false,
 				'closeButton' => false,
+				'url'         => $urlEdit,
 				'height'      => '400px',
 				'width'       => '800px',
 				'bodyHeight'  => '70',

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -192,14 +192,14 @@ class JFormFieldModal_Contact extends JFormField
 			'bootstrap.renderModal',
 			'contactSelect' . $this->id . 'Modal',
 			array(
-				'url'         => $urlSelect,
 				'title'       => JText::_('COM_CONTACT_CHANGE_CONTACT'),
-				'width'       => '800px',
+				'url'         => $urlSelect,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
 			)
 		);
 
@@ -208,14 +208,15 @@ class JFormFieldModal_Contact extends JFormField
 			'bootstrap.renderModal',
 			'contactEdit' . $value . 'Modal',
 			array(
-				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CONTACT_EDIT_CONTACT'),
+				'url'         => $urlEdit,
 				'backdrop'    => 'static',
+				'keyboard'    => false,
 				'closeButton' => false,
-				'width'       => '800px',
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -224,7 +225,7 @@ class JFormFieldModal_Contact extends JFormField
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
 						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-						. JText::_("JAPPLY") . '</button>'
+						. JText::_("JAPPLY") . '</button>',
 			)
 		);
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -192,12 +192,12 @@ class JFormFieldModal_Article extends JFormField
 			'bootstrap.renderModal',
 			'articleSelect' . $this->id . 'Modal',
 			array(
-				'url'         => $urlSelect,
 				'title'       => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
-				'width'       => '800px',
+				'url'         => $urlSelect,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
 			)
@@ -208,14 +208,15 @@ class JFormFieldModal_Article extends JFormField
 			'bootstrap.renderModal',
 			'articleEdit' . $value . 'Modal',
 			array(
-				'url'         => $urlEdit,
 				'title'       => JText::_('COM_CONTENT_EDIT_ARTICLE'),
 				'backdrop'    => 'static',
+				'keyboard'    => false,
 				'closeButton' => false,
-				'width'       => '800px',
+				'url'         => $urlEdit,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -199,7 +199,7 @@ class JFormFieldModal_Article extends JFormField
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
 			)
 		);
 
@@ -225,7 +225,7 @@ class JFormFieldModal_Article extends JFormField
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
 						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-						. JText::_("JAPPLY") . '</button>'
+						. JText::_("JAPPLY") . '</button>',
 			)
 		);
 

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -135,14 +135,15 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					'bootstrap.renderModal',
 					'moduleEdit' . $module->id . 'Modal',
 					array(
-						'url'         => $link,
 						'title'       => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 						'backdrop'    => 'static',
+						'keyboard'    => false,
 						'closeButton' => false,
+						'url'         => $link,
 						'height'      => '400px',
 						'width'       => '800px',
-						'modalWidth'  => '80',
 						'bodyHeight'  => '70',
+						'modalWidth'  => '80',
 						'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -151,7 +152,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 								. JText::_("JSAVE") . '</button>'
 								. '<button type="button" class="btn btn-success" aria-hidden="true"'
 								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-								. JText::_("JAPPLY") . '</button>'
+								. JText::_("JAPPLY") . '</button>',
 					)
 				); ?>
 			</tr>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -165,14 +165,15 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 												'bootstrap.renderModal',
 												'moduleEdit' . $module->id . 'Modal',
 												array(
-													'url'         => $link,
 													'title'       => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 													'backdrop'    => 'static',
+													'keyboard'    => false,
 													'closeButton' => false,
+													'url'         => $link,
 													'height'      => '400px',
 													'width'       => '800px',
-													'modalWidth'  => '80',
 													'bodyHeight'  => '70',
+													'modalWidth'  => '80',
 													'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 															. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 															. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -181,7 +182,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 															. JText::_("JSAVE") . '</button>'
 															. '<button type="button" class="btn btn-success" aria-hidden="true"'
 															. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-															. JText::_("JAPPLY") . '</button>'
+															. JText::_("JAPPLY") . '</button>',
 												)
 											); ?>
 									<?php endif; ?>
@@ -193,14 +194,15 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										'bootstrap.renderModal',
 										'moduleAddModal',
 										array(
-											'url'         => $link,
 											'title'       => JText::_('COM_MENUS_ADD_MENU_MODULE'),
 											'backdrop'    => 'static',
+											'keyboard'    => false,
 											'closeButton' => false,
+											'url'         => $link,
 											'height'      => '400px',
 											'width'       => '800px',
-											'modalWidth'  => '80',
 											'bodyHeight'  => '70',
+											'modalWidth'  => '80',
 											'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 													. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#closeBtn\').click();">'
 													. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -209,7 +211,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 													. JText::_("JSAVE") . '</button>'
 													. '<button type="button" class="btn btn-success" aria-hidden="true"'
 													. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#applyBtn\').click();">'
-													. JText::_("JAPPLY") . '</button>'
+													. JText::_("JAPPLY") . '</button>',
 										)
 									); ?>
 							<?php endif; ?>

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -192,14 +192,14 @@ class JFormFieldModal_Newsfeed extends JFormField
 			'bootstrap.renderModal',
 			'newsfeedSelect' . $this->id . 'Modal',
 			array(
-				'url'         => $urlSelect,
 				'title'       => JText::_('COM_NEWSFEEDS_SELECT_A_FEED'),
-				'width'       => '800px',
+				'url'         => $urlSelect,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
 			)
 		);
 
@@ -208,14 +208,15 @@ class JFormFieldModal_Newsfeed extends JFormField
 			'bootstrap.renderModal',
 			'newsfeedEdit' . $value . 'Modal',
 			array(
-				'url'         => $urlEdit,
 				'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
 				'backdrop'    => 'static',
+				'keyboard'    => false,
 				'closeButton' => false,
-				'width'       => '800px',
+				'url'         => $urlEdit,
 				'height'      => '400px',
-				'modalWidth'  => '80',
+				'width'       => '800px',
 				'bodyHeight'  => '70',
+				'modalWidth'  => '80',
 				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
 						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
@@ -224,7 +225,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 						. JText::_("JSAVE") . '</button>'
 						. '<button type="button" class="btn btn-success" aria-hidden="true"'
 						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-						. JText::_("JAPPLY") . '</button>'
+						. JText::_("JAPPLY") . '</button>',
 			)
 		);
 

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -25,12 +25,12 @@ extract($displayData);
  *                             - keyboard     boolean  Closes the modal when escape key is pressed (default = true)
  *                             - closeButton  boolean  Display modal close button (default = true)
  *                             - animation    boolean  Fade in from the top of the page (default = true)
- *                             - footer       string   Optional markup for the modal footer
  *                             - url          string   URL of a resource to be inserted as an <iframe> inside the modal body
  *                             - height       string   height of the <iframe> containing the remote resource
  *                             - width        string   width of the <iframe> containing the remote resource
  *                             - bodyHeight   int      Optional height of the modal body in viewport units (vh)
  *                             - modalWidth   int      Optional width of the modal in viewport units (vh)
+ *                             - footer       string   Optional markup for the modal footer
  * @param   string  $body      Markup for the modal body. Appended after the <iframe> if the url option is set
  *
  */


### PR DESCRIPTION
Pull Request for Issue comment https://github.com/joomla/joomla-cms/pull/10654#issuecomment-222332058.
cc/ @andrepereiradasilva 
#### Summary of Changes
- In already merged new edit modals, it was fixed to not allow closing of an edit modal on click (needed behavior for a clean item edit closing), to allow closing only on <code>close</code>, <code>Save & Close</code> and <code>Save</code> buttons, but it was still possible to close with escape key.
- This PR disable the possibility to close the edit modal when escape key is pressed
- A few ordering changes of modal params, to be consistend with the modal main jlayout
#### Testing Instructions

**To be tested on 3.6.0-alpha or latest staging!**
This could be tested for those modals (test that you can't close modal with escape key):
- **Menus** > **Manage** : button to edit <code>modules</code> and <code>Add a module for this menu</code>
- in all menu item edition : go to tab "Modules Assignment" and click on one of the modules name to open Edit modal.
- **Menus** > _Menu_ > **Menu item** with item type <code>Single Article</code> Select article, save and then click on <code>Edit</code> button to open Edit modal
- **Menus** > _Menu_ > **Menu item** with item type <code>Category Blog</code> Select category, save and then click on <code>Edit</code> button to open Edit modal
- **Menus** > _Menu_ > **Menu item** with item type <code>Single Contact</code> Select contact, save and then click on <code>Edit</code> button to open Edit modal
- **Menus** > _Menu_ > **Menu item** with item type <code>Single Newsfeed</code> Select newsfeed, save and then click on <code>Edit</code> button to open Edit modal
- <code>article</code>, <code>category</code>, <code>newsfeed</code>, <code>contact</code> in associations tab for each item should have the same behavior.
