### PR TITLE
Release Blocker: After update to Joomla 3.6 RC fails backend files path

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -45,7 +45,7 @@ class JApplicationAdministrator extends JApplicationCms
 		parent::__construct($input, $config, $client);
 
 		// Set the root in the URI based on the application name
-		JUri::root(null, rtrim(dirname(JUri::base(true)), '/'));
+		JUri::root(null, rtrim(dirname(JUri::base(true)), '/\\'));
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10955 .
#### Summary of Changes

fix rtrim if site is in document_root on windows
#### Testing Instructions
- Install site directly in document_root on windows
- Check if back-end works.
- Aplly changes from this PR manualy.
- Check again if the back-end works.
