### PR TITLE
[com_newsfeeds] Make ACL core.edit.own work (PR for 11466)

### DIFF
--- a/administrator/components/com_newsfeeds/controllers/newsfeed.php
+++ b/administrator/components/com_newsfeeds/controllers/newsfeed.php
@@ -60,9 +60,7 @@ class NewsfeedsControllerNewsfeed extends JControllerForm
 	 */
 	protected function allowEdit($data = array(), $key = 'id')
 	{
-		$user       = JFactory::getUser();
-		$recordId   = (int) isset($data[$key]) ? $data[$key] : 0;
-		$categoryId = 0;
+		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 
 		// Since there is no asset tracking, fallback to the component permissions.
 		if (!$recordId)
@@ -78,6 +76,8 @@ class NewsfeedsControllerNewsfeed extends JControllerForm
 		{
 			return false;
 		}
+
+		$user = JFactory::getUser();
 
 		// Check if can edit own core.edit.own.
 		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;

--- a/administrator/components/com_newsfeeds/controllers/newsfeed.php
+++ b/administrator/components/com_newsfeeds/controllers/newsfeed.php
@@ -80,10 +80,10 @@ class NewsfeedsControllerNewsfeed extends JControllerForm
 		$user = JFactory::getUser();
 
 		// Check if can edit own core.edit.own.
-		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $item->catid) && $item->created_by == $user->id;
 
 		// Check the category core.edit permissions.
-		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $item->catid);
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/controllers/newsfeed.php
+++ b/administrator/components/com_newsfeeds/controllers/newsfeed.php
@@ -60,25 +60,30 @@ class NewsfeedsControllerNewsfeed extends JControllerForm
 	 */
 	protected function allowEdit($data = array(), $key = 'id')
 	{
-		$user = JFactory::getUser();
-		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
+		$user       = JFactory::getUser();
+		$recordId   = (int) isset($data[$key]) ? $data[$key] : 0;
 		$categoryId = 0;
 
-		if ($recordId)
+		// Since there is no asset tracking, fallback to the component permissions.
+		if (!$recordId)
 		{
-			$categoryId = (int) $this->getModel()->getItem($recordId)->catid;
-		}
-
-		if ($categoryId)
-		{
-			// The category has been set. Check the category permissions.
-			return $user->authorise('core.edit', $this->option . '.category.' . $categoryId);
-		}
-		else
-		{
-			// Since there is no asset tracking, revert to the component permissions.
 			return parent::allowEdit($data, $key);
 		}
+
+		// Get the item.
+		$item = $this->getModel()->getItem($recordId);
+
+		// Since there is no item, return false.
+		if (empty($item))
+		{
+			return false;
+		}
+
+		// Check if can edit own core.edit.own.
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+
+		// Check the category core.edit permissions.
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -95,7 +95,7 @@ if ($saveOrder)
 					$canCreate  = $user->authorise('core.create',     'com_newsfeeds.category.' . $item->catid);
 					$canEdit    = $user->authorise('core.edit',       'com_newsfeeds.category.' . $item->catid);
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
-					$canEditOwn = $user->authorise('core.edit.own',   'com_newsfeeds.category.' . $item->id) && $item->created_by == $user->id;
+					$canEditOwn = $user->authorise('core.edit.own',   'com_newsfeeds.category.' . $item->catid) && $item->created_by == $user->id;
 					$canChange  = $user->authorise('core.edit.state', 'com_newsfeeds.category.' . $item->catid) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid?>">

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -16,9 +16,7 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app       = JFactory::getApplication();
 $user      = JFactory::getUser();
-$userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
@@ -97,6 +95,7 @@ if ($saveOrder)
 					$canCreate  = $user->authorise('core.create',     'com_newsfeeds.category.' . $item->catid);
 					$canEdit    = $user->authorise('core.edit',       'com_newsfeeds.category.' . $item->catid);
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id') || $item->checked_out == 0;
+					$canEditOwn = $user->authorise('core.edit.own',   'com_newsfeeds.category.' . $item->id) && $item->created_by == $user->id;
 					$canChange  = $user->authorise('core.edit.state', 'com_newsfeeds.category.' . $item->catid) && $canCheckin;
 					?>
 					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid?>">
@@ -140,7 +139,7 @@ if ($saveOrder)
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'newsfeeds.', $canCheckin); ?>
 								<?php endif; ?>
-								<?php if ($canEdit) : ?>
+								<?php if ($canEdit || $canEditOwn) : ?>
 									<a href="<?php echo JRoute::_('index.php?option=com_newsfeeds&task=newsfeed.edit&id=' . (int) $item->id); ?>">
 										<?php echo $this->escape($item->name); ?></a>
 								<?php else : ?>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -119,7 +119,7 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 			JToolbarHelper::addNew('newsfeed.add');
 		}
 
-		if ($canDo->get('core.edit'))
+		if ($canDo->get('core.edit') || $canDo->get('core.edit.own'))
 		{
 			JToolbarHelper::editList('newsfeed.edit');
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11466 (com_newsfeeds part).
#### Summary of Changes

The ACL core.edit.own is not working in newsfeeds.
This PR makes it work.
#### Testing Instructions
1. Use latest staging
2. Besides the Super User, create a user "test" added to "Administrator" group
3. Go to com_newsfeeds Options, Permissions tab and diable "Edit" for "Administrator" group
4. Now create a new newsfeed with the "test" user (use another browser or a private window)
5. Try to edit that item. You can't edit our own. **Bug**
6. Now do the same test but with a newsfeed category Permission. You can't edit our own. **Bug**
7. Apply patch, repeat step 5. and 6. and now you can  edit our own items.
8. Code review

Also use the two users to do a general test with the com_newsfeeds edit permissions to confirm all is fine.
#### Documentation Changes Required

None.
#### Notes

This problem was discovered in GsoC 2016 Multilingual project.
This is very similiar with https://github.com/joomla/joomla-cms/pull/11503.
