### PR TITLE
[com_redirect] Solve javascript error on bulk import modal close

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default_batch.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch.php
@@ -27,7 +27,7 @@ defined('_JEXEC') or die;
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.getElementById('batch_urls').value='';" data-dismiss="modal">
+		<button class="btn" data-dismiss="modal" type="button" onclick="document.getElementById('batch_urls').value='';">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('links.batch');">

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch.php
@@ -27,7 +27,7 @@ defined('_JEXEC') or die;
 		</div>
 	</div>
 	<div class="modal-footer">
-		<button class="btn" type="button" onclick="document.id('batch_urls').value=''" data-dismiss="modal">
+		<button class="btn" type="button" onclick="document.getElementById('batch_urls').value='';" data-dismiss="modal">
 			<?php echo JText::_('JCANCEL'); ?>
 		</button>
 		<button class="btn btn-primary" type="submit" onclick="Joomla.submitbutton('links.batch');">

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.id('batch_urls').value=''" data-dismiss="modal">
+<button class="btn" type="button" onclick="document.getElementById('batch_urls').value='';" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </button>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('links.batch');">

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch_urls').value='';" data-dismiss="modal">
+<button class="btn" data-dismiss="modal" type="button" onclick="document.getElementById('batch_urls').value='';">
 	<?php echo JText::_('JCANCEL'); ?>
 </button>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('links.batch');">


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

There is a javascript error on closing the "Bulk Import" modal of com_redirect.
This simple PR fixes it.
#### Testing Instructions

Code review, or:
1. Use latest staging
2. Open dev console on chrome
3. Go to Components -> Redirects and press "Bulk Import", the modal opens
4. Press "Cancel" on the modal, you'll see a javascript error on chrome console
5. Apply patch.
6. Repeat test, no js error.
