### PR TITLE
REGRESSION: [language filter plugin] 301 redirect without caching in browser

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -378,8 +378,11 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 
-			$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-			$this->app->setHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT');
+			// Don't cache the redirect in browser.
+			$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
+			$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+			$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+			$this->app->setHeader('Pragma', 'no-cache');
 			$this->app->sendHeaders();
 
 			if ($this->mode_sef)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -378,6 +378,10 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 
+			$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+			$this->app->setHeader('Expires', 'Mon, 26 Jul 1997 05:00:00 GMT');
+			$this->app->sendHeaders();
+
 			if ($this->mode_sef)
 			{
 				// Use the current language sef or the default one.


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11159 and https://github.com/joomla/joomla-cms/issues/11143.
#### Summary of Changes

Adds HTTP headers to not cache in browsers the language filter plugin 301 redirect.

The problem was created by https://github.com/joomla/joomla-cms/pull/8894.
#### Testing Instructions

See https://github.com/joomla/joomla-cms/issues/11159 and https://github.com/joomla/joomla-cms/issues/11143.

pinging @infograf768 and @ggppdk
