### PR TITLE
Fix build script on git 2.9

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -169,8 +169,16 @@ for ($num = $release - 1; $num >= 0; $num--)
 			continue;
 		}
 
+		// Handle renamed files since git 2.9.0
+		if (substr($file, 0, 1) == 'R')
+		{
+			// Get the file before and file after
+			$files = explode("\t", substr($file, 5));
+			$deletedFiles[] = $files[0];
+			$filesArray[$files[1]] = true;
+		}
 		// Don't add deleted files to the list
-		if (substr($file, 0, 1) != 'D')
+		else if (substr($file, 0, 1) != 'D')
 		{
 			$filesArray[$fileName] = true;
 		}


### PR DESCRIPTION
Git 2.9 handles renaming of files differently to versions before

```
Git 2.9 Release Notes
=====================

Backward compatibility notes
----------------------------

The end-user facing Porcelain level commands in the "git diff" and
"git log" family by default enable the rename detection; you can still
use "diff.renames" configuration variable to disable this.
```

This should fix this case
