### PR TITLE
There's no reason to instantiate TagsHelperRoute here

### DIFF
--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -17,7 +17,7 @@ defined('_JEXEC') or die;
 <?php else : ?>
 	<ul>
 	<?php foreach ($list as $item) : ?>
-	<li><?php $route = new TagsHelperRoute; ?>
+	<li>
 		<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">
 			<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 		<?php if ($display_count) : ?>


### PR DESCRIPTION
#### Summary of Changes

`TagsHelperRoute` is accessed here through its static methods.  There's no need to not only instantiate it, but instantiate a new instance on every loop.
#### Testing Instructions

`mod_tags_popular` still works.  Assuming it ever did to begin with.
