### PR TITLE
Incorrect option in tag item image float

### DIFF
--- a/administrator/components/com_tags/models/forms/tag.xml
+++ b/administrator/components/com_tags/models/forms/tag.xml
@@ -262,7 +262,7 @@
 				label="COM_TAGS_FLOAT_LABEL"
 				description="COM_TAGS_FLOAT_DESC"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 				<option value="right">COM_TAGS_RIGHT</option>
 				<option value="left">COM_TAGS_LEFT</option>
 				<option value="none">COM_TAGS_NONE</option>
@@ -307,7 +307,7 @@
 				label="COM_TAGS_FLOAT_LABEL"
 				description="COM_TAGS_FLOAT_DESC"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				<option value="">JGLOBAL_SELECT_AN_OPTION</option>
 				<option value="right">COM_TAGS_RIGHT</option>
 				<option value="left">COM_TAGS_LEFT</option>
 				<option value="none">COM_TAGS_NONE</option>


### PR DESCRIPTION
Pull Request for Issue #6511 .
#### Summary of Changes

There are two image fields for a tag and they have a float option. Probably due to a copy past error they offer a Global option but there is no where to set a global value.

This PR changes the meaningless use global string with a select an option string
#### AFTER PR

![v dt](https://cloud.githubusercontent.com/assets/1296369/17341819/4dae05ac-58ee-11e6-8b86-807ceb821cfb.png)
