### PR TITLE
Prevent misuse of show_noauth param when fulltext is empty

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -139,12 +139,10 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		/*
-		 * Check for no 'access-view' and empty full text,
-		 * - Redirect guest users to login
-		 * - Deny access to registered users with 403 code
-		 * NOTE: we do not recheck no access-view + show_noauth disabled ... since it was checked above
-		 */
+		// Check for no 'access-view' and empty fulltext,
+		// - Redirect guest users to login
+		// - Deny access to logged users with 403 code
+		// NOTE: we do not recheck for no access-view + show_noauth disabled ... since it was checked above
 		if ($item->params->get('access-view') == false && !strlen($item->fulltext))
 		{
 			if ( $this->user->get('guest') )
@@ -162,10 +160,8 @@ class ContentViewArticle extends JViewLegacy
 			}
 		}
 
-		/*
-		 * NOTE: we do set the text to contain the fulltext but it is the responsibility
-		 * of the layout to check view-access and only use "introtext" for guests
-		 */
+		// NOTE: The following code (usually) sets the text to contain the fulltext, but it is the
+		// responsibility of the layout to check 'access-view' and only use "introtext" for guests
 		if ($item->params->get('show_intro', '1') == '1')
 		{
 			$item->text = $item->introtext . ' ' . $item->fulltext;

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -139,16 +139,17 @@ class ContentViewArticle extends JViewLegacy
 			return;
 		}
 
-		// Check for no 'access-view' and empty fulltext,
-		// - Redirect guest users to login
-		// - Deny access to logged users with 403 code
-		// NOTE: we do not recheck for no access-view + show_noauth disabled ... since it was checked above
+		/* Check for no 'access-view' and empty fulltext,
+		 * - Redirect guest users to login
+		 * - Deny access to logged users with 403 code
+		 * NOTE: we do not recheck for no access-view + show_noauth disabled ... since it was checked above
+		 */
 		if ($item->params->get('access-view') == false && !strlen($item->fulltext))
 		{
 			if ($this->user->get('guest'))
 			{
 				$return = base64_encode(JUri::getInstance());
-				$login_url_with_return = JRoute::_('index.php?option=com_users&return='.$return);
+				$login_url_with_return = JRoute::_('index.php?option=com_users&return=' . $return);
 				$app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'notice');
 				$app->redirect($login_url_with_return, 403);
 			}

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -145,7 +145,7 @@ class ContentViewArticle extends JViewLegacy
 		// NOTE: we do not recheck for no access-view + show_noauth disabled ... since it was checked above
 		if ($item->params->get('access-view') == false && !strlen($item->fulltext))
 		{
-			if ( $this->user->get('guest') )
+			if ($this->user->get('guest'))
 			{
 				$return = base64_encode(JUri::getInstance());
 				$login_url_with_return = JRoute::_('index.php?option=com_users&return='.$return);


### PR DESCRIPTION
Pull Request for Issue #11285
#### Summary of Changes

Natural place to fix this is at the view.html.php that has a similar but incomplete check
#### Testing Instructions

**STEP 1:** Verify bug
1. Enable "Show unauthorized links" (e.g. globally for articles component)
2. Set an article to **non-public access** e.g. 'Registered', and make sure that the article **does not have read-more**
3. **Visit the article view as GUEST** and confirm that the all article text is showing

**STEP 2:** Test fix: Redirect guests to login 
4. Apply the patch and visit the article view again, you should redirected to login
5. Login as a "registered" user
6. Visit article, you should be able to view the article

**STEP 3:** Test fix: If logged user still did not gain access after login then a no access message work for logged users too
7. Edit article and set access to special
8. Visit article as "plain" registered users, you should get a 403 error
