### PR TITLE
[consistency] Add names in joomla core update servers

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -47,7 +47,7 @@
 	</fileset>
 
 	<updateservers>
-		<server type="collection">https://update.joomla.org/core/list.xml</server>
-		<server type="collection">https://update.joomla.org/jed/list.xml</server>
+		<server name="Joomla! Core" type="collection">https://update.joomla.org/core/list.xml</server>
+		<server name="Joomla! Extension Directory" type="collection">https://update.joomla.org/jed/list.xml</server>
 	</updateservers>
 </extension>


### PR DESCRIPTION
#### Summary of Changes

For consistency add the names of the update server in joomla core manifest file.

The names are the same in the installation sql.
See https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1793-L1794
#### Testing Instructions

Code review.
