### PR TITLE
[ACL] Don't allow to create tags if user is not allowed to do it

### DIFF
--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -110,6 +110,12 @@ class ContentViewForm extends JViewLegacy
 			$this->form->setFieldAttribute('language', 'default', $lang);
 		}
 
+		// If user not allowed to create tags, don't allow.
+		if (!$user->authorise('core.create', 'com_tags'))
+		{
+			$this->form->setFieldAttribute('tags', 'custom', 'deny');
+		}
+
 		$this->_prepareDocument();
 		parent::display($tpl);
 	}

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -110,12 +110,6 @@ class ContentViewForm extends JViewLegacy
 			$this->form->setFieldAttribute('language', 'default', $lang);
 		}
 
-		// If user not allowed to create tags, don't allow.
-		if (!$user->authorise('core.create', 'com_tags'))
-		{
-			$this->form->setFieldAttribute('tags', 'custom', 'deny');
-		}
-
 		$this->_prepareDocument();
 		parent::display($tpl);
 	}

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -210,7 +210,7 @@ class JHelperTags extends JHelper
 			foreach ($tags as $key => $tag)
 			{
 				// User is not allowed to create tags, so don't create.
-				if (strpos($tag, '#new#') !== false && JFactory::getUser()->authorise('core.create', 'com_tags'))
+				if (strpos($tag, '#new#') !== false && !JFactory::getUser()->authorise('core.create', 'com_tags'))
 				{
 					continue;
 				}

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -209,6 +209,12 @@ class JHelperTags extends JHelper
 
 			foreach ($tags as $key => $tag)
 			{
+				// User is not allowed to create tags, so don't create.
+				if (strpos($tag, '#new#') !== false && JFactory::getUser()->authorise('core.create', 'com_tags'))
+				{
+					continue;
+				}
+
 				// Remove the #new# prefix that identifies new tags
 				$tagText = str_replace('#new#', '', $tag);
 

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -204,13 +204,14 @@ class JHelperTags extends JHelper
 		{
 			// We will use the tags table to store them
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tags/tables');
-			$tagTable = JTable::getInstance('Tag', 'TagsTable');
-			$newTags = array();
+			$tagTable  = JTable::getInstance('Tag', 'TagsTable');
+			$newTags   = array();
+			$canCreate = JFactory::getUser()->authorise('core.create', 'com_tags');
 
 			foreach ($tags as $key => $tag)
 			{
 				// User is not allowed to create tags, so don't create.
-				if (strpos($tag, '#new#') !== false && !JFactory::getUser()->authorise('core.create', 'com_tags'))
+				if (strpos($tag, '#new#') !== false && !$canCreate)
 				{
 					continue;
 				}

--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -170,7 +170,7 @@ abstract class JHtmlTag
 		$displayData = array(
 			'minTermLength' => $minTermLength,
 			'selector'      => $selector,
-			'allowCustom'   => $allowCustom
+			'allowCustom'   => JFactory::getUser()->authorise('core.create', 'com_tags') ? $allowCustom : false,
 		);
 
 		JLayoutHelper::render('joomla.html.tag', $displayData);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11154.
#### Summary of Changes

Add com_tags core.create ACL check in tags fields.
#### Testing Instructions
- Use latest staging
- Create a user that is not allowed to create tags. "Denied" in create com_tags permissions.
- Login with that user  and try to edit an article and try to add a new tag. You can.
  ![image](https://cloud.githubusercontent.com/assets/9630530/17054102/32bd236c-4ffd-11e6-814d-0efce0774880.png)
- Apply patch
- Repeat the same steps, you CAN'T create tags.
- Now change the permission to "Allowed" in create com_tags permissions.
- Repeat the same steps, you CAN create tags.
- Do a code review

Note: try in the frontend and backend
