### PR TITLE
Better logout redirection fix

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -201,13 +201,25 @@ class UsersControllerUser extends UsersController
 
 			$return = 'index.php?Itemid=' . $return . $lang;
 		}
-		else
+		else 
 		{
-			// Don't redirect to an external URL.
-			if (!JUri::isInternal($return))
+			if ($return!='')
 			{
-				$return = '';
+				// Only URLs on current server
+				$url=parse_url($return);
+				$return=$url['path'];
+				if($url['query']!=''){ $return.='?'.$url['query']; }
+				if($url['fragment']!=''){ $return.='#'.$url['fragment']; }
 			}
+			if($return=='')
+			{
+				// Redirect to default menue item
+				$menu = $app->getMenu();
+				$default=$menu->getDefault();
+				$return = 'index.php?Itemid=' . $default->id;
+				$return=JRoute::_($return, false);
+			}			
+			$app->redirect($return);
 		}
 
 		// Redirect the user.


### PR DESCRIPTION
Pull Request for Issue #11093 .
#### Summary of Changes

Redirect to default menu item if $return is empty or to any other address on the server e.g. custom scripts. Not only joomla internal. Works also with other logout component like com_quicklogout.
#### Testing Instructions
1. created a user menu with a menu item Logout.
2. set the Logout menu item to redirect to the Homepage menu item.
3. click logout
