### PR TITLE
Make Install languages more prominent in the installer

### DIFF
--- a/installation/view/complete/tmpl/default.php
+++ b/installation/view/complete/tmpl/default.php
@@ -19,19 +19,34 @@ defined('_JEXEC') or die;
 	<div class="alert alert-success">
 		<h3><?php echo JText::_('INSTL_COMPLETE_TITLE'); ?></h3>
 	</div>
-	<div class="alert">
-		<p><?php echo JText::_('INSTL_COMPLETE_REMOVE_INSTALLATION'); ?></p>
-		<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>" />
-	</div>
-	<div class="btn-toolbar">
-		<div class="btn-group">
-			<a class="btn" href="<?php echo JUri::root(); ?>" title="<?php echo JText::_('JSITE'); ?>"><span class="icon-eye-open"></span> <?php echo JText::_('JSITE'); ?></a>
-		</div>
-		<div class="btn-group">
-			<a class="btn btn-primary" href="<?php echo JUri::root(); ?>administrator/" title="<?php echo JText::_('JADMINISTRATOR'); ?>"><span class="icon-lock icon-white"></span> <?php echo JText::_('JADMINISTRATOR'); ?></a>
+	<div class="row-fluid">	
+		<h3><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_1'); ?></h3>
+		<hr class="hr-condensed" />
+		<div class="row-fluid">	
+			<div class="span6">
+				<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC'); ?></p>
+				<p><a href="#" class="btn btn-primary" id="instLangs" onclick="return Install.goToPage('languages');"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('INSTL_COMPLETE_INSTALL_LANGUAGES'); ?></a></p>
+			</div>
+			<div class="alert span6">
+				<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC2'); ?></p>
+			</div>
 		</div>
 	</div>
 	<div class="row-fluid">
+		<div class="alert">
+			<p><?php echo JText::_('INSTL_COMPLETE_REMOVE_INSTALLATION'); ?></p>
+			<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>" />
+		</div>
+	</div>
+	<div class="row-fluid">
+		<div class="btn-toolbar span6">
+			<div class="btn-group">
+				<a class="btn" href="<?php echo JUri::root(); ?>" title="<?php echo JText::_('JSITE'); ?>"><span class="icon-eye-open"></span> <?php echo JText::_('JSITE'); ?></a>
+			</div>
+			<div class="btn-group">
+				<a class="btn btn-primary" href="<?php echo JUri::root(); ?>administrator/" title="<?php echo JText::_('JADMINISTRATOR'); ?>"><span class="icon-lock icon-white"></span> <?php echo JText::_('JADMINISTRATOR'); ?></a>
+			</div>
+		</div>
 		<div class="span6">
 			<h3><?php echo JText::_('INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS'); ?></h3>
 			<hr class="hr-condensed" />
@@ -60,13 +75,6 @@ defined('_JEXEC') or die;
 					</tr>
 				</tfoot>
 			</table>
-		</div>
-		<div id="languages" class="span6">
-			<h3><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_1'); ?></h3>
-			<hr class="hr-condensed" />
-			<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC'); ?></p>
-			<p><a href="#" class="btn btn-primary" id="instLangs" onclick="return Install.goToPage('languages');"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('INSTL_COMPLETE_INSTALL_LANGUAGES'); ?></a></p>
-			<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC2'); ?></p>
 		</div>
 	</div>
 	<?php if ($this->config) : ?>


### PR DESCRIPTION
I always manage to hit next before I see/remember the option to install the additional languages. 

This purely cosmetic PR reorders the screen to make installing additional languages and makes it seem part of the install process and not something as an afterthought (I hope)

I am sure designers can make it look even better ;)
#### Before

![before](https://cloud.githubusercontent.com/assets/1296369/17296517/952ba1dc-57f9-11e6-8ab1-1f5948449fe2.png)
#### After

![after](https://cloud.githubusercontent.com/assets/1296369/17296535/a8fdc83e-57f9-11e6-806e-977b62587b6e.png)
#### Testing

To test you will need to either download and install Joomla from here https://github.com/brianteeman/joomla-cms/archive/instal.zip or apply the patch to your test install of joomla - remove the configuration.php from the root. refresh the screen and reinstall Joomla
