### PR TITLE
[build/bump] Make bump update the links in the readme files also (md and txt)

### DIFF
--- a/build/bump.php
+++ b/build/bump.php
@@ -58,6 +58,7 @@ $readMeFiles = array(
 			'/README.md',
 			'/README.txt',
 			);
+
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
 

--- a/build/bump.php
+++ b/build/bump.php
@@ -54,6 +54,10 @@ $languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
 
 $antJobFile = '/build.xml';
 
+$readMeFiles = array(
+			'/README.md',
+			'/README.txt',
+			);
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
 
@@ -226,6 +230,18 @@ if (file_exists($rootPath . $antJobFile))
 	$fileContents = file_get_contents($rootPath . $antJobFile);
 	$fileContents = preg_replace('#<arg value="Joomla! CMS [^ ]* API" />#', '<arg value="Joomla! CMS ' . $version['main'] . ' API" />', $fileContents);
 	file_put_contents($rootPath . $antJobFile, $fileContents);
+}
+
+// Updates the version in readme files.
+foreach ($readMeFiles as $readMeFile)
+{
+	if (file_exists($rootPath . $readMeFile))
+	{
+		$fileContents = file_get_contents($rootPath . $readMeFile);
+		$fileContents = preg_replace('#Joomla! [0-9]+\.[0-9]+ (|\[)version#', 'Joomla! ' . $version['main'] . ' $1version', $fileContents);
+		$fileContents = preg_replace('#Joomla_[0-9]+\.[0-9]+_version#', 'Joomla_' . $version['main'] . '_version', $fileContents);
+		file_put_contents($rootPath . $readMeFile, $fileContents);
+	}
 }
 
 echo 'Version bump complete!' . PHP_EOL;


### PR DESCRIPTION
#### Summary of Changes

Simple PR. Make bump.php script update the versions and links in readme files also.
#### Testing Instructions

Code review, or:
1. Apply patch
2. Run `php build/bump.php -v 3.7.0`in joomla staging root
3. Check the readme files test links are changed

Hint: run `php build/bump.php -v 3.6.0-alpha2` to reset to previous version
