### PR TITLE
Missing tooltip in wrapper options

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.xml
+++ b/components/com_wrapper/views/wrapper/tmpl/default.xml
@@ -80,6 +80,7 @@
 				type="radio"
 				class="btn-group btn-group-yesno"
 				default="1"
+				description="COM_WRAPPER_FIELD_FRAME_DESC"
 				label="COM_WRAPPER_FIELD_FRAME_LABEL"
 			>
 				<option value="1">JYES</option>


### PR DESCRIPTION
In the menu type wrapper there is an options tab called advanced. Here the option to set the frame border was missing the tooltip even though  we had one in the language string
#### Summary of Changes

add tooltip
#### Testing Instructions

hover over "frame border" label
