### PR TITLE
Removed menutype variable in All Menu items menu link

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -137,7 +137,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	$menu->addSeparator();
 
-	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=', 'class:allmenu'));
+	$menu->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items', 'class:allmenu'));
 	$menu->addSeparator();
 
 	// Menu Types


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

Removed Unnecessary variable of menutype in **All Menu Items** link. 
#### Testing Instructions

Please check All Menu Items link in administrator.  
_**index.php?option=com_menus&view=items&menutype=**_
I have removed **menutype** variable in link.
