### PR TITLE
Loadmodule plugin refuses to load copied modules

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -113,7 +113,7 @@ class PlgContentLoadmodule extends JPlugin
 				$output = $this->_loadmod($module, $name, $stylemod);
 
 				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
-				$article->text = preg_replace("|$matchmod[0]|", addcslashes($output, '\\$'), $article->text, 1);
+				$article->text = preg_replace(addcslashes("|$matchmod[0]|", '()'), addcslashes($output, '\\$'), $article->text, 1);
 				$stylemod = $this->params->def('style', 'none');
 			}
 		}


### PR DESCRIPTION
#### Testing Instructions
1. In the back-end, create a module for the front-end side. The module type doesn't matter. Give it a name, for example "My Module".
2. Duplicate it with the "Duplicate" button in the top toolbar. The new module is automatically named "My Module (2)". Leave its name as is.
3. On both modules, ensure that the "Position" is "unset", or set it to a non-existing template position: we want to load the module through the content-loadmodule plugin, not through a standard template position. In addition ensure that the "Status" is "Published", and "Menu Assignment" to "All pages".  These conditions are necessary for the content-loadmodule to load the module.
4. Create an article. Within its content load the module using the content-loadmodule plugin. To avoid struggling with the correct syntax, you can use the "Module" editor button introduced recently. There select "My Module (2)" from the list by the green button, which corresponds to {loadmodule}. Do not use the yellow button, which would correspond to {loadposition}.
5. Take a look to your module in the front-end. I created a Menu Item of type "Articles » Single Article" for that purpose, but browsing your article through a blog view should make no difference.
6. You should see that the plugin code has not been replaced with the actual module. The plugin seems not working at all.
#### Summary of Changes

The problem is that loadmodule calls preg_replace using a literal string as pattern, while in a regular expression the parenthesis are metacharacters and must be escaped.

Frankly, I would suggest to change preg_replace with str_replace, but I've just escaped the parenthesis to fix this bug without opening a debate.
