### PR TITLE
Change unit test logger's log path

### DIFF
--- a/tests/unit/core/helper/helper.php
+++ b/tests/unit/core/helper/helper.php
@@ -174,7 +174,13 @@ class TestHelper
 	{
 		if (defined('JOOMLA_TEST_LOGGING') && JOOMLA_TEST_LOGGING === 'yes')
 		{
-			JLog::addLogger(array('logger' => 'formattedtext', 'text_file' => 'unit_test.php', 'text_file_path' => JPATH_ROOT . '/logs'));
+			JLog::addLogger(
+				array(
+					'logger'         => 'formattedtext',
+					'text_file'      => 'unit_test.php',
+					'text_file_path' => dirname(dirname(__DIR__)) . '/tmp'
+				)
+			);
 		}
 	}
 


### PR DESCRIPTION
#### Summary of Changes

Change the path that the unit test logging helper logs to from the old root logs directory to `tests/unit/tmp`
#### Testing Instructions

Review
