### PR TITLE
Code Style Fixes for administrator\components\com_categories

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -294,7 +294,7 @@ class CategoriesModelCategories extends JModelList
 				uc.name, 
 				ag.title, 
 				ua.name'
-			);
+		);
 
 		return $query;
 	}
@@ -360,7 +360,7 @@ class CategoriesModelCategories extends JModelList
 
 	/**
 	 * Method to load the countItems method from the extensions
-	 * 
+	 *
 	 * @param   stdClass[]  &$items     The category items
 	 * @param   string      $extension  The category extension
 	 *

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -339,7 +339,8 @@ class CategoriesModelCategory extends JModelAdmin
 				);
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
 				$data->set('access', $app->input->getInt('access',
-									(!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
+									(!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))
+				);
 			}
 		}
 

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -73,7 +73,7 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			if ($record->published != -2)
 			{
-				return 0;
+				return false;
 			}
 
 			return JFactory::getUser()->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
@@ -338,8 +338,9 @@ class CategoriesModelCategory extends JModelAdmin
 					)
 				);
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-				$data->set('access',
-							$app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))
+				$data->set(
+					'access',
+					$app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))
 				);
 			}
 		}

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -69,15 +69,12 @@ class CategoriesModelCategory extends JModelAdmin
 	 */
 	protected function canDelete($record)
 	{
-		if (!empty($record->id))
+		if (empty($record->id) || $record->published != -2)
 		{
-			if ($record->published != -2)
-			{
-				return false;
-			}
-
-			return JFactory::getUser()->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
+			return false;
 		}
+
+		return JFactory::getUser()->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
 	}
 
 	/**

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -73,7 +73,7 @@ class CategoriesModelCategory extends JModelAdmin
 		{
 			if ($record->published != -2)
 			{
-				return;
+				return 0;
 			}
 
 			return JFactory::getUser()->authorise('core.delete', $record->extension . '.category.' . (int) $record->id);
@@ -338,7 +338,8 @@ class CategoriesModelCategory extends JModelAdmin
 					)
 				);
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
+				$data->set('access', $app->input->getInt('access',
+									(!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'))));
 			}
 		}
 

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -338,8 +338,8 @@ class CategoriesModelCategory extends JModelAdmin
 					)
 				);
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-				$data->set('access', $app->input->getInt('access',
-									(!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))
+				$data->set('access',
+							$app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))
 				);
 			}
 		}

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -252,8 +252,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			foreach ($options as $i => $option)
 			{
 				/*
-				 * To take save or create in a category you need to have create rights for that category
-				 * Unless the item is already in that category.
+				 * To take save or create in a category you need to have create rights for that category unless the item is already in that category.
 				 * Unset the option if the user isn't authorised for it. In this field assets are always categories.
 				 */
 				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true && $option->level != 0)
