### PR TITLE
Use the API for inline javascript on email clocking

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -103,7 +103,7 @@ abstract class JHtmlEmail
 		};
 		";
 
-		if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
+		if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
 		{
 			// Use inline script for ajax calls
 			$inlineScript = "<script>" . $script . "</script>";

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -91,26 +91,31 @@ abstract class JHtmlEmail
 
 		$inlineScript = '';
 		$script       = "
-		document.onreadystatechange = function () {
-			if (document.readyState == 'interactive') {
+
 				document.getElementById('cloak" . $rand . "').innerHTML = '';
 				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
 				var path = 'hr' + 'ef' + '=';
 				var addy" . $rand . " = '" . @$mail[0] . "' + '&#64;';
 				addy" . $rand . " = addy" . $rand . " + '" . implode("' + '&#46;' + '", $mail_parts) . "';
 				$tmpScript
-			}
-		};
 		";
 
-		if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
+		if (strtolower(JFactory::getApplication()->input->server->get('HTTP_X_REQUESTED_WITH', '')) == 'xmlhttprequest')
 		{
 			// Use inline script for ajax calls
-			$inlineScript = "<script>" . $script . "</script>";
+			$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
 		}
 		else
 		{
-			JFactory::getDocument()->addScriptDeclaration($script);
+			JFactory::getDocument()->addScriptDeclaration(
+				"
+		document.onreadystatechange = function () {
+			if (document.readyState == 'interactive') {
+			" . $script . "
+			}
+		};
+				"
+			);
 		}
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -89,7 +89,6 @@ abstract class JHtmlEmail
 			$tmpScript = "document.getElementById('cloak" . $rand . "').innerHTML += addy" . $rand . ";";
 		}
 
-		$input        = JFactory::getApplication()->input;
 		$inlineScript = '';
 		$script       = "
 		document.onreadystatechange = function () {
@@ -104,7 +103,7 @@ abstract class JHtmlEmail
 		};
 		";
 
