### PR TITLE
revert 11161. somehow code not removed

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -414,13 +414,6 @@ class PlgSystemLanguageFilter extends JPlugin
 				}
 			}
 
-			// Don't cache the redirect in browser.
-			$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
-			$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-			$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-			$this->app->setHeader('Pragma', 'no-cache');
-			$this->app->sendHeaders();
-
 			if ($this->mode_sef)
 			{
 				// Use the current language sef or the default one.


### PR DESCRIPTION
#### Summary of Changes

Removes duplicate part from https://github.com/joomla/joomla-cms/pull/11161
#### Testing Instructions

Code review
#### Note

The code from https://github.com/joomla/joomla-cms/pull/11206 is still there https://github.com/joomla/joomla-cms/blob/staging/plugins/system/languagefilter/languagefilter.php#L448-L469

Somehow beetween commits and merges this was forgotten.

thanks @wilsonge for finding that.
