### PR TITLE
Meter field using JLayouts

### DIFF
--- a/layouts/joomla/form/field/meter.php
+++ b/layouts/joomla/form/field/meter.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ * @var   string   $animated        Is it animated.
+ * @var   string   $active          Is it active.
+ * @var   string   $min             The minimum value.
+ * @var   string   $max             The maximum value.
+ * @var   string   $step            The step value.
+ */
+
+// Initialize some field attributes.
+$class = 'progress ' . $class;
+$class .= $animated ? ' progress-striped' : '';
+$class .= $active ? ' active' : '';
+$class = 'class="' . $class . '"';
+
+$value = (float) $value;
+$value = $value < $min ? $min : $value;
+$value = $value > $max ? $max : $value;
+
+$data = '';
+$data .= 'data-max="' . $max . '"';
+$data .= ' data-min="' . $min . '"';
+$data .= ' data-step="' . $step . '"';
+$data .= ' data-value="' . $value . '"';
+
+$attributes = array(
+	$class,
+	!empty($width) ? ' style="width:' . $width . ';"' : '',
+	$data
+);
+
+$value = ((float) ($value - $min) * 100) / ($max - $min);
+?>
+<div <?php echo implode(' ', $attributes); ?> >
+	<div class="bar" style="width: <?php
+	echo strval($value); ?>%;<?php
+	echo !empty($color) ? ' background-color:' . $color . ';' : ''; ?>"></div>
+</div>

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -60,6 +60,15 @@ class JFormFieldMeter extends JFormFieldNumber
 	 */
 	protected $color;
 
+
+	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.7
+	 */
+	protected $layout = 'joomla.form.field.meter';
+
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
@@ -159,32 +168,32 @@ class JFormFieldMeter extends JFormFieldNumber
 	 */
 	protected function getInput()
 	{
+		// Trim the trailing line in the layout file
+		return rtrim($this->getRenderer($this->layout)->render($this->getLayoutData()), PHP_EOL);
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.5
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
+
 		// Initialize some field attributes.
-		$width = !empty($this->width) ? ' style="width:' . $this->width . ';"' : '';
-		$color = !empty($this->color) ? ' background-color:' . $this->color . ';' : '';
+		$extraData = array(
+			'width'    => $this->width,
+			'color'    => $this->color,
+			'animated' => $this->animated,
+			'active'   => $this->active,
+			'max'      => $this->max,
+			'min'      => $this->min,
+			'step'     => $this->step,
+		);
 
-		$data = '';
-		$data .= ' data-max="' . $this->max . '"';
-		$data .= ' data-min="' . $this->min . '"';
-		$data .= ' data-step="' . $this->step . '"';
-
-		$class = 'progress ' . $this->class;
-		$class .= $this->animated ? ' progress-striped' : '';
-		$class .= $this->active ? ' active' : '';
-		$class = ' class="' . $class . '"';
-
-		$value = (float) $this->value;
-		$value = $value < $this->min ? $this->min : $value;
-		$value = $value > $this->max ? $this->max : $value;
-
-		$data .= ' data-value="' . $this->value . '"';
-
-		$value = ((float) ($value - $this->min) * 100) / ($this->max - $this->min);
-
-		$html[] = '<div ' . $class . $width . $data . ' >';
-		$html[] = '		<div class="bar" style="width: ' . strval($value) . '%;' . $color . '"></div>';
-		$html[] = '</div>';
-
-		return implode('', $html);
+		return array_merge($data, $extraData);
 	}
 }

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -60,7 +60,6 @@ class JFormFieldMeter extends JFormFieldNumber
 	 */
 	protected $color;
 
-
 	/**
 	 * Name of the layout being used to render the field
 	 *


### PR DESCRIPTION
#### Separate logic/ output

Base work for better templating
#### Summary of Changes

Introduce a  layout for this field
#### Testing Instructions

Apply patch and rename any backend input to meter
eg

``` XML
<field name="mytextvalue" type="meter" default="Some text" label="Enter some text" description=""  />
```

Also consult: https://docs.joomla.org/Standard_form_field_types
