### PR TITLE
[language filter] Review HTTP redirect codes

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -401,13 +401,36 @@ class PlgSystemLanguageFilter extends JPlugin
 					$uri->setPath('index.php/' . $uri->getPath());
 				}
 
-				$this->app->redirect($uri->base() . $uri->toString(array('path', 'query', 'fragment')), 301);
+				$redirectUri = $uri->base() . $uri->toString(array('path', 'query', 'fragment'));
 			}
 			else
 			{
 				$uri->setVar('lang', $this->lang_codes[$lang_code]->sef);
-				$this->app->redirect($uri->base() . 'index.php?' . $uri->getQuery(), 301);
+				$redirectUri = $uri->base() . 'index.php?' . $uri->getQuery();
 			}
+
+			// Set redirect HTTP code to "302 Found".
+			$redirectHttpCode = 302;
+
+			// If selected language is the default language redirect code is "301 Moved Permanently".
+			if ($lang_code === $this->default_lang)
+			{
+				$redirectHttpCode = 301;
+			
+				// If configured to always use a sef prefix for default language we cannot cache this redirect in browser.
+				// 301 is cachable by default so we need to force to not cache it in browsers.
+				if ((int) $this->params->get('remove_default_prefix', 0) === 0)
+				{
+					$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
+					$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+					$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+					$this->app->setHeader('Pragma', 'no-cache');
+					$this->app->sendHeaders();
+				}
+			}
+			
+			// Redirect to language.
+			$this->app->redirect($redirectUri, $redirectHttpCode);
 		}
 
 		// We have found our language and now need to set the cookie and the language value in our system


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11165.
#### Summary of Changes

This PR reviews the HTTP status code of the redirects in the language filter plugins (current all are non cached 301 Moved Permanently).

After this PR the behaviour is the following:
- `/defaultlang*` to `/*` (remove language code is set to Yes) = 301 Moved Permanently
- `/*` to `/defaultlang*` (remove language code is set to No)  = 301 Moved Permanently (not cached)
- `/*` to `/otherlang*` (cookie language based redirect) = 302 Found
#### Testing Instructions
1. Use latest staging
2. Apply patch
3. Test in a multilanguage site the behaviour described above by testing all combinations in global config (SEF / non SEF / etc) and language filter plugin parameters.
4. Do a code review
#### More info

See discussion in https://github.com/joomla/joomla-cms/pull/11196
