### PR TITLE
Routing: Remove IDs from tags URLs, use menu item of tags view as default for tag view

### DIFF
--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -94,6 +94,14 @@ class TagsHelperRoute extends JHelperRoute
 			{
 				$link .= '&Itemid=' . $item;
 			}
+			else
+			{
+				$needles = array('tags' => array(0));
+				if ($item = self::_findItem($needles))
+				{
+					$link .= '&Itemid=' . $item;
+				}
+			}
 		}
 
 		return $link;
@@ -152,6 +160,10 @@ class TagsHelperRoute extends JHelperRoute
 									self::$lookup[$lang][$view][$item->query['id'][$position]] = $item->id;
 								}
 							}
+						}
+						elseif ($view == 'tags')
+						{
+							self::$lookup[$lang]['tags'][] = $item->id;
 						}
 					}
 				}

--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -96,12 +96,36 @@ class TagsHelperRoute extends JHelperRoute
 			}
 			else
 			{
-				$needles = array('tags' => array(0));
+				$needles = array('tags' => array(1, 0));
+
 				if ($item = self::_findItem($needles))
 				{
 					$link .= '&Itemid=' . $item;
 				}
 			}
+		}
+
+		return $link;
+	}
+
+	/**
+	 * Tries to load the router for the tags view.
+	 *
+	 * @return  string  URL link to pass to JRoute
+	 *
+	 * @since   3.7
+	 */
+	public static function getTagsRoute()
+	{
+		$needles = array(
+			'tags'  => array(0)
+		);
+
+		$link = 'index.php?option=com_tags&view=tags';
+
+		if ($item = self::_findItem($needles))
+		{
+			$link .= '&Itemid=' . $item;
 		}
 
 		return $link;

--- a/components/com_tags/router.php
+++ b/components/com_tags/router.php
@@ -103,8 +103,8 @@ class TagsRouter extends JComponentRouterBase
 		for ($i = 0; $i < $total; $i++)
 		{
 			$segments[$i] = str_replace(':', '-', $segments[$i]);
+			$position     = strpos($segments[$i], '-');
 
-			$position = strpos($segments[$i], '-');
 			if ($position)
 			{
 				// Remove id from segment
@@ -162,15 +162,14 @@ class TagsRouter extends JComponentRouterBase
 	 *
 	 * @return  string  The segment with founded id
 	 *
-	 * @since   3.6.1
+	 * @since   3.7
 	*/
 	protected function fixSegment($segment)
 	{
 		$db = JFactory::getDbo();
 
-		// Find or confirm tag id
-		$parts = explode(':', $segment, 2);
-		$alias = implode('-', $parts);
+		// Try to find tag id
+		$alias = str_replace(':', '-', $segment);
 
 		$query = $db->getQuery(true)
 			->select('id')
@@ -178,23 +177,6 @@ class TagsRouter extends JComponentRouterBase
 			->where($db->quoteName('alias') . " = " . $db->quote($alias));
 
 		$id = $db->setQuery($query)->loadResult();
-
-		if (!$id && ctype_digit($parts[0]))
-		{
-			// Alias contains id prefix - old way B/C
-			$alias = $parts[1];
-
-			$query->clear('where')
-				->where($db->quoteName('alias') . " = " . $db->quote($alias));
-
-			$id = $db->setQuery($query)->loadResult();
-
-			if ($parts[0] !== $id)
-			{
-				// Id with incorrect alias
-				return $segment;
-			}
-		}
 
 		if ($id)
 		{


### PR DESCRIPTION
Pull Request for Issue #11163.
### Summary of changes
- Remove tag id from SEF URL, but it is B/C.
- Treat (second menu item to view=tags if exists or) first menu item for tags as default menu item for tag view.

If tags list does not have any menu item then
replace 
`/component/tags/tag/123-mytag`
to
~~`/component/tags/mytag`~~
`/component/tags/tag/mytag`

If we have menu item with /tags alias for tags view:
then PR replace 
`/tags/tag/123-mytag`
to  
`/tags/mytag`

If we have second menu item with alias="tag"
then:
replace 
`/tags/tag/123-mytag`
to  
`/tag/mytag`

but link to list of tags is:
`/tags`
### Testing Instructions

Create a few tags and content with tags and test front end URLs.
### Documentation Changes Required

I do not know but there is one thing that can surprise.
#### Tag route changes:
1. First as usual we try to find menu item for a tag.
2. If menu item for the tag does not exists then:
   - try to find **second** menu item for view=tags, (ex. tag/...)
   - if not exists then try to find **first** menu item for view=tags. (ex. tags/...)  
