### PR TITLE
Use number_format() on stats module

### DIFF
--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -131,6 +131,7 @@ class ModStatsHelper
 					->from('#__weblinks')
 					->where('state = 1');
 				$db->setQuery($query);
+
 				try
 				{
 					$links = $db->loadResult();
@@ -158,6 +159,7 @@ class ModStatsHelper
 				->from('#__content')
 				->where('state = 1');
 			$db->setQuery($query);
+
 			try
 			{
 				$hits = $db->loadResult();
@@ -172,7 +174,7 @@ class ModStatsHelper
 				$rows[$i]        = new stdClass;
 				$rows[$i]->title = JText::_('MOD_STATS_ARTICLES_VIEW_HITS');
 				$rows[$i]->icon  = 'eye';
-				$rows[$i]->data  = $hits + $increase;
+				$rows[$i]->data  = number_format($hits + $increase, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'));
 			}
 		}
 


### PR DESCRIPTION
#### Summary of Changes

Runs the article hit count through `number_format()` for better display of the hit count.
#### Testing Instructions

Apply patch and note the better formatted numbers.

![screen shot 2016-06-10 at 10 57 09 am](https://cloud.githubusercontent.com/assets/368545/15970478/5936a26c-2efa-11e6-8a9b-4febe8c0e22b.png)

![screen shot 2016-06-10 at 10 57 49 am](https://cloud.githubusercontent.com/assets/368545/15970481/5adfa4c4-2efa-11e6-9787-867ee56391f1.png)
