### PR TITLE
_removeAdminMenus removes wrong menu items - nested table …

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -585,12 +585,18 @@ class JTableNested extends JTable
 				->where('lft BETWEEN ' . (int) $node->lft . ' AND ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 
-			// Compress the left and right values.
+			// Compress the left values.
 			$query->clear()
 				->update($this->_tbl)
 				->set('lft = lft - ' . (int) $node->width)
-				->set('rgt = rgt - ' . (int) $node->width)
 				->where('lft > ' . (int) $node->rgt);
+			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
+
+			// Compress the right values.
+			$query->clear()
+				->update($this->_tbl)
+				->set('rgt = rgt - ' . (int) $node->width)
+				->where('rgt > ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 		}
 		// Leave the children and move them up a level.
@@ -618,12 +624,18 @@ class JTableNested extends JTable
 				->where('parent_id = ' . (int) $node->$k);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 
-			// Shift all of the left and right values that are right of the node.
+			// Shift all of the left values that are right of the node.
 			$query->clear()
 				->update($this->_tbl)
 				->set('lft = lft - 2')
-				->set('rgt = rgt - 2')
 				->where('lft > ' . (int) $node->rgt);
+			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
+
+			// Shift all of the right values that are right of the node.
+			$query->clear()
+				->update($this->_tbl)
+				->set('rgt = rgt - 2')
+				->where('rgt > ' . (int) $node->rgt);
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_DELETE_FAILED');
 		}
 


### PR DESCRIPTION
Pull Request for Issue #11044.
#### Summary of Changes

I've restored how **nested table** deleted nodes until Joomla 3.5.

I think the problem was introduced as part as a code optimization that went too far here: https://github.com/joomla/joomla-cms/commit/28195290de257d791e0fb4ed41ad4bf5a7e09ce5
#### Testing Instructions

The key to force the bug  #11044 is in the order of menu items.
1. Modify _**removeAdminMenus** to force an inverse order of deletion, libraries/cms/installer/adapter/component.php, line 1087
   
   ```
   // Get the ids of the menu items
   $query = $db->getQuery(true)
               ->select('id')
               ->from('#__menu')
               ->where($db->quoteName('client_id') . ' = 1')
               ->where($db->quoteName('component_id') . ' = ' . (int) $id)
               ->order('id desc');
   ```
2. Install [Weblinks](https://github.com/joomla-extensions/weblinks/releases).
3. Manually add a menu item (any type)
4. Install [Weblinks](https://github.com/joomla-extensions/weblinks/releases) again. 
5. New menu item is removed!

Apply the patch and repeat the steps to verify that menu items are not removed.
