### PR TITLE
When uninstalling extension dont remove all category data

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -796,15 +796,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$asset->delete();
 		}
 
-		// Remove categories for this component
-		$query->clear()
-			->delete('#__categories')
-			->where('extension=' . $db->quote($this->element), 'OR')
-			->where('extension LIKE ' . $db->quote($this->element . '.%'));
-		$db->setQuery($query);
-		$db->execute();
-
-		// Clobber any possible pending updates
+		// Remove any possible pending updates
 		$update = JTable::getInstance('update');
 		$uid = $update->find(
 			array(


### PR DESCRIPTION
Pull Request for Issue Closes #11490 .
#### Steps to reproduce the issue
- Install 3rd party extension that uses Joomla category manager.
- Create category using that extension.
- Uninstall extension.
- Install same extension again.
- We can see that Category gets deleted with that extension.
#### Summary of Changes

Removal of code that deletes the categories and comment update to remove "clobber" and replace with delete
#### Testing Instructions
- Install 3rd party extension that uses Joomla category manager.
- Create category using that extension.
- Uninstall extension.
- Install same extension again.
- We can see that Category gets deleted with that extension.

Apply PR
- Install 3rd party extension that uses Joomla category manager.
- Create category using that extension.
- Uninstall extension.
- Install same extension again.
- We can see that Category **_does not**_ get deleted with that extension.
#### Documentation Changes Required

Maybe some, maybe a note to developers.
