### PR TITLE
Fix load language on seving component config

### DIFF
--- a/administrator/components/com_config/controller/component/save.php
+++ b/administrator/components/com_config/controller/component/save.php
@@ -49,6 +49,8 @@ class ConfigControllerComponentSave extends JControllerBase
 		$id     = $this->input->getInt('id');
 		$option = $this->input->get('component');
 		$user   = JFactory::getUser();
+		
+		ConfigHelperConfig::loadLanguageForComponent($option); // load component .sys language
 
 		// Check if the user is authorised to do this.
 		if (!$user->authorise('core.admin', $option) && !$user->authorise('core.options', $option))


### PR DESCRIPTION
If you field in config not valid on save, attribute message or label field lang constant not load.
This fix that.
