### PR TITLE
modal module style

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -28,15 +28,11 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 
 JFactory::getDocument()->addScriptDeclaration('
 moduleIns = function(type, name) {
-	var extraVal ,fieldExtra = jQuery("#extra_class");
-	extraVal = (fieldExtra.length && fieldExtra.val().length) ? "," + fieldExtra.val() : "";
-	window.parent.jInsertEditorText("{loadmodule " + type + "," + name + extraVal + "}", "' . $editor . '");
+	window.parent.jInsertEditorText("{loadmodule " + type + "," + name + "}", "' . $editor . '");
 	window.parent.jModalClose();
 };
 modulePosIns = function(position) {
-	var extraVal ,fieldExtra = jQuery("#extra_class");
-	extraVal = (fieldExtra.length && fieldExtra.val().length) ? "," + fieldExtra.val() : "";
-	window.parent.jInsertEditorText("{loadposition " + position +  extraVal  + "}", "' . $editor . '");
+	window.parent.jInsertEditorText("{loadposition " + position + "}", "' . $editor . '");
 	window.parent.jModalClose();
 };');
 ?>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -44,19 +44,6 @@ modulePosIns = function(position) {
 
 	<form action="<?php echo JRoute::_('index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
 
-		<div class="well">
-			<div class="control-group">
-				<div class="control-label">
-					<label for="extra_class" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_MODULES_EXTRA_STYLE_DESC'); ?>" aria-invalid="false">
-						<?php echo JText::_('COM_MODULES_EXTRA_STYLE_TITLE'); ?>
-					</label>
-				</div>
-				<div class="controls">
-					<input type="text" id="extra_class" value="" class="span12" size="45" maxlength="255" aria-invalid="false" />
-				</div>
-			</div>
-		</div>
-
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 		<div class="clearfix"></div>


### PR DESCRIPTION
Pull Request for Issue #8428 .
#### Summary of Changes

This simple PR removes the confusing styles input in the insert module modal editor-xtd button that can be found in the toolbar when editing content.

It is given priority by being at the top of the screen and yet it is a very rare use case that you would want to override the style already set in the module.

If absolutely needed a user can still set a style by adding it to the generated syntax in the content item itself
#### After PR

![cuuh](https://cloud.githubusercontent.com/assets/1296369/17397641/ebbb31d2-5a30-11e6-9edb-97897e6f1386.png)
