### PR TITLE
fixing E-Mail Cloaking with multiple addresses

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -108,11 +108,11 @@ abstract class JHtmlEmail
 		{
 			JFactory::getDocument()->addScriptDeclaration(
 				"
-		document.onreadystatechange = function () {
+		document.addEventListener('readystatechange',function () {
 			if (document.readyState == 'interactive') {
 			" . $script . "
 			}
-		};
+		}, false);
 				"
 			);
 		}


### PR DESCRIPTION
E-Mail Cloaking didn't work with multiple addresses on a page, because onreadystatechange event handler was overwritten with each address to cloak.
Fixed by using addEventListener method to register multiple event listeners.
