### PR TITLE
Hardcode English language messages in JComponentHelper::load()

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -462,17 +462,46 @@ class JComponentHelper
 		}
 		catch (RuntimeException $e)
 		{
-			// Fatal error.
-			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $e->getMessage()), JLog::WARNING, 'jerror');
+			/*
+			 * Fatal error
+			 *
+			 * It is possible for this error to be reached before the global JLanguage instance has been loaded so we check for its presence
+			 * before logging the error to ensure a human friendly message is always given
+			 */
+
+			if (JFactory::$language)
+			{
+				$msg = JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $e->getMessage());
+			}
+			else
+			{
+				$msg = sprintf('Error loading component: %1$s, %2$s', $option, $e->getMessage());
+			}
+
+			JLog::add($msg, JLog::WARNING, 'jerror');
 
 			return false;
 		}
 
 		if (empty(static::$components[$option]))
 		{
-			// Fatal error.
-			$error = JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND');
-			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $error), JLog::WARNING, 'jerror');
+			/*
+			 * Fatal error
+			 *
+			 * It is possible for this error to be reached before the global JLanguage instance has been loaded so we check for its presence
+			 * before logging the error to ensure a human friendly message is always given
+			 */
+
+			if (JFactory::$language)
+			{
+				$msg = JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'));
+			}
+			else
+			{
+				$msg = sprintf('Error loading component: %1$s, %2$s', $option, 'Component not found.');
+			}
+
+			JLog::add($msg, JLog::WARNING, 'jerror');
 
 			return false;
 		}


### PR DESCRIPTION
#### Summary of Changes

In a couple of scenarios, it is possible for `JComponentHelper` to attempt to load the component parameters before the global language singleton has been loaded, resulting in cases like one presented in #10815 where the user is getting an untranslated language key.  In those cases, we should use hardcoded language versus untranslatable language keys.
#### Testing Instructions

In both the site and admin applications, if the user is a guest, the `com_users` parameters will attempt to be loaded to find the configured guest user group.  This leads to a call to `JComponentHelper::load()` to load the component parameters into memory for the request (either from the cache system or a database request).

In this method, inside the try/catch block, throw a RuntimeException (so `throw new RuntimeException('Testing issue with unloaded language strings');`.  This will be caught in the catch block and should result in the hardcoded English message being used.
