### PR TITLE
JTable Not handling default values correctly in MSSQL 2008+

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -382,10 +382,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->Type), "nvarchar"))
-				{
-					$field->Default = "";
-				}
+				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|\)\)|\))$))/i", '', $field->Default);
 				$result[$field->Field] = $field;
 			}
 		}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -382,7 +382,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|\)\)|\))$))/i", '', $field->Default);
+				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|(?<!\()\)\)|\))$))/i", '', $field->Default);
 				$result[$field->Field] = $field;
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

Default values are not being assigned correctly for data types such as
Integer, Date and Datetime. So as a result it is causing the insert
query to fail. I have tested this on SQL SERVER 2008-2016.

The root cause of this issue lies with the getTableColumns in the SQL
server driver class, which relies on using the information_schema views
to get the information about the columns. The default values it
gets for the table columns are from the underlying system comments table
and as a result it is not in a format that can be injected as is into a
INSERT Query.

Below is a partial list of how the syscomments table stores default
values for the following data types:

Datatype :  int
Actual default Value : 0
Value  in syscomments table: ((0))

Datatype :  int
Actual default Value : 10
Value  in syscomments table: ((10))

Datatype :  Datetime
Actual default Value : ‘1900-01-01T00:00:00.000’ 
Value  in syscomments table: (‘1900-01-01T00:00:00.000’)

Datatype :  Datetime
Actual default Value : getdate()
Value  in syscomments table: (getdate())

Datatype :  Date
Actual default Value : ‘1900-01-01’
Value  in syscomments table: (‘1900-01-01’)

Datatype :  Varchar
Actual default Value : ''
Value  in syscomments table: ('')

Datatype :  Varchar
Actual default Value : '1234'
Value  in syscomments table: ('1234')

Datatype :  NVarchar
Actual default Value : N''
Value  in syscomments table: (N'')

Datatype :  NVarchar
Actual default Value : N'1234'
Value  in syscomments table: (N'1234')

Datatype :  Varchar
Actual default Value : NULL
Value  in syscomments table: (NULL)

You see the general pattern that the default value stored in the
syscomments table is wrapped around in curly brackets, whether that be
single or double depends on the data type.

Now the current implementation of the getTableColumns function only
deals with nvarchar  data types by assuming every default string value
will be an empty string  so defaults to that value ignoring the actual database value.  This works but IMHO it is a bit too simplistic in that it does not allow for default string
values that is not an empty string value.  Also it does not deal with
other data types such as datetime, date etc... So as a result the INSERT
query will still blow up when you try for example to pass the value ‘((0))’
for an integer data type.

My change just parses the value by removing the superfluous brackets and
returns the actual value for the data type in the correct format.

So for example the value ‘((0))’ will be returned as 0, (N‘1’) will
be returned as ‘1’ and value (getdate()) will be returned as getdate() and so on ....
