### PR TITLE
[com_menus] improve alias check and generation

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -388,7 +388,7 @@ class MenusControllerItem extends JControllerForm
 
 			// Redirect back to the edit screen.
 			$editUrl = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId);
-			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'warning');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 			$this->setRedirect(JRoute::_($editUrl, false));
 
 			return false;

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -28,10 +28,6 @@
 			hint="JFIELD_ALIAS_PLACEHOLDER"
 			size="40"/>
 
-		<field name="aliastip"
-			type="spacer"
-			label="COM_MENUS_TIP_ALIAS_LABEL"/>
-
 		<field
 			name="note"
 			type="text"

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -92,11 +92,6 @@ JFactory::getDocument()->addScriptDeclaration($script);
 		<div class="row-fluid">
 			<div class="span9">
 				<?php
-				if ($this->item->type == 'alias')
-				{
-					echo $this->form->getControlGroup('aliastip');
-				}
-
 				echo $this->form->getControlGroup('type');
 
 				if ($this->item->type == 'alias')

--- a/administrator/templates/hathor/html/com_menus/item/edit.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit.php
@@ -95,10 +95,6 @@ JFactory::getDocument()->addScriptDeclaration($script);
 					<?php echo $this->form->getInput('link'); ?></li>
 				<?php endif; ?>
 
-				<?php if ($this->item->type == 'alias') : ?>
-					<li> <?php echo $this->form->getLabel('aliastip'); ?></li>
-				<?php endif; ?>
-
 				<?php if ($this->item->type != 'url') : ?>
 					<li><?php echo $this->form->getLabel('alias'); ?>
 					<?php echo $this->form->getInput('alias'); ?></li>

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -205,7 +205,7 @@ class JTableMenu extends JTableNested
 				}
 			}
 
-			// The alias already exists. Enqueue a warning message and try a new one be adding "-X" (where X is a incremental number) to the alias.
+			// The alias already exists. Send an error message.
 			if ($errorType)
 			{
 				$message .= JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS' . ($this->menutype != $table->menutype ? '_ROOT' : ''));

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -189,8 +189,7 @@ class JTableMenu extends JTableNested
 				// If not exists a menu item at the same level with the same alias (in the All or the same language).
 				if (($table->load(array_replace($itemSearch, array('language' => '*'))) && ($table->id != $this->id || $this->id == 0))
 					|| ($table->load(array_replace($itemSearch, array('language' => $this->language))) && ($table->id != $this->id || $this->id == 0))
-					|| ($this->language == '*' && $table->load($itemSearch) && ($table->id != $this->id || $this->id == 0))
-				)
+					|| ($this->language == '*' && $table->load($itemSearch) && ($table->id != $this->id || $this->id == 0)))
 				{
 					$errorType = 'MULTILINGUAL';
 				}

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -97,18 +97,11 @@ class JTableMenu extends JTableNested
 
 			return false;
 		}
+
 		// Set correct component id to ensure proper 404 messages with separator items
 		if ($this->type == "separator")
 		{
 			$this->component_id = 0;
-		}
-
-		// If the alias field is empty, set it to the title.
-		$this->alias = trim($this->alias);
-
-		if ((empty($this->alias)) && ($this->type != 'alias' && $this->type != 'url'))
-		{
-			$this->alias = $this->title;
 		}
 
 		// Check for a path.
@@ -125,14 +118,6 @@ class JTableMenu extends JTableNested
 		if (trim($this->img) == '')
 		{
 			$this->img = ' ';
-		}
-
-		// Make the alias URL safe.
-		$this->alias = JApplicationHelper::stringURLSafe($this->alias, $this->language);
-
-		if (trim(str_replace('-', '', $this->alias)) == '')
-		{
-			$this->alias = JFactory::getDate()->format('Y-m-d-H-i-s');
 		}
 
 		// Cast the home property to an int for checking.
@@ -184,26 +169,50 @@ class JTableMenu extends JTableNested
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Menu', 'JTable', array('dbo' => $this->getDbo()));
 
