### PR TITLE
Add plugin events to JFile/JFolder

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -107,7 +107,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -151,7 +151,7 @@ class JFile
 			}
 
 			if($ret) {
-				self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
+				self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -227,7 +227,7 @@ class JFile
 			}
 		}
 
-		self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$file), 'method'=>__METHOD__));
+		self::triggerEvent(array('args'=>array('src'=>$file), 'method'=>__METHOD__));
 
 		return true;
 	}
@@ -273,7 +273,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -308,7 +308,7 @@ class JFile
 				}
 			}
 
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -425,7 +425,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -450,7 +450,7 @@ class JFile
 			}
 			
 			if($ret) {
-				self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
+				self::triggerEvent(array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -578,7 +578,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -627,7 +627,7 @@ class JFile
 			}
 
 			if($ret) {
-				self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
+				self::triggerEvent(array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -681,13 +681,12 @@ class JFile
 	/*
 	 * Triggers file plugin events
 	 * 
-	 * @param   string  $src  File path
-	 * @param   array   $options  Event options
+	 * @param   array   $args  Event args
 	 * 
 	 * @return bool success
 	 */
-	private static function triggerEvent($event, $args=array()) {
+	private static function triggerEvent($args=array()) {
 		JPluginHelper::importPlugin( 'file' );
-		JFactory::getApplication()->triggerEvent($event,$args);
+		JFactory::getApplication()->triggerEvent('onFilesystemEvent', $args);
 	}
 }

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -686,13 +686,13 @@ class JFile
 	 * @return bool success
 	 */
 	private static function triggerEvent($args=array()) {
-		$app = JFactory::getApplication();
 		JPluginHelper::importPlugin( 'file' );
-		if($app) {
-		    return $app->triggerEvent('onFilesystemEvent', $args);
-		} else {
+//		$app = JFactory::getApplication();
+//		if($app) {
+//		    return $app->triggerEvent('onFilesystemEvent', $args);
+//		} else {
 		    $dispatcher = JEventDispatcher::getInstance();
 		    return $dispatcher->trigger('onFilesystemEvent', $args);
-		}
+//		}
 	}
 }

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -686,7 +686,13 @@ class JFile
 	 * @return bool success
 	 */
 	private static function triggerEvent($args=array()) {
+		$app = JFactory::getApplication();
 		JPluginHelper::importPlugin( 'file' );
-		JFactory::getApplication()->triggerEvent('onFilesystemEvent', $args);
+		if($app) {
+		    return $app->triggerEvent('onFilesystemEvent', $args);
+		} else {
+		    $dispatcher = JEventDispatcher::getInstance();
+		    return $dispatcher->trigger('onFilesystemEvent', $args);
+		}
 	}
 }

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -107,6 +107,10 @@ class JFile
 				return false;
 			}
 
+			if($ret) {
+				self::triggerEvent($dest,array('action'=>'copy'));
+			}
+
 			return true;
 		}
 		else
@@ -146,6 +150,10 @@ class JFile
 				}
 
 				$ret = true;
+			}
+
+			if($ret) {
+				self::triggerEvent($dest,array('action'=>'copy'));
 			}
 
 			return $ret;
@@ -221,6 +229,8 @@ class JFile
 			}
 		}
 
+		self::triggerEvent($file,array('action'=>'delete'));
+
 		return true;
 	}
 
@@ -265,6 +275,8 @@ class JFile
 				return false;
 			}
 
+			self::triggerEvent($src,array('dest'=>$dest, 'path'=>$path, 'action'=>'move'));
+
 			return true;
 		}
 		else
@@ -297,6 +309,8 @@ class JFile
 					return false;
 				}
 			}
+
+			self::triggerEvent($src,array('dest'=>$dest, 'path'=>$path, 'action'=>'move'));
 
 			return true;
 		}
@@ -413,6 +427,8 @@ class JFile
 				return false;
 			}
 
+			self::triggerEvent($file, array('action'=>'write'));
+
 			return true;
 		}
 		else
@@ -433,6 +449,10 @@ class JFile
 			{
 				$file = $pathObject->clean($file);
 				$ret = is_int(file_put_contents($file, $buffer)) ? true : false;
+			}
+			
+			if($ret) {
+				self::triggerEvent($file, array('action'=>'write'));
 			}
 
 			return $ret;
@@ -560,6 +580,8 @@ class JFile
 				return false;
 			}
 
+			self::triggerEvent($dest, array('action'=>'upload'));
+
 			return true;
 		}
 		else
