### PR TITLE
Textarea field using JLayout

### DIFF
--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -53,8 +53,8 @@ $autocomplete = !$autocomplete ? 'autocomplete="off"' : 'autocomplete="' . $auto
 $autocomplete = $autocomplete == 'autocomplete="on"' ? '' : $autocomplete;
 
 $attributes = array(
-	$columns ? 'cols="' . $columns . '"' : '',
-	$rows ? 'rows="' . $rows . '"' : '',
+	$columns ? $columns : '',
+	$rows ? $rows : '',
 	!empty($class) ? 'class="' . $class . '"' : '',
 	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
 	$disabled ? 'disabled' : '',

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ */
+
+// Including fallback code for HTML5 non supported browsers.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
+
+// Initialize some field attributes.
+$autocomplete = !$autocomplete ? 'autocomplete="off"' : 'autocomplete="' . $autocomplete . '"';
+$autocomplete = $autocomplete == 'autocomplete="on"' ? '' : $autocomplete;
+
+$attributes = array(
+	$columns ? 'cols="' . $columns . '"' : '',
+	$rows ? 'rows="' . $rows . '"' : '',
+	!empty($class) ? 'class="' . $class . '"' : '',
+	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
+	$disabled ? 'disabled' : '',
+	$readonly ? 'readonly' : '',
+	$onchange ? 'onchange="' . $onchange . '"' : '',
+	$onclick ? 'onclick="' . $onclick . '"' : '',
+	$required ? 'required aria-required="true"' : '',
+	$autocomplete,
+	$autofocus ? 'autofocus' : '',
+	$spellcheck ? '' : 'spellcheck="false"',
+	$maxlength ? 'maxlength="' . $maxlength . '"' : ''
+
+);
+?>
+<textarea name="<?php
+echo $name; ?>" id="<?php
+echo $id; ?>" <?php
+echo
+	$columns . $rows . $class
+. $hint . $disabled . $readonly . $onchange . $onclick . $required . $autocomplete . $autofocus . $spellcheck . $maxlength ; ?> ><?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?></textarea>
+

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -72,7 +72,5 @@ $attributes = array(
 <textarea name="<?php
 echo $name; ?>" id="<?php
 echo $id; ?>" <?php
-echo
-	$columns . $rows . $class
-. $hint . $disabled . $readonly . $onchange . $onclick . $required . $autocomplete . $autofocus . $spellcheck . $maxlength ; ?> ><?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?></textarea>
+echo implode(' ', $attributes); ?> ><?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?></textarea>
 

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -51,6 +51,14 @@ class JFormFieldTextarea extends JFormField
 	protected $maxlength;
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.7
+	 */
+	protected $layout = 'joomla.form.field.textarea';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to the the value.
@@ -135,33 +143,32 @@ class JFormFieldTextarea extends JFormField
 	 */
 	protected function getInput()
 	{
-		// Translate placeholder text
-		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
+		// Trim the trailing line in the layout file
+		return rtrim($this->getRenderer($this->layout)->render($this->getLayoutData()), PHP_EOL);
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.7
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
 
 		// Initialize some field attributes.
-		$class        = !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$disabled     = $this->disabled ? ' disabled' : '';
-		$readonly     = $this->readonly ? ' readonly' : '';
 		$columns      = $this->columns ? ' cols="' . $this->columns . '"' : '';
 		$rows         = $this->rows ? ' rows="' . $this->rows . '"' : '';
-		$required     = $this->required ? ' required aria-required="true"' : '';
-		$hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : '';
-		$autocomplete = !$this->autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $this->autocomplete . '"';
-		$autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
-		$autofocus    = $this->autofocus ? ' autofocus' : '';
-		$spellcheck   = $this->spellcheck ? '' : ' spellcheck="false"';
 		$maxlength    = $this->maxlength ? ' maxlength="' . $this->maxlength . '"' : '';
 
-		// Initialize JavaScript field attributes.
-		$onchange = $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
-		$onclick = $this->onclick ? ' onclick="' . $this->onclick . '"' : '';
+		$extraData = array(
+			'maxlength'    => $maxlength,
+			'rows'         => $rows,
+			'columns'      => $columns
+		);
 
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
-		return '<textarea name="' . $this->name . '" id="' . $this->id . '"' . $columns . $rows . $class
-			. $hint . $disabled . $readonly . $onchange . $onclick . $required . $autocomplete . $autofocus . $spellcheck . $maxlength . ' >'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '</textarea>';
+		return array_merge($data, $extraData);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldTextareaTest.php
@@ -132,9 +132,11 @@ class JFormFieldTextareaTest extends TestCase
 			TestReflection::setValue($formField, $attr, $value);
 		}
 
+		$replaces = array("\n", "\r"," ", "\t");
+
 		$this->assertEquals(
-			$expected,
-			TestReflection::invoke($formField, 'getInput'),
+			str_replace($replaces, '', $expected),
+			str_replace($replaces, '', TestReflection::invoke($formField, 'getInput')),
 			'Line:' . __LINE__ . ' The field with no value and no checked attribute did not produce the right html'
 		);
 	}


### PR DESCRIPTION
#### Separate logic/ output

Base work for better templating
#### Summary of Changes

Introduce a  layout for this field
#### Testing Instructions

Apply patch and rename any backend input to textarea
eg

``` XML
<field name="mytextvalue" type="textarea" default="Some text" label="Enter some text" description="" size="10" />
```

Also consult: https://docs.joomla.org/Standard_form_field_types
