### PR TITLE
Don't need values for async/defer on HTML5

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -198,12 +198,22 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 			if ($strAttr['defer'])
 			{
-				$buffer .= ' defer="defer"';
+				$buffer .= ' defer';
+
+				if (!$document->isHtml5())
+				{
+					$buffer .= '="defer"';
+				}
 			}
 
 			if ($strAttr['async'])
 			{
-				$buffer .= ' async="async"';
+				$buffer .= ' async';
+
+				if (!$document->isHtml5())
+				{
+					$buffer .= '="async"';
+				}
 			}
 
 			$buffer .= '></script>' . $lnEnd;


### PR DESCRIPTION
#### Summary of Changes

In HTML5 we don't need to specify values for the async and defer attributes on script tags.  So, save a few characters in the HTML output, don't send them.
#### Testing Instructions

Pre-patch when adding an async'd script the output should be similar to this:

``` html
<script src="/templates/joomla/js/template.js" async="async"></script>
```

Post-patch, it should look like this:

``` html
<script src="/templates/joomla/js/template.js" async></script>
```
