### PR TITLE
There is no need to die here. Log and carry on.

### DIFF
--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -170,7 +170,9 @@ class JCacheStorage
 		// Validate the cache storage is supported on this platform
 		if (!$class::isSupported())
 		{
-			throw new RuntimeException(sprintf('The %s Cache Storage is not supported on this platform.', $handler));
+			JLog::add(sprintf('The %s Cache Storage is not supported on this platform.', $handler), JLog::WARNING, 'cache');
+
+			return self::getInstance('', $options);
 		}
 
 		return new $class($options);


### PR DESCRIPTION
#### Summary of Changes

Instead of throwing an exception when a requested cache handler is not available, get an instance of the base `JCacheStorage` class (which does not store anything) instead. Log a warning but do not die.  

I suppose this is controversial change. I recognize and agree that it's best to die anytime something goes wrong so that problems can be found and fixed asap. However, I think this is a bad place to strictly follow that philosophy. The reason is that Joomla tries to create cache handlers even when caching is turned off. It tries to create them with whatever handler they'd have used had caching been turned on. So your config may have `cache` set to `0` and `cache_handler` set to `file` and Joomla will attempt to create an instance of `JCacheStorageFile`. This might fail even though you had no intention of using caching at all. To me, that's just silly. 
#### Testing Instructions
1. Turn on caching and set it to use file
2. Remove or rename your cache folder
3. Notice that Joomla dies
4. Try to run `cli/finder_indexer.php` from the command line, notice that it dies even though it does not use caching
5. Apply the patch
6. Notice that these things do not die

This all seems terribly unlikely in real life, right? Take this case. You have a site which uses apc instead of file caching. You don't have a cache folder because you don't need one and you strictly limit write permissions for security reasons etc etc. You try to run the finder indexer which doesn't need to cache anything anyway. It dies because it turns off caching but sets the handler to file. 
