### PR TITLE
Don't pass params by reference

### DIFF
--- a/administrator/components/com_config/model/component.php
+++ b/administrator/components/com_config/model/component.php
@@ -178,7 +178,7 @@ class ConfigModelComponent extends ConfigModelForm
 			throw new RuntimeException($table->getError());
 		}
 
-		$result = $dispatcher->trigger('onExtensionBeforeSave', array($context, &$table, false));
+		$result = $dispatcher->trigger('onExtensionBeforeSave', array($context, $table, false));
 
 			// Store the data.
 		if (in_array(false, $result, true) || !$table->store())
@@ -187,7 +187,7 @@ class ConfigModelComponent extends ConfigModelForm
 		}
 
 		// Trigger the after save event.
-		$dispatcher->trigger('onExtensionAfterSave', array($context, &$table, false));
+		$dispatcher->trigger('onExtensionAfterSave', array($context, $table, false));
 
 		// Clean the component cache.
 		$this->cleanCache('_system', 0);


### PR DESCRIPTION
#### Summary of Changes

`ConfigModelComponent::save()` dispatches the `onExtension(Before|After)Save` events passing the `JTable` object by reference.  This is contradictory to how the `onXXX(Before|After)Save` events are dispatched in `JModelAdmin`.  The references are removed.
#### Testing Instructions

Events are correctly dispatched and processed when saving an extension record (com_config component, com_modules, and com_plugins as examples).
