### PR TITLE
If the component do not provide the manifest file, the menu type is n…

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -184,8 +184,8 @@ class MenusViewItems extends JViewLegacy
 								$titleParts[] = $vars['view'];
 							}
 
-							$value = implode(' » ', $titleParts);
 						}
+						$value = implode(' » ', $titleParts);
 					}
 					else
 					{


### PR DESCRIPTION
Pull Request for Issue none.

Moved the merge of the title outside the if (isset($vars['view'])) condition

Well, it's a bit silly but, install SobiPro, add a menu entry to any SobiPro functionality. If the menus entry is directly behind for example a menu entry to an article, the type of SobiPro menu entry will say: article >> single article  

If you apply the fix it will say: SobiPro 
