### PR TITLE
fix for issue if for what ever reason a empty string is sent to the r…

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -480,7 +480,7 @@ class JApplicationWeb extends JApplicationBase
 	public function redirect($url, $status = 303)
 	{
 		// Check for relative internal links.
-		if (preg_match('#^index\.php#', $url))
+		if (empty($url) || preg_match('#^index\.php#', $url))
 		{
 			// We changed this from "$this->get('uri.base.full') . $url" due to the inability to run the system tests with the original code
 			$url = JUri::base() . $url;


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes
#### Testing Instructions

…edirect function.

if ($url[0] == '/')... generates an error

PHP Notice: Uninitialized string offset: 0 in .../libraries/joomla/application/web.php on line 509

adding a check for empty $url fixes that.

not sure if this is correct way to add it.
