### PR TITLE
[Regression] Protostar is set two times as HTML5

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -29,9 +29,6 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 if($task == "edit" || $layout == "form" )
 {
 	$fullWidth = 1;


### PR DESCRIPTION
#### Summary of Changes

Minor correction as protostar index.php is being setted two times as html5. In:
- https://github.com/joomla/joomla-cms/blob/staging/templates/protostar/index.php#L19
- https://github.com/joomla/joomla-cms/blob/staging/templates/protostar/index.php#L33
#### Testing Instructions

Code review.
