### PR TITLE
Javascript consistency for XTD buttons

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -55,7 +55,7 @@ JFactory::getDocument()->addScriptDeclaration("
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -131,7 +131,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
 						</td>
 						<td>
-							<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<a href="javascript:void(0);" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>'">
 								<?php echo $this->escape($item->title); ?></a>
 							<div class="small">
 								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -29,9 +29,29 @@ JHtml::_('formbehavior.chosen', 'select');
 $searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
 JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
-$function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$editor    = $app->input->getCmd('editor', '');
+
+/*
+ * Javascript to insert the link
+ * View element calls jSelectArticle when an article is clicked
+ * jSelectArticle creates the link tag, sends it to the editor,
+ * and closes the select frame.
+ */
+JFactory::getDocument()->addScriptDeclaration("
+		function jSelectArticle(id, title, catid, object, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			window.parent.jInsertEditorText(tag, '" . $editor . "');
+			window.parent.jModalClose();
+		}
+");
 ?>
 <div class="container-popup">
 
@@ -111,7 +131,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
 						</td>
 						<td>
-							<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 								<?php echo $this->escape($item->title); ?></a>
 							<div class="small">
 								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -39,19 +39,19 @@ $editor    = $app->input->getCmd('editor', '');
  * jSelectArticle creates the link tag, sends it to the editor,
  * and closes the select frame.
  */
-JFactory::getDocument()->addScriptDeclaration("
-		function jSelectArticle(id, title, catid, object, link, lang)
-		{
+JFactory::getDocument()->addScriptDeclaration(
+		"
+		function jSelectArticle(id, title, catid, object, link, lang) {
 			var hreflang = '';
-			if (lang !== '')
-			{
+			if (lang !== '') {
 				var hreflang = ' hreflang = \"' + lang + '\"';
 			}
 			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
 			window.parent.jInsertEditorText(tag, '" . $editor . "');
 			window.parent.jModalClose();
 		}
-");
+		"
+);
 ?>
 <div class="container-popup">
 

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -32,14 +32,18 @@ JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searc
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $editor    = $app->input->getCmd('editor', '');
+$function  = $app->input->getCmd('function', 'jSelectArticle');
 
-/*
- * Javascript to insert the link
- * View element calls jSelectArticle when an article is clicked
- * jSelectArticle creates the link tag, sends it to the editor,
- * and closes the select frame.
- */
-JFactory::getDocument()->addScriptDeclaration(
+if ($function === 'jSelectArticle')
+{
+	/**
+	 * The function jSelectArticle is used on XTD Article
+	 * Javascript to insert the link
+	 * View element calls jSelectArticle when an article is clicked
+	 * jSelectArticle creates the link tag, sends it to the editor,
+	 * and closes the select frame.
+	 */
+	JFactory::getDocument()->addScriptDeclaration(
 		"
 		function jSelectArticle(id, title, catid, object, link, lang) {
 			var hreflang = '';
@@ -51,11 +55,19 @@ JFactory::getDocument()->addScriptDeclaration(
 			window.parent.jModalClose();
 		}
 		"
-);
+	);
+}
+else
+{
+	/**
+	 * This case is used in administrator component menus
+	 */
+	$function ='if (window.parent) window.parent.' . $function;
+}
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
@@ -131,7 +143,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
 						</td>
 						<td>
-							<a href="javascript:void(0);" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>'">
+							<a href="javascript:void(0);" onclick="<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>');">
 								<?php echo $this->escape($item->title); ?></a>
 							<div class="small">
 								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -20,9 +20,29 @@ require_once JPATH_ROOT . '/components/com_content/helpers/route.php';
 
 JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 
-$function  = $app->input->getCmd('function', 'jSelectArticle');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$editor    = $app->input->getCmd('editor', '');
+
+/*
+ * Javascript to insert the link
+ * View element calls jSelectArticle when an article is clicked
+ * jSelectArticle creates the link tag, sends it to the editor,
+ * and closes the select frame.
+ */
+JFactory::getDocument()->addScriptDeclaration("
+		function jSelectArticle(id, title, catid, object, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			window.parent.jInsertEditorText(tag, '" . $editor . "');
+			window.parent.jModalClose();
+		}
+");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function='.$function.'&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">
@@ -101,7 +121,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php foreach ($this->items as $i => $item) : ?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>');">
+					<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 						<?php echo $this->escape($item->title); ?></a>
 				</th>
 				<td class="center">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -141,7 +141,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
-					<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+					<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>'">
 						<?php echo $this->escape($item->title); ?></a>
 				</th>
 				<td class="center">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -44,7 +44,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 ");
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function='.$function.'&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -23,14 +23,18 @@ JHtml::addIncludePath(JPATH_COMPONENT.'/helpers/html');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $editor    = $app->input->getCmd('editor', '');
+$function  = $app->input->getCmd('function', 'jSelectArticle');
 
-/*
- * Javascript to insert the link
- * View element calls jSelectArticle when an article is clicked
- * jSelectArticle creates the link tag, sends it to the editor,
- * and closes the select frame.
- */
-JFactory::getDocument()->addScriptDeclaration(
+if ($function === 'jSelectArticle')
+{
+	/**
+	 * The function jSelectArticle is used on XTD Article
+	 * Javascript to insert the link
+	 * View element calls jSelectArticle when an article is clicked
+	 * jSelectArticle creates the link tag, sends it to the editor,
+	 * and closes the select frame.
+	 */
+	JFactory::getDocument()->addScriptDeclaration(
 		"
 		function jSelectArticle(id, title, catid, object, link, lang) {
 			var hreflang = '';
@@ -42,9 +46,18 @@ JFactory::getDocument()->addScriptDeclaration(
 			window.parent.jModalClose();
 		}
 		"
-);
+	);
+}
+else
+{
+	/**
+	 * This case is used in administrator component menus
+	 */
+	$function ='if (window.parent) window.parent.' . $function;
+}
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&function='
+	. $function . '&' . JSession::getFormToken() . '=1');?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">
 	<legend class="element-invisible"><?php echo JText::_('JSEARCH_FILTER_LABEL'); ?></legend>
 		<div class="filter-search">
@@ -141,7 +154,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
-					<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>'">
+					<a class="pointer" onclick="<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>');">
 						<?php echo $this->escape($item->title); ?></a>
 				</th>
 				<td class="center">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -30,19 +30,19 @@ $editor    = $app->input->getCmd('editor', '');
  * jSelectArticle creates the link tag, sends it to the editor,
  * and closes the select frame.
  */
-JFactory::getDocument()->addScriptDeclaration("
-		function jSelectArticle(id, title, catid, object, link, lang)
-		{
+JFactory::getDocument()->addScriptDeclaration(
+		"
+		function jSelectArticle(id, title, catid, object, link, lang) {
 			var hreflang = '';
-			if (lang !== '')
-			{
+			if (lang !== '') {
 				var hreflang = ' hreflang = \"' + lang + '\"';
 			}
 			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
 			window.parent.jInsertEditorText(tag, '" . $editor . "');
 			window.parent.jModalClose();
 		}
-");
+		"
+);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_content&view=articles&layout=modal&tmpl=component&'.JSession::getFormToken().'=1');?>" method="post" name="adminForm" id="adminForm">
 	<fieldset id="filter-bar">

--- a/administrator/templates/hathor/html/com_content/articles/modal.php
+++ b/administrator/templates/hathor/html/com_content/articles/modal.php
@@ -119,6 +119,26 @@ JFactory::getDocument()->addScriptDeclaration(
 
 		<tbody>
 		<?php foreach ($this->items as $i => $item) : ?>
+			<?php if ($item->language && JLanguageMultilang::isEnabled())
+			{
+				$tag = strlen($item->language);
+				if ($tag == 5)
+				{
+					$lang = substr($item->language, 0, 2);
+				}
+				elseif ($tag == 6)
+				{
+					$lang = substr($item->language, 0, 3);
+				}
+				else {
+					$lang = "";
+				}
+			}
+			elseif (!JLanguageMultilang::isEnabled())
+			{
+				$lang = "";
+			}
+			?>
 			<tr class="row<?php echo $i % 2; ?>">
 				<th>
 					<a class="pointer" onclick="jSelectArticle('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContentHelperRoute::getArticleRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -34,28 +34,6 @@ class PlgButtonArticle extends JPlugin
 	public function onDisplay($name)
 	{
 		/*
-		 * Javascript to insert the link
-		 * View element calls jSelectArticle when an article is clicked
-		 * jSelectArticle creates the link tag, sends it to the editor,
-		 * and closes the select frame.
-		 */
-		$js = "
-		function jSelectArticle(id, title, catid, object, link, lang)
-		{
-			var hreflang = '';
-			if (lang !== '')
-			{
-				var hreflang = ' hreflang = \"' + lang + '\"';
-			}
-			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
-			jInsertEditorText(tag, '" . $name . "');
-			jModalClose();
-		}";
-
-		$doc = JFactory::getDocument();
-		$doc->addScriptDeclaration($js);
-
-		/*
 		 * Use the built-in element view to select the article.
 		 * Currently uses blank class.
 		 */

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -37,7 +37,8 @@ class PlgButtonArticle extends JPlugin
 		 * Use the built-in element view to select the article.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;editor=' . $name . '&amp;' . JSession::getFormToken() . '=1';
+		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;editor='
+			. $name . '&amp;' . JSession::getFormToken() . '=1';
 
 		$button = new JObject;
 		$button->modal = true;

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -37,7 +37,7 @@ class PlgButtonArticle extends JPlugin
 		 * Use the built-in element view to select the article.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;editor=' . $name . '&amp;' . JSession::getFormToken() . '=1';
 
 		$button = new JObject;
 		$button->modal = true;

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -39,7 +39,8 @@ class PlgButtonReadmore extends JPlugin
 
 		$getContent = $this->_subject->getContent($name);
 		$present = JText::_('PLG_READMORE_ALREADY_EXISTS', true);
-		$js = "
+
+		$doc->addScriptDeclaration("
 			function insertReadmore(editor)
 			{
 				var content = $getContent
@@ -49,11 +50,10 @@ class PlgButtonReadmore extends JPlugin
 					return false;
 				} else {
 					jInsertEditorText('<hr id=\"system-readmore\" />', editor);
+					return false;
 				}
 			}
-			";
-
-		$doc->addScriptDeclaration($js);
+		");
 
 		$button          = new JObject;
 		$button->modal   = false;
@@ -61,10 +61,7 @@ class PlgButtonReadmore extends JPlugin
 		$button->onclick = 'insertReadmore(\'' . $name . '\');return false;';
 		$button->text    = JText::_('PLG_READMORE_BUTTON_READMORE');
 		$button->name    = 'arrow-down';
-
-		// @TODO: The button writer needs to take into account the javascript directive
-		// $button->link', 'javascript:void(0)');
-		$button->link    = '#';
+		$button->link   = '#'   ;
 
 		return $button;
 	}

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -40,20 +40,22 @@ class PlgButtonReadmore extends JPlugin
 		$getContent = $this->_subject->getContent($name);
 		$present = JText::_('PLG_READMORE_ALREADY_EXISTS', true);
 
-		$doc->addScriptDeclaration("
-			function insertReadmore(editor)
+		$doc->addScriptDeclaration(
+			"
+		function insertReadmore(editor)
+		{
+			var content = $getContent
+			if (content.match(/<hr\s+id=(\"|')system-readmore(\"|')\s*\/*>/i))
 			{
-				var content = $getContent
-				if (content.match(/<hr\s+id=(\"|')system-readmore(\"|')\s*\/*>/i))
-				{
-					alert('$present');
-					return false;
-				} else {
-					jInsertEditorText('<hr id=\"system-readmore\" />', editor);
-					return false;
-				}
+				alert('$present');
+				return false;
+			} else {
+				jInsertEditorText('<hr id=\"system-readmore\" />', editor);
+				return false;
 			}
-		");
+		}
+			"
+		);
 
 		$button          = new JObject;
 		$button->modal   = false;

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -63,7 +63,7 @@ class PlgButtonReadmore extends JPlugin
 		$button->onclick = 'insertReadmore(\'' . $name . '\');return false;';
 		$button->text    = JText::_('PLG_READMORE_BUTTON_READMORE');
 		$button->name    = 'arrow-down';
-		$button->link   = '#'   ;
+		$button->link   = '#';
 
 		return $button;
 	}


### PR DESCRIPTION
#### Use the same pattern for all XTD buttons javascript

Two reasons to have the script in the callable iframe:
- can be overridden easily, with an html override
- no call to `parent.window.Function()`
- consistency
#### Summary of Changes

Move code around
#### Testing Instructions

Create a new article
use the XTD buttons Article and Pagebreak and confirm that everything works as expected
Redo the same with Hathor as your template

Also try to create a menu for a single article, everything should work as usual
Easy testing
