### PR TITLE
Fix for subform field: fix default value for "max" and "groupByFieldset"

### DIFF
--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -121,12 +121,18 @@ class JFormFieldSubform extends JFormField
 				break;
 
 			case 'max':
-				$this->max = max(1, (int) $value);
+				if ($value)
+				{
+					$this->max = max(1, (int) $value);
+				}
 				break;
 
 			case 'groupByFieldset':
-				$value = (string) $value;
-				$this->groupByFieldset = !($value === 'false' || $value === 'off' || $value === '0');
+				if ($value !== null)
+				{
+					$value = (string) $value;
+					$this->groupByFieldset = !($value === 'false' || $value === 'off' || $value === '0');
+				}
 				break;
 
 			case 'layout':


### PR DESCRIPTION
#### Summary of Changes

This fix a default values for "max" and "groupByFieldset" properties, for subform field.
#### Testing Instructions

Use "Custom HTML" module and add subform field into the module xml:

``` xml
<field name="field-name" type="subform" formsource="modules/mod_custom/test1.xml" 
   multiple="true"  label="Subform Field" description="Subform Field Description" />
```

and create simple form xml in modules/mod_custom/test1.xml:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<form>
    <field name="test_text" type="text"
        label="test_text" description="test_text" />

    <field name="test_textarea" type="textarea"
        label="textarea"   />
</form>
```

**expected result**
You should see the subform inputs, with possibility to add new row.

**actuall result**
the subform is empty, and you can add only one row
