### PR TITLE
Remove double LIMIT keywords in Pdomysql driver

### DIFF
--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -377,12 +377,6 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		// Take a local copy so that we don't modify the original query and cause issues later
 		$query = $this->replacePrefix((string) $this->sql);
 
-		if (!($this->sql instanceof JDatabaseQuery) && ($this->limit > 0 || $this->offset > 0))
-		{
-			// @TODO
-			$query .= ' LIMIT ' . $this->offset . ', ' . $this->limit;
-		}
-
 		if (!is_object($this->connection))
 		{
 			JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database');


### PR DESCRIPTION
#### Summary of Changes
### This is a blog page in mysqli driver

![p-2016-06-17-003](https://cloud.githubusercontent.com/assets/1639206/16146882/f817963a-34b2-11e6-8beb-ff982f1626df.jpg)
### This is blog page in pdomysql driver

![p-2016-06-17-002](https://cloud.githubusercontent.com/assets/1639206/16146872/eba22488-34b2-11e6-966a-4c9d3c27e032.jpg)

Since Pdo driver has process limit in `setQuery()`, we don't need to process it twice.

See https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/database/driver/pdo.php#L714
#### Testing Instructions

Open any Joomla page with pagination or rows limit in debug mode. You will see double LIMIT in SQL debug console if driver is `pdomysql`, after this patch, the LIMIT keyword will only appear one.
