### PR TITLE
Zombie modules roaming the front-end

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -178,7 +178,10 @@ class PlgContentLoadmodule extends JPlugin
 		$params = array('style' => $style);
 		ob_start();
 
-		echo $renderer->render($mod, $params);
+		if ($mod->id)
+		{
+			echo $renderer->render($mod, $params);
+		}
 
 		self::$mods[$module] = ob_get_clean();
 


### PR DESCRIPTION
The plugin content-loadmodule supports "loadposition" and "loadmodule" syntax. While the first works fine, the latter creates zombie modules in the front-end.
#### Testing Instructions
1. In the back-end, create a module for the front-end side. The module type doesn't matter, but for testing purpose, a "Search" module is better.
2. Set some module properties to unique values, in order to distinguish your module by a zombie module. For example, setting "Show type" to "Show" and "Box Text" to "My Search Box" is fine.
3. Ensure that the "Position" is "unset", or set it to a non-existing template position: we want to load the module through the content-loadmodule plugin, not through a standard template position. In addition ensure that the "Status" is "Published", and "Menu Assignment" to "All pages".  These conditions are necessary for the content-loadmodule to load the module.
4. Create an article. Within its content load the module using the content-loadmodule plugin. The module type and title depends on the actual value used during module creation. For example in my case it's {loadmodule mod_search,My Search Module}. Do not use {loadposition} syntax, because loadposition works fine. The problem affects {loadmodule} only. If you prefer, you can also use the "Module" editor button introduced recently. In this case select the module by the green button, which corresponds to {loadmodule}. Do not use the yellow button, which would correspond to {loadposition}.
5. Take a look to your module in the front-end. I created a Menu Item of type "Articles » Single Article" for that purpose, but browsing your article through a blog view should make no difference.
6. You should see your module and recognize it by its title ("My Search Module") and by the content of its input ("My Search Box").

So far, so good. Now comes the creepy part.

Return to the back-end, Modules and "Unpublish" your test module. You would expect that the module disappears from the front-end, but in its place there is a brainless Search module. Module->id is 0 (zero), and all its properties are empty strings, so that its behaviour is left to the default (no title, Box Text = "Search...", etc).
#### Summary of Changes

The problem lies in the way loadmodule executes the module code.
While loadposition includes its modules within a "foreach" cycle, which protects modules code to be executed in case of an empty module list, a similar protection has not been implemented (yet) in loadmodule. As a consequence, the module rendering code is executed regardless of the module has been actually loaded or not.
