### PR TITLE
Deprecate the $_PROFILER global var

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -96,5 +96,6 @@ unset($config);
 // System profiler
 if (JDEBUG)
 {
+	// @deprecated 4.0 - The $_PROFILER global will be removed
 	$_PROFILER = JProfiler::getInstance('Application');
 }

--- a/administrator/index.php
+++ b/administrator/index.php
@@ -42,7 +42,7 @@ require_once JPATH_BASE . '/includes/helper.php';
 require_once JPATH_BASE . '/includes/toolbar.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
-JDEBUG ? $_PROFILER->setStart($startTime, $startMem)->mark('afterLoad') : null;
+JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
 // Instantiate the application.
 $app = JFactory::getApplication('administrator');

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -41,13 +41,13 @@ class FinderViewSearch extends JViewLegacy
 		// Get view data.
 		$state = $this->get('State');
 		$query = $this->get('Query');
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('afterFinderQuery') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('afterFinderQuery') : null;
 		$results = $this->get('Results');
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('afterFinderResults') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('afterFinderResults') : null;
 		$total = $this->get('Total');
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('afterFinderTotal') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('afterFinderTotal') : null;
 		$pagination = $this->get('Pagination');
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('afterFinderPagination') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('afterFinderPagination') : null;
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -105,11 +105,11 @@ class FinderViewSearch extends JViewLegacy
 
 		$this->prepareDocument($query);
 
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('beforeFinderLayout') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('beforeFinderLayout') : null;
 
 		parent::display($tpl);
 
-		JDEBUG ? $GLOBALS['_PROFILER']->mark('afterFinderLayout') : null;
+		JDEBUG ? JProfiler::getInstance('Application')->mark('afterFinderLayout') : null;
 	}
 
 	/**

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -96,5 +96,6 @@ unset($config);
 // System profiler
 if (JDEBUG)
 {
+	// @deprecated 4.0 - The $_PROFILER global will be removed
 	$_PROFILER = JProfiler::getInstance('Application');
 }

--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ if (!defined('_JDEFINES'))
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
-JDEBUG ? $_PROFILER->setStart($startTime, $startMem)->mark('afterLoad') : null;
+JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
 // Instantiate the application.
 $app = JFactory::getApplication('site');

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -199,7 +199,7 @@ class JAccess
 	public static function preload($assetTypes = 'components', $reload = false)
 	{
 		// Get instance of the Profiler:
-		$_PROFILER = JProfiler::getInstance('Application');
+		$profiler = JProfiler::getInstance('Application');
 
 		// Check for default case:
 		$isDefault = (is_string($assetTypes) && in_array($assetTypes, array('components', 'component')));
@@ -208,13 +208,13 @@ class JAccess
 		if ($isDefault)
 		{
 			// Mark in the profiler.
-			JDEBUG ? $_PROFILER->mark('Start JAccess::preload(components)') : null;
+			JDEBUG ? $profiler->mark('Start JAccess::preload(components)') : null;
 
 			$components = self::preloadComponents();
 			self::$preloadedAssetTypes = array_merge(self::$preloadedAssetTypes, array_flip($components));
 
 			// Mark in the profiler.
-			JDEBUG ? $_PROFILER->mark('Finish JAccess::preload(components)') : null;
+			JDEBUG ? $profiler->mark('Finish JAccess::preload(components)') : null;
 
 			// Quick short circuit for default case:
 			if ($isDefault)
@@ -235,15 +235,15 @@ class JAccess
 		{
 			if (!isset(self::$preloadedAssetTypes[$assetType]) || $reload)
 			{
-				JDEBUG ? $_PROFILER->mark('New JAccess Preloading Process(' . $assetType . ')') : null;
+				JDEBUG ? $profiler->mark('New JAccess Preloading Process(' . $assetType . ')') : null;
 
 				self::preloadPermissionsParentIdMapping($assetType);
-				JDEBUG ? $_PROFILER->mark('After preloadPermissionsParentIdMapping (' . $assetType . ')') : null;
+				JDEBUG ? $profiler->mark('After preloadPermissionsParentIdMapping (' . $assetType . ')') : null;
 
 				self::preloadPermissions($assetType);
-				JDEBUG ? $_PROFILER->mark('After preloadPermissions (' . $assetType . ')') : null;
+				JDEBUG ? $profiler->mark('After preloadPermissions (' . $assetType . ')') : null;
 
-				JDEBUG ? $_PROFILER->mark('End New JAccess Preloading Process(' . $assetType . ')') : null;
+				JDEBUG ? $profiler->mark('End New JAccess Preloading Process(' . $assetType . ')') : null;
 
 				self::$preloadedAssetTypes[$assetType] = true;
 			}
@@ -570,7 +570,7 @@ class JAccess
 	public static function getAssetRules($asset, $recursive = false)
 	{
 		// Get instance of the Profiler:
-		$_PROFILER = JProfiler::getInstance('Application');
+		$profiler = JProfiler::getInstance('Application');
 
 		$extensionName = self::getExtensionNameFromAsset($asset);
 
@@ -579,7 +579,7 @@ class JAccess
 		if ($recursive && isset(self::$assetPermissionsByName[$extensionName]) && isset(self::$assetPermissionsByName[$extensionName][$asset]))
 		{
 			// Mark in the profiler.
-			JDEBUG ? $_PROFILER->mark('Start JAccess::getAssetRules New (' . $asset . ')') : null;
+			JDEBUG ? $profiler->mark('Start JAccess::getAssetRules New (' . $asset . ')') : null;
 
 			$assetType = self::getAssetType($asset);
 			$assetId = self::$assetPermissionsByName[$extensionName][$asset]->id;
@@ -610,14 +610,14 @@ class JAccess
 			}
 
 			// Mark in the profiler.
-			JDEBUG ? $_PROFILER->mark('Finish JAccess::getAssetRules New (' . $asset . ')') : null;
+			JDEBUG ? $profiler->mark('Finish JAccess::getAssetRules New (' . $asset . ')') : null;
 
 			return self::$assetRulesIdentities[$hash];
 		}
 		else
 		{
 			// Mark in the profiler.
-			JDEBUG ? $_PROFILER->mark('Start JAccess::getAssetRules Old (' . $asset . ')') : null;
+			JDEBUG ? $profiler->mark('Start JAccess::getAssetRules Old (' . $asset . ')') : null;
 
 			if ($asset === "1")
 			{
@@ -685,7 +685,7 @@ class JAccess
 			$rules = new JAccessRules;
 			$rules->mergeCollection($result);
 
-			JDEBUG ? $_PROFILER->mark('Finish JAccess::getAssetRules Old (' . $asset . ')') : null;
+			JDEBUG ? $profiler->mark('Finish JAccess::getAssetRules Old (' . $asset . ')') : null;
 
 			return $rules;
 		}

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -52,8 +52,6 @@ class PlgSystemCache extends JPlugin
 	 */
 	public function onAfterInitialise()
 	{
-		global $_PROFILER;
-
 		$app  = JFactory::getApplication();
 		$user = JFactory::getUser();
 
@@ -83,7 +81,7 @@ class PlgSystemCache extends JPlugin
 
 			if (JDEBUG)
 			{
-				$_PROFILER->mark('afterCache');
+				JProfiler::getInstance('Application')->mark('afterCache');
 			}
 
 			$app->close();


### PR DESCRIPTION
#### Summary of Changes

Deprecates the `$_PROFILER` global variable.  The profiler should be accessed via the `JProfiler` API.  Replaced existing uses of the global variable with locally scoped versions.
#### Testing Instructions

While in debug mode, the application profiler should continue to work normally.
