### PR TITLE
Email Cloaking plugin corrupts HTML

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -479,9 +479,11 @@ class PlgContentEmailcloak extends JPlugin
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
 		}
 
-		// Search for plain text email addresses, such as email@example.org but not within HTML tags:
-		// <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
-		// The negative lookahead '(?![^<]*>)' is used to exclude this kind occurrences
+		/*
+		 Search for plain text email addresses, such as email@example.org but not within HTML tags:
+		 <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
+		 The negative lookahead '(?![^<]*>)' is used to exclude this kind occurrences
+		*/
 		$pattern = '~(?![^<>]*>)' . $searchEmail . '~i';
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -480,10 +480,10 @@ class PlgContentEmailcloak extends JPlugin
 		}
 
 		/*
-		 Search for plain text email addresses, such as email@example.org but not within HTML tags:
-		 <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
-		 The negative lookahead '(?![^<]*>)' is used to exclude this kind occurrences
-		*/
+		 * Search for plain text email addresses, such as email@example.org but not within HTML tags:
+		 * <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
+		 * The negative lookahead '(?![^<]*>)' is used to exclude this kind of occurrences
+		 */
 		$pattern = '~(?![^<>]*>)' . $searchEmail . '~i';
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -479,8 +479,10 @@ class PlgContentEmailcloak extends JPlugin
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
 		}
 
-		// Search for plain text email@example.org
-		$pattern = '~' . $searchEmail . '([^a-z0-9]|$)~i';
+		// Search for plain text email addresses, such as email@example.org but not within HTML tags:
+		// <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
+		// The negative lookahead '(?![^<]*>)' is used to exclude this kind occurrences
+		$pattern = '~(?![^<>]*>)' . $searchEmail . '~i';
 
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{


### PR DESCRIPTION
The plugin “Content - Email Cloaking”, under some circumstances, corrupts the HTML of the processed content.

The use of email addresses within attributes of HTML tags is legitimate in the HTML code of a Joomla article.
Chances are high this actually happens when users include any kind of modules within articles, using the “Content - Load Modules” plugin (now used more than ever, due to the new editor button “Module”).

An article containing this HTML code
`<img src="/envelope.png" title="email@address.com">`

Should appear like that:

![img-expected](https://cloud.githubusercontent.com/assets/1609992/17252677/83036c52-55a5-11e6-8a91-eb5330dd620d.png)

But the cloak plugin corrupts the output

`<img src="/envelope.png" title="<span id="cloak84493">This email address is being protected ...</span><script type='text/javascript'>...</script>`

Which produce that result:

![img-got](https://cloud.githubusercontent.com/assets/1609992/17252766/c8a99aec-55a5-11e6-8279-e32ee4c6299a.png)

The same goes for an input element

`<input type="text" value="" placeholder="email@address.com">`

Which should appear like that:

![input-expected](https://cloud.githubusercontent.com/assets/1609992/17252797/e56829f0-55a5-11e6-8b10-6ebf18f4424c.png)

but it becomes like that instead:

`<input type="text" value="" placeholder="<span id="cloak77416">This email address is being protected ...</span><script type='text/javascript'>...</script>`

![input-got](https://cloud.githubusercontent.com/assets/1609992/17252815/f8436cec-55a5-11e6-8ff5-132af825e509.png)
## The cause

HTML attributes (like title=”...”) don't allow any further nested HTML tags, nor JavaScripts inside them.
## Summary of Changes
1. The negative lookahead '(?![^<]*>)' added to the regular expression is used to exclude occurrences within HTML tags.
2. Added exhaustive comments to explain the reason behind the lookahead.
## Testing Instructions

[I have tested](https://regex101.com/r/rP2hR5/3) the new regular expression with a lot of sample text, and it behaves good to me, but everyone interested is encouraged to test further (we know how tricky regular expressions can be).
