### PR TITLE
Fix wrong quoting in PostgreSQL update files

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-05-06.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-05-06.sql
@@ -1,5 +1,6 @@
-DELETE FROM "#__extensions" WHERE "type" = "library" AND "element" = "simplepie";
-INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+DELETE FROM "#__extensions" WHERE "type" = 'library' AND "element" = 'simplepie';
+
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 (455, 'plg_installer_packageinstaller', 'plugin', 'packageinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 1, 0),
 (456, 'plg_installer_folderinstaller', 'plugin', 'folderinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 2, 0),
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 3, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-06-01.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.6.0-2016-06-01.sql
@@ -1,1 +1,1 @@
-UPDATE "#__extensions" SET "protected" = 1, "enabled" = 1 WHERE "name" = "com_ajax";
+UPDATE "#__extensions" SET "protected" = 1, "enabled" = 1 WHERE "name" = 'com_ajax';


### PR DESCRIPTION
Pull Request for Issue #10790
#### Summary of Changes

Incorrect quoting is used in the PostgreSQL update files resulting in the inability for all ~250 users of this database engine to upgrade to 3.6.
#### Testing Instructions

Review the modified files in accordance with the PostgreSQL specification.
