### PR TITLE
Move pagination list rendering to layout

### DIFF
--- a/layouts/joomla/pagination/list.php
+++ b/layouts/joomla/pagination/list.php
@@ -14,12 +14,9 @@ $list = $displayData['list'];
 <ul>
 	<li class="pagination-start"><?php echo $list['start']['data']; ?></li>
 	<li class="pagination-prev"><?php echo $list['previous']['data']; ?></li>
-	<?php
-	foreach ($list['pages'] as $page)
-	{
-		echo '<li>' . $page['data'] . '</li>';
-	}
-	?>
+	<?php foreach ($list['pages'] as $page) : ?>
+		<?php echo '<li>' . $page['data'] . '</li>'; ?>
+	<?php endforeach; ?>
 	<li class="pagination-next"><?php echo $list['next']['data']; ?></li>
 	<li class="pagination-end"><?php echo $list['end']['data']; ?></li>
 </ul>

--- a/layouts/joomla/pagination/list.php
+++ b/layouts/joomla/pagination/list.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+$list = $displayData['list'];
+?>
+<ul>
+	<li class="pagination-start"><?php echo $list['start']['data']; ?></li>
+	<li class="pagination-prev"><?php echo $list['previous']['data']; ?></li>
+	<?php
+	foreach ($list['pages'] as $page)
+	{
+		echo '<li>' . $page['data'] . '</li>';
+	}
+	?>
+	<li class="pagination-next"><?php echo $list['next']['data']; ?></li>
+	<li class="pagination-end"><?php echo $list['end']['data']; ?></li>
+</ul>

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -341,6 +341,7 @@ class JPagination
 			 */
 			if (function_exists('pagination_list_render'))
 			{
+				JLog::add('pagination_list_render is deprecated. Use the layout joomla.pagination.list instead.', JLog::WARNING, 'deprecated');
 				$listOverride = true;
 			}
 		}

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -672,21 +672,7 @@ class JPagination
 	 */
 	protected function _list_render($list)
 	{
-		// Reverse output rendering for right-to-left display.
-		$html = '<ul>';
-		$html .= '<li class="pagination-start">' . $list['start']['data'] . '</li>';
-		$html .= '<li class="pagination-prev">' . $list['previous']['data'] . '</li>';
-
-		foreach ($list['pages'] as $page)
-		{
-			$html .= '<li>' . $page['data'] . '</li>';
-		}
-
-		$html .= '<li class="pagination-next">' . $list['next']['data'] . '</li>';
-		$html .= '<li class="pagination-end">' . $list['end']['data'] . '</li>';
-		$html .= '</ul>';
-
-		return $html;
+		return JLayoutHelper::render('joomla.pagination.list', array('list' => $list));
 	}
 
 	/**

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -335,6 +335,10 @@ class JPagination
 				$itemOverride = true;
 			}
 
+			/*
+			 * @deprecated The list rendering is now a layout.
+			 * @see JPagination::_list_render()
+			 */
 			if (function_exists('pagination_list_render'))
 			{
 				$listOverride = true;

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -447,7 +447,9 @@ class JPaginationTest extends TestCase
 
 		$result = $pagination->getPagesLinks();
 
-		$this->assertEquals($result, $expected, 'The expected output of the pagination is incorrect');
+		$replaces = array("\n", "\r"," ", "\t");
+
+		$this->assertEquals(str_replace($replaces, '', $result), str_replace($replaces, '', $expected), 'The expected output of the pagination is incorrect');
 
 		unset($pagination);
 	}
@@ -651,7 +653,9 @@ class JPaginationTest extends TestCase
 
 		$string = TestReflection::invoke($pagination, '_list_render', $list);
 
-		$this->assertEquals($string, $expected, 'The list render method is not outputting the expected results');
+		$replaces = array("\n", "\r"," ", "\t");
+
+		$this->assertEquals(str_replace($replaces, '', $string), str_replace($replaces, '', $expected), 'The list render method is not outputting the expected results');
 
 		unset($pagination);
 	}

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -447,9 +447,7 @@ class JPaginationTest extends TestCase
 
 		$result = $pagination->getPagesLinks();
 
-		$replaces = array("\n", "\r"," ", "\t");
-
-		$this->assertEquals(str_replace($replaces, '', $result), str_replace($replaces, '', $expected), 'The expected output of the pagination is incorrect');
+		$this->assertXmlStringEqualsXmlString($result, $expected, 'The expected output of the pagination is incorrect');
 
 		unset($pagination);
 	}
@@ -653,9 +651,7 @@ class JPaginationTest extends TestCase
 
 		$string = TestReflection::invoke($pagination, '_list_render', $list);
 
-		$replaces = array("\n", "\r"," ", "\t");
-
-		$this->assertEquals(str_replace($replaces, '', $string), str_replace($replaces, '', $expected), 'The list render method is not outputting the expected results');
+		$this->assertXmlStringEqualsXmlString($string, $expected, 'The list render method is not outputting the expected results');
 
 		unset($pagination);
 	}


### PR DESCRIPTION
#### Summary of Changes

The pagination list rendering is moved to a layout.
#### Testing Instructions
- Create a lot of articles with featured set to yes
- Open the site on the front

On the default start page on the bottom should the pagination list be shown. The list should look the same as without the patch.
