### PR TITLE
[cache] Catch cache storage exception

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -463,7 +463,21 @@ class JCache
 			return self::$_handler[$hash];
 		}
 
-		self::$_handler[$hash] = JCacheStorage::getInstance($this->_options['storage'], $this->_options);
+		try
+		{
+			self::$_handler[$hash] = JCacheStorage::getInstance($this->_options['storage'], $this->_options);
+		}
+		catch (RuntimeException $e)
+		{
+			self::$_handler[$hash] = $e;
+
+			$app = JFactory::getApplication();
+
+			if ($app->isAdmin())
+			{
+				$app->enqueueMessage($e->getMessage(), 'error');
+			}
+		}
 
 		return self::$_handler[$hash];
 	}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -471,12 +471,7 @@ class JCache
 		{
 			self::$_handler[$hash] = $e;
 
-			$app = JFactory::getApplication();
-
-			if ($app->isAdmin())
-			{
-				$app->enqueueMessage($e->getMessage(), 'error');
-			}
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
 		}
 
 		return self::$_handler[$hash];


### PR DESCRIPTION
This is a part of other my PR #10565.
I split it because it is more important part and simpler to test.

[UPDATED]
#### Summary of Changes

Catch exception from storage (ex memcache) class in main cache class.

If we turn off memcache for a few seconds or minutes or set incorrect port then joomla website display JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING.

On php7 memcache is not available so when admin move to php7 
then website should display correct error message.
#### Testing Instructions

Before patch:
1) Go to joomla backend and enable working cache like memcache(-d).
2) Turn off cache server or change the port (for memcache) from 11211 to some not working like 11234.
3) You should get error JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING.

After patch:
1) Go to joomla back-end and enable working cache like memcache(-d).
2) Turn off cache server or change the port (for memcache) from 11211 to some not working like 11234.
3) You should get correct warning message.
