### PR TITLE
Remove usage of deprecated JArrayHelper - libraries/joomla

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.utilities.arrayhelper');
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Class that handles all access authorisation routines.
@@ -849,7 +849,7 @@ class JAccess
 				$result = $db->loadColumn();
 
 				// Clean up any NULL or duplicate values, just in case
-				JArrayHelper::toInteger($result);
+				$result = ArrayHelper::toInteger($result);
 
 				if (empty($result))
 				{
@@ -898,7 +898,7 @@ class JAccess
 		$result = $db->loadColumn();
 
 		// Clean up any NULL values, just in case
-		JArrayHelper::toInteger($result);
+		$result = ArrayHelper::toInteger($result);
 
 		return $result;
 	}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -10,9 +10,9 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 jimport('joomla.filesystem.path');
-jimport('joomla.utilities.arrayhelper');
 
 /**
  * Form Class for the Joomla Platform.
@@ -173,7 +173,7 @@ class JForm
 				// If the field exists set the value.
 				$this->data->set($level, $v);
 			}
-			elseif (is_object($v) || JArrayHelper::isAssociative($v))
+			elseif (is_object($v) || ArrayHelper::isAssociative($v))
 			{
 				// If the value is an object or an associative array, hand it off to the recursive bind level method.
 				$this->bindLevel($level, $v);
@@ -1266,7 +1266,7 @@ class JForm
 
 				$value = is_array($value) ? $value : array($value);
 
-				JArrayHelper::toInteger($value);
+				$value = ArrayHelper::toInteger($value);
 				$return = $value;
 				break;
 

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Extension table
@@ -127,7 +128,7 @@ class JTableExtension extends JTable
 		$k = $this->_tbl_key;
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
 		$state = (int) $state;
 

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Table class supporting modified pre-order tree traversal behavior.
  *
@@ -895,7 +897,7 @@ class JTableNested extends JTable
 		$query = $this->_db->getQuery(true);
 
 		// Sanitize input.
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
 		$state = (int) $state;
 

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Users table
@@ -138,7 +139,7 @@ class JTableUser extends JTable
 		if ($return && !empty($this->groups))
 		{
 			// Set the group ids.
-			JArrayHelper::toInteger($this->groups);
+			$this->groups = ArrayHelper::toInteger($this->groups);
 
 			// Get the titles for the user groups.
 			$query = $this->_db->getQuery(true)

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Authorisation helper class, provides static methods to perform various tasks relevant
  * to the Joomla user and authorisation classes
@@ -153,7 +155,7 @@ abstract class JUserHelper
 		$user = JUser::getInstance((int) $userId);
 
 		// Set the group ids.
-		JArrayHelper::toInteger($groups);
+		$groups = ArrayHelper::toInteger($groups);
 		$user->groups = $groups;
 
 		// Get the titles for the user groups.

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * User class.  Handles all application interaction with a user
@@ -612,7 +613,7 @@ class JUser extends JObject
 				return false;
 			}
 
-			$this->password_clear = JArrayHelper::getValue($array, 'password', '', 'string');
+			$this->password_clear = ArrayHelper::getValue($array, 'password', '', 'string');
 
 			$array['password'] = $this->userHelper->hashPassword($array['password']);
 
@@ -640,7 +641,7 @@ class JUser extends JObject
 					return false;
 				}
 
-				$this->password_clear = JArrayHelper::getValue($array, 'password', '', 'string');
+				$this->password_clear = ArrayHelper::getValue($array, 'password', '', 'string');
 
 				// Check if the user is reusing the current password if required to reset their password
 				if ($this->requireReset == 1 && $this->userHelper->verifyPassword($this->password_clear, $this->password))


### PR DESCRIPTION
#### Summary of Changes

Remove usage of deprecated JArrayHelper from libraries/joomla. No programmatic changes intended.
#### Testing Instructions
- User groups assignment should save and retrieve correctly.
- User passwords change should save correctly.
- All edit forms should show the correct data loaded while editing.
- Publish/unpublish extensions and categories should work correctly.
- Review code
