### PR TITLE
Use correct parameter type (Fix #11082)

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -484,8 +484,7 @@ class JFile
 			if ($FTPOptions['enabled'] == 1)
 			{
 				// Connect the FTP client
-				jimport('joomla.client.ftp');
-				$ftp = JFTP::getInstance($FTPOptions['host'], $FTPOptions['port'], null, $FTPOptions['user'], $FTPOptions['pass']);
+				$ftp = JClientFtp::getInstance($FTPOptions['host'], $FTPOptions['port'], array(), $FTPOptions['user'], $FTPOptions['pass']);
 
 				// Translate path for the FTP account and use FTP write buffer to file
 				$file = JPath::clean(str_replace(JPATH_ROOT, $FTPOptions['root'], $file), '/');


### PR DESCRIPTION
Pull Request for Issue #11082
#### Summary of Changes

The third parameter is typehinted as an array so passing a null value is not allowed.  Pass an array instead.
#### Testing Instructions

Code review.
