### PR TITLE
revert showon icons

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -265,8 +265,7 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 			description="JGLOBAL_SHOW_PRINT_ICON_DESC"
-			default="1"
-			showon="show_icons:1">
+			default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
@@ -277,8 +276,7 @@
 			class="btn-group btn-group-yesno"
 			label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
 			description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
-			default="1"
-			showon="show_icons:1">
+			default="1">
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>


### PR DESCRIPTION
My mistake. The option to Show Article icons doesnt control the options below so the showon should not be there. This reverts it
#### Before

The option Show Icons will hide or show the two options below
#### After

The option Show Icons has no effect on the two options below
