### PR TITLE
Fix repeated invalid HTML for modal module edit links, in menu item form

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -130,7 +130,6 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 								<?php echo JText::_('JNO'); ?>
 							</span>
 						<?php endif;?>
-				</td>
 			<?php echo JHtml::_(
 					'bootstrap.renderModal',
 					'moduleEdit' . $module->id . 'Modal',
@@ -155,6 +154,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 								. JText::_("JAPPLY") . '</button>',
 					)
 				); ?>
+				</td>
 			</tr>
 		<?php endforeach; ?>
 		</tbody>


### PR DESCRIPTION
#### Issue

Menu edit form / Module assignment TAB
- the module listing places the hidden modal HTML code between last /td and /tr, that is invalid HTML code is invalid **without real need for it being invalid**
#### Summary of Changes

The /td is move down to include the HTML code of the modal
#### Testing Instructions

Review code to see that the /td move after the hidden modal HTML code 
1. Edit a menu item, 
2. click on the "Module assignment" TAB and then click to edit a module
3. See the invalid HTML warnings
4. Apply patch and verify that the modal works and closes (use latest staging, not J3.6.0) and that you do not get the invalid HTML warning anymore
