### PR TITLE
User with edit_own permission should be able to load Versions for the item concerned

### DIFF
--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -112,7 +112,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -112,7 +112,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -112,7 +112,7 @@ class BannersViewBanner extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.banner', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -117,7 +117,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -117,7 +117,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -117,7 +117,7 @@ class BannersViewClient extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
+			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
 			{
 				JToolbarHelper::versions('com_banners.client', $this->item->id);
 			}

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -166,33 +166,34 @@ class CategoriesViewCategory extends JViewLegacy
 			JToolbarHelper::apply('category.apply');
 			JToolbarHelper::save('category.save');
 			JToolbarHelper::save2new('category.save2new');
+			JToolbarHelper::cancel('category.cancel');
 		}
 
 		// If not checked out, can save the item.
-		elseif (!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_user_id == $userId)))
-		{
-			JToolbarHelper::apply('category.apply');
-			JToolbarHelper::save('category.save');
-
-			if ($canDo->get('core.create'))
-			{
-				JToolbarHelper::save2new('category.save2new');
-			}
-		}
-
-		// If an existing item, can save to a copy.
-		if (!$isNew && $canDo->get('core.create'))
-		{
-			JToolbarHelper::save2copy('category.save2copy');
-		}
-
-		if (empty($this->item->id))
-		{
-			JToolbarHelper::cancel('category.cancel');
-		}
 		else
 		{
-			if ($componentParams->get('save_history', 0) && $user->authorise('core.edit'))
+			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
+			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_user_id == $userId);
+
+			// Can't save the record if it's checked out and editable
+			if (!$checkedOut && $itemEditable)
+			{
+				JToolbarHelper::apply('category.apply');
+				JToolbarHelper::save('category.save');
+
+				if ($canDo->get('core.create'))
+				{
+					JToolbarHelper::save2new('category.save2new');
+				}
+			}
+
+			// If an existing item, can save to a copy.
+			if ($canDo->get('core.create'))
+			{
+				JToolbarHelper::save2copy('category.save2copy');
+			}
+
+			if ($componentParams->get('save_history', 0) && $itemEditable)
 			{
 				$typeAlias = $extension . '.category';
 				JToolbarHelper::versions($typeAlias, $this->item->id);

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -129,7 +129,7 @@ class ContactViewContact extends JViewLegacy
 				JToolbarHelper::save2copy('contact.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_contact.contact', $this->item->id);
 			}

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -106,20 +106,19 @@ class ContactViewContact extends JViewLegacy
 		}
 		else
 		{
-			// Can't save the record if it's checked out.
-			if (!$checkedOut)
-			{
-				// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
-				if ($canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId))
-				{
-					JToolbarHelper::apply('contact.apply');
-					JToolbarHelper::save('contact.save');
+			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
+			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
-					// We can save this record, but check the create permission to see if we can return to make a new one.
-					if ($canDo->get('core.create'))
-					{
-						JToolbarHelper::save2new('contact.save2new');
-					}
+			// Can't save the record if it's checked out and editable
+			if (!$checkedOut && $itemEditable)
+			{
+				JToolbarHelper::apply('contact.apply');
+				JToolbarHelper::save('contact.save');
+
+				// We can save this record, but check the create permission to see if we can return to make a new one.
+				if ($canDo->get('core.create'))
+				{
+					JToolbarHelper::save2new('contact.save2new');
 				}
 			}
 
@@ -129,7 +128,7 @@ class ContactViewContact extends JViewLegacy
 				JToolbarHelper::save2copy('contact.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
+			if ($this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				JToolbarHelper::versions('com_contact.contact', $this->item->id);
 			}

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -124,7 +124,7 @@ class ContentViewArticle extends JViewLegacy
 				JToolbarHelper::save2copy('article.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($canDo->get('core.edit') || $canDo->get('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_content.article', $this->item->id);
 			}

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -101,20 +101,19 @@ class ContentViewArticle extends JViewLegacy
 		}
 		else
 		{
-			// Can't save the record if it's checked out.
-			if (!$checkedOut)
-			{
-				// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
-				if ($canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId))
-				{
-					JToolbarHelper::apply('article.apply');
-					JToolbarHelper::save('article.save');
+			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
+			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
-					// We can save this record, but check the create permission to see if we can return to make a new one.
-					if ($canDo->get('core.create'))
-					{
-						JToolbarHelper::save2new('article.save2new');
-					}
+			// Can't save the record if it's checked out and editable
+			if (!$checkedOut && $itemEditable)
+			{
+				JToolbarHelper::apply('article.apply');
+				JToolbarHelper::save('article.save');
+
+				// We can save this record, but check the create permission to see if we can return to make a new one.
+				if ($canDo->get('core.create'))
+				{
+					JToolbarHelper::save2new('article.save2new');
 				}
 			}
 
@@ -124,7 +123,7 @@ class ContentViewArticle extends JViewLegacy
 				JToolbarHelper::save2copy('article.save2copy');
 			}
 
-			if ($this->state->params->get('save_history', 0) && ($canDo->get('core.edit') || $canDo->get('core.edit.own')))
+			if ($this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				JToolbarHelper::versions('com_content.article', $this->item->id);
 			}

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -53,6 +53,7 @@ class ContenthistoryModelCompare extends JModelItem
 			}
 
 			$user = JFactory::getUser();
+
 			// Access check
 			if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
 			{

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -55,11 +55,7 @@ class ContenthistoryModelCompare extends JModelItem
 			$user = JFactory::getUser();
 
 			// Access check
-			if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
-			{
-				$return = true;
-			}
-			elseif ($user->authorise('core.edit.own', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
+			if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id) || $this->canEdit($table1))
 			{
 				$return = true;
 			}
@@ -87,5 +83,47 @@ class ContenthistoryModelCompare extends JModelItem
 		}
 
 		return false;
+	}
+
+	/**
+	 * Method to test whether a record is editable
+	 *
+	 * @param   JTableContenthistory  $record  A JTable object.
+	 *
+	 * @return  boolean  True if allowed to edit the record. Defaults to the permission set in the component.
+	 *
+	 * @since   3.6
+	 */
+	protected function canEdit($record)
+	{
+		$result = false;
+
+		if (!empty($record->ucm_type_id))
+		{
+			// Check that the type id matches the type alias
+			$typeAlias = JFactory::getApplication()->input->get('type_alias');
+
+			/** @var JTableContenttype $contentTypeTable */
+			$contentTypeTable = JTable::getInstance('Contenttype', 'JTable');
+
+			if ($contentTypeTable->getTypeId($typeAlias) == $record->ucm_type_id)
+			{
+				/**
+				 * Make sure user has edit privileges for this content item. Note that we use edit permissions
+				 * for the content item, not delete permissions for the content history row.
+				 */
+				$user   = JFactory::getUser();
+				$result = $user->authorise('core.edit', $typeAlias . '.' . (int) $record->ucm_item_id);
+
+				// Finally try session (this catch catches edit.own case too)
+				if (!$result)
+				{
+					$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $typeAlias) . '.id');
+					$result = in_array((int) $record->ucm_item_id, $values);
+				}
+			}
+		}
+
+		return $result;
 	}
 }

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -114,13 +114,14 @@ class ContenthistoryModelCompare extends JModelItem
 				 */
 				$user   = JFactory::getUser();
 				$result = $user->authorise('core.edit', $typeAlias . '.' . (int) $record->ucm_item_id);
