### PR TITLE
Use showon for googlefont in protostar

### DIFF
--- a/templates/protostar/templateDetails.xml
+++ b/templates/protostar/templateDetails.xml
@@ -87,7 +87,8 @@
 
 				<field name="googleFontName" class="" type="text" default="Open+Sans"
 					label="TPL_PROTOSTAR_FONT_NAME_LABEL"
-					description="TPL_PROTOSTAR_FONT_NAME_DESC" />
+					description="TPL_PROTOSTAR_FONT_NAME_DESC" 
+					showon="googleFont:1" />
 
 				<field name="fluidContainer"
 					type="radio"


### PR DESCRIPTION
Simple PR for the  protostar template style
In the advanced tab the selection of the google font is hidden if Google Font for Headings is set to no
![googlefont](https://cloud.githubusercontent.com/assets/1296369/17449856/159f088c-5b55-11e6-9f69-d12af5d05f8e.gif)
