### PR TITLE
Clone the URI so we only manipulate it locally.

### DIFF
--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -79,7 +79,7 @@ class PlgContentVote extends JPlugin
 
 			if ($view == 'article' && $row->state == 1)
 			{
-				$uri = JUri::getInstance();
+				$uri = clone JUri::getInstance();
 				$uri->setVar('hitcount', '0');
 
 				// Create option list for voting select box


### PR DESCRIPTION
Pull Request for Issue #11016 .
#### Summary of Changes

Cloning the JURI instance before we manipulate it in the vote plugin. This way, the adjusted query will only be used for the vote plugin and doesn't change the global object.
#### Testing Instructions

From original Issue:

> Install a multilanguage site with the automatic installation that offers Joomla. 2 languages are enough.
> In Articles Options set the parameter Show Voting on Show.
> In frontend click on an article and then look the url generated when you go over flags.
> 
> If you click on the english article and then click on the english flag, you will see that the url change, 
> at the end &hitcount=0 is added

After applying the PR, the `&hitcount=0` isn't added anymore to the flag, but still is in the vote button.
