### PR TITLE
Fix the ordering of articles and featured

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -241,7 +241,18 @@ class ContentModelArticle extends JModelAdmin
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$condition = 'catid = ' . (int) $table->catid . ' AND state >= 0';
+			$table->ordering = $table->getEarlierOrder($condition);
+
+			if ($table->ordering < 1)
+			{
+				// We have to reorder old ordering from 1,2,3, ...
+				// To ... ,2147483644, 2147483645, 2147483646
+				$table->reorder($condition);
+
+				// Get value again
+				$table->ordering = $table->getEarlierOrder($condition);
+			}
 		}
 	}
 
@@ -504,7 +515,7 @@ class ContentModelArticle extends JModelAdmin
 			$catid = CategoriesHelper::validateCategoryId($data['catid'], 'com_content');
 		}
 
-		// Save New Categoryg
+		// Save New Category
 		if ($catid == 0 && $this->canCreateCategory())
 		{
 			$table = array();
@@ -673,9 +684,22 @@ class ContentModelArticle extends JModelAdmin
 				// Featuring.
 				$tuples = array();
 
+				$ordering = $table->getEarlierOrder();
+
+				if ($ordering < 1)
+				{
+					// We have to reorder old ordering from 1,2,3, ...
+					// To ... ,2147483644, 2147483645, 2147483646
+					$table->reorder();
+
+					// Get value again
+					$ordering = $table->getEarlierOrder();
+				}
+
 				foreach ($new_featured as $pk)
 				{
-					$tuples[] = $pk . ', 0';
+					$tuples[] = $pk . ', ' . $ordering;
+					$ordering--;
 				}
 
 				if (count($tuples))
@@ -697,8 +721,6 @@ class ContentModelArticle extends JModelAdmin
 
 			return false;
 		}
-
-		$table->reorder();
 
 		$this->cleanCache();
 

--- a/administrator/components/com_content/tables/featured.php
+++ b/administrator/components/com_content/tables/featured.php
@@ -17,6 +17,14 @@ defined('_JEXEC') or die;
 class ContentTableFeatured extends JTable
 {
 	/**
+	 * Indicator that the column ordering use large numbers.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_large_ordering_numbers = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  &$db  Database connector object

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -117,6 +117,14 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	protected $_jsonEncode = array();
 
 	/**
+	 * Indicator that the column ordering use large numbers.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_large_ordering_numbers = false;
+
+	/**
 	 * Object constructor to set table and key fields.  In most cases this will
 	 * be overridden by child classes to explicitly set the table and key fields
 	 * for a particular database table.
@@ -1273,6 +1281,44 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 	}
 
 	/**
+	 * Method to get the earlier ordering value for a group of rows defined by an SQL WHERE clause.
+	 *
+	 * This is useful for placing a new item first in a group of items in the table.
+	 *
+	 * @param   string  $where  WHERE clause to use for selecting the MIN(ordering) for the table.
+	 *
+	 * @return  integer  The first free ordering value.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  UnexpectedValueException
+	 */
+	public function getEarlierOrder($where = '')
+	{
+		// If there is no ordering field set an error and return false.
+		if (!property_exists($this, 'ordering'))
+		{
+			throw new UnexpectedValueException(sprintf('%s does not support ordering.', get_class($this)));
+		}
+
+		// Get the least ordering value for a given where clause.
+		$query = $this->_db->getQuery(true)
+			->select('COALESCE(MIN(ordering), 2147483647)')
+			->from($this->_tbl)
+			->where('ordering >= 0');
+
+		if ($where)
+		{
+			$query->where($where);
+		}
+
+		$this->_db->setQuery($query);
+		$min = (int) $this->_db->loadResult();
+
+		// Return the first ordering value - 1.
+		return ($min - 1);
+	}
+
+	/**
 	 * Method to get the next ordering value for a group of rows defined by an SQL WHERE clause.
 	 *
 	 * This is useful for placing a new item last in a group of items in the table.
@@ -1354,12 +1400,15 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		$k = $this->_tbl_key;
 
+		// To use more efficient alternative sort in descending order
+		$order_by = $this->_large_ordering_numbers ? 'ordering DESC' : 'ordering';
+
 		// Get the primary keys and ordering values for the selection.
 		$query = $this->_db->getQuery(true)
 			->select(implode(',', $this->_tbl_keys) . ', ordering')
 			->from($this->_tbl)
 			->where('ordering >= 0')
-			->order('ordering');
+			->order($order_by);
 
 		// Setup the extra where and ordering clause data.
 		if ($where)
@@ -1370,19 +1419,24 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
 
+		// Last reserved number for alternative re-order
+		$last = 2147483647;
+
 		// Compact the ordering values.
 		foreach ($rows as $i => $row)
 		{
 			// Make sure the ordering is a positive integer.
 			if ($row->ordering >= 0)
 			{
+				$ordering = $this->_large_ordering_numbers ? ($last - $i - 1) : ($i + 1);
+
 				// Only update rows that are necessary.
-				if ($row->ordering != $i + 1)
+				if ($row->ordering != $ordering)
 				{
 					// Update the row ordering field.
 					$query->clear()
 						->update($this->_tbl)
-						->set('ordering = ' . ($i + 1));
+						->set('ordering = ' . $ordering);
 					$this->appendPrimaryKeys($query, $row);
 					$this->_db->setQuery($query);
 					$this->_db->execute();

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -20,6 +20,14 @@ use Joomla\Registry\Registry;
 class JTableContent extends JTable
 {
 	/**
+	 * Indicator that the column ordering use large numbers.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_large_ordering_numbers = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object


### PR DESCRIPTION
Pull Request for Issue #11103.
#### Summary of Changes

Fix the ordering of articles and do not loose performance.

Notice:
I do not know does 2147483647 is good number to be max of ordering field (look at code) across all database types?
#### Testing Instructions

[UPDATED]

1) Download and Install Joomla 3.6.0 with sample data "test", "testing" or something like that
2) Install [com_patchtester.zip](https://github.com/joomla-extensions/patchtester/releases/tag/2.0.1) latest stable version
3) On backend go to Menu -> All Front End Views -> Featured Articles
4) In layout search for "Category Order" and change to "No Order". Article Order should be set to "Featured Article Order"
5) Go to `/index.php/featured-articles`

6) Back to backend and add a new article with title "Featured 1".
7) Set it as featured. Category could be "Uncategorised"
8) Go to `/administrator/index.php?option=com_content&view=featured`
9) Change select box "Sort Table by:" to "Ordering ascending"
10) Your new added article "Featured 1" should be at the bottom
11) Go to `/index.php/featured-articles` and try to find your article "Featured 1", should at the end

11) Go to `/administrator/index.php?option=com_patchtester`
12) Fetch Data
13) Search for "Fix the ordering of articles and featured"
14) Apply Patch 11139

15) Add next article with title "Featured 2", set as featured. Category could be "Uncategorised"
16) Go to `/administrator/index.php?option=com_content&view=featured`
17) Sort Table by should be "Ordering ascending"

18) Now "Featured 2" is on the top and "Featured 1" is the last one.
19) Go to `/index.php/featured-articles` and try to find your article "Featured 2", should at the top

20) Go back to `/administrator/index.php?option=com_content&view=featured` and reorder "Featured 1" to the first place.
21) Go to `/index.php/featured-articles` and "Featured 1" and "Featured 2" should at the top.

22) You can do a few more detailed test if you like to.
