### PR TITLE
Rename JDatabaseIteratorAzure to JDatabaseIteratorSqlazure

### DIFF
--- a/libraries/joomla/database/iterator/sqlazure.php
+++ b/libraries/joomla/database/iterator/sqlazure.php
@@ -14,6 +14,6 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  12.1
  */
-class JDatabaseIteratorAzure extends JDatabaseIteratorSqlsrv
+class JDatabaseIteratorSqlazure extends JDatabaseIteratorSqlsrv
 {
 }


### PR DESCRIPTION
Fixes a fatal error when viewing articles on an Azure database by
bringing the naming in line with the rest of the Azure-related classes.

It seems to have been missed in a rename at some point, because everything else Azure-related is currently named Sqlazure except this. When trying to use the class, Joomla looks for Sqlazure, which causes a fatal error (red box on the page, no site content) since it's just called Azure.
