### PR TITLE
Allow uninstall() method of script.php to decide keeping component categories

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -671,7 +671,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected function setUnInstallFlags(array $unInstallFlags)
+	public function setUnInstallFlags(array $unInstallFlags)
 	{
 		$this->unInstallFlags = $unInstallFlags;
 	}

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -817,7 +817,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		}
 
 		// Remove categories for this component, if this flag has not been cleared by: com_componentnameInstallerScript::uninstall()
-		if ($this->unInstallFlags['delete_cats'])
+		if (!empty($this->unInstallFlags['delete_cats']))
 		{
 			$query->clear()
 				->delete('#__categories')


### PR DESCRIPTION
Pull Request for Issue #11490
#### Summary of Changes

Currently during component uninstallation, the Joomla uninstall adapter always deletes the categories of the component being uninstalled
- this is a problem when component gives option to the user to keep the extension's data

(typically **when going to reinstall** the extension after uninstall it), **because all data are kept but the categories are lost**
#### Testing Instructions

Now during uninstalling the categories of the component can be kept if desired
(user choice to kept extension data)

At file script.php of you extension, inside method: uninstall(), add:

```
function uninstall($parent)
{
    $parent->setUnInstallFlags(array('delete_cats'=>false));
    // ... remaining code
}
```

Reinstall extension and confirm that categories have not been deleted
