### PR TITLE
Improve JHtmlNumber::bytes

### DIFF
--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -59,7 +59,7 @@ abstract class JHtmlNumber
 		// If no unit is requested return early
 		if ($unit === '')
 		{
-			return $oBytes;
+			return (string) $oBytes;
 		}
 
 		$suffixes = array('b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');

--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -21,10 +21,10 @@ abstract class JHtmlNumber
 	 * kilobytes, megabytes, etc.
 	 *
 	 * By default, the proper format will automatically be chosen.
-	 * However, one of the allowed unit types may also be used instead.
+	 * However, one of the allowed unit types (viz. 'b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB') may also be used instead.
 	 *
-	 * @param   integer  $bytes      The number of bytes.
-	 * @param   string   $unit       The type of unit to return.
+	 * @param   string   $bytes      The number of bytes. Can be either numeric or suffixed format: 32M, 60K, 12G or 812b
+	 * @param   string   $unit       The type of unit to return. Special: Blank string '' for no unit and 'auto' to choose automatically (default)
 	 * @param   integer  $precision  The number of digits to be used after the decimal place.
 	 *
 	 * @return  string   The number of bytes in the proper units.
@@ -33,28 +33,46 @@ abstract class JHtmlNumber
 	 */
 	public static function bytes($bytes, $unit = 'auto', $precision = 2)
 	{
-		// No explicit casting $bytes to integer here, since it might overflow
-		// on 32-bit systems
-		$precision = (int) $precision;
+		/*
+		 * Allowed 123.45, 123.45 M, 123.45 MB, 1.2345E+12MB, 1.2345E+12 MB etc.
+		 * i.e. – Any number in decimal digits or in sci. notation, optional space, optional 1-2 letter unit suffix
+		 */
+		if (is_numeric($bytes))
+		{
+			$oBytes = $bytes;
+			$oUnit  = null;
+		}
+		else
+		{
+			preg_match('/(.*?)\s?([KMGTPEZY]?B?)$/i', trim($bytes), $matches);
+			list(, $oBytes, $oUnit) = $matches;
+		}
 
-		if (empty($bytes))
+		if (empty($oBytes) || !is_numeric($oBytes))
 		{
 			return 0;
 		}
 
-		$unitTypes = array('b', 'kb', 'MB', 'GB', 'TB', 'PB');
+		$factor = $oUnit ? pow(1024, stripos('BKMGTPEZY', $oUnit[0])) : 1;
+		$oBytes = round($oBytes * $factor);
 
-		// Default automatic method.
-		$i = floor(log($bytes, 1024));
-
-		// User supplied method:
-		if ($unit !== 'auto' && in_array($unit, $unitTypes))
+		// If no unit is requested return early
+		if ($unit === '')
 		{
-			$i = array_search($unit, $unitTypes, true);
+			return $oBytes;
 		}
 
-		// TODO Allow conversion of units where $bytes = '32M'.
+		$suffixes = array('b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
 
-		return round($bytes / pow(1024, $i), $precision) . ' ' . $unitTypes[$i];
+		// Default automatic method
+		$i = floor(log($oBytes, 1024));
+
+		// User supplied method
+		if ($unit !== 'auto' && in_array($unit, $suffixes))
+		{
+			$i = array_search($unit, $suffixes, true);
+		}
+
+		return round($oBytes / pow(1024, $i), (int) $precision) . ' ' . $suffixes[$i];
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
@@ -32,7 +32,7 @@ class JHtmlNumberTest extends TestCase
 				1,
 			),
 			array(
-				'1 kb',
+				'1 kB',
 				1024,
 			),
 			array(
@@ -58,6 +58,31 @@ class JHtmlNumberTest extends TestCase
 
 			// Test units.
 			array(
+				'1 YB',
+				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+				'auto',
+			),
+			array(
+				'1 YB',
+				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+				'YB',
+			),
+			array(
+				'1024 ZB',
+				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+				'ZB',
+			),
+			array(
+				'1048576 EB',
+				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+				'EB',
+			),
+			array(
+				'1 PB',
+				1024 * 1024 * 1024 * 1024 * 1024,
+				'PB',
+			),
+			array(
 				'1024 TB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'TB',
@@ -73,44 +98,65 @@ class JHtmlNumberTest extends TestCase
 				'MB',
 			),
 			array(
-				'1099511627776 kb',
+				'1099511627776 kB',
 				1024 * 1024 * 1024 * 1024 * 1024,
-				'kb',
+				'kB',
 			),
 			array(
 				'1.1258999068426E+15 b',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'b',
 			),
+			array(
+				'1.1258999068426E+15',
+				1024 * 1024 * 1024 * 1024 * 1024,
+				'',
+			),
 
 			// Test precision
 			array(
-				'1.33 kb',
+				'1.33 kB',
 				1357,
 			),
 			array(
-				'1.3 kb',
+				'1.3 kB',
 				1357,
 				null,
 				1
 			),
 			array(
-				'1.33 kb',
+				'1.33 kB',
 				1357,
 				null,
 				2
 			),
 			array(
-				'1.325 kb',
+				'1.325 kB',
 				1357,
 				null,
 				3
 			),
 			array(
-				'1.3252 kb',
+				'1.3252 kB',
 				1357,
 				null,
 				4
+			),
+
+			// Test unit suffixed inputs
+			array(
+				'1 MB',
+				'1024K',
+			),
+			array(
+				'1024 MB',
+				'1 GB',
+				'MB'
+			),
+			array(
+				'10.5 GB',
+				'1.0752E+4 MB',
+				'GB'
 			),
 		);
 	}
