### PR TITLE
[mod_logged]: Tag <a> contains duplicated `class` attribute

### DIFF
--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<div class="row-fluid">
 			<div class="span7">
 				<?php if ($user->client_id == 0) : ?>
-					<a class="hasTooltip" title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini">
+					<a title="<?php echo JHtml::tooltipText('MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini hasTooltip">
 						<span class="icon-remove icon-white" title="<?php echo JText::_('JLOGOUT'); ?>"></span>
 					</a>
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #11441 .
#### Summary of Changes

Tag must contain a single class attribute: class="hasTooltip btn btn-danger btn-mini"
Tag contains duplicated class attribute: class="hasTooltip" at the start and class="btn btn-danger btn-mini" at the end of list of attributes. This meant the button wasnt not being displayed.

This is the admin module to display a list of logged in users. If you dont have this ADMIN module published then you should publish in the cpanel position

Make sure you have one user logged in at the front end of your site. The module should now show two users as per the screenshot below. Ensure that the tooltip is still working and the button is red. 
#### Before PR

![ujg](https://cloud.githubusercontent.com/assets/1296369/17402267/3e9cbee8-5a4a-11e6-9286-53393cecfd97.png)
#### After PR

![hegm](https://cloud.githubusercontent.com/assets/1296369/17402222/fa307682-5a49-11e6-9deb-c610041c628a.png)
