### PR TITLE
[associations helper] Use JLoader to load the router to make association links

### DIFF
--- a/components/com_contact/helpers/association.php
+++ b/components/com_contact/helpers/association.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('ContactHelper', JPATH_ADMINISTRATOR . '/components/com_contact/helpers/contact.php');
+JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**
@@ -29,15 +30,11 @@ abstract class ContactHelperAssociation extends CategoryHelperAssociation
 	 *
 	 * @since  3.0
 	 */
-
 	public static function getAssociations($id = 0, $view = null)
 	{
-		jimport('helper.route', JPATH_COMPONENT_SITE);
-
-		$app = JFactory::getApplication();
-		$jinput = $app->input;
-		$view = is_null($view) ? $jinput->get('view') : $view;
-		$id = empty($id) ? $jinput->getInt('id') : $id;
+		$jinput = JFactory::getApplication()->input;
+		$view   = is_null($view) ? $jinput->get('view') : $view;
+		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
 		if ($view == 'contact')
 		{

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
-JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
+JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('ContentHelper', JPATH_ADMINISTRATOR . '/components/com_content/helpers/content.php');
+JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**
@@ -29,15 +30,11 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	 *
 	 * @since  3.0
 	 */
-
 	public static function getAssociations($id = 0, $view = null)
 	{
-		jimport('helper.route', JPATH_COMPONENT_SITE);
-
-		$app = JFactory::getApplication();
-		$jinput = $app->input;
-		$view = is_null($view) ? $jinput->get('view') : $view;
-		$id = empty($id) ? $jinput->getInt('id') : $id;
+		$jinput = JFactory::getApplication()->input;
+		$view   = is_null($view) ? $jinput->get('view') : $view;
+		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
 		if ($view == 'article')
 		{

--- a/components/com_newsfeeds/helpers/association.php
+++ b/components/com_newsfeeds/helpers/association.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('NewsfeedsHelper', JPATH_ADMINISTRATOR . '/components/com_newsfeeds/helpers/newsfeeds.php');
+JLoader::register('NewsfeedsHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**
@@ -29,15 +30,11 @@ abstract class NewsfeedsHelperAssociation extends CategoryHelperAssociation
 	 *
 	 * @since  3.0
 	 */
-
 	public static function getAssociations($id = 0, $view = null)
 	{
-		jimport('helper.route', JPATH_COMPONENT_SITE);
-
-		$app = JFactory::getApplication();
-		$jinput = $app->input;
-		$view = is_null($view) ? $jinput->get('view') : $view;
-		$id = empty($id) ? $jinput->getInt('id') : $id;
+		$jinput = JFactory::getApplication()->input;
+		$view   = is_null($view) ? $jinput->get('view') : $view;
+		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
 		if ($view == 'newsfeed')
 		{

--- a/components/com_newsfeeds/helpers/association.php
+++ b/components/com_newsfeeds/helpers/association.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 JLoader::register('NewsfeedsHelper', JPATH_ADMINISTRATOR . '/components/com_newsfeeds/helpers/newsfeeds.php');
-JLoader::register('NewsfeedsHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
+JLoader::register('NewsfeedsHelperRoute', JPATH_SITE . '/components/com_newsfeeds/helpers/route.php');
 JLoader::register('CategoryHelperAssociation', JPATH_ADMINISTRATOR . '/components/com_categories/helpers/association.php');
 
 /**


### PR DESCRIPTION
#### Summary of Changes

The component router helper should be registered in the component association helper so when loading the helper it's already auto-loaded.
So we drop `jimport` and use `JLoader::register`
#### Testing Instructions

In multilanguage site, component items Associations tabs work fine (business as usual) in all core components (com_content, com_contact and com_newsfeeds) that supports associations (excluding com_menus that does not need this).
#### Notes

This issue was discovered in the GsoC multilingual association sproject.

Note: a similiar PR will be made for com_weblinks repository.

@infograf768 @alikon @jreys please test
