### PR TITLE
Fix pagination

### DIFF
--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -707,7 +707,7 @@ class JModelList extends JModelLegacy
 			}
 		}
 
-		if (($cur_state != $new_state) && ($resetPage))
+		if (($cur_state != $new_state) && $new_state !== null && ($resetPage))
 		{
 			$input->set('limitstart', 0);
 		}


### PR DESCRIPTION
Pull Request for Issue #10822 .
#### Summary of Changes

Fixes the pagination sometimes unnecessarily resetting it's offset
#### Testing Instructions

Filter articles by category. Navigate to the second page of results and edit any article. Close the article and you'll find yourself back on the first page of results. After this patch you will find that you stay on the second page.

Please check a variety of resetting searches & queries because I'm not 100% of this fix
