### PR TITLE
Use the layout to render the user params fieldsets

### DIFF
--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -75,32 +75,9 @@ $fieldsets = $this->form->getFieldsets();
 			<?php endif; ?>
 
 			<?php
-			foreach ($fieldsets as $fieldset) :
-				if ($fieldset->name == 'user_details') :
-					continue;
-				endif;
+			$this->ignore_fieldsets = array('user_details');
+			echo JLayoutHelper::render('joomla.edit.params', $this);
 			?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', $fieldset->name, JText::_($fieldset->label)); ?>
-				<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
-					<?php if ($field->hidden) : ?>
-						<div class="control-group">
-							<div class="controls">
-								<?php echo $field->input; ?>
-							</div>
-						</div>
-					<?php else: ?>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $field->label; ?>
-							</div>
-							<div class="controls">
-								<?php echo $field->input; ?>
-							</div>
-						</div>
-					<?php endif; ?>
-				<?php endforeach; ?>
-		<?php echo JHtml::_('bootstrap.endTab'); ?>
-		<?php endforeach; ?>
 
 		<?php if (!empty($this->tfaform) && $this->item->id): ?>
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'twofactorauth', JText::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>


### PR DESCRIPTION
#### Summary of Changes

The _params_ _fieldsets_ in the user details should be rendered the same way as in other parts of Joomla, trough a layout.
#### Testing Instructions

Edit a user in the back end. The same form should be shown as without the patch, no changes.

This is a follow up PR from the custom fields project, issue is https://github.com/joomla-projects/custom-fields/issues/139.
