### PR TITLE
Miscellaneous Doc Block Tweaks

### DIFF
--- a/administrator/components/com_categories/tables/category.php
+++ b/administrator/components/com_categories/tables/category.php
@@ -24,7 +24,6 @@ class CategoriesTableCategory extends JTableCategory
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @see     https://docs.joomla.org/JTableNested/delete
 	 * @since   2.5
 	 */
 	public function delete($pk = null, $children = false)

--- a/administrator/components/com_menus/tables/menu.php
+++ b/administrator/components/com_menus/tables/menu.php
@@ -25,7 +25,6 @@ class MenusTableMenu extends JTableMenu
 	 * @return  boolean  True on success.
 	 *
 	 * @since   2.5
-	 * @see     https://docs.joomla.org/JTableNested/delete
 	 */
 	public function delete($pk = null, $children = false)
 	{

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -263,7 +263,6 @@ class TagsTableTag extends JTableNested
 	 * @return  boolean  True on success.
 	 *
 	 * @since   3.1
-	 * @see     https://docs.joomla.org/JTableNested/delete
 	 */
 	public function delete($pk = null, $children = false)
 	{

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -75,7 +75,6 @@ class UsersTableNote extends JTable
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/publish
 	 * @since   2.5
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -214,7 +214,7 @@ abstract class JHtml
 	 *
 	 * @return  mixed   Function result or false on error.
 	 *
-	 * @see     http://php.net/manual/en/function.call-user-func-array.php
+	 * @see     https://secure.php.net/manual/en/function.call-user-func-array.php
 	 * @since   1.6
 	 * @throws  InvalidArgumentException
 	 */

--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -153,7 +153,7 @@ final class JVersion
 	 *
 	 * @return  boolean True if the version is compatible.
 	 *
-	 * @see     http://www.php.net/version_compare
+	 * @see     https://secure.php.net/version_compare
 	 * @since   1.0
 	 */
 	public function isCompatible($minimum)

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -16,15 +16,15 @@ use Joomla\Registry\Registry;
 /**
  * Class to turn JApplicationCli applications into daemons.  It requires CLI and PCNTL support built into PHP.
  *
- * @see    http://www.php.net/manual/en/book.pcntl.php
- * @see    http://php.net/manual/en/features.commandline.php
+ * @see    https://secure.php.net/manual/en/book.pcntl.php
+ * @see    https://secure.php.net/manual/en/features.commandline.php
  * @since  11.1
  */
 class JApplicationDaemon extends JApplicationCli
 {
 	/**
 	 * @var    array  The available POSIX signals to be caught by default.
-	 * @see    http://php.net/manual/pcntl.constants.php
+	 * @see    https://secure.php.net/manual/pcntl.constants.php
 	 * @since  11.1
 	 */
 	protected static $signals = array(

--- a/libraries/joomla/archive/gzip.php
+++ b/libraries/joomla/archive/gzip.php
@@ -15,7 +15,7 @@ jimport('joomla.filesystem.file');
  * Gzip format adapter for the JArchive class
  *
  * This class is inspired from and draws heavily in code and concept from the Compress package of
- * The Horde Project <http://www.horde.org>
+ * The Horde Project <https://www.horde.org>
  *
  * @contributor  Michael Slusarz <slusarz@horde.org>
  * @contributor  Michael Cochrane <mike@graftonhall.co.nz>

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -17,7 +17,7 @@ jimport('joomla.filesystem.path');
  * Tar format adapter for the JArchive class
  *
  * This class is inspired from and draws heavily in code and concept from the Compress package of
- * The Horde Project <http://www.horde.org>
+ * The Horde Project <https://www.horde.org>
  *
  * @contributor  Michael Slusarz <slusarz@horde.org>
  * @contributor  Michael Cochrane <mike@graftonhall.co.nz>

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -26,7 +26,7 @@ jimport('joomla.filesystem.folder');
  * Peter Listiak <mlady@users.sourceforge.net>
  *
  * This class is inspired from and draws heavily in code and concept from the Compress package of
- * The Horde Project <http://www.horde.org>
+ * The Horde Project <https://www.horde.org>
  *
  * @contributor  Chuck Hagenbuch <chuck@horde.org>
  * @contributor  Michael Slusarz <slusarz@horde.org>
@@ -605,7 +605,7 @@ class JArchiveZip implements JArchiveExtractable
 	/**
 	 * Creates the ZIP file.
 	 *
-	 * Official ZIP file format: http://www.pkware.com/appnote.txt
+	 * Official ZIP file format: https://support.pkware.com/display/PKZIP/APPNOTE
 	 *
 	 * @param   array   &$contents  An array of existing zipped files.
 	 * @param   array   &$ctrlDir   An array of central directory information.

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -23,7 +23,7 @@ class JCacheControllerCallback extends JCacheController
 	 * as long as the first argument passed is the callback definition.
 	 *
 	 * The callback definition can be in several forms:
-	 * - Standard PHP Callback array see <http://php.net/callback> [recommended]
+	 * - Standard PHP Callback array see <https://secure.php.net/callback> [recommended]
 	 * - Function name as a string eg. 'foo' for function foo()
 	 * - Static method name as a string eg. 'MyClass::myMethod' for method myMethod() of class MyClass
 	 *
@@ -71,7 +71,7 @@ class JCacheControllerCallback extends JCacheController
 			/*
 			 * This is a really not so smart way of doing this... we provide this for backward compatability but this
 			 * WILL! disappear in a future version.  If you are using this syntax change your code to use the standard
-			 * PHP callback array syntax: <http://php.net/callback>
+			 * PHP callback array syntax: <https://secure.php.net/callback>
 			 *
 			 * We have to use some silly global notation to pull it off and this is very unreliable
 			 */

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * APC cache storage handler
  *
- * @see    http://php.net/manual/en/book.apc.php
+ * @see    https://secure.php.net/manual/en/book.apc.php
  * @since  11.1
  */
 class JCacheStorageApc extends JCacheStorage

--- a/libraries/joomla/cache/storage/apcu.php
+++ b/libraries/joomla/cache/storage/apcu.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * APCu cache storage handler
  *
- * @see    http://php.net/manual/en/ref.apcu.php
+ * @see    https://secure.php.net/manual/en/ref.apcu.php
  * @since  3.5
  */
 class JCacheStorageApcu extends JCacheStorage

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Memcache cache storage handler
  *
- * @see    http://php.net/manual/en/book.memcache.php
+ * @see    https://secure.php.net/manual/en/book.memcache.php
  * @since  11.1
  */
 class JCacheStorageMemcache extends JCacheStorage

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Memcached cache storage handler
  *
- * @see    http://php.net/manual/en/book.memcached.php
+ * @see    https://secure.php.net/manual/en/book.memcached.php
  * @since  12.1
  */
 class JCacheStorageMemcached extends JCacheStorage

--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * WinCache cache storage handler
  *
- * @see    http://php.net/manual/en/book.wincache.php
+ * @see    https://secure.php.net/manual/en/book.wincache.php
  * @since  11.1
  */
 class JCacheStorageWincache extends JCacheStorage

--- a/libraries/joomla/client/ldap.php
+++ b/libraries/joomla/client/ldap.php
@@ -552,8 +552,8 @@ class JClientLdap
 	 *
 	 * Please keep this document block and author attribution in place.
 	 *
-	 * Novell Docs, see: http://developer.novell.com/ndk/doc/ndslib/schm_enu/data/sdk5624.html#sdk5624
-	 * for Address types: http://developer.novell.com/ndk/doc/ndslib/index.html?page=/ndk/doc/ndslib/schm_enu/data/sdk4170.html
+	 * Novell Docs, see: https://developer.novell.com/ndk/doc/ndslib/schm_enu/data/sdk5624.html#sdk5624
+	 * for Address types: https://developer.novell.com/ndk/doc/ndslib/index.html?page=/ndk/doc/ndslib/schm_enu/data/sdk4170.html
 	 * LDAP Format, String:
 	 * taggedData = uint32String "#" octetstring
 	 * byte 0 = uint32String = Address Type: 0= IPX Address; 1 = IP Address

--- a/libraries/joomla/crypt/cipher/3des.php
+++ b/libraries/joomla/crypt/cipher/3des.php
@@ -18,14 +18,14 @@ class JCryptCipher3Des extends JCryptCipherMcrypt
 {
 	/**
 	 * @var    integer  The mcrypt cipher constant.
-	 * @see    http://www.php.net/manual/en/mcrypt.ciphers.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.ciphers.php
 	 * @since  12.1
 	 */
 	protected $type = MCRYPT_3DES;
 
 	/**
 	 * @var    integer  The mcrypt block cipher mode.
-	 * @see    http://www.php.net/manual/en/mcrypt.constants.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.constants.php
 	 * @since  12.1
 	 */
 	protected $mode = MCRYPT_MODE_CBC;

--- a/libraries/joomla/crypt/cipher/blowfish.php
+++ b/libraries/joomla/crypt/cipher/blowfish.php
@@ -18,14 +18,14 @@ class JCryptCipherBlowfish extends JCryptCipherMcrypt
 {
 	/**
 	 * @var    integer  The mcrypt cipher constant.
-	 * @see    http://www.php.net/manual/en/mcrypt.ciphers.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.ciphers.php
 	 * @since  12.1
 	 */
 	protected $type = MCRYPT_BLOWFISH;
 
 	/**
 	 * @var    integer  The mcrypt block cipher mode.
-	 * @see    http://www.php.net/manual/en/mcrypt.constants.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.constants.php
 	 * @since  12.1
 	 */
 	protected $mode = MCRYPT_MODE_CBC;

--- a/libraries/joomla/crypt/cipher/mcrypt.php
+++ b/libraries/joomla/crypt/cipher/mcrypt.php
@@ -143,7 +143,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 	 *
 	 * @return  string  The derived key.
 	 *
-	 * @see     http://en.wikipedia.org/wiki/PBKDF2
+	 * @see     https://en.wikipedia.org/wiki/PBKDF2
 	 * @see     http://www.ietf.org/rfc/rfc2898.txt
 	 * @since   12.1
 	 */

--- a/libraries/joomla/crypt/cipher/mcrypt.php
+++ b/libraries/joomla/crypt/cipher/mcrypt.php
@@ -18,14 +18,14 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 {
 	/**
 	 * @var    integer  The mcrypt cipher constant.
-	 * @see    http://www.php.net/manual/en/mcrypt.ciphers.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.ciphers.php
 	 * @since  12.1
 	 */
 	protected $type;
 
 	/**
 	 * @var    integer  The mcrypt block cipher mode.
-	 * @see    http://www.php.net/manual/en/mcrypt.constants.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.constants.php
 	 * @since  12.1
 	 */
 	protected $mode;

--- a/libraries/joomla/crypt/cipher/rijndael256.php
+++ b/libraries/joomla/crypt/cipher/rijndael256.php
@@ -18,14 +18,14 @@ class JCryptCipherRijndael256 extends JCryptCipherMcrypt
 {
 	/**
 	 * @var    integer  The mcrypt cipher constant.
-	 * @see    http://www.php.net/manual/en/mcrypt.ciphers.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.ciphers.php
 	 * @since  12.1
 	 */
 	protected $type = MCRYPT_RIJNDAEL_256;
 
 	/**
 	 * @var    integer  The mcrypt block cipher mode.
-	 * @see    http://www.php.net/manual/en/mcrypt.constants.php
+	 * @see    https://secure.php.net/manual/en/mcrypt.constants.php
 	 * @since  12.1
 	 */
 	protected $mode = MCRYPT_MODE_CBC;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * MySQLi database driver
  *
- * @see    http://php.net/manual/en/book.mysqli.php
+ * @see    https://secure.php.net/manual/en/book.mysqli.php
  * @since  12.1
  */
 class JDatabaseDriverMysqli extends JDatabaseDriver

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Oracle database driver
  *
- * @see    http://php.net/pdo
+ * @see    https://secure.php.net/pdo
  * @since  12.1
  */
 class JDatabaseDriverOracle extends JDatabaseDriverPdo

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Joomla Platform PDO Database Driver Class
  *
- * @see    http://php.net/pdo
+ * @see    https://secure.php.net/pdo
  * @since  12.1
  */
 abstract class JDatabaseDriverPdo extends JDatabaseDriver
@@ -491,15 +491,15 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 	/**
 	 * Retrieve a PDO database connection attribute
-	 * http://www.php.net/manual/en/pdo.getattribute.php
 	 *
 	 * Usage: $db->getOption(PDO::ATTR_CASE);
 	 *
 	 * @param   mixed  $key  One of the PDO::ATTR_* Constants
 	 *
-	 * @return mixed
+	 * @return  mixed
 	 *
-	 * @since  12.1
+	 * @see     https://secure.php.net/manual/en/pdo.getattribute.php
+	 * @since   12.1
 	 */
 	public function getOption($key)
 	{
@@ -522,18 +522,16 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 
 	/**
 	 * Sets an attribute on the PDO database handle.
-	 * http://www.php.net/manual/en/pdo.setattribute.php
 	 *
 	 * Usage: $db->setOption(PDO::ATTR_CASE, PDO::CASE_UPPER);
 	 *
 	 * @param   integer  $key    One of the PDO::ATTR_* Constants
-	 * @param   mixed    $value  One of the associated PDO Constants
-	 *                           related to the particular attribute
-	 *                           key.
+	 * @param   mixed    $value  One of the associated PDO Constants related to the particular attribute key.
 	 *
-	 * @return boolean
+	 * @return  boolean
 	 *
-	 * @since  12.1
+	 * @see     https://secure.php.net/manual/en/pdo.setattribute.php
+	 * @since   12.1
 	 */
 	public function setOption($key, $value)
 	{

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -12,10 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * MySQL database driver supporting PDO based connections
  *
- * @package     Joomla.Platform
- * @subpackage  Database
- * @see         http://php.net/manual/en/ref.pdo-mysql.php
- * @since       3.4
+ * @see    https://secure.php.net/manual/en/ref.pdo-mysql.php
+ * @since  3.4
  */
 class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 {

--- a/libraries/joomla/database/driver/sqlazure.php
+++ b/libraries/joomla/database/driver/sqlazure.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * SQL Server database driver
  *
- * @see    http://msdn.microsoft.com/en-us/library/ee336279.aspx
+ * @see    https://azure.microsoft.com/en-us/documentation/services/sql-database/
  * @since  12.1
  */
 class JDatabaseDriverSqlazure extends JDatabaseDriverSqlsrv

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * SQLite database driver
  *
- * @see    http://php.net/pdo
+ * @see    https://secure.php.net/pdo
  * @since  12.1
  */
 class JDatabaseDriverSqlite extends JDatabaseDriverPdo

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * SQL Server database driver
  *
- * @see    http://msdn.microsoft.com/en-us/library/cc296152(SQL.90).aspx
+ * @see    https://msdn.microsoft.com/en-us/library/cc296152(SQL.90).aspx
  * @since  12.1
  */
 class JDatabaseDriverSqlsrv extends JDatabaseDriver

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -15,7 +15,6 @@ defined('JPATH_PLATFORM') or die;
  * This is the Observable part of the Observer design pattern
  * for the event architecture.
  *
- * @link   https://docs.joomla.org/Tutorial:Plugins Plugin tutorials
  * @see    JPlugin
  * @since  12.1
  */

--- a/libraries/joomla/feed/parser/rss/itunes.php
+++ b/libraries/joomla/feed/parser/rss/itunes.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * RSS Feed Parser Namespace handler for iTunes.
  *
- * @see    http://www.apple.com/itunes/podcasts/specs.html
+ * @see    https://itunespartner.apple.com/en/podcasts/overview
  * @since  12.3
  */
 class JFeedParserRssItunes implements JFeedParserNamespace

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -25,7 +25,7 @@ class JFilesystemHelper
 	 *
 	 * @return  mixed
 	 *
-	 * @see     http://www.php.net/manual/en/function.filesize.php#71098
+	 * @see     https://secure.php.net/manual/en/function.filesize.php#71098
 	 * @since   11.1
 	 */
 	public static function remotefsize($url)
@@ -120,7 +120,7 @@ class JFilesystemHelper
 	 *
 	 * @return  mixed
 	 *
-	 * @see     http://www.php.net/manual/en/function.ftp-chmod.php
+	 * @see     https://secure.php.net/manual/en/function.ftp-chmod.php
 	 * @since   11.1
 	 */
 	public static function ftpChmod($url, $mode)

--- a/libraries/joomla/filesystem/stream.php
+++ b/libraries/joomla/filesystem/stream.php
@@ -17,11 +17,11 @@ defined('JPATH_PLATFORM') or die;
  * atomic manner.
  *
  * @note   This class adheres to the stream wrapper operations:
- * @see    http://php.net/manual/en/function.stream-get-wrappers.php
- * @see    http://php.net/manual/en/intro.stream.php PHP Stream Manual
- * @see    http://php.net/manual/en/wrappers.php Stream Wrappers
- * @see    http://php.net/manual/en/filters.php Stream Filters
- * @see    http://php.net/manual/en/transports.php Socket Transports (used by some options, particularly HTTP proxy)
+ * @see    https://secure.php.net/manual/en/function.stream-get-wrappers.php
+ * @see    https://secure.php.net/manual/en/intro.stream.php PHP Stream Manual
+ * @see    https://secure.php.net/manual/en/wrappers.php Stream Wrappers
+ * @see    https://secure.php.net/manual/en/filters.php Stream Filters
+ * @see    https://secure.php.net/manual/en/transports.php Socket Transports (used by some options, particularly HTTP proxy)
  * @since  11.1
  */
 class JStream extends JObject
@@ -533,7 +533,7 @@ class JStream extends JObject
 	 *
 	 * @return  mixed
 	 *
-	 * @see     http://php.net/manual/en/function.fread.php
+	 * @see     https://secure.php.net/manual/en/function.fread.php
 	 * @since   11.1
 	 */
 	public function read($length = 0)
@@ -636,7 +636,7 @@ class JStream extends JObject
 	 *
 	 * @return  boolean  True on success, false on failure
 	 *
-	 * @see     http://php.net/manual/en/function.fseek.php
+	 * @see     https://secure.php.net/manual/en/function.fseek.php
 	 * @since   11.1
 	 */
 	public function seek($offset, $whence = SEEK_SET)
@@ -749,7 +749,7 @@ class JStream extends JObject
 	 *
 	 * @return  boolean
 	 *
-	 * @see     http://php.net/manual/en/function.fwrite.php
+	 * @see     https://secure.php.net/manual/en/function.fwrite.php
 	 * @since   11.1
 	 */
 	public function write(&$string, $length = 0, $chunk = 0)
@@ -891,7 +891,7 @@ class JStream extends JObject
 	 *
 	 * @return  array  header/metadata
 	 *
-	 * @see     http://php.net/manual/en/function.stream-get-meta-data.php
+	 * @see     https://secure.php.net/manual/en/function.stream-get-meta-data.php
 	 * @since   11.1
 	 */
 	public function get_meta_data()
@@ -936,7 +936,7 @@ class JStream extends JObject
 	 *
 	 * @return  void
 	 *
-	 * @see     http://php.net/stream_context_create
+	 * @see     https://secure.php.net/stream_context_create
 	 * @since   11.1
 	 */
 	public function setContextOptions($context)
@@ -954,8 +954,8 @@ class JStream extends JObject
 	 *
 	 * @return  void
 	 *
-	 * @see     http://php.net/stream_context_create Stream Context Creation
-	 * @see     http://php.net/manual/en/context.php Context Options for various streams
+	 * @see     https://secure.php.net/stream_context_create Stream Context Creation
+	 * @see     https://secure.php.net/manual/en/context.php Context Options for various streams
 	 * @since   11.1
 	 */
 	public function addContextEntry($wrapper, $name, $value)
@@ -972,7 +972,7 @@ class JStream extends JObject
 	 *
 	 * @return  void
 	 *
-	 * @see     http://php.net/stream_context_create
+	 * @see     https://secure.php.net/stream_context_create
 	 * @since   11.1
 	 */
 	public function deleteContextEntry($wrapper, $name)
@@ -1042,7 +1042,7 @@ class JStream extends JObject
 	 *
 	 * @return  mixed
 	 *
-	 * @see     http://php.net/manual/en/function.stream-filter-append.php
+	 * @see     https://secure.php.net/manual/en/function.stream-filter-append.php
 	 * @since   11.1
 	 */
 	public function appendFilter($filtername, $read_write = STREAM_FILTER_READ, $params = array())
@@ -1083,7 +1083,7 @@ class JStream extends JObject
 	 *
 	 * @return  mixed
 	 *
-	 * @see     http://php.net/manual/en/function.stream-filter-prepend.php
+	 * @see     https://secure.php.net/manual/en/function.stream-filter-prepend.php
 	 * @since   11.1
 	 */
 	public function prependFilter($filtername, $read_write = STREAM_FILTER_READ, $params = array())

--- a/libraries/joomla/filesystem/streams/string.php
+++ b/libraries/joomla/filesystem/streams/string.php
@@ -127,7 +127,7 @@ class JStreamString
 	 *
 	 * @return  array
 	 *
-	 * @see     http://www.php.net/manual/en/streamwrapper.stream-stat.php
+	 * @see     https://secure.php.net/manual/en/streamwrapper.stream-stat.php
 	 * @since   11.1
 	 */
 	public function stream_stat()
@@ -143,7 +143,7 @@ class JStreamString
 	 *
 	 * @return  array
 	 *
-	 * @see     http://php.net/manual/en/streamwrapper.url-stat.php
+	 * @see     https://secure.php.net/manual/en/streamwrapper.url-stat.php
 	 * @since   11.1
 	 */
 	public function url_stat($path, $flags = 0)
@@ -179,7 +179,7 @@ class JStreamString
 	 *
 	 * @since   11.1
 	 *
-	 * @see     http://www.php.net/manual/en/streamwrapper.stream-read.php
+	 * @see     https://secure.php.net/manual/en/streamwrapper.stream-read.php
 	 */
 	public function stream_read($count)
 	{

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -63,7 +63,7 @@ class JFormRuleUrl extends JFormRule
 		 * Note that parse_url() does not always parse accurately without a scheme,
 		 * but at least the path should be set always. Note also that parse_url()
 		 * returns False for seriously malformed URLs instead of an associative array.
-		 * @see http://php.net/manual/en/function.parse-url.php
+		 * @see https://secure.php.net/manual/en/function.parse-url.php
 		 */
 		if ($urlParts === false or !array_key_exists('scheme', $urlParts))
 		{

--- a/libraries/joomla/github/package/activity.php
+++ b/libraries/joomla/github/package/activity.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.3 (CMS)
  *
- * @documentation  http://developer.github.com/v3/activity/
+ * @documentation  https://developer.github.com/v3/activity/
  *
  * @property-read  JGithubPackageActivityEvents  $events  GitHub API object for markdown.
  */

--- a/libraries/joomla/github/package/activity/events.php
+++ b/libraries/joomla/github/package/activity/events.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity Events class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/activity/events/
+ * @documentation https://developer.github.com/v3/activity/events/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/activity/notifications.php
+++ b/libraries/joomla/github/package/activity/notifications.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity Events class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/activity/notifications/
+ * @documentation https://developer.github.com/v3/activity/notifications/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/activity/starring.php
+++ b/libraries/joomla/github/package/activity/starring.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity Events class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/activity/starring/
+ * @documentation https://developer.github.com/v3/activity/starring/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/activity/watching.php
+++ b/libraries/joomla/github/package/activity/watching.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity Watching Events class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/activity/watching/
+ * @documentation https://developer.github.com/v3/activity/watching/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/authorization.php
+++ b/libraries/joomla/github/package/authorization.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Authorization class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/oauth/
+ * @documentation https://developer.github.com/v3/oauth/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/data.php
+++ b/libraries/joomla/github/package/data.php
@@ -12,11 +12,11 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API DB class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/git/
+ * @documentation https://developer.github.com/v3/git/
  *
  * @since  12.3
  *
- * http://developer.github.com/v3/git/
+ * https://developer.github.com/v3/git/
  * Git DB API
  *
  * The Git Database API gives you access to read and write raw Git objects to your Git database on GitHub and to list

--- a/libraries/joomla/github/package/data/blobs.php
+++ b/libraries/joomla/github/package/data/blobs.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * takes an encoding parameter that can be either utf-8 or base64. If your data cannot be
  * losslessly sent as a UTF-8 string, you can base64 encode it.
  *
- * @documentation http://developer.github.com/v3/git/blobs/
+ * @documentation https://developer.github.com/v3/git/blobs/
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/data/commits.php
+++ b/libraries/joomla/github/package/data/commits.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Data Commits class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/git/commits/
+ * @documentation https://developer.github.com/v3/git/commits/
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/data/refs.php
+++ b/libraries/joomla/github/package/data/refs.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/git/refs/
+ * @documentation https://developer.github.com/v3/git/refs/
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/data/tags.php
+++ b/libraries/joomla/github/package/data/tags.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * This tags API only deals with tag objects - so only annotated tags, not lightweight tags.
  *
- * @documentation http://developer.github.com/v3/git/tags/
+ * @documentation https://developer.github.com/v3/git/tags/
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/data/trees.php
+++ b/libraries/joomla/github/package/data/trees.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Data Trees class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/git/trees/
+ * @documentation https://developer.github.com/v3/git/trees/
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/gists.php
+++ b/libraries/joomla/github/package/gists.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Gists class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/gists
+ * @documentation https://developer.github.com/v3/gists
  *
  * @since  11.3
  *

--- a/libraries/joomla/github/package/gists/comments.php
+++ b/libraries/joomla/github/package/gists/comments.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Gists Comments class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/gists/comments/
+ * @documentation https://developer.github.com/v3/gists/comments/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/gitignore.php
+++ b/libraries/joomla/github/package/gitignore.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * The .gitignore Templates API lists and fetches templates from the GitHub .gitignore repository.
  *
- * @documentation http://developer.github.com/v3/gitignore/
+ * @documentation https://developer.github.com/v3/gitignore/
  * @documentation https://github.com/github/gitignore
  *
  * @since  12.4

--- a/libraries/joomla/github/package/issues.php
+++ b/libraries/joomla/github/package/issues.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Issues class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/issues
+ * @documentation https://developer.github.com/v3/issues
  *
  * @since  11.3
  *

--- a/libraries/joomla/github/package/issues/assignees.php
+++ b/libraries/joomla/github/package/issues/assignees.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Assignees class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/issues/assignees/
+ * @documentation https://developer.github.com/v3/issues/assignees/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/issues/comments.php
+++ b/libraries/joomla/github/package/issues/comments.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * The Issue Comments API supports listing, viewing, editing, and creating comments
  * on issues and pull requests.
  *
- * @documentation http://developer.github.com/v3/issues/comments/
+ * @documentation https://developer.github.com/v3/issues/comments/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/issues/events.php
+++ b/libraries/joomla/github/package/issues/events.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  * This is useful both for display on issue/pull request information pages and also
  * to determine who should be notified of comments.
  *
- * @documentation http://developer.github.com/v3/issues/events/
+ * @documentation https://developer.github.com/v3/issues/events/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/issues/labels.php
+++ b/libraries/joomla/github/package/issues/labels.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Milestones class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/issues/labels/
+ * @documentation https://developer.github.com/v3/issues/labels/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/issues/milestones.php
+++ b/libraries/joomla/github/package/issues/milestones.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Milestones class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/issues/milestones/
+ * @documentation https://developer.github.com/v3/issues/milestones/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/markdown.php
+++ b/libraries/joomla/github/package/markdown.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Markdown class.
  *
- * @documentation http://developer.github.com/v3/markdown
+ * @documentation https://developer.github.com/v3/markdown
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/orgs.php
+++ b/libraries/joomla/github/package/orgs.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.3 (CMS)
  *
- * @documentation  http://developer.github.com/v3/orgs/
+ * @documentation  https://developer.github.com/v3/orgs/
  *
  * @property-read  JGithubPackageOrgsMembers  $members  GitHub API object for members.
  * @property-read  JGithubPackageOrgsTeams    $teams    GitHub API object for teams.

--- a/libraries/joomla/github/package/orgs/members.php
+++ b/libraries/joomla/github/package/orgs/members.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Orgs Members class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/orgs/members/
+ * @documentation https://developer.github.com/v3/orgs/members/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/orgs/teams.php
+++ b/libraries/joomla/github/package/orgs/teams.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * All actions against teams require at a minimum an authenticated user who is a member
  * of the owner’s team in the :org being managed. Additionally, OAuth users require “user” scope.
  *
- * @documentation http://developer.github.com/v3/orgs/teams/
+ * @documentation https://developer.github.com/v3/orgs/teams/
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/pulls.php
+++ b/libraries/joomla/github/package/pulls.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Pull Requests class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/pulls
+ * @documentation https://developer.github.com/v3/pulls
  *
  * @since  11.3
  *

--- a/libraries/joomla/github/package/pulls/comments.php
+++ b/libraries/joomla/github/package/pulls/comments.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Pulls Comments class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/pulls/comments/
+ * @documentation https://developer.github.com/v3/pulls/comments/
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/repositories.php
+++ b/libraries/joomla/github/package/repositories.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.3 (CMS)
  *
- * @documentation  http://developer.github.com/v3/repos
+ * @documentation  https://developer.github.com/v3/repos
  *
  * @property-read  JGithubPackageRepositoriesCollaborators  $collaborators  GitHub API object for collaborators.
  * @property-read  JGithubPackageRepositoriesComments       $comments       GitHub API object for comments.

--- a/libraries/joomla/github/package/repositories/collaborators.php
+++ b/libraries/joomla/github/package/repositories/collaborators.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Repositories Collaborators class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/collaborators
+ * @documentation https://developer.github.com/v3/repos/collaborators
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/comments.php
+++ b/libraries/joomla/github/package/repositories/comments.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Repositories Comments class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/comments
+ * @documentation https://developer.github.com/v3/repos/comments
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/commits.php
+++ b/libraries/joomla/github/package/repositories/commits.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Repositories Commits class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/commits
+ * @documentation https://developer.github.com/v3/repos/commits
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/contents.php
+++ b/libraries/joomla/github/package/repositories/contents.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * These API methods let you retrieve the contents of files within a repository as Base64 encoded content.
  * See media types for requesting raw or other formats.
  *
- * @documentation http://developer.github.com/v3/repos/contents
+ * @documentation https://developer.github.com/v3/repos/contents
  *
  * @since  11.3
  */
@@ -43,9 +43,9 @@ class JGithubPackageRepositoriesContents extends JGithubPackage
 	 * "type": "file",
 	 * "encoding": "base64",
 	 * "_links": {
-	 * "git": "https://api.github.com/repos/pengwynn/octokit/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
-	 * "self": "https://api.github.com/repos/pengwynn/octokit/contents/README.md",
-	 * "html": "https://github.com/pengwynn/octokit/blob/master/README.md"
+	 * "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+	 * "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+	 * "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
 	 * },
 	 * "size": 5362,
 	 * "name": "README.md",
@@ -102,9 +102,9 @@ class JGithubPackageRepositoriesContents extends JGithubPackage
 	 * "type": "file",
 	 * "encoding": "base64",
 	 * "_links": {
-	 * "git": "https://api.github.com/repos/pengwynn/octokit/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
-	 * "self": "https://api.github.com/repos/pengwynn/octokit/contents/README.md",
-	 * "html": "https://github.com/pengwynn/octokit/blob/master/README.md"
+	 * "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+	 * "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+	 * "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
 	 * },
 	 * "size": 5362,
 	 * "name": "README.md",
@@ -164,7 +164,7 @@ class JGithubPackageRepositoriesContents extends JGithubPackage
 	 *
 	 * To follow redirects with curl, use the -L switch:
 	 *
-	 * curl -L https://api.github.com/repos/pengwynn/octokit/tarball > octokit.tar.gz
+	 * curl -L https://api.github.com/repos/octokit/octokit.rb/tarball > octokit.tar.gz
 	 *
 	 * @param   string  $owner           The name of the owner of the GitHub repository.
 	 * @param   string  $repo            The name of the GitHub repository.

--- a/libraries/joomla/github/package/repositories/downloads.php
+++ b/libraries/joomla/github/package/repositories/downloads.php
@@ -14,9 +14,9 @@ defined('JPATH_PLATFORM') or die;
  *
  * The downloads API is for package downloads only.
  * If you want to get source tarballs you should use
- * http://developer.github.com/v3/repos/contents/#get-archive-link instead.
+ * https://developer.github.com/v3/repos/contents/#get-archive-link instead.
  *
- * @documentation http://developer.github.com/v3/repos/downloads
+ * @documentation https://developer.github.com/v3/repos/downloads
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/forks.php
+++ b/libraries/joomla/github/package/repositories/forks.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Forks class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/forks
+ * @documentation https://developer.github.com/v3/repos/forks
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/hooks.php
+++ b/libraries/joomla/github/package/repositories/hooks.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Hooks class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/hooks
+ * @documentation https://developer.github.com/v3/repos/hooks
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/repositories/keys.php
+++ b/libraries/joomla/github/package/repositories/keys.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Forks class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/keys
+ * @documentation https://developer.github.com/v3/repos/keys
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/merging.php
+++ b/libraries/joomla/github/package/repositories/merging.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Repositories Merging class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/merging
+ * @documentation https://developer.github.com/v3/repos/merging
  *
  * @since  11.3
  */

--- a/libraries/joomla/github/package/repositories/statistics.php
+++ b/libraries/joomla/github/package/repositories/statistics.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * The Repository Statistics API allows you to fetch the data that GitHub uses for
  * visualizing different types of repository activity.
  *
- * @documentation http://developer.github.com/v3/repos/statistics
+ * @documentation https://developer.github.com/v3/repos/statistics
  *
  * @since  3.3 (CMS)
  */

--- a/libraries/joomla/github/package/repositories/statuses.php
+++ b/libraries/joomla/github/package/repositories/statuses.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/statuses
+ * @documentation https://developer.github.com/v3/repos/statuses
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/search.php
+++ b/libraries/joomla/github/package/search.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Search class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/search
+ * @documentation https://developer.github.com/v3/search
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/users.php
+++ b/libraries/joomla/github/package/users.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/users
+ * @documentation https://developer.github.com/v3/repos/users
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/users/emails.php
+++ b/libraries/joomla/github/package/users/emails.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * Management of email addresses via the API requires that you are authenticated
  * through basic auth or OAuth with the user scope.
  *
- * @documentation http://developer.github.com/v3/repos/users/emails
+ * @documentation https://developer.github.com/v3/repos/users/emails
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/users/followers.php
+++ b/libraries/joomla/github/package/users/followers.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/users/followers
+ * @documentation https://developer.github.com/v3/repos/users/followers
  *
  * @since  12.3
  */

--- a/libraries/joomla/github/package/users/keys.php
+++ b/libraries/joomla/github/package/users/keys.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @documentation http://developer.github.com/v3/repos/users/keys
+ * @documentation https://developer.github.com/v3/repos/users/keys
  *
  * @since  12.3
  */

--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -29,7 +29,7 @@ class JHttpTransportCurl implements JHttpTransport
 	 *
 	 * @param   Registry  $options  Client options object.
 	 *
-	 * @see     http://www.php.net/manual/en/function.curl-setopt.php
+	 * @see     https://secure.php.net/manual/en/function.curl-setopt.php
 	 * @since   11.3
 	 * @throws  RuntimeException
 	 */

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -901,9 +901,8 @@ class JImage
 	/**
 	 * Method to flip the current image.
 	 *
-	 * @param   integer  $mode       The flip mode for flipping the image {@link http://php.net/imageflip#refsect1-function.imageflip-parameters}
-	 * @param   boolean  $createNew  If true the current image will be cloned, flipped and returned; else
-	 *                               the current image will be flipped and returned.
+	 * @param   integer  $mode       The flip mode for flipping the image {@link https://secure.php.net/imageflip#refsect1-function.imageflip-parameters}
+	 * @param   boolean  $createNew  If true the current image will be cloned, flipped and returned; else the current image will be flipped and returned.
 	 *
 	 * @return  JImage
 	 *
@@ -959,7 +958,7 @@ class JImage
 	 *
 	 * @return  boolean
 	 *
-	 * @see     http://www.php.net/manual/image.constants.php
+	 * @see     https://secure.php.net/manual/image.constants.php
 	 * @since   11.3
 	 * @throws  LogicException
 	 */

--- a/libraries/joomla/observable/interface.php
+++ b/libraries/joomla/observable/interface.php
@@ -30,7 +30,6 @@ defined('JPATH_PLATFORM') or die;
  * 4) in the methods that need to be observed, add, e.g. (name of event, params of event):
  * 		$this->_observers->update('onBeforeLoad', array($keys, $reset));
  *
- * @link   https://docs.joomla.org/JObservableInterface
  * @since  3.1.2
  */
 interface JObservableInterface

--- a/libraries/joomla/observer/interface.php
+++ b/libraries/joomla/observer/interface.php
@@ -41,7 +41,6 @@ defined('JPATH_PLATFORM') or die;
  * JObserverMapper::addObserverClassToClass('ObserverClassname', 'ObservableClassname', array('paramName' => 'paramValue'));
  * where the last array will be provided to the observer instanciator function createObserver.
  *
- * @link   https://docs.joomla.org/JObserverInterface
  * @since  3.1.2
  */
 interface JObserverInterface

--- a/libraries/joomla/observer/mapper.php
+++ b/libraries/joomla/observer/mapper.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Observer mapping pattern implementation for Joomla
  *
- * @link   https://docs.joomla.org/JObserverMapper
  * @since  3.1.2
  */
 class JObserverMapper

--- a/libraries/joomla/observer/updater.php
+++ b/libraries/joomla/observer/updater.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Observer updater pattern implementation for Joomla
  *
- * @link   https://docs.joomla.org/JObserverUpdater
  * @since  3.1.2
  */
 class JObserverUpdater implements JObserverUpdaterInterface

--- a/libraries/joomla/observer/updater/interface.php
+++ b/libraries/joomla/observer/updater/interface.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Observer updater pattern implementation for Joomla
  *
- * @link   https://docs.joomla.org/JObserverUpdater
  * @since  3.1.2
  */
 interface JObserverUpdaterInterface

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Custom session storage handler for PHP
  *
- * @see    http://www.php.net/manual/en/function.session-set-save-handler.php
+ * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
  * @todo   When dropping compatibility with PHP 5.3 use the SessionHandlerInterface and the SessionHandler class
  * @since  11.1
  */

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * APC session storage handler for PHP
  *
- * @see    http://www.php.net/manual/en/function.session-set-save-handler.php
+ * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
  * @since  11.1
  */
 class JSessionStorageApc extends JSessionStorage

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Database session storage handler for PHP
  *
- * @see    http://www.php.net/manual/en/function.session-set-save-handler.php
+ * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
  * @since  11.1
  */
 class JSessionStorageDatabase extends JSessionStorage

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * File session handler for PHP
  *
- * @see    http://www.php.net/manual/en/function.session-set-save-handler.php
+ * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
  * @since  11.1
  */
 class JSessionStorageNone extends JSessionStorage

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Table class supporting modified pre-order tree traversal behavior.
  *
- * @link   https://docs.joomla.org/JTableAsset
  * @since  11.1
  */
 class JTableAsset extends JTableNested
@@ -92,7 +91,6 @@ class JTableAsset extends JTableNested
 	 *
 	 * @return  boolean  True if the instance is sane and able to be stored in the database.
 	 *
-	 * @link    https://docs.joomla.org/JTable/check
 	 * @since   11.1
 	 */
 	public function check()
@@ -139,7 +137,6 @@ class JTableAsset extends JTableNested
 	 *
 	 * @return  integer  1 + value of root rgt on success, false on failure
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/rebuild
 	 * @since   3.5
 	 * @throws  RuntimeException on database error.
 	 */

--- a/libraries/joomla/table/interface.php
+++ b/libraries/joomla/table/interface.php
@@ -10,49 +10,46 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * table class interface.
+ * Table class interface.
  *
  * @since  3.2
  */
 interface JTableInterface
 {
 	/**
-	 * Method to bind an associative array or object to the JTable instance.This
-	 * method only binds properties that are publicly accessible and optionally
-	 * takes an array of properties to ignore when binding.
+	 * Method to bind an associative array or object to the JTableInterface instance.
 	 *
-	 * @param   mixed  $src     An associative array or object to bind to the JTable instance.
+	 * This method only binds properties that are publicly accessible and optionally takes an array of properties to ignore when binding.
+	 *
+	 * @param   mixed  $src     An associative array or object to bind to the JTableInterface instance.
 	 * @param   mixed  $ignore  An optional array or space separated list of properties to ignore while binding.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/bind
 	 * @since   3.2
 	 * @throws  UnexpectedValueException
 	 */
 	public function bind($src, $ignore = array());
 
 	/**
-	 * Method to perform sanity checks on the JTable instance properties to ensure
-	 * they are safe to store in the database. Child classes should override this
-	 * method to make sure the data they are storing in the database is safe and
+	 * Method to perform sanity checks on the JTableInterface instance properties to ensure they are safe to store in the database.
+	 *
+	 * Implementations of this interface should use this method to make sure the data they are storing in the database is safe and
 	 * as expected before storage.
 	 *
-	 * @return boolean True if the instance is sane and able to be stored in the database.
+	 * @return  boolean  True if the instance is sane and able to be stored in the database.
 	 *
-	 * @link https://docs.joomla.org/JTable/check
-	 * @since 3.2
+	 * @since   3.2
 	 */
 	public function check();
 
 	/**
-	 * Override parent delete method to delete tags information.
+	 * Method to delete a record.
 	 *
 	 * @param   mixed  $pk  An optional primary key value to delete.  If not set the instance property value is used.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/delete
 	 * @since   3.2
 	 * @throws  UnexpectedValueException
 	 */
@@ -63,7 +60,6 @@ interface JTableInterface
 	 *
 	 * @return  JDatabaseDriver  The internal database driver object.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getDBO
 	 * @since   3.2
 	 */
 	public function getDbo();
@@ -73,14 +69,12 @@ interface JTableInterface
 	 *
 	 * @return  string  The name of the primary key for the table.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getKeyName
 	 * @since   3.2
 	 */
 	public function getKeyName();
 
 	/**
-	 * Method to load a row from the database by primary key and bind the fields
-	 * to the JTable instance properties.
+	 * Method to load a row from the database by primary key and bind the fields to the JTableInterface instance properties.
 	 *
 	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.  If not
 	 *                           set the instance property value is used.
@@ -88,38 +82,33 @@ interface JTableInterface
 	 *
 	 * @return  boolean  True if successful. False if row not found.
 	 *
-	 * @link    https://docs.joomla.org/JTable/load
 	 * @since   3.2
 	 * @throws  RuntimeException
 	 * @throws  UnexpectedValueException
 	 */
 	public function load($keys = null, $reset = true);
 
-
 	/**
-	 * Method to reset class properties to the defaults set in the class
-	 * definition. It will ignore the primary key as well as any private class
-	 * properties.
+	 * Method to reset class properties to the defaults set in the class definition.
+	 *
+	 * It will ignore the primary key as well as any private class properties.
 	 *
 	 * @return  void
 	 *
-	 * @link    https://docs.joomla.org/JTable/reset
 	 * @since   3.2
 	 */
 	public function reset();
 
 	/**
-	 * Method to store a row in the database from the JTable instance properties.
-	 * If a primary key value is set the row with that primary key value will be
-	 * updated with the instance property values.  If no primary key value is set
-	 * a new row will be inserted into the database with the properties from the
-	 * JTable instance.
+	 * Method to store a row in the database from the JTableInterface instance properties.
+	 *
+	 * If a primary key value is set the row with that primary key value will be updated with the instance property values.
+	 * If no primary key value is set a new row will be inserted into the database with the properties from the JTableInterface instance.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/store
 	 * @since   3.2
 	 */
 	public function store($updateNulls = false);

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -12,14 +12,12 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Table class supporting modified pre-order tree traversal behavior.
  *
- * @link   https://docs.joomla.org/JTableNested
  * @since  11.1
  */
 class JTableNested extends JTable
 {
 	/**
-	 * Object property holding the primary key of the parent node.  Provides
-	 * adjacency list data for nodes.
+	 * Object property holding the primary key of the parent node.  Provides adjacency list data for nodes.
 	 *
 	 * @var    integer
 	 * @since  11.1
@@ -35,8 +33,7 @@ class JTableNested extends JTable
 	public $level;
 
 	/**
-	 * Object property holding the left value of the node for managing its
-	 * placement in the nested sets tree.
+	 * Object property holding the left value of the node for managing its placement in the nested sets tree.
 	 *
 	 * @var    integer
 	 * @since  11.1
@@ -44,8 +41,7 @@ class JTableNested extends JTable
 	public $lft;
 
 	/**
-	 * Object property holding the right value of the node for managing its
-	 * placement in the nested sets tree.
+	 * Object property holding the right value of the node for managing its placement in the nested sets tree.
 	 *
 	 * @var    integer
 	 * @since  11.1
@@ -53,8 +49,7 @@ class JTableNested extends JTable
 	public $rgt;
 
 	/**
-	 * Object property holding the alias of this node used to constuct the
-	 * full text path, forward-slash delimited.
+	 * Object property holding the alias of this node used to constuct the full text path, forward-slash delimited.
 	 *
 	 * @var    string
 	 * @since  11.1
@@ -63,6 +58,7 @@ class JTableNested extends JTable
 
 	/**
 	 * Object property to hold the location type to use when storing the row.
+	 *
 	 * Possible values are: ['before', 'after', 'first-child', 'last-child'].
 	 *
 	 * @var    string
@@ -71,9 +67,9 @@ class JTableNested extends JTable
 	protected $_location;
 
 	/**
-	 * Object property to hold the primary key of the location reference node to
-	 * use when storing the row.  A combination of location type and reference
-	 * node describes where to store the current node in the tree.
+	 * Object property to hold the primary key of the location reference node to use when storing the row.
+	 *
+	 * A combination of location type and reference node describes where to store the current node in the tree.
 	 *
 	 * @var    integer
 	 * @since  11.1
@@ -241,7 +237,6 @@ class JTableNested extends JTable
 	 *
 	 * @return  mixed    Boolean true on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/move
 	 * @since   11.1
 	 */
 	public function move($delta, $where = '')
@@ -294,7 +289,6 @@ class JTableNested extends JTable
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/moveByReference
 	 * @since   11.1
 	 * @throws  RuntimeException on database error.
 	 */
@@ -693,7 +687,6 @@ class JTableNested extends JTable
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/store
 	 * @since   11.1
 	 */
 	public function store($updateNulls = false)
@@ -885,9 +878,8 @@ class JTableNested extends JTable
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/publish
 	 * @since   11.1
-	 * @throws UnexpectedValueException
+	 * @throws  UnexpectedValueException
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{
@@ -1262,7 +1254,6 @@ class JTableNested extends JTable
 	 *
 	 * @return  integer  1 + value of root rgt on success, false on failure
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/rebuild
 	 * @since   11.1
 	 * @throws  RuntimeException on database error.
 	 */
@@ -1346,14 +1337,12 @@ class JTableNested extends JTable
 	}
 
 	/**
-	 * Method to rebuild the node's path field from the alias values of the
-	 * nodes from the current node to the root node of the tree.
+	 * Method to rebuild the node's path field from the alias values of the nodes from the current node to the root node of the tree.
 	 *
 	 * @param   integer  $pk  Primary key of the node for which to get the path.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTableNested/rebuildPath
 	 * @since   11.1
 	 */
 	public function rebuildPath($pk = null)

--- a/libraries/joomla/table/observer.php
+++ b/libraries/joomla/table/observer.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Table class supporting modified pre-order tree traversal behavior.
  *
- * @link   https://docs.joomla.org/JTableObserver
  * @since  3.1.2
  */
 abstract class JTableObserver implements JObserverInterface

--- a/libraries/joomla/table/observer/contenthistory.php
+++ b/libraries/joomla/table/observer/contenthistory.php
@@ -12,7 +12,6 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Table class supporting modified pre-order tree traversal behavior.
  *
- * @link   https://docs.joomla.org/JTableObserver
  * @since  3.2
  */
 class JTableObserverContenthistory extends JTableObserver

--- a/libraries/joomla/table/observer/tags.php
+++ b/libraries/joomla/table/observer/tags.php
@@ -16,7 +16,6 @@ defined('JPATH_PLATFORM') or die;
  * The classes extending this class should not be instanciated directly, as they
  * are automatically instanciated by the JObserverMapper
  *
- * @link   https://docs.joomla.org/JTableObserver
  * @since  3.1.2
  */
 class JTableObserverTags extends JTableObserver

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -874,9 +874,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 * the table rows based on the filter.  The ordering filter is an instance property name.  The rows that will be reordered
 	 * are those whose value matches the JTable instance for the property specified.
 	 *
-	 * @param   array|object   $src             An associative array or object to bind to the JTable instance.
-	 * @param   string         $orderingFilter  Filter for the order updating
-	 * @param   array|string   $ignore          An optional array or space separated list of properties to ignore while binding.
+	 * @param   array|object  $src             An associative array or object to bind to the JTable instance.
+	 * @param   string        $orderingFilter  Filter for the order updating
+	 * @param   array|string  $ignore          An optional array or space separated list of properties to ignore while binding.
 	 *
 	 * @return  boolean  True on success.
 	 *

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -252,9 +252,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Static method to get an instance of a JTable class if it can be found in
-	 * the table include paths.  To add include paths for searching for JTable
-	 * classes see JTable::addIncludePath().
+	 * Static method to get an instance of a JTable class if it can be found in the table include paths.
+	 *
+	 * To add include paths for searching for JTable classes see JTable::addIncludePath().
 	 *
 	 * @param   string  $type    The type (name) of the JTable class to get an instance of.
 	 * @param   string  $prefix  An optional prefix for the table class name.
@@ -262,7 +262,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  JTable|boolean   A JTable object if found or boolean false on failure.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getInstance
 	 * @since   11.1
 	 */
 	public static function getInstance($type, $prefix = 'JTable', $config = array())
@@ -307,13 +306,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 	/**
 	 * Add a filesystem path where JTable should search for table class files.
-	 * You may either pass a string or an array of paths.
 	 *
-	 * @param   mixed  $path  A filesystem path or array of filesystem paths to add.
+	 * @param   array|string  $path  A filesystem path or array of filesystem paths to add.
 	 *
 	 * @return  array  An array of filesystem paths to find JTable classes in.
 	 *
-	 * @link    https://docs.joomla.org/JTable/addIncludePath
 	 * @since   11.1
 	 */
 	public static function addIncludePath($path = null)
@@ -369,15 +366,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to return the title to use for the asset table.  In
-	 * tracking the assets a title is kept for each asset so that there is some
-	 * context available in a unified access manager.  Usually this would just
-	 * return $this->title or $this->name or whatever is being used for the
-	 * primary name of the row. If this method is not overridden, the asset name is used.
+	 * Method to return the title to use for the asset table.
+	 *
+	 * In tracking the assets a title is kept for each asset so that there is some context available in a unified access manager.
+	 * Usually this would just return $this->title or $this->name or whatever is being used for the primary name of the row.
+	 * If this method is not overridden, the asset name is used.
 	 *
 	 * @return  string  The string to use as the title in the asset table.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getAssetTitle
 	 * @since   11.1
 	 */
 	protected function _getAssetTitle()
@@ -387,10 +383,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 	/**
 	 * Method to get the parent asset under which to register this one.
-	 * By default, all assets are registered to the ROOT node with ID,
-	 * which will default to 1 if none exists.
-	 * The extended class can define a table and id to lookup.  If the
-	 * asset does not exist it will be created.
+	 *
+	 * By default, all assets are registered to the ROOT node with ID, which will default to 1 if none exists.
+	 * An extended class can define a table and ID to lookup.  If the asset does not exist it will be created.
 	 *
 	 * @param   JTable   $table  A JTable object for the asset parent.
 	 * @param   integer  $id     Id to look up
@@ -454,8 +449,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 * @return  string  The name of the database table being modeled.
 	 *
 	 * @since   11.1
-	 *
-	 * @link    https://docs.joomla.org/JTable/getTableName
 	 */
 	public function getTableName()
 	{
@@ -469,7 +462,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  mixed  Array of primary key field names or string containing the first primary key field.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getKeyName
 	 * @since   11.1
 	 */
 	public function getKeyName($multiple = false)
@@ -497,7 +489,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  JDatabaseDriver  The internal database driver object.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getDBO
 	 * @since   11.1
 	 */
 	public function getDbo()
@@ -512,7 +503,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/setDBO
 	 * @since   11.1
 	 */
 	public function setDbo($db)
@@ -562,7 +552,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  void
 	 *
-	 * @link    https://docs.joomla.org/JTable/reset
 	 * @since   11.1
 	 */
 	public function reset()
@@ -586,8 +575,8 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 * method only binds properties that are publicly accessible and optionally
 	 * takes an array of properties to ignore when binding.
 	 *
-	 * @param   mixed  $src     An associative array or object to bind to the JTable instance.
-	 * @param   mixed  $ignore  An optional array or space separated list of properties to ignore while binding.
+	 * @param   array|object  $src     An associative array or object to bind to the JTable instance.
+	 * @param   array|string  $ignore  An optional array or space separated list of properties to ignore while binding.
 	 *
 	 * @return  boolean  True on success.
 	 *
@@ -643,16 +632,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to load a row from the database by primary key and bind the fields
-	 * to the JTable instance properties.
+	 * Method to load a row from the database by primary key and bind the fields to the JTable instance properties.
 	 *
-	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.  If not
-	 *                           set the instance property value is used.
+	 * @param   mixed    $keys   An optional primary key value to load the row by, or an array of fields to match.
+	 *                           If not set the instance property value is used.
 	 * @param   boolean  $reset  True to reset the default values before loading the new row.
 	 *
 	 * @return  boolean  True if successful. False if row not found.
 	 *
-	 * @link    https://docs.joomla.org/JTable/load
 	 * @since   11.1
 	 * @throws  InvalidArgumentException
 	 * @throws  RuntimeException
@@ -745,14 +732,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to perform sanity checks on the JTable instance properties to ensure
-	 * they are safe to store in the database.  Child classes should override this
-	 * method to make sure the data they are storing in the database is safe and
-	 * as expected before storage.
+	 * Method to perform sanity checks on the JTable instance properties to ensure they are safe to store in the database.
+	 *
+	 * Child classes should override this method to make sure the data they are storing in the database is safe and as expected before storage.
 	 *
 	 * @return  boolean  True if the instance is sane and able to be stored in the database.
 	 *
-	 * @link    https://docs.joomla.org/JTable/check
 	 * @since   11.1
 	 */
 	public function check()
@@ -762,16 +747,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 	/**
 	 * Method to store a row in the database from the JTable instance properties.
-	 * If a primary key value is set the row with that primary key value will be
-	 * updated with the instance property values.  If no primary key value is set
-	 * a new row will be inserted into the database with the properties from the
-	 * JTable instance.
+	 *
+	 * If a primary key value is set the row with that primary key value will be updated with the instance property values.
+	 * If no primary key value is set a new row will be inserted into the database with the properties from the JTable instance.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/store
 	 * @since   11.1
 	 */
 	public function store($updateNulls = false)
@@ -885,21 +868,18 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to provide a shortcut to binding, checking and storing a JTable
-	 * instance to the database table.  The method will check a row in once the
-	 * data has been stored and if an ordering filter is present will attempt to
-	 * reorder the table rows based on the filter.  The ordering filter is an instance
-	 * property name.  The rows that will be reordered are those whose value matches
-	 * the JTable instance for the property specified.
+	 * Method to provide a shortcut to binding, checking and storing a JTable instance to the database table.
 	 *
-	 * @param   mixed   $src             An associative array or object to bind to the JTable instance.
-	 * @param   string  $orderingFilter  Filter for the order updating
-	 * @param   mixed   $ignore          An optional array or space separated list of properties
-	 *                                   to ignore while binding.
+	 * The method will check a row in once the data has been stored and if an ordering filter is present will attempt to reorder
+	 * the table rows based on the filter.  The ordering filter is an instance property name.  The rows that will be reordered
+	 * are those whose value matches the JTable instance for the property specified.
+	 *
+	 * @param   array|object   $src             An associative array or object to bind to the JTable instance.
+	 * @param   string         $orderingFilter  Filter for the order updating
+	 * @param   array|string   $ignore          An optional array or space separated list of properties to ignore while binding.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/save
 	 * @since   11.1
 	 */
 	public function save($src, $orderingFilter = '', $ignore = '')
@@ -948,7 +928,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/delete
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1018,20 +997,17 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to check a row out if the necessary properties/fields exist.  To
-	 * prevent race conditions while editing rows in a database, a row can be
-	 * checked out if the fields 'checked_out' and 'checked_out_time' are available.
-	 * While a row is checked out, any attempt to store the row by a user other
-	 * than the one who checked the row out should be held until the row is checked
-	 * in again.
+	 * Method to check a row out if the necessary properties/fields exist.
+	 *
+	 * To prevent race conditions while editing rows in a database, a row can be checked out if the fields 'checked_out' and 'checked_out_time'
+	 * are available. While a row is checked out, any attempt to store the row by a user other than the one who checked the row out should be
+	 * held until the row is checked in again.
 	 *
 	 * @param   integer  $userId  The Id of the user checking out the row.
-	 * @param   mixed    $pk      An optional primary key value to check out.  If not set
-	 *                            the instance property value is used.
+	 * @param   mixed    $pk      An optional primary key value to check out.  If not set the instance property value is used.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/checkOut
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1090,14 +1066,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to check a row in if the necessary properties/fields exist.  Checking
-	 * a row in will allow other users the ability to edit the row.
+	 * Method to check a row in if the necessary properties/fields exist.
+	 *
+	 * Checking a row in will allow other users the ability to edit the row.
 	 *
 	 * @param   mixed  $pk  An optional primary key value to check out.  If not set the instance property value is used.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/checkIn
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1202,7 +1178,6 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/hit
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1255,18 +1230,15 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to determine if a row is checked out and therefore uneditable by
-	 * a user. If the row is checked out by the same user, then it is considered
-	 * not checked out -- as the user can still edit it.
+	 * Method to determine if a row is checked out and therefore uneditable by a user.
 	 *
-	 * @param   integer  $with     The userid to preform the match with, if an item is checked
-	 *                             out by this user the function will return false.
-	 * @param   integer  $against  The userid to perform the match against when the function
-	 *                             is used as a static function.
+	 * If the row is checked out by the same user, then it is considered not checked out -- as the user can still edit it.
+	 *
+	 * @param   integer  $with     The user ID to preform the match with, if an item is checked out by this user the function will return false.
+	 * @param   integer  $against  The user ID to perform the match against when the function is used as a static function.
 	 *
 	 * @return  boolean  True if checked out.
 	 *
-	 * @link    https://docs.joomla.org/JTable/isCheckedOut
 	 * @since   11.1
 	 */
 	public function isCheckedOut($with = 0, $against = null)
@@ -1298,13 +1270,13 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 	/**
 	 * Method to get the next ordering value for a group of rows defined by an SQL WHERE clause.
+	 *
 	 * This is useful for placing a new item last in a group of items in the table.
 	 *
 	 * @param   string  $where  WHERE clause to use for selecting the MAX(ordering) for the table.
 	 *
-	 * @return  mixed  Boolean false an failure or the next ordering value as an integer.
+	 * @return  integer  The next ordering value.
 	 *
-	 * @link    https://docs.joomla.org/JTable/getNextOrder
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1359,14 +1331,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to compact the ordering values of rows in a group of rows
-	 * defined by an SQL WHERE clause.
+	 * Method to compact the ordering values of rows in a group of rows defined by an SQL WHERE clause.
 	 *
 	 * @param   string  $where  WHERE clause to use for limiting the selection of rows to compact the ordering values.
 	 *
 	 * @return  mixed  Boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/reorder
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1421,15 +1391,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 	/**
 	 * Method to move a row in the ordering sequence of a group of rows defined by an SQL WHERE clause.
+	 *
 	 * Negative numbers move the row up in the sequence and positive numbers move it down.
 	 *
 	 * @param   integer  $delta  The direction and magnitude to move the row in the ordering sequence.
-	 * @param   string   $where  WHERE clause to use for limiting the selection of rows to compact the
-	 *                           ordering values.
+	 * @param   string   $where  WHERE clause to use for limiting the selection of rows to compact the ordering values.
 	 *
-	 * @return  mixed    Boolean  True on success.
+	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/move
 	 * @since   11.1
 	 * @throws  UnexpectedValueException
 	 */
@@ -1515,18 +1484,16 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
-	 * Method to set the publishing state for a row or list of rows in the database
-	 * table.  The method respects checked out rows by other users and will attempt
-	 * to checkin rows that it can after adjustments are made.
+	 * Method to set the publishing state for a row or list of rows in the database table.
 	 *
-	 * @param   mixed    $pks     An optional array of primary key values to update.
-	 *                            If not set the instance property value is used.
+	 * The method respects checked out rows by other users and will attempt to checkin rows that it can after adjustments are made.
+	 *
+	 * @param   mixed    $pks     An optional array of primary key values to update. If not set the instance property value is used.
 	 * @param   integer  $state   The publishing state. eg. [0 = unpublished, 1 = published]
-	 * @param   integer  $userId  The user id of the user performing the operation.
+	 * @param   integer  $userId  The user ID of the user performing the operation.
 	 *
 	 * @return  boolean  True on success; false if $pks is empty.
 	 *
-	 * @link    https://docs.joomla.org/JTable/publish
 	 * @since   11.1
 	 */
 	public function publish($pks = null, $state = 1, $userId = 0)

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -283,16 +283,14 @@ class JTableUser extends JTable
 
 	/**
 	 * Method to store a row in the database from the JTable instance properties.
-	 * If a primary key value is set the row with that primary key value will be
-	 * updated with the instance property values.  If no primary key value is set
-	 * a new row will be inserted into the database with the properties from the
-	 * JTable instance.
+	 *
+	 * If a primary key value is set the row with that primary key value will be updated with the instance property values.
+	 * If no primary key value is set a new row will be inserted into the database with the properties from the JTable instance.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/store
 	 * @since   11.1
 	 */
 	public function store($updateNulls = false)

--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -494,7 +494,7 @@ abstract class JArrayHelper
 	 *
 	 * @return  array
 	 *
-	 * @see     http://php.net/manual/en/function.array-unique.php
+	 * @see     https://secure.php.net/manual/en/function.array-unique.php
 	 * @since   11.2
 	 * @deprecated  4.0 Use Joomla\Utilities\ArrayHelper::arrayUnique instead
 	 */

--- a/libraries/legacy/database/mysqli.php
+++ b/libraries/legacy/database/mysqli.php
@@ -14,7 +14,7 @@ JLog::add('JDatabaseMysqli is deprecated, use JDatabaseDriverMysqli instead.', J
 /**
  * MySQLi database driver
  *
- * @see         http://php.net/manual/en/book.mysqli.php
+ * @see         https://secure.php.net/manual/en/book.mysqli.php
  * @since       11.1
  * @deprecated  13.1 (Platform) & 4.0 (CMS) - Use JDatabaseDriverMysqli instead.
  */

--- a/libraries/legacy/database/sqlazure.php
+++ b/libraries/legacy/database/sqlazure.php
@@ -14,7 +14,7 @@ JLog::add('JDatabaseSqlazure is deprecated, use JDatabaseDriverSqlazure instead.
 /**
  * SQL Server database driver
  *
- * @see         http://msdn.microsoft.com/en-us/library/ee336279.aspx
+ * @see         https://azure.microsoft.com/en-us/documentation/services/sql-database/
  * @since       11.1
  * @deprecated  13.1 (Platform) & 4.0 (CMS) - Use JDatabaseDriverSqlazure instead.
  */

--- a/libraries/legacy/database/sqlsrv.php
+++ b/libraries/legacy/database/sqlsrv.php
@@ -14,7 +14,7 @@ JLog::add('JDatabaseSqlsrv is deprecated, use JDatabaseDriverSqlsrv instead.', J
 /**
  * SQL Server database driver
  *
- * @see         http://msdn.microsoft.com/en-us/library/cc296152(SQL.90).aspx
+ * @see         https://msdn.microsoft.com/en-us/library/cc296152(SQL.90).aspx
  * @since       11.1
  * @deprecated  13.1 (Platform) & 4.0 (CMS) - Use JDatabaseDriverSqlsrv instead.
  */

--- a/libraries/legacy/table/menu/type.php
+++ b/libraries/legacy/table/menu/type.php
@@ -73,16 +73,14 @@ class JTableMenuType extends JTable
 
 	/**
 	 * Method to store a row in the database from the JTable instance properties.
-	 * If a primary key value is set the row with that primary key value will be
-	 * updated with the instance property values.  If no primary key value is set
-	 * a new row will be inserted into the database with the properties from the
-	 * JTable instance.
+	 *
+	 * If a primary key value is set the row with that primary key value will be updated with the instance property values.
+	 * If no primary key value is set a new row will be inserted into the database with the properties from the JTable instance.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/store
 	 * @since   11.1
 	 */
 	public function store($updateNulls = false)
@@ -164,7 +162,6 @@ class JTableMenuType extends JTable
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @link    https://docs.joomla.org/JTable/delete
 	 * @since   11.1
 	 */
 	public function delete($pk = null)

--- a/libraries/platform.php
+++ b/libraries/platform.php
@@ -56,7 +56,7 @@ final class JPlatform
 	 *
 	 * @return  boolean  True if the version is compatible.
 	 *
-	 * @see     http://www.php.net/version_compare
+	 * @see     https://secure.php.net/version_compare
 	 * @since   11.1
 	 * @deprecated  4.0  Deprecated without replacement
 	 */


### PR DESCRIPTION
#### Summary of Changes
- Removes links to the docs wiki for JTable; many of these don't exist or represent the Joomla 1.5 API
- Changes links for `php.net` to consistently use the `https://secure.php.net` mirror
- Changes all GitHub links to use https to avoid a needless redirect when the API site's docs are compiled
- Other miscellaneous link updates to remove needless redirects
- Minor formatting tweaks on some JTable doc blocks (this mostly impacts how some stuff renders when the API site's compiled)
#### Testing Instructions

Review
