### PR TITLE
[installation] Auto-add language associations on multilanguage install

### DIFF
--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -94,7 +94,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		// Check if user has activated the multilingual site
 		$data = $this->input->post->get('jform', array(), 'array');
 
-		if (int) $data['activateMultilanguage'])
+		if ((int) $data['activateMultilanguage'])
 		{
 			if (!$model->enablePlugin('plg_system_languagefilter'))
 			{

--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -92,10 +92,9 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		}
 
 		// Check if user has activated the multilingual site
-		$data                = $this->input->post->get('jform', array(), 'array');
-		$activeMultilanguage = (int) $data['activateMultilanguage'];
+		$data = $this->input->post->get('jform', array(), 'array');
 
-		if ($activeMultilanguage)
+		if ((int) $data['activateMultilanguage'])
 		{
 			if (!$model->enablePlugin('plg_system_languagefilter'))
 			{
@@ -122,12 +121,11 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 			JLoader::registerPrefix('J', JPATH_PLATFORM . '/legacy');
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/tables/');
 
-			$siteLanguages = $model->getInstalledlangsFrontend();
+			$siteLanguages       = $model->getInstalledlangsFrontend();
+			$groupedAssociations = array();
 
 			foreach ($siteLanguages as $siteLang)
 			{
-				$error = false;
-
 				// Add Language Manager: Content Languages
 				$tableLanguage = JTable::getInstance('Language');
 
@@ -142,59 +140,58 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 					{
 						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CONTENT_LANGUAGE', $siteLang->name));
 
-						$error = true;
+						continue;
 					}
 				}
 
-				if (!$error && !$model->addMenuGroup($siteLang))
+				if (!$model->addMenuGroup($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU', $siteLang->name));
 
-					$error = true;
+					continue;
 				}
 
-				if (!$error && !$model->addMenuItem($siteLang))
+				if (!$tableMenuItem = $model->addMenuItem($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM', $siteLang->name));
 
-					$error = true;
+					continue;
 				}
 
-				if (!$error && !$model->addModuleMenu($siteLang))
+				$groupedAssociations['com_menus.item'][$siteLang->language] = $tableMenuItem->id;
+
+				if (!$model->addModuleMenu($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_MODULE', $frontend_lang));
 
-					$error = true;
+					continue;
 				}
 
-				$installContent = (int) $data['installLocalisedContent'];
-
-				if ($installContent)
+				if ((int) $data['installLocalisedContent'])
 				{
-					if (!$error)
+					if (!$tableCategory = $model->addCategory($siteLang))
 					{
-						$tableCategory = $model->addCategory($siteLang);
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
 
-						if ($tableCategory === false)
-						{
-							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
-
-							$error = true;
-						}
+						continue;
 					}
 
-					if (!$error)
+					$groupedAssociations['com_categories.item'][$siteLang->language] = $tableCategory->id;
+
+					if (!$tableArticle = $model->addArticle($siteLang, $tableCategory->id))
 					{
-						$categoryId = $tableCategory->id;
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
 
-						if (!$model->addArticle($siteLang, $categoryId))
-						{
-							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
-
-							$error = true;
-						}
+						continue;
 					}
+
+					$groupedAssociations['com_content.item'][$siteLang->language] = $tableArticle->id;
 				}
+			}
+
+			if (!$model->addAssociations($groupedAssociations))
+			{
+				$app->enqueueMessage(JText::_('INSTL_DEFAULTLANGUAGE_COULD_NOT_ADD_ASSOCIATIONS'));
 			}
 
 			if (!$model->disableModuleMainMenu())

--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -92,10 +92,9 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		}
 
 		// Check if user has activated the multilingual site
-		$data                = $this->input->post->get('jform', array(), 'array');
-		$activeMultilanguage = (int) $data['activateMultilanguage'];
+		$data = $this->input->post->get('jform', array(), 'array');
 
-		if ($activeMultilanguage)
+		if (int) $data['activateMultilanguage'])
 		{
 			if (!$model->enablePlugin('plg_system_languagefilter'))
 			{
@@ -122,12 +121,11 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 			JLoader::registerPrefix('J', JPATH_PLATFORM . '/legacy');
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/tables/');
 
-			$siteLanguages = $model->getInstalledlangsFrontend();
+			$siteLanguages       = $model->getInstalledlangsFrontend();
+			$groupedAssociations = array();
 
 			foreach ($siteLanguages as $siteLang)
 			{
-				$error = false;
-
 				// Add Language Manager: Content Languages
 				$tableLanguage = JTable::getInstance('Language');
 
@@ -141,54 +139,53 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 					if (!$model->addLanguage($siteLang, $sefLangString))
 					{
 						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CONTENT_LANGUAGE', $siteLang->name));
-						$error = true;
+						continue;
 					}
 				}
 
-				if (!$error && !$model->addMenuGroup($siteLang))
+				if (!$model->addMenuGroup($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU', $siteLang->name));
-					$error = true;
+					continue;
 				}
 
-				if (!$error && !$model->addMenuItem($siteLang))
+				if (!$tableMenuItem = $model->addMenuItem($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM', $siteLang->name));
-					$error = true;
+					continue;
 				}
 
-				if (!$error && !$model->addModuleMenu($siteLang))
+				$groupedAssociations['com_menus.item'][$siteLang->language] = $tableMenuItem->id;
+
+				if (!$model->addModuleMenu($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_MODULE', $frontend_lang));
-					$error = true;
+					continue;
 				}
 
-				$installContent = (int) $data['installLocalisedContent'];
-
-				if ($installContent)
+				if ((int) $data['installLocalisedContent'])
 				{
-					if (!$error)
+					if (!$tableCategory = $model->addCategory($siteLang))
 					{
-						$tableCategory = $model->addCategory($siteLang);
-
-						if ($tableCategory === false)
-						{
-							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
-							$error = true;
-						}
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY', $frontend_lang));
+						continue;
 					}
 
-					if (!$error)
-					{
-						$categoryId = $tableCategory->id;
+					$groupedAssociations['com_categories.item'][$siteLang->language] = $tableCategory->id;
 
-						if (!$model->addArticle($siteLang, $categoryId))
-						{
-							$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
-							$error = true;
-						}
+					if (!$tableArticle = $model->addArticle($siteLang, $tableCategory->id))
+					{
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE', $frontend_lang));
+						continue;
 					}
+
+					$groupedAssociations['com_content.item'][$siteLang->language] = $tableArticle->id;
 				}
+			}
+
+			if (!$model->addAssociations($groupedAssociations))
+			{
+				$app->enqueueMessage(JText::_('INSTL_DEFAULTLANGUAGE_COULD_NOT_ADD_ASSOCIATIONS'));
 			}
 
 			if (!$model->disableModuleMainMenu())

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -1194,7 +1194,7 @@ class InstallationModelLanguages extends JModelBase
 	/**
 	 * Create the language associations.
 	 *
-	 * @param   array  $associations  Array of language associations fro all items.
+	 * @param   array  $groupedAssociations  Array of language associations for all items.
 	 *
 	 * @return  boolean  True on success.
 	 *

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -852,7 +852,7 @@ class InstallationModelLanguages extends JModelBase
 	 *
 	 * @param   stdClass  $itemLanguage  Language Object.
 	 *
-	 * @return  boolean
+	 * @return  JTable|boolean Menu Item Object. False otherwise.
 	 *
 	 * @since   3.2
 	 */
@@ -867,7 +867,6 @@ class InstallationModelLanguages extends JModelBase
 		$alias = 'home_' . $itemLanguage->language;
 
 		$menuItem = array(
-			'id'           => 0,
 			'title'        => $title,
 			'alias'        => $alias,
 			'menutype'     => 'mainmenu-' . strtolower($itemLanguage->language),
@@ -917,7 +916,7 @@ class InstallationModelLanguages extends JModelBase
 			return false;
 		}
 
-		return true;
+		return $tableItem;
 	}
 
 	/**
@@ -1048,7 +1047,7 @@ class InstallationModelLanguages extends JModelBase
 	 *
 	 * @param   stdClass  $itemLanguage  Language Object.
 	 *
-	 * @return  JTable Category Object.
+	 * @return  JTable|boolean Category Object. False otherwise.
 	 *
 	 * @since   3.2
 	 */
@@ -1110,7 +1109,7 @@ class InstallationModelLanguages extends JModelBase
 	 * @param   stdClass  $itemLanguage  Language Object.
 	 * @param   int       $categoryId    The id of the category where we want to add the article.
 	 *
-	 * @return  JTable Category Object
+	 * @return  JTable|boolean Article Object. False otherwise.
 	 *
 	 * @since   3.2
 	 */
@@ -1187,6 +1186,45 @@ class InstallationModelLanguages extends JModelBase
 		catch (JDatabaseExceptionExecuting $e)
 		{
 			return false;
+		}
+
+		return $article;
+	}
+
+	/**
+	 * Create the language associations.
+	 *
+	 * @param   array  $associations  Array of language associations fro all items.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addAssociations($groupedAssociations)
+	{
+		$db = JFactory::getDbo();
+
+		foreach ($groupedAssociations as $context => $associations)
+		{
+			$key   = md5(json_encode($associations));
+			$query = $db->getQuery(true)
+				->insert('#__associations');
+
+			foreach ($associations as $language => $id)
+			{
+				$query->values(((int) $id) . ',' . $db->quote($context) . ',' . $db->quote($key));
+			}
+
+			$db->setQuery($query);
+
+			try
+			{
+				$db->execute();
+			}
+			catch (RuntimeException $e)
+			{
+				return false;
+			}
 		}
 
 		return true;


### PR DESCRIPTION
#### Summary of Changes

This PR makes installation process auto create the language associations between the items (menu items, categories and articles) when installing a multilanguage site.
#### Testing Instructions
1. Download https://github.com/andrepereiradasilva/joomla-cms/archive/associations-on-install.zip (staging + this PR)
2. Make a new install with this package
   - In the sample data install step, select `None (Required for basic native multilingual site creation)` 
   - Install two or more languages
   - Select to install sample multilingual content
3. After install, login to backend and check menu items, categories and articles now have the language associations.

![image](https://cloud.githubusercontent.com/assets/9630530/17074018/724b4768-506e-11e6-9218-da18c1d1e43f.png)
