### PR TITLE
Fixed users with permissions not allowed to change ACL

### DIFF
--- a/administrator/components/com_config/controller/application/store.php
+++ b/administrator/components/com_config/controller/application/store.php
@@ -24,8 +24,10 @@ class ConfigControllerApplicationStore extends JControllerBase
 	 */
 	public function execute()
 	{
+		$component = $this->input->get->get('comp');
+
 		// Check if the user is authorized to do this.
-		if (!JFactory::getUser()->authorise('core.admin'))
+		if (!JFactory::getUser()->authorise('core.admin', $component))
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
 			$this->app->redirect('index.php');
@@ -33,7 +35,7 @@ class ConfigControllerApplicationStore extends JControllerBase
 
 		// Get Post DATA
 		$permissions = array(
-			'component' => $this->input->get->get('comp'),
+			'component' => $component,
 			'action'    => $this->input->get->get('action'),
 			'rule'      => $this->input->get->get('rule'),
 			'value'     => $this->input->get->get('value'),


### PR DESCRIPTION
Related to #10763 
#### Summary of Changes

A user with permission to make ACL changes is denied access because the check is incomplete. The user that is part of the Administrator group or a child thereof can login and edit the permissions in Articles for example. However when this user tries that the access is denied because the access check is only done on the global level, not on the actual component level.
#### Testing Instructions
1. Login with a user that is part of the Administrator or subgroup of this
2. Go to Content -> Articles
3. Click on the Options button
4. Click on the Permission tab
5. Try to change a permission, there will be no visible answer from the server (unless #10763 is applied) 
6. Apply the patch
7. Change a permission
8. The permission is now changed

A little help from my friends @andrepereiradasilva and @infograf768 
