### PR TITLE
Add setDocumentTitle() function in JViewLegacy

### DIFF
--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -831,7 +831,7 @@ class JViewLegacy extends JObject
 	/**
 	 * Sets the document title according to Global Configuration options
 	 *
-	 * @param   string  $title   The page title
+	 * @param   string  $title  The page title
 	 *
 	 * @return  void
 	 *

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -827,4 +827,34 @@ class JViewLegacy extends JObject
 
 		return $this->form;
 	}
+
+	/**
+	 * Sets the document title according to Global Configuration options
+	 *
+	 * @param   string  $title   The page title
+	 *
+	 * @return  void
+	 *
+	 * @since   3.6
+	 */
+	public function setDocumentTitle($title)
+	{
+		$app = JFactory::getApplication();
+
+		// Check for empty title and add site name if param is set
+		if (empty($title))
+		{
+			$title = $app->get('sitename');
+		}
+		elseif ($app->get('sitename_pagetitles', 0) == 1)
+		{
+			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
+		}
+		elseif ($app->get('sitename_pagetitles', 0) == 2)
+		{
+			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
+		}
+
+		$this->document->setTitle($title);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #11215 .
#### Summary of Changes

This is just a helper function to allow developers to set the document title according to what options have been set in regards to the "Include Site Name in Page Titles" option from Global Configuration - without the need to duplicate this same logic in every view.
#### Testing Instructions

Call `$this->setDocumentTitle($title);` in your view's `display()` function; for example, this part from `/components/com_users/views/login/view.html.php`:

``` php
$title = $this->params->get('page_title', '');

if (empty($title))
{
    $title = $app->get('sitename');
}
elseif ($app->get('sitename_pagetitles', 0) == 1)
{
    $title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
}
elseif ($app->get('sitename_pagetitles', 0) == 2)
{
    $title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
}

$this->document->setTitle($title);
```

Can be simplified into:

``` php
$this->setDocumentTitle($this->params->get('page_title', ''));
```

Same goes for all other components Joomla! is using, since they all duplicate the same code.