@@ -118,10 +164,10 @@ class JHtmlNumberTest extends TestCase
 	/**
 	 * Tests the JHtmlNumber::bytes method.
 	 *
-	 * @param   string   $result     @todo
-	 * @param   integer  $bytes      @todo
-	 * @param   string   $unit       @todo
-	 * @param   integer  $precision  @todo
+	 * @param   string   $result     The expected result to match against.
+	 * @param   string   $bytes      The number of bytes. Can be either numeric or suffixed format: 32M, 60K, 12G or 812b
+	 * @param   string   $unit       The type of unit to return. Special: Blank string '' for no unit and 'auto' to choose automatically (default)
+	 * @param   integer  $precision  The number of digits to be used after the decimal place.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
#### Summary of Changes

Allow parsing of input in suffixed format such as "128M", "1.2G", "340K", "1234.56 MB" for conversion.
Allow returning number of bytes without any unit suffix
Added support for suffixes EB, ZB, YB.
#### Testing Instructions

Apparently no straight-forward way to test within Joomla. Please write some code that uses the method `JHtmlNumber::bytes()`

A sample code is given below (Seeds are taken from Unit Test, you may want to use your own test data):

``` php
echo JHtml::_('number.bytes', 1, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 0, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024, 'auto'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024, 'YB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024, 'ZB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024, 'EB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'PB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'TB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'GB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'MB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'kB'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, 'b'). "\n";
echo JHtml::_('number.bytes', 1024 * 1024 * 1024 * 1024 * 1024, ''). "\n";
echo JHtml::_('number.bytes', 1357, 'auto'). "\n";
echo JHtml::_('number.bytes', 1357, 'auto', 1). "\n";
echo JHtml::_('number.bytes', 1357, 'auto', 2). "\n";
echo JHtml::_('number.bytes', 1357, 'auto', 3). "\n";
echo JHtml::_('number.bytes', 1357, 'auto', 4). "\n";
echo JHtml::_('number.bytes', '1024K', 'auto'). "\n";
echo JHtml::_('number.bytes', '1 GB', 'MB'). "\n";
echo JHtml::_('number.bytes', '1.0752E+4 MB', 'GB'). "\n";
```

Expect the following output from above:

```
1 b
1 kB
1 MB
1 GB
1 TB
1 PB
0
1 YB
1 YB
1024 ZB
1048576 EB
1 PB
1024 TB
1048576 GB
1073741824 MB
1099511627776 kB
1.1258999068426E+15 b
1.1258999068426E+15
1.33 kB
1.3 kB
1.33 kB
1.325 kB
1.3252 kB
1 MB
1024 MB
10.5 GB
```

PS: There is probably a B/C break due to 'kb' changed to 'kB'. Please advise if that needs to be addressed.
