### PR TITLE
SEF mode Links from Numeric Tag Won't work in Popular Tags module

### DIFF
--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -43,7 +43,7 @@ if (!count($list)) : ?>
 		endif;
 ?>
 		<span class="tag">
-			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
+			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">
 				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 			<?php if ($display_count) : ?>
 				<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10689
Original issue description

> #### Steps to reproduce the issue
> 
> Create a numeric tag in an article and create a new Popular Tags module, using the cloud display option.
> #### Expected result
> 
> Display an article which is tagged by the numeric tag.
> #### Actual result
> 
> 404 Error
> #### System information (as much as possible)
> 
> Joomla 3.5.1/php 7.0/mysql 5.7.11/ SEF mode
> #### Additional comments
> 
> To correct this, modify modules/mod_tags_popular/tmpl/cloud.php, line 46 should contain
> ...$item->tag_id . '-' . $item->alias)...
> instead of
> ...$item->tag_id . ':' . $item->alias)...
