### PR TITLE
System template with just component's output

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1,9 +1,3 @@
-/* Hey #joomlers, 
-*  this dummy text is part of a example for a blog post about contributing to Joomla core.
-*  
-*  Please ignore it! 
-*/
-
 article,
 aside,
 details,

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1,3 +1,9 @@
+/* Hey #joomlers, 
+*  this dummy text is part of a example for a blog post about contributing to Joomla core.
+*  
+*  Please ignore it! 
+*/
+
 article,
 aside,
 details,

--- a/templates/system/ajax.php
+++ b/templates/system/ajax.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Template.system
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+?>
+
+<jdoc:include type="message" />
+<jdoc:include type="component" />


### PR DESCRIPTION
Pull Request for Issue #11202 .
#### Summary of Changes

Create a template file to get only the componet's output.
#### Testing Instructions

Add `?tmpl=ajax` at the end of the URL i.e. `www.site.any/alias-example?tmpl=ajax`
The component's HTML should be available with no html, head, body tags.
