### PR TITLE
New font for CodeMirror: Space Mono

### DIFF
--- a/plugins/editors/codemirror/fonts.json
+++ b/plugins/editors/codemirror/fonts.json
@@ -74,6 +74,11 @@
 		"url": "//fonts.googleapis.com/css?family=Source+Code+Pro",
 		"css": "'Source Code Pro', monospace"
 	},
+	"space_mono": {
+		"name": "Space Mono",
+		"url": "//fonts.googleapis.com/css?family=Space+Mono",
+		"css": "'Space Mono', monospace"
+	},
 	"ubuntu_mono": {
 		"name": "Ubuntu Mono",
 		"url": "//fonts.googleapis.com/css?family=Ubuntu+Mono",


### PR DESCRIPTION
#### Summary of Changes

Added information about a new monospaced font available from Google fonts.
#### Testing Instructions

Select 'Space Mono' in the CodeMirror plugin settings. Open a CodeMirror editor. The font should be 'Space Mono'.

Space Mono is a monospaced font and basically suitable for code but does feature some questionable ligatures. I can't promise you'll love it. 
