### PR TITLE
[Categories Table] Allow to save the custom creator

### DIFF
--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -219,9 +219,17 @@ class JTableCategory extends JTableNested
 		}
 		else
 		{
-			// New category
-			$this->created_time = $date->toSql();
-			$this->created_user_id = $user->get('id');
+			// New category. A category created_time and created_user_id field can be set by the user,
+			// so we don't touch either of these if they are set.
+			if (!(int) $this->created_time)
+			{
+				$this->created_time = $date->toSql();
+			}
+
+			if (empty($this->created_user_id))
+			{
+				$this->created_user_id = $user->get('id');
+			}
 		}
 
 		// Verify that the alias is unique


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Simple PR.
Categories table doesn't allow to customize the category creator on new category.
Content table allows just that (in https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/table/content.php#L323-L333).

This PR change the categories table to allow that too.
#### Testing Instructions

_simple test_
- Use latest staging
- Besides "Super User" create and additional user "Test User"
- Create a new category and change the category creator to be the "Test User" before saving
  ![image](https://cloud.githubusercontent.com/assets/9630530/17071864/2adfc618-505c-11e6-899b-cfafb4afc876.png)
- Save the category, edit it again and check the Creted By is "Super User" instead of "Test User"
- Apply patch
- Repeat steps. All good now

Note: This will also allow to do this in bulk import trough JTable
