### PR TITLE
Allow the vote plugin's position to be configured

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_content_vote.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_vote.ini
@@ -6,7 +6,7 @@
 PLG_CONTENT_VOTE="Content - Vote"
 PLG_VOTE_BOTTOM="Bottom"
 PLG_VOTE_LABEL="Please Rate"
-PLG_VOTE_POSITION_DESC="Set where the article's voting data is displayed"
+PLG_VOTE_POSITION_DESC="Set where the voting is displayed."
 PLG_VOTE_POSITION_LABEL="Position"
 PLG_VOTE_RATE="Rate"
 PLG_VOTE_STAR_ACTIVE="Star Active"

--- a/administrator/language/en-GB/en-GB.plg_content_vote.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_vote.ini
@@ -4,10 +4,14 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_VOTE="Content - Vote"
+PLG_VOTE_BOTTOM="Bottom"
 PLG_VOTE_LABEL="Please Rate"
+PLG_VOTE_POSITION_DESC="Set where the article's voting data is displayed"
+PLG_VOTE_POSITION_LABEL="Position"
 PLG_VOTE_RATE="Rate"
 PLG_VOTE_STAR_ACTIVE="Star Active"
 PLG_VOTE_STAR_INACTIVE="Star Inactive"
+PLG_VOTE_TOP="Top"
 PLG_VOTE_USER_RATING="User Rating:&#160;%1$s&#160;/&#160;%2$s"
 PLG_VOTE_VOTE="Vote %s"
 PLG_VOTE_XML_DESCRIPTION="Add Voting functionality to Articles."

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -56,7 +56,7 @@ class PlgContentVote extends JPlugin
 	}
 
 	/**
-	 * Displays the voting area if in an article if displayed at the top of the article
+	 * Displays the voting area when viewing an article and the voting section is displayed before the article
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin
 	 * @param   object   &$row     The article object
@@ -78,7 +78,7 @@ class PlgContentVote extends JPlugin
 	}
 
 	/**
-	 * Displays the voting area if in an article if displayed at the bottom of the article
+	 * Displays the voting area when viewing an article and the voting section is displayed after the article
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin
 	 * @param   object   &$row     The article object
@@ -100,7 +100,7 @@ class PlgContentVote extends JPlugin
 	}
 
 	/**
-	 * Displays the voting area if in an article
+	 * Displays the voting area
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin
 	 * @param   object   &$row     The article object

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -33,7 +33,30 @@ class PlgContentVote extends JPlugin
 	protected $autoloadLanguage = true;
 
 	/**
-	 * Displays the voting area if in an article
+	 * The position the voting data is displayed in relative to the article.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $votingPosition;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   object  &$subject  The object to observe
+	 * @param   array   $config    An optional associative array of configuration settings.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(&$subject, $config)
+	{
+		parent::__construct($subject, $config);
+
+		$this->votingPosition = $this->params->get('position', 'top');
+	}
+
+	/**
+	 * Displays the voting area if in an article if displayed at the top of the article
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin
 	 * @param   object   &$row     The article object
@@ -44,7 +67,51 @@ class PlgContentVote extends JPlugin
 	 *
 	 * @since   1.6
 	 */
-	public function onContentBeforeDisplay($context, &$row, &$params, $page=0)
+	public function onContentBeforeDisplay($context, &$row, &$params, $page = 0)
+	{
+		if ($this->votingPosition != 'top')
+		{
+			return '';
+		}
+
+		return $this->displayVotingData($context, $row, $params, $page);
+	}
+
+	/**
+	 * Displays the voting area if in an article if displayed at the bottom of the article
+	 *
+	 * @param   string   $context  The context of the content being passed to the plugin
+	 * @param   object   &$row     The article object
+	 * @param   object   &$params  The article params
+	 * @param   integer  $page     The 'page' number
+	 *
+	 * @return  string|boolean  HTML string containing code for the votes if in com_content else boolean false
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onContentAfterDisplay($context, &$row, &$params, $page = 0)
+	{
+		if ($this->votingPosition != 'bottom')
+		{
+			return '';
+		}
+
+		return $this->displayVotingData($context, $row, $params, $page);
+	}
+
+	/**
+	 * Displays the voting area if in an article
+	 *
+	 * @param   string   $context  The context of the content being passed to the plugin
+	 * @param   object   &$row     The article object
+	 * @param   object   &$params  The article params
+	 * @param   integer  $page     The 'page' number
+	 *
+	 * @return  string|boolean  HTML string containing code for the votes if in com_content else boolean false
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function displayVotingData($context, &$row, &$params, $page)
 	{
 		$parts = explode(".", $context);
 

--- a/plugins/content/vote/vote.xml
+++ b/plugins/content/vote/vote.xml
@@ -19,6 +19,18 @@
 	</languages>
 	<config>
 		<fields name="params">
+			<fieldset name="basic">
+				<field
+					name="position"
+					type="list"
+					default="top"
+					description="PLG_VOTE_POSITION_DESC"
+					label="PLG_VOTE_POSITION_LABEL"
+				>
+					<option value="top">PLG_VOTE_TOP</option>
+					<option value="bottom">PLG_VOTE_BOTTOM</option>
+				</field>
+			</fieldset>
 		</fields>
 	</config>
 </extension>


### PR DESCRIPTION
#### Summary of Changes

Presently the voting plugin only triggers for the `onContentBeforeDisplay` event.  This PR adds the `onContentAfterDisplay` event as well and makes the position configurable.
#### Testing Instructions

Apply this patch from a checkout of the `3.7.x` branch and ensure the new configuration works correctly.
