### PR TITLE
Fix SEF plugin breaking HTML while trying to make inline background url paths absolute

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -155,7 +155,7 @@ class PlgSystemSef extends JPlugin
 		{
 			$regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[49];)?(?!/|\&\#0?3[49];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[49];)?\)';
 			$regex  = '#style=\s*([\'\"])(.*):' . $regex_url . '#m';
-			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5$6)', $buffer);
+			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5)', $buffer);
 			$this->checkBuffer($buffer);
 		}
 

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -153,7 +153,8 @@ class PlgSystemSef extends JPlugin
 		// Replace all unknown protocols in CSS background image.
 		if (strpos($buffer, 'style=') !== false)
 		{
-			$regex  = '#style=\s*([\'\"])(.*):\s*url\s*\(([\'\"]|\&\#0?3[4|9];)?(?!/|\&\#0?3[4|9];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[4|9];)?\)#m';
+			$regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[4|9];)?(?!/|\&\#0?3[4|9];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[4|9];)?\)';
+			$regex  = '#style=\s*([\'\"])(.*):' . $regex_url . '#m';
 			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5$6)', $buffer);
 			$this->checkBuffer($buffer);
 		}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -153,7 +153,7 @@ class PlgSystemSef extends JPlugin
 		// Replace all unknown protocols in CSS background image.
 		if (strpos($buffer, 'style=') !== false)
 		{
-			$regex  = '#style=\s*([\'\"])(.*):\s*url\s*\(([\'\"])?(?!/|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]?)\)#m';
+			$regex  = '#style=\s*([\'\"])(.*):\s*url\s*\(([\'\"]|\&\#0?3[4|9];)?(?!/|\&\#0?3[4|9];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[4|9];)?\)#m';
 			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5$6)', $buffer);
 			$this->checkBuffer($buffer);
 		}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -153,7 +153,7 @@ class PlgSystemSef extends JPlugin
 		// Replace all unknown protocols in CSS background image.
 		if (strpos($buffer, 'style=') !== false)
 		{
-			$regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[4|9];)?(?!/|\&\#0?3[4|9];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[4|9];)?\)';
+			$regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[49];)?(?!/|\&\#0?3[49];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[49];)?\)';
 			$regex  = '#style=\s*([\'\"])(.*):' . $regex_url . '#m';
 			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5$6)', $buffer);
 			$this->checkBuffer($buffer);

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -153,8 +153,8 @@ class PlgSystemSef extends JPlugin
 		// Replace all unknown protocols in CSS background image.
 		if (strpos($buffer, 'style=') !== false)
 		{
-			$regex  = '#style=\s*[\'\"](.*):\s*url\s*\([\'\"]?(?!/|' . $protocols . '|\#)([^\)\'\"]+)[\'\"]?\)#m';
-			$buffer = preg_replace($regex, 'style="$1: url(\'' . $base . '$2$3\')', $buffer);
+			$regex  = '#style=\s*([\'\"])(.*):\s*url\s*\(([\'\"])?(?!/|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]?)\)#m';
+			$buffer = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5$6)', $buffer);
 			$this->checkBuffer($buffer);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #11264 and issue:  #7267 

The SEF plugin attempts to make inline background url paths absolute but adding / or /jfolder/ to them

Example of broken cases:

```
<div id='bg-image' style='background-image:url(database/bg-home.jpg);'></div>
<div id='bg-image4' style='background-image:url("database/bg-home.jpg");'></div>
<div id='bg-image5' style='background-image:url(&34;database/bg-home.jpg&34;);'></div>
```

the above will become:

```
<div id='bg-image' style="background-image: url('/jfolder/database/bg-home.jpg');'></div>
<div id='bg-image4' style="background-image: url('/jfolder/database/bg-home.jpg');'></div>
<div id='bg-image5' style="background-image: url('/jfolder/&34;database/bg-home.jpg');'></div>
```

which are obviously broken
#### Summary of Changes

Added handling of cases

