### PR TITLE
Assocications - Change notice to warning

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1224,12 +1224,12 @@ abstract class JModelAdmin extends JModelForm
 				}
 			}
 
-			// Show a notice if the item isn't assigned to a language but we have associations.
+			// Show an error if the item isn't assigned to a language but we have associations.
 			if ($associations && ($table->language == '*'))
 			{
 				JFactory::getApplication()->enqueueMessage(
 					JText::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'),
-					'notice'
+					'error'
 				);
 			}
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1224,12 +1224,12 @@ abstract class JModelAdmin extends JModelForm
 				}
 			}
 
-			// Show an error if the item isn't assigned to a language but we have associations.
+			// Show a warning if the item isn't assigned to a language but we have associations.
 			if ($associations && ($table->language == '*'))
 			{
 				JFactory::getApplication()->enqueueMessage(
 					JText::_(strtoupper($this->option) . '_ERROR_ALL_LANGUAGE_ASSOCIATED'),
-					'error'
+					'warning'
 				);
 			}
 


### PR DESCRIPTION
#### Summary of Changes

On a multilingual site if you try to associate an item with Language=All to another language you get a notice that you cant. This should be a warning
#### Testing Instructions
1. On a multilingual site try to associate a contact with language =all to a a contact with a language=en-GB
2. On a multilingual site try to associate a newsfeed with language =all to a a contact with a language=en-GB
3. On a multilingual site try to associate a content item with language =all to a a contact with a language=en-GB
#### Before

![1jii](https://cloud.githubusercontent.com/assets/1296369/16300179/7e41ee7c-3936-11e6-81a2-0fb92a2a1baf.png)
#### After

![5amu](https://cloud.githubusercontent.com/assets/1296369/16300589/8f7e6916-3938-11e6-960b-c723b35fc94b.png)
