### PR TITLE
Recursive option for folderlist

### DIFF
--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -201,7 +201,7 @@ class JFormFieldFolderList extends JFormFieldList
 		}
 
 		// Get a list of folders in the search path with the given filter.
-		$folders = JFolder::folders($path, $this->filter, $this->recursive, $this->recursive);
+		$folders = JFolder::folders($path, $this->filter, $this->recursive, true);
 
 		// Build the options list from the list of folders.
 		if (is_array($folders))
@@ -217,10 +217,8 @@ class JFormFieldFolderList extends JFormFieldList
 					}
 				}
 
-				if ($this->recursive)
-				{
-					$folder = str_replace($path, '', $folder);
-				}
+				// Remove the root part and the leading /
+				$folder = trim(str_replace($path, '', $folder), '/');
 
 				$options[] = JHtml::_('select.option', $folder, $folder);
 			}

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -44,6 +44,14 @@ class JFormFieldFolderList extends JFormFieldList
 	protected $exclude;
 
 	/**
+	 * The recursive.
+	 *
+	 * @var    string
+	 * @since  3.6
+	 */
+	protected $recursive;
+
+	/**
 	 * The hideNone.
 	 *
 	 * @var    boolean
@@ -82,6 +90,7 @@ class JFormFieldFolderList extends JFormFieldList
 		{
 			case 'filter':
 			case 'exclude':
+			case 'recursive':
 			case 'hideNone':
 			case 'hideDefault':
 			case 'directory':
@@ -108,6 +117,7 @@ class JFormFieldFolderList extends JFormFieldList
 			case 'filter':
 			case 'directory':
 			case 'exclude':
+			case 'recursive':
 				$this->$name = (string) $value;
 				break;
 
@@ -144,6 +154,9 @@ class JFormFieldFolderList extends JFormFieldList
 		{
 			$this->filter  = (string) $this->element['filter'];
 			$this->exclude = (string) $this->element['exclude'];
+
+			$recursive       = (string) $this->element['recursive'];
+			$this->recursive = ($recursive == 'true' || $recursive == 'recursive' || $recursive == '1');
 
 			$hideNone       = (string) $this->element['hide_none'];
 			$this->hideNone = ($hideNone == 'true' || $hideNone == 'hideNone' || $hideNone == '1');
@@ -188,7 +201,7 @@ class JFormFieldFolderList extends JFormFieldList
 		}
 
 		// Get a list of folders in the search path with the given filter.
-		$folders = JFolder::folders($path, $this->filter);
+		$folders = JFolder::folders($path, $this->filter, $this->recursive, $this->recursive);
 
 		// Build the options list from the list of folders.
 		if (is_array($folders))
@@ -202,6 +215,11 @@ class JFormFieldFolderList extends JFormFieldList
 					{
 						continue;
 					}
+				}
+
+				if ($this->recursive)
+				{
+					$folder = str_replace($path, '', $folder);
 				}
 
 				$options[] = JHtml::_('select.option', $folder, $folder);


### PR DESCRIPTION
#### Summary of Changes

The folderlist form field got a new option to show the list the folders recursive.
#### Testing Instructions
- Add the following XML string to the file administrator/components/com_content/models/forms/article.xml in the basic fieldset around line 152.

``` xml
    <field name="directory" type="folderlist" directory="images" class="input-xxlarge"
            required="true" hide_none="true" hide_default="true" recursive="true"
            label="COM_FIELDS_FIELD_IMAGELIST_DIRECTORY_LABEL"
            description="COM_FIELDS_FIELD_IMAGELIST_DIRECTORY_DESC">
            <option value=""></option>
    </field>
```
- Open an article in the back end.
- Navigate to the options tab.
#### Expected result

You should see a new select box which lists all folders recursively which are in the images folder.
#### Actual result

Only the folders below the images folders are shown.

Would be great to get that into 3.6 as it is needed for https://github.com/joomla-projects/custom-fields/issues/97.
