### PR TITLE
Preventing slashes added by bootstrap tab if lang string contains single quote

### DIFF
--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -55,7 +55,7 @@ $fieldsets = $this->form->getFieldsets();
 			continue;
 		}
 		?>
-		<?php echo JHtml::_('bootstrap.addTab', 'myTab', $fieldset->name, JText::_($fieldset->label, true)); ?>
+		<?php echo JHtml::_('bootstrap.addTab', 'myTab', $fieldset->name, JText::_($fieldset->label)); ?>
 		<?php foreach ($this->form->getFieldset($fieldset->name) as $field) : ?>
 			<?php if ($field->hidden) : ?>
 				<div class="control-group">

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit_options.php
@@ -13,7 +13,7 @@ foreach ($this->fieldsets as $name => $fieldset)
 {
 	if (!isset($fieldset->repeat) || isset($fieldset->repeat) && $fieldset->repeat == false)
 	{
-		$label = !empty($fieldset->label) ? JText::_($fieldset->label, true) : JText::_('COM_PLUGINS_' . $fieldset->name . '_FIELDSET_LABEL', true);
+		$label = !empty($fieldset->label) ? JText::_($fieldset->label) : JText::_('COM_PLUGINS_' . $fieldset->name . '_FIELDSET_LABEL', true);
 		$optionsname = 'options-' . $fieldset->name;
 		echo JHtml::_('bootstrap.addTab', 'myTab', $optionsname,  $label);
 

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -171,7 +171,7 @@ jimport('joomla.html.html.bootstrap');
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE', true)); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE')); ?>
 		<?php endif; ?>
 		<?php if ($this->params->get('presentation_style') == 'plain'):?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_PROFILE') . '</h3>';  ?>

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -49,16 +49,16 @@ if ($displayData->get('show_options', 1))
 
 		if (!empty($fieldSet->label))
 		{
-			$label = JText::_($fieldSet->label, true);
+			$label = JText::_($fieldSet->label);
 		}
 		else
 		{
 			$label = strtoupper('JGLOBAL_FIELDSET_' . $name);
-			if (JText::_($label, true) == $label)
+			if (JText::_($label) == $label)
 			{
 				$label = strtoupper($app->input->get('option') . '_' . $name . '_FIELDSET_LABEL');
 			}
-			$label = JText::_($label, true);
+			$label = JText::_($label);
 		}
 
 		echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-' . $name, $label);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11400

The issue comes from the fact that json_encode was added in https://github.com/joomla/joomla-cms/pull/3922 in \layouts\libraries\cms\html\bootstrap\addtabscript.php

@vinespie 
Please add the test instructions.
