### PR TITLE
[Send Test Mail] Javascript green message should have "Message" title

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -778,7 +778,7 @@ class ConfigModelApplication extends ConfigModelForm
 			}
 			else
 			{
-				$app->enqueueMessage(JText::sprintf('COM_CONFIG_SENDMAIL_SUCCESS', $app->get('mailfrom'), $methodName), 'success');
+				$app->enqueueMessage(JText::sprintf('COM_CONFIG_SENDMAIL_SUCCESS', $app->get('mailfrom'), $methodName), 'message');
 			}
 
 			return true;


### PR DESCRIPTION
#### Summary of Changes

Very simple PR: the send test mail message type should be `message`, not `success`.
There is no `success` message type.

Types of messages:
- `message`: green
- `warning`: yellow
- `notice`: blue
- `error`: red

Note that all other send test mail messages (error warnings) have the title.
#### Testing Instructions

Code review.

But if you really want to test:
- Before patch "Send Test mail" message when a link is sent the resulting js green message doesn't have title.
- After patch there is a "Message" title in the green message (like already works in case of warnings or errors).
