### PR TITLE
Remove redundant else clause

### DIFF
--- a/libraries/joomla/event/event.php
+++ b/libraries/joomla/event/event.php
@@ -68,9 +68,5 @@ abstract class JEvent extends JObject
 		{
 			return call_user_func_array(array($this, $event), $args);
 		}
-		else
-		{
-			return null;
-		}
 	}
 }


### PR DESCRIPTION
No point in returning null in an else clause because the method will return null if it drops past the if statement anyway.
