### PR TITLE
Fix reference notice in PHP 7

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -387,12 +387,12 @@ class CategoriesModelCategories extends JModelList
 		{
 			require_once $file;
 
-			$prefix = ucfirst(str_replace('com_', '', $component));
+			$prefix = ucfirst($eName);
 			$cName = $prefix . 'Helper';
 
 			if (class_exists($cName) && is_callable(array($cName, 'countItems')))
 			{
-				call_user_func(array($cName, 'countItems'), $items, $section);
+				$cName::countItems($items, $section);
 			}
 		}
 	}


### PR DESCRIPTION
Pull Request for Issue #11274.
#### Summary of Changes

See: https://github.com/joomla/joomla-cms/issues/11274#issuecomment-235235670
#### Testing Instructions

See: https://github.com/joomla/joomla-cms/issues/11274#issue-167188264

My comment: I'm not sure, if this is the best solution, perhaps we could use `call_user_func_array` and give the values as reference
