### PR TITLE
Prevent Super User from demoting itself

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -381,155 +381,165 @@ class ConfigModelApplication extends ConfigModelForm
 
 		try
 		{
-			// Load the current settings for this component
-			$query = $this->db->getQuery(true)
-				->select($this->db->quoteName(array('name', 'rules')))
-				->from($this->db->quoteName('#__assets'))
-				->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
+			// Check if this group has super user permissions
+			$isSuperUser = JAccess::checkGroup($permission['rule'], 'core.admin');
 
-			$this->db->setQuery($query);
-
-			// Load the results as a list of stdClass objects (see later for more options on retrieving data).
-			$results = $this->db->loadAssocList();
-
-			// No record found, let's create one
-			if (empty($results))
+			// Make sure the super user is not changing the super user status
+			if ($isSuperUser && $permission['action'] === 'core.admin')
 			{
-				$data = array();
-				$data[$permission['action']] = array();
-				$data[$permission['action']] = array($permission['rule'] => $permission['value']);
-
-				$rules = new JAccessRules($data);
-				$asset = JTable::getInstance('asset');
-				$asset->rules = (string) $rules;
-				$asset->name  = (string) $permission['component'];
-				$asset->title = (string) $permission['title'];
-
-				if (!$asset->check() || !$asset->store())
-				{
-					$result['message'] = JText::_('SOME_ERROR_CODE');
-					$result['result'] = false;
-				}
-			}
-			else
-			{
-				// Decode the rule settings
-				$temp = json_decode($results[0]['rules'], true);
-
-				// Check if a new value is to be set
-				if (isset($permission['value']))
-				{
-					// Check if we already have an action entry
-					if (!isset($temp[$permission['action']]))
-					{
-						$temp[$permission['action']] = array();
-					}
-
-					// Check if we already have a rule entry
-					if (!isset($temp[$permission['action']][$permission['rule']]))
-					{
-						$temp[$permission['action']][$permission['rule']] = array();
-					}
-
-					// Set the new permission
-					$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
-
-					// Check if we have an inherited setting
-					if (strlen($permission['value']) === 0)
-					{
-						unset($temp[$permission['action']][$permission['rule']]);
-					}
-				}
-				else
-				{
-					// There is no value so remove the action as it's not needed
-					unset($temp[$permission['action']]);
-				}
-
-				// Store the new permissions
-				$temp  = json_encode($temp);
-				$query = $this->db->getQuery(true)
-					->update($this->db->quoteName('#__assets'))
-					->set($this->db->quoteName('rules') . ' = ' . $this->db->quote($temp))
-					->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
-
-				$this->db->setQuery($query)->execute();
+				$result['message'] = JText::_('JLIB_USER_ERROR_CANNOT_DEMOTE_SELF');
+				$result['result'] = false;
 			}
 
 			if ($result['result'])
 			{
-				// Need to find the asset id by the name of the component.
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('id'))
-					->from($db->quoteName('#__assets'))
-					->where($db->quoteName('name') . ' = ' . $db->quote($permission['component']));
-				$db->setQuery($query);
-				$assetId = (int) $db->loadResult();
+				// Load the current settings for this component
+				$query = $this->db->getQuery(true)
+					->select($this->db->quoteName(array('name', 'rules')))
+					->from($this->db->quoteName('#__assets'))
+					->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
 
-				// Get the new calculated setting for this action
-				$inheritedRule = JAccess::checkGroup($permission['rule'], $permission['action'], $assetId);
+				$this->db->setQuery($query);
 
-				// Get the rules for just this asset (non-recursive).
-				$assetRules = JAccess::getAssetRules($assetId);
+				// Load the results as a list of stdClass objects (see later for more options on retrieving data).
+				$results = $this->db->loadAssocList();
 
-				// Get the actual setting for the action for this group.
-				$assetRule = $assetRules->allow($permission['action'], $permission['rule']);
-
-				// Check if this group has super user permissions
-				$isSuperUser = JAccess::checkGroup($permission['rule'], 'core.admin');
-
-				// If we have a super user we do not need to check anything, super users have all the access
-				if ($isSuperUser)
+				// No record found, let's create one
+				if (empty($results))
 				{
-					$result['class'] = 'label label-success';
-					$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_ALLOWED_ADMIN');
+					$data = array();
+					$data[$permission['action']] = array();
+					$data[$permission['action']] = array($permission['rule'] => $permission['value']);
+
+					$rules = new JAccessRules($data);
+					$asset = JTable::getInstance('asset');
+					$asset->rules = (string) $rules;
+					$asset->name  = (string) $permission['component'];
+					$asset->title = (string) $permission['title'];
+
+					if (!$asset->check() || !$asset->store())
+					{
+						$result['message'] = JText::_('SOME_ERROR_CODE');
+						$result['result'] = false;
+					}
 				}
-
-				// This is where we show the current effective settings considering current group, path and cascade.
-				// Check whether this is a component or global. Change the text slightly.
-
-				// We are not a super user
-				if (!$isSuperUser)
+				else
 				{
-					// We are explicitly allowed
-					if ($assetRule === true)
+					// Decode the rule settings
+					$temp = json_decode($results[0]['rules'], true);
+
+					// Check if a new value is to be set
+					if (isset($permission['value']))
 					{
-						if ($inheritedRule === false)
+						// Check if we already have an action entry
+						if (!isset($temp[$permission['action']]))
 						{
-							// A parent group has been set to denied, we cannot overrule that
-							$result['class'] = 'label label-important';
-							$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_NOT_ALLOWED_ADMIN_CONFLICT');
+							$temp[$permission['action']] = array();
 						}
-						else
+
+						// Check if we already have a rule entry
+						if (!isset($temp[$permission['action']][$permission['rule']]))
 						{
-							$result['class'] = 'label label-success';
-							$result['text'] = JText::_('JLIB_RULES_ALLOWED');
+							$temp[$permission['action']][$permission['rule']] = array();
+						}
+
+						// Set the new permission
+						$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
+
+						// Check if we have an inherited setting
+						if (strlen($permission['value']) === 0)
+						{
+							unset($temp[$permission['action']][$permission['rule']]);
 						}
 					}
-					// We are explicitly denied
-					elseif ($assetRule === false)
-					{
-						$result['class'] = 'label label-important';
-						$result['text'] = JText::_('JLIB_RULES_NOT_ALLOWED');
-					}
-					// Nothing is explicitly set, check inheritance
 					else
 					{
-						if ($inheritedRule === null)
+						// There is no value so remove the action as it's not needed
+						unset($temp[$permission['action']]);
+					}
+
+					// Store the new permissions
+					$temp  = json_encode($temp);
+					$query = $this->db->getQuery(true)
+						->update($this->db->quoteName('#__assets'))
+						->set($this->db->quoteName('rules') . ' = ' . $this->db->quote($temp))
+						->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
+
+					$this->db->setQuery($query)->execute();
+				}
+
+				if ($result['result'])
+				{
+					// Need to find the asset id by the name of the component.
+					$db = JFactory::getDbo();
+					$query = $db->getQuery(true)
+						->select($db->quoteName('id'))
+						->from($db->quoteName('#__assets'))
+						->where($db->quoteName('name') . ' = ' . $db->quote($permission['component']));
+					$db->setQuery($query);
+					$assetId = (int) $db->loadResult();
+
+					// Get the new calculated setting for this action
+					$inheritedRule = JAccess::checkGroup($permission['rule'], $permission['action'], $assetId);
+
+					// Get the rules for just this asset (non-recursive).
+					$assetRules = JAccess::getAssetRules($assetId);
+
+					// Get the actual setting for the action for this group.
+					$assetRule = $assetRules->allow($permission['action'], $permission['rule']);
+
+					// If we have a super user we do not need to check anything, super users have all the access
+					if ($isSuperUser)
+					{
+						$result['class'] = 'label label-success';
+						$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_ALLOWED_ADMIN');
+					}
+
+					// This is where we show the current effective settings considering current group, path and cascade.
+					// Check whether this is a component or global. Change the text slightly.
+
+					// We are not a super user
+					if (!$isSuperUser)
+					{
+						// We are explicitly allowed
+						if ($assetRule === true)
+						{
+							if ($inheritedRule === false)
+							{
+								// A parent group has been set to denied, we cannot overrule that
+								$result['class'] = 'label label-important';
+								$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_NOT_ALLOWED_ADMIN_CONFLICT');
+							}
+							else
+							{
+								$result['class'] = 'label label-success';
+								$result['text'] = JText::_('JLIB_RULES_ALLOWED');
+							}
+						}
+						// We are explicitly denied
+						elseif ($assetRule === false)
 						{
 							$result['class'] = 'label label-important';
 							$result['text'] = JText::_('JLIB_RULES_NOT_ALLOWED');
 						}
-						elseif ($inheritedRule === true)
+						// Nothing is explicitly set, check inheritance
+						else
 						{
-							$result['class'] = 'label label-success';
-							$result['text'] = JText::_('JLIB_RULES_ALLOWED');
-						}
-						elseif ($inheritedRule === false)
-						{
-							$result['class'] = 'label';
-							$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_NOT_ALLOWED_LOCKED');
+							if ($inheritedRule === null)
+							{
+								$result['class'] = 'label label-important';
+								$result['text'] = JText::_('JLIB_RULES_NOT_ALLOWED');
+							}
+							elseif ($inheritedRule === true)
+							{
+								$result['class'] = 'label label-success';
+								$result['text'] = JText::_('JLIB_RULES_ALLOWED');
+							}
+							elseif ($inheritedRule === false)
+							{
+								$result['class'] = 'label';
+								$result['text'] = '<span class="icon-lock icon-white"></span>' . JText::_('JLIB_RULES_NOT_ALLOWED_LOCKED');
+							}
 						}
 					}
 				}


### PR DESCRIPTION
#### Summary of Changes

Currently it is possible as a super user to remove your own super user rights. This causes you to be locked out from your own site.
#### Testing Instructions
1. Login to the administrator section as Super User
2. Go to System -> Global Configuration -> Permissions
3. Click on the Super Users tab
4. Set the Super User option to Denied
5. Success and you are locked out :)
6. Fix the database so you can login by going to ID 1 in the assets table and set core.admin to {"8":1}
7. Apply the patch
8. Login to the administrator section as Super User
9. Go to System -> Global Configuration -> Permissions
10. Click on the Super Users tab
11. Set the Super User option to Denied
12. You are informed you cannot demote yourself and you stay logged in

Calling the troops @andrepereiradasilva and @infograf768 :+1: 
