### PR TITLE
remove redirect in template manager

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -194,7 +194,7 @@ if($this->type == 'font')
 					<h2><?php echo JText::_('COM_TEMPLATES_HOME_HEADING'); ?></h2>
 					<p><?php echo JText::_('COM_TEMPLATES_HOME_TEXT'); ?></p>
 					<p>
-						<a href="https://docs.joomla.org/J3.2:How_to_use_the_Template_Manager" target="_blank" class="btn btn-primary btn-large">
+						<a href="https://docs.joomla.org/J3.x:How_to_use_the_Template_Manager" target="_blank" class="btn btn-primary btn-large">
 							<?php echo JText::_('COM_TEMPLATES_HOME_BUTTON'); ?>
 						</a>
 					</p>

--- a/administrator/templates/hathor/html/com_templates/template/default.php
+++ b/administrator/templates/hathor/html/com_templates/template/default.php
@@ -287,7 +287,7 @@ if($this->type == 'font')
 				<h1><p><?php echo JText::_('COM_TEMPLATES_HOME_HEADING'); ?></p></h1>
 				<p><?php echo JText::_('COM_TEMPLATES_HOME_TEXT'); ?></p>
 				<p>
-					<a href="https://docs.joomla.org/J3.2:How_to_use_the_Template_Manager" target="_blank">
+					<a href="https://docs.joomla.org/J3.x:How_to_use_the_Template_Manager" target="_blank">
 						<?php echo JText::_('COM_TEMPLATES_HOME_BUTTON'); ?>
 					</a>
 				</p>


### PR DESCRIPTION
The link to the help site for Documentation in the Template manager goes to a link that is then 301 redirected to another link

This PR just removes the need for the redirect and goes directly to the correct url