+			}
 
-				// Finally try session (this catch catches edit.own case too)
-				if (!$result)
-				{
-					$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $typeAlias) . '.id');
-					$result = in_array((int) $record->ucm_item_id, $values);
-				}
+			// Finally try session (this catches edit.own case too)
+			if (!$result)
+			{
+				$contentTypeTable->load($record->ucm_type_id);
+				$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $contentTypeTable->type_alias) . '.id');
+				$result = in_array((int) $record->ucm_item_id, $typeEditables);
 			}
 		}
 

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -52,8 +52,17 @@ class ContenthistoryModelCompare extends JModelItem
 				return false;
 			}
 
+			$user = JFactory::getUser();
 			// Access check
-			if (!JFactory::getUser()->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
+			if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
+			{
+				$return = true;
+			}
+			elseif ($user->authorise('core.edit.own', $contentTypeTable->type_alias . '.' . (int) $table1->ucm_item_id))
+			{
+				$return = true;
+			}
+			else
 			{
 				$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
 
@@ -61,16 +70,19 @@ class ContenthistoryModelCompare extends JModelItem
 			}
 
 			// All's well, process the records
-			foreach (array($table1, $table2) as $table)
+			if ($return = true)
 			{
-				$object = new stdClass;
-				$object->data = ContenthistoryHelper::prepareData($table);
-				$object->version_note = $table->version_note;
-				$object->save_date = $table->save_date;
-				$result[] = $object;
-			}
+				foreach (array($table1, $table2) as $table)
+				{
+					$object = new stdClass;
+					$object->data = ContenthistoryHelper::prepareData($table);
+					$object->version_note = $table->version_note;
+					$object->save_date = $table->save_date;
+					$result[] = $object;
+				}
 
-			return $result;
+				return $result;
+			}
 		}
 
 		return false;

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -70,7 +70,7 @@ class ContenthistoryModelCompare extends JModelItem
 			}
 
 			// All's well, process the records
