### PR TITLE
Make the tag parameters available

### DIFF
--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -23,7 +23,9 @@ abstract class ModTagsPopularHelper
 	 *
 	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
-	 * @return mixed
+	 * @return  mixed
+	 *
+	 * @since   3.1
 	 */
 	public static function getList(&$params)
 	{
@@ -42,7 +44,8 @@ abstract class ModTagsPopularHelper
 					'MAX(' . $db->quoteName('tag_id') . ') AS tag_id',
 					' COUNT(*) AS count', 'MAX(t.title) AS title',
 					'MAX(' . $db->quoteName('t.access') . ') AS access',
-					'MAX(' . $db->quoteName('t.alias') . ') AS alias'
+					'MAX(' . $db->quoteName('t.alias') . ') AS alias',
+					'MAX(' . $db->quoteName('t.params') . ') AS params',
 				)
 			)
 			->group($db->quoteName(array('tag_id', 'title', 'access', 'alias')))


### PR DESCRIPTION
#### Summary of Changes

When rendering tags with the module mod_tags_popular it is not possible to access the settings of the tag itself such as the class of that specific tag. This pull request adds the stored parameters as an option that can be used.

Use-case: styling of tags using the class set for this particular tag.
#### Testing Instructions
1. Go to Components -> Tags
2. Edit a tag and set a value in the  **CSS Class for tag link** field
3. Save the tag
4. Open the file modules\mod_tags_popular\tmpl\default.php
5. Check the content of $item, the class value is not available anywhere
6. Apply pull request
7. Check the content of $item, the param value is now available

The parameters can now be used as:

``` php
$tagParams = new \Joomla\Registry\Registry($item->params);
$link_class = $tagParams->get('tag_link_class');
```

@designbengel This one is for you :)
