### PR TITLE
Add connection to pg_query

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -138,8 +138,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		}
 
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
-		pg_query('SET standard_conforming_strings=off');
-		pg_query('SET escape_string_warning=off');
+		pg_query($this->connection,'SET standard_conforming_strings=off');
+		pg_query($this->connection,'SET escape_string_warning=off');
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -138,8 +138,8 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		}
 
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
-		pg_query($this->connection,'SET standard_conforming_strings=off');
-		pg_query($this->connection,'SET escape_string_warning=off');
+		pg_query($this->connection, 'SET standard_conforming_strings=off');
+		pg_query($this->connection, 'SET escape_string_warning=off');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for "Although connection can be omitted, it is not recommended".
#### Summary of Changes

The [`pg_query()` manual states](http://php.net/manual/en/function.pg-query.php) "Note: Although connection can be omitted, it is not recommended, since it can be the cause of hard to find bugs in scripts." looks like HHVM is more strict about expecting the connection parameter.

This also solves a notice in HHVM testing [pg_query() expects exactly 2 parameters, 1 given](https://travis-ci.org/photodude/joomla-cms/jobs/146006189#L1234-L1242)
#### Testing Instructions

Test by checking for normal function under PostgreSQL or I recommend by code review.
