### PR TITLE
Article options radio

### DIFF
--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -78,7 +78,7 @@
 
 		<field
 			name="info_block_show_title"
-			type="list"
+			type="radio"
 			class="btn-group"
 			label="COM_CONTENT_FIELD_INFOBLOCK_TITLE_LABEL"
 			description="COM_CONTENT_FIELD_INFOBLOCK_TITLE_DESC">

--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -83,8 +83,8 @@
 			label="COM_CONTENT_FIELD_INFOBLOCK_TITLE_LABEL"
 			description="COM_CONTENT_FIELD_INFOBLOCK_TITLE_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
-			<option	value="0">JHIDE</option>
 			<option	value="1">JSHOW</option>
+			<option	value="0">JHIDE</option>
 		</field>
 
 		<field


### PR DESCRIPTION
As mentioned in #11262 the Single Article menu options uses a different layout to the com_content article options (and all other layouts). This PR is not to address that.

This PR just makes all the options for a Single Article menu consistent - see screenshots
#### Before

![singlearticle-before](https://cloud.githubusercontent.com/assets/1296369/17097216/bc0f34bc-5254-11e6-8051-031595e74490.png)
#### After

![singlearticleafter](https://cloud.githubusercontent.com/assets/1296369/17097214/b83a171c-5254-11e6-9e84-95a3b4348a90.png)
