### PR TITLE
Password field using JLayout

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ */
+
+if ($this->meter)
+{
+	// Load script on document load.
+	JFactory::getDocument()->addScriptDeclaration(
+		"
+		jQuery(document).ready(function() {
+			new Form.PasswordStrength('" . $id . "',
+				{
+					threshold: " . $threshold . ",
+					onUpdate: function(element, strength, threshold) {
+						element.set('data-passwordstrength', strength);
+					}
+				});
+		});"
+	);
+}
+
+// Including fallback code for HTML5 non supported browsers.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
+
+$attributes = array(
+	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
+	!$autocomplete ? 'autocomplete="off"' : '',
+	!empty($class) ? 'class="' . $class . '"' : '',
+	$readonly ? 'readonly' : '',
+	$disabled ? 'disabled' : '',
+	!empty($size) ? 'size="' . $size . '"' : '',
+	!empty($maxLength) ? 'maxlength="' . $maxLength . '"' : '',
+	$required ? 'required aria-required="true"' : '',
+	$autofocus ? 'autofocus' : '',
+);
+
+?>
+<input type="password" name="<?php
+echo $name; ?>" id="<?php
+echo $id; ?>" value="<?php
+echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php
+echo implode(' ', $attributes); ?> />

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -44,7 +44,7 @@ extract($displayData);
  * @var   string   $accept          File types that are accepted.
  */
 
-if ($this->meter)
+if ($meter)
 {
 	// Load script on document load.
 	JFactory::getDocument()->addScriptDeclaration(

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -170,6 +170,7 @@ class JFormFieldPassword extends JFormField
 			'maxLength' => $this->maxLength,
 			'meter'     => $this->meter,
 			'threshold' => $this->threshold,
+			'meter'     => $this->meter,
 		);
 
 		return array_merge($data, $extraData);

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -52,6 +52,14 @@ class JFormFieldPassword extends JFormField
 	protected $meter = false;
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.7
+	 */
+	protected $layout = 'joomla.form.field.password';
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to the the value.
@@ -142,44 +150,28 @@ class JFormFieldPassword extends JFormField
 	 */
 	protected function getInput()
 	{
-		// Translate placeholder text
-		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
+		// Trim the trailing line in the layout file
+		return rtrim($this->getRenderer($this->layout)->render($this->getLayoutData()), PHP_EOL);
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.7
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
 
 		// Initialize some field attributes.
-		$size         = !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$maxLength    = !empty($this->maxLength) ? ' maxlength="' . $this->maxLength . '"' : '';
-		$class        = !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$readonly     = $this->readonly ? ' readonly' : '';
-		$disabled     = $this->disabled ? ' disabled' : '';
-		$required     = $this->required ? ' required aria-required="true"' : '';
-		$hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : '';
-		$autocomplete = !$this->autocomplete ? ' autocomplete="off"' : '';
-		$autofocus    = $this->autofocus ? ' autofocus' : '';
+		$extraData = array(
+			'maxLength' => $this->maxLength,
+			'meter'     => $this->meter,
+			'threshold' => $this->threshold,
+		);
 
-		if ($this->meter)
-		{
-			JHtml::_('script', 'system/passwordstrength.js', true, true);
-			$script = 'new Form.PasswordStrength("' . $this->id . '",
-				{
-					threshold: ' . $this->threshold . ',
-					onUpdate: function(element, strength, threshold) {
-						element.set("data-passwordstrength", strength);
-					}
-				}
-			);';
-
-			// Load script on document load.
-			JFactory::getDocument()->addScriptDeclaration(
-				"jQuery(document).ready(function(){" . $script . "});"
-			);
-		}
-
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
-		return '<input type="password" name="' . $this->name . '" id="' . $this->id . '"' .
-			' value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $hint . $autocomplete .
-			$class . $readonly . $disabled . $size . $maxLength . $required . $autofocus . ' />';
+		return array_merge($data, $extraData);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldPasswordTest.php
@@ -211,9 +211,11 @@ class JFormFieldPasswordTest extends TestCase
 			TestReflection::setValue($formField, $attr, $value);
 		}
 
+		$replaces = array("\n", "\r"," ", "\t");
+
 		$this->assertEquals(
-			$expected,
-			TestReflection::invoke($formField, 'getInput'),
+			str_replace($replaces, '', $expected),
+			str_replace($replaces, '', TestReflection::invoke($formField, 'getInput')),
 			'Line:' . __LINE__ . ' The field with no value and no checked attribute did not produce the right html'
 		);
 	}


### PR DESCRIPTION
#### Separate logic/ output

Base work for better templating
#### Summary of Changes

Introduce a  layout for this field
#### Testing Instructions

Apply patch and rename any backend input to password
eg

``` XML
<field name="mytextvalue" type="password" default="Some text" label="Enter some text" description="" size="10" />
```

Also consult: https://docs.joomla.org/Standard_form_field_types
