### PR TITLE
Removed superfluous logic from JFormRuleEmail

### DIFF
--- a/libraries/joomla/form/rule/email.php
+++ b/libraries/joomla/form/rule/email.php
@@ -52,14 +52,6 @@ class JFormRuleEmail extends JFormRule
 			return true;
 		}
 
-		// If the tld attribute is present, change the regular expression to require at least 2 characters for it.
-		$tld = ((string) $element['tld'] == 'tld' || (string) $element['tld'] == 'required');
-
-		if ($tld)
-		{
-			$this->regex = '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$';
-		}
-
 		// Determine if the multiple attribute is present
 		$multiple = ((string) $element['multiple'] == 'true' || (string) $element['multiple'] == 'multiple');
 


### PR DESCRIPTION
#### Summary of Changes

The email address pattern property is set by default, and the conditional code makes no changes to it so can therefore be removed.  In addition, the $tld variable can be removed as it is no longer required.
#### Testing Instructions

Run tests as normal.  Tests don't need to be modified as only redundant logic was removed.
