### PR TITLE
Email cloaking

### DIFF
--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -99,7 +99,7 @@ abstract class JHtmlEmail
 				$tmpScript
 		";
 
-		// Use inline script for ajax calls
+		// TODO: Use inline script for now
 		$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;

--- a/libraries/cms/html/email.php
+++ b/libraries/cms/html/email.php
@@ -99,23 +99,8 @@ abstract class JHtmlEmail
 				$tmpScript
 		";
 
-		if (strtolower(JFactory::getApplication()->input->server->get('HTTP_X_REQUESTED_WITH', '')) == 'xmlhttprequest')
-		{
-			// Use inline script for ajax calls
-			$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
-		}
-		else
-		{
-			JFactory::getDocument()->addScriptDeclaration(
-				"
-		document.onreadystatechange = function () {
-			if (document.readyState == 'interactive') {
-			" . $script . "
-			}
-		};
-				"
-			);
-		}
+		// Use inline script for ajax calls
+		$inlineScript = "<script type='text/javascript'>" . $script . "</script>";
 
 		return '<span id="cloak' . $rand . '">' . JText::_('JLIB_HTML_CLOAKING') . '</span>' . $inlineScript;
 	}


### PR DESCRIPTION
Pull Request for Issue #11456 .
#### Summary of Changes

Fixes email cloaking plugin loosing html data
#### Testing Instructions

Create an article with body `<a href="mailto:toto@toto.com" class="nameofmyclass">email</a>` and email cloak plugin enabled. Before note the class is stripped after the class exists
