### PR TITLE
update captcha message

### DIFF
--- a/language/en-GB/en-GB.com_contact.ini
+++ b/language/en-GB/en-GB.com_contact.ini
@@ -6,7 +6,7 @@
 COM_CONTACT_ADDRESS="Address"
 COM_CONTACT_ARTICLES_HEADING="Contact's articles"
 COM_CONTACT_CAPTCHA_LABEL="Captcha"
-COM_CONTACT_CAPTCHA_DESC="Type in the textbox what you see in the image."
+COM_CONTACT_CAPTCHA_DESC="Please complete the security check."
 COM_CONTACT_CAT_NUM="# of Contacts :"
 COM_CONTACT_CONTACT_DEFAULT_LABEL="Send an Email"
 COM_CONTACT_CONTACT_EMAIL_A_COPY_DESC="Sends a copy of the message to the address you have supplied."

--- a/language/en-GB/en-GB.com_users.ini
+++ b/language/en-GB/en-GB.com_users.ini
@@ -5,7 +5,7 @@
 
 COM_USERS_ACTIVATION_TOKEN_NOT_FOUND="Verification code not found."
 COM_USERS_CAPTCHA_LABEL="Captcha"
-COM_USERS_CAPTCHA_DESC="Type in the textbox what you see in the image."
+COM_USERS_CAPTCHA_DESC="Please complete the security check."
 COM_USERS_DATABASE_ERROR="Error getting the user from the database: %s"
 COM_USERS_DESIRED_PASSWORD="Enter your desired password."
 COM_USERS_DESIRED_USERNAME="Enter your desired username."


### PR DESCRIPTION
#### Summary of Changes

The tooltip text for the captcha field on the contact form (and probably elsewhere) is "Type in the textbox what you see in the image".  However, this is not relevant for reCaptcha v2.  

The new tooltip is Please complete the security check.

This should cover all the possible ways the recaptcha2 (and old v1) will be dispalyed 