@@ -267,7 +266,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		{
 			/*
 			 * If you are only allowed to edit in this category but not edit.state, you should not get any
-			 * Option to change the category parent for a category or the category for a content item,
+			 * option to change the category parent for a category or the category for a content item,
 			 * but you should be able to save in that category.
 			 */
 			foreach ($options as $i => $option)

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -23,7 +23,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * To allow creation of new categories.
 	 *
-	 * @var    int
+	 * @var    integer
 	 * @since  3.6
 	 */
 	protected $allowAdd;
@@ -251,8 +251,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		{
 			foreach ($options as $i => $option)
 			{
-				/* To take save or create in a category you need to have create rights for that category
-				 * unless the item is already in that category.
+				/*
+				 * To take save or create in a category you need to have create rights for that category
+				 * Unless the item is already in that category.
 				 * Unset the option if the user isn't authorised for it. In this field assets are always categories.
 				 */
 				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true && $option->level != 0)
@@ -264,8 +265,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		// If you have an existing category id things are more complex.
 		else
 		{
-			/* If you are only allowed to edit in this category but not edit.state, you should not get any
-			 * option to change the category parent for a category or the category for a content item,
+			/*
+			 * If you are only allowed to edit in this category but not edit.state, you should not get any
+			 * Option to change the category parent for a category or the category for a content item,
 			 * but you should be able to save in that category.
 			 */
 			foreach ($options as $i => $option)
@@ -285,8 +287,10 @@ class JFormFieldCategoryEdit extends JFormFieldList
 					unset($options[$i]);
 				}
 
-				// However, if you can edit.state you can also move this to another category for which you have
-				// create permission and you should also still be able to save in the current category.
+				/*
+				 * However, if you can edit.state you can also move this to another category for which you have
+				 * create permission and you should also still be able to save in the current category.
+				 */
 				if (($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
 					&& ($option->value != $oldCat && !isset($oldParent)))
 				{
@@ -362,7 +366,10 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		$attr .= $this->autofocus ? ' autofocus' : '';
 
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true' || (string) $this->disabled == '1'|| (string) $this->disabled == 'true')
+		if ((string) $this->readonly == '1'
+			|| (string) $this->readonly == 'true'
+			|| (string) $this->disabled == '1'
+			|| (string) $this->disabled == 'true')
 		{
 			$attr .= ' disabled="disabled"';
 		}

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -134,8 +134,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 			foreach ($options as $i => $option)
 			{
 				/*
-				 * To take save or create in a category you need to have create rights for that category
-				 * Unless the item is already in that category.
+				 * To take save or create in a category you need to have create rights for that category unless the item is already in that category.
 				 * Unset the option if the user isn't authorised for it. In this field assets are always categories.
 				 */
 				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
@@ -151,7 +150,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 			{
 				/*
 				 * If you are only allowed to edit in this category but not edit.state, you should not get any
-				 * Option to change the category parent for a category or the category for a content item,
+				 * option to change the category parent for a category or the category for a content item,
 				 * but you should be able to save in that category.
 				 */
 				if ($user->authorise('core.edit.state', $extension . '.category.' . $oldCat) != true)

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -133,8 +133,9 @@ class JFormFieldCategoryParent extends JFormFieldList
 		{
 			foreach ($options as $i => $option)
 			{
-				/* To take save or create in a category you need to have create rights for that category
-				 * unless the item is already in that category.
+				/*
+				 * To take save or create in a category you need to have create rights for that category
+				 * Unless the item is already in that category.
 				 * Unset the option if the user isn't authorised for it. In this field assets are always categories.
 				 */
 				if ($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
@@ -148,8 +149,9 @@ class JFormFieldCategoryParent extends JFormFieldList
 		{
 			foreach ($options as $i => $option)
 			{
-				/* If you are only allowed to edit in this category but not edit.state, you should not get any
-				 * option to change the category parent for a category or the category for a content item,
+				/*
+				 * If you are only allowed to edit in this category but not edit.state, you should not get any
+				 * Option to change the category parent for a category or the category for a content item,
 				 * but you should be able to save in that category.
 				 */
 				if ($user->authorise('core.edit.state', $extension . '.category.' . $oldCat) != true)
@@ -160,8 +162,10 @@ class JFormFieldCategoryParent extends JFormFieldList
 						unset($options[$i]);
 					}
 				}
-				// However, if you can edit.state you can also move this to another category for which you have
-				// create permission and you should also still be able to save in the current category.
+				/*
+				 * However, if you can edit.state you can also move this to another category for which you have
+				 * create permission and you should also still be able to save in the current category.
+				 */
 				elseif (($user->authorise('core.create', $extension . '.category.' . $option->value) != true)
 					&& $option->value != $oldCat
 				)

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -206,10 +206,11 @@ class CategoriesViewCategory extends JViewLegacy
 
 		JToolbarHelper::divider();
 
-		// Compute the ref_key if it does exist in the component
-		if (!$lang->hasKey(
-			$ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY'
-			))
+		// Compute the ref_key
+		$ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY';
+
+		// Check if thr computed ref_key does exist in the component
+		if (!$lang->hasKey($ref_key))
 		{
 			$ref_key = 'JHELP_COMPONENTS_'
 						. strtoupper(substr($component, 4) . ($section ? "_$section" : ''))

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -142,7 +142,8 @@ class CategoriesViewCategory extends JViewLegacy
 		// Else if the component section string exits, let's use it
 		elseif ($lang->hasKey($component_section_key = $component . ($section ? "_$section" : '')))
 		{
-			$title = JText::sprintf('COM_CATEGORIES_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE', $this->escape(JText::_($component_section_key)));
+			$title = JText::sprintf('COM_CATEGORIES_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT')
+			. '_TITLE', $this->escape(JText::_($component_section_key)));
 		}
 		// Else use the base title
 		else
@@ -205,12 +206,15 @@ class CategoriesViewCategory extends JViewLegacy
 		JToolbarHelper::divider();
 
 		// Compute the ref_key if it does exist in the component
-		if (!$lang->hasKey($ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY'))
+		if (!$lang->hasKey($ref_key = strtoupper($component . ($section ? "_$section" : ''))
+		. '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY'))
 		{
-			$ref_key = 'JHELP_COMPONENTS_' . strtoupper(substr($component, 4) . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT');
+			$ref_key = 'JHELP_COMPONENTS_' . strtoupper(substr($component, 4)
+			. ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT');
 		}
 
-		/* Get help for the category/section view for the component by
+		/*
+		 * Get help for the category/section view for the component by
 		 * -remotely searching in a language defined dedicated URL: *component*_HELP_URL
 		 * -locally  searching in a component help file if helpURL param exists in the component and is set to ''
 		 * -remotely searching in a component URL if helpURL param exists in the component and is NOT set to ''

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -143,7 +143,8 @@ class CategoriesViewCategory extends JViewLegacy
 		elseif ($lang->hasKey($component_section_key = $component . ($section ? "_$section" : '')))
 		{
 			$title = JText::sprintf('COM_CATEGORIES_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT')
-			. '_TITLE', $this->escape(JText::_($component_section_key)));
+					. '_TITLE', $this->escape(JText::_($component_section_key))
+					);
 		}
 		// Else use the base title
 		else
@@ -206,11 +207,13 @@ class CategoriesViewCategory extends JViewLegacy
 		JToolbarHelper::divider();
 
 		// Compute the ref_key if it does exist in the component
-		if (!$lang->hasKey($ref_key = strtoupper($component . ($section ? "_$section" : ''))
-		. '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY'))
+		if (!$lang->hasKey(
+			$ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY'
+			))
 		{
-			$ref_key = 'JHELP_COMPONENTS_' . strtoupper(substr($component, 4)
-			. ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT');
+			$ref_key = 'JHELP_COMPONENTS_'
+						. strtoupper(substr($component, 4) . ($section ? "_$section" : ''))
+						. '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT');
 		}
 
 		/*


### PR DESCRIPTION
Pull Request for Code Style Fixes for administrator\components\com_categories.
#### Summary of Changes
- Multi-line function call not indented correctly
- Line exceeds 150 characters
- Function return type is not void, but function is returning void here
- Block comment text must start on a new line
- Multi-line block comment not used
- Comment must start with a capital letter
- Expected "integer" but found "int" for @var tag in member variable
  comment

[Automatically fixed with PHPCS2 fixers](https://github.com/joomla/coding-standards/pull/109) and some minor edits
#### Testing Instructions

Merge by code review (or just test that categories still function normally in front end and back end)
