### PR TITLE
TinyMCE support for inline multi-language tags

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -760,20 +760,29 @@ JS;
 <<<JS
 						{ text: "$name",
 						onclick: function () {
-							ed.onNodeChange.add(function(ed, cm, n, co) {
-								n = ed.dom.getParent(n, 'SPAN');
-			
-								cm.setDisabled('span', co);
-								cm.setDisabled('attribs', n && n.nodeName == 'BODY');
-								cm.setActive('span', 0);
-			
-								if (n) {
-									do {
-										cm.setDisabled(n.nodeName.toLowerCase(), 0);
-										cm.setActive(n.nodeName.toLowerCase(), 1);
-									} while (n = n.parentNode);
-								}
+	
+							ed.on('NodeChange', function(e) {
+							if (e.element.nodeName == 'P') {
+								var spanEl = document.createElement('SPAN');
+								//spanEl.language = "$title";
+								e.element.appendChild(spanEl)
+							}
 							});
+      
+							// ed.onNodeChange.add(function(ed, cm, n, co) {
+							// 	n = ed.dom.getParent(n, 'SPAN');
+							//
+							// 	cm.setDisabled('span', co);
+							// 	cm.setDisabled('attribs', n && n.nodeName == 'BODY');
+							// 	cm.setActive('span', 0);
+							//
+							// 	if (n) {
+							// 		do {
+							// 			cm.setDisabled(n.nodeName.toLowerCase(), 0);
+							// 			cm.setActive(n.nodeName.toLowerCase(), 1);
+							// 		} while (n = n.parentNode);
+							// 	}
+							// });
 					} },
 JS;
 			}
@@ -935,7 +944,7 @@ JS;
 			case 0: /* Simple mode*/
 				$script .= "
 			menubar: false,
-			toolbar1: \"bold italics underline strikethrough | undo redo | bullist numlist | $toolbar5 | code\",
+			toolbar1: \"bold italics underline strikethrough | undo redo | bullist numlist | $toolbar5 | code langs\",
 			plugins: \"$dragDropPlg code\",
 		});
 		";
@@ -944,7 +953,7 @@ JS;
 				case 1:
 				default: /* Advanced mode*/
 					$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
-						. "| outdent indent | undo redo | link unlink anchor image code | hr table | subscript superscript | charmap";
+						. "| outdent indent | undo redo | link unlink anchor image code | hr table | subscript superscript | charmap langs";
 
 				$script .= "
 			valid_elements : \"$valid_elements\",
@@ -960,7 +969,8 @@ JS;
 			// Advanced Options
 			$resizing
 			height : \"$html_height\",
-			width : \"$html_width\"
+			width : \"$html_width\",
+			$ltempConstructor
 		});
 			";
 				break;
@@ -971,7 +981,7 @@ JS;
 			extended_valid_elements : \"$elements\",
 			invalid_elements : \"$invalid_elements\",
 			// Plugins
-			plugins : \"$plugins $dragDropPlg\",
+			plugins : \"$plugins $dragDropPlg langs\",
 			// Toolbar
 			toolbar1: \"$toolbar1 langs\",
 			removed_menuitems: \"newdocument\",

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -760,29 +760,8 @@ JS;
 <<<JS
 						{ text: "$name",
 						onclick: function () {
-	
-							ed.on('NodeChange', function(e) {
-							if (e.element.nodeName == 'P') {
-								var spanEl = document.createElement('SPAN');
-								//spanEl.language = "$title";
-								e.element.appendChild(spanEl)
-							}
-							});
-      
-							// ed.onNodeChange.add(function(ed, cm, n, co) {
-							// 	n = ed.dom.getParent(n, 'SPAN');
-							//
-							// 	cm.setDisabled('span', co);
-							// 	cm.setDisabled('attribs', n && n.nodeName == 'BODY');
-							// 	cm.setActive('span', 0);
-							//
-							// 	if (n) {
-							// 		do {
-							// 			cm.setDisabled(n.nodeName.toLowerCase(), 0);
-							// 			cm.setActive(n.nodeName.toLowerCase(), 1);
-							// 		} while (n = n.parentNode);
-							// 	}
-							// });
+							ed.focus();
+							ed.selection.setContent('<span language="' + "$title" + '">' + ed.selection.getContent() + '</span>');
 					} },
 JS;
 			}
@@ -792,11 +771,6 @@ JS;
 		$ltempConstructor .=
 			<<<JS
 					]
-
-		// ed.onPreInit.add(function() {
-		// 	ed.dom.create('span');
-		// });
-	// });
 	});
 	}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla-projects/accessibility/issues/2
#### Summary of Changes

Support for `<span language="en-EN"` depending on the language selected on the dropdown button.
#### Testing Instructions

Apply patch.
Make sure that you have more than one language installed in joomla, either wise you won't see something new :)

Select some text and then select the required language from the language button (it's a drop down)

Inspect the selected text to make sure that the text is wrapped with the span and the language tag.

Save and see if changes are retained
#### Preview

<img width="1117" alt="screen shot 2016-07-30 at 17 47 07" src="https://cloud.githubusercontent.com/assets/3889375/17271182/e7d32158-567d-11e6-9474-218cb3d2b959.png">
