### PR TITLE
Templates are in the scope of JDocument

### DIFF
--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 // Get additional language strings prefixed with TPL_HATHOR
 // @todo: Do we realy need this?
 $lang = JFactory::getLanguage();
@@ -16,7 +18,6 @@ $lang->load('tpl_hathor', JPATH_ADMINISTRATOR)
 || $lang->load('tpl_hathor', JPATH_ADMINISTRATOR . '/templates/hathor/language');
 
 $app = JFactory::getApplication();
-$doc = JFactory::getDocument();
 
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
@@ -25,10 +26,10 @@ JHtml::_('jquery.framework');
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
+$this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -40,21 +41,21 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -62,17 +63,17 @@ $file = 'language/' . $lang->getTag() . '/' . $lang->getTag().'.css';
 
 if (JFile::exists($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load template javascript
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
+$this->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -9,8 +9,9 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app   = JFactory::getApplication();
-$doc   = JFactory::getDocument();
 $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
@@ -19,10 +20,10 @@ $user  = JFactory::getUser();
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
+$this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -34,21 +35,21 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -56,17 +57,17 @@ $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (JFile::exists($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load template javascript
-$doc->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
+$this->addScript($this->baseurl . '/templates/' . $this->template . '/js/template.js', 'text/javascript');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentError $this */
+
 $app = JFactory::getApplication();
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -9,8 +9,9 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app   = JFactory::getApplication();
-$doc   = JFactory::getDocument();
 $lang  = JFactory::getLanguage();
 $input = $app->input;
 $user  = JFactory::getUser();
@@ -22,10 +23,10 @@ JHtml::_('jquery.framework');
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheetVersion($this->baseurl . '/templates/system/css/system.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/system/css/system.css');
 
-// Loadtemplate CSS
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+// Load template CSS
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -37,19 +38,19 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'));
 }
 
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
+	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Load specific language related CSS
@@ -57,7 +58,7 @@ $languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (file_exists($languageCss) && filesize($languageCss) > 0)
 {
-	$doc->addStyleSheetVersion($languageCss);
+	$this->addStyleSheetVersion($languageCss);
 }
 
 // Load custom.css
@@ -65,11 +66,11 @@ $customCss = 'templates/' . $this->template . '/css/custom.css';
 
 if (file_exists($customCss) && filesize($customCss) > 0)
 {
-	$doc->addStyleSheetVersion($customCss);
+	$this->addStyleSheetVersion($customCss);
 }
 
 // Load template javascript
-$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Logo file
 if ($this->params->get('logoFile'))

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -9,9 +9,10 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app  = JFactory::getApplication();
 $lang = JFactory::getLanguage();
-$doc  = JFactory::getDocument();
 
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
@@ -26,10 +27,10 @@ JHtml::_('behavior.noframes');
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load system style CSS
-$doc->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
+$this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
 // Loadtemplate CSS
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load additional CSS styles for colors
 if (!$this->params->get('colourChoice'))
@@ -41,21 +42,21 @@ else
 	$colour = htmlspecialchars($this->params->get('colourChoice'), ENT_COMPAT, 'UTF-8');
 }
 
-$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
+$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '.css');
 
 // Load specific language related CSS
 $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for rtl sites
 if ($this->direction == 'rtl')
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template_rtl.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/colour_' . $colour . '_rtl.css');
 }
 
 // Load specific language related CSS
