### PR TITLE
Fix postgresql driver setUtf() method

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -883,6 +883,11 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	{
 		$this->connect();
 
+		if (!function_exists('pg_set_client_encoding'))
+		{
+			return -1;
+		}
+
 		return pg_set_client_encoding($this->connection, 'UTF8');
 	}
 


### PR DESCRIPTION
Pull Request for Issue pg_set_client_encoding method does not exist in some postgresql extensions. HHVM is one example where [the postgresql extension deviates from the typical Zend postgresql module](https://github.com/PocketRent/hhvm-pgsql/tree/master#differences-from-zend) php function set. 
#### Summary of Changes

return -1 i.e. a failure when the pg_set_client_encoding method does not exist.
#### Testing Instructions

This is not easily testable unless you happen to have a postgresql module where the pg_set_client_encoding method does not exist.

Recommend to merge by code review.
