### PR TITLE
Password rule language dependency

### DIFF
--- a/libraries/cms/form/rule/password.php
+++ b/libraries/cms/form/rule/password.php
@@ -77,6 +77,9 @@ class JFormRulePassword extends JFormRule
 
 		$valueLength = strlen($value);
 
+		// Load language file of com_users component
+		JFactory::getLanguage()->load('com_users');
+
 		// We set a maximum length to prevent abuse since it is unfiltered.
 		if ($valueLength > 4096)
 		{


### PR DESCRIPTION
### Context

When using the form password rule out of the com_users component, eg in a third component, we are facing an untranslated language string:

```
COM_USERS_MSG_NOT_ENOUGH_INTEGERS_N
COM_USERS_MSG_NOT_ENOUGH_SYMBOLS_N
COM_USERS_MSG_NOT_ENOUGH_UPPERCASE_LETTERS_N
COM_USERS_MSG_PASSWORD_TOO_SHORT_N
```
#### Summary of Changes

Load the com_users language file in the rule for translation
#### Testing Instructions

Edit files:
- `pathToJoomla\components\com_content\models\forms\article.xml`
  add before the field id [line 4]

``` xml
<field
    name="test"
    type="password"
    validate="password"
    label="Test" />
```
- `pathToJoomla\components\com_content\views\form\tmpl\edit.php`
  add before the render title field [line 83]

``` php
<?php echo $this->form->renderField('test'); ?>
```

Then in backend edit the com_users settings:
Password Minimum Length : 2
Password Minimum Integers : 1
Password Minimum Symbols : 1
Password Minimum Upper Case : 1

Login frontend as super user
Go to: `yourDomain/index.php?option=com_content&view=form&layout=edit`

Type in "Title" field something and type in Test field: aa
Save to hit the issue

```
COM_USERS_MSG_NOT_ENOUGH_INTEGERS_N
COM_USERS_MSG_NOT_ENOUGH_SYMBOLS_N
COM_USERS_MSG_NOT_ENOUGH_UPPERCASE_LETTERS_N
COM_USERS_MSG_PASSWORD_TOO_SHORT_N
Invalid field: Test
```

Apply fix, retry and no more untranslated string
