### PR TITLE
Correctly document returns from methods returning JError calls

### DIFF
--- a/administrator/components/com_menus/controllers/menus.php
+++ b/administrator/components/com_menus/controllers/menus.php
@@ -138,9 +138,9 @@ class MenusControllerMenus extends JControllerLegacy
 	/**
 	 * Temporary method. This should go into the 1.5 to 1.6 upgrade routines.
 	 *
-	 * @return   void
+	 * @return  JException|void  JException instance on error
 	 *
-	 * @since  1.6
+	 * @since   1.6
 	 */
 	public function resync()
 	{

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1186,7 +1186,7 @@ class MenusModelItem extends JModelAdmin
 	/**
 	 * Method rebuild the entire nested set tree.
 	 *
-	 * @return  boolean  False on failure or error, true otherwise.
+	 * @return  boolean|JException  Boolean true on success, boolean false or JException instance on error
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -375,7 +375,7 @@ class ModulesModelModule extends JModelAdmin
 	 *
 	 * @param   array  &$pks  An array of primary key IDs.
 	 *
-	 * @return  boolean  True if successful.
+	 * @return  boolean|JException  Boolean true on success, JException instance on error
 	 *
 	 * @since   1.6
 	 * @throws  Exception

--- a/administrator/components/com_users/models/levels.php
+++ b/administrator/components/com_users/models/levels.php
@@ -177,7 +177,7 @@ class UsersModelLevels extends JModelList
 	 * @param   array    $pks    An array of primary key ids.
 	 * @param   integer  $order  Order position
 	 *
-	 * @return   boolean
+	 * @return  boolean|JException  Boolean true on success, boolean false or JException instance on error
 	 */
 	public function saveorder($pks, $order)
 	{

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -66,7 +66,7 @@ class ContentModelArticle extends JModelItem
 	 *
 	 * @param   integer  $pk  The id of the article.
 	 *
-	 * @return  mixed  Menu item data object on success, false on failure.
+	 * @return  object|boolean|JException  Menu item data object on success, boolean false or JException instance on error
 	 */
 	public function getItem($pk = null)
 	{

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -795,7 +795,7 @@ class JApplicationCms extends JApplicationWeb
 	 * @param   array  $credentials  Array('username' => string, 'password' => string)
 	 * @param   array  $options      Array('remember' => boolean)
 	 *
-	 * @return  boolean  True on success.
+	 * @return  boolean|JException  True on success, false if failed or silent handling is configured, or a JException object on authentication error.
 	 *
 	 * @since   3.2
 	 */
@@ -839,17 +839,11 @@ class JApplicationCms extends JApplicationWeb
 						case JAuthentication::STATUS_EXPIRED:
 							return JError::raiseWarning('102002', JText::_('JLIB_LOGIN_EXPIRED'));
 
-							break;
-
 						case JAuthentication::STATUS_DENIED:
 							return JError::raiseWarning('102003', JText::_('JLIB_LOGIN_DENIED'));
 
-							break;
-
 						default:
 							return JError::raiseWarning('102004', JText::_('JLIB_LOGIN_AUTHORISATION'));
-
-							break;
 					}
 				}
 			}

--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -137,7 +137,9 @@ class JArchiveBzip2 implements JArchiveExtractable
 	 * @param   int     $code  The application-internal error code for this error
 	 * @param   string  $msg   The error message, which may also be shown the user if need be.
 	 *
-	 * @return mixed JError object or Runtime Exception
+	 * @return  JException  JException instance if JError class exists
+	 *
+	 * @throws  RuntimeException if JError class does not exist
 	 */
 	private function raiseWarning($code, $msg)
 	{

--- a/libraries/joomla/archive/gzip.php
+++ b/libraries/joomla/archive/gzip.php
@@ -147,7 +147,9 @@ class JArchiveGzip implements JArchiveExtractable
 	 * @param   int     $code  The application-internal error code for this error
 	 * @param   string  $msg   The error message, which may also be shown the user if need be.
 	 *
-	 * @return mixed JError object or Runtime Exception
+	 * @return  JException  JException instance if JError class exists
+	 *
+	 * @throws  RuntimeException if JError class does not exist
 	 */
 	private function raiseWarning($code, $msg)
 	{

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -66,10 +66,10 @@ class JArchiveTar implements JArchiveExtractable
 	 * @param   string  $destination  Path to extract archive into
 	 * @param   array   $options      Extraction options [unused]
 	 *
-	 * @return  boolean True if successful
+	 * @return  boolean|JException  True on success, JException instance on failure if JError class exists
 	 *
-	 * @throws  RuntimeException
 	 * @since   11.1
+	 * @throws  RuntimeException if JError class does not exist
 	 */
 	public function extract($archive, $destination, array $options = array())
 	{
@@ -148,18 +148,10 @@ class JArchiveTar implements JArchiveExtractable
 	 *
 	 * @param   string  &$data  The Tar archive buffer.
 	 *
-	 * @return   array  Archive metadata array
-	 * <pre>
-	 * KEY: Position in the array
-	 * VALUES: 'attr'  --  File attributes
-	 * 'data'  --  Raw file contents
-	 * 'date'  --  File modification time
-	 * 'name'  --  Filename
-	 * 'size'  --  Original file size
-	 * 'type'  --  File type
-	 * </pre>
+	 * @return  boolean|JException  True on success, JException instance on failure if JError class exists
 	 *
-	 * @since    11.1
+	 * @since   11.1
+	 * @throws  RuntimeException if JError class does not exist
 	 */
 	protected function _getTarInfo(& $data)
 	{

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -144,7 +144,9 @@ class JArchiveZip implements JArchiveExtractable
 	 * @param   int     $code  The application-internal error code for this error
 	 * @param   string  $msg   The error message, which may also be shown the user if need be.
 	 *
-	 * @return mixed JError object or Runtime Exception
+	 * @return  JException  JException instance if JError class exists
+	 *
+	 * @throws  RuntimeException if JError class does not exist
 	 */
 	private function raiseWarning($code, $msg)
 	{

--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -609,7 +609,7 @@ class JApplication extends JApplicationBase
 	 * @param   array  $credentials  Array('username' => string, 'password' => string)
 	 * @param   array  $options      Array('remember' => boolean)
 	 *
-	 * @return  boolean  True on success.
+	 * @return  boolean|JException  True on success, false if failed or silent handling is configured, or a JException object on authentication error.
 	 *
 	 * @since   11.1
 	 * @deprecated  4.0

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1271,7 +1271,7 @@ abstract class JModelAdmin extends JModelForm
 	 * @param   array    $pks    An array of primary key ids.
 	 * @param   integer  $order  +1 or -1
 	 *
-	 * @return  mixed
+	 * @return  boolean|JException  Boolean true on success, boolean false or JException instance on error
 	 *
 	 * @since   12.2
 	 */

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -100,7 +100,7 @@ class JViewCategory extends JViewLegacy
 	/**
 	 * Method with common display elements used in category list displays
 	 *
-	 * @return  void
+	 * @return  boolean|JException|void  Boolean false or JException instance on error, nothing otherwise
 	 *
 	 * @since   3.2
 	 */


### PR DESCRIPTION
#### Summary of Changes

Ensure correct return types are documented for methods where a `return JError::raise*()` line is in use.
#### Testing Instructions

Review.
