### PR TITLE
Change clear cache in joomla update

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -228,13 +228,13 @@ class JoomlaupdateModelDefault extends JModelLegacy
 
 		if ($db->execute())
 		{
-			$this->_message = JText::_('JLIB_INSTALLER_PURGED_UPDATES');
+			$this->_message = JText::_('COM_JOOMLAUPDATE_CHECKED_UPDATES');
 
 			return true;
 		}
 		else
 		{
-			$this->_message = JText::_('JLIB_INSTALLER_FAILED_TO_PURGE_UPDATES');
+			$this->_message = JText::_('COM_JOOMLAUPDATE_FAILED_TO_CHECK_UPDATES');
 
 			return false;
 		}

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -72,7 +72,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 
 		// Set the toolbar information.
 		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'loop install');
-		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'JTOOLBAR_PURGE_CACHE', false);
+		JToolbarHelper::custom('update.purge', 'loop', 'loop', 'COM_JOOMLAUPDATE_TOOLBAR_CHECK', false);
 
 		// Add toolbar buttons.
 		$user = JFactory::getUser();

--- a/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
+++ b/administrator/language/en-GB/en-GB.com_joomlaupdate.ini
@@ -3,6 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+COM_JOOMLAUPDATE_CHECKED_UPDATES="Checked for updates."
 COM_JOOMLAUPDATE_CONFIG_CUSTOMURL_DESC="This is a custom XML update source URL, used only when the &quot;Update Source&quot; option is set to &quot;Custom URL&quot;."
 COM_JOOMLAUPDATE_CONFIG_CUSTOMURL_LABEL="Custom URL"
 COM_JOOMLAUPDATE_CONFIG_SOURCES_DESC="Configure where Joomla gets its update information from."
@@ -15,6 +16,8 @@ COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_LABEL="Update Channel"
 COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_NEXT="Joomla Next"
 COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_TESTING="Testing"
 COM_JOOMLAUPDATE_CONFIGURATION="Joomla Update: Options"
+COM_JOOMLAUPDATE_FAILED_TO_CHECK_UPDATES="Failed to check for updates."
+COM_JOOMLAUPDATE_TOOLBAR_CHECK="Check for Updates"
 COM_JOOMLAUPDATE_OVERVIEW="Joomla Update"
 COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP="Cleaning up after installation."
 COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE="Update to version %s is complete."


### PR DESCRIPTION
Pull Request for Issue #11090 .

Users reported that the Clear Cache button on the Joomla Update component was confusing
As far as I can tell when you clicked on it it would recheck for a new joomla update (assumption based on observing the timestamp changing in the #__update_sites db table)
#### Summary of Changes

This PR renames the button and changes its icon to be Check for Updates and also changes the associated success and error message

![2ery](https://cloud.githubusercontent.com/assets/1296369/17378080/77ec5262-59b4-11e6-8a6f-4ba9c2be35bf.png)
