### PR TITLE
Bootstrap popup with mootools compatibility #2

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -49,7 +49,7 @@ if ($isMoo)
 		<?php if (!$userRequired) : ?>
 		<div class="pull-left">
 			<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
-				data-user-field="<?php echo $this->escape($field);?>"><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
+				data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>value="0" onclick="window.parent.jSelectUser(this)"<?php endif; ?>><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
 		</div>
 		<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -27,6 +27,22 @@ $listDirn        = $this->escape($this->state->get('list.direction'));
 $enabledStates   = array(0 => 'icon-publish', 1 => 'icon-unpublish');
 $activatedStates = array(0 => 'icon-publish', 1 => 'icon-unpublish');
 $userRequired    = (int) $input->get('required', 0, 'int');
+
+/**
+ * Mootools compatibility
+ *
+ * There is an extra option passed in the url for the iframe &ismoo=0 for the bootstraped field.
+ * By default the value will be 1 or defaults to mootools behaviour using function jSelectUser()
+ *
+ * This should be removed when mootools won't be shipped by Joomla.
+ */
+$isMoo      = $input->getInt('ismoo', 1);
+
+if ($isMoo)
+{
+	$onClick = "window.parent.jSelectUser(this);window.parent.jQuery('.modal.in').modal('hide');";
+}
+
 ?>
 <div class="container-popup">
 	<form action="<?php echo JRoute::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64')); ?>" method="post" name="adminForm" id="adminForm">
@@ -79,7 +95,7 @@ $userRequired    = (int) $input->get('required', 0, 'int');
 				<tr class="row<?php echo $i % 2; ?>">
 					<td>
 						<a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
-							data-user-field="<?php echo $this->escape($field);?>" onclick="if (window.parent) window.parent.jSelectUser(this);">
+							data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>onclick="<?php echo $onClick; ?>"<?php endif; ?>>
 							<?php echo $this->escape($item->name); ?>
 						</a>
 					</td>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -49,7 +49,7 @@ if ($isMoo)
 		<?php if (!$userRequired) : ?>
 		<div class="pull-left">
 			<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
-				data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>value="0" onclick="window.parent.jSelectUser(this)"<?php endif; ?>><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
+				data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>value="" onclick="window.parent.jSelectUser(this)"<?php endif; ?>><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
 		</div>
 		<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>

--- a/administrator/templates/isis/html/layouts/joomla/form/field/user.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/user.php
@@ -48,7 +48,7 @@ extract($displayData);
 
 // Set the link for the user selection page
 $link = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required='
-	. ($required ? 1 : 0) . '&amp;field={field-user-id}'
+	. ($required ? 1 : 0) . '&amp;field={field-user-id}&ismoo=0'
 	. (isset($groups) ? ('&amp;groups=' . base64_encode(json_encode($groups))) : '')
 	. (isset($excluded) ? ('&amp;excluded=' . base64_encode(json_encode($excluded))) : '');
 

--- a/administrator/templates/isis/html/layouts/joomla/form/field/user.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/user.php
@@ -48,7 +48,7 @@ extract($displayData);
 
 // Set the link for the user selection page
 $link = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required='
-	. ($required ? 1 : 0) . '&amp;field={field-user-id}&ismoo=0'
+	. ($required ? 1 : 0) . '&amp;field={field-user-id}&amp;ismoo=0'
 	. (isset($groups) ? ('&amp;groups=' . base64_encode(json_encode($groups))) : '')
 	. (isset($excluded) ? ('&amp;excluded=' . base64_encode(json_encode($excluded))) : '');
 

--- a/templates/protostar/html/layouts/joomla/form/field/user.php
+++ b/templates/protostar/html/layouts/joomla/form/field/user.php
@@ -48,7 +48,7 @@ extract($displayData);
 
 // Set the link for the user selection page
 $link = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required='
-	. ($required ? 1 : 0) . '&amp;field={field-user-id}'
+	. ($required ? 1 : 0) . '&amp;field={field-user-id}&ismoo=0'
 	. (isset($groups) ? ('&amp;groups=' . base64_encode(json_encode($groups))) : '')
 	. (isset($excluded) ? ('&amp;excluded=' . base64_encode(json_encode($excluded))) : '');
 

--- a/templates/protostar/html/layouts/joomla/form/field/user.php
+++ b/templates/protostar/html/layouts/joomla/form/field/user.php
@@ -48,7 +48,7 @@ extract($displayData);
 
 // Set the link for the user selection page
 $link = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required='
-	. ($required ? 1 : 0) . '&amp;field={field-user-id}&ismoo=0'
+	. ($required ? 1 : 0) . '&amp;field={field-user-id}&amp;ismoo=0'
 	. (isset($groups) ? ('&amp;groups=' . base64_encode(json_encode($groups))) : '')
 	. (isset($excluded) ? ('&amp;excluded=' . base64_encode(json_encode($excluded))) : '');
 


### PR DESCRIPTION
### This fixes a B/C for form field user
#### Summary of Changes

Introduce an option that will provide the needed backwards compatibility.
#### Testing Instructions

Apply patch
- Bootstrap mode
  Test creating a new article and ensure that the field for selecting a user still works.
- Mixed mode
  Edit administrator/components/com_content/views/article/tmpl/edit.php
  and paste the code bellow after line 81 (just before `?>`)

``` php
JHtml::_('behavior.modal');

$idTag = 'jform_name';

$test_control[] = '<input type="text" disabled id="' .$idTag . '_id" name="' . $idTag . '" value="" style="display: block"/>';

$test_control[] = '<a class="modal btn" title="XXXXX" href="index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;required=1&amp;field=jform_name"'
    . ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">SELECT MOOTOOLS</a>';

echo implode('', $test_control);
```

Test again the previous scenario as well as the new button that will appear above the tabs (that's a mootools modal). The field should be filled with the user id selected in the pop up
- Compatibility Mode (AKA Mootools)
  Keep the changes in edit.php
  Rename administrator/templates/isis/html/layouts/joomla/form/field/user.php to xxxuser.php
  Repeat the previous testing steps
