### PR TITLE
code style fix for administrator/components/com_cache

### DIFF
--- a/administrator/components/com_cache/controller.php
+++ b/administrator/components/com_cache/controller.php
@@ -93,6 +93,7 @@ class CacheController extends JControllerLegacy
 				JFactory::getApplication()->enqueueMessage(JText::_('COM_CACHE_EXPIRED_ITEMS_HAVE_BEEN_DELETED'), 'message');
 			}
 		}
+
 		$this->setRedirect('index.php?option=com_cache');
 	}
 
@@ -152,6 +153,7 @@ class CacheController extends JControllerLegacy
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('COM_CACHE_EXPIRED_ITEMS_HAVE_BEEN_PURGED'), 'message');
 		}
+
 		$this->setRedirect('index.php?option=com_cache&view=purge');
 	}
 }

--- a/administrator/components/com_cache/models/cache.php
+++ b/administrator/components/com_cache/models/cache.php
@@ -196,7 +196,7 @@ class CacheModelCache extends JModelList
 	/**
 	 * Get the number of current Cache Groups.
 	 *
-	 * @return  int
+	 * @return  integer
 	 */
 	public function getTotal()
 	{


### PR DESCRIPTION
Pull Request for code style
#### Summary of Changes

Expected "integer" but found "int" for function return type
No blank line found after control structure

[Automatically fixed with PHPCS2 fixers](https://github.com/joomla/coding-standards/pull/109)
#### Testing Instructions

merge by code review
