### PR TITLE
Fix non-escaped HTML TAG parameter title for ACL rules selectors, by stripping HTML tags from it

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -285,7 +285,7 @@ class JFormFieldRules extends JFormField
 				$html[] = '<select onchange="sendPermissions.call(this, event)" data-chosen="true" class="input-small novalidate"'
 					. ' name="' . $this->name . '[' . $action->name . '][' . $group->value . ']"'
 					. ' id="' . $this->id . '_' . $action->name	. '_' . $group->value . '"'
-					. ' title="' . JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text)) . '">';
+					. ' title="' . strip_tags(JText::sprintf('JLIB_RULES_SELECT_ALLOW_DENY_GROUP', JText::_($action->title), trim($group->text))) . '">';
 
 				/**
 				 * Possible values:


### PR DESCRIPTION
Pull Request for Issue #10876 
#### Summary of Changes

The title (HTML tag parameter) of the ACL selectors (inherit / allow / deny),
- is not escaped resulting in HTML validation errors, if the title contains HTML

We either need 
- to strip HTML tags 
- or escape the HTML special characters and add "hasToolTip" class to the ACL inherit / allow / deny selector

This PR suggest to strip HTML tags
#### Testing Instructions

Open any HTML form with rules and hover over the rules (over the select element: inherit / Allow / Deny), the tooltip should appear (browser native tooltip) without errors

Then add some html to the language string of a rule:
e.g.

```
        <action name="core.create" title="LANG_STRING_WITH_HTML" ... />
```

The HTML will appear next to the selector but it will be stripped from the browser native tooltip
