### PR TITLE
[installation] update user ids even if there is no sample data

### DIFF
--- a/installation/controller/install/database.php
+++ b/installation/controller/install/database.php
@@ -44,6 +44,12 @@ class InstallationControllerInstallDatabase extends JControllerBase
 		// Attempt to create the database tables.
 		$return = $db->createTables($options);
 
+		// We need to run this to update joomla.sql created user id.
+		if ($return)
+		{
+			$return = $db->updateUserIds($options);
+		}
+
 		$r = new stdClass;
 		$r->view = 'install';
 

--- a/installation/controller/install/database.php
+++ b/installation/controller/install/database.php
@@ -39,15 +39,22 @@ class InstallationControllerInstallDatabase extends JControllerBase
 		$options = $model->getOptions();
 
 		// Get the database model.
-		$db = new InstallationModelDatabase;
+		$dbModel = new InstallationModelDatabase;
 
 		// Attempt to create the database tables.
-		$return = $db->createTables($options);
+		$return = $dbModel->createTables($options);
 
-		// We need to run this to update joomla.sql created user id.
+		// Run Cms data post install to update user ids.
 		if ($return)
 		{
-			$return = $db->updateUserIds($options);
+			if (!$db = $dbModel->initialise($options))
+			{
+				$return = false;
+			}
+			else
+			{
+				$return = $dbModel->postInstallCmsData($db);
+			}
 		}
 
 		$r = new stdClass;

--- a/installation/controller/install/database.php
+++ b/installation/controller/install/database.php
@@ -39,23 +39,10 @@ class InstallationControllerInstallDatabase extends JControllerBase
 		$options = $model->getOptions();
 
 		// Get the database model.
-		$dbModel = new InstallationModelDatabase;
+		$db = new InstallationModelDatabase;
 
 		// Attempt to create the database tables.
