### PR TITLE
Fix item alias

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -231,6 +231,17 @@ class JRouterSite extends JRouter
 		{
 			$item = $this->menu->getItem($this->getVar('Itemid'));
 
+			if ($item && $item->type == 'alias')
+			{
+				$newItem = $this->menu->getItem($item->params->get('aliasoptions'));
+
+				if ($newItem)
+				{
+					$item->query     = array_merge($item->query, $newItem->query);
+					$item->component = $newItem->component;
+				}
+			}
+
 			if ($item !== null && is_array($item->query))
 			{
 				$vars = $vars + $item->query;
@@ -377,6 +388,17 @@ class JRouterSite extends JRouter
 
 			if ($found)
 			{
+				if ($found->type == 'alias')
+				{
+					$newItem = $this->menu->getItem($found->params->get('aliasoptions'));
+
+					if ($newItem)
+					{
+						$found->query     = array_merge($found->query, $newItem->query);
+						$found->component = $newItem->component;
+					}
+				}
+
 				$vars['Itemid'] = $found->id;
 				$vars['option'] = $found->component;
 			}


### PR DESCRIPTION
Pull Request for Issue #10721 .
#### Summary of Changes

If any menu item is created (example item id is 480) 
then every URL like `index.php?Itemid=480` should always work 
but without that PR on menu item alias joomla returns 404.

#### Testing Instructions

* create menu item alias to existed com_content category/article, or whatever 
* after save, find out ID of menu item ex. Itemid=480 in my fresh joomla staging
![joomla_win_3 6 6](https://cloud.githubusercontent.com/assets/9054379/21767468/af7b7b30-d674-11e6-8344-ac1ec270be4e.jpeg)

* go to the front end at `index.php?Itemid=480`
* before patch you get error 404
* after patch you will see the correct page
