### PR TITLE
Contact "Image" column parameter in the Beez override: #10902

### DIFF
--- a/templates/beez3/html/com_contact/category/default_items.php
+++ b/templates/beez3/html/com_contact/category/default_items.php
@@ -19,7 +19,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <?php else : ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-<?php if ($this->params->get('show_pagination_limit')) : ?>
+<?php if ($this->params->get('show_pagination_limit',1)) : ?>
 	<fieldset class="filters">
 	<legend class="hidelabeltxt"><?php echo JText::_('JGLOBAL_FILTER_LABEL'); ?></legend>
 
@@ -33,7 +33,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php if ($this->params->get('show_headings')) : ?>
 		<thead><tr>
 
-			<?php if ($this->params->get('show_image_heading')) : ?>
+			<?php if ($this->params->get('show_image_heading',1)) : ?>
 			<th class="item-image">
 			</th>
 			<?php endif; ?>
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<tr class="cat-list-row<?php echo $i % 2; ?>" >
 				<?php endif; ?>
 
-					<?php if ($this->params->get('show_image_heading')) : ?>
+					<?php if ($this->params->get('show_image_heading',1)) : ?>
 						<td class="item-image">
 							<?php if ($this->items[$i]->image) : ?>
 								<?php echo JHtml::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?>

--- a/templates/beez3/html/com_contact/category/default_items.php
+++ b/templates/beez3/html/com_contact/category/default_items.php
@@ -19,7 +19,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 <?php else : ?>
 
 <form action="<?php echo htmlspecialchars(JUri::getInstance()->toString()); ?>" method="post" name="adminForm" id="adminForm">
-<?php if ($this->params->get('show_pagination_limit',1)) : ?>
+<?php if ($this->params->get('show_pagination_limit', 1)) : ?>
 	<fieldset class="filters">
 	<legend class="hidelabeltxt"><?php echo JText::_('JGLOBAL_FILTER_LABEL'); ?></legend>
 
@@ -33,7 +33,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php if ($this->params->get('show_headings')) : ?>
 		<thead><tr>
 
-			<?php if ($this->params->get('show_image_heading',1)) : ?>
+			<?php if ($this->params->get('show_image_heading', 1)) : ?>
 			<th class="item-image">
 			</th>
 			<?php endif; ?>
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<tr class="cat-list-row<?php echo $i % 2; ?>" >
 				<?php endif; ?>
 
-					<?php if ($this->params->get('show_image_heading',1)) : ?>
+					<?php if ($this->params->get('show_image_heading', 1)) : ?>
 						<td class="item-image">
 							<?php if ($this->items[$i]->image) : ?>
 								<?php echo JHtml::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?>


### PR DESCRIPTION
Pull Request for Issue #10901  .
#### Summary of Changes

Added ,1 to the parameters in beez template override to make them show without the need of saving Options
#### Testing Instructions

Create some contacts and assign an Image to the contacts. Create a menu item type "List Contacts in a Category". In Components > Contacts > Options > List Layouts look the parameter "Image", it is set to Show.
Look in frontend with beez template the menu item you created and will see that the image column now is present (and also the filters).
