### PR TITLE
Fixed 500 error in admin when logged in and calling JSON view

### DIFF
--- a/administrator/components/com_login/controller.php
+++ b/administrator/components/com_login/controller.php
@@ -36,6 +36,12 @@ class LoginController extends JControllerLegacy
 		$this->input->set('view', 'login');
 		$this->input->set('layout', 'default');
 
+		// For non-html formats we do not have login view, so just display 403 instead
+		if ($this->input->get('format', 'html') !== 'html')
+		{
+			throw new RuntimeException(JText::_('JERROR_ALERTNOAUTHOR'), 403);
+		}
+
 		parent::display();
 	}
 


### PR DESCRIPTION
Pull Request for Issue #10212.
#### Summary of Changes

By default if user hasn't logged in or the session has timed out, Joomla Administrator attempts to call login view. 

Because of the login view only exists for HTML, JSON calls fail with `500 View not found [name, type, prefix]: login, json, loginView` error. This is bad as it prevents JavaScript from detecting the missing permissions and reacting properly to the AJAX response.

The best solution in ideal world would be not to call `com_login` and let the component to handle the error by itself, but because of the changed behaviour would likely cause a huge amount of vulnerabilities in 3rd party components, the second best solution is to emulate components default behaviour when user has no access to it.

My proposal is to throw `403 You are not authorised to view this resource.` error instead of `500`. This is the default error message when you are logged in but your user doesn't have the proper admin permissions for the given component. This error message is shown in admin regardless of if the view/task exists or not.

In addition to JSON, this change changes behaviour from all non-HTML responses.

More discussion about this issue can be found from Issue #10212.
#### Testing Instructions

Log out and enter to `administrator/index.php?option=com_xxx&format=json` (GET or POST). Note that the contents of the URL doesn't matter as `com_login` intercepts the call.

In unpatched version you will get this error:

```
500 View not found [name, type, prefix]: login, json, loginView
```

In patched version the error changes into:

```
403 You are not authorised to view this resource.
```

Both errors are handled by default error page and they are in HTML.

Note: Component and view doesn't need to exist as the request gets intercepted by Joomla.
