### PR TITLE
[installation] correct category creator user ids in multilangue install

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1059,22 +1059,23 @@ class InstallationModelLanguages extends JModelBase
 		$title = $newlanguage->_('JCATEGORY');
 
 		// Initialize a new category.
-		$category                  = JTable::getInstance('Category');
+		$category = JTable::getInstance('Category');
 
 		$data = array(
-			'extension'    => 'com_content',
-			'title'        => $title . ' (' . strtolower($itemLanguage->language) . ')',
-			'description'  => '',
-			'published'    => 1,
-			'access'       => 1,
-			'params'       => '{"target":"","image":""}',
-			'metadesc'     => '',
-			'metakey'      => '',
-			'metadata'     => '{"page_title":"","author":"","robots":""}',
-			'created_time' => JFactory::getDate()->toSql(),
-			'language'     => $itemLanguage->language,
-			'rules'        => array(),
-			'parent_id'    => 1
+			'extension'       => 'com_content',
+			'title'           => $title . ' (' . strtolower($itemLanguage->language) . ')',
+			'description'     => '',
+			'published'       => 1,
+			'access'          => 1,
+			'params'          => '{"target":"","image":""}',
+			'metadesc'        => '',
+			'metakey'         => '',
+			'metadata'        => '{"page_title":"","author":"","robots":""}',
+			'created_time'    => JFactory::getDate()->toSql(),
+			'created_user_id' => (int) $this->getAdminId(),
+			'language'        => $itemLanguage->language,
+			'rules'           => array(),
+			'parent_id'       => 1,
 		);
 
 		// Set the location in the tree.
@@ -1120,9 +1121,11 @@ class InstallationModelLanguages extends JModelBase
 
 		$newlanguage = new JLanguage($itemLanguage->language, false);
 		$newlanguage->load('com_content.sys', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
-		$title = $newlanguage->_('COM_CONTENT_CONTENT_TYPE_ARTICLE');
+		$title       = $newlanguage->_('COM_CONTENT_CONTENT_TYPE_ARTICLE');
+		$currentDate = JFactory::getDate()->toSql();
 
-		$article                   = JTable::getInstance('Content');
+		// Initialize a new article.
+		$article = JTable::getInstance('Content');
 
 		$data = array(
 			'title'            => $title . ' (' . strtolower($itemLanguage->language) . ')',
@@ -1137,10 +1140,10 @@ class InstallationModelLanguages extends JModelBase
 			'images'           => json_encode(array()),
 			'urls'             => json_encode(array()),
 			'state'            => 1,
-			'created'          => JFactory::getDate()->toSql(),
-			'created_by'       => $this->getAdminId(),
+			'created'          => $currentDate,
+			'created_by'       => (int) $this->getAdminId(),
 			'created_by_alias' => 'Joomla',
-			'publish_up'       => JFactory::getDate()->toSql(),
+			'publish_up'       => $currentDate,
 			'publish_down'     => $db->getNullDate(),
 			'version'          => 1,
 			'catid'            => $categoryId,

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -219,9 +219,17 @@ class JTableCategory extends JTableNested
 		}
 		else
 		{
-			// New category
-			$this->created_time = $date->toSql();
-			$this->created_user_id = $user->get('id');
+			// New category. A category created_time and created_user_id field can be set by the user,
+			// so we don't touch either of these if they are set.
+			if (!(int) $this->created_time)
+			{
+				$this->created_time = $date->toSql();
+			}
+
+			if (empty($this->created_user_id))
+			{
+				$this->created_user_id = $user->get('id');
+			}
 		}
 
 		// Verify that the alias is unique


### PR DESCRIPTION
#### Summary of Changes

Add the correct category creator id in a multilanguage install.
Before patch the creator id is 0, after patch is the super user id (as for the articles).
#### Testing Instructions
1. Use latest staging and make a new install with `None (Required for basic native multilingual site creation)` in the sample data install step and install languages after with sample multilangual content
2. Check the categories table is created with user id `0`
   ![image](https://cloud.githubusercontent.com/assets/9630530/17072456/46617270-5060-11e6-89b8-c762d0eb4dc0.png)
3. Now download https://github.com/andrepereiradasilva/joomla-cms/archive/patch-9.zip (staging + this PR)
4. Repeat step 1 to 2 check is all ok now.
5. Do a code review.

Note: to simplify testing i incorporated PR https://github.com/joomla/joomla-cms/pull/11251 here (and closed it). for the category table changes see that PR description.
