### PR TITLE
Create a cache directory for the install app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /administrator/cache
 /administrator/logs
 /cache
+/installation/cache
 /tmp
 /configuration.php
 /.htaccess

--- a/installation/cache/index.html
+++ b/installation/cache/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>


### PR DESCRIPTION
Pull Request for Issue #10696
#### Summary of Changes

Create a cache directory for the install app so that a path lives at its defined `JPATH_CACHE` path of `installation/cache` and makes the default configuration for the filesystem cache handler actually work in that environment because of deep rooted internal coupling to the caching API.
#### Testing Instructions

Installing languages works right.  Pre-patch it fails based on diagnosis in linked issue.
