### PR TITLE
[com_content] Do not generate query twice on featured view and archive view

### DIFF
--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -60,6 +60,16 @@ class ContentModelArchive extends ContentModelArticles
 		$itemid = $app->input->get('Itemid', 0, 'int');
 		$limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
 		$this->setState('list.limit', $limit);
+
+		// Set the archive ordering
+		$articleOrderby   = $params->get('orderby_sec', 'rdate');
+		$articleOrderDate = $params->get('order_date');
+
+		// No category ordering
+		$secondary = ContentHelperQuery::orderbySecondary($articleOrderby, $articleOrderDate);
+
+		$this->setState('list.ordering', $secondary . ', a.created DESC');
+		$this->setState('list.direction', '');
 	}
 
 	/**
@@ -71,19 +81,8 @@ class ContentModelArchive extends ContentModelArticles
 	 */
 	protected function getListQuery()
 	{
-		// Set the archive ordering
 		$params = $this->state->params;
-		$articleOrderby = $params->get('orderby_sec', 'rdate');
 		$articleOrderDate = $params->get('order_date');
-
-		// No category ordering
-		$categoryOrderby = '';
-		$secondary = ContentHelperQuery::orderbySecondary($articleOrderby, $articleOrderDate) . ', ';
-		$primary = ContentHelperQuery::orderbyPrimary($categoryOrderby);
-
-		$orderby = $primary . ' ' . $secondary . ' a.created DESC ';
-		$this->setState('list.ordering', $orderby);
-		$this->setState('list.direction', '');
 
 		// Create a new query object.
 		$query = parent::getListQuery();

--- a/components/com_content/models/featured.php
+++ b/components/com_content/models/featured.php
@@ -71,6 +71,16 @@ class ContentModelFeatured extends ContentModelArticles
 			$featuredCategories = $params->get('featured_categories');
 			$this->setState('filter.frontpage.categories', $featuredCategories);
 		}
+
+		$articleOrderby   = $params->get('orderby_sec', 'rdate');
+		$articleOrderDate = $params->get('order_date');
+		$categoryOrderby  = $params->def('orderby_pri', '');
+
+		$secondary = ContentHelperQuery::orderbySecondary($articleOrderby, $articleOrderDate);
+		$primary   = ContentHelperQuery::orderbyPrimary($categoryOrderby);
+
+		$this->setState('list.ordering', $primary . $secondary . ', a.created DESC');
+		$this->setState('list.direction', '');
 	}
 
 	/**
@@ -119,18 +129,6 @@ class ContentModelFeatured extends ContentModelArticles
 	 */
 	protected function getListQuery()
 	{
-		// Set the blog ordering
-		$params = $this->state->params;
-		$articleOrderby = $params->get('orderby_sec', 'rdate');
-		$articleOrderDate = $params->get('order_date');
-		$categoryOrderby = $params->def('orderby_pri', '');
-		$secondary = ContentHelperQuery::orderbySecondary($articleOrderby, $articleOrderDate) . ', ';
-		$primary = ContentHelperQuery::orderbyPrimary($categoryOrderby);
-
-		$orderby = $primary . ' ' . $secondary . ' a.created DESC ';
-		$this->setState('list.ordering', $orderby);
-		$this->setState('list.direction', '');
-
 		// Create a new query object.
 		$query = parent::getListQuery();
 


### PR DESCRIPTION
#### Summary of Changes

Do not generate sql query twice: on `getItems` and on `getTotal`.

Remove `$this->setState('list.ordering', ...` from `getListQuery` method and move it to `populateState`.
#### Testing Instructions

1) Create a menu item for com_content featured view.
a) Set  `Category Order`: No Order
b) Set  `Article Order`: Author Alphabetical

2) Create a second menu item for com_content archive view
a) Set `Article Order` as Title Alphabetical

3) Add debug info:
a) at the top of method `getListQuery`:
https://github.com/joomla/joomla-cms/blob/staging/components/com_content/models/featured.php#L121
replace `{` by:

``` php
{echo "<code>getListQuery RUN</code>";
```

b) Do the same for https://github.com/joomla/joomla-cms/blob/staging/components/com_content/models/archive.php#L72

4) Go to the first menu item. You should see text "getListQuery RUN" twice.
5) Go to the second menu item. You should see text "getListQuery RUN" twice.

6) Apply this PR and also add debug info at the top of method `getListQuery`.

7) Go to the first menu item. You should see text "getListQuery RUN" only once.
8) Go to the second menu item. You should see text "getListQuery RUN" only once.
