### PR TITLE
Version History: Modify author and date only when not toggling Keep Forever

### DIFF
--- a/libraries/cms/table/contenthistory.php
+++ b/libraries/cms/table/contenthistory.php
@@ -78,8 +78,12 @@ class JTableContenthistory extends JTable
 			$this->set('sha1_hash', $this->getSha1($this->get('version_data'), $typeTable));
 		}
 
-		$this->set('editor_user_id', JFactory::getUser()->id);
-		$this->set('save_date', JFactory::getDate()->toSql());
+		// Modify author and date only when not toggling Keep Forever
+		if (is_null($this->get('keep_forever')))
+		{
+			$this->set('editor_user_id', JFactory::getUser()->id);
+			$this->set('save_date', JFactory::getDate()->toSql());
+		}
 
 		return parent::store($updateNulls);
 	}


### PR DESCRIPTION
Pull Request for Issue #8522
#### Testing Instructions

Make sure version history is enabled for content
Create an article, save it several times with some different content
Login (at back-end) as a different user, open that article for editing, open version history modal window
Toggle "Keep forever" state for any version and note their author and date changes
#### Expected result

Version date and author would stay intact, "keep forever" status would change
#### Actual result

Author and date get overwritten, so there's no way to figure who and when actually created that version

Patch and test again.
