### PR TITLE
Text field using JLayouts

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -50,11 +50,6 @@ JHtml::_('script', 'system/html5fallback.js', false, true);
 
 $list = '';
 
-/* Get the field options for the datalist.
-Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
-$options  = (array) $this->getSuggestions();
-
-
 if ($options)
 {
 	$list = 'list="' . $id . '_datalist"';

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ */
+
+// Including fallback code for HTML5 non supported browsers.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
+
+$list = '';
+
+/* Get the field options for the datalist.
+Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
+$options  = (array) $this->getSuggestions();
+
+
+if ($options)
+{
+	$list = 'list="' . $id . '_datalist"';
+}
+
+$autocomplete = !$autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $autocomplete . '"';
+$autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
+
+$attributes = array(
+	!empty($class) ? 'class="' . $class . '"' : '',
+	!empty($size) ? 'size="' . $size . '"' : '',
+	$disabled ? 'disabled' : '',
+	$readonly ? 'readonly' : '',
+	$list,
+	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
+	$onchange ? ' onchange="' . $onchange . '"' : '',
+	!empty($maxLength) ? $maxLength : '',
+	$required ? 'required aria-required="true"' : '',
+	$autocomplete,
+	$autofocus ? ' autofocus' : '',
+	$spellcheck ? '' : 'spellcheck="false"',
+	!empty($inputmode) ? 'inputmode="' . $inputmode . '"' : '',
+	!empty($pattern) ? 'pattern="' . $pattern . '"' : '',
+);
+?>
+<input type="text" name="<?php
+echo $name; ?>" id="<?php
+echo $id; ?>" <?php
+echo $dirname; ?> value="<?php
+echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?> <?php implode(' ', $attributes); ?> />
+<?php if ($options) : ?>
+	<datalist id="<?php echo $id; ?>_datalist">
+		<?php foreach ($options as $option) : ?>
+			<?php if (!$option->value) : ?>
+			<?php continue; ?>
+			<?php endif; ?>
+			<option value="<?php echo $option->value; ?>"><?php echo $option->text; ?></option>
+		<?php endforeach; ?>
+	</datalist>
+<?php endif; ?>

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -79,7 +79,7 @@ $attributes = array(
 echo $name; ?>" id="<?php
 echo $id; ?>" <?php
 echo $dirname; ?> value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?> <?php implode(' ', $attributes); ?> />
+echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo implode(' ', $attributes); ?> />
 <?php if ($options) : ?>
 	<datalist id="<?php echo $id; ?>_datalist">
 		<?php foreach ($options as $option) : ?>

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -50,6 +50,15 @@ class JFormFieldText extends JFormField
 	 */
 	protected $dirname;
 
