### PR TITLE
text string layout

### DIFF
--- a/language/en-GB/en-GB.mod_menu.ini
+++ b/language/en-GB/en-GB.mod_menu.ini
@@ -18,6 +18,6 @@ MOD_MENU_FIELD_STARTLEVEL_DESC="Level to start rendering the menu at. Setting th
 MOD_MENU_FIELD_STARTLEVEL_LABEL="Start Level"
 MOD_MENU_FIELD_TAG_ID_DESC="An ID attribute to assign to the root ul tag of the menu (optional)."
 MOD_MENU_FIELD_TAG_ID_LABEL="Menu Tag ID"
-MOD_MENU_FIELD_TARGET_DESC="JavaScript values to position a popup window, eg top=50,left=50,width=200,height=300."
+MOD_MENU_FIELD_TARGET_DESC="JavaScript values to position a popup window, eg top=50, left=50, width=200, height=300."
 MOD_MENU_FIELD_TARGET_LABEL="Target Position"
 MOD_MENU_XML_DESCRIPTION="This module displays a menu on the Frontend."


### PR DESCRIPTION
This is a cosmetic change only - by adding the spaces the tooltip is displayed better. 

I have checked that the code itself still works if there are spaces in the string (see #11380 for how to use this obscure feature)
#### Before

![bc8p](https://cloud.githubusercontent.com/assets/1296369/17293594/25c11c60-57e9-11e6-8ca8-2f7c06328271.png)
#### After

![xffd](https://cloud.githubusercontent.com/assets/1296369/17293605/2f1f79dc-57e9-11e6-83bb-5b9117ba422d.png)
