### PR TITLE
Adding export of data to JDatabaseExporterMysqli

### DIFF
--- a/libraries/joomla/database/exporter.php
+++ b/libraries/joomla/database/exporter.php
@@ -73,6 +73,7 @@ abstract class JDatabaseExporter
 
 		// Export with only structure
 		$this->withStructure();
+		$this->withData();
 
 		// Export as xml.
 		$this->asXml();
@@ -224,6 +225,22 @@ abstract class JDatabaseExporter
 	public function withStructure($setting = true)
 	{
 		$this->options->withStructure = (boolean) $setting;
+
+		return $this;
+	}
+
+	/**
+	 * Sets an internal option to export the data of the input table(s).
+	 *
+	 * @param   boolean  $setting  True to export the data, false to not.
+	 *
+	 * @return  JDatabaseExporter  Method supports chaining.
+	 *
+	 * @since   3.6
+	 */
+	public function withData($setting = false)
+	{
+		$this->options->withData = (boolean) $setting;
 
 		return $this;
 	}

--- a/libraries/joomla/database/exporter/mysqli.php
+++ b/libraries/joomla/database/exporter/mysqli.php
@@ -94,7 +94,7 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 	 *
 	 * @return  array  An array of XML lines (strings).
 	 *
-	 * @since   11.1
+	 * @since   3.6
 	 * @throws  Exception if an error occurs.
 	 */
 	protected function buildXmlData()
@@ -108,7 +108,6 @@ class JDatabaseExporterMysqli extends JDatabaseExporter
 
 			// Get the details columns information.
 			$fields = $this->db->getTableColumns($table, false);
-			$keys = $this->db->getTableKeys($table);
 			$query = $this->db->getQuery(true);
 			$query->select($query->qn(array_keys($fields)))
 				->from($query->qn($table));

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -153,6 +153,52 @@ abstract class JDatabaseImporter
 	}
 
 	/**
+	 * Import the data from the source into the existing tables.
+	 *
+	 * @return  void
+	 *
+	 * @note    Currently only supports XML format.
+	 * @since   3.6
+	 * @throws  RuntimeException on error.
+	 */
+	public function importData()
+	{
+		if ($this->from instanceof SimpleXMLElement)
+		{
+			$xml = $this->from;
+		}
+		else
+		{
+			$xml = new SimpleXMLElement($this->from);
+		}
+
+		// Get all the table definitions.
+		$xmlTables = $xml->xpath('database/table_data');
+
+		foreach ($xmlTables as $table)
+		{
+			$tableName = (string) $table['name'];
+
+			$rows = $table->children();
+
+			foreach ($rows as $row)
+			{
+				if ($row->getName() == 'row')
+				{
+					$entry = new stdClass();
+
+					foreach ($row->children() as $data)
+					{
+						$entry->{(string) $data['name']} = (string) $data;
+					}
+
+					$this->db->insertObject($tableName, $entry);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Merges the incoming structure definition with the existing structure.
 	 *
 	 * @return  void

--- a/libraries/joomla/database/importer.php
+++ b/libraries/joomla/database/importer.php
@@ -185,7 +185,7 @@ abstract class JDatabaseImporter
 			{
 				if ($row->getName() == 'row')
 				{
-					$entry = new stdClass();
+					$entry = new stdClass;
 
 					foreach ($row->children() as $data)
 					{


### PR DESCRIPTION
This change adds the export of data to the MySQL(i) exporter. Since we want to prevent a backwards compatibility breach, no method interface has been added to JDatabaseExporter, something that should be done when moving to 4.0.

The code is not really suitable for large tables, since it would eat up memory till it fails. There is little that we can do to fix that.

I've put this together rather quickly, so there are no unittests yet. If there is general interest in this, I'll provide them later.