### PR TITLE
Ensure params is a Registry before cloning it

### DIFF
--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -87,16 +87,16 @@ class ContentModelArticle extends JModelItem
 				$query = $db->getQuery(true)
 					->select(
 						$this->getState(
-							'item.select', 'a.id, a.asset_id, a.title, a.alias, a.introtext, a.fulltext, ' .
+							'item.select', 'a.id, a.asset_id, a.title, a.alias, a.introtext, a.fulltext, '
 							// If badcats is not null, this means that the article is inside an unpublished category
 							// In this case, the state is set to 0 to indicate Unpublished (even if the article state is Published)
-							'CASE WHEN badcats.id is null THEN a.state ELSE 0 END AS state, ' .
-							'a.catid, a.created, a.created_by, a.created_by_alias, ' .
+							. 'CASE WHEN badcats.id is null THEN a.state ELSE 0 END AS state, '
+							. 'a.catid, a.created, a.created_by, a.created_by_alias, '
 							// Use created if modified is 0
-							'CASE WHEN a.modified = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.modified END as modified, ' .
-							'a.modified_by, a.checked_out, a.checked_out_time, a.publish_up, a.publish_down, ' .
-							'a.images, a.urls, a.attribs, a.version, a.ordering, ' .
-							'a.metakey, a.metadesc, a.access, a.hits, a.metadata, a.featured, a.language, a.xreference'
+							. 'CASE WHEN a.modified = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.modified END as modified, '
+							. 'a.modified_by, a.checked_out, a.checked_out_time, a.publish_up, a.publish_down, '
+							. 'a.images, a.urls, a.attribs, a.version, a.ordering, '
+							. 'a.metakey, a.metadesc, a.access, a.hits, a.metadata, a.featured, a.language, a.xreference'
 						)
 					);
 				$query->from('#__content AS a');
@@ -173,15 +173,19 @@ class ContentModelArticle extends JModelItem
 				$registry = new Registry;
 				$registry->loadString($data->attribs);
 
-				//$data->params = clone $this->getState('params');
-				//let's check if the state params is a object. if not take care.
+				// $data->params = clone $this->getState('params');
+				// Let's check if the state params is a object. if not take care.
 				$tempparams = $this->getState('params');
-		                if(is_object($tempparams)){
-		                    $data->params = clone $tempparams;
-		                }
-		                else{
-		                    $data->params = new Registry;
-		                }
+
+				if (is_object($tempparams))
+				{
+					$data->params = clone $tempparams;
+				}
+				else
+				{
+					$data->params = new Registry;
+				}
+
 				$data->params->merge($registry);
 
 				$registry = new Registry;

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -173,7 +173,15 @@ class ContentModelArticle extends JModelItem
 				$registry = new Registry;
 				$registry->loadString($data->attribs);
 
-				$data->params = clone $this->getState('params');
+				//$data->params = clone $this->getState('params');
+				//let's check if the state params is a object. if not take care.
+				$tempparams = $this->getState('params');
+		                if(is_object($tempparams)){
+		                    $data->params = clone $tempparams;
+		                }
+		                else{
+		                    $data->params = new Registry;
+		                }
 				$data->params->merge($registry);
 
 				$registry = new Registry;


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

situation: when you need use the site part com_content article model outside of com_content or calling model using 'ignore_request' => true
1. include the model require_once JPATH_SITE . '/components/com_content/models/article.php';
2. take instance of the model  $articlemodel = JModelLegacy::getInstance('Article', 'ContentModel', array('ignore_request' => true));
   //see I used 'ignore_request' => true   and in such case the param object stored in state in null or not an object.
3. $articlemodel->setState('article.id', 1);  //suppose I need info for article of id 1 (i hard coded it for testing)
4.   $article = $articlemodel->getItem();  //get the information

Error: php error  " __clone method called on non-object in   ...." for line $data->params = clone $this->getState('params');  as the param object is empty and can not be clone. 

So the quick fix can be 

//$data->params = clone $this->getState('params');
$tempparams = $this->getState('params');
                if(is_object($tempparams)){
                    $data->params = clone $tempparams;
                }
                else{
                    $data->params = new Registry;
                }
