### PR TITLE
[Regression][fix]Migration from 2.5.28 to 3.6 returns Fatal errors & reverts #9655

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -31,6 +31,8 @@ class JoomlaInstallerScript
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
 		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_DELETE_FILES'), JLog::INFO, 'Update');
 
+		// This needs to stay for 2.5 update compatibility
+		$this->deleteUnexistingFiles();
 		$this->updateManifestCaches();
 		$this->updateDatabase();
 		$this->clearRadCache();


### PR DESCRIPTION
Pull Request for Issue #11117 .
#### Summary of Changes

Reverts #9655

There reason is simple. The new file that calls the post update deletion of the files get not called if you update from 2.5 to 3.6 ther for this needs to stay in the script.php too.
#### Testing Instructions

install 2.5
Update to 3.6
see the issue

```
Notice: Undefined property: LoginController::$input in ...administrator\components\com_login\controller.php on line 36
Fatal error: Call to a member function set() on null in ...administrator\components\com_login\controller.php on line 36
```

roll back to 2.5
install the update to 3.6 with the changes in this patch (or use this update server: http://www.jah-tz.de/downloads/core/list.xml)
there should be no issues on updating.

@wilsonge please have a look here if this can go into 3.6.1 too as exactly that happen what you guess in the original thread: https://github.com/joomla/joomla-cms/commit/c864a01a15b85379e182c4231969d9e72f67d46c
