### PR TITLE
[language filter plugin] do not cache any 301 redirect

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -446,16 +446,12 @@ class PlgSystemLanguageFilter extends JPlugin
 			{
 				$redirectHttpCode = 301;
 			
-				// If configured to always use a sef prefix for default language we cannot cache this redirect in browser.
-				// 301 is cachable by default so we need to force to not cache it in browsers.
-				if ((int) $this->params->get('remove_default_prefix', 0) === 0)
-				{
-					$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
-					$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-					$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-					$this->app->setHeader('Pragma', 'no-cache');
-					$this->app->sendHeaders();
-				}
+				// We cannot cache this redirect in browser. 301 is cachable by default so we need to force to not cache it in browsers.
+				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
+				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+				$this->app->setHeader('Pragma', 'no-cache');
+				$this->app->sendHeaders();
 			}
 			
 			// Redirect to language.


### PR DESCRIPTION
#### Summary of Changes

If you use latest staging in multilanguage with language filter plugin with `Remove URL Language Code` set to `Yes`, you will notice in the frontpage that switching from default language to other language and back to default language will not work properly.

When https://github.com/joomla/joomla-cms/pull/11206 was tested with success all worked fine because this issue was masked by the duplicated code removed in https://github.com/joomla/joomla-cms/pull/11314.

So, this PR makes so that joomla does not cache any language filter 301 redirect to avoid any browser cache issues.
#### Testing Instructions
1. Use latest staging in multilanguage (2 languages - en-GB and fr-FR), language filter plugin enabled and with `Remove URL Language Code` set to `Yes`.
2. Clear all your browser cache
3. Now go to your site homepage in default language
4. Click on french flag - all ok
5. Now click on english flag to go back to default language - all ok
6. Click on french flag again - all ok
7. Now click on english flag to go back to default language - **Bug! It stays in french**
8. Apply patch
9. Repeat steps from 2. to 7. All ok now
10. Code review

Note: this happens because by the second `/en/` to `/`  (step 7) the redirect is already cached in the browser so the language cookie is not changed back to en-GB.

@infograf768 @ggppdk please test
@wilsonge please check also
