### PR TITLE
PHP Fatal error: Call to a member function get() on null

### DIFF
--- a/components/com_mailto/views/mailto/view.html.php
+++ b/components/com_mailto/views/mailto/view.html.php
@@ -53,8 +53,7 @@ class MailtoViewMailto extends JViewLegacy
 		$data = new stdClass;
 
 		$input      = $app->input;
-		$method     = $input->getMethod();
-		$data->link = urldecode($input->$method->get('link', '', 'BASE64'));
+		$data->link = urldecode($input->get('link', '', 'BASE64'));
 
 		if ($data->link == '')
 		{

--- a/components/com_mailto/views/mailto/view.html.php
+++ b/components/com_mailto/views/mailto/view.html.php
@@ -52,8 +52,7 @@ class MailtoViewMailto extends JViewLegacy
 		$app  = JFactory::getApplication();
 		$data = new stdClass;
 
-		$input      = $app->input;
-		$data->link = urldecode($input->get('link', '', 'BASE64'));
+		$data->link = urldecode($app->input->get('link', '', 'BASE64'));
 
 		if ($data->link == '')
 		{

--- a/components/com_users/models/login.php
+++ b/components/com_users/models/login.php
@@ -56,10 +56,9 @@ class UsersModelLogin extends JModelForm
 		$data = $app->getUserState('users.login.form.data', array());
 
 		$input = $app->input;
-		$method = $input->getMethod();
 
 		// Check for return URL from the request first
-		if ($return = $input->$method->get('return', '', 'BASE64'))
+		if ($return = $input->get('return', '', 'BASE64'))
 		{
 			$data['return'] = base64_decode($return);
 

--- a/components/com_users/models/login.php
+++ b/components/com_users/models/login.php
@@ -55,10 +55,8 @@ class UsersModelLogin extends JModelForm
 		$app  = JFactory::getApplication();
 		$data = $app->getUserState('users.login.form.data', array());
 
-		$input = $app->input;
-
 		// Check for return URL from the request first
-		if ($return = $input->get('return', '', 'BASE64'))
+		if ($return = $app->input->get('return', '', 'BASE64'))
 		{
 			$data['return'] = base64_decode($return);
 


### PR DESCRIPTION
#### Preamble

HTTP methods includes HEAD, PUT and DELETE in addition to the classic GET and POST.
Among them, the HEAD method is largely used by uptime monitor programs or services that check whether our website is still alive.
#### Problem description

The HEAD method causes the crash with a fatal error in two components: com_users and com_mailto.
The reason is the attempt to explicit access a property of JInput that depends on the HTTP method used.
`$input->$method->get(...);`
In details,
when the HTTP method is GET, it becomes `$input->get->get(...);`
when the HTTP method is POST, it becomes `$input->post->get(...);`
when the HTTP method is HEAD, it becomes `$input->head->get(...);` which does not exist and causes a fatal error.
#### Summary of Changes

I've replaced the explicit method call `$input->$method->get(...);` in favour of implicit method call `$input->get(...);` letting JInput choose the appropriate input channel (GET or POST) that is one of the task that JInput has designed to do, and it does it well.
#### Testing Instructions
1. telnet localhost 80

`HEAD /index.php?option=com_users HTTP/1.1` _(Hit ENTER)_
`host: localhost` _(Hit ENTER twice)_

PHP Fatal error: Call to a member function get() on null in [...]/components/com_users/models/login.php on line 62
1. telnet localhost 80

`HEAD /index.php?option=com_mailto HTTP/1.1` _(Hit ENTER)_
`host: localhost` _(Hit ENTER twice)_

PHP Fatal error: Call to a member function get() on null in [...]/components/com_mailto/views/mailto/view.html.php on line 57
