### PR TITLE
Global configuration: always save validated data in the session

### DIFF
--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -71,7 +71,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 		// Validate the posted data.
 		$return = $model->validate($form, $data);
 
-		// Save the data in the session.
+		// Save the posted data in the session.
 		$this->app->setUserState('com_config.config.global.data', $data);
 
 		// Check for validation errors.
@@ -89,15 +89,15 @@ class ConfigControllerApplicationSave extends JControllerBase
 		$data   = $return;
 		$return = $model->save($data);
 
+		// Save the validated data in the session.
+		$this->app->setUserState('com_config.config.global.data', $data);
+
 		// Check the return value.
 		if ($return === false)
 		{
 			/*
 			 * The save method enqueued all messages for us, so we just need to redirect back.
 			 */
-
-			// Save the data in the session.
-			$this->app->setUserState('com_config.config.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
 			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));


### PR DESCRIPTION
When changing the global configuration the validated data should always be saved in the session and not only in case of an error when saving the global configuration in configuration.php failed.

There is an issue when writing numeric values in exponential representaion into any of the numeric fields of the global configuration (like "1.5e+1" instead of 15). This form is valid and is accepted by modern browsers as the content of numeric fields, but when it comes to saving such values within Joomla the value is changed but this is not immediately visible for the administrator.

#### Testing Instructions

**Status Quo**
- Open the global configuration form and activate the "System" tab
- Locate the "Cache Time" field and check its value (the value is "15" by default)
- Overwrite the default value with "1.5e+1" and press the "Save" button
- Check the configuration.php file, the value for "$cachetime" is "1"
- The value shown in the global configuration form is "15"
- Press the "Save & Close" button
- Check the configuration.php file, the value for "$cachetime" is "15"

**Change**
- Now install this PR
- Open the global configuration form and activate the "System" tab
- Replace the value "15" in the "Cache Time" field with "1.5e+1" and press the "Save" button
- Check the configuration.php file, the value for "$cachetime" is "1"
- The value shown in the global configuration form is now "1" too
- Replace the value "1" with "15" and press the "Save & Close" button
- Check the configuration.php file, the value for "$cachetime" is "15"

**Notes**
- It is IMO in general a good idea to save the validated data of a form in the session such that the result of the validation will be shown in case that the form was not closed which is the case if you press the "Save" button. Otherwise the data presented in the form might not be identical to the data saved in the configuration file (in case of the global configuration) or in the database.
- Even if the exponential representation of a numeric value is somewhat esoteric it is valid and it is accepted by modern browsers if the type of the input field is "number". Due to that the validation method for numeric fields should probably be changed such that it not only accepts such values (which is the case today) but also converts them correctly into a number ("1.5e+1" should be converted into "15", not into "1" as is the case today). But this is beyond the scope of this PR.
