### PR TITLE
PHP Notice: Undefined index: HTTP_HOST

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -849,7 +849,7 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// Try to acquire the server host, if set.
-		$host = $this->input->server->getString('HTTP_HOST');
+		$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
 
 		/*
 		 * There are some differences in the way that Apache and IIS populate server environment variables.  To

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -848,8 +848,8 @@ class JApplicationWeb extends JApplicationBase
 			$scheme = 'http://';
 		}
 
-		// Try to acquire the server host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
-		$host = $this->input->server->getString('HTTP_HOST', $this->input->server->getString('SERVER_NAME'));
+		// Try to acquire the server host, if set.
+		$host = $this->input->server->getString('HTTP_HOST');
 
 		/*
 		 * There are some differences in the way that Apache and IIS populate server environment variables.  To

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -848,6 +848,9 @@ class JApplicationWeb extends JApplicationBase
 			$scheme = 'http://';
 		}
 
+		// Try to acquire the server host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
+		$host = $this->input->server->getString('HTTP_HOST', $this->input->server->getString('SERVER_NAME'));
+
 		/*
 		 * There are some differences in the way that Apache and IIS populate server environment variables.  To
 		 * properly detect the requested URI we need to adjust our algorithm based on whether or not we are getting
@@ -860,13 +863,13 @@ class JApplicationWeb extends JApplicationBase
 		if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI']))
 		{
 			// The URI is built from the HTTP_HOST and REQUEST_URI environment variables in an Apache environment.
-			$uri = $scheme . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+			$uri = $scheme . $host . $_SERVER['REQUEST_URI'];
 		}
 		// If not in "Apache Mode" we will assume that we are in an IIS environment and proceed.
 		elseif (isset($_SERVER['HTTP_HOST']))
 		{
 			// IIS uses the SCRIPT_NAME variable instead of a REQUEST_URI variable... thanks, MS
-			$uri = $scheme . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
+			$uri = $scheme . $host . $_SERVER['SCRIPT_NAME'];
 
 			// If the QUERY_STRING variable exists append it to the URI string.
 			if (isset($_SERVER['QUERY_STRING']) && !empty($_SERVER['QUERY_STRING']))

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -72,6 +72,9 @@ class JUri extends Uri
 					$https = '://';
 				}
 
+				// Try to acquire the server host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
+				$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : $_SERVER['SERVER_NAME'];
+				
 				/*
 				 * Since we are assigning the URI from the server variables, we first need
 				 * to determine if we are running on apache or IIS.  If PHP_SELF and REQUEST_URI
@@ -82,7 +85,7 @@ class JUri extends Uri
 				{
 					// To build the entire URI we need to prepend the protocol, and the http host
 					// to the URI string.
-					$theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+					$theURI = 'http' . $https . $host . $_SERVER['REQUEST_URI'];
 				}
 				else
 				{
@@ -93,7 +96,7 @@ class JUri extends Uri
 					 *
 					 * IIS uses the SCRIPT_NAME variable instead of a REQUEST_URI variable... thanks, MS
 					 */
-					$theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
+					$theURI = 'http' . $https . $host . $_SERVER['SCRIPT_NAME'];
 
 					// If the query string exists append it to the URI string
 					if (isset($_SERVER['QUERY_STRING']) && !empty($_SERVER['QUERY_STRING']))

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -72,8 +72,8 @@ class JUri extends Uri
 					$https = '://';
 				}
 
-				// Try to acquire the server host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
-				$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : $_SERVER['SERVER_NAME'];
+				// Try to acquire the server host, if set.
+				$host = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : '';
 				
 				/*
 				 * Since we are assigning the URI from the server variables, we first need

--- a/modules/mod_wrapper/helper.php
+++ b/modules/mod_wrapper/helper.php
@@ -44,8 +44,8 @@ class ModWrapperHelper
 			// Adds 'http://' if none is set
 			if (substr($url, 0, 1) == '/')
 			{
-				// Relative url in component. use server http_host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
-				$host = JFactory::getApplication()->input->server->getString('HTTP_HOST', JFactory::getApplication()->input->server->getString('SERVER_NAME'));
+				// Relative url in component. use server http_host, if set.
+				$host = JFactory::getApplication()->input->server->getString('HTTP_HOST');
 				$url = 'http://' . $host . $url;
 			}
 			elseif (!strstr($url, 'http') && !strstr($url, 'https'))

--- a/modules/mod_wrapper/helper.php
+++ b/modules/mod_wrapper/helper.php
@@ -44,8 +44,9 @@ class ModWrapperHelper
 			// Adds 'http://' if none is set
 			if (substr($url, 0, 1) == '/')
 			{
-				// Relative url in component. use server http_host.
-				$url = 'http://' . $_SERVER['HTTP_HOST'] . $url;
+				// Relative url in component. use server http_host, if set. Gracefully fallback to the server name in case of HTTP 1.0, where HTTP_HOST is not set.
+				$host = JFactory::getApplication()->input->server->getString('HTTP_HOST', JFactory::getApplication()->input->server->getString('SERVER_NAME'));
+				$url = 'http://' . $host . $url;
 			}
 			elseif (!strstr($url, 'http') && !strstr($url, 'https'))
 			{


### PR DESCRIPTION
#### Summary of Changes

The current code relies on the presence of the super-global variable HTTP_HOST, which is not always set.
In case of HTTP 1.0 requests, HTTP_HOST is not set. This causes a series of PHP notices:

Undefined index: HTTP_HOST in [...]/libraries/joomla/application/web.php on line 867
Undefined index: HTTP_HOST in [...]/libraries/joomla/uri/uri.php on line 85
Undefined index: HTTP_HOST in [...]/modules/mod_wrapper/helper.php on line 48
#### Testing Instructions
1. Force your browser to use HTTP protocol 1.0 instead of 1.1, **or** simply telnet to your testing web server to the port 80
   `telnet localhost 80`
   and ask for the user reminder form using HTTP 1.0 protocol:
   `GET index.php?option=com_users&view=remind HTTP/1.0` _(Don't forget to press enter twice after this command.)_
2. Check the error log of your web server for the PHP notices mentioned above.

In case you have PHP DISPLAY ERROR active, the PHP notices will be present in the HTML output in addition to the web server log, but it's hard to find them by eye within the whole HTML code received in the telnet console.
