### PR TITLE
If article page does not exist, throw 404

### DIFF
--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -82,6 +82,11 @@ class PlgContentPagebreak extends JPlugin
 		// Simple performance check to determine whether bot should process further.
 		if (JString::strpos($row->text, 'class="system-pagebreak') === false)
 		{
+			if ($page > 0)
+			{
+				throw new Exception(JText::_('JERROR_PAGE_NOT_FOUND'), 404);
+			}
+			
 			return true;
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

This is in addition to https://github.com/joomla/joomla-cms/pull/5306 which was merged some time ago. While that pull request fixed issue with invalid article pages when article still had some pages, there was still a problem if you would completely remove page breaks from an article, because then the exception would never be thrown, it was too low in the code. Now if plugin detects that there are no pagebreaks in the article body, it will also additionaly check if there is a request for a subpage, and if yes throw 404.
#### Testing Instructions

To test, try opening some article that does not have page breaks and add to the end of the url ?start=xx where xx is any number. You should see the article normally. Apply the patch and make sure the same link gives 404 page.
