### PR TITLE
Remove unused paramater in Tags:Tagged Items

### DIFF
--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -253,15 +253,6 @@
 				<option value="0">COM_TAGS_EXCLUDE</option>
 				<option value="1">COM_TAGS_INCLUDE</option>
 			</field>		
-		
-			<field
-				name="maximum"
-				type="text"
-				default="200"
-				filter="integer"
-				label="COM_TAGS_LIST_MAX_LABEL"
-				description="COM_TAGS_LIST_MAX_DESC">
-			</field>
 				
 		</fieldset>
 		


### PR DESCRIPTION
There is a parameter in the menu item Tags:Tagged Items, item selection options called "maximum"

This shouldnt be there at all as there is no code to use the param. It looks like a siple copy paste error from another tag menu item
#### Summary of Changes

This simple PR removes the option
Even if a user had set a value here there is no b/c issue as there was no code that would ever use the value
