### PR TITLE
Remove insert module button

### DIFF
--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -92,7 +92,7 @@
 			description="COM_BANNERS_FIELD_DESCRIPTION_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak"
+			hide="readmore,pagebreak,module"
 		/>
 
 		<field

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -93,7 +93,7 @@
 			description="COM_CONTACT_FIELD_INFORMATION_MISC_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak,module"
+			hide="readmore,pagebreak"
 		/>
 
 		<field

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -93,7 +93,7 @@
 			description="COM_CONTACT_FIELD_INFORMATION_MISC_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak"
+			hide="readmore,pagebreak,module"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #10525 .

Based on feedback in #10539 
This PR removes the ability to insert a module into 
~~Contact Form information~~
~~Tag description~~
~~Category description~~
Banner Description
#### Testing Instructions

Open above forms and see that the module button is not present in the tinymce toolbar
