### PR TITLE
Properly align content after XTD buttons

### DIFF
--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $buttons = $displayData;
 
 ?>
-<div id="editor-xtd-buttons" class="btn-toolbar pull-left">
+<div id="editor-xtd-buttons" class="btn-toolbar pull-left clearfix">
 	<?php if ($buttons) : ?>
 		<?php foreach ($buttons as $button) : ?>
 			<?php echo JLayoutHelper::render('joomla.editors.buttons.button', $button); ?>

--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $buttons = $displayData;
 
 ?>
-<div id="editor-xtd-buttons" class="btn-toolbar pull-left clearfix">
+<div id="editor-xtd-buttons" class="btn-toolbar pull-left">
 	<?php if ($buttons) : ?>
 		<?php foreach ($buttons as $button) : ?>
 			<?php echo JLayoutHelper::render('joomla.editors.buttons.button', $button); ?>

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1003,7 +1003,7 @@ class PlgEditorTinymce extends JPlugin
 		$textarea->height  = $height;
 		$textarea->content = $content;
 
-		$editor = '<div class="editor">';
+		$editor = '<div class="editor clearfix">';
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-extensions/weblinks/pull/223
#### Summary of Changes

Just adding a class `clearfix` in the container div of the XTD-buttons
#### Testing Instructions

Apply patch and then test https://github.com/joomla-extensions/weblinks/pull/223
