### PR TITLE
Add PHP 7.1 to Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       env: RUN_PHPCS="yes" INSTALL_APCU="yes"
     - php: 7.0
       env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+    - php: 7.1
+      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
     - php: hhvm
       sudo: true
       dist: trusty
@@ -39,6 +41,7 @@ matrix:
         - redis-server
       env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
+    - php: 7.1
     - php: hhvm
 
 services:

--- a/build/travis/phpenv/apcu-7.1.ini
+++ b/build/travis/phpenv/apcu-7.1.ini
@@ -1,0 +1,2 @@
+apc.enabled=true
+apc.enable_cli=true


### PR DESCRIPTION
PHP 7.1 is available on Travis-CI for testing.  Adding it as an allowed failure to our test matrix.

Note that on my test run, PHPUnit segfaulted, and the issue probably won't be fixed because PHPUnit 4.8 technically wasn't declared compatible with PHP 7 IIRC.  Shouldn't prevent this being added since it's in the allowed failure category.
