### PR TITLE
Email form field using JLayout

### DIFF
--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -72,4 +72,4 @@ echo $name; ?>"<?php
 echo !empty($class) ? ' class="validate-email ' . $class . '"' : ' class="validate-email"'; ?> id="<?php
 echo $id; ?>" value="<?php
 echo htmlspecialchars(JStringPunycode::emailToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>"
-<?php echo implode(' ', $atributes); ?> />
+<?php echo implode(' ', $attributes); ?> />

--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   array    $checkedOptions  Options that will be set as checked.
+ * @var   boolean  $hasValue        Has this field a value assigned?
+ * @var   array    $options         Options available for this field.
+ * @var   array    $inputType       Options available for this field.
+ * @var   array    $spellcheck      Options available for this field.
+ * @var   string   $accept          File types that are accepted.
+ */
+
+$autocomplete = !$autocomplete ? 'autocomplete="off"' : 'autocomplete="' . $autocomplete . '"';
+$autocomplete = $autocomplete == 'autocomplete="on"' ? '' : $autocomplete;
+
+$attributes = array(
+	$spellcheck ? '' : 'spellcheck="false"',
+	!empty($size) ? 'size="' . $size . '"' : '',
+	$disabled ? 'disabled' : '',
+	$readonly ? 'readonly' : '',
+	$onchange ? 'onchange="' . $onchange . '"' : '',
+	$autocomplete,
+	$multiple ? 'multiple' : '',
+	!empty($maxLength) ? 'maxlength="' . $maxLength . '"' : '',
+	strlen($hint) ? 'placeholder="' . $hint . '"' : '',
+	$required ? 'required aria-required="true"' : '',
+	$autofocus ? 'autofocus' : '',
+);
+
+// Including fallback code for HTML5 non supported browsers.
+JHtml::_('jquery.framework');
+JHtml::_('script', 'system/html5fallback.js', false, true);
+
+?>
+<input type="email" name="<?php
+echo $name; ?>"<?php
+echo !empty($class) ? ' class="validate-email ' . $class . '"' : ' class="validate-email"'; ?> id="<?php
+echo $id; ?>" value="<?php
+echo htmlspecialchars(JStringPunycode::emailToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>"
+<?php echo implode(' ', $atributes); ?> />

--- a/libraries/joomla/form/fields/email.php
+++ b/libraries/joomla/form/fields/email.php
@@ -30,6 +30,14 @@ class JFormFieldEMail extends JFormFieldText
 	protected $type = 'Email';
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  3.7
+	 */
+	protected $layout = 'joomla.form.field.email';
+
+	/**
 	 * Method to get the field input markup for e-mail addresses.
 	 *
 	 * @return  string  The field input markup.
@@ -38,32 +46,24 @@ class JFormFieldEMail extends JFormFieldText
 	 */
 	protected function getInput()
 	{
-		// Translate placeholder text
-		$hint = $this->translateHint ? JText::_($this->hint) : $this->hint;
+		// Trim the trailing line in the layout file
+		return rtrim($this->getRenderer($this->layout)->render($this->getLayoutData()), PHP_EOL);
+	}
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since 3.5
+	 */
+	protected function getLayoutData()
+	{
+		$data = parent::getLayoutData();
 
-		// Initialize some field attributes.
-		$size         = !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$maxLength    = !empty($this->maxLength) ? ' maxlength="' . $this->maxLength . '"' : '';
-		$class        = !empty($this->class) ? ' class="validate-email ' . $this->class . '"' : ' class="validate-email"';
-		$readonly     = $this->readonly ? ' readonly' : '';
-		$disabled     = $this->disabled ? ' disabled' : '';
-		$required     = $this->required ? ' required aria-required="true"' : '';
-		$hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : '';
-		$autocomplete = !$this->autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $this->autocomplete . '"';
-		$autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
-		$autofocus    = $this->autofocus ? ' autofocus' : '';
-		$multiple     = $this->multiple ? ' multiple' : '';
-		$spellcheck   = $this->spellcheck ? '' : ' spellcheck="false"';
-
-		// Initialize JavaScript field attributes.
-		$onchange = $this->onchange ? ' onchange="' . $this->onchange . '"' : '';
-
-		// Including fallback code for HTML5 non supported browsers.
-		JHtml::_('jquery.framework');
-		JHtml::_('script', 'system/html5fallback.js', false, true);
-
-		return '<input type="email" name="' . $this->name . '"' . $class . ' id="' . $this->id . '" value="'
-			. htmlspecialchars(JStringPunycode::emailToUTF8($this->value), ENT_COMPAT, 'UTF-8') . '"' . $spellcheck . $size . $disabled . $readonly
-			. $onchange . $autocomplete . $multiple . $maxLength . $hint . $required . $autofocus . ' />';
+		$extraData = array(
+			'maxLength'  => $this->maxLength,
+			'multiple'   => $this->multiple,
+		);
+		return array_merge($data, $extraData);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldEmailTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldEmailTest.php
@@ -91,9 +91,11 @@ class JFormFieldEMailTest extends TestCaseDatabase
 			TestReflection::setValue($formField, $attr, $value);
 		}
 
+		$replaces = array("\n", "\r"," ", "\t");
+
 		$this->assertEquals(
-			$expected,
-			TestReflection::invoke($formField, 'getInput'),
+			str_replace($replaces, '', $expected),
+			str_replace($replaces, '', TestReflection::invoke($formField, 'getInput')),
 			'Line:' . __LINE__ . ' The field with no value and no checked attribute did not produce the right html'
 		);
 	}


### PR DESCRIPTION
#### Separate logic/ output

Base work for better templating
#### Summary of Changes

Introduce a  layout for this field
#### Testing Instructions

Apply patch and rename any backend input to email
eg

``` XML
<field name="mytextvalue" type="emil" default="Some text" label="Enter some text" description="" />
```

Also consult: https://docs.joomla.org/Standard_form_field_types
