### PR TITLE
Front End Module editing when using html5 module tags

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -38,7 +38,7 @@ if ($parameters->get('redirect_edit', 'site') == 'site')
 $count = 0;
 $moduleHtml = preg_replace(
 	// Replace first tag of module with a class
-	'/^(\s*<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]*)"/',
+	'/^(\s*<(?:div|span|nav|ul|ol|h\d|section|aside|nav|address|article) [^>]*class="[^"]*)"/',
 	// By itself, adding class jmoddiv and data attributes for the url and tooltip:
 	'\\1 jmoddiv" data-jmodediturl="' . $editUrl . '" data-target="' . $target . '" data-jmodtip="'
 	.	JHtml::tooltipText(


### PR DESCRIPTION
Pull Request for Issue #9973 .
#### Summary of Changes

Ensure that front end module editing works when you have set the Module Tag in the advanced options of the module to an option other than div such as aside
#### Testing Instructions

Set the Module Tag in the advanced options of a module to an option other than div such as aside
Make sure Module editing is enabled for the front end in the global configuration
Login to your site as an admin in the front end
Hover over all the modules and you should see an edit icon in the top right 
This will not work for the module that you have set to aside
Apply the PR and it will work for all the modules
