### PR TITLE
system/sef plugin background image parser regexp bug

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -153,7 +153,7 @@ class PlgSystemSef extends JPlugin
 		// Replace all unknown protocols in CSS background image.
 		if (strpos($buffer, 'style=') !== false)
 		{
-			$regex  = '#style=\s*[\'\"](.*):\s*url\s*\([\'\"]?(?!/|' . $protocols . '|\#)([^\)\'\"]+)[\'\"]?\)#m';
+			$regex  = '#style=\s*[\'\"](.*):\s*url\s*\([\'\"]?(?!/|\&\#039;|' . $protocols . '|\#)([^\)\'\"]+)[\'\"]?\)#m';
 			$buffer = preg_replace($regex, 'style="$1: url(\'' . $base . '$2$3\')', $buffer);
 			$this->checkBuffer($buffer);
 		}


### PR DESCRIPTION
Pull Request for Issue #7267 .
## Bug

The problem is that using images in the style attributes for background images and  the image urls with a full url:

`<div style="background-image: url(&#039;http://test.org/test.png&#039;)"></div>`

The regexp is in plugins/system/sef/sef.php which used to find image urls in style attributes to fix them to the current site's relative path:
## Test:

`<div style="background-image: url(&#039;http://test.org/test.png&#039;)"></div>`
### Result:

`<div style="background-image: url("/my/site/path/&#039;http://test.org/test.png&#039;")"></div>`
### Desired result: - (Regexp do not match this url.)

`<div style="background-image: url(&#039;http://test.org/test.png&#039;)"></div>`
