### PR TITLE
Switch to install route if checking for the existing extension finds no result and we came in via the update route

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -148,10 +148,14 @@ abstract class JInstallerAdapter extends JAdapterInstance
 				array('element' => $this->element, 'type' => $this->type)
 			);
 
-			// If it does exist, load it
+			// If it does exist, load it, otherwise consider this a new installation if we're on the update route
 			if ($this->currentExtensionId)
 			{
-				$this->extension->load(array('element' => $this->element, 'type' => $this->type));
+				$this->extension->load(array('extension_id' => $this->currentExtensionId));
+			}
+			elseif (!$this->currentExtensionId && $this->getRoute() == 'update')
+			{
+				$this->setRoute('install');
 			}
 		}
 		catch (RuntimeException $e)

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -53,6 +53,16 @@ class JInstallerAdapterModule extends JInstallerAdapter
 					'client_id' => $this->clientId
 				)
 			);
+
+			// If it does exist, load it, otherwise consider this a new installation if we're on the update route
+			if ($this->currentExtensionId)
+			{
+				$this->extension->load(array('extension_id' => $this->currentExtensionId));
+			}
+			elseif (!$this->currentExtensionId && $this->getRoute() == 'update')
+			{
+				$this->setRoute('install');
+			}
 		}
 		catch (RuntimeException $e)
 		{

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -49,6 +49,16 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 			$this->currentExtensionId = $this->extension->find(
 				array('type' => $this->type, 'element' => $this->element, 'folder' => $this->group)
 			);
+
+			// If it does exist, load it, otherwise consider this a new installation if we're on the update route
+			if ($this->currentExtensionId)
+			{
+				$this->extension->load(array('extension_id' => $this->currentExtensionId));
+			}
+			elseif (!$this->currentExtensionId && $this->getRoute() == 'update')
+			{
+				$this->setRoute('install');
+			}
 		}
 		catch (RuntimeException $e)
 		{

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -45,6 +45,16 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 					'client_id' => $this->clientId
 				)
 			);
+
+			// If it does exist, load it, otherwise consider this a new installation if we're on the update route
+			if ($this->currentExtensionId)
+			{
+				$this->extension->load(array('extension_id' => $this->currentExtensionId));
+			}
+			elseif (!$this->currentExtensionId && $this->getRoute() == 'update')
+			{
+				$this->setRoute('install');
+			}
 		}
 		catch (RuntimeException $e)
 		{

--- a/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
@@ -116,7 +116,7 @@ class JInstallerAdapterTest extends TestCaseDatabase
 		// Ensure that load is called once the extension ID is found
 		$mockTableExtension->expects($this->once())
 			->method('load')
-			->with(array('element' => $element, 'type' => $type));
+			->with(array('extension_id' => $extensionId));
 
 		TestReflection::setValue($object, 'extension', $mockTableExtension);
 		TestReflection::setValue($object, 'type', $type);


### PR DESCRIPTION
Pull Request for Issue #9585
#### Summary of Changes

There are some behaviors in the install adapters which are different between the update and install routes which can cause an incorrect installation.  This PR tries to switch to the install route if the check for the existing extension's data yields no result from the database, but only against the update route.

Also, this makes all `checkExistingExtension()` method implementations consistent in loading the extension record if the ID is found.
#### Testing Instructions

See #9585 for additional info including reproduction instructions.