-			if ($return = true)
+			if ($return == true)
 			{
 				foreach (array($table1, $table2) as $table)
 				{

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -68,13 +68,14 @@ class ContenthistoryModelHistory extends JModelList
 				 */
 				$user   = JFactory::getUser();
 				$result = $user->authorise('core.edit', $typeAlias . '.' . (int) $record->ucm_item_id);
+			}
 
-				// Finally try session (this catch catches edit.own case too)
-				if (!$result)
-				{
-					$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $typeAlias) . '.id');
-					$result = in_array((int) $record->ucm_item_id, $values);
-				}
+			// Finally try session (this catches edit.own case too)
+			if (!$result)
+			{
+				$contentTypeTable->load($record->ucm_type_id);
+				$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $contentTypeTable->type_alias) . '.id');
+				$result = in_array((int) $record->ucm_item_id, $typeEditables);
 			}
 		}
 

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -147,6 +147,7 @@ class ContenthistoryModelHistory extends JModelList
 	public function getItems()
 	{
 		$items = parent::getItems();
+		$user = JFactory::getUser();
 
 		if ($items === false)
 		{
@@ -171,15 +172,20 @@ class ContenthistoryModelHistory extends JModelList
 		}
 
 		// Access check
-		if (!JFactory::getUser()->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $items[0]->ucm_item_id))
+		if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $items[0]->ucm_item_id))
+		{
+			return $items;
+		}
+		elseif ($user->authorise('core.edit.own', $contentTypeTable->type_alias . '.' . (int) $items[0]->ucm_item_id))
+		{
+			return $items;
+		}
+		else
 		{
 			$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
 
 			return false;
 		}
-
-		// All good, return the items array
-		return $items;
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -46,8 +46,17 @@ class ContenthistoryModelPreview extends JModelItem
 			return false;
 		}
 
+		$user = JFactory::getUser();
 		// Access check
-		if (!JFactory::getUser()->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table->ucm_item_id))
+		if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table->ucm_item_id))
+		{
+			$return = true;
+		}
+		elseif ($user->authorise('core.edit.own', $contentTypeTable->type_alias . '.' . (int) $table->ucm_item_id))
+		{
+			$return = true;
+		}
+		else
 		{
 			$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
 
@@ -55,11 +64,14 @@ class ContenthistoryModelPreview extends JModelItem
 		}
 
 		// Good to go, finish processing the data
-		$result = new stdClass;
-		$result->save_date = $table->save_date;
-		$result->version_note = $table->version_note;
-		$result->data = ContenthistoryHelper::prepareData($table);
+		if ($return = true)
+		{
+			$result = new stdClass;
+			$result->save_date = $table->save_date;
+			$result->version_note = $table->version_note;
+			$result->data = ContenthistoryHelper::prepareData($table);
 
-		return $result;
+			return $result;
+		}
 	}
 }

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -47,6 +47,7 @@ class ContenthistoryModelPreview extends JModelItem
 		}
 
 		$user = JFactory::getUser();
+
 		// Access check
 		if ($user->authorise('core.edit', $contentTypeTable->type_alias . '.' . (int) $table->ucm_item_id))
 		{

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -101,13 +101,14 @@ class ContenthistoryModelPreview extends JModelItem
 				 */
 				$user   = JFactory::getUser();
 				$result = $user->authorise('core.edit', $typeAlias . '.' . (int) $record->ucm_item_id);
+			}
 
