### PR TITLE
Fix secondary menu position if overflowing viewport

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -10,6 +10,8 @@
 {
 	$(document).ready(function()
 	{
+		var $w = $(window);
+
 		$('*[rel=tooltip]').tooltip();
 
 		// Turn radios into btn-group
@@ -73,13 +75,13 @@
 
 		});
 
-		menuScroll.find('.dropdown-submenu > a').on('mouseenter', function() {
+		menuScroll.find('.dropdown-submenu > a').on('mouseover', function() {
 
 			var $self        = $(this);
 			var dropdown     = $self.next('ul');
 			var submenuWidth = dropdown.outerWidth();
 			var offsetTop    = $self.offset().top;
-			var scroll       = $(window).scrollTop() + 8;
+			var scroll       = $w.scrollTop() + 8;
 
 			// Set the submenu position
 			if ($('html').attr('dir') == 'rtl')
@@ -101,6 +103,15 @@
 			dropdown.hide();
 			emptyMenu.show().html(dropdown.html());
 
+			// Check if the full element is visivle. If not, adjust the position
+			if (emptyMenu.Jvisible() !== true)
+			{
+				console.log('something');
+				emptyMenu.css({
+					top : ($w.height() - emptyMenu.outerHeight()) - $('#status').height()
+				});
+			}
+
 		});
 		menuScroll.find('a.no-dropdown').on('mouseenter', function() {
 
@@ -112,6 +123,27 @@
 			emptyMenu.empty().hide();
 
 		});
+
+		$.fn.Jvisible = function(partial,hidden)
+		{
+			if (this.length < 1)
+			{
+				return;
+			}
+
+			var $t = this.length > 1 ? this.eq(0) : this,
+				t  = $t.get(0)
+
+			var viewTop         = $w.scrollTop(),
+				viewBottom      = (viewTop + $w.height()) - $('#status').height(),
+				offset          = $t.offset(),
+				_top            = offset.top,
+				_bottom         = _top + $t.height(),
+				compareTop      = partial === true ? _bottom : _top,
+				compareBottom   = partial === true ? _top : _bottom;
+
+			return !!t.offsetWidth * t.offsetHeight && ((compareBottom <= viewBottom) && (compareTop >= viewTop));
+		};
 
 		/**
 		 * USED IN: All views with toolbar and sticky bar enabled

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -103,7 +103,7 @@
 			dropdown.hide();
 			emptyMenu.show().html(dropdown.html());
 
-			// Check if the full element is visivle. If not, adjust the position
+			// Check if the full element is visible. If not, adjust the position
 			if (emptyMenu.Jvisible() !== true)
 			{
 				console.log('something');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -106,7 +106,6 @@
 			// Check if the full element is visible. If not, adjust the position
 			if (emptyMenu.Jvisible() !== true)
 			{
-				console.log('something');
 				emptyMenu.css({
 					top : ($w.height() - emptyMenu.outerHeight()) - $('#status').height()
 				});


### PR DESCRIPTION
Pull Request for Issue #11013.
#### Summary of Changes

Fixes the position of the secondary dropdown if it overflows the viewport height
#### Testing Instructions

First, ensure the "Banners" menu item is at the bottom of the "Components" dropdown, bu openening the following file `ROOT/administrator/language/en-GB/en-GB.com_banners.sys.ini`

and changing:
`COM_BANNERS="Banners"`
to:
`COM_BANNERS="Zbanners"`

Then ensure you're viewport height is relatively small. **Before** the patch, the secondary dropdown should look like this:
![06d9fc5e-41c3-11e6-9dec-f2131123ba8f](https://cloud.githubusercontent.com/assets/2019801/16783137/c87fc588-487a-11e6-80f4-262d55a5fdfb.png)

As you can see, it's overflowing the viewport height.

**Once the patch is applied, the position will change so all menu items are visible.**
