### PR TITLE
Configure JDocumentError instance with all attributes

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -35,14 +35,30 @@ class JErrorPage
 		{
 			try
 			{
+				$app = JFactory::getApplication();
+
 				// If site is offline and it's a 404 error, just go to index (to see offline message, instead of 404)
 				if ($error->getCode() == '404' && JFactory::getConfig()->get('offline') == 1)
 				{
-					JFactory::getApplication()->redirect('index.php');
+					$app->redirect('index.php');
 				}
 
-				$app      = JFactory::getApplication();
-				$document = JDocument::getInstance('error');
+				$attributes = array(
+					'charset'   => 'utf-8',
+					'lineend'   => 'unix',
+					'tab'       => "\t",
+					'language'  => 'en-GB',
+					'direction' => 'ltr',
+				);
+
+				// If there is a JLanguage instance in JFactory then let's pull the language and direction from its metadata
+				if (JFactory::$language)
+				{
+					$attributes['language']  = JFactory::getLanguage()->getTag();
+					$attributes['direction'] = JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
+				}
+
+				$document = JDocument::getInstance('error', $attributes);
 
 				if (!$document)
 				{

--- a/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
+++ b/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
@@ -44,7 +44,18 @@ class JErrorPageTest extends TestCaseDatabase
 	{
 		$documentResponse = '<title>500 - Testing JErrorPage::render() with RuntimeException</title>Testing JErrorPage::render() with RuntimeException';
 
-		$key = serialize(array('error', array()));
+		$key = serialize(
+			array(
+				'error',
+				array(
+					'charset'   => 'utf-8',
+					'lineend'   => 'unix',
+					'tab'       => "\t",
+					'language'  => 'en-GB',
+					'direction' => 'ltr',
+				),
+			)
+		);
 
 		$mockErrorDocument = $this->getMockBuilder('JDocumentError')
 			->setMethods(array('setError', 'setTitle', 'render'))
@@ -77,7 +88,18 @@ class JErrorPageTest extends TestCaseDatabase
 	{
 		$documentResponse = '<title>500 - Testing JErrorPage::render() with PHP 7 Error</title>Testing JErrorPage::render() with PHP 7 Error';
 
-		$key = serialize(array('error', array()));
+		$key = serialize(
+			array(
+				'error',
+				array(
+					'charset'   => 'utf-8',
+					'lineend'   => 'unix',
+					'tab'       => "\t",
+					'language'  => 'en-GB',
+					'direction' => 'ltr',
+				),
+			)
+		);
 
 		$mockErrorDocument = $this->getMockBuilder('JDocumentError')
 			->setMethods(array('setError', 'setTitle', 'render'))


### PR DESCRIPTION
#### Summary of Changes

When `JErrorPage::render()` instantiates the `JDocumentError` instance for the error page, it doesn't inject any attributes into the object the same as if it were instantiated through another path (i.e. the install app's `loadDocument` method).  This means the `JDocumentError` doesn't have the correct language or direction data within it if checking `$this->language` or `$this->direction` as done in HTML templates.

This PR will inject the same attributes into the `JDocumentError` instance as if it were instantiated another way and if the language data is available (it may be possible to hit the error page before the `JLanguage` singleton is instantiated) we'll add that to the attributes array.
#### Testing Instructions

Set your template to Beez3 for the frontend or Hathor on the backend; the other templates try to grab these attributes out of the `JDocument` instance in `JFactory` so it's harder to test against them.  Trigger an error page somehow, preferably with another language active.  Pre-patch, note the incorrect attributes in the `<html>` tag.  Post-patch, it should be correct if `JLanguage` has been instantiated before the error page has been triggered.
