### PR TITLE
[com_menus] New menu item. Force client in menu item parent to not show admin menus

### DIFF
--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -43,6 +43,7 @@ class JFormFieldMenuParent extends JFormFieldList
 			->from('#__menu AS a')
 			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
+		// Filter by menu type.
 		if ($menuType = $this->form->getValue('menutype'))
 		{
 			$query->where('a.menutype = ' . $db->quote($menuType));
@@ -50,6 +51,14 @@ class JFormFieldMenuParent extends JFormFieldList
 		else
 		{
 			$query->where('a.menutype != ' . $db->quote(''));
+		}
+
+		// Filter by client id.
+		$clientId = $this->getAttribute('clientid', null);
+
+		if (!is_null($clientId))
+		{
+			$query->where($db->quoteName('a.client_id') . ' = ' . (int) $clientId);
 		}
 
 		// Prevent parenting to children of this item.

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -54,7 +54,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		}
 
 		// Filter by client id.
-		$clientId = $this->getAttribute('clientid', null);
+		$clientId = $this->getAttribute('clientid');
 
 		if (!is_null($clientId))
 		{

--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -95,6 +95,7 @@
 			description="COM_MENUS_ITEM_FIELD_PARENT_DESC"
 			default="1"
 			filter="int"
+			clientid="0"
 			size="1">
 			<option
 				value="1">COM_MENUS_ITEM_ROOT</option>


### PR DESCRIPTION
Pull Request for New Issue.
#### Summary of Changes

Another joomla cms bug was discovered in joomla gsoc multilangue project.
When creating a new menu item without menu type selected the parent id select box shows all site AND admin menus!
This PR intends to solves that.
#### Testing Instructions
1. Use latest staging
2. Logout
3. Login in Admin and go directy to Menus -> All Menu Items
4. Click New
5. Check the parent menu selector. you will see something like this
   ![image](https://cloud.githubusercontent.com/assets/9630530/17255703/3bc8942c-55b2-11e6-8b59-88fa2176bc89.png)
6. Apply patch
7. Do the same tests, check all is fine
8. Test creating/editing menu items to make sure nothing is breaked
9. Code review

@infograf768 @jreys @alikon 