-				// Finally try session (this catch catches edit.own case too)
-				if (!$result)
-				{
-					$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $typeAlias) . '.id');
-					$result = in_array((int) $record->ucm_item_id, $values);
-				}
+			// Finally try session (this catches edit.own case too)
+			if (!$result)
+			{
+				$contentTypeTable->load($record->ucm_type_id);
+				$typeEditables = (array) JFactory::getApplication()->getUserState(str_replace('.', '.edit.', $contentTypeTable->type_alias) . '.id');
+				$result = in_array((int) $record->ucm_item_id, $typeEditables);
 			}
 		}
 

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -64,7 +64,7 @@ class ContenthistoryModelPreview extends JModelItem
 		}
 
 		// Good to go, finish processing the data
-		if ($return = true)
+		if ($return == true)
 		{
 			$result = new stdClass;
 			$result->save_date = $table->save_date;

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -115,7 +115,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_newsfeeds.newsfeed', $this->item->id);
 			}

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -115,7 +115,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
+			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				JToolbarHelper::versions('com_newsfeeds.newsfeed', $this->item->id);
 			}

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -116,7 +116,7 @@ class TagsViewTag extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
 			{
 				JToolbarHelper::versions('com_tags.tag', $this->item->id);
 			}

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -90,33 +90,34 @@ class TagsViewTag extends JViewLegacy
 			JToolbarHelper::apply('tag.apply');
 			JToolbarHelper::save('tag.save');
 			JToolbarHelper::save2new('tag.save2new');
+			JToolbarHelper::cancel('tag.cancel');
 		}
 
 		// If not checked out, can save the item.
-		elseif (!$checkedOut && ($canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_user_id == $userId)))
-		{
-			JToolbarHelper::apply('tag.apply');
-			JToolbarHelper::save('tag.save');
-
-			if ($canDo->get('core.create'))
-			{
-				JToolbarHelper::save2new('tag.save2new');
-			}
-		}
-
-		// If an existing item, can save to a copy.
-		if (!$isNew && $canDo->get('core.create'))
-		{
-			JToolbarHelper::save2copy('tag.save2copy');
-		}
-
-		if (empty($this->item->id))
-		{
-			JToolbarHelper::cancel('tag.cancel');
-		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && ($user->authorise('core.edit') || $user->authorise('core.edit.own')))
+			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
+			$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_user_id == $userId);
+
+			// Can't save the record if it's checked out and editable
+			if (!$checkedOut && $itemEditable)
+			{
+				JToolbarHelper::apply('tag.apply');
+				JToolbarHelper::save('tag.save');
+	
+				if ($canDo->get('core.create'))
+				{
+					JToolbarHelper::save2new('tag.save2new');
+				}
+			}
+
+			// If an existing item, can save to a copy.
+			if ($canDo->get('core.create'))
+			{
+				JToolbarHelper::save2copy('tag.save2copy');
+			}
+
+			if ($this->state->params->get('save_history', 0) && $itemEditable)
 			{
 				JToolbarHelper::versions('com_tags.tag', $this->item->id);
 			}

--- a/administrator/components/com_users/views/note/view.html.php
+++ b/administrator/components/com_users/views/note/view.html.php
@@ -114,7 +114,7 @@ class UsersViewNote extends JViewLegacy
 		}
 		else
 		{
-			if ($this->state->params->get('save_history', 0) && $user->authorise('core.edit'))
+			if ($this->state->params->get('save_history', 0) && $canDo->get('core.edit'))
 			{
 				JToolbarHelper::versions('com_users.note', $this->item->id);
 			}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10813
#### Testing Instructions

create a group "authors team" with parent "registered".
administrator interface access allowed:

following permissions for articles:
Configure ACL & Options - Not Allowed.
Configure Options Only - Not Allowed.
Access Administration Interface - Allowed
Create - Allowed
Delete - Not Allowed.
Edit - Not Allowed.
Edit State - Allowed
Edit Own - Allowed

Logging in as a member of "authors team"
Go to articles manager and open an existing article
Create a new article and save
Open the same article. 

Before patch, the user has no access to the Versions button and permission is not granted in the com_contenthistory models.

Patch and test on banner, banner client, contact, article, newsfeed
