### PR TITLE
Decimal fields return a comma

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -444,7 +444,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$result[$field->Field] = preg_replace("/[(0-9)]/", '', $field->Type);
+				$result[$field->Field] = preg_replace("/[(0-9),]/", '', $field->Type);
 			}
 		}
 		// If we want the whole field data object add that to the list.


### PR DESCRIPTION
#### Summary of Changes

The function getTableColumns() with the flag typeOnly returns only the field types without any size information. Now this works fine for all fields except decimal as this contains a comma in it's definition.

Before:
![before_fix](https://cloud.githubusercontent.com/assets/359377/17098276/c714da8a-5261-11e6-9b97-b45c918e6180.png)

After:
![after_fix](https://cloud.githubusercontent.com/assets/359377/17098279/cca063de-5261-11e6-85b7-00fe8bfb8767.png)
#### Testing Instructions
1. Alter the assets table with the following code. Change jos to your own prefix if you use another.
   
   ``` sql
   ALTER TABLE `jos_assets`
   ADD COLUMN `values` DECIMAL(10,5) NULL AFTER `rules`;
   ```
2. Open the file administrator/components/com_cpanel/views/cpanel/tmpl/default.php
3. Add the following code after line 14:
   
   ``` php
    $db = JFactory::getDbo();
    $cols = $db->getTableColumns('#__assets', true);
   ?>
   <pre><?php
   echo __FILE__ . '::' . __LINE__ . ':: ';
   echo 'cols: ';
   echo '<div style="font-size: 1.5em;">';
   print_r($cols);
   echo '</div>';
   ?></pre><?php
   ```
4. Open the URL <site>/administrator/index.php
5. See the before code. There is a comma after the decimal.
6. Apply the patch
7. Reload the page
8. See the after code. The decimal is gone.
9. You can remove the decimal column again :)
