### PR TITLE
Generalizing hide associations

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit_associations.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit_associations.php
@@ -9,11 +9,4 @@
 
 defined('_JEXEC') or die;
 
-if ($this->item->id != 0 && $this->item->language != '*')
-{
-	echo JLayoutHelper::render('joomla.edit.associations', $this);
-}
-else
-{
-	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-}
+echo JLayoutHelper::render('joomla.edit.associations', $this);

--- a/administrator/components/com_contact/views/contact/tmpl/edit_associations.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit_associations.php
@@ -9,11 +9,4 @@
 
 defined('_JEXEC') or die;
 
-if ($this->item->id != 0 && $this->item->language != '*')
-{
-	echo JLayoutHelper::render('joomla.edit.associations', $this);
-}
-else
-{
-	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-}
+echo JLayoutHelper::render('joomla.edit.associations', $this);

--- a/administrator/components/com_content/views/article/tmpl/edit_associations.php
+++ b/administrator/components/com_content/views/article/tmpl/edit_associations.php
@@ -9,11 +9,4 @@
 
 defined('_JEXEC') or die;
 
-if ($this->item->id != 0 && $this->item->language != '*')
-{
-	echo JLayoutHelper::render('joomla.edit.associations', $this);
-}
-else
-{
-	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-}
+echo JLayoutHelper::render('joomla.edit.associations', $this);

--- a/administrator/components/com_menus/views/item/tmpl/edit_associations.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_associations.php
@@ -9,11 +9,4 @@
 
 defined('_JEXEC') or die;
 
-if ($this->item->id != 0 && $this->item->language != '*')
-{
-	echo JLayoutHelper::render('joomla.edit.associations', $this);
-}
-else
-{
-	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-}
+echo JLayoutHelper::render('joomla.edit.associations', $this);

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit_associations.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit_associations.php
@@ -9,11 +9,4 @@
 
 defined('_JEXEC') or die;
 
-if ($this->item->id != 0 && $this->item->language != '*')
-{
-	echo JLayoutHelper::render('joomla.edit.associations', $this);
-}
-else
-{
-	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-}
+echo JLayoutHelper::render('joomla.edit.associations', $this);

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -10,4 +10,12 @@
 defined('JPATH_BASE') or die;
 
 // JLayout for standard handling of associations fields in the administrator items edit screens.
-echo $displayData->getForm()->renderFieldset('item_associations');
+if ($displayData->getForm()->getValue('id') != 0 && $displayData->getForm()->getValue('language') != "*")
+{
+	echo $displayData->getForm()->renderFieldset('item_associations');
+}
+else
+{
+	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
+	echo '<div class="hidden">' . $displayData->getForm()->renderFieldset('item_associations') . '<div>';
+}


### PR DESCRIPTION
#### Summary of Changes

This patch hides the associations edit (if new item or language = all) while still keeping the element in the html, so it can still be accessed elsewhere. I created this so I can have a better implementation of the side-by-side feature on my [GSoC project](https://github.com/joomla-projects/gsoc16_improved-multi-lingual). @infograf768 @alikon @andrepereiradasilva
#### Testing Instructions

Open a new item, see if you have the associations edit displayed. When saved, set the language to "all" and save, check if the associations edit is still hidden.

Try this on:
- Articles (and categories)
- Contacts (and categories)
- Newsfeeds (and categories)
- Menus
