### PR TITLE
If $app->login() failed and return false or return exception then react in the same way

### DIFF
--- a/administrator/components/com_login/controller.php
+++ b/administrator/components/com_login/controller.php
@@ -74,7 +74,7 @@ class LoginController extends JControllerLegacy
 			}
 		}
 
-		parent::display();
+		$this->display();
 	}
 
 	/**

--- a/administrator/components/com_login/controller.php
+++ b/administrator/components/com_login/controller.php
@@ -57,7 +57,7 @@ class LoginController extends JControllerLegacy
 
 		$result = $app->login($credentials, array('action' => 'core.login.admin'));
 
-		if (!($result instanceof Exception))
+		if ($result && !($result instanceof Exception))
 		{
 			// Only redirect to an internal URL.
 			if (JUri::isInternal($return))


### PR DESCRIPTION
#### Summary of Changes

If $app->login() returns false or throws exception then it should be the same effect, means do not use 303 redirection.
Redirection 303 should be only use on login success. 

Backend login fails if:
- $app->login() return false or
- $app->login() throw Exception

Or success if:
- $app->login() return true

Currently Joomla uses redirection if login method return false which is incorrect.

After that patch Apache module security can be use to limit POST requests.
Request POST with http code 200 (login fails) or 303 (login success)
#### Testing Instructions

Apply patch and 
1) try to login with valid username/password. Joomla should use redirection.
2) try to login with **invalid** username/password. Joomla should **not** use redirection.
