### PR TITLE
Remove duplicated text in options

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -696,9 +696,6 @@
 			type="spacer"
 			hr="true"
 			/>
-		<field name="subcategories" type="spacer" class="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-			/>
 
 		<field name="show_subcategory_content" type="list"
 				default="0"

--- a/components/com_content/views/categories/tmpl/default.xml
+++ b/components/com_content/views/categories/tmpl/default.xml
@@ -209,10 +209,6 @@
 				<option value="1">JGLOBAL_ACROSS</option>
 			</field>
 
-			<field name="subcategories" type="spacer" class="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-			/>
-
 		<field name="show_subcategory_content" type="list"
 
 				description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -205,13 +205,6 @@
 				</field>
 
 				<field
-					name="subcategories"
-					type="spacer"
-					class="spacer"
-					label="JGLOBAL_SUBSLIDER_BLOG_EXTENDED_LABEL"
-				/>
-
-				<field
 					name="show_subcategory_content"
 					type="list"
 					description="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC"


### PR DESCRIPTION
In the options for the category blog we have some text to explain what an option does when we already have a tooltip for that. Based on the name of the string I think this is a leftover legacy thing that we dont need any more.

This simple PR removes the string from display
### Before

![2bqr](https://cloud.githubusercontent.com/assets/1296369/16559938/38bda5ac-41e8-11e6-856b-abf1cbc7b037.png)
### After

![xjv8](https://cloud.githubusercontent.com/assets/1296369/16559951/45134f6e-41e8-11e6-9a26-8855e8aace5b.png)
