### PR TITLE
Deprecate overriding pagination functions

### DIFF
--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -9,6 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
+/** @var JPaginationObject $item */
 $item = $displayData['data'];
 
 $display = $item->text;

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -330,8 +330,17 @@ class JPagination
 		{
 			include_once $chromePath;
 
+			/*
+			 * @deprecated Item rendering should use a layout
+			 */
 			if (function_exists('pagination_item_active') && function_exists('pagination_item_inactive'))
 			{
+				JLog::add(
+					'pagination_item_active and pagination_item_inactive are deprecated. Use the layout joomla.pagination.link instead.',
+					JLog::WARNING,
+					'deprecated'
+				);
+
 				$itemOverride = true;
 			}
 
@@ -526,6 +535,8 @@ class JPagination
 
 			if (function_exists('pagination_list_footer'))
 			{
+				JLog::add('pagination_list_footer is deprecated. Use the layout joomla.pagination.links instead.', JLog::WARNING, 'deprecated');
+
 				return pagination_list_footer($list);
 			}
 		}
@@ -697,6 +708,7 @@ class JPagination
 	 * @return  string  HTML link
 	 *
 	 * @since   1.5
+	 * @note    As of 4.0 this method will proxy to `JLayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => true])`
 	 */
 	protected function _item_active(JPaginationObject $item)
 	{
@@ -729,6 +741,7 @@ class JPagination
 	 * @return  string
 	 *
 	 * @since   1.5
+	 * @note    As of 4.0 this method will proxy to `JLayoutHelper::render('joomla.pagination.link', ['data' => $item, 'active' => false])`
 	 */
 	protected function _item_inactive(JPaginationObject $item)
 	{


### PR DESCRIPTION
#### Summary of Changes

Deprecates support for all overriding pagination functions (the functions in a template's `html/pagination.php` file) in favor of using `JLayout` consistently.  Except for the one added in #10982 deprecation notices are added when checking for the presence of these functions.

It is also noted that the `_item_active()` and `_item_inactive()` methods of `JPagination` will proxy to the `joomla.pagination.link` layout as of 4.0.  I did not make this change in the code now because the current functions and the default layout produce different HTML so this prevents an unwanted markup change which may affect how sites are rendered.
#### Testing Instructions

Code review and maintainer decision.
#### Forward Compatibility

It is possible to create a `html/pagination.php` file that is compatible with the proposed use of `JLayout` and still be backward compatible as long as the `JLayout` API is available.  [This gist](https://gist.github.com/mbabker/41c6b172ced159f85707dd4154cc934a) is the `html/pagination.php` file we use for the `joomla.org` site template taking advantage of `pagination_list_footer()` already having inbuilt JLayout support and proxying the remaining methods to compatible layouts.
