### PR TITLE
Use intro_image in newsfeed

### DIFF
--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -34,7 +34,7 @@ class ContentViewCategory extends JViewCategoryfeed
 	 */
 	protected function reconcileNames($item)
 	{
-		// Get description, into_image, author and date
+		// Get description, intro_image, author and date
 		$app               = JFactory::getApplication();
 		$params            = $app->getParams();
 		$item->description = '';

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -40,6 +40,7 @@ class ContentViewCategory extends JViewCategoryfeed
 		$item->description = '';
 		$obj = json_decode($item->images);
 		$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
+
 		if (isset($introImage) && ($introImage != "")) 
 		{
 			$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -34,10 +34,17 @@ class ContentViewCategory extends JViewCategoryfeed
 	 */
 	protected function reconcileNames($item)
 	{
-		// Get description, author and date
+		// Get description, into_image, author and date
 		$app               = JFactory::getApplication();
 		$params            = $app->getParams();
-		$item->description = $params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext;
+		$item->description = '';
+		$obj = json_decode($item->images);
+		$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '' ;
+		if (isset($introImage) && ($introImage != "")) {
+			$image = preg_match('/http/', $introImage)? $introImage : JURI::root().$introImage;
+			$item->description = '<p><img src="'.$image.'" /></p>';
+		}
+		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext.$item->fulltext : $item->introtext);         
 
 		// Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists
 		if (!$item->params->get('feed_summary', 0) && $item->params->get('feed_show_readmore', 0) && $item->fulltext)

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -39,12 +39,13 @@ class ContentViewCategory extends JViewCategoryfeed
 		$params            = $app->getParams();
 		$item->description = '';
 		$obj = json_decode($item->images);
-		$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '' ;
-		if (isset($introImage) && ($introImage != "")) {
-			$image = preg_match('/http/', $introImage)? $introImage : JURI::root().$introImage;
-			$item->description = '<p><img src="'.$image.'" /></p>';
+		$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
+		if (isset($introImage) && ($introImage != "")) 
+		{
+			$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;
+			$item->description = '<p><img src="' . $image . '" /></p>';
 		}
-		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext.$item->fulltext : $item->introtext);         
+		$item->description .= ($params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext);         
 
 		// Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists
 		if (!$item->params->get('feed_summary', 0) && $item->params->get('feed_show_readmore', 0) && $item->fulltext)

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -61,10 +61,10 @@ class ContentViewFeatured extends JViewLegacy
 
 			$description = '';
 			$obj = json_decode($row->images);
-			$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '' ;
+			$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
 			if (isset($introImage) && ($introImage != "")) 
 			{
-				$image = preg_match('/http/', $introImage)? $introImage : JURI::root().$introImage;
+				$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;
 				$description = '<p><img src="' . $image . '" /></p>';
 			}
 			$description .= ($params->get('feed_summary', 0) ? $row->introtext . $row->fulltext : $row->introtext);  			

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -62,6 +62,7 @@ class ContentViewFeatured extends JViewLegacy
 			$description = '';
 			$obj = json_decode($row->images);
 			$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
+
 			if (isset($introImage) && ($introImage != "")) 
 			{
 				$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -59,7 +59,15 @@ class ContentViewFeatured extends JViewLegacy
 			$db->setQuery($query);
 			$row->fulltext = $db->loadResult();
 
-			$description = ($params->get('feed_summary', 0) ? $row->introtext . $row->fulltext : $row->introtext);
+			$description = '';
+			$obj = json_decode($row->images);
+			$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '' ;
+			if (isset($introImage) && ($introImage != "")) 
+			{
+				$image = preg_match('/http/', $introImage)? $introImage : JURI::root().$introImage;
+				$description = '<p><img src="' . $image . '" /></p>';
+			}
+			$description .= ($params->get('feed_summary', 0) ? $row->introtext . $row->fulltext : $row->introtext);  			
 			$author      = $row->created_by_alias ? $row->created_by_alias : $row->author;
 
 			// Load individual item creator class


### PR DESCRIPTION
Pull Request for Issue #8198 .
#### Summary of Changes

Publishing RSS feeds from Joomla doesn't include the intro_image field
#### Testing Instructions

Publish a news feed for a category and ensue that at least one article in the category uses the intro_text field

This code is provided by @nunoleite 
