### PR TITLE
reCaptcha does not work for severeal languages. #fixes https://github.com/joomla/joomla-cms/issues/10809

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -61,15 +61,12 @@ class PlgCaptchaRecaptcha extends JPlugin
 			// Load callback first for browser compatibility
 			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
 
-			/**
-			 * fixing the recaptcha on a danisch contact-form.
-			 * See https://developers.google.com/recaptcha/docs/language where for "danisch" the language-key is "da" and not "da-DA".
-			 * PM RH 13.06.2016
-			 **/
+			// fixing the recaptcha on a danisch contact-form.
+			// See https://developers.google.com/recaptcha/docs/language where for "danisch" the language-key is "da" and not "da-DA".
 				$lang = JFactory::getLanguage()->getTag(); // returns da-DA or en-GB
 				$lang = explode("-", $lang);
-				$lang = $lang[0]; // is "da" or "en" only. 
-				$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&hl='.$lang.'&render=explicit';
+				$lang = $lang[0]; // is "da" or "en" only.
+				$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&hl=' . $lang . '&render=explicit';
 			
 			JHtml::_('script', $file);
 		}

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -63,9 +63,10 @@ class PlgCaptchaRecaptcha extends JPlugin
 
 			// fixing the recaptcha on a danisch contact-form.
 			// See https://developers.google.com/recaptcha/docs/language where for "danisch" the language-key is "da" and not "da-DA".
-				$lang = JFactory::getLanguage()->getTag(); // returns da-DA or en-GB
-				$lang = explode("-", $lang);
+				$langtag = JFactory::getLanguage()->getTag(); // returns da-DA or en-GB
+				$lang = explode("-", $langtag);
 				$lang = $lang[0]; // is "da" or "en" only.
+				if ($lang=="zh") $lang = langtag; // the only exception where the short language-code is not available is "zh" (Chinese)
 				$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&hl=' . $lang . '&render=explicit';
 			
 			JHtml::_('script', $file);

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -61,7 +61,16 @@ class PlgCaptchaRecaptcha extends JPlugin
 			// Load callback first for browser compatibility
 			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', false, true);
 
-			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
+			/**
+			 * fixing the recaptcha on a danisch contact-form.
+			 * See https://developers.google.com/recaptcha/docs/language where for "danisch" the language-key is "da" and not "da-DA".
+			 * PM RH 13.06.2016
+			 **/
+				$lang = JFactory::getLanguage()->getTag(); // returns da-DA or en-GB
+				$lang = explode("-", $lang);
+				$lang = $lang[0]; // is "da" or "en" only. 
+				$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&hl='.$lang.'&render=explicit';
+			
 			JHtml::_('script', $file);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #10809 
#### Summary of Changes

plugins\captcha\recaptcha\recaptcha.php -> at line 64.
changed  `JFactory::getLanguage()->getTag()` to 

```
$lang = JFactory::getLanguage()->getTag();
$lang = explode("-", $lang);
$lang = $lang[0];
$file ='https://www.google.com/recaptcha/api.jsonload=JoomlaInitReCaptcha2&hl='.$lang.'&render=explicit';
```
#### Testing Instructions

See the Issue for testing / reproducing instructions: https://github.com/joomla/joomla-cms/issues/10809
