### PR TITLE
Fixing not closed div

### DIFF
--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -17,5 +17,5 @@ if ($displayData->getForm()->getValue('id') != 0 && $displayData->getForm()->get
 else
 {
 	echo '<div class="alert alert-info">' . JText::_('JGLOBAL_ASSOC_NOT_POSSIBLE') . '</div>';
-	echo '<div class="hidden">' . $displayData->getForm()->renderFieldset('item_associations') . '<div>';
+	echo '<div class="hidden">' . $displayData->getForm()->renderFieldset('item_associations') . '</div>';
 }


### PR DESCRIPTION
#### Summary of Changes

This is a fix for #11316 , sorry for any inconveniences, I've tested with success
#### Testing Instructions

Open a new item, see if you have the associations edit displayed. When saved, set the language to "all" and save, check if the associations edit is still hidden.

Try this on:
- Articles (and categories)
- Contacts (and categories)
- Newsfeeds (and categories)
- Menus