+
+	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.7
+	 */
+	protected $layout = 'joomla.form.field.text';
+
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
@@ -217,21 +226,24 @@ class JFormFieldText extends JFormField
 	protected function getLayoutData()
 	{
 		$data = parent::getLayoutData();
+
 		// Initialize some field attributes.
 		$maxLength    = !empty($this->maxLength) ? ' maxlength="' . $this->maxLength . '"' : '';
-		$pattern      = !empty($this->pattern) ? ' pattern="' . $this->pattern . '"' : '';
 		$inputmode    = !empty($this->inputmode) ? ' inputmode="' . $this->inputmode . '"' : '';
 		$dirname      = !empty($this->dirname) ? ' dirname="' . $this->dirname . '"' : '';
+
 		/* Get the field options for the datalist.
-Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
+			Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
 		$options  = (array) $this->getSuggestions();
+
 		$extraData = array(
 			'maxLength' => $maxLength,
-			'pattern'   => $pattern,
+			'pattern'   => $this->pattern,
 			'inputmode' => $inputmode,
 			'dirname'   => $dirname,
 			'options'   => $options,
 		);
+
 		return array_merge($data, $extraData);
 	}
 }

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -50,7 +50,6 @@ class JFormFieldText extends JFormField
 	 */
 	protected $dirname;
 
-
 	/**
 	 * Name of the layout being used to render the field
 	 *

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -162,63 +162,7 @@ class JFormFieldText extends JFormField
 	 */
 	protected function getInput()
 	{
-		// Translate placeholder text
-		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
-
-		// Initialize some field attributes.
-		$size         = !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$maxLength    = !empty($this->maxLength) ? ' maxlength="' . $this->maxLength . '"' : '';
-		$class        = !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$readonly     = $this->readonly ? ' readonly' : '';
-		$disabled     = $this->disabled ? ' disabled' : '';
-		$required     = $this->required ? ' required aria-required="true"' : '';
-		$hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : '';
-		$autocomplete = !$this->autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $this->autocomplete . '"';
-		$autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
-		$autofocus    = $this->autofocus ? ' autofocus' : '';
-		$spellcheck   = $this->spellcheck ? '' : ' spellcheck="false"';
-		$pattern      = !empty($this->pattern) ? ' pattern="' . $this->pattern . '"' : '';
-		$inputmode    = !empty($this->inputmode) ? ' inputmode="' . $this->inputmode . '"' : '';
-		$dirname      = !empty($this->dirname) ? ' dirname="' . $this->dirname . '"' : '';
-
-		// Initialize JavaScript field attributes.
-		$onchange = !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
-
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
-		$datalist = '';
-		$list     = '';
-
-		/* Get the field options for the datalist.
-		Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
-		$options  = (array) $this->getSuggestions();
-
-		if ($options)
-		{
-			$datalist = '<datalist id="' . $this->id . '_datalist">';
-
-			foreach ($options as $option)
-			{
-				if (!$option->value)
-				{
-					continue;
-				}
-
-				$datalist .= '<option value="' . $option->value . '">' . $option->text . '</option>';
-			}
-
-			$datalist .= '</datalist>';
-			$list     = ' list="' . $this->id . '_datalist"';
-		}
-
-		$html[] = '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' . $dirname . ' value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $class . $size . $disabled . $readonly . $list
-			. $hint . $onchange . $maxLength . $required . $autocomplete . $autofocus . $spellcheck . $inputmode . $pattern . ' />';
-		$html[] = $datalist;
-
-		return implode($html);
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
 	}
 
 	/**
@@ -261,5 +205,33 @@ class JFormFieldText extends JFormField
 	protected function getSuggestions()
 	{
 		return $this->getOptions();
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.7
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
+		// Initialize some field attributes.
+		$maxLength    = !empty($this->maxLength) ? ' maxlength="' . $this->maxLength . '"' : '';
+		$pattern      = !empty($this->pattern) ? ' pattern="' . $this->pattern . '"' : '';
+		$inputmode    = !empty($this->inputmode) ? ' inputmode="' . $this->inputmode . '"' : '';
+		$dirname      = !empty($this->dirname) ? ' dirname="' . $this->dirname . '"' : '';
+		/* Get the field options for the datalist.
+Note: getSuggestions() is deprecated and will be changed to getOptions() with 4.0. */
+		$options  = (array) $this->getSuggestions();
+		$extraData = array(
+			'maxLength' => $maxLength,
+			'pattern'   => $pattern,
+			'inputmode' => $inputmode,
+			'dirname'   => $dirname,
+			'options'   => $options,
+		);
+		return array_merge($data, $extraData);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextTest.php
@@ -128,9 +128,11 @@ class JFormFieldTextTest extends TestCase
 			TestReflection::setValue($formField, $attr, $value);
 		}
 
+		$replaces = array("\n", "\r"," ", "\t");
+
 		$this->assertEquals(
-			$expected,
-			TestReflection::invoke($formField, 'getInput'),
+			str_replace($replaces, '', TestReflection::invoke($formField, 'getInput')),
+			str_replace($replaces, '', $expected),
 			'Line:' . __LINE__ . ' The field did not produce the right html'
 		);
 	}


### PR DESCRIPTION
#### Separate logic/ output

Base work for better templating
#### Summary of Changes

Introduce a  layout for this field
#### Testing Instructions

Apply patch and rename any backend input to text
eg

``` XML
<field name="mytextvalue" type="text" default="Some text" label="Enter some text" description="" size="10" />
```

Also consult: https://docs.joomla.org/Standard_form_field_types
