### PR TITLE
User save profile: read requested data from session after form validation failed

### DIFF
--- a/components/com_users/controllers/profile.php
+++ b/components/com_users/controllers/profile.php
@@ -135,6 +135,10 @@ class UsersControllerProfile extends UsersController
 				}
 			}
 
+			// Unset the passwords.
+			unset($requestData['password1']);
+			unset($requestData['password2']);
+
 			// Save the data in the session.
 			$app->setUserState('com_users.edit.profile.data', $requestData);
 

--- a/components/com_users/controllers/profile.php
+++ b/components/com_users/controllers/profile.php
@@ -98,10 +98,10 @@ class UsersControllerProfile extends UsersController
 		$userId = (int) $user->get('id');
 
 		// Get the user data.
-		$data = $app->input->post->get('jform', array(), 'array');
+		$requestData = $app->input->post->get('jform', array(), 'array');
 
 		// Force the ID to this user.
-		$data['id'] = $userId;
+		$requestData['id'] = $userId;
 
 		// Validate the posted data.
 		$form = $model->getForm();
@@ -114,7 +114,7 @@ class UsersControllerProfile extends UsersController
 		}
 
 		// Validate the posted data.
-		$data = $model->validate($form, $data);
+		$data = $model->validate($form, $requestData);
 
 		// Check for errors.
 		if ($data === false)
@@ -136,7 +136,7 @@ class UsersControllerProfile extends UsersController
 			}
 
 			// Save the data in the session.
-			$app->setUserState('com_users.edit.profile.data', $data);
+			$app->setUserState('com_users.edit.profile.data', $requestData);
 
 			// Redirect back to the edit screen.
 			$userId = (int) $app->getUserState('com_users.edit.profile.id');


### PR DESCRIPTION
#### Summary of Changes

[front-end] On save user profile, read requested data from session after form validation failed.
#### Testing Instructions

I believe that code review should be enough.
Please compare to https://github.com/joomla/joomla-cms/blob/staging/components/com_users/controllers/registration.php

**Otherwise**
Front-end: 
[before and after patch]
Go to user profile view, next to edit form and try to save some changes.
For valid changes/data there won't be any difference.

After patch for saving invalid data there will be difference, 
because invalid/request data will be load from session
and the user won't need to re-change valid fields again.
