### PR TITLE
Build script tweaks

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -24,15 +24,7 @@
 // Set path to git binary (e.g., /usr/local/git/bin/git or /usr/bin/git)
 ob_start();
 passthru('which git', $systemGit);
-$systemGit = ob_get_clean();
-$gitPath   = '/usr/bin/git';
-
-// Sanity check - Make sure $gitPath is the same path the system recognizes
-if (substr($systemGit, 0, -1) != $gitPath)
-{
-	echo '$gitPath does not match path to local git executable, please set $gitPath to: ' . substr($systemGit, 0, -1) . "\n";
-	exit;
-}
+$systemGit = trim(ob_get_clean());
 
 // Make sure file and folder permissions are set correctly
 umask(022);
@@ -63,7 +55,7 @@ mkdir($fullpath);
 
 echo "Copy the files from the git repository.\n";
 chdir($repo);
-system($gitPath . ' archive ' . $fullVersion . ' | tar -x -C ' . $fullpath);
+system($systemGit . ' archive ' . $fullVersion . ' | tar -x -C ' . $fullpath);
 
 chdir($tmp);
 system('mkdir diffdocs');
@@ -144,7 +136,7 @@ for ($num = $release - 1; $num >= 0; $num--)
 
 	// Here we get a list of all files that have changed between the two tags ($previousTag and $fullVersion) and save in diffdocs
 	$previousTag = $version . '.' . $num;
-	$command     = $gitPath . ' diff tags/' . $previousTag . ' tags/' . $fullVersion . ' --name-status > diffdocs/' . $version . '.' . $num;
+	$command     = $systemGit . ' diff tags/' . $previousTag . ' tags/' . $fullVersion . ' --name-status > diffdocs/' . $version . '.' . $num;
 
 	system($command);
 

--- a/build/build.php
+++ b/build/build.php
@@ -161,15 +161,33 @@ for ($num = $release - 1; $num >= 0; $num--)
 			continue;
 		}
 
-		// Don't add deleted files to the list
-		if (substr($file, 0, 1) != 'D')
+		// Act on the file based on the action
+		switch (substr($file, 0, 1))
 		{
-			$filesArray[$fileName] = true;
-		}
-		else
-		{
-			// Add deleted files to the deleted files list
-			$deletedFiles[] = $fileName;
+			// This is a new case with git 2.9 to handle renamed files
+			case 'R':
+				// Explode the file on the tab character; key 0 is the action (rename), key 1 is the old filename, and key 2 is the new filename
+				$renamedFileData = explode("\t", $file);
+
+				// Add the new file for packaging
+				$filesArray[$renamedFileData[2]] = true;
+
+				// And flag the old file as deleted
+				$deletedFiles[] = $renamedFileData[1];
+
+				break;
+
+			// Deleted files
+			case 'D':
+				$deletedFiles[] = $fileName;
+
+				break;
+
+			// Regular additions and modifications
+			default:
+				$filesArray[$fileName] = true;
+
+				break;
 		}
 	}
 


### PR DESCRIPTION
#### Summary of Changes
- Instead of having a hardcoded binary path for git, just use the result of `which git` (sorry anyone who might ever have to package this stuff on Windows, this probably makes it even more difficult)
- Add handling for git 2.9's B/C breaking change regarding renamed files
#### Testing Instructions

On a Linux based platform, build packages of the CMS and ensure they are assembled correctly.

// @wilsonge 
