### PR TITLE
Fix updater sql files parser

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -814,7 +814,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		{
 			if ($this->getManifest()->update)
 			{
-				$result = $this->parent->parseSchemaUpdates($this->getManifest()->update->schemas, $this->extension->extension_id,$this->getManifest()->version);
+				$result = $this->parent->parseSchemaUpdates($this->getManifest()->update->schemas, $this->extension->extension_id, $this->getManifest()->version);
 
 				if ($result === false)
 				{

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -814,7 +814,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		{
 			if ($this->getManifest()->update)
 			{
-				$result = $this->parent->parseSchemaUpdates($this->getManifest()->update->schemas, $this->extension->extension_id);
+				$result = $this->parent->parseSchemaUpdates($this->getManifest()->update->schemas, $this->extension->extension_id,$this->getManifest()->version);
 
 				if ($result === false)
 				{

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -339,6 +339,21 @@ class JInstaller extends JAdapter
 	}
 
 	/**
+	 * Sets an installer path by name
+	 *
+	 * @param   string $name  Path name
+	 * @param   string $value Path
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	public function setPath($name, $value)
+	{
+		$this->paths[$name] = $value;
+	}
+
+	/**
 	 * Installation abort method
 	 *
 	 * @param   string $msg  Abort message from the installer
@@ -457,23 +472,6 @@ class JInstaller extends JAdapter
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get the installation manifest object
-	 *
-	 * @return  SimpleXMLElement  Manifest object
-	 *
-	 * @since   3.1
-	 */
-	public function getManifest()
-	{
-		if (!is_object($this->manifest))
-		{
-			$this->findManifest();
-		}
-
-		return $this->manifest;
 	}
 
 	// Adapter functions
@@ -595,18 +593,20 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Sets an installer path by name
+	 * Get the installation manifest object
 	 *
-	 * @param   string $name  Path name
-	 * @param   string $value Path
-	 *
-	 * @return  void
+	 * @return  SimpleXMLElement  Manifest object
 	 *
 	 * @since   3.1
 	 */
-	public function setPath($name, $value)
+	public function getManifest()
 	{
-		$this->paths[$name] = $value;
+		if (!is_object($this->manifest))
+		{
+			$this->findManifest();
+		}
+
+		return $this->manifest;
 	}
 
 	/**
@@ -804,8 +804,7 @@ class JInstaller extends JAdapter
 			try
 			{
 				$adapter->prepareDiscoverInstall();
-			}
-			catch (RuntimeException $e)
+			} catch (RuntimeException $e)
 			{
 				$this->abort($e->getMessage());
 

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1108,7 +1108,7 @@ class JInstaller extends JAdapter
 
 					foreach ($files as $file)
 					{
-						if (version_compare($file, $version) > 0)
+						if (version_compare($file, $version)>0 && ($top_version && version_compare($file, $top_version)<=0 || !$top_version))
 						{
 							$buffer = file_get_contents($this->getPath('extension_root') . '/' . $schemapath . '/' . $file . '.sql');
 

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -804,7 +804,8 @@ class JInstaller extends JAdapter
 			try
 			{
 				$adapter->prepareDiscoverInstall();
-			} catch (RuntimeException $e)
+			}
+			catch (RuntimeException $e)
 			{
 				$this->abort($e->getMessage());
 

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1108,7 +1108,7 @@ class JInstaller extends JAdapter
 
 					foreach ($files as $file)
 					{
-						if (version_compare($file, $version)>0 && ($top_version && version_compare($file, $top_version)<=0 || !$top_version))
+						if (version_compare($file, $version) > 0 && ($top_version && version_compare($file, $top_version) <= 0 || !$top_version))
 						{
 							$buffer = file_get_contents($this->getPath('extension_root') . '/' . $schemapath . '/' . $file . '.sql');
 

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -29,6 +29,7 @@ class JInstaller extends JAdapter
 	 * @deprecated  4.0
 	 */
 	protected static $instance;
+
 	/**
 	 * JInstaller instances container.
 	 *
@@ -36,6 +37,7 @@ class JInstaller extends JAdapter
 	 * @since  3.4
 	 */
 	protected static $instances;
+
 	/**
 	 * The manifest trigger class
 	 *
@@ -43,6 +45,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	public $manifestClass = null;
+
 	/**
 	 * Extension Table Entry
 	 *
@@ -50,6 +53,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	public $extension = null;
+
 	/**
 	 * The output from the install/uninstall scripts
 	 *
@@ -57,6 +61,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 * */
 	public $message = null;
+
 	/**
 	 * The installation manifest XML object
 	 *
@@ -64,6 +69,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	public $manifest = null;
+
 	/**
 	 * Array of paths needed by the installer
 	 *
@@ -71,6 +77,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $paths = array();
+
 	/**
 	 * True if package is an upgrade
 	 *
@@ -78,6 +85,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $upgrade = null;
+
 	/**
 	 * True if existing files can be overwritten
 	 *
@@ -85,6 +93,7 @@ class JInstaller extends JAdapter
 	 * @since  12.1
 	 */
 	protected $overwrite = false;
+
 	/**
 	 * Stack of installation steps
 	 * - Used for installation rollback
@@ -93,6 +102,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $stepStack = array();
+
 	/**
 	 * The extension message that appears
 	 *
@@ -100,6 +110,7 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $extension_message = null;
+
 	/**
 	 * The redirect URL if this extension (can be null if no redirect)
 	 *
@@ -111,9 +122,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Constructor
 	 *
-	 * @param   string $basepath      Base Path of the adapters
-	 * @param   string $classprefix   Class prefix of adapters
-	 * @param   string $adapterfolder Name of folder to append to base path
+	 * @param   string  $basepath       Base Path of the adapters
+	 * @param   string  $classprefix    Class prefix of adapters
+	 * @param   string  $adapterfolder  Name of folder to append to base path
 	 *
 	 * @since   3.1
 	 */
@@ -127,9 +138,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Returns the global Installer object, only creating it if it doesn't already exist.
 	 *
-	 * @param   string $basepath      Base Path of the adapters
-	 * @param   string $classprefix   Class prefix of adapters
-	 * @param   string $adapterfolder Name of folder to append to base path
+	 * @param   string  $basepath       Base Path of the adapters
+	 * @param   string  $classprefix    Class prefix of adapters
+	 * @param   string  $adapterfolder  Name of folder to append to base path
 	 *
 	 * @return  JInstaller  An installer object
 	 *
@@ -166,7 +177,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the allow overwrite switch
 	 *
-	 * @param   boolean $state Overwrite switch state
+	 * @param   boolean  $state  Overwrite switch state
 	 *
 	 * @return  boolean  True it state is set, false if it is not
 	 *
@@ -203,7 +214,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the redirect location
 	 *
-	 * @param   string $newurl New redirect location
+	 * @param   string  $newurl  New redirect location
 	 *
 	 * @return  void
 	 *
@@ -229,7 +240,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the upgrade switch
 	 *
-	 * @param   boolean $state Upgrade switch state
+	 * @param   boolean  $state  Upgrade switch state
 	 *
 	 * @return  boolean  True if upgrade, false otherwise
 	 *
@@ -254,7 +265,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Pushes a step onto the installer stack for rolling back steps
 	 *
-	 * @param   array $step Installer step
+	 * @param   array  $step  Installer step
 	 *
 	 * @return  void
 	 *
@@ -268,7 +279,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Package installation method
 	 *
-	 * @param   string $path Path to package source folder
+	 * @param   string  $path  Path to package source folder
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -341,8 +352,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Sets an installer path by name
 	 *
-	 * @param   string $name  Path name
-	 * @param   string $value Path
+	 * @param   string  $name   Path name
+	 * @param   string  $value  Path
 	 *
 	 * @return  void
 	 *
@@ -356,8 +367,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Installation abort method
 	 *
-	 * @param   string $msg  Abort message from the installer
-	 * @param   string $type Package type if defined
+	 * @param   string  $msg   Abort message from the installer
+	 * @param   string  $type  Package type if defined
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -444,8 +455,8 @@ class JInstaller extends JAdapter
 	 * Prepare for installation: this method sets the installation directory, finds
 	 * and checks the installation file and verifies the installation type.
 	 *
-	 * @param   string  $route         The install route being followed
-	 * @param   boolean $returnAdapter Flag to return the instantiated adapter
+	 * @param   string   $route          The install route being followed
+	 * @param   boolean  $returnAdapter  Flag to return the instantiated adapter
 	 *
 	 * @return  boolean|JInstallerAdapter  JInstallerAdapter object if explicitly requested otherwise boolean
 	 *
@@ -551,8 +562,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Get an installer path by name
 	 *
-	 * @param   string $name    Path name
-	 * @param   string $default Default value
+	 * @param   string  $name     Path name
+	 * @param   string  $default  Default value
 	 *
 	 * @return  string  Path
 	 *
@@ -566,7 +577,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Is the XML file a valid Joomla installation manifest file.
 	 *
-	 * @param   string $file An xmlfile path to check
+	 * @param   string  $file  An xmlfile path to check
 	 *
 	 * @return  SimpleXMLElement|null  A SimpleXMLElement, or null if the file failed to parse
 	 *
@@ -613,8 +624,8 @@ class JInstaller extends JAdapter
 	 * Fetches an adapter and adds it to the internal storage if an instance is not set
 	 * while also ensuring its a valid adapter name
 	 *
-	 * @param   string $name    Name of adapter to return
-	 * @param   array  $options Adapter options
+	 * @param   string  $name     Name of adapter to return
+	 * @param   array   $options  Adapter options
 	 *
 	 * @return  JInstallerAdapter
 	 *
@@ -637,8 +648,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Gets a list of available install adapters.
 	 *
-	 * @param   array $options An array of options to inject into the adapter
-	 * @param   array $custom  Array of custom install adapters
+	 * @param   array  $options  An array of options to inject into the adapter
+	 * @param   array  $custom   Array of custom install adapters
 	 *
 	 * @return  array  An array of available install adapters.
 	 *
@@ -708,8 +719,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to load an adapter instance
 	 *
-	 * @param   string $adapter Adapter name
-	 * @param   array  $options Adapter options
+	 * @param   string  $adapter  Adapter name
+	 * @param   array   $options  Adapter options
 	 *
 	 * @return  JInstallerAdapter
 	 *
@@ -749,7 +760,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Discovered package installation method
 	 *
-	 * @param   integer $eid Extension ID
+	 * @param   integer  $eid  Extension ID
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -888,7 +899,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Loads all adapters.
 	 *
-	 * @param   array $options Adapter options
+	 * @param   array  $options  Adapter options
 	 *
 	 * @return  void
 	 *
@@ -904,7 +915,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Package update method
 	 *
-	 * @param   string $path Path to package source folder
+	 * @param   string  $path  Path to package source folder
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -966,9 +977,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Package uninstallation method
 	 *
-	 * @param   string  $type       Package type
-	 * @param   mixed   $identifier Package identifier for adapter
-	 * @param   integer $cid        Application ID; deprecated in 1.6
+	 * @param   string   $type        Package type
+	 * @param   mixed    $identifier  Package identifier for adapter
+	 * @param   integer  $cid         Application ID; deprecated in 1.6
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -1009,7 +1020,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Refreshes the manifest cache stored in #__extensions
 	 *
-	 * @param   integer $eid Extension ID
+	 * @param   integer  $eid  Extension ID
 	 *
 	 * @return  boolean
 	 *
@@ -1069,7 +1080,7 @@ class JInstaller extends JAdapter
 	 * Backward compatible method to parse through a queries element of the
 	 * installation manifest file and take appropriate action.
 	 *
-	 * @param   SimpleXMLElement $element The XML node to process
+	 * @param   SimpleXMLElement  $element  The XML node to process
 	 *
 	 * @return  mixed  Number of queries processed or False on error
 	 *
@@ -1118,7 +1129,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to extract the name of a discreet installation sql file from the installation manifest file.
 	 *
-	 * @param   object $element The XML node to process
+	 * @param   object  $element  The XML node to process
 	 *
 	 * @return  mixed  Number of queries processed or False on error
 	 *
@@ -1208,8 +1219,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the schema version for an extension by looking at its latest update
 	 *
-	 * @param   SimpleXMLElement $schema Schema Tag
-	 * @param   integer          $eid    Extension ID
+	 * @param   SimpleXMLElement  $schema  Schema Tag
+	 * @param   integer           $eid     Extension ID
 	 *
 	 * @return  void
 	 *
@@ -1277,9 +1288,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   SimpleXMLElement $schema      The XML node to process
-	 * @param   integer          $eid         Extension Identifier
-	 * @param   SimpleXMLElement $top_version The XML node to process containing verion we updating to
+	 * @param   SimpleXMLElement  $schema       The XML node to process
+	 * @param   integer           $eid          Extension Identifier
+	 * @param   SimpleXMLElement  $top_version  The XML node to process containing verion we updating to
 	 *
 	 * @return  boolean           Result of the operations
 	 *
@@ -1420,10 +1431,10 @@ class JInstaller extends JAdapter
 	 * Method to parse through a files element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   SimpleXMLElement $element  The XML node to process
-	 * @param   integer          $cid      Application ID of application to install to
-	 * @param   array            $oldFiles List of old files (SimpleXMLElement's)
-	 * @param   array            $oldMD5   List of old MD5 sums (indexed by filename with value as MD5)
+	 * @param   SimpleXMLElement  $element   The XML node to process
+	 * @param   integer           $cid       Application ID of application to install to
+	 * @param   array             $oldFiles  List of old files (SimpleXMLElement's)
+	 * @param   array             $oldMD5    List of old MD5 sums (indexed by filename with value as MD5)
 	 *
 	 * @return  boolean      True on success
 	 *
@@ -1547,8 +1558,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Compares two "files" entries to find deleted files/folders
 	 *
-	 * @param   array $old_files An array of SimpleXMLElement objects that are the old files
-	 * @param   array $new_files An array of SimpleXMLElement objects that are the new files
+	 * @param   array  $old_files  An array of SimpleXMLElement objects that are the old files
+	 * @param   array  $new_files  An array of SimpleXMLElement objects that are the new files
 	 *
 	 * @return  array  An array with the delete files and folders in findDeletedFiles[files] and findDeletedFiles[folders] respectively
 	 *
@@ -1655,8 +1666,8 @@ class JInstaller extends JAdapter
 	 *
 	 * Copy files from source directory to the target directory
 	 *
-	 * @param   array   $files     Array with filenames
-	 * @param   boolean $overwrite True if existing files can be replaced
+	 * @param   array    $files      Array with filenames
+	 * @param   boolean  $overwrite  True if existing files can be replaced
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -1768,8 +1779,8 @@ class JInstaller extends JAdapter
 	 * Method to parse through a languages element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   SimpleXMLElement $element The XML node to process
-	 * @param   integer          $cid     Application ID of application to install to
+	 * @param   SimpleXMLElement  $element  The XML node to process
+	 * @param   integer           $cid      Application ID of application to install to
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -1884,8 +1895,8 @@ class JInstaller extends JAdapter
 	 * Method to parse through a media element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   SimpleXMLElement $element The XML node to process
-	 * @param   integer          $cid     Application ID of application to install to
+	 * @param   SimpleXMLElement  $element  The XML node to process
+	 * @param   integer           $cid      Application ID of application to install to
 	 *
 	 * @return  boolean     True on success
 	 *
@@ -2018,8 +2029,8 @@ class JInstaller extends JAdapter
 	 * Method to parse through a files element of the installation manifest and remove
 	 * the files that were installed
 	 *
-	 * @param   object  $element The XML node to process
-	 * @param   integer $cid     Application ID of application to remove from
+	 * @param   object   $element  The XML node to process
+	 * @param   integer  $cid      Application ID of application to remove from
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -2175,7 +2186,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Copies the installation manifest file to the extension folder in the given client
 	 *
-	 * @param   integer $cid Where to copy the installfile [optional: defaults to 1 (admin)]
+	 * @param   integer  $cid  Where to copy the installfile [optional: defaults to 1 (admin)]
 	 *
 	 * @return  boolean  True on success, False on error
 	 *
@@ -2219,7 +2230,7 @@ class JInstaller extends JAdapter
 	 *
 	 * XML Root tag should be 'install' except for languages which use meta file.
 	 *
-	 * @param   string $path Full path to XML file.
+	 * @param   string  $path  Full path to XML file.
 	 *
 	 * @return  array  XML metadata.
 	 *
@@ -2290,10 +2301,10 @@ class JInstaller extends JAdapter
 	/**
 	 * Cleans up discovered extensions if they're being installed some other way
 	 *
-	 * @param   string  $type    The type of extension (component, etc)
-	 * @param   string  $element Unique element identifier (e.g. com_content)
-	 * @param   string  $folder  The folder of the extension (plugins; e.g. system)
-	 * @param   integer $client  The client application (administrator or site)
+	 * @param   string   $type     The type of extension (component, etc)
+	 * @param   string   $element  Unique element identifier (e.g. com_content)
+	 * @param   string   $folder   The folder of the extension (plugins; e.g. system)
+	 * @param   integer  $client   The client application (administrator or site)
 	 *
 	 * @return  object    Result of query
 	 *
@@ -2317,7 +2328,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Loads an MD5SUMS file into an associative array
 	 *
-	 * @param   string $filename Filename to load
+	 * @param   string  $filename  Filename to load
 	 *
 	 * @return  array  Associative array with filenames as the index and the MD5 as the value
 	 *

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1036,8 +1036,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   SimpleXMLElement  $schema  The XML node to process
-	 * @param   integer           $eid     Extension Identifier
+	 * @param   SimpleXMLElement  $schema  		The XML node to process
+	 * @param   integer           $eid     		Extension Identifier
+	 * @param   SimpleXMLElement  $top_version  The XML node to process containing verion we updating to
 	 *
 	 * @return  boolean           Result of the operations
 	 *

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1036,9 +1036,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   SimpleXMLElement  $schema  		The XML node to process
-	 * @param   integer           $eid     		Extension Identifier
-	 * @param   SimpleXMLElement  $top_version  The XML node to process containing verion we updating to
+	 * @param   SimpleXMLElement $schema The XML node to process
+	 * @param   integer $eid Extension Identifier
+	 * @param   SimpleXMLElement $top_version The XML node to process containing verion we updating to
 	 *
 	 * @return  boolean           Result of the operations
 	 *

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -22,21 +22,20 @@ jimport('joomla.base.adapter');
 class JInstaller extends JAdapter
 {
 	/**
-	 * Array of paths needed by the installer
+	 * JInstaller instance container.
 	 *
-	 * @var    array
-	 * @since  3.1
+	 * @var    JInstaller
+	 * @since       3.1
+	 * @deprecated  4.0
 	 */
-	protected $paths = array();
-
+	protected static $instance;
 	/**
-	 * True if package is an upgrade
+	 * JInstaller instances container.
 	 *
-	 * @var    boolean
-	 * @since  3.1
+	 * @var    JInstaller[]
+	 * @since  3.4
 	 */
-	protected $upgrade = null;
-
+	protected static $instances;
 	/**
 	 * The manifest trigger class
 	 *
@@ -44,7 +43,41 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	public $manifestClass = null;
-
+	/**
+	 * Extension Table Entry
+	 *
+	 * @var    JTableExtension
+	 * @since  3.1
+	 */
+	public $extension = null;
+	/**
+	 * The output from the install/uninstall scripts
+	 *
+	 * @var    string
+	 * @since  3.1
+	 * */
+	public $message = null;
+	/**
+	 * The installation manifest XML object
+	 *
+	 * @var    object
+	 * @since  3.1
+	 */
+	public $manifest = null;
+	/**
+	 * Array of paths needed by the installer
+	 *
+	 * @var    array
+	 * @since  3.1
+	 */
+	protected $paths = array();
+	/**
+	 * True if package is an upgrade
+	 *
+	 * @var    boolean
+	 * @since  3.1
+	 */
+	protected $upgrade = null;
 	/**
 	 * True if existing files can be overwritten
 	 *
@@ -52,7 +85,6 @@ class JInstaller extends JAdapter
 	 * @since  12.1
 	 */
 	protected $overwrite = false;
-
 	/**
 	 * Stack of installation steps
 	 * - Used for installation rollback
@@ -61,31 +93,6 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $stepStack = array();
-
-	/**
-	 * Extension Table Entry
-	 *
-	 * @var    JTableExtension
-	 * @since  3.1
-	 */
-	public $extension = null;
-
-	/**
-	 * The output from the install/uninstall scripts
-	 *
-	 * @var    string
-	 * @since  3.1
-	 * */
-	public $message = null;
-
-	/**
-	 * The installation manifest XML object
-	 *
-	 * @var    object
-	 * @since  3.1
-	 */
-	public $manifest = null;
-
 	/**
 	 * The extension message that appears
 	 *
@@ -93,7 +100,6 @@ class JInstaller extends JAdapter
 	 * @since  3.1
 	 */
 	protected $extension_message = null;
-
 	/**
 	 * The redirect URL if this extension (can be null if no redirect)
 	 *
@@ -103,28 +109,11 @@ class JInstaller extends JAdapter
 	protected $redirect_url = null;
 
 	/**
-	 * JInstaller instance container.
-	 *
-	 * @var    JInstaller
-	 * @since  3.1
-	 * @deprecated  4.0
-	 */
-	protected static $instance;
-
-	/**
-	 * JInstaller instances container.
-	 *
-	 * @var    JInstaller[]
-	 * @since  3.4
-	 */
-	protected static $instances;
-
-	/**
 	 * Constructor
 	 *
-	 * @param   string  $basepath       Base Path of the adapters
-	 * @param   string  $classprefix    Class prefix of adapters
-	 * @param   string  $adapterfolder  Name of folder to append to base path
+	 * @param   string $basepath      Base Path of the adapters
+	 * @param   string $classprefix   Class prefix of adapters
+	 * @param   string $adapterfolder Name of folder to append to base path
 	 *
 	 * @since   3.1
 	 */
@@ -138,9 +127,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Returns the global Installer object, only creating it if it doesn't already exist.
 	 *
-	 * @param   string  $basepath       Base Path of the adapters
-	 * @param   string  $classprefix    Class prefix of adapters
-	 * @param   string  $adapterfolder  Name of folder to append to base path
+	 * @param   string $basepath      Base Path of the adapters
+	 * @param   string $classprefix   Class prefix of adapters
+	 * @param   string $adapterfolder Name of folder to append to base path
 	 *
 	 * @return  JInstaller  An installer object
 	 *
@@ -177,7 +166,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the allow overwrite switch
 	 *
-	 * @param   boolean  $state  Overwrite switch state
+	 * @param   boolean $state Overwrite switch state
 	 *
 	 * @return  boolean  True it state is set, false if it is not
 	 *
@@ -214,7 +203,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the redirect location
 	 *
-	 * @param   string  $newurl  New redirect location
+	 * @param   string $newurl New redirect location
 	 *
 	 * @return  void
 	 *
@@ -240,7 +229,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the upgrade switch
 	 *
-	 * @param   boolean  $state  Upgrade switch state
+	 * @param   boolean $state Upgrade switch state
 	 *
 	 * @return  boolean  True if upgrade, false otherwise
 	 *
@@ -263,56 +252,9 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Get the installation manifest object
-	 *
-	 * @return  SimpleXMLElement  Manifest object
-	 *
-	 * @since   3.1
-	 */
-	public function getManifest()
-	{
-		if (!is_object($this->manifest))
-		{
-			$this->findManifest();
-		}
-
-		return $this->manifest;
-	}
-
-	/**
-	 * Get an installer path by name
-	 *
-	 * @param   string  $name     Path name
-	 * @param   string  $default  Default value
-	 *
-	 * @return  string  Path
-	 *
-	 * @since   3.1
-	 */
-	public function getPath($name, $default = null)
-	{
-		return (!empty($this->paths[$name])) ? $this->paths[$name] : $default;
-	}
-
-	/**
-	 * Sets an installer path by name
-	 *
-	 * @param   string  $name   Path name
-	 * @param   string  $value  Path
-	 *
-	 * @return  void
-	 *
-	 * @since   3.1
-	 */
-	public function setPath($name, $value)
-	{
-		$this->paths[$name] = $value;
-	}
-
-	/**
 	 * Pushes a step onto the installer stack for rolling back steps
 	 *
-	 * @param   array  $step  Installer step
+	 * @param   array $step Installer step
 	 *
 	 * @return  void
 	 *
@@ -324,10 +266,83 @@ class JInstaller extends JAdapter
 	}
 
 	/**
+	 * Package installation method
+	 *
+	 * @param   string $path Path to package source folder
+	 *
+	 * @return  boolean  True if successful
+	 *
+	 * @since   3.1
+	 */
+	public function install($path = null)
+	{
+		if ($path && JFolder::exists($path))
+		{
+			$this->setPath('source', $path);
+		}
+		else
+		{
+			$this->abort(JText::_('JLIB_INSTALLER_ABORT_NOINSTALLPATH'));
+
+			return false;
+		}
+
+		if (!$adapter = $this->setupInstall('install', true))
+		{
+			$this->abort(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'));
+
+			return false;
+		}
+
+		if (!is_object($adapter))
+		{
+			return false;
+		}
+
+		// Add the languages from the package itself
+		if (method_exists($adapter, 'loadLanguage'))
+		{
+			$adapter->loadLanguage($path);
+		}
+
+		// Fire the onExtensionBeforeInstall event.
+		JPluginHelper::importPlugin('extension');
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger(
+			'onExtensionBeforeInstall',
+			array(
+				'method'    => 'install',
+				'type'      => $this->manifest->attributes()->type,
+				'manifest'  => $this->manifest,
+				'extension' => 0
+			)
+		);
+
+		// Run the install
+		$result = $adapter->install();
+
+		// Fire the onExtensionAfterInstall
+		$dispatcher->trigger(
+			'onExtensionAfterInstall',
+			array('installer' => clone $this, 'eid' => $result)
+		);
+
+		if ($result !== false)
+		{
+			// Refresh versionable assets cache
+			JFactory::getApplication()->flushAssets();
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Installation abort method
 	 *
-	 * @param   string  $msg   Abort message from the installer
-	 * @param   string  $type  Package type if defined
+	 * @param   string $msg  Abort message from the installer
+	 * @param   string $type Package type if defined
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -336,7 +351,7 @@ class JInstaller extends JAdapter
 	public function abort($msg = null, $type = null)
 	{
 		$retval = true;
-		$step = array_pop($this->stepStack);
+		$step   = array_pop($this->stepStack);
 
 		// Raise abort warning
 		if ($msg)
@@ -366,7 +381,7 @@ class JInstaller extends JAdapter
 
 				case 'extension':
 					// Get database connector object
-					$db = $this->getDbo();
+					$db    = $this->getDbo();
 					$query = $db->getQuery(true);
 
 					// Remove the entry from the #__extensions table
@@ -410,85 +425,331 @@ class JInstaller extends JAdapter
 		return $retval;
 	}
 
-	// Adapter functions
-
 	/**
-	 * Package installation method
+	 * Prepare for installation: this method sets the installation directory, finds
+	 * and checks the installation file and verifies the installation type.
 	 *
-	 * @param   string  $path  Path to package source folder
+	 * @param   string  $route         The install route being followed
+	 * @param   boolean $returnAdapter Flag to return the instantiated adapter
 	 *
-	 * @return  boolean  True if successful
+	 * @return  boolean|JInstallerAdapter  JInstallerAdapter object if explicitly requested otherwise boolean
 	 *
 	 * @since   3.1
 	 */
-	public function install($path = null)
+	public function setupInstall($route = 'install', $returnAdapter = false)
 	{
-		if ($path && JFolder::exists($path))
+		// We need to find the installation manifest file
+		if (!$this->findManifest())
 		{
-			$this->setPath('source', $path);
+			return false;
+		}
+
+		// Load the adapter(s) for the install manifest
+		$type   = (string) $this->manifest->attributes()->type;
+		$params = array('route' => $route, 'manifest' => $this->getManifest());
+
+		// Load the adapter
+		$adapter = $this->getAdapter($type, $params);
+
+		if ($returnAdapter)
+		{
+			return $adapter;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the installation manifest object
+	 *
+	 * @return  SimpleXMLElement  Manifest object
+	 *
+	 * @since   3.1
+	 */
+	public function getManifest()
+	{
+		if (!is_object($this->manifest))
+		{
+			$this->findManifest();
+		}
+
+		return $this->manifest;
+	}
+
+	// Adapter functions
+
+	/**
+	 * Tries to find the package manifest file
+	 *
+	 * @return  boolean  True on success, False on error
+	 *
+	 * @since   3.1
+	 */
+	public function findManifest()
+	{
+		// Do nothing if folder does not exist for some reason
+		if (!JFolder::exists($this->getPath('source')))
+		{
+			return false;
+		}
+
+		// Main folder manifests (higher priority)
+		$parentXmlfiles = JFolder::files($this->getPath('source'), '.xml$', false, true);
+
+		// Search for children manifests (lower priority)
+		$allXmlFiles = JFolder::files($this->getPath('source'), '.xml$', 1, true);
+
+		// Create an unique array of files ordered by priority
+		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
+
+		// If at least one XML file exists
+		if (!empty($xmlfiles))
+		{
+			foreach ($xmlfiles as $file)
+			{
+				// Is it a valid Joomla installation manifest file?
+				$manifest = $this->isManifest($file);
+
+				if (!is_null($manifest))
+				{
+					// If the root method attribute is set to upgrade, allow file overwrite
+					if ((string) $manifest->attributes()->method == 'upgrade')
+					{
+						$this->upgrade   = true;
+						$this->overwrite = true;
+					}
+
+					// If the overwrite option is set, allow file overwriting
+					if ((string) $manifest->attributes()->overwrite == 'true')
+					{
+						$this->overwrite = true;
+					}
+
+					// Set the manifest object and path
+					$this->manifest = $manifest;
+					$this->setPath('manifest', $file);
+
+					// Set the installation source path to that of the manifest file
+					$this->setPath('source', dirname($file));
+
+					return true;
+				}
+			}
+
+			// None of the XML files found were valid install files
+			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), JLog::WARNING, 'jerror');
+
+			return false;
 		}
 		else
 		{
-			$this->abort(JText::_('JLIB_INSTALLER_ABORT_NOINSTALLPATH'));
+			// No XML files were found in the install folder
+			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), JLog::WARNING, 'jerror');
 
 			return false;
 		}
+	}
 
-		if (!$adapter = $this->setupInstall('install', true))
+	/**
+	 * Get an installer path by name
+	 *
+	 * @param   string $name    Path name
+	 * @param   string $default Default value
+	 *
+	 * @return  string  Path
+	 *
+	 * @since   3.1
+	 */
+	public function getPath($name, $default = null)
+	{
+		return (!empty($this->paths[$name])) ? $this->paths[$name] : $default;
+	}
+
+	/**
+	 * Is the XML file a valid Joomla installation manifest file.
+	 *
+	 * @param   string $file An xmlfile path to check
+	 *
+	 * @return  SimpleXMLElement|null  A SimpleXMLElement, or null if the file failed to parse
+	 *
+	 * @since   3.1
+	 */
+	public function isManifest($file)
+	{
+		$xml = simplexml_load_file($file);
+
+		// If we cannot load the XML file return null
+		if (!$xml)
 		{
-			$this->abort(JText::_('JLIB_INSTALLER_ABORT_DETECTMANIFEST'));
+			return null;
+		}
 
+		// Check for a valid XML root tag.
+		if ($xml->getName() != 'extension')
+		{
+			return null;
+		}
+
+		// Valid manifest file return the object
+		return $xml;
+	}
+
+	/**
+	 * Sets an installer path by name
+	 *
+	 * @param   string $name  Path name
+	 * @param   string $value Path
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	public function setPath($name, $value)
+	{
+		$this->paths[$name] = $value;
+	}
+
+	/**
+	 * Fetches an adapter and adds it to the internal storage if an instance is not set
+	 * while also ensuring its a valid adapter name
+	 *
+	 * @param   string $name    Name of adapter to return
+	 * @param   array  $options Adapter options
+	 *
+	 * @return  JInstallerAdapter
+	 *
+	 * @since       3.4
+	 * @deprecated  4.0  The internal adapter cache will no longer be supported,
+	 *                   use loadAdapter() to fetch an adapter instance
+	 */
+	public function getAdapter($name, $options = array())
+	{
+		$this->getAdapters($options);
+
+		if (!$this->setAdapter($name, $this->_adapters[$name]))
+		{
 			return false;
 		}
 
-		if (!is_object($adapter))
+		return $this->_adapters[$name];
+	}
+
+	/**
+	 * Gets a list of available install adapters.
+	 *
+	 * @param   array $options An array of options to inject into the adapter
+	 * @param   array $custom  Array of custom install adapters
+	 *
+	 * @return  array  An array of available install adapters.
+	 *
+	 * @since   3.4
+	 * @note    As of 4.0, this method will only return the names of available adapters and will not
+	 *          instantiate them and store to the $_adapters class var.
+	 */
+	public function getAdapters($options = array(), array $custom = array())
+	{
+		$files = new DirectoryIterator($this->_basepath . '/' . $this->_adapterfolder);
+
+		// Process the core adapters
+		foreach ($files as $file)
 		{
-			return false;
+			$fileName = $file->getFilename();
+
+			// Only load for php files.
+			if (!$file->isFile() || $file->getExtension() != 'php')
+			{
+				continue;
+			}
+
+			// Derive the class name from the filename.
+			$name  = str_ireplace('.php', '', trim($fileName));
+			$class = $this->_classprefix . ucfirst($name);
+
+			// Core adapters should autoload based on classname, keep this fallback just in case
+			if (!class_exists($class))
+			{
+				// Try to load the adapter object
+				require_once $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName;
+
+				if (!class_exists($class))
+				{
+					// Skip to next one
+					continue;
+				}
+			}
+
+			$this->_adapters[$name] = $this->loadAdapter($name, $options);
 		}
 
-		// Add the languages from the package itself
-		if (method_exists($adapter, 'loadLanguage'))
+		// Add any custom adapters if specified
+		if (count($custom) >= 1)
 		{
-			$adapter->loadLanguage($path);
+			foreach ($custom as $adapter)
+			{
+				// Setup the class name
+				// TODO - Can we abstract this to not depend on the Joomla class namespace without PHP namespaces?
+				$class = $this->_classprefix . ucfirst(trim($adapter));
+
+				// If the class doesn't exist we have nothing left to do but look at the next type. We did our best.
+				if (!class_exists($class))
+				{
+					continue;
+				}
+
+				$this->_adapters[$name] = $this->loadAdapter($name, $options);
+			}
 		}
 
-		// Fire the onExtensionBeforeInstall event.
-		JPluginHelper::importPlugin('extension');
-		$dispatcher = JEventDispatcher::getInstance();
-		$dispatcher->trigger(
-			'onExtensionBeforeInstall',
-			array(
-				'method' => 'install',
-				'type' => $this->manifest->attributes()->type,
-				'manifest' => $this->manifest,
-				'extension' => 0
-			)
-		);
+		return $this->_adapters;
+	}
 
-		// Run the install
-		$result = $adapter->install();
+	// Utility functions
 
-		// Fire the onExtensionAfterInstall
-		$dispatcher->trigger(
-			'onExtensionAfterInstall',
-			array('installer' => clone $this, 'eid' => $result)
-		);
+	/**
+	 * Method to load an adapter instance
+	 *
+	 * @param   string $adapter Adapter name
+	 * @param   array  $options Adapter options
+	 *
+	 * @return  JInstallerAdapter
+	 *
+	 * @since   3.4
+	 * @throws  InvalidArgumentException
+	 */
+	public function loadAdapter($adapter, $options = array())
+	{
+		$class = $this->_classprefix . ucfirst($adapter);
 
-		if ($result !== false)
+		if (!class_exists($class))
 		{
-			// Refresh versionable assets cache
-			JFactory::getApplication()->flushAssets();
+			// @deprecated 4.0 - The adapter should be autoloaded or manually included by the caller
+			$path = $this->_basepath . '/' . $this->_adapterfolder . '/' . $adapter . '.php';
 
-			return true;
+			// Try to load the adapter object
+			if (!file_exists($path))
+			{
+				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
+			}
+
+			// Try once more to find the class
+			require_once $path;
+
+			if (!class_exists($class))
+			{
+				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
+			}
 		}
 
-		return false;
+		// Ensure the adapter type is part of the options array
+		$options['type'] = $adapter;
+
+		return new $class($this, $this->getDbo(), $options);
 	}
 
 	/**
 	 * Discovered package installation method
 	 *
-	 * @param   integer  $eid  Extension ID
+	 * @param   integer $eid Extension ID
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -564,9 +825,9 @@ class JInstaller extends JAdapter
 		$dispatcher->trigger(
 			'onExtensionBeforeInstall',
 			array(
-				'method' => 'discover_install',
-				'type' => $this->extension->get('type'),
-				'manifest' => null,
+				'method'    => 'discover_install',
+				'type'      => $this->extension->get('type'),
+				'manifest'  => null,
 				'extension' => $this->extension->get('extension_id')
 			)
 		);
@@ -625,9 +886,25 @@ class JInstaller extends JAdapter
 	}
 
 	/**
+	 * Loads all adapters.
+	 *
+	 * @param   array $options Adapter options
+	 *
+	 * @return  void
+	 *
+	 * @since       3.4
+	 * @deprecated  4.0  Individual adapters should be instantiated as needed
+	 * @note        This method is serving as a proxy of the legacy JAdapter API into the preferred API
+	 */
+	public function loadAllAdapters($options = array())
+	{
+		$this->getAdapters($options);
+	}
+
+	/**
 	 * Package update method
 	 *
-	 * @param   string  $path  Path to package source folder
+	 * @param   string $path Path to package source folder
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -689,9 +966,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Package uninstallation method
 	 *
-	 * @param   string   $type        Package type
-	 * @param   mixed    $identifier  Package identifier for adapter
-	 * @param   integer  $cid         Application ID; deprecated in 1.6
+	 * @param   string  $type       Package type
+	 * @param   mixed   $identifier Package identifier for adapter
+	 * @param   integer $cid        Application ID; deprecated in 1.6
 	 *
 	 * @return  boolean  True if successful
 	 *
@@ -732,7 +1009,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Refreshes the manifest cache stored in #__extensions
 	 *
-	 * @param   integer  $eid  Extension ID
+	 * @param   integer $eid Extension ID
 	 *
 	 * @return  boolean
 	 *
@@ -788,47 +1065,11 @@ class JInstaller extends JAdapter
 		return false;
 	}
 
-	// Utility functions
-
-	/**
-	 * Prepare for installation: this method sets the installation directory, finds
-	 * and checks the installation file and verifies the installation type.
-	 *
-	 * @param   string   $route          The install route being followed
-	 * @param   boolean  $returnAdapter  Flag to return the instantiated adapter
-	 *
-	 * @return  boolean|JInstallerAdapter  JInstallerAdapter object if explicitly requested otherwise boolean
-	 *
-	 * @since   3.1
-	 */
-	public function setupInstall($route = 'install', $returnAdapter = false)
-	{
-		// We need to find the installation manifest file
-		if (!$this->findManifest())
-		{
-			return false;
-		}
-
-		// Load the adapter(s) for the install manifest
-		$type   = (string) $this->manifest->attributes()->type;
-		$params = array('route' => $route, 'manifest' => $this->getManifest());
-
-		// Load the adapter
-		$adapter = $this->getAdapter($type, $params);
-
-		if ($returnAdapter)
-		{
-			return $adapter;
-		}
-
-		return true;
-	}
-
 	/**
 	 * Backward compatible method to parse through a queries element of the
 	 * installation manifest file and take appropriate action.
 	 *
-	 * @param   SimpleXMLElement  $element  The XML node to process
+	 * @param   SimpleXMLElement $element The XML node to process
 	 *
 	 * @return  mixed  Number of queries processed or False on error
 	 *
@@ -837,7 +1078,7 @@ class JInstaller extends JAdapter
 	public function parseQueries(SimpleXMLElement $element)
 	{
 		// Get the database connector object
-		$db = & $this->_db;
+		$db = &$this->_db;
 
 		if (!$element || !count($element->children()))
 		{
@@ -877,7 +1118,7 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to extract the name of a discreet installation sql file from the installation manifest file.
 	 *
-	 * @param   object  $element  The XML node to process
+	 * @param   object $element The XML node to process
 	 *
 	 * @return  mixed  Number of queries processed or False on error
 	 *
@@ -891,8 +1132,8 @@ class JInstaller extends JAdapter
 			return 0;
 		}
 
-		$queries = array();
-		$db = & $this->_db;
+		$queries  = array();
+		$db       = &$this->_db;
 		$dbDriver = strtolower($db->name);
 
 		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
@@ -906,7 +1147,7 @@ class JInstaller extends JAdapter
 		foreach ($element->children() as $file)
 		{
 			$fCharset = (strtolower($file->attributes()->charset) == 'utf8') ? 'utf8' : '';
-			$fDriver = strtolower($file->attributes()->driver);
+			$fDriver  = strtolower($file->attributes()->driver);
 
 			if ($fDriver == 'mysqli' || $fDriver == 'pdomysql')
 			{
@@ -967,8 +1208,8 @@ class JInstaller extends JAdapter
 	/**
 	 * Set the schema version for an extension by looking at its latest update
 	 *
-	 * @param   SimpleXMLElement  $schema  Schema Tag
-	 * @param   integer           $eid     Extension ID
+	 * @param   SimpleXMLElement $schema Schema Tag
+	 * @param   integer          $eid    Extension ID
 	 *
 	 * @return  void
 	 *
@@ -978,7 +1219,7 @@ class JInstaller extends JAdapter
 	{
 		if ($eid && $schema)
 		{
-			$db = JFactory::getDbo();
+			$db          = JFactory::getDbo();
 			$schemapaths = $schema->children();
 
 			if (!$schemapaths)
@@ -1036,9 +1277,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   SimpleXMLElement	$schema 		The XML node to process
-	 * @param   integer 			$eid 			Extension Identifier
-	 * @param   SimpleXMLElement	$top_version	The XML node to process containing verion we updating to
+	 * @param   SimpleXMLElement $schema      The XML node to process
+	 * @param   integer          $eid         Extension Identifier
+	 * @param   SimpleXMLElement $top_version The XML node to process containing verion we updating to
 	 *
 	 * @return  boolean           Result of the operations
 	 *
@@ -1051,7 +1292,7 @@ class JInstaller extends JAdapter
 		// Ensure we have an XML element and a valid extension id
 		if ($eid && $schema)
 		{
-			$db = JFactory::getDbo();
+			$db          = JFactory::getDbo();
 			$schemapaths = $schema->children();
 
 			if (count($schemapaths))
@@ -1179,10 +1420,10 @@ class JInstaller extends JAdapter
 	 * Method to parse through a files element of the installation manifest and take appropriate
 	 * action.
 	 *
-	 * @param   SimpleXMLElement  $element   The XML node to process
-	 * @param   integer           $cid       Application ID of application to install to
-	 * @param   array             $oldFiles  List of old files (SimpleXMLElement's)
-	 * @param   array             $oldMD5    List of old MD5 sums (indexed by filename with value as MD5)
+	 * @param   SimpleXMLElement $element  The XML node to process
+	 * @param   integer          $cid      Application ID of application to install to
+	 * @param   array            $oldFiles List of old files (SimpleXMLElement's)
+	 * @param   array            $oldMD5   List of old MD5 sums (indexed by filename with value as MD5)
 	 *
 	 * @return  boolean      True on success
 	 *
@@ -1207,12 +1448,12 @@ class JInstaller extends JAdapter
 		 */
 		if ($client)
 		{
-			$pathname = 'extension_' . $client->name;
+			$pathname    = 'extension_' . $client->name;
 			$destination = $this->getPath($pathname);
 		}
 		else
 		{
-			$pathname = 'extension_root';
+			$pathname    = 'extension_root';
 			$destination = $this->getPath($pathname);
 		}
 
@@ -1263,16 +1504,16 @@ class JInstaller extends JAdapter
 		// Copy the MD5SUMS file if it exists
 		if (file_exists($source . '/MD5SUMS'))
 		{
-			$path['src'] = $source . '/MD5SUMS';
+			$path['src']  = $source . '/MD5SUMS';
 			$path['dest'] = $destination . '/MD5SUMS';
 			$path['type'] = 'file';
-			$copyfiles[] = $path;
+			$copyfiles[]  = $path;
 		}
 
 		// Process each file in the $files array (children of $tagName).
 		foreach ($element->children() as $file)
 		{
-			$path['src'] = $source . '/' . $file;
+			$path['src']  = $source . '/' . $file;
 			$path['dest'] = $destination . '/' . $file;
 
 			// Is this path a file or folder?
@@ -1301,705 +1542,13 @@ class JInstaller extends JAdapter
 		}
 
 		return $this->copyFiles($copyfiles);
-	}
-
-	/**
-	 * Method to parse through a languages element of the installation manifest and take appropriate
-	 * action.
-	 *
-	 * @param   SimpleXMLElement  $element  The XML node to process
-	 * @param   integer           $cid      Application ID of application to install to
-	 *
-	 * @return  boolean  True on success
-	 *
-	 * @since   3.1
-	 */
-	public function parseLanguages(SimpleXMLElement $element, $cid = 0)
-	{
-		// TODO: work out why the below line triggers 'node no longer exists' errors with files
-		if (!$element || !count($element->children()))
-		{
-			// Either the tag does not exist or has no children therefore we return zero files processed.
-			return 0;
-		}
-
-		$copyfiles = array();
-
-		// Get the client info
-		$client = JApplicationHelper::getClientInfo($cid);
-
-		// Here we set the folder we are going to copy the files to.
-		// 'languages' Files are copied to JPATH_BASE/language/ folder
-
-		$destination = $client->path . '/language';
-
-		/*
-		 * Here we set the folder we are going to copy the files from.
-		 *
-		 * Does the element have a folder attribute?
-		 *
-		 * If so this indicates that the files are in a subdirectory of the source
-		 * folder and we should append the folder attribute to the source path when
-		 * copying files.
-		 */
-
-		$folder = (string) $element->attributes()->folder;
-
-		if ($folder && file_exists($this->getPath('source') . '/' . $folder))
-		{
-			$source = $this->getPath('source') . '/' . $folder;
-		}
-		else
-		{
-			$source = $this->getPath('source');
-		}
-
-		// Process each file in the $files array (children of $tagName).
-		foreach ($element->children() as $file)
-		{
-			/*
-			 * Language files go in a subfolder based on the language code, ie.
-			 * <language tag="en-US">en-US.mycomponent.ini</language>
-			 * would go in the en-US subdirectory of the language folder.
-			 */
-
-			// We will only install language files where a core language pack
-			// already exists.
-
-			if ((string) $file->attributes()->tag != '')
-			{
-				$path['src'] = $source . '/' . $file;
-
-				if ((string) $file->attributes()->client != '')
-				{
-					// Override the client
-					$langclient = JApplicationHelper::getClientInfo((string) $file->attributes()->client, true);
-					$path['dest'] = $langclient->path . '/language/' . $file->attributes()->tag . '/' . basename((string) $file);
-				}
-				else
-				{
-					// Use the default client
-					$path['dest'] = $destination . '/' . $file->attributes()->tag . '/' . basename((string) $file);
-				}
-
-				// If the language folder is not present, then the core pack hasn't been installed... ignore
-				if (!JFolder::exists(dirname($path['dest'])))
-				{
-					continue;
-				}
-			}
-			else
-			{
-				$path['src'] = $source . '/' . $file;
-				$path['dest'] = $destination . '/' . $file;
-			}
-
-			/*
-			 * Before we can add a file to the copyfiles array we need to ensure
-			 * that the folder we are copying our file to exits and if it doesn't,
-			 * we need to create it.
-			 */
-
-			if (basename($path['dest']) != $path['dest'])
-			{
-				$newdir = dirname($path['dest']);
-
-				if (!JFolder::create($newdir))
-				{
-					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), JLog::WARNING, 'jerror');
-
-					return false;
-				}
-			}
-
-			// Add the file to the copyfiles array
-			$copyfiles[] = $path;
-		}
-
-		return $this->copyFiles($copyfiles);
-	}
-
-	/**
-	 * Method to parse through a media element of the installation manifest and take appropriate
-	 * action.
-	 *
-	 * @param   SimpleXMLElement  $element  The XML node to process
-	 * @param   integer           $cid      Application ID of application to install to
-	 *
-	 * @return  boolean     True on success
-	 *
-	 * @since   3.1
-	 */
-	public function parseMedia(SimpleXMLElement $element, $cid = 0)
-	{
-		if (!$element || !count($element->children()))
-		{
-			// Either the tag does not exist or has no children therefore we return zero files processed.
-			return 0;
-		}
-
-		$copyfiles = array();
-
-		// Here we set the folder we are going to copy the files to.
-		// Default 'media' Files are copied to the JPATH_BASE/media folder
-
-		$folder = ((string) $element->attributes()->destination) ? '/' . $element->attributes()->destination : null;
-		$destination = JPath::clean(JPATH_ROOT . '/media' . $folder);
-
-		// Here we set the folder we are going to copy the files from.
-
-		/*
-		 * Does the element have a folder attribute?
-		 * If so this indicates that the files are in a subdirectory of the source
-		 * folder and we should append the folder attribute to the source path when
-		 * copying files.
-		 */
-
-		$folder = (string) $element->attributes()->folder;
-
-		if ($folder && file_exists($this->getPath('source') . '/' . $folder))
-		{
-			$source = $this->getPath('source') . '/' . $folder;
-		}
-		else
-		{
-			$source = $this->getPath('source');
-		}
-
-		// Process each file in the $files array (children of $tagName).
-		foreach ($element->children() as $file)
-		{
-			$path['src'] = $source . '/' . $file;
-			$path['dest'] = $destination . '/' . $file;
-
-			// Is this path a file or folder?
-			$path['type'] = ($file->getName() == 'folder') ? 'folder' : 'file';
-
-			/*
-			 * Before we can add a file to the copyfiles array we need to ensure
-			 * that the folder we are copying our file to exits and if it doesn't,
-			 * we need to create it.
-			 */
-
-			if (basename($path['dest']) != $path['dest'])
-			{
-				$newdir = dirname($path['dest']);
-
-				if (!JFolder::create($newdir))
-				{
-					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), JLog::WARNING, 'jerror');
-
-					return false;
-				}
-			}
-
-			// Add the file to the copyfiles array
-			$copyfiles[] = $path;
-		}
-
-		return $this->copyFiles($copyfiles);
-	}
-
-	/**
-	 * Method to parse the parameters of an extension, build the INI
-	 * string for its default parameters, and return the INI string.
-	 *
-	 * @return  string   INI string of parameter values
-	 *
-	 * @since   3.1
-	 */
-	public function getParams()
-	{
-		// Validate that we have a fieldset to use
-		if (!isset($this->manifest->config->fields->fieldset))
-		{
-			return '{}';
-		}
-		// Getting the fieldset tags
-		$fieldsets = $this->manifest->config->fields->fieldset;
-
-		// Creating the data collection variable:
-		$ini = array();
-
-		// Iterating through the fieldsets:
-		foreach ($fieldsets as $fieldset)
-		{
-			if (!count($fieldset->children()))
-			{
-				// Either the tag does not exist or has no children therefore we return zero files processed.
-				return null;
-			}
-
-			// Iterating through the fields and collecting the name/default values:
-			foreach ($fieldset as $field)
-			{
-				// Check against the null value since otherwise default values like "0"
-				// cause entire parameters to be skipped.
-
-				if (($name = $field->attributes()->name) === null)
-				{
-					continue;
-				}
-
-				if (($value = $field->attributes()->default) === null)
-				{
-					continue;
-				}
-
-				$ini[(string) $name] = (string) $value;
-			}
-		}
-
-		return json_encode($ini);
-	}
-
-	/**
-	 * Copyfiles
-	 *
-	 * Copy files from source directory to the target directory
-	 *
-	 * @param   array    $files      Array with filenames
-	 * @param   boolean  $overwrite  True if existing files can be replaced
-	 *
-	 * @return  boolean  True on success
-	 *
-	 * @since   3.1
-	 */
-	public function copyFiles($files, $overwrite = null)
-	{
-		/*
-		 * To allow for manual override on the overwriting flag, we check to see if
-		 * the $overwrite flag was set and is a boolean value.  If not, use the object
-		 * allowOverwrite flag.
-		 */
-
-		if (is_null($overwrite) || !is_bool($overwrite))
-		{
-			$overwrite = $this->overwrite;
-		}
-
-		/*
-		 * $files must be an array of filenames.  Verify that it is an array with
-		 * at least one file to copy.
-		 */
-		if (is_array($files) && count($files) > 0)
-		{
-			foreach ($files as $file)
-			{
-				// Get the source and destination paths
-				$filesource = JPath::clean($file['src']);
-				$filedest = JPath::clean($file['dest']);
-				$filetype = array_key_exists('type', $file) ? $file['type'] : 'file';
-
-				if (!file_exists($filesource))
-				{
-					/*
-					 * The source file does not exist.  Nothing to copy so set an error
-					 * and return false.
-					 */
-					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), JLog::WARNING, 'jerror');
-
-					return false;
-				}
-				elseif (($exists = file_exists($filedest)) && !$overwrite)
-				{
-					// It's okay if the manifest already exists
-					if ($this->getPath('manifest') == $filesource)
-					{
-						continue;
-					}
-
-					// The destination file already exists and the overwrite flag is false.
-					// Set an error and return false.
-					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FILE_EXISTS', $filedest), JLog::WARNING, 'jerror');
-
-					return false;
-				}
-				else
-				{
-					// Copy the folder or file to the new location.
-					if ($filetype == 'folder')
-					{
-						if (!(JFolder::copy($filesource, $filedest, null, $overwrite)))
-						{
-							JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER', $filesource, $filedest), JLog::WARNING, 'jerror');
-
-							return false;
-						}
-
-						$step = array('type' => 'folder', 'path' => $filedest);
-					}
-					else
-					{
-						if (!(JFile::copy($filesource, $filedest, null)))
-						{
-							JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FILE', $filesource, $filedest), JLog::WARNING, 'jerror');
-
-							// In 3.2, TinyMCE language handling changed.  Display a special notice in case an older language pack is installed.
-							if (strpos($filedest, 'media/editors/tinymce/jscripts/tiny_mce/langs'))
-							{
-								JLog::add(JText::_('JLIB_INSTALLER_NOT_ERROR'), JLog::WARNING, 'jerror');
-							}
-
-							return false;
-						}
-
-						$step = array('type' => 'file', 'path' => $filedest);
-					}
-
-					/*
-					 * Since we copied a file/folder, we want to add it to the installation step stack so that
-					 * in case we have to roll back the installation we can remove the files copied.
-					 */
-					if (!$exists)
-					{
-						$this->stepStack[] = $step;
-					}
-				}
-			}
-		}
-		else
-		{
-			// The $files variable was either not an array or an empty array
-			return false;
-		}
-
-		return count($files);
-	}
-
-	/**
-	 * Method to parse through a files element of the installation manifest and remove
-	 * the files that were installed
-	 *
-	 * @param   object   $element  The XML node to process
-	 * @param   integer  $cid      Application ID of application to remove from
-	 *
-	 * @return  boolean  True on success
-	 *
-	 * @since   3.1
-	 */
-	public function removeFiles($element, $cid = 0)
-	{
-		if (!$element || !count($element->children()))
-		{
-			// Either the tag does not exist or has no children therefore we return zero files processed.
-			return true;
-		}
-
-		$retval = true;
-
-		// Get the client info if we're using a specific client
-		if ($cid > -1)
-		{
-			$client = JApplicationHelper::getClientInfo($cid);
-		}
-		else
-		{
-			$client = null;
-		}
-
-		// Get the array of file nodes to process
-		$files = $element->children();
-
-		if (count($files) == 0)
-		{
-			// No files to process
-			return true;
-		}
-
-		$folder = '';
-
-		/*
-		 * Here we set the folder we are going to remove the files from.  There are a few
-		 * special cases that need to be considered for certain reserved tags.
-		 */
-		switch ($element->getName())
-		{
-			case 'media':
-				if ((string) $element->attributes()->destination)
-				{
-					$folder = (string) $element->attributes()->destination;
-				}
-				else
-				{
-					$folder = '';
-				}
-
-				$source = $client->path . '/media/' . $folder;
-
-				break;
-
-			case 'languages':
-				$lang_client = (string) $element->attributes()->client;
-
-				if ($lang_client)
-				{
-					$client = JApplicationHelper::getClientInfo($lang_client, true);
-					$source = $client->path . '/language';
-				}
-				else
-				{
-					if ($client)
-					{
-						$source = $client->path . '/language';
-					}
-					else
-					{
-						$source = '';
-					}
-				}
-
-				break;
-
-			default:
-				if ($client)
-				{
-					$pathname = 'extension_' . $client->name;
-					$source = $this->getPath($pathname);
-				}
-				else
-				{
-					$pathname = 'extension_root';
-					$source = $this->getPath($pathname);
-				}
-
-				break;
-		}
-
-		// Process each file in the $files array (children of $tagName).
-		foreach ($files as $file)
-		{
-			/*
-			 * If the file is a language, we must handle it differently.  Language files
-			 * go in a subdirectory based on the language code, ie.
-			 * <language tag="en_US">en_US.mycomponent.ini</language>
-			 * would go in the en_US subdirectory of the languages directory.
-			 */
-
-			if ($file->getName() == 'language' && (string) $file->attributes()->tag != '')
-			{
-				if ($source)
-				{
-					$path = $source . '/' . $file->attributes()->tag . '/' . basename((string) $file);
-				}
-				else
-				{
-					$target_client = JApplicationHelper::getClientInfo((string) $file->attributes()->client, true);
-					$path = $target_client->path . '/language/' . $file->attributes()->tag . '/' . basename((string) $file);
-				}
-
-				// If the language folder is not present, then the core pack hasn't been installed... ignore
-				if (!JFolder::exists(dirname($path)))
-				{
-					continue;
-				}
-			}
-			else
-			{
-				$path = $source . '/' . $file;
-			}
-
-			// Actually delete the files/folders
-
-			if (is_dir($path))
-			{
-				$val = JFolder::delete($path);
-			}
-			else
-			{
-				$val = JFile::delete($path);
-			}
-
-			if ($val === false)
-			{
-				JLog::add('Failed to delete ' . $path, JLog::WARNING, 'jerror');
-				$retval = false;
-			}
-		}
-
-		if (!empty($folder))
-		{
-			JFolder::delete($source);
-		}
-
-		return $retval;
-	}
-
-	/**
-	 * Copies the installation manifest file to the extension folder in the given client
-	 *
-	 * @param   integer  $cid  Where to copy the installfile [optional: defaults to 1 (admin)]
-	 *
-	 * @return  boolean  True on success, False on error
-	 *
-	 * @since   3.1
-	 */
-	public function copyManifest($cid = 1)
-	{
-		// Get the client info
-		$client = JApplicationHelper::getClientInfo($cid);
-
-		$path['src'] = $this->getPath('manifest');
-
-		if ($client)
-		{
-			$pathname = 'extension_' . $client->name;
-			$path['dest'] = $this->getPath($pathname) . '/' . basename($this->getPath('manifest'));
-		}
-		else
-		{
-			$pathname = 'extension_root';
-			$path['dest'] = $this->getPath($pathname) . '/' . basename($this->getPath('manifest'));
-		}
-
-		return $this->copyFiles(array($path), true);
-	}
-
-	/**
-	 * Tries to find the package manifest file
-	 *
-	 * @return  boolean  True on success, False on error
-	 *
-	 * @since   3.1
-	 */
-	public function findManifest()
-	{
-		// Do nothing if folder does not exist for some reason
-		if (!JFolder::exists($this->getPath('source')))
-		{
-			return false;
-		}
-
-		// Main folder manifests (higher priority)
-		$parentXmlfiles = JFolder::files($this->getPath('source'), '.xml$', false, true);
-
-		// Search for children manifests (lower priority)
-		$allXmlFiles    = JFolder::files($this->getPath('source'), '.xml$', 1, true);
-
-		// Create an unique array of files ordered by priority
-		$xmlfiles = array_unique(array_merge($parentXmlfiles, $allXmlFiles));
-
-		// If at least one XML file exists
-		if (!empty($xmlfiles))
-		{
-			foreach ($xmlfiles as $file)
-			{
-				// Is it a valid Joomla installation manifest file?
-				$manifest = $this->isManifest($file);
-
-				if (!is_null($manifest))
-				{
-					// If the root method attribute is set to upgrade, allow file overwrite
-					if ((string) $manifest->attributes()->method == 'upgrade')
-					{
-						$this->upgrade = true;
-						$this->overwrite = true;
-					}
-
-					// If the overwrite option is set, allow file overwriting
-					if ((string) $manifest->attributes()->overwrite == 'true')
-					{
-						$this->overwrite = true;
-					}
-
-					// Set the manifest object and path
-					$this->manifest = $manifest;
-					$this->setPath('manifest', $file);
-
-					// Set the installation source path to that of the manifest file
-					$this->setPath('source', dirname($file));
-
-					return true;
-				}
-			}
-
-			// None of the XML files found were valid install files
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDJOOMLAXMLSETUPFILE'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
-		else
-		{
-			// No XML files were found in the install folder
-			JLog::add(JText::_('JLIB_INSTALLER_ERROR_NOTFINDXMLSETUPFILE'), JLog::WARNING, 'jerror');
-
-			return false;
-		}
-	}
-
-	/**
-	 * Is the XML file a valid Joomla installation manifest file.
-	 *
-	 * @param   string  $file  An xmlfile path to check
-	 *
-	 * @return  SimpleXMLElement|null  A SimpleXMLElement, or null if the file failed to parse
-	 *
-	 * @since   3.1
-	 */
-	public function isManifest($file)
-	{
-		$xml = simplexml_load_file($file);
-
-		// If we cannot load the XML file return null
-		if (!$xml)
-		{
-			return null;
-		}
-
-		// Check for a valid XML root tag.
-		if ($xml->getName() != 'extension')
-		{
-			return null;
-		}
-
-		// Valid manifest file return the object
-		return $xml;
-	}
-
-	/**
-	 * Generates a manifest cache
-	 *
-	 * @return string serialised manifest data
-	 *
-	 * @since   3.1
-	 */
-	public function generateManifestCache()
-	{
-		return json_encode(self::parseXMLInstallFile($this->getPath('manifest')));
-	}
-
-	/**
-	 * Cleans up discovered extensions if they're being installed some other way
-	 *
-	 * @param   string   $type     The type of extension (component, etc)
-	 * @param   string   $element  Unique element identifier (e.g. com_content)
-	 * @param   string   $folder   The folder of the extension (plugins; e.g. system)
-	 * @param   integer  $client   The client application (administrator or site)
-	 *
-	 * @return  object    Result of query
-	 *
-	 * @since   3.1
-	 */
-	public function cleanDiscoveredExtension($type, $element, $folder = '', $client = 0)
-	{
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->delete($db->quoteName('#__extensions'))
-			->where('type = ' . $db->quote($type))
-			->where('element = ' . $db->quote($element))
-			->where('folder = ' . $db->quote($folder))
-			->where('client_id = ' . (int) $client)
-			->where('state = -1');
-		$db->setQuery($query);
-
-		return $db->execute();
 	}
 
 	/**
 	 * Compares two "files" entries to find deleted files/folders
 	 *
-	 * @param   array  $old_files  An array of SimpleXMLElement objects that are the old files
-	 * @param   array  $new_files  An array of SimpleXMLElement objects that are the new files
+	 * @param   array $old_files An array of SimpleXMLElement objects that are the old files
+	 * @param   array $new_files An array of SimpleXMLElement objects that are the new files
 	 *
 	 * @return  array  An array with the delete files and folders in findDeletedFiles[files] and findDeletedFiles[folders] respectively
 	 *
@@ -2102,38 +1651,567 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Loads an MD5SUMS file into an associative array
+	 * Copyfiles
 	 *
-	 * @param   string  $filename  Filename to load
+	 * Copy files from source directory to the target directory
 	 *
-	 * @return  array  Associative array with filenames as the index and the MD5 as the value
+	 * @param   array   $files     Array with filenames
+	 * @param   boolean $overwrite True if existing files can be replaced
+	 *
+	 * @return  boolean  True on success
 	 *
 	 * @since   3.1
 	 */
-	public function loadMD5Sum($filename)
+	public function copyFiles($files, $overwrite = null)
 	{
-		if (!file_exists($filename))
+		/*
+		 * To allow for manual override on the overwriting flag, we check to see if
+		 * the $overwrite flag was set and is a boolean value.  If not, use the object
+		 * allowOverwrite flag.
+		 */
+
+		if (is_null($overwrite) || !is_bool($overwrite))
 		{
-			// Bail if the file doesn't exist
+			$overwrite = $this->overwrite;
+		}
+
+		/*
+		 * $files must be an array of filenames.  Verify that it is an array with
+		 * at least one file to copy.
+		 */
+		if (is_array($files) && count($files) > 0)
+		{
+			foreach ($files as $file)
+			{
+				// Get the source and destination paths
+				$filesource = JPath::clean($file['src']);
+				$filedest   = JPath::clean($file['dest']);
+				$filetype   = array_key_exists('type', $file) ? $file['type'] : 'file';
+
+				if (!file_exists($filesource))
+				{
+					/*
+					 * The source file does not exist.  Nothing to copy so set an error
+					 * and return false.
+					 */
+					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+				elseif (($exists = file_exists($filedest)) && !$overwrite)
+				{
+					// It's okay if the manifest already exists
+					if ($this->getPath('manifest') == $filesource)
+					{
+						continue;
+					}
+
+					// The destination file already exists and the overwrite flag is false.
+					// Set an error and return false.
+					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FILE_EXISTS', $filedest), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+				else
+				{
+					// Copy the folder or file to the new location.
+					if ($filetype == 'folder')
+					{
+						if (!(JFolder::copy($filesource, $filedest, null, $overwrite)))
+						{
+							JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FOLDER', $filesource, $filedest), JLog::WARNING, 'jerror');
+
+							return false;
+						}
+
+						$step = array('type' => 'folder', 'path' => $filedest);
+					}
+					else
+					{
+						if (!(JFile::copy($filesource, $filedest, null)))
+						{
+							JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_FAIL_COPY_FILE', $filesource, $filedest), JLog::WARNING, 'jerror');
+
+							// In 3.2, TinyMCE language handling changed.  Display a special notice in case an older language pack is installed.
+							if (strpos($filedest, 'media/editors/tinymce/jscripts/tiny_mce/langs'))
+							{
+								JLog::add(JText::_('JLIB_INSTALLER_NOT_ERROR'), JLog::WARNING, 'jerror');
+							}
+
+							return false;
+						}
+
+						$step = array('type' => 'file', 'path' => $filedest);
+					}
+
+					/*
+					 * Since we copied a file/folder, we want to add it to the installation step stack so that
+					 * in case we have to roll back the installation we can remove the files copied.
+					 */
+					if (!$exists)
+					{
+						$this->stepStack[] = $step;
+					}
+				}
+			}
+		}
+		else
+		{
+			// The $files variable was either not an array or an empty array
 			return false;
 		}
 
-		$data = file($filename, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-		$retval = array();
+		return count($files);
+	}
 
-		foreach ($data as $row)
+	/**
+	 * Method to parse through a languages element of the installation manifest and take appropriate
+	 * action.
+	 *
+	 * @param   SimpleXMLElement $element The XML node to process
+	 * @param   integer          $cid     Application ID of application to install to
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   3.1
+	 */
+	public function parseLanguages(SimpleXMLElement $element, $cid = 0)
+	{
+		// TODO: work out why the below line triggers 'node no longer exists' errors with files
+		if (!$element || !count($element->children()))
 		{
-			// Split up the data
-			$results = explode('  ', $row);
+			// Either the tag does not exist or has no children therefore we return zero files processed.
+			return 0;
+		}
 
-			// Cull any potential prefix
-			$results[1] = str_replace('./', '', $results[1]);
+		$copyfiles = array();
 
-			// Throw into the array
-			$retval[$results[1]] = $results[0];
+		// Get the client info
+		$client = JApplicationHelper::getClientInfo($cid);
+
+		// Here we set the folder we are going to copy the files to.
+		// 'languages' Files are copied to JPATH_BASE/language/ folder
+
+		$destination = $client->path . '/language';
+
+		/*
+		 * Here we set the folder we are going to copy the files from.
+		 *
+		 * Does the element have a folder attribute?
+		 *
+		 * If so this indicates that the files are in a subdirectory of the source
+		 * folder and we should append the folder attribute to the source path when
+		 * copying files.
+		 */
+
+		$folder = (string) $element->attributes()->folder;
+
+		if ($folder && file_exists($this->getPath('source') . '/' . $folder))
+		{
+			$source = $this->getPath('source') . '/' . $folder;
+		}
+		else
+		{
+			$source = $this->getPath('source');
+		}
+
+		// Process each file in the $files array (children of $tagName).
+		foreach ($element->children() as $file)
+		{
+			/*
+			 * Language files go in a subfolder based on the language code, ie.
+			 * <language tag="en-US">en-US.mycomponent.ini</language>
+			 * would go in the en-US subdirectory of the language folder.
+			 */
+
+			// We will only install language files where a core language pack
+			// already exists.
+
+			if ((string) $file->attributes()->tag != '')
+			{
+				$path['src'] = $source . '/' . $file;
+
+				if ((string) $file->attributes()->client != '')
+				{
+					// Override the client
+					$langclient   = JApplicationHelper::getClientInfo((string) $file->attributes()->client, true);
+					$path['dest'] = $langclient->path . '/language/' . $file->attributes()->tag . '/' . basename((string) $file);
+				}
+				else
+				{
+					// Use the default client
+					$path['dest'] = $destination . '/' . $file->attributes()->tag . '/' . basename((string) $file);
+				}
+
+				// If the language folder is not present, then the core pack hasn't been installed... ignore
+				if (!JFolder::exists(dirname($path['dest'])))
+				{
+					continue;
+				}
+			}
+			else
+			{
+				$path['src']  = $source . '/' . $file;
+				$path['dest'] = $destination . '/' . $file;
+			}
+
+			/*
+			 * Before we can add a file to the copyfiles array we need to ensure
+			 * that the folder we are copying our file to exits and if it doesn't,
+			 * we need to create it.
+			 */
+
+			if (basename($path['dest']) != $path['dest'])
+			{
+				$newdir = dirname($path['dest']);
+
+				if (!JFolder::create($newdir))
+				{
+					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+			}
+
+			// Add the file to the copyfiles array
+			$copyfiles[] = $path;
+		}
+
+		return $this->copyFiles($copyfiles);
+	}
+
+	/**
+	 * Method to parse through a media element of the installation manifest and take appropriate
+	 * action.
+	 *
+	 * @param   SimpleXMLElement $element The XML node to process
+	 * @param   integer          $cid     Application ID of application to install to
+	 *
+	 * @return  boolean     True on success
+	 *
+	 * @since   3.1
+	 */
+	public function parseMedia(SimpleXMLElement $element, $cid = 0)
+	{
+		if (!$element || !count($element->children()))
+		{
+			// Either the tag does not exist or has no children therefore we return zero files processed.
+			return 0;
+		}
+
+		$copyfiles = array();
+
+		// Here we set the folder we are going to copy the files to.
+		// Default 'media' Files are copied to the JPATH_BASE/media folder
+
+		$folder      = ((string) $element->attributes()->destination) ? '/' . $element->attributes()->destination : null;
+		$destination = JPath::clean(JPATH_ROOT . '/media' . $folder);
+
+		// Here we set the folder we are going to copy the files from.
+
+		/*
+		 * Does the element have a folder attribute?
+		 * If so this indicates that the files are in a subdirectory of the source
+		 * folder and we should append the folder attribute to the source path when
+		 * copying files.
+		 */
+
+		$folder = (string) $element->attributes()->folder;
+
+		if ($folder && file_exists($this->getPath('source') . '/' . $folder))
+		{
+			$source = $this->getPath('source') . '/' . $folder;
+		}
+		else
+		{
+			$source = $this->getPath('source');
+		}
+
+		// Process each file in the $files array (children of $tagName).
+		foreach ($element->children() as $file)
+		{
+			$path['src']  = $source . '/' . $file;
+			$path['dest'] = $destination . '/' . $file;
+
+			// Is this path a file or folder?
+			$path['type'] = ($file->getName() == 'folder') ? 'folder' : 'file';
+
+			/*
+			 * Before we can add a file to the copyfiles array we need to ensure
+			 * that the folder we are copying our file to exits and if it doesn't,
+			 * we need to create it.
+			 */
+
+			if (basename($path['dest']) != $path['dest'])
+			{
+				$newdir = dirname($path['dest']);
+
+				if (!JFolder::create($newdir))
+				{
+					JLog::add(JText::sprintf('JLIB_INSTALLER_ERROR_CREATE_DIRECTORY', $newdir), JLog::WARNING, 'jerror');
+
+					return false;
+				}
+			}
+
+			// Add the file to the copyfiles array
+			$copyfiles[] = $path;
+		}
+
+		return $this->copyFiles($copyfiles);
+	}
+
+	/**
+	 * Method to parse the parameters of an extension, build the INI
+	 * string for its default parameters, and return the INI string.
+	 *
+	 * @return  string   INI string of parameter values
+	 *
+	 * @since   3.1
+	 */
+	public function getParams()
+	{
+		// Validate that we have a fieldset to use
+		if (!isset($this->manifest->config->fields->fieldset))
+		{
+			return '{}';
+		}
+		// Getting the fieldset tags
+		$fieldsets = $this->manifest->config->fields->fieldset;
+
+		// Creating the data collection variable:
+		$ini = array();
+
+		// Iterating through the fieldsets:
+		foreach ($fieldsets as $fieldset)
+		{
+			if (!count($fieldset->children()))
+			{
+				// Either the tag does not exist or has no children therefore we return zero files processed.
+				return null;
+			}
+
+			// Iterating through the fields and collecting the name/default values:
+			foreach ($fieldset as $field)
+			{
+				// Check against the null value since otherwise default values like "0"
+				// cause entire parameters to be skipped.
+
+				if (($name = $field->attributes()->name) === null)
+				{
+					continue;
+				}
+
+				if (($value = $field->attributes()->default) === null)
+				{
+					continue;
+				}
+
+				$ini[(string) $name] = (string) $value;
+			}
+		}
+
+		return json_encode($ini);
+	}
+
+	/**
+	 * Method to parse through a files element of the installation manifest and remove
+	 * the files that were installed
+	 *
+	 * @param   object  $element The XML node to process
+	 * @param   integer $cid     Application ID of application to remove from
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   3.1
+	 */
+	public function removeFiles($element, $cid = 0)
+	{
+		if (!$element || !count($element->children()))
+		{
+			// Either the tag does not exist or has no children therefore we return zero files processed.
+			return true;
+		}
+
+		$retval = true;
+
+		// Get the client info if we're using a specific client
+		if ($cid > -1)
+		{
+			$client = JApplicationHelper::getClientInfo($cid);
+		}
+		else
+		{
+			$client = null;
+		}
+
+		// Get the array of file nodes to process
+		$files = $element->children();
+
+		if (count($files) == 0)
+		{
+			// No files to process
+			return true;
+		}
+
+		$folder = '';
+
+		/*
+		 * Here we set the folder we are going to remove the files from.  There are a few
+		 * special cases that need to be considered for certain reserved tags.
+		 */
+		switch ($element->getName())
+		{
+			case 'media':
+				if ((string) $element->attributes()->destination)
+				{
+					$folder = (string) $element->attributes()->destination;
+				}
+				else
+				{
+					$folder = '';
+				}
+
+				$source = $client->path . '/media/' . $folder;
+
+				break;
+
+			case 'languages':
+				$lang_client = (string) $element->attributes()->client;
+
+				if ($lang_client)
+				{
+					$client = JApplicationHelper::getClientInfo($lang_client, true);
+					$source = $client->path . '/language';
+				}
+				else
+				{
+					if ($client)
+					{
+						$source = $client->path . '/language';
+					}
+					else
+					{
+						$source = '';
+					}
+				}
+
+				break;
+
+			default:
+				if ($client)
+				{
+					$pathname = 'extension_' . $client->name;
+					$source   = $this->getPath($pathname);
+				}
+				else
+				{
+					$pathname = 'extension_root';
+					$source   = $this->getPath($pathname);
+				}
+
+				break;
+		}
+
+		// Process each file in the $files array (children of $tagName).
+		foreach ($files as $file)
+		{
+			/*
+			 * If the file is a language, we must handle it differently.  Language files
+			 * go in a subdirectory based on the language code, ie.
+			 * <language tag="en_US">en_US.mycomponent.ini</language>
+			 * would go in the en_US subdirectory of the languages directory.
+			 */
+
+			if ($file->getName() == 'language' && (string) $file->attributes()->tag != '')
+			{
+				if ($source)
+				{
+					$path = $source . '/' . $file->attributes()->tag . '/' . basename((string) $file);
+				}
+				else
+				{
+					$target_client = JApplicationHelper::getClientInfo((string) $file->attributes()->client, true);
+					$path          = $target_client->path . '/language/' . $file->attributes()->tag . '/' . basename((string) $file);
+				}
+
+				// If the language folder is not present, then the core pack hasn't been installed... ignore
+				if (!JFolder::exists(dirname($path)))
+				{
+					continue;
+				}
+			}
+			else
+			{
+				$path = $source . '/' . $file;
+			}
+
+			// Actually delete the files/folders
+
+			if (is_dir($path))
+			{
+				$val = JFolder::delete($path);
+			}
+			else
+			{
+				$val = JFile::delete($path);
+			}
+
+			if ($val === false)
+			{
+				JLog::add('Failed to delete ' . $path, JLog::WARNING, 'jerror');
+				$retval = false;
+			}
+		}
+
+		if (!empty($folder))
+		{
+			JFolder::delete($source);
 		}
 
 		return $retval;
+	}
+
+	/**
+	 * Copies the installation manifest file to the extension folder in the given client
+	 *
+	 * @param   integer $cid Where to copy the installfile [optional: defaults to 1 (admin)]
+	 *
+	 * @return  boolean  True on success, False on error
+	 *
+	 * @since   3.1
+	 */
+	public function copyManifest($cid = 1)
+	{
+		// Get the client info
+		$client = JApplicationHelper::getClientInfo($cid);
+
+		$path['src'] = $this->getPath('manifest');
+
+		if ($client)
+		{
+			$pathname     = 'extension_' . $client->name;
+			$path['dest'] = $this->getPath($pathname) . '/' . basename($this->getPath('manifest'));
+		}
+		else
+		{
+			$pathname     = 'extension_root';
+			$path['dest'] = $this->getPath($pathname) . '/' . basename($this->getPath('manifest'));
+		}
+
+		return $this->copyFiles(array($path), true);
+	}
+
+	/**
+	 * Generates a manifest cache
+	 *
+	 * @return string serialised manifest data
+	 *
+	 * @since   3.1
+	 */
+	public function generateManifestCache()
+	{
+		return json_encode(self::parseXMLInstallFile($this->getPath('manifest')));
 	}
 
 	/**
@@ -2141,7 +2219,7 @@ class JInstaller extends JAdapter
 	 *
 	 * XML Root tag should be 'install' except for languages which use meta file.
 	 *
-	 * @param   string  $path  Full path to XML file.
+	 * @param   string $path Full path to XML file.
 	 *
 	 * @return  array  XML metadata.
 	 *
@@ -2182,18 +2260,18 @@ class JInstaller extends JAdapter
 		$data['type'] = $xml->getName() == 'metafile' ? 'language' : (string) $xml->attributes()->type;
 
 		$data['creationDate'] = ((string) $xml->creationDate) ? (string) $xml->creationDate : JText::_('Unknown');
-		$data['author'] = ((string) $xml->author) ? (string) $xml->author : JText::_('Unknown');
+		$data['author']       = ((string) $xml->author) ? (string) $xml->author : JText::_('Unknown');
 
-		$data['copyright'] = (string) $xml->copyright;
+		$data['copyright']   = (string) $xml->copyright;
 		$data['authorEmail'] = (string) $xml->authorEmail;
-		$data['authorUrl'] = (string) $xml->authorUrl;
-		$data['version'] = (string) $xml->version;
+		$data['authorUrl']   = (string) $xml->authorUrl;
+		$data['version']     = (string) $xml->version;
 		$data['description'] = (string) $xml->description;
-		$data['group'] = (string) $xml->group;
+		$data['group']       = (string) $xml->group;
 
 		if ($xml->files && count($xml->files->children()))
 		{
-			$filename = JFile::getName($path);
+			$filename         = JFile::getName($path);
 			$data['filename'] = JFile::stripExt($filename);
 
 			foreach ($xml->files->children() as $oneFile)
@@ -2210,153 +2288,64 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Fetches an adapter and adds it to the internal storage if an instance is not set
-	 * while also ensuring its a valid adapter name
+	 * Cleans up discovered extensions if they're being installed some other way
 	 *
-	 * @param   string  $name     Name of adapter to return
-	 * @param   array   $options  Adapter options
+	 * @param   string  $type    The type of extension (component, etc)
+	 * @param   string  $element Unique element identifier (e.g. com_content)
+	 * @param   string  $folder  The folder of the extension (plugins; e.g. system)
+	 * @param   integer $client  The client application (administrator or site)
 	 *
-	 * @return  JInstallerAdapter
+	 * @return  object    Result of query
 	 *
-	 * @since       3.4
-	 * @deprecated  4.0  The internal adapter cache will no longer be supported,
-	 *                   use loadAdapter() to fetch an adapter instance
+	 * @since   3.1
 	 */
-	public function getAdapter($name, $options = array())
+	public function cleanDiscoveredExtension($type, $element, $folder = '', $client = 0)
 	{
-		$this->getAdapters($options);
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->delete($db->quoteName('#__extensions'))
+			->where('type = ' . $db->quote($type))
+			->where('element = ' . $db->quote($element))
+			->where('folder = ' . $db->quote($folder))
+			->where('client_id = ' . (int) $client)
+			->where('state = -1');
+		$db->setQuery($query);
 
-		if (!$this->setAdapter($name, $this->_adapters[$name]))
+		return $db->execute();
+	}
+
+	/**
+	 * Loads an MD5SUMS file into an associative array
+	 *
+	 * @param   string $filename Filename to load
+	 *
+	 * @return  array  Associative array with filenames as the index and the MD5 as the value
+	 *
+	 * @since   3.1
+	 */
+	public function loadMD5Sum($filename)
+	{
+		if (!file_exists($filename))
 		{
+			// Bail if the file doesn't exist
 			return false;
 		}
 
-		return $this->_adapters[$name];
-	}
+		$data   = file($filename, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+		$retval = array();
 
-	/**
-	 * Gets a list of available install adapters.
-	 *
-	 * @param   array  $options  An array of options to inject into the adapter
-	 * @param   array  $custom   Array of custom install adapters
-	 *
-	 * @return  array  An array of available install adapters.
-	 *
-	 * @since   3.4
-	 * @note    As of 4.0, this method will only return the names of available adapters and will not
-	 *          instantiate them and store to the $_adapters class var.
-	 */
-	public function getAdapters($options = array(), array $custom = array())
-	{
-		$files = new DirectoryIterator($this->_basepath . '/' . $this->_adapterfolder);
-
-		// Process the core adapters
-		foreach ($files as $file)
+		foreach ($data as $row)
 		{
-			$fileName = $file->getFilename();
+			// Split up the data
+			$results = explode('  ', $row);
 
-			// Only load for php files.
-			if (!$file->isFile() || $file->getExtension() != 'php')
-			{
-				continue;
-			}
+			// Cull any potential prefix
+			$results[1] = str_replace('./', '', $results[1]);
 
-			// Derive the class name from the filename.
-			$name  = str_ireplace('.php', '', trim($fileName));
-			$class = $this->_classprefix . ucfirst($name);
-
-			// Core adapters should autoload based on classname, keep this fallback just in case
-			if (!class_exists($class))
-			{
-				// Try to load the adapter object
-				require_once $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName;
-
-				if (!class_exists($class))
-				{
-					// Skip to next one
-					continue;
-				}
-			}
-
-			$this->_adapters[$name] = $this->loadAdapter($name, $options);
+			// Throw into the array
+			$retval[$results[1]] = $results[0];
 		}
 
-		// Add any custom adapters if specified
-		if (count($custom) >= 1)
-		{
-			foreach ($custom as $adapter)
-			{
-				// Setup the class name
-				// TODO - Can we abstract this to not depend on the Joomla class namespace without PHP namespaces?
-				$class = $this->_classprefix . ucfirst(trim($adapter));
-
-				// If the class doesn't exist we have nothing left to do but look at the next type. We did our best.
-				if (!class_exists($class))
-				{
-					continue;
-				}
-
-				$this->_adapters[$name] = $this->loadAdapter($name, $options);
-			}
-		}
-
-		return $this->_adapters;
-	}
-
-	/**
-	 * Method to load an adapter instance
-	 *
-	 * @param   string  $adapter  Adapter name
-	 * @param   array   $options  Adapter options
-	 *
-	 * @return  JInstallerAdapter
-	 *
-	 * @since   3.4
-	 * @throws  InvalidArgumentException
-	 */
-	public function loadAdapter($adapter, $options = array())
-	{
-		$class = $this->_classprefix . ucfirst($adapter);
-
-		if (!class_exists($class))
-		{
-			// @deprecated 4.0 - The adapter should be autoloaded or manually included by the caller
-			$path = $this->_basepath . '/' . $this->_adapterfolder . '/' . $adapter . '.php';
-
-			// Try to load the adapter object
-			if (!file_exists($path))
-			{
-				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
-			}
-
-			// Try once more to find the class
-			require_once $path;
-
-			if (!class_exists($class))
-			{
-				throw new InvalidArgumentException(sprintf('The %s install adapter does not exist.', $adapter));
-			}
-		}
-
-		// Ensure the adapter type is part of the options array
-		$options['type'] = $adapter;
-
-		return new $class($this, $this->getDbo(), $options);
-	}
-
-	/**
-	 * Loads all adapters.
-	 *
-	 * @param   array  $options  Adapter options
-	 *
-	 * @return  void
-	 *
-	 * @since       3.4
-	 * @deprecated  4.0  Individual adapters should be instantiated as needed
-	 * @note        This method is serving as a proxy of the legacy JAdapter API into the preferred API
-	 */
-	public function loadAllAdapters($options = array())
-	{
-		$this->getAdapters($options);
+		return $retval;
 	}
 }

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1036,9 +1036,9 @@ class JInstaller extends JAdapter
 	/**
 	 * Method to process the updates for an item
 	 *
-	 * @param   SimpleXMLElement $schema The XML node to process
-	 * @param   integer $eid Extension Identifier
-	 * @param   SimpleXMLElement $top_version The XML node to process containing verion we updating to
+	 * @param   SimpleXMLElement	$schema 		The XML node to process
+	 * @param   integer 			$eid 			Extension Identifier
+	 * @param   SimpleXMLElement	$top_version	The XML node to process containing verion we updating to
 	 *
 	 * @return  boolean           Result of the operations
 	 *

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1043,7 +1043,7 @@ class JInstaller extends JAdapter
 	 *
 	 * @since   3.1
 	 */
-	public function parseSchemaUpdates(SimpleXMLElement $schema, $eid)
+	public function parseSchemaUpdates(SimpleXMLElement $schema, $eid, $top_version = null)
 	{
 		$update_count = 0;
 


### PR DESCRIPTION
Pull Request for **Installer run all SQL updates**.
Installer run all SQL updates starting from previous version, and not paying attention to current version that we are updating to.
#### Summary of Changes

Added "top_version" range
#### Testing Instructions

Update extension from version 3.1.020 to 3.1.24
With 
3.1.019
3.1.021
3.1.024
3.1.025
sql update files
_result_: version installed is 3.1.024 and DB version is **3.1.024** (instead of 3.1.024 and **3.1.025** as before)
