### PR TITLE
Utilize unionAll query element and fix position of order by in JDatabaseQuery

### DIFF
--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -251,14 +251,19 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->having;
 				}
 
-				if ($this->order)
-				{
-					$query .= (string) $this->order;
-				}
-
 				if ($this->union)
 				{
 					$query .= (string) $this->union;
+				}
+
+				if ($this->unionAll)
+				{
+					$query .= (string) $this->unionAll;
+				}
+
+				if ($this->order)
+				{
+					$query .= (string) $this->order;
 				}
 
 				break;
@@ -1489,7 +1494,7 @@ abstract class JDatabaseQuery
 	 * @param   boolean  $distinct  True to only return distinct rows from the union.
 	 * @param   string   $glue      The glue by which to join the conditions.
 	 *
-	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @link http://dev.mysql.com/doc/refman/5.0/en/union.html
 	 *
@@ -1532,7 +1537,7 @@ abstract class JDatabaseQuery
 	 * @param   mixed   $query  The JDatabaseQuery object or string to union.
 	 * @param   string  $glue   The glue by which to join the conditions.
 	 *
-	 * @return  mixed   The JDatabaseQuery object on success or boolean false on failure.
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @see     union
 	 *
@@ -1740,9 +1745,9 @@ abstract class JDatabaseQuery
 	 * Prefixing the interval with a - (negative sign) will cause subtraction to be used.
 	 * Note: Not all drivers support all units.
 	 *
-	 * @param   datetime  $date      The date to add to. May be date or datetime
-	 * @param   string    $interval  The string representation of the appropriate number of units
-	 * @param   string    $datePart  The part of the date to perform the addition on
+	 * @param   mixed   $date      The date to add to. May be date or datetime
+	 * @param   string  $interval  The string representation of the appropriate number of units
+	 * @param   string  $datePart  The part of the date to perform the addition on
 	 *
 	 * @return  string  The string with the appropriate sql for addition of dates
 	 *
@@ -1766,7 +1771,7 @@ abstract class JDatabaseQuery
 	 * @param   boolean  $distinct  Not used - ignored.
 	 * @param   string   $glue      Not used - ignored.
 	 *
-	 * @return  mixed    The JDatabaseQuery object on success or boolean false on failure.
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
 	 * @see     union
 	 *

--- a/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
+++ b/tests/unit/suites/libraries/joomla/database/JDatabaseQueryTest.php
@@ -280,7 +280,9 @@ class JDatabaseQueryTest extends TestCase
 			->where('b.id = 1')
 			->group('a.id')
 			->having('COUNT(a.id) > 3')
-			->order('a.id');
+			->union('SELECT c.id FROM c')
+			->unionAll('SELECT d.id FROM d')
+			->order('id');
 
 		$this->assertThat(
 			(string) $this->_instance,
@@ -291,7 +293,9 @@ class JDatabaseQueryTest extends TestCase
 					PHP_EOL . "WHERE b.id = 1" .
 					PHP_EOL . "GROUP BY a.id" .
 					PHP_EOL . "HAVING COUNT(a.id) > 3" .
-					PHP_EOL . "ORDER BY a.id"
+					PHP_EOL . "UNION (SELECT c.id FROM c)" .
+					PHP_EOL . "UNION ALL (SELECT d.id FROM d)" .
+					PHP_EOL . "ORDER BY id"
 			),
 			'Tests for correct rendering.'
 		);


### PR DESCRIPTION
Pull Request for Issue #7970.
#### Summary of Changes
- Utilise `unionAll` element in the select query, previously it was always being ignored.
- Rearrange the order of appending `union`, `unionAll`, `order` to render a valid query when all these three are used together in a query.
- Fix return type in method doc blocks.
- Update test case for the JDatabaseQuery::toString method to test all the element for select query.
#### Testing Instructions
1. Build any sql query using instances of `JDatabaseQuery` using various database types.
2. Build query which also uses `union` or `unionAll` or both of them.
3. Build query which uses `union` or `unionAll` as well as `order`.

You can use the following sample query as a hint what you need to test.

``` php
$db    = JFactory::getDbo();
$query = $db->getQuery(true);
$query->select('a.id')
    ->from('#__content AS a')
    ->union('SELECT c.id FROM #__content AS c')
    ->unionAll('SELECT d.id FROM #__content AS d')
    ->order('id');
```

should give

``` sql
SELECT a.id
FROM is2_content AS a
UNION (SELECT c.id FROM is2_content AS c)
UNION ALL (SELECT d.id FROM is2_content AS d)
ORDER BY id
```

Without this patch you get

``` sql
SELECT a.id
FROM is2_content AS a
ORDER BY id
UNION (SELECT c.id FROM is2_content AS c)
```

Please note that the `UNION ALL  (SELECT d.id FROM is2_content AS d)` is missing also the order by clause comes before union which is wrong. 

Fixes #7970
