### PR TITLE
Reorder tables with single SQL query (all DBs compatible), greatly improving reorder performance

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -239,7 +239,7 @@ class ContentModelArticle extends JModelAdmin
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$table->ordering = $table->getNextOrder('catid = ' . (int) $table->catid . ' AND state >= 0');
 		}
 	}
 
@@ -659,10 +659,12 @@ class ContentModelArticle extends JModelAdmin
 
 				// Featuring.
 				$tuples = array();
+				$ordering = $table->getNextOrder();
 
 				foreach ($new_featured as $pk)
 				{
-					$tuples[] = $pk . ', 0';
+					$tuples[] = $pk . ', ' . $ordering;
+					$ordering++;
 				}
 
 				if (count($tuples))
@@ -683,8 +685,6 @@ class ContentModelArticle extends JModelAdmin
 
 			return false;
 		}
-
-		$table->reorder();
 
 		$this->cleanCache();
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -239,7 +239,7 @@ class ContentModelArticle extends JModelAdmin
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->ordering = $table->getNextOrder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
 		}
 	}
 
@@ -659,12 +659,10 @@ class ContentModelArticle extends JModelAdmin
 
 				// Featuring.
 				$tuples = array();
-				$ordering = $table->getNextOrder();
 
 				foreach ($new_featured as $pk)
 				{
-					$tuples[] = $pk . ', ' . $ordering;
-					$ordering++;
+					$tuples[] = $pk . ', 0';
 				}
 
 				if (count($tuples))
@@ -685,6 +683,8 @@ class ContentModelArticle extends JModelAdmin
 
 			return false;
 		}
+
+		$table->reorder();
 
 		$this->cleanCache();
 

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1372,11 +1372,13 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
 
-		// Reorder configuration
+		// Reorder configuration,
 		$uses_single_key = count($this->_tbl_keys) == 1;
-		$pk_is_int = false;    // TODO check DB schema and if pk column is integer do not quote ! (minor/medium performance concern)
-		$max_recs = 10000;     // Update in 10,000 records steps, default server config should support 50,000+ records anyway e.g. mySQL has default 1MByte packet size or more
 		$keyname = $this->_tbl_key;
+
+		// Update in 10,000 records steps, default server config should support 50,000+ records anyway e.g. mySQL has default 1MB packet size
+		$max_recs = 10000;
+		$key_is_int = false;
 
 		// Reorder data and counters
 		$when_clauses = array();
@@ -1399,9 +1401,9 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 						{
 							$step++;
 						}
-						$pk = $pk_is_int ? $row->$keyname : $this->_db->quote($row->$keyname); // TODO check DB schema and if pk column is integer do not quote ! (minor/medium performance concern)
+						$pk = $key_is_int ? $row->$keyname : $this->_db->quote($row->$keyname);
 						$order_pks[$step][] = $pk;
-						$when_clauses[$step][] = ' WHEN '.$pk.' THEN '.($i + 1);
+						$when_clauses[$step][] = ' WHEN ' . $pk . ' THEN ' . ($i + 1);
 					}
 					else
 					{
@@ -1423,12 +1425,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			$_tbl = $this->_db->quoteName($this->_tbl);
 			$_tblkey = $this->_db->quoteName($this->_tbl_key);
 
-			foreach($when_clauses as $step => $clauses)
+			foreach ($when_clauses as $step => $clauses)
 			{
 				$query = 'UPDATE ' . $_tbl . ' SET ordering = CASE ' . $_tblkey
 					. implode(' ', $when_clauses[$step])
-					.' END '
-					.' WHERE ' . $_tblkey . ' IN ('. implode(',', $order_pks[$step]) .')';
+					. ' END '
+					. ' WHERE ' . $_tblkey . ' IN (' . implode(',', $order_pks[$step]) . ')';
 
 				$this->_db->setQuery($query);
 				$this->_db->execute();

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1371,6 +1371,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
+
 		// Reorder configuration
 		$uses_single_key = count($this->_tbl_keys) == 1;
 		$pk_is_int = false;    // TODO check DB schema and if pk column is integer do not quote ! (minor/medium performance concern)

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1372,7 +1372,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		$this->_db->setQuery($query);
 		$rows = $this->_db->loadObjectList();
 		// Reorder configuration
-		$uses_single_key = count($this->_tbl_keys == 1);
+		$uses_single_key = count($this->_tbl_keys) == 1;
 		$pk_is_int = false;    // TODO check DB schema and if pk column is integer do not quote ! (minor/medium performance concern)
 		$max_recs = 10000;     // Update in 10,000 records steps, default server config should support 50,000+ records anyway e.g. mySQL has default 1MByte packet size or more
 		$keyname = $this->_tbl_key;

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1420,11 +1420,11 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 		// Update in 'max_recs' records steps, e.g. 10,000 records per step
 		if ($uses_single_key)
 		{
+			$_tbl = $this->_db->quoteName($this->_tbl);
+			$_tblkey = $this->_db->quoteName($this->_tbl_key);
+
 			foreach($when_clauses as $step => $clauses)
 			{
-				$_tbl = $this->_db->quoteName($this->_tbl);
-				$_tblkey = $this->_db->quoteName($this->_tbl_key);
-
 				$query = 'UPDATE ' . $_tbl . ' SET ordering = CASE ' . $_tblkey
 					. implode(' ', $when_clauses[$step])
 					.' END '


### PR DESCRIPTION
**Performance fix** for JTable::reorder(),
- fixes performance issue on new article save: #10567
- ~~greatly improves performance / race condition issues on drag and drop reordering and break-up: #4303~~

It should work in all Database servers, since it uses **case/when/then/else/end expression**,  (SQL-92)
#### Summary of Changes
- Replace multiple reordering SQL queries with a single query
- Thus updates 10,000 records per query during re-ordering
#### Testing Instructions

1 - Applying PR to **latest staging**
2 - It helps to make the per row ORDER inputs visible, to do it add CSS to your backend template file:   **/templates/isis/css/template.css**

```
.text-area-order, .sortable-handler + input {
  display: inline !important;  width: 40px; text-align: right;
}
```

You may want to add just before JTable::reorder() final return;
https://github.com/joomla/joomla-cms/pull/11184/files#diff-8254e2c441a41d3fa26f0f83fbbb3043R1431

```
JFactory::getApplication()->enqueueMessage('<b>reorder()</b>:<br/>'.$query, 'message');
```
1. Then create new article 
2. Click "Save and close" (not "Save", since we want to see the enqueued message and also list the orderings in article manager) see an example in picture

![table_reorder_single_query](https://cloud.githubusercontent.com/assets/5092940/16932698/c9703da8-4d50-11e6-9d12-f0e983f62494.png)
