### PR TITLE
Show the menu title above the tabs

### DIFF
--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -30,19 +30,13 @@ JFactory::getDocument()->addScriptDeclaration("
 ");
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form">
-
+	
+	<?php echo JLayoutHelper::render('joomla.edit.title_alias', $this); ?>
+	
 	<div class="form-horizontal">
 		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'details')); ?>
 
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_MENUS_MENU_DETAILS')); ?>
-			<div class="control-group">
-				<div class="control-label">
-					<?php echo $this->form->getLabel('title'); ?>
-				</div>
-				<div class="controls">
-					<?php echo $this->form->getInput('title'); ?>
-				</div>
-			</div>
 			<div class="control-group">
 				<div class="control-label">
 					<?php echo $this->form->getLabel('menutype'); ?>


### PR DESCRIPTION
Pull Request for Issue # .

While editing the menu permissions, at the moment you do not see which menu you are working on.  Showing the menu title above the tabs as usual could avoid errors.

Summary of Changes:
The menu title is set above the tabs on the menu edit screen. 

Testing Instructions
- In the backend go to menus.
- Select a menu and activate edit.
- You see two tabs: Details and permissions.
- Go to permissions. At this time ou do not see which menu you are working on.
- Apply the patch and repeat.
- The menu title is visible above the tabs