@@ -604,6 +626,10 @@ class JFile
 				{
 					JLog::add(JText::sprintf('JLIB_FILESYSTEM_ERROR_WARNFS_ERR04', $src, $dest), JLog::WARNING, 'jerror');
 				}
+			}
+
+			if($ret) {
+				self::triggerEvent($dest, array('action'=>'upload'));
 			}
 
 			return $ret;
@@ -652,5 +678,21 @@ class JFile
 		{
 			return $file;
 		}
+	}
+
+	/*
+	 * Triggers file plugin events
+	 * 
+	 * @param   string  $src  File path
+	 * @param   array   $options  Event options
+	 * 
+	 * @return bool success
+	 */
+	private static function triggerEvent($src, $args=array()) {
+		$action = $args['action']?:'Copy';
+		$args = array('src'=>$src);
+		JPluginHelper::importPlugin( 'file' );
+		$dispatcher = JEventDispatcher::getInstance();
+		return $dispatcher->trigger( 'onFile'.ucfirst($action), $args );
 	}
 }

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -107,7 +107,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent($dest,array('action'=>'copy'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -151,7 +151,7 @@ class JFile
 			}
 
 			if($ret) {
-				self::triggerEvent($dest,array('action'=>'copy'));
+				self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -227,7 +227,7 @@ class JFile
 			}
 		}
 
-		self::triggerEvent($file,array('action'=>'delete'));
+		self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$file), 'method'=>__METHOD__));
 
 		return true;
 	}
@@ -273,7 +273,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent($src,array('dest'=>$dest, 'path'=>$path, 'action'=>'move'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -308,7 +308,7 @@ class JFile
 				}
 			}
 
-			self::triggerEvent($src,array('dest'=>$dest, 'path'=>$path, 'action'=>'move'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest, 'path'=>$path), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -425,7 +425,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent($file, array('action'=>'write'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -450,7 +450,7 @@ class JFile
 			}
 			
 			if($ret) {
-				self::triggerEvent($file, array('action'=>'write'));
+				self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$file), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -578,7 +578,7 @@ class JFile
 				return false;
 			}
 
-			self::triggerEvent($dest, array('action'=>'upload'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
 
 			return true;
 		}
@@ -627,7 +627,7 @@ class JFile
 			}
 
 			if($ret) {
-				self::triggerEvent($dest, array('action'=>'upload'));
+				self::triggerEvent('onFilesystemEvent', array('args'=>array('dest'=>$dest), 'method'=>__METHOD__));
 			}
 
 			return $ret;
@@ -686,11 +686,8 @@ class JFile
 	 * 
 	 * @return bool success
 	 */
-	private static function triggerEvent($src, $args=array()) {
-		$action = $args['action']?:'Copy';
-		$args = array('src'=>$src);
+	private static function triggerEvent($event, $args=array()) {
 		JPluginHelper::importPlugin( 'file' );
-		$dispatcher = JEventDispatcher::getInstance();
-		return $dispatcher->trigger( 'onFile'.ucfirst($action), $args );
+		JFactory::getApplication()->triggerEvent($event,$args);
 	}
 }

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -107,9 +107,7 @@ class JFile
 				return false;
 			}
 
-			if($ret) {
-				self::triggerEvent($dest,array('action'=>'copy'));
-			}
+			self::triggerEvent($dest,array('action'=>'copy'));
 
 			return true;
 		}

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -153,7 +153,7 @@ abstract class JFolder
 			}
 		}
 
-		self::triggerEvent($src,array('dest'=>$dest, 'action'=>'copy'));
+		self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 
 		return true;
 	}
@@ -209,7 +209,7 @@ abstract class JFolder
 		// Check if dir already exists
 		if (self::exists($path))
 		{
-			self::triggerEvent($path,array('action'=>'create'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 			
 			return true;
 		}
@@ -285,7 +285,7 @@ abstract class JFolder
 			@umask($origmask);
 		}
 
-		self::triggerEvent($path,array('action'=>'create'));
+		self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 
 		return $ret;
 	}
@@ -390,7 +390,7 @@ abstract class JFolder
 		}
 		
 		if($ret) {
-			self::triggerEvent($path,array('action'=>'delete'));
+			self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 		}
 
 		return $ret;
@@ -471,7 +471,7 @@ abstract class JFolder
 		}
 
 		if($ret) {
-		    self::triggerEvent($src,array('dest'=>$dest,'action'=>'move'));
+		    self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 		}
 
 		return $ret;
