### PR TITLE
Fix: Warning: Parameter 1 to JError::customErrorPage()  PHP7.0.9

### DIFF
--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -784,7 +784,7 @@ abstract class JError
 	/**
 	 * Display a custom error page and exit gracefully
 	 *
-	 * @param   JException  &$error  Exception object
+	 * @param   JException  $error  Exception object
 	 *
 	 * @return  void
 	 *

--- a/libraries/legacy/error/error.php
+++ b/libraries/legacy/error/error.php
@@ -791,7 +791,7 @@ abstract class JError
 	 * @deprecated  12.1
 	 * @since   11.1
 	 */
-	public static function customErrorPage(&$error)
+	public static function customErrorPage($error)
 	{
 		JLog::add('JError::customErrorPage() is deprecated, use JErrorPage::render() instead.', JLog::WARNING, 'deprecated');
 

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -62,7 +62,7 @@ class PlgSystemRedirect extends JPlugin
 	 *
 	 * @since   1.6
 	 */
-	public static function handleError(JException &$error)
+	public static function handleError(JException $error)
 	{
 		self::doErrorHandling($error);
 	}

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -56,7 +56,7 @@ class PlgSystemRedirect extends JPlugin
 	/**
 	 * Method to handle an error condition from JError.
 	 *
-	 * @param   JException  &$error  The JException object to be handled.
+	 * @param   JException  $error  The JException object to be handled.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
On the new PHP 7.0.9 version you will getting some  warnings like:

Warning: Parameter 1 to JError::customErrorPage() expected to be a reference, value given in C:\wamp\www\develop\libraries\legacy\error\error.php on line 781 

test instructions:

Set environment to PHP 7.0.9
Use a component that using custom error pages like kunena.

Add a extra letter on the url on the category name.

Before fix:
above warning message
After fix:
Showed the custom error page
