### PR TITLE
[com_banners] User not allowed to core.manage? Use 403 php exception (instead of a 404 JError)

### DIFF
--- a/administrator/components/com_banners/banners.php
+++ b/administrator/components/com_banners/banners.php
@@ -12,7 +12,7 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_banners'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	throw new Exception(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 // Execute the task.


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

Replace com_banners exisiting 404 JError for a 403 php exception when the user does not have access to "Access Administration Interface" (core.manage).
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/17372250/f2d6984e-599a-11e6-8016-3aa75863ff66.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/17372276/0d4a5b7a-599b-11e6-9bdf-02beaefa567e.png)
#### Testing Instructions
1. Use latest staging
2. Create a user and add it to "Administrator" group
3. Go to com_banners and set "Access Administration Interface" (core.manage) to "Denied" for "Administrator" group
4. Login with the Administrator user in a private window and go to /administrator/index.php?option=com_banners
5. See the red message (Before)
6. Apply patch
7. Repeat step 4, you'll see now a 403 error (After).

If this change is ok i can do it for the other components that uses JError here.
