### PR TITLE
Only build list array if function exists

### DIFF
--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -513,19 +513,20 @@ class JPagination
 
 		if (file_exists($chromePath))
 		{
-			$list = array();
-			$list['prefix'] = $this->prefix;
-			$list['limit'] = $this->limit;
-			$list['limitstart'] = $this->limitstart;
-			$list['total'] = $this->total;
-			$list['limitfield'] = $this->getLimitBox();
-			$list['pagescounter'] = $this->getPagesCounter();
-			$list['pageslinks'] = $this->getPagesLinks();
-
 			include_once $chromePath;
 
 			if (function_exists('pagination_list_footer'))
 			{
+				$list = array(
+					'prefix'       => $this->prefix,
+					'limit'        => $this->limit,
+					'limitstart'   => $this->limitstart,
+					'total'        => $this->total,
+					'limitfield'   => $this->getLimitBox(),
+					'pagescounter' => $this->getPagesCounter(),
+					'pageslinks'   => $this->getPagesLinks(),
+				);
+
 				return pagination_list_footer($list);
 			}
 		}


### PR DESCRIPTION
#### Summary of Changes

The `$list` data array is only used if the `pagination_list_footer()` function exists in the template.  So only build it if the function exists.
#### Testing Instructions

No change to how pagination is built.  Sorry, off hand I don't know the trace to get this specific function to trigger.