-		if ($input->getCmd('option') == 'com_ajax' || $input->getCmd('tmpl') == 'component')
+		if(!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest')
 		{
 			// Use inline script for ajax calls
 			$inlineScript = "<script>" . $script . "</script>";

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -89,8 +89,9 @@ abstract class JHtmlEmail
 			$tmpScript = "document.getElementById('cloak" . $rand . "').innerHTML += addy" . $rand . ";";
 		}
 
-		JFactory::getDocument()->addScriptDeclaration(
-		"
+		$input        = JFactory::getApplication()->input;
+		$inlineScript = '';
+		$script       = "
 		document.onreadystatechange = function () {
 			if (document.readyState == 'interactive') {
 				document.getElementById('cloak" . $rand . "').innerHTML = '';
@@ -101,10 +102,19 @@ abstract class JHtmlEmail
 				$tmpScript
 			}
 		};
-		"
-		);
+		";
 
-		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>';
+		if ($input->getCmd('option') == 'com_ajax' || $input->getCmd('tmpl') == 'component')
+		{
+			// Use inline script for ajax calls
+			$inlineScript = "<script>" . $script . "</script>";
+		}
+		else
+		{
+			JFactory::getDocument()->addScriptDeclaration($script);
+		}
+
+		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}
 
 	/**

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -47,12 +47,12 @@ abstract class JHtmlEmail
 		// Convert mail
 		$mail = static::convertEncoding($mail);
 
+		// Random hash
+		$rand = md5($mail . rand(1, 100000));
+
 		// Split email by @ symbol
 		$mail       = explode('@', $mail);
 		$mail_parts = explode('.', $mail[1]);
-
-		// Random number
-		$rand       = rand(1, 100000);
 
 		if ($mailto)
 		{
@@ -75,18 +75,18 @@ abstract class JHtmlEmail
 					$tmpScript = "var addy_text" . $rand . " = '" . $text . "';";
 				}
 
-				$tmpScript .= "document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
+				$tmpScript .= "document.getElementById('cloak" . $rand . "').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
 					. $rand . " + '\'>'+addy_text" . $rand . "+'<\/a>';";
 			}
 			else
 			{
-				$tmpScript = "document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
+				$tmpScript = "document.getElementById('cloak" . $rand . "').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
 					. $rand . " + '\'>' +addy" . $rand . "+'<\/a>';";
 			}
 		}
 		else
 		{
-			$tmpScript = "document.getElementById('cloak$rand').innerHTML += addy" . $rand . ";";
+			$tmpScript = "document.getElementById('cloak" . $rand . "').innerHTML += addy" . $rand . ";";
 		}
 
 		$doc          = JFactory::getDocument();

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -91,7 +91,6 @@ abstract class JHtmlEmail
 
 		$inlineScript = '';
 		$script       = "
-
 				document.getElementById('cloak" . $rand . "').innerHTML = '';
 				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
 				var path = 'hr' + 'ef' + '=';

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -93,7 +93,7 @@ abstract class JHtmlEmail
 		$commentStart = '';
 		$commentEnd   = '';
 
-		if ($doc->_type != 'html')
+		if ($doc->getType() != 'html')
 		{
 			$commentStart = '\n //<!--\n';
 			$commentEnd   = '\n //--> \n';
@@ -104,7 +104,7 @@ abstract class JHtmlEmail
 		$commentStart
 		document.onreadystatechange = function () {
 			if (document.readyState == 'interactive') {
-				document.getElementById('cloak$rand').innerHTML = '';
+				document.getElementById('cloak" . $rand . "').innerHTML = '';
 				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
 				var path = 'hr' + 'ef' + '=';
 				var addy" . $rand . " = '" . @$mail[0] . "' + '&#64;';

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -89,19 +89,8 @@ abstract class JHtmlEmail
 			$tmpScript = "document.getElementById('cloak" . $rand . "').innerHTML += addy" . $rand . ";";
 		}
 
-		$doc          = JFactory::getDocument();
-		$commentStart = '';
-		$commentEnd   = '';
-
-		if ($doc->getType() != 'html')
-		{
-			$commentStart = '\n //<!--\n';
-			$commentEnd   = '\n //--> \n';
-		}
-
-		$doc->addScriptDeclaration(
+		JFactory::getDocument()->addScriptDeclaration(
 		"
-		$commentStart
 		document.onreadystatechange = function () {
 			if (document.readyState == 'interactive') {
 				document.getElementById('cloak" . $rand . "').innerHTML = '';
@@ -112,7 +101,6 @@ abstract class JHtmlEmail
 				$tmpScript
 			}
 		};
-		$commentEnd
 		"
 		);
 

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -67,15 +67,15 @@ abstract class JHtmlEmail
 					// Split email by @ symbol
 					$text = explode('@', $text);
 					$text_parts = explode('.', $text[1]);
-					$tmpScriptA = "var addy_text" . $rand . " = '" . @$text[0] . "' + '&#64;' + '" . implode("' + '&#46;' + '", @$text_parts)
+					$tmpScript = "var addy_text" . $rand . " = '" . @$text[0] . "' + '&#64;' + '" . implode("' + '&#46;' + '", @$text_parts)
 						. "';";
 				}
 				else
 				{
-					$tmpScriptA = "var addy_text" . $rand . " = '" . $text . "';";
+					$tmpScript = "var addy_text" . $rand . " = '" . $text . "';";
 				}
 
-				$tmpScript = "document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
+				$tmpScript .= "document.getElementById('cloak$rand').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"
 					. $rand . " + '\'>'+addy_text" . $rand . "+'<\/a>';";
 			}
 			else
@@ -99,7 +99,7 @@ abstract class JHtmlEmail
 			$commentEnd   = '\n //--> \n';
 		}
 
-		JFactory::getDocument()->addScriptDeclaration(
+		$doc->addScriptDeclaration(
 		"
 		$commentStart
 		document.onreadystatechange = function () {
@@ -109,7 +109,6 @@ abstract class JHtmlEmail
 				var path = 'hr' + 'ef' + '=';
 				var addy" . $rand . " = '" . @$mail[0] . "' + '&#64;';
 				addy" . $rand . " = addy" . $rand . " + '" . implode("' + '&#46;' + '", $mail_parts) . "';
-				$tmpScriptA
 				$tmpScript
 			}
 		};

--- a/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
@@ -27,7 +27,7 @@ class JHtmlEmailTest extends PHPUnit_Framework_TestCase
 	{
 		$this->assertThat(
 			JHtmlEmail::cloak('admin@joomla.org'),
-			$this->StringContains('<a href="mailto:admin@joomla.org">admin@joomla.org</a>'),
+			$this->StringContains('<span id="cloak'),
 			'Cloak e-mail with mailto link'
 		);
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
@@ -27,7 +27,7 @@ class JHtmlEmailTest extends PHPUnit_Framework_TestCase
 	{
 		$this->assertThat(
 			JHtmlEmail::cloak('admin@joomla.org'),
-			$this->StringContains(".innerHTML += '<a ' + path + '\'' + prefix + ':' + addy"),
+			$this->StringContains('<a href="mailto:admin@joomla.org">admin@joomla.org</a>'),
 			'Cloak e-mail with mailto link'
 		);
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlEmailTest.php
@@ -33,19 +33,19 @@ class JHtmlEmailTest extends PHPUnit_Framework_TestCase
 
 		$this->assertThat(
 			JHtmlEmail::cloak('admin@joomla.org', false),
-			$this->StringContains("var path = 'hr' + 'ef' + '=';"),
+			$this->StringContains('<span id="cloak'),
 			'Cloak e-mail with no mailto link'
 		);
 
 		$this->assertThat(
 			JHtmlEmail::cloak('admin@joomla.org', true, 'administrator@joomla.org'),
-			$this->StringContains("var addy_text"),
+			$this->StringContains('<span id="cloak'),
 			'Cloak e-mail with mailto link and separate e-mail address text'
 		);
 
 		$this->assertThat(
 			JHtmlEmail::cloak('admin@joomla.org', true, 'Joomla! Administrator', false),
-			$this->StringContains("var addy_text"),
+			$this->StringContains('<span id="cloak'),
 			'Cloak e-mail with mailto link and separate non-e-mail address text'
 		);
 	}


### PR DESCRIPTION
#### Don't inject scripts in the document
#### Summary of Changes

Using the API for inline script
#### Testing Instructions

Create a new article and write an email address in it. save it and make a menu so you can see it in the front end.
Make sure the plugin email cloacking is enabled

Apply patch
Visit the page you should still see the email address
Disable the javascript in your browser and refresh the page. You should see the next message:
This email address is being protected from spambots. You need JavaScript enabled to view it.

Useful link: https://developer.mozilla.org/en-US/docs/Web/Events/readystatechange
