### PR TITLE
Move travis cs check to php7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ matrix:
     - php: 5.5
       env: INSTALL_APCU="yes"
     - php: 5.6
-      env: RUN_PHPCS="yes" INSTALL_APCU="yes"
+      env: INSTALL_APCU="yes"
     - php: 7.0
-      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: RUN_PHPCS="yes" INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm
       sudo: true
       dist: trusty


### PR DESCRIPTION
#### Summary of Changes

Just an idea.
In theory php 7.x is faster and uses less memory so move cs check to php 7.x build.
#### Testing Instructions

Code review
