### PR TITLE
Check & early return if not caching, use get method

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -68,7 +68,7 @@ class JCache
 
 		if (empty($this->_options['storage']))
 		{
-			$this->_options['caching'] = false;
+			$this->setCaching(false);
 		}
 	}
 
@@ -184,13 +184,18 @@ class JCache
 	 */
 	public function get($id, $group = null)
 	{
+		if (!$this->getCaching())
+		{
+			return false;
+		}
+
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
 		// Get the storage
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof Exception))
 		{
 			return $handler->get($id, $group, $this->_options['checkTime']);
 		}
@@ -207,10 +212,15 @@ class JCache
 	 */
 	public function getAll()
 	{
+		if (!$this->getCaching())
+		{
+			return false;
+		}
+
 		// Get the storage
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof Exception))
 		{
 			return $handler->getAll();
 		}
@@ -231,13 +241,18 @@ class JCache
 	 */
 	public function store($data, $id, $group = null)
 	{
+		if (!$this->getCaching())
+		{
+			return false;
+		}
+
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
 		// Get the storage and store the cached data
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof Exception))
 		{
 			return $handler->store($id, $group, $data);
 		}
@@ -348,7 +363,7 @@ class JCache
 		 */
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['locking'] == true && $this->_options['caching'] == true)
+		if (!($handler instanceof Exception) && $this->_options['locking'] == true && $this->getCaching())
 		{
 			$locked = $handler->lock($id, $group, $locktime);
 
@@ -367,7 +382,7 @@ class JCache
 		$looptime = $locktime * 10;
 		$id2      = $id . '_lock';
 
-		if ($this->_options['locking'] == true && $this->_options['caching'] == true)
+		if ($this->_options['locking'] == true && $this->getCaching())
 		{
 			$data_lock = $this->get($id2, $group);
 		}
@@ -397,7 +412,7 @@ class JCache
 			}
 		}
 
-		if ($this->_options['locking'] == true && $this->_options['caching'] == true)
+		if ($this->_options['locking'] == true && $this->getCaching())
 		{
 			$returning->locked = $this->store(1, $id2, $group);
 		}
@@ -428,7 +443,7 @@ class JCache
 		// Allow handlers to perform unlocking on their own
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['caching'])
+		if (!($handler instanceof Exception) && $this->getCaching())
 		{
 			$unlocked = $handler->unlock($id, $group);
 
@@ -439,7 +454,7 @@ class JCache
 		}
 
 		// Fallback
-		if ($this->_options['caching'])
+		if ($this->getCaching())
 		{
 			$unlock = $this->remove($id . '_lock', $group);
 		}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -351,6 +351,13 @@ class JCache
 		$returning = new stdClass;
 		$returning->locklooped = false;
 
+		if (!$this->getCaching())
+		{
+			$returning->locked = false;
+
+			return $returning;
+		}
+
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
@@ -363,7 +370,7 @@ class JCache
 		 */
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->_options['locking'] == true && $this->getCaching())
+		if (!($handler instanceof Exception) && $this->_options['locking'] == true)
 		{
 			$locked = $handler->lock($id, $group, $locktime);
 
@@ -382,7 +389,7 @@ class JCache
 		$looptime = $locktime * 10;
 		$id2      = $id . '_lock';
 
-		if ($this->_options['locking'] == true && $this->getCaching())
+		if ($this->_options['locking'] == true)
 		{
 			$data_lock = $this->get($id2, $group);
 		}
@@ -412,7 +419,7 @@ class JCache
 			}
 		}
 
-		if ($this->_options['locking'] == true && $this->getCaching())
+		if ($this->_options['locking'] == true)
 		{
 			$returning->locked = $this->store(1, $id2, $group);
 		}
@@ -435,6 +442,11 @@ class JCache
 	 */
 	public function unlock($id, $group = null)
 	{
+		if (!$this->getCaching())
+		{
+			return false;
+		}
+
 		$unlock = false;
 
 		// Get the default group
@@ -443,7 +455,7 @@ class JCache
 		// Allow handlers to perform unlocking on their own
 		$handler = $this->_getStorage();
 
-		if (!($handler instanceof Exception) && $this->getCaching())
+		if (!($handler instanceof Exception))
 		{
 			$unlocked = $handler->unlock($id, $group);
 


### PR DESCRIPTION
#### Summary of Changes

In methods in `JCache` where we're already checking if caching is enabled and the check isn't deeply integrated into other logic in the method, move the check to the beginning of the method and early return if we aren't caching (this prevents the need to instantiate a storage adapter and lessens the occurrence of that "Cache Storage not supported" message).  Also use the get method to make this check for better readability and needing to change less references if the options reference ever changed.
#### Testing Instructions

If caching is disabled, calls that result in `JCache::get()`, `JCache::getAll()`, or`JCache::store()` being triggered should not result in a call to `JCache::_getStorage()` or `JCacheStorage::getInstance()`.  Note this isn't a foolproof test, i.e. if something initializes cache locking first that will trigger a call to get a storage adapter.
