### PR TITLE
Adding an asset_id column in _languages table

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-06-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.6.0-2016-06-05.sql
@@ -1,0 +1,5 @@
+--
+-- Add ACL check for to #__languages
+--
+
+ALTER TABLE `#__languages` ADD COLUMN `asset_id` INT(11) NOT NULL AFTER `lang_id`;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-06-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-06-05.sql
@@ -1,0 +1,5 @@
+--
+-- Add ACL check for to #__languages
+--
+
+ALTER TABLE "#__languages" ADD COLUMN "asset_id" bigint DEFAULT 0 NOT NULL;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-06-05.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.6.0-2016-06-05.sql
@@ -1,0 +1,5 @@
+--
+-- Add ACL check for to #__languages
+--
+
+ALTER TABLE [#__languages] ADD [asset_id] [bigint] NOT NULL DEFAULT 0;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1183,6 +1183,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_types` (
 
 CREATE TABLE IF NOT EXISTS `#__languages` (
   `lang_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `asset_id` int(11) NOT NULL,
   `lang_code` char(7) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
   `title` varchar(50) NOT NULL,
   `title_native` varchar(50) NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1120,6 +1120,7 @@ CREATE TABLE "#__finder_types" (
 --
 CREATE TABLE "#__languages" (
   "lang_id" serial NOT NULL,
+  "asset_id" bigint DEFAULT 0 NOT NULL,
   "lang_code" varchar(7) NOT NULL,
   "title" varchar(50) NOT NULL,
   "title_native" varchar(50) NOT NULL,

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1,3 +1,4 @@
+__menu_type
 /****** Object:  Table [#__assets] ******/
 SET QUOTED_IDENTIFIER ON;
 
@@ -1857,6 +1858,7 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__languages](
 	[lang_id] [bigint] IDENTITY(1,1) NOT NULL,
+	[asset_id] [bigint] NOT NULL DEFAULT 0,
 	[lang_code] [nvarchar](7) NOT NULL,
 	[title] [nvarchar](50) NOT NULL,
 	[title_native] [nvarchar](50) NOT NULL,

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1,4 +1,3 @@
-__menu_type
 /****** Object:  Table [#__assets] ******/
 SET QUOTED_IDENTIFIER ON;
 


### PR DESCRIPTION
As title says.
Creating this column for future implementation of ACL for Content Languages.
