### PR TITLE
fix the size perameters of TinyMCE

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -327,7 +327,13 @@ class PlgEditorTinymce extends JPlugin
 		$access = array_flip($access);
 
 		$html_height = $this->params->get('html_height', '550');
+		if (is_numeric($height)) {
+			$html_height = $height;
+		}
 		$html_width  = $this->params->get('html_width', '');
+		if (is_numeric($width)) {
+			$html_width = $width;
+		}
 
 		if ($html_width == 750)
 		{

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -993,7 +993,8 @@ class PlgEditorTinymce extends JPlugin
 		$textarea->height  = $height;
 		$textarea->content = $content;
 
-		$editor = '<div class="editor">';
+	        $cssWidth  = ($textarea->width) ? ' style="width: ' . (int) $textarea->width . 'px"' : '';
+	        $editor = '<div class="editor"' . $cssWidth . '>';
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -327,11 +327,16 @@ class PlgEditorTinymce extends JPlugin
 		$access = array_flip($access);
 
 		$html_height = $this->params->get('html_height', '550');
-		if (is_numeric($height)) {
+		
+		if (is_numeric($height))
+		{
 			$html_height = $height;
 		}
+		
 		$html_width  = $this->params->get('html_width', '');
-		if (is_numeric($width)) {
+		
+		if (is_numeric($width))
+		{
 			$html_width = $width;
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -993,8 +993,8 @@ class PlgEditorTinymce extends JPlugin
 		$textarea->height  = $height;
 		$textarea->content = $content;
 
-	        $cssWidth  = ($textarea->width) ? ' style="width: ' . (int) $textarea->width . 'px"' : '';
-	        $editor = '<div class="editor"' . $cssWidth . '>';
+		$cssWidth  = ($textarea->width) ? ' style="width: ' . (int) $textarea->width . 'px"' : '';
+		$editor = '<div class="editor"' . $cssWidth . '>';
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';


### PR DESCRIPTION
## Summary of Changes

TinyMce always ignored custom size for editor and it's a problem for developers who use editors in his components and they can't change the height of this editor.