### PR TITLE
Run SEF plugin also when SEF URLs are not enabled

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -86,7 +86,7 @@ class PlgSystemSef extends JPlugin
 	 */
 	public function onAfterRender()
 	{
-		if (!$this->app->isSite() || $this->app->get('sef', '0') == '0')
+		if (!$this->app->isSite())
 		{
 			return;
 		}


### PR DESCRIPTION
This change enables the SEF plugin to run even when the SEF URLs are not enabled. The background is, that with the new routing system the component routers are always invoked and called with each URL in order to do the necessary changes, especially setting the right Itemid. Without this change, the URLs everywhere are processed, except for those in content, when the SEF URLs are disabled. That means that with the new system, URLs in content would not get the right Itemid.
