### PR TITLE
remove double space

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -115,7 +115,7 @@ JFactory::getDocument()->addStyleDeclaration(
 						);
 						?>
 						<p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>
-							&nbsp;&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
+							<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
 						<input class="btn" type="button"
 							value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>"
 							onclick="Joomla.submitbuttonInstallWebInstaller()"/>

--- a/administrator/templates/hathor/html/com_installer/install/default_form.php
+++ b/administrator/templates/hathor/html/com_installer/install/default_form.php
@@ -82,7 +82,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<?php if ($this->showJedAndWebInstaller && !$this->showMessage) : ?>
 		<div class="alert j-jed-message" style="margin-bottom: 20px; line-height: 2em; color:#333333; clear:both;">
 			<a href="index.php?option=com_config&view=component&component=com_installer&path=&return=<?php echo urlencode(base64_encode(JUri::getInstance())); ?>" class="close hasTooltip" data-dismiss="alert" title="<?php echo str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')); ?>">&times;</a>
-			<p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>&nbsp;&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
+			<p><?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_INFO'); ?>&nbsp;<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
 			<input class="btn" type="button" value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>" onclick="Joomla.submitbuttonInstallWebInstaller()" />
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
The message about installing the "Install from Web" plugin has two hard coded spaces between the strings. The style guide "https://joomla.github.io/user-interface-text/?user-interface-text/punctuation.md" says we should only have one.

Both hard coded spaces are removed because the browser interprets the tabs as a space so isnt needed at all
