### PR TITLE
Graceful recovery for issue: You are not permitted to use that link to directly access ...

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -522,48 +522,51 @@ class JControllerLegacy extends JObject
 			$values = (array) $app->getUserState($context . '.id');
 
 			$result = in_array((int) $id, $values);
+
 			if (!$result)
 			{
-				// Add some fault-tolerance to the system and (re-) calculate edit permission and checkout the record,
-				// NOTE: 3rd party extensions need to re-implement this, only if they need to pass to allowEdit more than just: "id"=>NNN
-				//
-				// CASE 1: The initial "edit-task", failed to update session properly, due to race-conditions
-				// CASE 2: The initial "edit-task", was never called because the HTTP request was cached by the browser for any reason
-				
+				/*
+				Add some fault-tolerance to the system and (re-) calculate edit permission and checkout the record,
+				NOTE: 3rd party extensions need to re-implement this, only if they need to pass to allowEdit more than just: "id"=>NNN
+
+				CASE 1: The initial "edit-task", failed to update session properly, due to race-conditions
+				CASE 2: The initial "edit-task", was never called because the HTTP request was cached by the browser for any reason
+				*/
+
 				$context_arr = explode(".", $context);
 				$viewName = $this->input->get('view');
 				$optionName = $this->input->get('option');
-				
+
 				// This IF is not really needed, but it may prevent the code from running in an non-desired, non-foreseen case
 				if ( $optionName == reset($context_arr) && $viewName == end($context_arr) )
 				{
-					$controller_name = ucfirst($this->getName()) .'Controller'. ucfirst($viewName);
-					$controller_path = JPATH::clean(JPATH_COMPONENT.'/controllers/'.$viewName.'.php');
-					
+					$controller_name = ucfirst($this->getName()) . 'Controller' . ucfirst($viewName);
+					$controller_path = JPATH::clean(JPATH_COMPONENT . '/controllers/' . $viewName . '.php');
+
 					if ( file_exists($controller_path) )
 					{
-						require_once( $controller_path );
+						require_once $controller_path;
 						$controller = new $controller_name;
 						$model = $controller->getModel();
-						
+
 						// Only calculate edit permission if model was found
 						if ( is_object($model) )
 						{
 							$table = $model->getTable();
-							
+
 							// Determine the name of the primary key for the data.
 							$key = $table->getKeyName();
-							
+
 							// Access check
 							$allowEdit = $controller->allowEdit(array($key => $id), $key);
-							
+
 							// Checkout item if possible
 							if ($allowEdit)
 							{
 								$checkin = property_exists($table, 'checked_out');
 								$checkoutOK = !$checkin || $model->checkout($id);
 							}
-							
+
 							$result = $allowEdit && $checkoutOK;
 						}
 					}


### PR DESCRIPTION
Add some fault-tolerance to the system and recalculate edit permission (also checking out the record)

**CASE 1**: The initial "edit-task", failed to update session properly, due to race-conditions
**CASE 2**: The initial "edit-task", was never called because the HTTP request was cached by the browser for any reason

See issue here for a detailed discussion: #8757

**NOTE:**
3rd party extensions that extend JControllerLegacy need to re-implement this, 
- if they need to pass to allowEdit more than just: "id"=>NNN

Maybe best solution would be instatiate the view inside the controller add / edit task,
- but this means that all tasks would need to re-direct to the edit task instead of the view ... e.g. the 'apply' task, etc, **which is a major B/C break**, so i did not make such a PR !
- if you do not like something this PR, then **please comment and help** fix / improve it

**Testing:**
Try adding this to your .htaccess to force browser caching of the requests that try to add article/record "is-editable" into the sessions (NOTE: the bad effects for the effected URLs will persist for an hour, so do not add more to it)

```
ExpiresDefault "now plus 1 hour"
```