```
style='...url("...")'
style='...url(&#34;...&#34;);'
style="...url(&#39;...&#39;);"
```
#### Testing Instructions

Apply patch and at the bottom of index.php of protostar (just before &lt;/body&gt; TAG) add:

```
<!-- RELATIVE urls (this must be replaced) -->
        <!-- WITHOUT quotes: url() -->
    <div id='rel-image1' style='background-image:url(relative/bg-home.jpg);'></div>
    <div id='rel-image2' style="background-image:url(relative/bg-home.jpg);"></div>
    <div id='rel-image1a' style='color:red; background-image:url(relative/bg-home.jpg);'></div>
    <div id='rel-image2a' style="color:red; background-image:url(relative/bg-home.jpg);"></div>

        <!-- WITH single/double quotes:  url("") or url('') -->
    <div id='rel-image3' style="background-image:url('relative/bg-home.jpg');"></div>
    <div id='rel-image4' style='background-image:url("relative/bg-home.jpg");'></div>
    <div id='rel-image3a' style="color:red; background-image:url('relative/bg-home.jpg');"></div>
    <div id='rel-image4a' style='color:red; background-image:url("relative/bg-home.jpg");'></div>    

        <!-- Single/double quotes written as special characters &#34; &#39;-->
    <div id='rel-image5' style='background-image:url(&#34;relative/bg-home.jpg&#34;);'></div>
    <div id='rel-image6' style="background-image:url(&#39;relative/bg-home.jpg&#39;);"></div>
    <div id='rel-image7' style='background-image:url(&#034;relative/bg-home.jpg&#034;);'></div>
    <div id='rel-image8' style="background-image:url(&#039;relative/bg-home.jpg&#039;);"></div>


<!-- ABSOLUTE urls (plugin must NOT replace) -->
        <!-- WITHOUT quotes: url() -->
    <div id='abs-image1' style='background-image:url(http://absolute_url_dom.org/absolute/bg-home.jpg);'></div>
    <div id='abs-image2' style="background-image:url(http://absolute_url_dom.org/absolute/bg-home.jpg);"></div>
    <div id='abs-image3' style='background-image:url(/absolute/bg-home.jpg);'></div>
    <div id='abs-image4' style="background-image:url(/absolute/bg-home.jpg);"></div>

        <!-- WITH single/double quotes:  url("") or url('') and ABSOLUTE urls-->        
    <div id='abs-image7' style="background-image:url('http://absolute_url_dom.org/absolute/bg-home.jpg');"></div>
    <div id='abs-image8' style='background-image:url("http://absolute_url_dom.org/absolute/bg-home.jpg");'></div>
    <div id='abs-image9' style="background-image:url('/absolute/bg-home.jpg');"></div>
    <div id='abs-image10' style='background-image:url("/absolute/bg-home.jpg");'></div>

        <!-- Case with single/double quotes written as special characters for ABSOLUTE URLs -->
    <div id='bg-image11' style='background-image:url(&#034;http://absolute_url_dom.org/absolute/bg-home.jpg&#034;);'></div>
    <div id='bg-image12' style="background-image:url(&#039;http://absolute_url_dom.org/absolute/bg-home.jpg&#039;);"></div>
    <div id='bg-image13' style='background-image:url(&#34;http://absolute_url_dom.org/absolute/bg-home.jpg&#34;);'></div>
    <div id='bg-image14' style="background-image:url(&#39;http://absolute_url_dom.org/absolute/bg-home.jpg&#39;);"></div>
    <div id='bg-image15' style='background-image:url(&#034;/absolute/bg-home.jpg&#034;);'></div>
    <div id='bg-image16' style="background-image:url(&#039;/absolute/bg-home.jpg&#039;);"></div>
    <div id='bg-image17' style='background-image:url(&#34;/absolute/bg-home.jpg&#34;);'></div>
    <div id='bg-image18' style="background-image:url(&#39;/absolute/bg-home.jpg&#39;);"></div>
```

after patch the will be no broken HTML

PS: there is almost zero performance impact to the regexp , we simply capture the quotes and use them, the regexp has no other changes
