### PR TITLE
showon category create an article

### DIFF
--- a/components/com_content/views/form/tmpl/edit.xml
+++ b/components/com_content/views/form/tmpl/edit.xml
@@ -23,7 +23,8 @@
 				type="category"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				extension="com_content"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC" />
+				description="JGLOBAL_CHOOSE_CATEGORY_DESC" 
+				showon="enable_category:1" />
 		</fieldset>
 	</fields>
 </metadata>


### PR DESCRIPTION
Simple PR for the create article menu item
In the options tab the selection of the default category is hidden if it is not set to being used
![showin](https://cloud.githubusercontent.com/assets/1296369/17449298/9d6015a8-5b51-11e6-9513-4081c8799fa4.gif)
