### PR TITLE
Rebuild Update Sites Message

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -361,7 +361,7 @@ class InstallerModelUpdatesites extends InstallerModel
 		}
 		else
 		{
-			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_WARNING'), 'warning');
+			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_WARNING'), 'message');
 		}
 	}
 


### PR DESCRIPTION
In Extension Manager Updates there is a toolbar button that lets you rebuild the list

It has two messages

> Update sites have been rebuilt from manifest files.

and

> Update sites have been rebuilt. No extension with updates sites discovered."

The first is a message and the second a warning but to me they are both messages - there is nothing to warn me about
#### Before

![qco](https://cloud.githubusercontent.com/assets/1296369/17443992/947db358-5b35-11e6-80d9-cf8fe6f016b6.png)
#### After

![k ei](https://cloud.githubusercontent.com/assets/1296369/17444003/a2ffdc6c-5b35-11e6-9ac4-8b333c73d23f.png)
