### PR TITLE
alternative readmore error

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -148,7 +148,7 @@ JHtml::_('behavior.caption');
 		<?php
 		if ($attribs->alternative_readmore == null) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		elseif ($readmore = $this->item->alternative_readmore) :
+		elseif ($readmore = $attribs->alternative_readmore) :
 			echo $readmore;
 			if ($params->get('show_readmore_title', 0) != 0) :
 				echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));


### PR DESCRIPTION
In certain circumstances an alternative readmore would not be displayed and an error would be present in the logs 

> PHP Notice:  Undefined property: stdClass::$alternative_readmore
#### Testing Instructions
1. Create an article with a readmore and set it to registered users
2. In the options tab at the bottom create a read more text
3. Create a menu item (single article) to this article
4. Set Show intro text as Show
5. Set Show Unauthorised Links as Yes
6. Visit menu item on the front end and you will not see the alternative readmore text you created and in your logs you will see an error `PHP Notice:  Undefined property: stdClass::$alternative_readmore`

Apply the patch
Repeat step 6 above. You will see the alternative readmore text created in step 2 and there will be no error in your logs 
