### PR TITLE
Catch database exception in JInstaller::abort()

### DIFF
--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -458,6 +458,7 @@ JLIB_INSTALLER_ABORT_CREATE_DIRECTORY="Extension %1$s: Failed to create folder: 
 JLIB_INSTALLER_ABORT_DEBUG="Installation unexpectedly terminated:"
 JLIB_INSTALLER_ABORT_DETECTMANIFEST="Unable to detect manifest file."
 JLIB_INSTALLER_ABORT_DIRECTORY="Extension %1$s: Another %2$s is already using the named folder: %3$s. Are you trying to install the same extension again?"
+JLIB_INSTALLER_ABORT_ERROR_DELETING_EXTENSIONS_RECORD="Could not delete the extension's record from the database."
 JLIB_INSTALLER_ABORT_EXTENSIONNOTVALID="Extension is not valid."
 JLIB_INSTALLER_ABORT_FILE_INSTALL_COPY_SETUP="Files Install: Could not copy setup file."
 JLIB_INSTALLER_ABORT_FILE_INSTALL_CUSTOM_INSTALL_FAILURE="Files Install: Custom install routine failure."

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -458,6 +458,7 @@ JLIB_INSTALLER_ABORT_CREATE_DIRECTORY="Extension %1$s: Failed to create folder: 
 JLIB_INSTALLER_ABORT_DEBUG="Installation unexpectedly terminated:"
 JLIB_INSTALLER_ABORT_DETECTMANIFEST="Unable to detect manifest file."
 JLIB_INSTALLER_ABORT_DIRECTORY="Extension %1$s: Another %2$s is already using the named folder: %3$s. Are you trying to install the same extension again?"
+JLIB_INSTALLER_ABORT_ERROR_DELETING_EXTENSIONS_RECORD="Could not delete the extension's record from the database."
 JLIB_INSTALLER_ABORT_EXTENSIONNOTVALID="Extension is not valid."
 JLIB_INSTALLER_ABORT_FILE_INSTALL_COPY_SETUP="Files Install: Could not copy setup file."
 JLIB_INSTALLER_ABORT_FILE_INSTALL_CUSTOM_INSTALL_FAILURE="Files Install: Custom install routine failure."

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -373,7 +373,20 @@ class JInstaller extends JAdapter
 					$query->delete($db->quoteName('#__extensions'))
 						->where($db->quoteName('extension_id') . ' = ' . (int) $step['id']);
 					$db->setQuery($query);
-					$stepval = $db->execute();
+
+					try
+					{
+						$db->execute();
+
+						$stepval = true;
+					}
+					catch (JDatabaseExceptionExecuting $e)
+					{
+						// The database API will have already logged the error it caught, we just need to alert the user to the issue
+						JLog::add(JText::_('JLIB_INSTALLER_ABORT_ERROR_DELETING_EXTENSIONS_RECORD'), JLog::WARNING, 'jerror');
+
+						$stepval = false;
+					}
 
 					break;
 


### PR DESCRIPTION
#### Summary of Changes

Catch a possible exception in `JInstaller::abort()` when attempting to delete the record from the database.
#### Testing Instructions

Review it.  It'd really be too difficult to create a scenario to trigger this exact error without causing chaos.
