### PR TITLE
Change how JPluginHelper caches data; support Closures in JCacheControllerCallback

### DIFF
--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -291,26 +291,24 @@ abstract class JPluginHelper
 		}
 
 		$user = JFactory::getUser();
-		$cache = JFactory::getCache('com_plugins', '');
 
 		$levels = implode(',', $user->getAuthorisedViewLevels());
 
-		if (!(static::$plugins = $cache->get($levels)))
-		{
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select('folder AS type, element AS name, params')
-				->from('#__extensions')
-				->where('enabled = 1')
-				->where('type =' . $db->quote('plugin'))
-				->where('state IN (0,1)')
-				->where('access IN (' . $levels . ')')
-				->order('ordering');
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('folder AS type, element AS name, params')
+			->from('#__extensions')
+			->where('enabled = 1')
+			->where('type =' . $db->quote('plugin'))
+			->where('state IN (0,1)')
+			->where('access IN (' . $levels . ')')
+			->order('ordering');
+		$db->setQuery($query);
 
-			static::$plugins = $db->setQuery($query)->loadObjectList();
+		/** @var JCacheControllerCallback $cache */
+		$cache = JFactory::getCache('com_plugins', 'callback');
 
-			$cache->store(static::$plugins, $levels);
-		}
+		static::$plugins = $cache->get(array($db, 'loadObjectList'), array(), md5($levels), false);
 
 		return static::$plugins;
 	}

--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -296,7 +296,7 @@ abstract class JPluginHelper
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('folder AS type, element AS name, params')
+			->select(array($db->quoteName('folder', 'type'), $db->quoteName('element', 'name'), $db->quoteName('params')))
 			->from('#__extensions')
 			->where('enabled = 1')
 			->where('type =' . $db->quote('plugin'))

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -56,7 +56,7 @@ class JCacheControllerCallback extends JCacheController
 	public function get($callback, $args = array(), $id = false, $wrkarounds = false, $woptions = array())
 	{
 		// Normalize callback
-		if (is_array($callback))
+		if (is_array($callback) || is_callable($callback))
 		{
 			// We have a standard php callback array -- do nothing
 		}
@@ -139,7 +139,7 @@ class JCacheControllerCallback extends JCacheController
 				if (method_exists($document, 'getHeadData'))
 				{
 					$coptions['headerbefore'] = $document->getHeadData();
-				}	
+				}
 			}
 			else
 			{


### PR DESCRIPTION
#### Summary of Changes

Changes how `JPluginHelper::load()` caches data to use the callback caching controller instead of the generic base class and implements a cache ID based on the authorized access levels for the user.
#### Testing Instructions

With caching enabled, the proper plugins should be loaded for an allowed usergroup list on each request and this data cached.
