### PR TITLE
[com_plugins] plugins view: add missing Edit tooltip

### DIFF
--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -118,7 +118,7 @@ if ($saveOrder)
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'plugins.', $canCheckin); ?>
 							<?php endif; ?>
 							<?php if ($canEdit) : ?>
-								<a href="<?php echo JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . (int) $item->extension_id); ?>">
+								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . (int) $item->extension_id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 									<?php echo $item->name; ?></a>
 							<?php else : ?>
 									<?php echo $item->name; ?>


### PR DESCRIPTION
#### Summary of Changes

Simple PR to add edit tooltip to com_plugins plugins view.
#### Testing Instructions

Very simple test.
1. Use latest staging
2. Go to Extensions -> Plugins
3. Mouseover the plugin title link and see there is no "Edit" tooltip
4. Apply patch
5. Repeat steps 2 and 3. There is a "Edit" tooltip now.