@@ -732,16 +732,13 @@ abstract class JFolder
 	/*
 	 * Triggers file plugin events
 	 * 
-	 * @param   string  $src  File path
-	 * @param   array   $options  Event options
+	 * @param   string  $event  File path
+	 * @param   array   $args  Event args
 	 * 
 	 * @return bool success
 	 */
-	private static function triggerEvent($src, $args=array()) {
-		$action = $args['action']?:'Copy';
-		$args = array('src'=>$src);
+	private static function triggerEvent($event, $args=array()) {
 		JPluginHelper::importPlugin( 'file' );
-		$dispatcher = JEventDispatcher::getInstance();
-		return $dispatcher->trigger( 'onFolder'.ucfirst($action), $args );
+		JFactory::getApplication()->triggerEvent($event,$args);
 	}
 }

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -153,9 +153,7 @@ abstract class JFolder
 			}
 		}
 
-		if($ret) {
-			self::triggerEvent($src,array('dest'=>$dest, 'action'=>'copy'));
-		}
+		self::triggerEvent($src,array('dest'=>$dest, 'action'=>'copy'));
 
 		return true;
 	}

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -737,13 +737,13 @@ abstract class JFolder
 	 * @return bool success
 	 */
 	private static function triggerEvent($args=array()) {
-		$app = JFactory::getApplication();
 		JPluginHelper::importPlugin( 'file' );
-		if($app) {
-		    return $app->triggerEvent('onFilesystemEvent', $args);
-		} else {
+//		$app = JFactory::getApplication();
+//		if($app) {
+//		    return $app->triggerEvent('onFilesystemEvent', $args);
+//		} else {
 		    $dispatcher = JEventDispatcher::getInstance();
 		    return $dispatcher->trigger('onFilesystemEvent', $args);
-		}
+//		}
 	}
 }

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -737,7 +737,13 @@ abstract class JFolder
 	 * @return bool success
 	 */
 	private static function triggerEvent($args=array()) {
+		$app = JFactory::getApplication();
 		JPluginHelper::importPlugin( 'file' );
-		JFactory::getApplication()->triggerEvent('onFilesystemEvent', $args);
+		if($app) {
+		    return $app->triggerEvent('onFilesystemEvent', $args);
+		} else {
+		    $dispatcher = JEventDispatcher::getInstance();
+		    return $dispatcher->trigger('onFilesystemEvent', $args);
+		}
 	}
 }

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -153,7 +153,7 @@ abstract class JFolder
 			}
 		}
 
-		self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
+		self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 
 		return true;
 	}
@@ -209,7 +209,7 @@ abstract class JFolder
 		// Check if dir already exists
 		if (self::exists($path))
 		{
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 			
 			return true;
 		}
@@ -285,7 +285,7 @@ abstract class JFolder
 			@umask($origmask);
 		}
 
-		self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
+		self::triggerEvent(array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 
 		return $ret;
 	}
@@ -390,7 +390,7 @@ abstract class JFolder
 		}
 		
 		if($ret) {
-			self::triggerEvent('onFilesystemEvent', array('args'=>array('path'=>$path), 'method'=>__METHOD__));
+			self::triggerEvent(array('args'=>array('path'=>$path), 'method'=>__METHOD__));
 		}
 
 		return $ret;
@@ -471,7 +471,7 @@ abstract class JFolder
 		}
 
 		if($ret) {
-		    self::triggerEvent('onFilesystemEvent', array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
+		    self::triggerEvent(array('args'=>array('src'=>$src, 'dest'=>$dest), 'method'=>__METHOD__));
 		}
 
 		return $ret;
@@ -732,13 +732,12 @@ abstract class JFolder
 	/*
 	 * Triggers file plugin events
 	 * 
-	 * @param   string  $event  File path
 	 * @param   array   $args  Event args
 	 * 
 	 * @return bool success
 	 */
-	private static function triggerEvent($event, $args=array()) {
+	private static function triggerEvent($args=array()) {
 		JPluginHelper::importPlugin( 'file' );
-		JFactory::getApplication()->triggerEvent($event,$args);
+		JFactory::getApplication()->triggerEvent('onFilesystemEvent', $args);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #10568 
#### Summary of Changes

JFile::copy/delete/move/upload/write
JFolder::copy/create/delete/move
trigger onFilesystemEvent
#### Testing Instructions

Create a file plugin (/plugins/file) with this event and watch the logs as you mess with files and folders in the media manager:

```
public function onFilesystemEvent($args,$caller) {
    error_log(print_r($args,true));
    error_log(print_r($caller,true));
}
```
