### PR TITLE
[PostgreSQL] Add group by menu type title to avoid sql error

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -243,8 +243,7 @@ class MenusModelItems extends JModelList
 
 		// Join over the menu types.
 		$query->select($db->quoteName('mt.title', 'menutype_title'))
-			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'))
-			->group('mt.title');
+			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'));
 
 		// Join over the associations.
 		$assoc = JLanguageAssociations::isEnabled();
@@ -254,7 +253,7 @@ class MenusModelItems extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name');
+				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.title');
 		}
 
 		// Join over the extensions

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -243,7 +243,8 @@ class MenusModelItems extends JModelList
 
 		// Join over the menu types.
 		$query->select($db->quoteName('mt.title', 'menutype_title'))
-			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'));
+			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'))
+			->group('mt.title');
 
 		// Join over the associations.
 		$assoc = JLanguageAssociations::isEnabled();


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11445.
#### Summary of Changes

Adds group by clause so query also works on PostgreSQL.
#### Testing Instructions
1. Use 3.6.1 with PostgreSQL
2. Go to menus lists and you will get the error described in the issue
3. Apply patch
4. There should be no error anymore

Didn't test in PostgreSQL because i don't have any installation, just followed the same logic as others.

Test also if all continues to work with MySQL.
#### Additional comments

If joomla suports other database systems people are needed to test on this database systems.

@minhworks Please confirm this works.
