### PR TITLE
Fix PHP 7 compatibility when attaching observer type of FOFUtilsObservableEvent

### DIFF
--- a/libraries/fof/utils/observable/dispatcher.php
+++ b/libraries/fof/utils/observable/dispatcher.php
@@ -186,7 +186,6 @@ class FOFUtilsObservableDispatcher extends FOFUtilsObject
             }
 
             $this->_observers[] = $observer;
-            end($this->_observers);
             $methods = array($observer['event']);
         }
         else
@@ -225,6 +224,7 @@ class FOFUtilsObservableDispatcher extends FOFUtilsObject
             //$methods = get_class_methods($observer);
         }
 
+        end($this->_observers);
         $key = key($this->_observers);
 
         foreach ($methods as $method)

--- a/libraries/fof/utils/observable/dispatcher.php
+++ b/libraries/fof/utils/observable/dispatcher.php
@@ -186,6 +186,7 @@ class FOFUtilsObservableDispatcher extends FOFUtilsObject
             }
 
             $this->_observers[] = $observer;
+            end($this->_observers);
             $methods = array($observer['event']);
         }
         else
@@ -208,6 +209,9 @@ class FOFUtilsObservableDispatcher extends FOFUtilsObject
 
             $this->_observers[] = $observer;
 
+            // Required in PHP 7 since foreach() doesn't advance the internal array counter, see http://php.net/manual/en/migration70.incompatible.php
+            end($this->_observers);
+
             $methods = array();
 
             foreach(get_class_methods($observer) as $obs_method)
@@ -224,7 +228,6 @@ class FOFUtilsObservableDispatcher extends FOFUtilsObject
             //$methods = get_class_methods($observer);
         }
 
-        end($this->_observers);
         $key = key($this->_observers);
 
         foreach ($methods as $method)


### PR DESCRIPTION
#### Summary of Changes

Fix PHP 7 compatibility when attaching observer type of FOFUtilsObservableEvent

Read this issue https://github.com/akeeba/fof/issues/593
and this commit https://github.com/joomla/joomla-cms/commit/791f5612ac7305f94789411f4c3fc459c91077a5
#### Testing Instructions

Just review the code. When you will attach more then one observer type of FOFUtilsObservableEvent with the same event name (e.g. onAfterGetItem) then only the first observer will be fired twice.
