### PR TITLE
Respect disabled for radio buttons and btn-group class (isis)

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -15,11 +15,10 @@
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
 
-		$('fieldset').each(function() {
+		$('fieldset .btn-group').each(function() {
 			// Handle disabled property
-			if ($(this).hasClass('btn-group') && $(this).prop('disabled')) {
+			if ($(this).prop('disabled')) {
 				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
-
 			}
 		});
 

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -16,9 +16,10 @@
 		$('.radio.btn-group label').addClass('btn');
 
 		$('fieldset.btn-group').each(function() {
-			// Handle disabled property
+			// Handle disabled, prevent clicks on the container, and add disabled style to each button
 			if ($(this).prop('disabled')) {
-				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+				$(this).css('pointer-events', 'none').off('click');
+				$(this).find('.btn').addClass('disabled');
 			}
 		});
 

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -14,10 +14,17 @@
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
-		$('.btn-group label:not(.active)').click(function()
+		$('.btn-group label:not(.active)').click(function(evt)
 		{
 			var label = $(this);
 			var input = $('#' + label.attr('for'));
+
+			// Handle disabled property
+			if (input.prop('disabled')) {
+				label.addClass('disabled');
+				evt.stopPropagation();
+				return false;
+			}
 
 			if (!input.prop('checked')) {
 				label.closest('.btn-group').find('label').removeClass('active btn-success btn-danger btn-primary');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -15,7 +15,7 @@
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
 
-		$('fieldset .btn-group').each(function() {
+		$('fieldset.btn-group').each(function() {
 			// Handle disabled property
 			if ($(this).prop('disabled')) {
 				$(this).addClass('disabled').css('pointer-events', 'none').off('click');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -14,17 +14,19 @@
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
-		$('.btn-group label:not(.active)').click(function(evt)
+
+		$('fieldset').each(function() {
+			// Handle disabled property
+			if ($(this).hasClass('btn-group-yesno') && $(this).prop('disabled')) {
+				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+
+			}
+		});
+
+		$('.btn-group label:not(.active)').click(function()
 		{
 			var label = $(this);
 			var input = $('#' + label.attr('for'));
-
-			// Handle disabled property
-			if (input.prop('disabled')) {
-				label.addClass('disabled');
-				evt.stopPropagation();
-				return false;
-			}
 
 			if (!input.prop('checked')) {
 				label.closest('.btn-group').find('label').removeClass('active btn-success btn-danger btn-primary');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -17,7 +17,7 @@
 
 		$('fieldset').each(function() {
 			// Handle disabled property
-			if ($(this).hasClass('btn-group-yesno') && $(this).prop('disabled')) {
+			if ($(this).hasClass('btn-group') && $(this).prop('disabled')) {
 				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
 
 			}

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -94,9 +94,10 @@ JText::script('INSTL_FTP_SETTINGS_CORRECT');
 				    $('.radio.btn-group label').addClass('btn');
 
 					$('fieldset.btn-group').each(function() {
-						// Handle disabled property
+						// Handle disabled, prevent clicks on the container, and add disabled style to each button
 						if ($(this).prop('disabled')) {
-							$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+							$(this).css('pointer-events', 'none').off('click');
+							$(this).find('.btn').addClass('disabled');
 						}
 					});
 

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -92,6 +92,14 @@ JText::script('INSTL_FTP_SETTINGS_CORRECT');
 
 					// Turn radios into btn-group
 				    $('.radio.btn-group label').addClass('btn');
+
+					$('fieldset.btn-group').each(function() {
+						// Handle disabled property
+						if ($(this).prop('disabled')) {
+							$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+						}
+					});
+
 				    $(".btn-group label:not(.active)").click(function()
 					{
 				        var label = $(this);

--- a/templates/beez3/javascript/template.js
+++ b/templates/beez3/javascript/template.js
@@ -14,6 +14,14 @@
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
+
+		$('fieldset.btn-group').each(function() {
+			// Handle disabled property
+			if ($(this).prop('disabled')) {
+				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+			}
+		});
+
 		$(".btn-group label:not(.active)").click(function()
 		{
 			var label = $(this);

--- a/templates/beez3/javascript/template.js
+++ b/templates/beez3/javascript/template.js
@@ -16,9 +16,10 @@
 		$('.radio.btn-group label').addClass('btn');
 
 		$('fieldset.btn-group').each(function() {
-			// Handle disabled property
+			// Handle disabled, prevent clicks on the container, and add disabled style to each button
 			if ($(this).prop('disabled')) {
-				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+				$(this).css('pointer-events', 'none').off('click');
+				$(this).find('.btn').addClass('disabled');
 			}
 		});
 

--- a/templates/protostar/js/template.js
+++ b/templates/protostar/js/template.js
@@ -14,6 +14,14 @@
 
 		// Turn radios into btn-group
 		$('.radio.btn-group label').addClass('btn');
+
+		$('fieldset.btn-group').each(function() {
+			// Handle disabled property
+			if ($(this).prop('disabled')) {
+				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+			}
+		});
+
 		$(".btn-group label:not(.active)").click(function()
 		{
 			var label = $(this);

--- a/templates/protostar/js/template.js
+++ b/templates/protostar/js/template.js
@@ -16,9 +16,10 @@
 		$('.radio.btn-group label').addClass('btn');
 
 		$('fieldset.btn-group').each(function() {
-			// Handle disabled property
+			// Handle disabled, prevent clicks on the container, and add disabled style to each button
 			if ($(this).prop('disabled')) {
-				$(this).addClass('disabled').css('pointer-events', 'none').off('click');
+				$(this).css('pointer-events', 'none').off('click');
+				$(this).find('.btn').addClass('disabled');
 			}
 		});
 


### PR DESCRIPTION
#### Patch for disabling the buttons if that's the code in the xml
#### The Problem:

Edit `administrator/components/com_config/model/form/application.xml`
and replace lines 255-265 with:

``` xml
        <field
            name="debug"
            type="radio"
            disabled="true"
            class="btn-group btn-group-yesno"
            default="0"
            label="COM_CONFIG_FIELD_DEBUG_SYSTEM_LABEL"
            description="COM_CONFIG_FIELD_DEBUG_SYSTEM_DESC"
            filter="integer">
            <option value="1">JYES</option>
            <option value="0">JNO</option>
        </field>
```

Although the input SHOULD be disabled, user can change it 😕
#### Testing Instructions

Apply the patch and repeat the above steps that reveal the problem
#### Preview

![screen shot 2016-06-29 at 22 26 43](https://cloud.githubusercontent.com/assets/3889375/16465686/aa0eeb10-3e48-11e6-958e-bf968ab37f4c.png)
