### PR TITLE
Make sure we check on the action name

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -315,7 +315,6 @@ class JFormFieldRules extends JFormField
 
 					// This is where we show the current effective settings considering currrent group, path and cascade.
 					// Check whether this is a component or global. Change the text slightly.
-
 					if (JAccess::checkGroup($group->value, $action->name, $assetId) !== true)
 					{
 						if ($inheritedRule === null)

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -316,7 +316,7 @@ class JFormFieldRules extends JFormField
 					// This is where we show the current effective settings considering currrent group, path and cascade.
 					// Check whether this is a component or global. Change the text slightly.
 
-					if (JAccess::checkGroup($group->value, 'core.admin', $assetId) !== true)
+					if (JAccess::checkGroup($group->value, $action->name, $assetId) !== true)
 					{
 						if ($inheritedRule === null)
 						{
@@ -346,7 +346,7 @@ class JFormFieldRules extends JFormField
 					}
 					else
 					{
-						// Special handling for  groups that have global admin because they can't  be denied.
+						// Special handling for groups that have global admin because they can't be denied.
 						// The admin rights can be changed.
 						if ($action->name === 'core.admin')
 						{


### PR DESCRIPTION
Pull Request for Issue #10552 
#### Summary of Changes

When checking the access status for a given action, we should check on that current active action. This was hardcoded to core.admin so only this action was checked. This change fixes that.
#### Testing Instructions
1. Go to System -> Global Configuration
2. Click on Banners
3. Click on the Permission Tab
4. Click on the Administrator group and see the following permissions:

![com_banners_administrator_permission_staging](https://cloud.githubusercontent.com/assets/359377/15805172/1b27ce28-2b22-11e6-9f17-e53fc92e66a1.png)
5. All Calculated settings are set to Allowed (Super User)
6. This is wrong because **Configure Options Only** is not set to allowed anywhere
7. Apply the patch and reload the page
8. Click on the Administrator group and see the following permissions:
![com_banners_administrator_permission_patch](https://cloud.githubusercontent.com/assets/359377/15805186/79649d2c-2b22-11e6-871d-cb194d4dbafd.png)
9. The **Configure Options Only** is now set to Not Allowed as it should be
#### Known issues

The setting of (Super User) is not correct either but this pull request doesn't fix that. The plan is to propose multiple small pull requests to fix the ACL issues. This way we can keep track of the changes easier.
