### PR TITLE
Fix last menu items not accessible on small viewport height (Isis) & improve menu scrolling

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -69,16 +69,34 @@
 		/**
 		 * Append submenu items to empty UL on hover allowing a scrollable dropdown
 		 */
-		var menuScroll = $('#menu > li > ul')
-		var emptyMenu  = $('#nav-empty');
-		var menuWidth;
+		var menuScroll = $('#menu > li > ul'),
+			emptyMenu  = $('#nav-empty');
 
-		$('#menu > li > a').on('click mouseenter', function() {
+		$('#menu > li').on('click mouseenter', function() {
 
+			// Set max-height (and width if scroll) for dropdown menu, depending of window height
+			var $dropdownMenu    = $(this).children('ul'),
+				windowHeight     = $w.height(),
+				linkHeight       = $(this).outerHeight(true),
+				statusHeight     = $('#status').outerHeight(true),
+				menuHeight       = $dropdownMenu.height(),
+				menuOuterHeight  = $dropdownMenu.outerHeight(true),
+				scrollMenuWidth  = $dropdownMenu.width() + 15,
+				maxHeight        = windowHeight - (linkHeight + statusHeight + (menuOuterHeight - menuHeight) + 20);
+
+			if (maxHeight < menuHeight) {
+				$dropdownMenu.css('width', scrollMenuWidth);
+			} else if (maxHeight > menuHeight) {
+				$dropdownMenu.css('width', 'auto');
+			}
+
+			$dropdownMenu.css('max-height', maxHeight);
+
+			// Get the submenu position
 			linkWidth        = $(this).outerWidth(true);
-			menuWidth        = $(this).next('ul').width();
-			linkPaddingLeft  = $(this).css('padding-left');
-			offsetLeft       = Math.round($(this).parents('li').offset().left) - parseInt(linkPaddingLeft);
+			menuWidth        = $dropdownMenu.width();
+			linkPaddingLeft  = $(this).children('a').css('padding-left');
+			offsetLeft       = Math.round($(this).offset().left) - parseInt(linkPaddingLeft);
 
 			emptyMenu.empty().hide();
 
@@ -86,11 +104,12 @@
 
 		menuScroll.find('.dropdown-submenu > a').on('mouseover', function() {
 
-			var $self        = $(this);
-			var dropdown     = $self.next('ul');
-			var submenuWidth = dropdown.outerWidth();
-			var offsetTop    = $self.offset().top;
-			var scroll       = $w.scrollTop() + 8;
+			var $self           = $(this),
+				dropdown        = $self.next('ul'),
+				submenuWidth    = dropdown.outerWidth(),
+				offsetTop       = $self.offset().top,
+				linkPaddingTop  = parseInt(dropdown.css('padding-top')) + parseInt($(this).css('padding-top')),
+				scroll          = $w.scrollTop() + linkPaddingTop;
 
 			// Set the submenu position
 			if ($('html').attr('dir') == 'rtl')


### PR DESCRIPTION
#### Summary of Changes
- Fix accessibility of last menu items of each dropdown if window viewport height is too small to display the full menu and viewport height is less than <code>570px</code>
- Set dynamically <code>max-height</code> for the dropdown menu to adapt window vierport height.
- Set dynamically the <code>padding-top</code> for the submenus (replace <code>8</code> value for offset top by getting parent menu link and dropdown padding-top)
#### Testing Instructions
- Apply Patch
- Clear all caches (admin and browser)
- Resize your window in order to hide bottom of one or more dropdown menu when opened
- Mouse over the dropdown, with patch applied, the scrolling will be automatically added if needed (without patch, not possible to access last items of the dropdown)
- Check if submenu position top is still align with the menu dropdown
- Play a bit with different window heights to check if behavior is working as expected : last menu items always accessible when hovering the menu)

**Before Patch on latest staging** : 
(to take into account last changes for submenu dynamic position when outside the viewport: #11080 )
![capture d ecran 2016-07-20 a 16 37 42](https://cloud.githubusercontent.com/assets/2385058/16990698/43f90c1e-4e99-11e6-8806-7e92517bd31b.png)

**After Patch** : 
![capture d ecran 2016-07-20 a 16 51 34](https://cloud.githubusercontent.com/assets/2385058/16990981/4e936fa6-4e9a-11e6-99ab-2d76a01c8e93.png)

cc/ @C-Lodder 
