### PR TITLE
Declare the document variable

### DIFF
--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -19,6 +19,13 @@ defined('JPATH_PLATFORM') or die;
 class JViewLegacy extends JObject
 {
 	/**
+	 * The active document object
+	 *
+	 * @var    JDocument
+	 */
+	public $document;
+
+	/**
 	 * The name of the view
 	 *
 	 * @var    array


### PR DESCRIPTION
#### Summary of Changes

`JControllerLegacy::display()` injects a `JDocument` instance into `JViewLegacy` objects [here](https://github.com/joomla/joomla-cms/blob/3.6.0-beta2/libraries/legacy/controller/legacy.php#L654).  There is not a `JViewLegacy::$document` class member variable defined.  Now there is.
#### Testing Instructions

Review.
