### PR TITLE
Reduce the getModel methods from 3 lines into one

### DIFF
--- a/administrator/components/com_content/controllers/articles.php
+++ b/administrator/components/com_content/controllers/articles.php
@@ -117,9 +117,7 @@ class ContentControllerArticles extends JControllerAdmin
 	 */
 	public function getModel($name = 'Article', $prefix = 'ContentModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_content/controllers/featured.php
+++ b/administrator/components/com_content/controllers/featured.php
@@ -90,8 +90,6 @@ class ContentControllerFeatured extends ContentControllerArticles
 	 */
 	public function getModel($name = 'Feature', $prefix = 'ContentModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_finder/controllers/index.php
+++ b/administrator/components/com_finder/controllers/index.php
@@ -29,9 +29,7 @@ class FinderControllerIndex extends JControllerAdmin
 	 */
 	public function getModel($name = 'Index', $prefix = 'FinderModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_finder/controllers/maps.php
+++ b/administrator/components/com_finder/controllers/maps.php
@@ -29,8 +29,6 @@ class FinderControllerMaps extends JControllerAdmin
 	 */
 	public function getModel($name = 'Maps', $prefix = 'FinderModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_languages/controllers/languages.php
+++ b/administrator/components/com_languages/controllers/languages.php
@@ -29,9 +29,7 @@ class LanguagesControllerLanguages extends JControllerAdmin
 	 */
 	public function getModel($name = 'Language', $prefix = 'LanguagesModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_menus/controllers/menus.php
+++ b/administrator/components/com_menus/controllers/menus.php
@@ -45,9 +45,7 @@ class MenusControllerMenus extends JControllerLegacy
 	 */
 	public function getModel($name = 'Menu', $prefix = 'MenusModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_messages/controllers/messages.php
+++ b/administrator/components/com_messages/controllers/messages.php
@@ -29,8 +29,6 @@ class MessagesControllerMessages extends JControllerAdmin
 	 */
 	public function getModel($name = 'Message', $prefix = 'MessagesModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_modules/controllers/modules.php
+++ b/administrator/components/com_modules/controllers/modules.php
@@ -63,8 +63,6 @@ class ModulesControllerModules extends JControllerAdmin
 	 */
 	public function getModel($name = 'Module', $prefix = 'ModulesModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_newsfeeds/controllers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/controllers/newsfeeds.php
@@ -29,8 +29,7 @@ class NewsfeedsControllerNewsfeeds extends JControllerAdmin
 	 */
 	public function getModel($name = 'Newsfeed', $prefix = 'NewsfeedsModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_plugins/controllers/plugins.php
+++ b/administrator/components/com_plugins/controllers/plugins.php
@@ -29,8 +29,6 @@ class PluginsControllerPlugins extends JControllerAdmin
 	 */
 	public function getModel($name = 'Plugin', $prefix = 'PluginsModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -111,9 +111,7 @@ class RedirectControllerLinks extends JControllerAdmin
 	 */
 	public function getModel($name = 'Link', $prefix = 'RedirectModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_tags/controllers/tags.php
+++ b/administrator/components/com_tags/controllers/tags.php
@@ -29,9 +29,7 @@ class TagsControllerTags extends JControllerAdmin
 	 */
 	public function getModel($name = 'Tag', $prefix = 'TagsModel', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/administrator/components/com_templates/controllers/styles.php
+++ b/administrator/components/com_templates/controllers/styles.php
@@ -62,9 +62,7 @@ class TemplatesControllerStyles extends JControllerAdmin
 	 */
 	public function getModel($name = 'Style', $prefix = 'TemplatesModel', $config = array())
 	{
-		$model = parent::getModel($name, $prefix, array('ignore_request' => true));
-
-		return $model;
+		return parent::getModel($name, $prefix, array('ignore_request' => true));
 	}
 
 	/**

--- a/administrator/components/com_templates/controllers/template.php
+++ b/administrator/components/com_templates/controllers/template.php
@@ -167,9 +167,7 @@ class TemplatesControllerTemplate extends JControllerLegacy
 	 */
 	public function getModel($name = 'Template', $prefix = 'TemplatesModel', $config = array())
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -195,9 +195,7 @@ class ContentControllerArticle extends JControllerForm
 	 */
 	public function getModel($name = 'form', $prefix = '', $config = array('ignore_request' => true))
 	{
-		$model = parent::getModel($name, $prefix, $config);
-
-		return $model;
+		return parent::getModel($name, $prefix, $config);
 	}
 
 	/**


### PR DESCRIPTION
#### Summary of Changes

``` php
-       $model = parent::getModel($name, $prefix, $config);
-
-       return $model;
+       return parent::getModel($name, $prefix, $config);
```

reduce the method from 3 lines into one
#### Testing Instructions

Code Review and / or make sure the components still works as before