@@ -63,13 +64,13 @@ $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (JFile::exists($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load additional CSS styles for bold Text
 if ($this->params->get('boldText'))
 {
-	$doc->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
+	$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/boldtext.css');
 }
 
 // Logo file

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -9,22 +9,21 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$lang            = JFactory::getLanguage();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
+/** @var JDocumentHtml $this */
+
+$app  = JFactory::getApplication();
+$lang = JFactory::getLanguage();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
@@ -34,7 +33,7 @@ $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load custom.css
@@ -42,13 +41,13 @@ $file = 'templates/' . $this->template . '/css/custom.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheetVersion($file);
+	$this->addStyleSheetVersion($file);
 }
 
 // Link color
 if ($this->params->get('linkColor'))
 {
-	$doc->addStyleDeclaration('a { color: ' . $this->params->get('linkColor') . '; }');
+	$this->addStyleDeclaration('a { color: ' . $this->params->get('linkColor') . '; }');
 }
 ?>
 <!DOCTYPE html>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -11,22 +11,15 @@ defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
 
+/** @var JDocumentError $this */
+
 // Getting params from template
 $params = JFactory::getApplication()->getTemplate(true)->params;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$lang            = JFactory::getLanguage();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
-$input           = $app->input;
-$user            = JFactory::getUser();
-
-// Output document as HTML5.
-if (is_callable(array($doc, 'setHtml5')))
-{
-	$doc->setHtml5(true);
-}
+$app   = JFactory::getApplication();
+$lang  = JFactory::getLanguage();
+$input = $app->input;
+$user  = JFactory::getUser();
 
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -9,16 +9,15 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$lang            = JFactory::getLanguage();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
-$input           = $app->input;
-$user            = JFactory::getUser();
+/** @var JDocumentHtml $this */
+
+$app   = JFactory::getApplication();
+$lang  = JFactory::getLanguage();
+$input = $app->input;
+$user  = JFactory::getUser();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
@@ -28,17 +27,17 @@ $mainPageUri = $frontEndUri->toString();
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load specific language related CSS
 $languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (file_exists($languageCss) && filesize($languageCss) > 0)
 {
-	$doc->addStyleSheetVersion($languageCss);
+	$this->addStyleSheetVersion($languageCss);
 }
 
 // Load custom.css
@@ -46,7 +45,7 @@ $customCss = 'templates/' . $this->template . '/css/custom.css';
 
 if (file_exists($customCss) && filesize($customCss) > 0)
 {
-	$doc->addStyleSheetVersion($customCss);
+	$this->addStyleSheetVersion($customCss);
 }
 
 // Detecting Active Variables
@@ -126,7 +125,7 @@ if ($stickyToolbar)
 // Template color
 if ($navbar_color)
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	.navbar-inner,
 	.navbar-inverse .navbar-inner,
 	.dropdown-menu li > a:hover,
@@ -143,7 +142,7 @@ if ($navbar_color)
 // Template header color
 if ($header_color)
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	.header {
 		background: " . $header_color . ";
 	}");
@@ -152,7 +151,7 @@ if ($header_color)
 // Sidebar background color
 if ($this->params->get('sidebarColor'))
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	.nav-list > .active > a,
 	.nav-list > .active > a:hover {
 		background: " . $this->params->get('sidebarColor') . ";
@@ -162,7 +161,7 @@ if ($this->params->get('sidebarColor'))
 // Link color
 if ($this->params->get('linkColor'))
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	a,
 	.j-toggle-sidebar-button {
 		color: " . $this->params->get('linkColor') . ";

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -9,12 +9,13 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app  = JFactory::getApplication();
-$doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
@@ -29,7 +30,7 @@ JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
@@ -39,7 +40,7 @@ $file = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheet($file);
+	$this->addStyleSheet($file);
 }
 
 // Load custom.css
@@ -47,7 +48,7 @@ $file = 'templates/' . $this->template . '/css/custom.css';
 
 if (is_file($file))
 {
-	$doc->addStyleSheetVersion($file);
+	$this->addStyleSheetVersion($file);
 }
 
 // Detecting Active Variables
@@ -71,14 +72,14 @@ function colorIsLight($color)
 // Background color
 if ($background_color)
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	.view-login {
 		background-color: " . $background_color . ";
 	}");
 }
 
 // Responsive Styles
-$doc->addStyleDeclaration("
+$this->addStyleDeclaration("
 	@media (max-width: 480px) {
 		.view-login .container {
 			margin-top: -170px;
@@ -92,7 +93,7 @@ $doc->addStyleDeclaration("
 // Check if debug is on
 if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) || $app->get('debug', 0)))
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	.view-login .container {
 		position: static;
 		margin-top: 20px;

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var JDocumentHtml $this */
+
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var JDocumentError $this */
+
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>" >

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -8,6 +8,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 // Add Stylesheets
 JHtml::_('bootstrap.loadCss', true, $this->direction);
 JHtml::_('stylesheet', 'installation/template/css/template.css');
@@ -18,7 +20,6 @@ JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 JHtml::_('script', 'installation/template/js/installation.js');
-
 
 // Load JavaScript message titles
 JText::script('ERROR');
@@ -54,7 +55,7 @@ JText::script('INSTL_FTP_SETTINGS_CORRECT');
 			});
 		</script>
 	</head>
-	<body data-basepath="<?php echo JURI::root(true); ?>">
+	<body data-basepath="<?php echo JUri::root(true); ?>">
 		<!-- Header -->
 		<div class="header">
 			<img src="<?php echo $this->baseurl ?>/template/images/joomla.png" alt="Joomla" />

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -349,7 +349,7 @@ class JDocument
 	/**
 	 * Get the contents of the document buffer
 	 *
-	 * @return  The contents of the document buffer
+	 * @return  mixed
 	 *
 	 * @since   11.1
 	 */

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $color = $this->params->get('templatecolor');
 
 // Output as HTML5

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentError $this */
+
 $showRightColumn = 0;
 $showleft        = 0;
 $showbottom      = 0;

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -10,6 +10,8 @@
 // No direct access.
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 JLoader::import('joomla.filesystem.file');
 
 // Check modules

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -9,19 +9,18 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
+/** @var JDocumentHtml $this */
+
+$app = JFactory::getApplication();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -9,17 +9,10 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$user            = JFactory::getUser();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
+/** @var JDocumentError $this */
 
-// Output document as HTML5.
-if (is_callable(array($doc, 'setHtml5')))
-{
-	$doc->setHtml5(true);
-}
+$app  = JFactory::getApplication();
+$user = JFactory::getUser();
 
 // Getting params from template
 $params = $app->getTemplate(true)->params;
@@ -122,17 +115,17 @@ else
 					</a>
 					<div class="header-search pull-right">
 						<?php // Display position-0 modules ?>
-						<?php echo $doc->getBuffer('modules', 'position-0', array('style' => 'none')); ?>
+						<?php echo $this->getBuffer('modules', 'position-0', array('style' => 'none')); ?>
 					</div>
 				</div>
 			</header>
 			<div class="navigation">
 				<?php // Display position-1 modules ?>
-				<?php echo $doc->getBuffer('modules', 'position-1', array('style' => 'none')); ?>
+				<?php echo $this->getBuffer('modules', 'position-1', array('style' => 'none')); ?>
 			</div>
 			<!-- Banner -->
 			<div class="banner">
-				<?php echo $doc->getBuffer('modules', 'banner', array('style' => 'xhtml')); ?>
+				<?php echo $this->getBuffer('modules', 'banner', array('style' => 'xhtml')); ?>
 			</div>
 			<div class="row-fluid">
 				<div id="content" class="span12">
@@ -154,7 +147,7 @@ else
 								<?php if (JModuleHelper::getModule('search')) : ?>
 									<p><strong><?php echo JText::_('JERROR_LAYOUT_SEARCH'); ?></strong></p>
 									<p><?php echo JText::_('JERROR_LAYOUT_SEARCH_PAGE'); ?></p>
-									<?php echo $doc->getBuffer('module', 'search'); ?>
+									<?php echo $this->getBuffer('module', 'search'); ?>
 								<?php endif; ?>
 								<p><?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?></p>
 								<p><a href="<?php echo $this->baseurl; ?>/index.php" class="btn"><span class="icon-home"></span> <?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></p>
@@ -195,7 +188,7 @@ else
 	<div class="footer">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<hr />
-			<?php echo $doc->getBuffer('modules', 'footer', array('style' => 'none')); ?>
+			<?php echo $this->getBuffer('modules', 'footer', array('style' => 'none')); ?>
 			<p class="pull-right">
 				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
@@ -206,6 +199,6 @@ else
 			</p>
 		</div>
 	</div>
-	<?php echo $doc->getBuffer('modules', 'debug', array('style' => 'none')); ?>
+	<?php echo $this->getBuffer('modules', 'debug', array('style' => 'none')); ?>
 </body>
 </html>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -9,14 +9,13 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$user            = JFactory::getUser();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
+/** @var JDocumentHtml $this */
+
+$app  = JFactory::getApplication();
+$user = JFactory::getUser();
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 // Getting params from template
 $params = $app->getTemplate(true)->params;
@@ -41,16 +40,16 @@ else
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Use of Google Font
 if ($this->params->get('googleFont'))
 {
-	$doc->addStyleSheet('//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
-	$doc->addStyleDeclaration("
+	$this->addStyleSheet('//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
+	$this->addStyleDeclaration("
 	h1, h2, h3, h4, h5, h6, .site-title {
 		font-family: '" . str_replace('+', ' ', $this->params->get('googleFontName')) . "', sans-serif;
 	}");
@@ -59,7 +58,7 @@ if ($this->params->get('googleFont'))
 // Template color
 if ($this->params->get('templateColor'))
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	body.site {
 		border-top: 3px solid " . $this->params->get('templateColor') . ";
 		background-color: " . $this->params->get('templateBackgroundColor') . ";

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -9,31 +9,30 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 $app              = JFactory::getApplication();
-$doc              = JFactory::getDocument();
-$this->language   = $doc->language;
-$this->direction  = $doc->direction;
 
 // Output as HTML5
-$doc->setHtml5(true);
+$this->setHtml5(true);
 
 $fullWidth = 1;
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$doc->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
 
 // Add Stylesheets
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
-$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/offline.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
+$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/offline.css');
 
 // Use of Google Font
 if ($this->params->get('googleFont'))
 {
-	$doc->addStyleSheet('//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
-	$doc->addStyleDeclaration("
+	$this->addStyleSheet('//fonts.googleapis.com/css?family=' . $this->params->get('googleFontName'));
+	$this->addStyleDeclaration("
 	h1, h2, h3, h4, h5, h6, .site-title {
 		font-family: '" . str_replace('+', ' ', $this->params->get('googleFontName')) . "', sans-serif;
 	}");
@@ -42,7 +41,7 @@ if ($this->params->get('googleFont'))
 // Template color
 if ($this->params->get('templateColor'))
 {
-	$doc->addStyleDeclaration("
+	$this->addStyleDeclaration("
 	body.site {
 		border-top: 3px solid " . $this->params->get('templateColor') . ";
 		background-color: " . $this->params->get('templateBackgroundColor') . ";
@@ -67,7 +66,7 @@ $userCss = JPATH_SITE . '/templates/' . $this->template . '/css/user.css';
 
 if (file_exists($userCss) && filesize($userCss) > 0)
 {
-	$doc->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/user.css');
+	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/user.css');
 }
 
 // Load optional RTL Bootstrap CSS

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -8,6 +8,9 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var JDocumentHtml $this */
+
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -9,17 +9,15 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentError $this */
+
 if (!isset($this->error))
 {
 	$this->error = JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 	$this->debug = false;
 }
 
-// Get language and direction
-$doc             = JFactory::getDocument();
-$app             = JFactory::getApplication();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
+$app = JFactory::getApplication();
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $this->language; ?>" lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app = JFactory::getApplication();
 
 // Add JavaScript Frameworks


### PR DESCRIPTION
#### Summary of Changes

Templates are not scope isolated and therefore are loaded in the context of the `JDocument` instance which renders them.  Therefore there is no need to reach to `JFactory::getDocument()` to grab a `JDocument` instance.

`JDocumentError` does NOT have `(is|set)Html5` methods, so no need to conditionally call those; calling them anyway has no effect on the error page being rendered.
#### Testing Instructions

Templates render correctly.