-		$return = $dbModel->createTables($options);
-
-		// Run Cms data post install to update user ids.
-		if ($return)
-		{
-			if (!$db = $dbModel->initialise($options))
-			{
-				$return = false;
-			}
-			else
-			{
-				$return = $dbModel->postInstallCmsData($db);
-			}
-		}
+		$return = $db->installCmsData($options);
 
 		$r = new stdClass;
 		$r->view = 'install';

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -819,7 +819,7 @@ class InstallationModelDatabase extends JModelBase
 	/**
 	 * Method to update the user id of sql data content to the new rand user id.
 	 *
-	 * @param   JDatabaseDriver  $db       Database connector object $db*.
+	 * @param   JDatabaseDriver  $db  Database connector object $db*.
 	 *
 	 * @return  boolean  True on success.
 	 *

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -783,7 +783,7 @@ class InstallationModelDatabase extends JModelBase
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since   3.6.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function updateUserIds($options = array(), $db = null)
 	{

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -761,7 +761,7 @@ class InstallationModelDatabase extends JModelBase
 	}
 
 	/**
-	 * Method to update the user id of the sample data content to the new rand user id.
+	 * Sample data tables and data post install process.
 	 *
 	 * @param   JDatabaseDriver  $db  Database connector object $db*.
 	 *
@@ -771,27 +771,36 @@ class InstallationModelDatabase extends JModelBase
 	 */
 	protected function postInstallSampleData($db)
 	{
-		// Update the user ids.
-		$db->updateUserIds(array(), $db);
+		// Update the sample data user ids.
+		$this->updateUserIds($db);
 	}
 
 	/**
-	 * Method to update the user id of the sample data content to the new rand user id.
+	 * Cms tables and data post install process.
 	 *
-	 * @param   array            $options  The options array.
+	 * @param   JDatabaseDriver  $db  Database connector object $db*.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function postInstallCmsData($db)
+	{
+		// Update the sample data user ids.
+		$this->updateUserIds($db);
+	}
+
+	/**
+	 * Method to update the user id of sql data content to the new rand user id.
+	 *
 	 * @param   JDatabaseDriver  $db       Database connector object $db*.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function updateUserIds($options = array(), $db = null)
+	protected function updateUserIds($db)
 	{
-		if ($db === null && !$db = $this->initialise($options))
-		{
-			return false;
-		}
-
 		// Create the ID for the root user.
 		$userId = self::getUserId();
 

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -776,6 +776,32 @@ class InstallationModelDatabase extends JModelBase
 	}
 
 	/**
+	 * Method to install the cms data.
+	 *
+	 * @param   array  $options  The options array.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function installCmsData($options)
+	{
+		// Attempt to create the database tables.
+		if (!$this->createTables($options))
+		{
+			return false;
+		}
+
+		if (!$db = $this->initialise($options))
+		{
+			return false;
+		}
+
+		// Run Cms data post install to update user ids.
+		return $this->postInstallCmsData($db);
+	}
+
+	/**
 	 * Cms tables and data post install process.
 	 *
 	 * @param   JDatabaseDriver  $db  Database connector object $db*.

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -771,7 +771,7 @@ class InstallationModelDatabase extends JModelBase
 	 */
 	protected function postInstallSampleData($db)
 	{
-		// Update the uiser Ids.
+		// Update the user ids.
 		$db->updateUserIds(array(), $db);
 	}
 

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -771,19 +771,40 @@ class InstallationModelDatabase extends JModelBase
 	 */
 	protected function postInstallSampleData($db)
 	{
+		// Update the uiser Ids.
+		$db->updateUserIds(array(), $db);
+	}
+
+	/**
+	 * Method to update the user id of the sample data content to the new rand user id.
+	 *
+	 * @param   array            $options  The options array.
+	 * @param   JDatabaseDriver  $db       Database connector object $db*.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   3.6.1
+	 */
+	public function updateUserIds($options = array(), $db = null)
+	{
+		if ($db === null && !$db = $this->initialise($options))
+		{
+			return false;
+		}
+
 		// Create the ID for the root user.
 		$userId = self::getUserId();
 
 		// Update all created_by field of the tables with the random user id
 		// categories (created_user_id), contact_details, content, newsfeeds.
 		$updates_array = array(
-			'categories' => 'created_user_id',
+			'categories'      => 'created_user_id',
 			'contact_details' => 'created_by',
-			'content' => 'created_by',
-			'newsfeeds' => 'created_by',
-			'tags' => 'created_user_id',
-			'ucm_content' => 'core_created_user_id',
-			'ucm_history' => 'editor_user_id'
+			'content'         => 'created_by',
+			'newsfeeds'       => 'created_by',
+			'tags'            => 'created_user_id',
+			'ucm_content'     => 'core_created_user_id',
+			'ucm_history'     => 'editor_user_id',
 		);
 
 		foreach ($updates_array as $table => $field)
@@ -794,6 +815,8 @@ class InstallationModelDatabase extends JModelBase
 			);
 			$db->execute();
 		}
+
+		return true;
 	}
 
 	/**

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -850,8 +850,6 @@ class InstallationModelDatabase extends JModelBase
 			);
 			$db->execute();
 		}
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11228.
#### Summary of Changes

When you make a new install of Joomla without sample data, i.e., selecting `None (Required for basic native multilingual site creation)` in the sample data install step, joomla will install the joomla.sql without changing the ids of the created_user_id in the table records.

One example is the `#__categories` table "Uncategorised" categories. The user id 42 ( https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L241-L247 ) is hardcoded as you can see from next picture.

![image](https://cloud.githubusercontent.com/assets/9630530/17058297/9ce19bfa-5017-11e6-9dc3-d20cd1f0bfd5.png)

This is a bug by itself (exists on 3.5.1 too), but in latest staging this leads to a warning when trying to edit those categories because the user id doesn't exist.

![image](https://cloud.githubusercontent.com/assets/9630530/17058318/bd04d938-5017-11e6-852d-0f988a2749ed.png)

This user_id needs to be updated to the random generated super user id.
This PR solves this issue.
#### Testing Instructions
1. Use latest staging and make a new install with `None (Required for basic native multilingual site creation)` in the sample data install step
2. Check the categories table is created with user id 42
3. Check when you edit any "Uncategorised" category you have the warning above.
4. Now download https://github.com/andrepereiradasilva/joomla-cms/archive/update-ids.zip (staging + this PR)
5. Repeat step 1 to 3 check is all ok now.
6. Do a code review.
