### PR TITLE
Use layouts in the vote plugin

### DIFF
--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.vote
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $context  The context of the content being passed to the plugin
+ * @var   object   &$row     The article object
+ * @var   object   &$params  The article params
+ * @var   integer  $page     The 'page' number
+ * @var   array    $parts    The context segments
+ * @var   string   $path     Path to this file
+ */
+
+$rating = (int) @$row->rating;
+
+$img = '';
+
+// Look for images in template if available
+$starImageOn  = JHtml::_('image', 'system/rating_star.png', JText::_('PLG_VOTE_STAR_ACTIVE'), null, true);
+$starImageOff = JHtml::_('image', 'system/rating_star_blank.png', JText::_('PLG_VOTE_STAR_INACTIVE'), null, true);
+
+for ($i = 0; $i < $rating; $i++)
+{
+	$img .= $starImageOn;
+}
+
+for ($i = $rating; $i < 5; $i++)
+{
+	$img .= $starImageOff;
+}
+
+?>
+<div class="content_rating" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+	<p class="unseen element-invisible">
+		<?php echo JText::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
+		<meta itemprop="ratingCount" content="<?php echo (int) $row->rating_count; ?>" />
+		<meta itemprop="worstRating" content="0" />
+	</p>
+	<?php echo $img; ?>
+</div>

--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.vote
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $context  The context of the content being passed to the plugin
+ * @var   object   &$row     The article object
+ * @var   object   &$params  The article params
+ * @var   integer  $page     The 'page' number
+ * @var   array    $parts    The context segments
+ * @var   string   $path     Path to this file
+ */
+
+$uri = clone JUri::getInstance();
+$uri->setVar('hitcount', '0');
+
+// Create option list for voting select box
+$options = [];
+
+for ($i = 1; $i < 6; $i++)
+{
+	$options[] = JHtml::_('select.option', $i, JText::sprintf('PLG_VOTE_VOTE', $i));
+}
+
+?>
+<form method="post" action="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" class="form-inline">
+	<span class="content_vote">
+		<label class="unseen element-invisible" for="content_vote_'<?php echo (int) $row->id; ?>"><?php echo JText::_('PLG_VOTE_LABEL'); ?></label>
+		<?php echo JHtml::_('select.genericlist', $options, 'user_rating', null, 'value', 'text', '5', 'content_vote_' . (int) $row->id); ?>
+		&#160;<input class="btn btn-mini" type="submit" name="submit_vote" value="<?php echo JText::_('PLG_VOTE_RATE'); ?>" />
+		<input type="hidden" name="task" value="article.vote" />
+		<input type="hidden" name="hitcount" value="0" />
+		<input type="hidden" name="url" value="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+	</span>
+</form>

--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -24,7 +24,7 @@ $uri = clone JUri::getInstance();
 $uri->setVar('hitcount', '0');
 
 // Create option list for voting select box
-$options = [];
+$options = array();
 
 for ($i = 1; $i < 6; $i++)
 {

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -17,6 +17,14 @@ defined('_JEXEC') or die;
 class PlgContentVote extends JPlugin
 {
 	/**
+	 * Application object
+	 *
+	 * @var    JApplicationCms
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $app;
+
+	/**
 	 * Load the language file on instantiation.
 	 *
 	 * @var    boolean
@@ -32,7 +40,7 @@ class PlgContentVote extends JPlugin
 	 * @param   object   &$params  The article params
 	 * @param   integer  $page     The 'page' number
 	 *
-	 * @return  mixed  html string containing code for the votes if in com_content else boolean false
+	 * @return  string|boolean  HTML string containing code for the votes if in com_content else boolean false
 	 *
 	 * @since   1.6
 	 */
@@ -45,64 +53,28 @@ class PlgContentVote extends JPlugin
 			return false;
 		}
 
-		$html = '';
-
-		if (!empty($params) && $params->get('show_vote', null))
+		if (empty($params) || !$params->get('show_vote', null))
 		{
-			$rating = (int) @$row->rating;
+			return '';
+		}
 
-			$view = JFactory::getApplication()->input->getString('view', '');
-			$img = '';
+		// Get the path for the rating summary layout file
+		$path = JPluginHelper::getLayoutPath('content', 'vote', 'rating');
 
-			// Look for images in template if available
-			$starImageOn  = JHtml::_('image', 'system/rating_star.png', JText::_('PLG_VOTE_STAR_ACTIVE'), null, true);
-			$starImageOff = JHtml::_('image', 'system/rating_star_blank.png', JText::_('PLG_VOTE_STAR_INACTIVE'), null, true);
+		// Render the layout
+		ob_start();
+		include $path;
+		$html = ob_get_clean();
 
-			for ($i = 0; $i < $rating; $i++)
-			{
-				$img .= $starImageOn;
-			}
+		if ($this->app->input->getString('view', '') == 'article' && $row->state == 1)
+		{
+			// Get the path for the voting form layout file
+			$path = JPluginHelper::getLayoutPath('content', 'vote', 'vote');
 
-			for ($i = $rating; $i < 5; $i++)
-			{
-				$img .= $starImageOff;
-			}
-
-			$html .= '<div class="content_rating" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">';
-			$html .= '<p class="unseen element-invisible">'
-					. JText::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>')
-					. '<meta itemprop="ratingCount" content="' . (int) $row->rating_count . '" />'
-					. '<meta itemprop="worstRating" content="0" />'
-					. '</p>';
-			$html .= $img;
-			$html .= '</div>';
-
-			if ($view == 'article' && $row->state == 1)
-			{
-				$uri = clone JUri::getInstance();
-				$uri->setVar('hitcount', '0');
-
-				// Create option list for voting select box
-				$options = array();
-
-				for ($i = 1; $i < 6; $i++)
-				{
-					$options[] = JHtml::_('select.option', $i, JText::sprintf('PLG_VOTE_VOTE', $i));
-				}
-
-				// Generate voting form
-				$html .= '<form method="post" action="' . htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8') . '" class="form-inline">';
-				$html .= '<span class="content_vote">';
-				$html .= '<label class="unseen element-invisible" for="content_vote_' . $row->id . '">' . JText::_('PLG_VOTE_LABEL') . '</label>';
-				$html .= JHtml::_('select.genericlist', $options, 'user_rating', null, 'value', 'text', '5', 'content_vote_' . $row->id);
-				$html .= '&#160;<input class="btn btn-mini" type="submit" name="submit_vote" value="' . JText::_('PLG_VOTE_RATE') . '" />';
-				$html .= '<input type="hidden" name="task" value="article.vote" />';
-				$html .= '<input type="hidden" name="hitcount" value="0" />';
-				$html .= '<input type="hidden" name="url" value="' . htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8') . '" />';
-				$html .= JHtml::_('form.token');
-				$html .= '</span>';
-				$html .= '</form>';
-			}
+			// Render the layout
+			ob_start();
+			include $path;
+			$html .= ob_get_clean();
 		}
 
 		return $html;

--- a/plugins/content/vote/vote.xml
+++ b/plugins/content/vote/vote.xml
@@ -11,6 +11,7 @@
 	<description>PLG_VOTE_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="vote">vote.php</filename>
+		<folder>tmpl</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_content_vote.ini</language>


### PR DESCRIPTION
#### Summary of Changes

This makes it rather easy to customize the voting plugin's output by moving all the logic for the different parts of it to layouts.
#### Testing Instructions

Apply patch, ensure plugin still renders correctly.  Override one of the new layouts (place at `templates/<template>/html/plg_content_vote/<layout>.php`) and ensure your override is used.
