### PR TITLE
Support collection of custom stats in admin stats module

### DIFF
--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -175,6 +175,29 @@ class ModStatsHelper
 				$rows[$i]->title = JText::_('MOD_STATS_ARTICLES_VIEW_HITS');
 				$rows[$i]->icon  = 'eye';
 				$rows[$i]->data  = number_format($hits + $increase, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'));
+				$i++;
+			}
+		}
+
+		// Include additional data defined by published system plugins
+		JPluginHelper::importPlugin('system');
+
+		$app    = JFactory::getApplication();
+		$arrays = (array) $app->triggerEvent('onGetStats', array('mod_stats_admin'));
+
+		foreach ($arrays as $response)
+		{
+			foreach ($response as $row)
+			{
+				// We only add a row if the title and data are given
+				if (isset($row['title']) && isset($row['data']))
+				{
+					$rows[$i]        = new stdClass;
+					$rows[$i]->title = $row['title'];
+					$rows[$i]->icon  = isset($row['icon']) ? $row['icon'] : 'info';
+					$rows[$i]->data  = $row['data'];
+					$i++;
+				}
 			}
 		}
 


### PR DESCRIPTION
#### Summary of Changes

Similar to how the quickicons module triggers an event to add additional items to its output, this adds support for the `mod_stats_admin` module to do the same.

A new `onGetStats` event is published with a single parameter, a context (hardcoded to `mod_stats_admin`) and any plugin responding to this event is expected to return an array matching this schema:

``` php
array(
    'title' => 'Stats Item Title',
    'data' => 'Data to be displayed',
    'icon' => 'Optional IcoMoon font icon for the row, defaulting to "info" if not set',
);
```

The title and data attributes MUST be defined or a row is not added.

Similar to the quickicons implementation, items can NOT be removed via the plugin event.
#### Testing Instructions

Add the following method to a system plugin:

``` php
    public function onGetStats($context)
    {
        return array(
            array(
                'title' => 'Plays Audio',
                'data'  => JText::_('JNO'),
                'icon'  => 'music',
            ),
        );
    }
```

With the admin stats module enabled, you should see a new row with this data.
