### PR TITLE
Module Article Category Cache

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -49,7 +49,7 @@ switch ($mode)
 		break;
 }
 
-$cacheid = md5(serialize(array ($idbase, $module->module)));
+$cacheid = md5(serialize(array ($idbase, $module->module, $module->id)));
 
 $cacheparams               = new stdClass;
 $cacheparams->cachemode    = 'id';


### PR DESCRIPTION
Pull Request for Issue #8270 .
#### Testing Instructions

Create two identical instances of the module article category on the same page but set one to sort article title ascending and the other to article title descending
You will see it works perfectly

Enable joomla cache and you will see that the modules are now sorted identically which is wrong

Apply this patch
Clear the Joomla cache
You will now see that the modules behave correctly
