### PR TITLE
Remove typo of a single quote that is not needed on the Install From …

### DIFF
--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -36,5 +36,5 @@ JFactory::getDocument()->addScriptDeclaration('
 </div>
 <div class="form-actions">
 	<input type="button" class="btn btn-primary" id="installbutton_url"
-		value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonurl()" />'
+		value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonurl()" />
 </div>


### PR DESCRIPTION
Remove typo of a single quote that is not needed on the Install From Url screen
#### Summary of Changes

remove a single '
#### Testing Instructions

On the page /administrator/index.php?option=com_installer&view=install there is a tiny ' next to the Check and install button

Apply patch

magically that tiny insignificant, easily overlooked smudge on my screen, I mean tiny single quote is gone from next to the Check and Install button. 
