### PR TITLE
Let categories ignore wrong ID while creating over articles

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -148,7 +148,7 @@ class CategoriesHelper
 		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_categories/models');
 		JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_categories/tables');
 
-		$categoryModel = JModelLegacy::getInstance('Category', 'CategoriesModel');
+		$categoryModel = JModelLegacy::getInstance('Category', 'CategoriesModel', array('ignore_request' => true));
 		$categoryModel->save($data);
 
 		$catid = $categoryModel->getState('category.id');


### PR DESCRIPTION
Pull Request for Issue #11162 .
#### Summary of Changes

Fixes bug 2+3 from the issue: the category model now ignores the article ID and creates a new category instead of updating
#### Testing Instructions

Edit an article with an ID where you have also a category with the same ID

before: instead of creating a new category, the existing category will be updated
after: new category will be created
