### PR TITLE
Do not redirect in a JSON call but return a JSON string

### DIFF
--- a/administrator/components/com_config/controller/application/store.php
+++ b/administrator/components/com_config/controller/application/store.php
@@ -27,8 +27,9 @@ class ConfigControllerApplicationStore extends JControllerBase
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			echo new JResponseJson(json_encode(false), JText::_('JERROR_ALERTNOAUTHOR'));
+
+			JFactory::getApplication()->close();
 		}
 
 		// Get Post DATA
@@ -52,5 +53,7 @@ class ConfigControllerApplicationStore extends JControllerBase
 		{
 			echo new JResponseJson(json_encode(false), 0);
 		}
+
+		JFactory::getApplication()->close();
 	}
 }


### PR DESCRIPTION
#### Summary of Changes

The storing of ACL permissions is always done through AJAX. When a user doesn't have permissions a redirect to the index.php happens but this has no effect in an AJAX call causing the call to die with no notice.

This change fixes that by returning a JSON call with the message to show to the user.

This is not the fix for allowing this user to make the change, just deal with the incorrect redirect.
#### Testing Instructions
1. Login with a user that is part of the Manager/Administrator/or subgroup of this
2. Go to Content -> Articles
3. Click on the Options tab
4. Try to change a permission, there will be no answer from the server. The AJAX call has died with a redirect which can't be parsed.
5. Apply the patch
6. Try to change the permission again and now you will get the notice
   ![no_access](https://cloud.githubusercontent.com/assets/359377/15920288/fc07082a-2e18-11e6-8ddf-33b54ca94edf.png)
7. Problem solved

Pretty please @andrepereiradasilva and @infograf768
