### PR TITLE
[com_contact] Make ACL core.edit.own work (PR for 11466)

### DIFF
--- a/administrator/components/com_contact/controllers/contact.php
+++ b/administrator/components/com_contact/controllers/contact.php
@@ -60,21 +60,29 @@ class ContactControllerContact extends JControllerForm
 	protected function allowEdit($data = array(), $key = 'id')
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
-		$categoryId = 0;
 
-		if ($recordId)
+		// Since there is no asset tracking, fallback to the component permissions.
+		if (!$recordId)
 		{
-			$categoryId = (int) $this->getModel()->getItem($recordId)->catid;
+			return parent::allowEdit($data, $key);
 		}
 
-		if ($categoryId)
+		// Get the item.
+		$item = $this->getModel()->getItem($recordId);
+
+		// Since there is no item, return false.
+		if (empty($item))
 		{
-			// The category has been set. Check the category permissions.
-			return JFactory::getUser()->authorise('core.edit', $this->option . '.category.' . $categoryId);
+			return false;
 		}
 
-		// Since there is no asset tracking, revert to the component permissions.
-		return parent::allowEdit($data, $key);
+		$user = JFactory::getUser();
+
+		// Check if can edit own core.edit.own.
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+
+		// Check the category core.edit permissions.
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
 	}
 
 	/**

--- a/administrator/components/com_contact/controllers/contact.php
+++ b/administrator/components/com_contact/controllers/contact.php
@@ -79,10 +79,10 @@ class ContactControllerContact extends JControllerForm
 		$user = JFactory::getUser();
 
 		// Check if can edit own core.edit.own.
-		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $record->catid) && $item->created_by == $user->id;
+		$canEditOwn = $user->authorise('core.edit.own', $this->option . '.category.' . (int) $item->catid) && $item->created_by == $user->id;
 
 		// Check the category core.edit permissions.
-		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $record->catid);
+		return $canEditOwn || $user->authorise('core.edit', $this->option . '.category.' . (int) $item->catid);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11466 (com_contact part).
#### Summary of Changes

The ACL core.edit.own is not working in com_contact.
This PR makes it work.
#### Testing Instructions
1. Use latest staging
2. Besides the Super User, create a user "test" added to "Administrator" group
3. Go to com_contact Options, Permissions tab and diable "Edit" for "Administrator" group
4. Now create a new contact with the "test" user (use another browser or a private window)
5. Try to edit that item. You can't edit our own. **Bug**
6. Now do the same test but with a contact category Permission. You can't edit our own. **Bug**
7. Apply patch, repeat step 5. and 6. and now you can  edit our own items.
8. Code review

Also use the two users to do a general test with the com_contact edit permissions to confirm all is fine.
#### Documentation Changes Required

None.
#### Notes

This problem was discovered in GsoC 2016 Multilingual project.

This is very similiar with https://github.com/joomla/joomla-cms/pull/11502.
