### PR TITLE
[searchtools] Add 200 and 500 to limit box default values

### DIFF
--- a/libraries/cms/form/field/limitbox.php
+++ b/libraries/cms/form/field/limitbox.php
@@ -39,7 +39,7 @@ class JFormFieldLimitbox extends JFormFieldList
 	 *
 	 * @var  array
 	 */
-	protected $defaultLimits = array(5, 10, 15, 20, 25, 30, 50, 100);
+	 protected $defaultLimits = array(5, 10, 15, 20, 25, 30, 50, 100, 200, 500);
 
 	/**
 	 * Method to get the options to populate to populate list

--- a/libraries/cms/form/field/limitbox.php
+++ b/libraries/cms/form/field/limitbox.php
@@ -39,7 +39,7 @@ class JFormFieldLimitbox extends JFormFieldList
 	 *
 	 * @var  array
 	 */
-	 protected $defaultLimits = array(5, 10, 15, 20, 25, 30, 50, 100, 200, 500);
+	protected $defaultLimits = array(5, 10, 15, 20, 25, 30, 50, 100, 200, 500);
 
 	/**
 	 * Method to get the options to populate to populate list


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11118.
#### Summary of Changes

Add 200 and 500 to searchtools limit box values as it exists in global config.
#### Testing Instructions

very simple test:
1. Apply patch
2. Go to Global Configuration - Site Settings
3. Select one of the new values (either 200 or 500)
4. Save
5. Logout 
6. Login
7. Go to content articles and check the preselected value in the limit select is the value you selected in 3.

More info see https://github.com/joomla/joomla-cms/issues/11118
