### PR TITLE
Correct model helpers include paths (com_menus item, com_user debuguser and debuggroup)

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\Registry\Registry;
 
 jimport('joomla.filesystem.path');
-require_once JPATH_COMPONENT . '/helpers/menus.php';
+JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/content.php');
 
 /**
  * Menu Item Model for Menus.

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\Registry\Registry;
 
 jimport('joomla.filesystem.path');
-JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/content.php');
+JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 
 /**
  * Menu Item Model for Menus.

--- a/administrator/components/com_users/models/debuggroup.php
+++ b/administrator/components/com_users/models/debuggroup.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_COMPONENT . '/helpers/debug.php';
+JLoader::register('UsersHelperDebug', JPATH_ADMINISTRATOR . '/components/com_users/helpers/debug.php');
 
 /**
  * Methods supporting a list of user records.

--- a/administrator/components/com_users/models/debuguser.php
+++ b/administrator/components/com_users/models/debuguser.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-require_once JPATH_COMPONENT . '/helpers/debug.php';
+JLoader::register('UsersHelperDebug', JPATH_ADMINISTRATOR . '/components/com_users/helpers/debug.php');
 
 /**
  * Methods supporting a list of user records.


### PR DESCRIPTION
#### Summary of Changes

The include helper path in com_menus item, com_users debuguser and com_users debuggroup is not correct and when loading the model will generate a **php fatal error**.
#### Testing Instructions
- Use latest staging
- Add this lines to isis index.php

``` php
JLoader::register('MenusModelItem', JPATH_ADMINISTRATOR . '/components/com_menus/models/item.php');
$model = JModelLegacy::getInstance('Item', 'MenusModel', array('ignore_request' => true));

JLoader::register('UsersModelDebugUser', JPATH_ADMINISTRATOR . '/components/com_users/models/debuguser.php');
$model = JModelLegacy::getInstance('DebugUser', 'UsersModel', array('ignore_request' => true));

JLoader::register('UsersModelDebuggroup', JPATH_ADMINISTRATOR . '/components/com_users/models/debuggroup.php');
$model = JModelLegacy::getInstance('Debuggroup', 'UsersModel', array('ignore_request' => true));
```
- Try to load any admin page. You get a Fatal error, you'll notice in the fatal error the patch where is trying to laod the helper is not correct.

```
Warning: require_once(/path/to/joomla-staging/administrator/components/com_xxxxxx/helpers/menus.php): failed to open stream: No such file or directory in /path/to/joomla-staging/administrator/components/com_menus/models/item.php on line 15
Fatal error: require_once(): Failed opening required '/path/to/joomla-staging/administrator/components/com_xxxxxx/helpers/menus.php' (include_path='/path/to/joomla-staging/') in /path/to/joomla-staging/administrator/components/com_menus/models/item.php on line 15
```
- Apply this patch
- Repeat process and confirm no fatal error now.
- Check menu itmes works fine and debuguser and debuggroup work fine too
- Do a simple code review (3 lines of code).
#### Notes

This problem was discovered when trying to load the menu items model in the GsoC 2016 Improved Multi-lingual Content Management
