### PR TITLE
[com_menus] items list view: show menu type title instead of menu type

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_items.xml
+++ b/administrator/components/com_menus/models/forms/filter_items.xml
@@ -78,8 +78,8 @@
 			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="a.menutype ASC">COM_MENUS_HEADING_MENU_ASC</option>
-			<option value="a.menutype DESC">COM_MENUS_HEADING_MENU_DESC</option>
+			<option value="menutype_title ASC">COM_MENUS_HEADING_MENU_ASC</option>
+			<option value="menutype_title DESC">COM_MENUS_HEADING_MENU_DESC</option>
 			<option value="a.home ASC">COM_MENUS_HEADING_HOME_ASC</option>
 			<option value="a.home DESC">COM_MENUS_HEADING_HOME_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -245,7 +245,6 @@ class MenusModelItems extends JModelList
 		$query->select($db->quoteName('mt.title', 'menutype_title'))
 			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'));
 
-
 		// Join over the associations.
 		$assoc = JLanguageAssociations::isEnabled();
 

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -30,7 +30,7 @@ class MenusModelItems extends JModelList
 		{
 			$config['filter_fields'] = array(
 				'id', 'a.id',
-				'menutype', 'a.menutype',
+				'menutype', 'a.menutype', 'menutype_title',
 				'title', 'a.title',
 				'alias', 'a.alias',
 				'published', 'a.published',
@@ -240,6 +240,11 @@ class MenusModelItems extends JModelList
 		// Join over the asset groups.
 		$query->select('ag.title AS access_level')
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
+
+		// Join over the menu types.
+		$query->select($db->quoteName('mt.title', 'menutype_title'))
+			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'));
+
 
 		// Join over the associations.
 		$assoc = JLanguageAssociations::isEnabled();

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -78,7 +78,7 @@ if ($menuType == '')
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_MENU', 'a.menutype', $listDirn, $listOrder); ?>
+							<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_MENU', 'menutype_title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="5%" class="center nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_HOME', 'a.home', $listDirn, $listOrder); ?>
@@ -203,7 +203,7 @@ if ($menuType == '')
 							</div>
 						</td>
 						<td class="small hidden-phone">
-							<?php echo $this->escape($item->menutype); ?>
+							<?php echo $this->escape($item->menutype_title); ?>
 						</td>
 						<td class="center hidden-phone">
 							<?php if ($item->type == 'component') : ?>


### PR DESCRIPTION
#### Summary of Changes

For consistency, changes the menu type to Menu Type Title in the menu items list view.
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/16897530/fe14ef6e-4bab-11e6-81c6-fdd578cb7157.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/16897526/e20663a2-4bab-11e6-8a51-e46d032796be.png)
#### Testing Instructions

Easy test:
- Use latest staging
- Apply patch
- Go to menus and check the "Menu" column now shows the Menu Type Title, instead of the menu type.
