### PR TITLE
[com_installer] database view: move messages to view html file

### DIFF
--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -22,16 +22,8 @@ defined('_JEXEC') or die;
 		<div id="j-main-container">
 	<?php endif;?>
 		<?php if ($this->errorCount === 0) : ?>
-			<div class="alert alert-info">
-				<a class="close" data-dismiss="alert" href="#">&times;</a>
-				<?php echo JText::_('COM_INSTALLER_MSG_DATABASE_OK'); ?>
-			</div>
 			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'other')); ?>
 		<?php else : ?>
-			<div class="alert alert-error">
-				<a class="close" data-dismiss="alert" href="#">&times;</a>
-				<?php echo JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'); ?>
-			</div>
 			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'problems')); ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'problems', JText::plural('COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL', $this->errorCount)); ?>
 				<fieldset class="panelform">

--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -57,6 +57,15 @@ class InstallerViewDatabase extends InstallerViewDefault
 			$this->errorCount++;
 		}
 
+		if ($this->errorCount === 0)
+		{
+			JFactory::getApplication->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_OK'), 'notice');
+		}
+		else
+		{
+			JFactory::getApplication->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'), 'warning');
+		}
+
 		parent::display($tpl);
 	}
 

--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -59,11 +59,11 @@ class InstallerViewDatabase extends InstallerViewDefault
 
 		if ($this->errorCount === 0)
 		{
-			JFactory::getApplication->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_OK'), 'notice');
+			JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_OK'), 'notice');
 		}
 		else
 		{
-			JFactory::getApplication->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'), 'warning');
+			JFactory::getApplication()->enqueueMessage(JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'), 'warning');
 		}
 
 		parent::display($tpl);

--- a/administrator/templates/hathor/html/com_installer/database/default.php
+++ b/administrator/templates/hathor/html/com_installer/database/default.php
@@ -21,11 +21,9 @@ defined('_JEXEC') or die;
 	<div id="j-main-container">
 <?php endif;?>
 <?php if ($this->errorCount === 0) : ?>
-    <p class="nowarning"><?php echo JText::_('COM_INSTALLER_MSG_DATABASE_OK'); ?></p>
 	<?php echo JHtml::_('sliders.start', 'database-sliders', array('useCookie' => 1)); ?>
 
 <?php else : ?>
-	<p class="warning"><?php echo JText::_('COM_INSTALLER_MSG_DATABASE_ERRORS'); ?></p>
 	<?php echo JHtml::_('sliders.start', 'database-sliders', array('useCookie' => 1)); ?>
 
 	<?php $panelName = JText::plural('COM_INSTALLER_MSG_N_DATABASE_ERROR_PANEL', $this->errorCount); ?>


### PR DESCRIPTION
#### Summary of Changes

Moves database messages to the view like done in all other views.
With that it now uses the joomla messages api.

Also, the error message in now a warning.
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/16135410/59e47920-341b-11e6-827a-e41d340ca14d.png)

![image](https://cloud.githubusercontent.com/assets/9630530/16135446/8af22f9e-341b-11e6-974d-91ac4220f44b.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/16135412/5e25fd4c-341b-11e6-86bd-a2cb1cddf130.png)

![image](https://cloud.githubusercontent.com/assets/9630530/16135441/87298db2-341b-11e6-863f-19a70355500c.png)
#### Testing Instructions
1. Use latest staging
2. Apply patch
3. Go to Extension -> Database
4. Check notice and warning message work fine.
5. Test in hathor too

hint: to test the warning message, temporary change joomla version in `#__schemas` table
