### PR TITLE
Modify modules cs rules

### DIFF
--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -30,7 +30,6 @@
 		<!-- These exceptions are temporary for now -->
 		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
 		<exclude-pattern type="relative">components/*</exclude-pattern>
-		<exclude-pattern type="relative">modules/*</exclude-pattern>
 		<exclude-pattern type="relative">libraries/cms/*</exclude-pattern>
 		<exclude-pattern type="relative">libraries/joomla/*</exclude-pattern>
 	</rule>

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -26,13 +26,6 @@
 	<exclude-pattern type="relative">plugins/captcha/recaptcha/recaptchalib.php</exclude-pattern>
 
 	<!-- Include all sniffs in an external standard directory -->
-	<rule ref="Generic.CodeAnalysis.UselessOverridingMethod">
-		<!-- These exceptions are temporary for now -->
-		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
-		<exclude-pattern type="relative">components/*</exclude-pattern>
-		<exclude-pattern type="relative">libraries/cms/*</exclude-pattern>
-		<exclude-pattern type="relative">libraries/joomla/*</exclude-pattern>
-	</rule>
 	<rule ref="Generic.Files.EndFileNewline">
 		<!-- These exceptions are temporary for now, possibly permanent -->
 		<exclude-pattern type="relative">*/tmpl/*</exclude-pattern>

--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -95,7 +95,7 @@
 		<!-- These exceptions are temporary for now -->
 		<exclude-pattern type="relative">administrator/components/*</exclude-pattern>
 		<exclude-pattern type="relative">components/*</exclude-pattern>
-		<exclude-pattern type="relative">modules/*</exclude-pattern>
+		<exclude-pattern type="relative">modules/mod_articles_category/helper.php</exclude-pattern>
 		<exclude-pattern type="relative">libraries/cms/*</exclude-pattern>
 	</rule>
 	<rule ref="PEAR.NamingConventions.ValidClassName">


### PR DESCRIPTION
Pull Request for improvment .
#### Summary of Changes
- modify PEAR.Functions.ValidDefaultValue exclude pattern
- removed Generic.CodeAnalysis.UselessOverridingMethod for modules folder
#### Testing Instructions

Check if travis still passes
#### Additional comments

I modified the exclusion for `PEAR.Functions.ValidDefaultValue` exclude pattern due to the result of this travis build https://travis-ci.org/wojsmol/joomla-cms/jobs/137958211

cc @wilsonge @photodude 