-		if ($table->load(
-				array(
-				'alias' => $this->alias,
-				'parent_id' => $this->parent_id,
-				'client_id' => (int) $this->client_id,
-				'language' => $this->language
-				)
-			)
-			&& ($table->id != $this->id || $this->id == 0))
+		$originalAlias = trim($this->alias);
+		$this->alias   = !$originalAlias ? $this->title : $originalAlias;
+		$this->alias   = JApplicationHelper::stringURLSafe(trim($this->alias), $this->language);
+		
+		// If alias still empty (for instance, new menu item with chinese characters with no unicode alias setting).
+		if (empty($this->alias))
 		{
-			if ($this->menutype == $table->menutype)
+			$this->alias = JFactory::getDate()->format('Y-m-d-H-i-s');
+		}
+		else
+		{
+			$itemSearch = array('alias' => $this->alias, 'parent_id' => $this->parent_id, 'client_id' => (int) $this->client_id);
+			$errorType  = '';
+
+			// Check if the alias already exists. For multilingual site.
+			if (JLanguageMultilang::isEnabled())
 			{
-				$this->setError(JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS'));
+				// If not exists a menu item at the same level with the same alias (in the All or the same language).
+				if (($table->load(array_replace($itemSearch, array('language' => '*'))) && ($table->id != $this->id || $this->id == 0))
+					|| ($table->load(array_replace($itemSearch, array('language' => $this->language))) && ($table->id != $this->id || $this->id == 0))
+					|| ($this->language == '*' && $table->load($itemSearch) && ($table->id != $this->id || $this->id == 0))
+					)
+				{
+					$errorType = 'MULTILINGUAL';
+				}
 			}
+			// Check if the alias already exists. For monolingual site.
 			else
 			{
-				$this->setError(JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_ROOT'));
+				// If not exists a menu item at the same level with the same alias (in any language).
+				if ($table->load($itemSearch) && ($table->id != $this->id || $this->id == 0))
+				{
+					$errorType = 'MONOLINGUAL';
+				}
 			}
 
-			return false;
+			// The alias already exists. Enqueue a warning message and try a new one be adding "-X" (where X is a incremental number) to the alias.
+			if ($errorType)
+			{
+				$message .= JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS' . ($this->menutype != $table->menutype ? '_ROOT' : ''));
+				$this->setError($message);
+
+				return false;
+			}
 		}
 
 		if ($this->home == '1')

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -172,7 +172,7 @@ class JTableMenu extends JTableNested
 		$originalAlias = trim($this->alias);
 		$this->alias   = !$originalAlias ? $this->title : $originalAlias;
 		$this->alias   = JApplicationHelper::stringURLSafe(trim($this->alias), $this->language);
-		
+
 		// If alias still empty (for instance, new menu item with chinese characters with no unicode alias setting).
 		if (empty($this->alias))
 		{
@@ -190,7 +190,7 @@ class JTableMenu extends JTableNested
 				if (($table->load(array_replace($itemSearch, array('language' => '*'))) && ($table->id != $this->id || $this->id == 0))
 					|| ($table->load(array_replace($itemSearch, array('language' => $this->language))) && ($table->id != $this->id || $this->id == 0))
 					|| ($this->language == '*' && $table->load($itemSearch) && ($table->id != $this->id || $this->id == 0))
-					)
+				)
 				{
 					$errorType = 'MULTILINGUAL';
 				}

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -207,7 +207,7 @@ class JTableMenu extends JTableNested
 			// The alias already exists. Send an error message.
 			if ($errorType)
 			{
-				$message .= JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS' . ($this->menutype != $table->menutype ? '_ROOT' : ''));
+				$message = JText::_('JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS' . ($this->menutype != $table->menutype ? '_ROOT' : ''));
 				$this->setError($message);
 
 				return false;


### PR DESCRIPTION
#### Summary of Changes

This PR makes several changes on the menu alias generate process.
- Improves alias generation
- Improves alias conflict detection

Also solves some issues in the current alias generate process:
1. In a monolingual site (language filter plugin disabled), create a menu item with the same alias as other menu item you have in the same/other menu root but with different language.
   
   You'll notice it will save with success but it shouldn't.
2. In a multilingual site (language filter plugin enabled), create a menu item with the same alias as other menu item with All language you have in the same/other menu root but in a different language.
   
   You'll notice it will save with success but it shouldn't.
3. Create a menu item of System Links -> _Any type_
   
   You'll notice the generate alias is the current date, not menu item title.
#### Testing Instructions

This needs to be tested with the proper attention.
- Use latest staging and apply patch
- Install one adicional language (example: fr-FR)
- Create the following menu structure:

```
 Menu Type 1:
 - Menu item A: Language All, Alias: menu-item-a
 - Menu item B: Language en-GB, Alias: menu-item-b
 - Menu item C: Language fr-FR, Alias: menu-item-c
 Menu Type 2:
 - Menu item D: Language All, Alias: menu-item-d
 - Menu item E: Language en-GB, Alias: menu-item-e
 - Menu item F: Language fr-FR, Alias: menu-item-f
```
- Apply patch
- Set the site to monolingual (Disable Language Filter System plugin)
- Change the alias in `Menu item B` to `menu-item-a`. It should give a error message.
- Change the alias in `Menu item F` to `menu-item-a`. It should give a error message.
- Now set the site to multilingual (Enable Language Filter System plugin)
- Change the alias in `Menu item B` to `menu-item-a`. It should give a error message.
- Change the alias in `Menu item F` to `menu-item-e`. It should save fine.
- Change the alias in `Menu item E` to `menu-item-a`. It should give a error message.
- Now create a menu item of System Type -> Menu alias and let it auto generate the alias. It should generate fine (without the date as alias).
- Play a little with the alias and check everything is fine (test with and without unicode in global config).

Finally do a code review of the changes.
#### Observations

The alias cannot be duplicated in the following cases:
###### Monolingual Site (language filter plugin disabled)
1. The menu item is at root level and has the same alias of other menu item that is at root level of any other menu.
2. The menu item is not at root level, but was the has the same alias of other menu item that has the  same parent.
###### Multilingual Site (language filter plugin enabled)
1. The menu item language is "All", is at root level and has the same alias of other menu item (any language) that is at root level of any other menu.
2. The menu item language is NOT "All", is at root level and has the same alias of other menu item (same or "All" language) that is at root level of any other menu.
3. The menu item language is "All", is not at root level, but was the has the same alias of other menu item (any language) that has the  same parent.
4. The menu item language is "All", is not at root level, but was the has the same alias of other menu item (same or "All" language) that has the  same parent.

@infograf768 please check if all is working fine.
