### PR TITLE
News feed relative images

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -131,8 +131,8 @@ else
 						$text = JFilterOutput::stripImages($text);
 					}
 					$text = JHtml::_('string.truncate', $text, $this->params->get('feed_character_count'));
-					$domain = preg_replace( "~^(https?://[^/]).$~", "\1/", $this->rssDoc[ $i ]->uri );
-					$text = str_replace( ' src="/', ' src="' . $domain, $text );
+					$domain = preg_replace("~^(https?://[^/]).$~", "\1/", $this->rssDoc[ $i ]->uri);
+					$text = str_replace(' src="/', ' src="' . $domain, $text);
 
 						echo str_replace('&apos;', "'", $text);
 					?>

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -131,6 +131,9 @@ else
 						$text = JFilterOutput::stripImages($text);
 					}
 					$text = JHtml::_('string.truncate', $text, $this->params->get('feed_character_count'));
+					$domain = preg_replace( "~^(https?://[^/]).$~", "\1/", $this->rssDoc[ $i ]->uri );
+					$text = str_replace( ' src="/', ' src="' . $domain, $text );
+
 						echo str_replace('&apos;', "'", $text);
 					?>
 					</div>


### PR DESCRIPTION
Pull Request for Issue #7805 .

#### Summary of Changes
Displaying RSS feeds using com_newsfeed, many providers mistakenly use relative addressing to display images which results in feed display which includes numerous broken image links.

This code is provided by @monkeytrainer12