### PR TITLE
folderlist form field returning full paths on Windows (issue #11102)

### DIFF
--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -244,6 +244,14 @@
 		<fieldset name="basic">
 
 			<field
+				directory="/administrator/components/com_categories/"
+				label="Folder Test"
+				name="folderlist_test"
+				description="A test for the folderlist form field"
+				type="folderlist"
+			/>
+
+			<field
 				name="category_layout"
 				type="componentlayout"
 				label="JFIELD_ALT_LAYOUT_LABEL"

--- a/administrator/components/com_categories/models/forms/category.xml
+++ b/administrator/components/com_categories/models/forms/category.xml
@@ -244,14 +244,6 @@
 		<fieldset name="basic">
 
 			<field
-				directory="/administrator/components/com_categories/"
-				label="Folder Test"
-				name="folderlist_test"
-				description="A test for the folderlist form field"
-				type="folderlist"
-			/>
-
-			<field
 				name="category_layout"
 				type="componentlayout"
 				label="JFIELD_ALT_LAYOUT_LABEL"

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -616,7 +616,7 @@ abstract class JFolder
 				&& (empty($excludefilter_string) || !preg_match($excludefilter_string, $file)))
 			{
 				// Compute the fullpath
-				$fullpath = $path . '/' . $file;
+				$fullpath = rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $file;
 
 				// Compute the isDir flag
 				$isDir = is_dir($fullpath);

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -190,7 +190,7 @@ class JFormFieldFolderList extends JFormFieldList
 		}
 
 		$pathObject = new JFilesystemWrapperPath;
-		$path = $pathObject->clean($path);
+		$path = $pathObject->check($path);
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -189,6 +189,9 @@ class JFormFieldFolderList extends JFormFieldList
 			$path = JPATH_ROOT . '/' . $path;
 		}
 
+		$pathObject = new JFilesystemWrapperPath;
+		$path = $pathObject->clean($path);
+
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)
 		{
@@ -218,7 +221,7 @@ class JFormFieldFolderList extends JFormFieldList
 				}
 
 				// Remove the root part and the leading /
-				$folder = trim(str_replace($path, '', $folder), '/');
+				$folder = trim(str_replace($path, '', $folder), DIRECTORY_SEPARATOR);
 
 				$options[] = JHtml::_('select.option', $folder, $folder);
 			}


### PR DESCRIPTION
Pull Request for Issue #11102 .

Issue is that folderlist on Windows now returns full paths instead of just folder names.
#### Summary of Changes

Fix for JFolder::_items() to use DIRECTORY_SEPARATOR instead of / when building full paths, and to rtrim the separator before concatenating file to path, to avoid double separators.

Fix for JFormFieldFolderList, to clean the path, which will then correctly match the path coming back from JFolder::folders(), and trim DIRECTORY_SEPARATOR instead of /.
#### Testing Instructions

Add a folderlist field to a form in the backend.  I used com_categories.  Edit ./administrator/components/com_categories/models/forms/category.xml.  Around line 246, in the 'basic' fieldset, add ...

```
            <field
                directory="/administrator/components/com_categories/"
                label="Folder Test"
                name="folderlist_test"
                description="A test for the folderlist form field"
                type="folderlist"
                recursive="true"
            />
```

Open the J! backend, and edit any existing Category (under the Content menu).  Go to the Options tab.  You will see a new dropdown, "Folder Test".  On a UN*X machine, it'll be just the folder names.  On a Windows machine, it will be full absolute paths.

Apply the PR.

Reload the page.  The folder dropdown will now just be folder name.
