### PR TITLE
JModelForm - add parameter group to preprocessData

### DIFF
--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -228,16 +228,17 @@ abstract class JModelForm extends JModelLegacy
 	 *
 	 * @param   string  $context  The context identifier.
 	 * @param   mixed   &$data    The data to be processed. It gets altered directly.
+	 * @param   string  $group    The name of the plugin group to import (defaults to "content").
 	 *
 	 * @return  void
 	 *
 	 * @since   3.1
 	 */
-	protected function preprocessData($context, &$data)
+	protected function preprocessData($context, &$data, $group = 'content')
 	{
 		// Get the dispatcher and load the users plugins.
 		$dispatcher = JEventDispatcher::getInstance();
-		JPluginHelper::importPlugin('content');
+		JPluginHelper::importPlugin($group);
 
 		// Trigger the data preparation event.
 		$results = $dispatcher->trigger('onContentPrepareData', array($context, &$data));


### PR DESCRIPTION
#### Summary of Changes

To be more compatibility with below:

``` php
protected function preprocessForm(JForm $form, $data, $group = 'content')
```

I have added parameter  $group = 'content'  to preprocessData function.

``` php
protected function preprocessData($context, &$data, $group = 'content')
```

New JModelForm will be more flexible to use with ex. user profile. 
#### Testing Instructions

Go to front end article/category view and check does content event loads. 
