### PR TITLE
Password autocapitalize off

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -41,7 +41,7 @@ JHtml::_('formbehavior.chosen');
 							<?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 						</label>
 					</span>
-					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"/>
+					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="input-medium" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"  autocapitalize="none"/>
 					<a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset" class="btn width-auto hasTooltip" title="<?php echo JText::_('MOD_LOGIN_RESET'); ?>">
 						<span class="icon-help"></span>
 					</a>

--- a/administrator/templates/hathor/html/mod_login/default.php
+++ b/administrator/templates/hathor/html/mod_login/default.php
@@ -18,7 +18,7 @@ JHtml::_('behavior.keepalive');
 		<input name="username" id="mod-login-username" type="text" size="15" autofocus="true" />
 
 		<label id="mod-login-password-lbl" for="mod-login-password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-		<input name="passwd" id="mod-login-password" type="password" size="15" />
+		<input name="passwd" id="mod-login-password" type="password" size="15"  autocapitalize="none" />
 		<?php if (count($twofactormethods) > 1): ?>
 			<div class="control-group">
 				<div class="controls">


### PR DESCRIPTION
Allegedly there are some mobile devices that ignore the w3c standards and will try to capitalise the input in a password field.
Mobile chrome and safari support a NON-standard attribute that can be used to prevent this. 
https://developer.mozilla.org/en/docs/Web/HTML/Element/Input#attr-autocapitalize
https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize

**Note** 
this will probably cause w3c standards validation to fail
This may not work at all on old iOS devices as prior to iOS5 the format was "off" not "one"
The default even on these devices is that autocapitalize is not enabled for any field of type password
#### Summary of Changes

Added the attribute to the admin login screen only
If accepted this will need to be applied to the other 84 instances of type="password"
#### Testing Instructions

I have NO idea at all how to test this as I have not found a single device amongst my collection that misbehaves and breaks the standards and tries to autocapitalise a password field
