### PR TITLE
Update Sites rebuild message

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -361,7 +361,7 @@ class InstallerModelUpdatesites extends InstallerModel
 		}
 		else
 		{
-			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_WARNING'), 'warning');
+			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_MESSAGE'), 'message');
 		}
 	}
 

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -145,6 +145,7 @@ COM_INSTALLER_MSG_UPDATESITES_DELETE_CANNOT_DELETE="%s update site cannot be del
 COM_INSTALLER_MSG_UPDATESITES_N_DELETE_UPDATESITES_DELETED="%s update sites have been deleted."
 COM_INSTALLER_MSG_UPDATESITES_N_DELETE_UPDATESITES_DELETED_1="1 update site has been deleted."
 COM_INSTALLER_MSG_UPDATESITES_REBUILD_EXTENSION_PLUGIN_NOT_ENABLED="The <a href="_QQ_"%s"_QQ_">Joomla Extension Plugin</a> is disabled. This plugin must be enabled to rebuild the update sites."
+COM_INSTALLER_MSG_UPDATESITES_REBUILD_MESSAGE="Update sites have been rebuilt. No extension with an update site has been discovered."
 COM_INSTALLER_MSG_UPDATESITES_REBUILD_NOT_PERMITTED="Rebuilding update sites is not permitted."
 COM_INSTALLER_MSG_UPDATESITES_REBUILD_WARNING="Update sites have been rebuilt. No extension with updates sites discovered."
 COM_INSTALLER_MSG_UPDATESITES_REBUILD_SUCCESS="Update sites have been rebuilt from manifest files."


### PR DESCRIPTION
This PR changes the displayed information from a warning to a message and improves the grammar of the message. Note because it changed from a warning to a message the language KEY changed as well. I did not remove the old KEY following our current practice
#### Testing Instructions

Go to Extensions -> Update Sites and select Rebuild on the toolbar
#### Before

![t0 w](https://cloud.githubusercontent.com/assets/1296369/17326135/3ea0b0e2-58a7-11e6-89b5-fb2bdd5cbc93.png)
#### After

![g21c](https://cloud.githubusercontent.com/assets/1296369/17326136/3fcbe766-58a7-11e6-91e8-3f5359e3c469.png)
