### PR TITLE
TinyMCE init() issue #11190

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -129,7 +129,7 @@ class PlgEditorTinymce extends JPlugin
 		$language = JFactory::getLanguage();
 		$mode     = (int) $this->params->get('mode', 1);
 		$theme    = 'modern';
-		$idField  = str_replace('[', '_', substr($name, 0, -1));
+		$id       = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
 
 		// List the skins
 		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);


### PR DESCRIPTION
Pull Request for Issue #11190  .
#### Summary of Changes

The `$idField` variable is never used throughout the code, seems to be an attempt to sanitize the `$id`. I've added some more filtering to produce a usable id. Should work for multiple editors as well.
#### Testing Instructions

Testing instructions can be found in the issue description.
