### PR TITLE
Fixed extra parameter

### DIFF
--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -40,7 +40,7 @@ class PlgSystemUpdatenotification extends JPlugin
 
 		/** @var \Joomla\Registry\Registry $params */
 		$params        = $component->params;
-		$cache_timeout = $params->get('cachetimeout', 6, 'int');
+		$cache_timeout = (int) $params->get('cachetimeout', 6);
 		$cache_timeout = 3600 * $cache_timeout;
 
 		// Do we need to run? Compare the last run timestamp stored in the plugin's options with the current


### PR DESCRIPTION
#### Summary of Changes

There is a call to method Registry::get() with 3 parameters, while it only accepts 2 parameters
(see libraries/vendor/joomla/registry/src/Registry.php)
`public function get($path, $default = null)`

The code has been clearly copied / pasted from a call to JInput::get(), which actually accepts a third parameter indicating the filter type, and 'int' is a valid value.

If we want to be sure to get an int, the correct way is use a cast as we already did 3 lines below.
