### PR TITLE
[permission panel] vertical middle align table cells and remove bottom margin

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8304,6 +8304,14 @@ body.modal-open {
 .modal-header {
 	text-align: left;
 }
+#permissions table td,
+#page-permissions table td {
+	vertical-align: middle;
+}
+#permissions table select,
+#page-permissions table select {
+	margin-bottom: 0;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8304,3 +8304,11 @@ body.modal-open {
 .modal-header {
 	text-align: left;
 }
+#permissions table td,
+#page-permissions table td {
+	vertical-align: middle;
+}
+#permissions table select,
+#page-permissions table select {
+	margin-bottom: 0;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1363,3 +1363,16 @@ body.modal-open {
 .modal-header {
 	text-align: left;
 }
+
+/* ACL Permission page */
+#permissions,
+#page-permissions {
+	table {
+		td {
+			vertical-align: middle;
+		}
+		select {
+			margin-bottom: 0;
+		}
+	}
+}


### PR DESCRIPTION
#### Summary of Changes

Simple CSS PR for permissions page.

Vertical align table cells and remove bototm margin from select in global configration permisison page.
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/16167849/7c2d7f68-34f2-11e6-88d4-514769690c42.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/16167865/ab2a9404-34f2-11e6-8937-0354e1631cb1.png)
#### Testing Instructions

Very simple test.
1. Apply patch
2. Go to Global config permisison tab and refresh browser cache
3. Check the table cells are vertical middle align and there is no extra space in the bottom of the select boxes
