### PR TITLE
[com_content] - use index scan instead of sequential scan

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -584,7 +584,7 @@ class ContentModelArticle extends JModelAdmin
 
 				$table = JTable::getInstance('Content', 'JTable');
 
-				if ($table->load(array('alias' => $data['alias'], 'catid' => $data['catid'])))
+				if ($table->load(array('catid' => $data['catid'], 'alias' => $data['alias'])))
 				{
 					$msg = JText::_('COM_CONTENT_SAVE_WARNING');
 				}

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -873,7 +873,7 @@ abstract class JModelAdmin extends JModelForm
 		// Alter the title & alias
 		$table = $this->getTable();
 
-		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
+		while ($table->load(array('catid' => $category_id, 'alias => $alias)))
 		{
 			$title = JString::increment($title);
 			$alias = JString::increment($alias, 'dash');

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -873,7 +873,7 @@ abstract class JModelAdmin extends JModelForm
 		// Alter the title & alias
 		$table = $this->getTable();
 
-		while ($table->load(array('catid' => $category_id, 'alias => $alias)))
+		while ($table->load(array('catid' => $category_id, 'alias' => $alias)))
 		{
 			$title = JString::increment($title);
 			$alias = JString::increment($alias, 'dash');

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -336,7 +336,7 @@ class JTableContent extends JTable
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Content', 'JTable', array('dbo' => $this->getDbo()));
 
-		if ($table->load(array('alias' => $this->alias, 'catid' => $this->catid)) && ($table->id != $this->id || $this->id == 0))
+		if ($table->load(array('catid' => $this->catid, 'alias' => $this->alias)) && ($table->id != $this->id || $this->id == 0))
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_ARTICLE_UNIQUE_ALIAS'));
 


### PR DESCRIPTION
#### Summary of Changes

use index scan instead of sequential scan changing the order of the `WHERE` conditions
#### Testing Instructions

save/create an article this query is executed to verify  that there is no the same alias i guess
![usenoindex](https://cloud.githubusercontent.com/assets/181681/15742246/01906490-28be-11e6-905d-0f07f80be9b8.PNG)

as you can see enabling debug plugin + some dirty hack see https://github.com/joomla/joomla-cms/issues/10567#issuecomment-220854012  thanks @ggppdk 

the `#__content` table is scanned sequential  but that table alreay have an index on the field `catid`,
so we can have some performance benefit simply take advantages from the index

apply  the patch and then the index is used
![usetheindex](https://cloud.githubusercontent.com/assets/181681/15742439/2dee89ee-28bf-11e6-836e-1652dc0a3bfa.PNG)
#### Additional comments

question for the #php experts 
Can someone explain why this query is issued 3 times ??? 

can give some speed to #10567
