### PR TITLE
Fix logging in in PHP 5.3

### DIFF
--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -22,7 +22,7 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 * @var    boolean
 	 * @since  3.5
 	 */
-	private $started;
+	private $started = false;
 
 	/**
 	 * Has the session been closed
@@ -30,7 +30,7 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 * @var    boolean
 	 * @since  3.5
 	 */
-	private $closed;
+	private $closed = false;
 
 	/**
 	 * Starts the session
@@ -151,6 +151,7 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 
 		// Workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
 		session_write_close();
+		$this->closed = true;
 
 		if (isset($_SESSION))
 		{


### PR DESCRIPTION
Pull Request for Issue #11428 .
#### Summary of Changes

Fixes login in PHP 5.3
#### Testing Instructions

Test logging in and logging out. In PHP 5.4+ continues to work in 5.3 it starts working again
