### PR TITLE
Regression: Fix edit check in backend articles manager, always denying edit after soft deny

### DIFF
--- a/administrator/components/com_content/controllers/article.php
+++ b/administrator/components/com_content/controllers/article.php
@@ -84,45 +84,32 @@ class ContentControllerArticle extends JControllerForm
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
-		$userId = $user->get('id');
 
-		// If we get a deny at the component level, we cannot override here.
-		if (!parent::allowEdit($data, $key))
+		// For new record (id:0) return component permission
+		if (!$recordId)
 		{
-			return false;
+			return parent::allowEdit($data, $key);
 		}
 
-		// Check general edit permission first.
+		// Check edit on the record asset (explicit or inherited)
 		if ($user->authorise('core.edit', 'com_content.article.' . $recordId))
 		{
 			return true;
 		}
 
-		// Fallback on edit.own.
-		// First test if the permission is available.
+		// Check edit own on the record asset (explicit or inherited)
 		if ($user->authorise('core.edit.own', 'com_content.article.' . $recordId))
 		{
-			// Now test the owner is the user.
-			$ownerId = (int) isset($data['created_by']) ? $data['created_by'] : 0;
+			// Existing record already has an owner, get it
+			$record = $this->getModel()->getItem($recordId);
 
-			if (empty($ownerId) && $recordId)
+			if (empty($record))
 			{
-				// Need to do a lookup from the model.
-				$record = $this->getModel()->getItem($recordId);
-
-				if (empty($record))
-				{
-					return false;
-				}
-
-				$ownerId = $record->created_by;
+				return false;
 			}
 
-			// If the owner matches 'me' then permission is granted.
-			if ($ownerId == $userId)
-			{
-				return true;
-			}
+			// Grant if current user is the owner of the record
+			return $user->get('id') == $record->created_by;
 		}
 
 		return false;

--- a/administrator/components/com_content/controllers/article.php
+++ b/administrator/components/com_content/controllers/article.php
@@ -85,10 +85,10 @@ class ContentControllerArticle extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// Zero record (id:0) return false, if caller wants component permissions just get them directly
+		// Zero record (id:0), return component edit permission by calling parent controller method
 		if (!$recordId)
 		{
-			return false;
+			return parent::allowEdit($data, $key);
 		}
 
 		// Check edit on the record asset (explicit or inherited)
@@ -108,7 +108,7 @@ class ContentControllerArticle extends JControllerForm
 				return false;
 			}
 
-			// Grant if current user is owner of the record, note: zero id is guest
+			// Grant if current user is owner of the record
 			return $user->get('id') == $record->created_by;
 		}
 

--- a/administrator/components/com_content/controllers/article.php
+++ b/administrator/components/com_content/controllers/article.php
@@ -85,7 +85,8 @@ class ContentControllerArticle extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// For new record (id:0) return component permission
+		// Zero record (id:0) return component permission, e.g. show edit btn
+		// for creating new record, allowAdd() must be used instead (core.create)
 		if (!$recordId)
 		{
 			return parent::allowEdit($data, $key);
@@ -108,7 +109,7 @@ class ContentControllerArticle extends JControllerForm
 				return false;
 			}
 
-			// Grant if current user is the owner of the record
+			// Grant if current user is owner of the record, note: zero id is guest
 			return $user->get('id') == $record->created_by;
 		}
 

--- a/administrator/components/com_content/controllers/article.php
+++ b/administrator/components/com_content/controllers/article.php
@@ -85,11 +85,10 @@ class ContentControllerArticle extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// Zero record (id:0) return component permission, e.g. show edit btn
-		// for creating new record, allowAdd() must be used instead (core.create)
+		// Zero record (id:0) return false, if caller wants component permissions just get them directly
 		if (!$recordId)
 		{
-			return parent::allowEdit($data, $key);
+			return false;
 		}
 
 		// Check edit on the record asset (explicit or inherited)

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -105,10 +105,10 @@ class ContentControllerArticle extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// Zero record (id:0) return false, if caller wants component permissions just get them directly
+		// Zero record (id:0), return component edit permission by calling parent controller method
 		if (!$recordId)
 		{
-			return false;
+			return parent::allowEdit($data, $key);
 		}
 
 		// Check edit on the record asset (explicit or inherited)
@@ -128,7 +128,7 @@ class ContentControllerArticle extends JControllerForm
 				return false;
 			}
 
-			// Grant if current user is owner of the record, note: zero id is guest
+			// Grant if current user is owner of the record
 			return $user->get('id') == $record->created_by;
 		}
 

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -105,10 +105,10 @@ class ContentControllerArticle extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// For new record (id:0) return component permission
+		// Zero record (id:0) return false, if caller wants component permissions just get them directly
 		if (!$recordId)
 		{
-			return parent::allowEdit($data, $key);
+			return false;
 		}
 
 		// Check edit on the record asset (explicit or inherited)
@@ -128,7 +128,7 @@ class ContentControllerArticle extends JControllerForm
 				return false;
 			}
 
-			// Grant if current user is the owner of the record
+			// Grant if current user is owner of the record, note: zero id is guest
 			return $user->get('id') == $record->created_by;
 		}
 

--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -103,45 +103,36 @@ class ContentControllerArticle extends JControllerForm
 	protected function allowEdit($data = array(), $key = 'id')
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
-		$user     = JFactory::getUser();
-		$userId   = $user->get('id');
-		$asset    = 'com_content.article.' . $recordId;
+		$user = JFactory::getUser();
 
-		// Check general edit permission first.
-		if ($user->authorise('core.edit', $asset))
+		// For new record (id:0) return component permission
+		if (!$recordId)
+		{
+			return parent::allowEdit($data, $key);
+		}
+
+		// Check edit on the record asset (explicit or inherited)
+		if ($user->authorise('core.edit', 'com_content.article.' . $recordId))
 		{
 			return true;
 		}
 
-		// Fallback on edit.own.
-		// First test if the permission is available.
-		if ($user->authorise('core.edit.own', $asset))
+		// Check edit own on the record asset (explicit or inherited)
+		if ($user->authorise('core.edit.own', 'com_content.article.' . $recordId))
 		{
-			// Now test the owner is the user.
-			$ownerId = (int) isset($data['created_by']) ? $data['created_by'] : 0;
+			// Existing record already has an owner, get it
+			$record = $this->getModel()->getItem($recordId);
 
-			if (empty($ownerId) && $recordId)
+			if (empty($record))
 			{
-				// Need to do a lookup from the model.
-				$record = $this->getModel()->getItem($recordId);
-
-				if (empty($record))
-				{
-					return false;
-				}
-
-				$ownerId = $record->created_by;
+				return false;
 			}
 
-			// If the owner matches 'me' then do the test.
-			if ($ownerId == $userId)
-			{
-				return true;
-			}
+			// Grant if current user is the owner of the record
+			return $user->get('id') == $record->created_by;
 		}
 
-		// Since there is no asset tracking, revert to the component permissions.
-		return parent::allowEdit($data, $key);
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #11463  and #11510 
#### Summary of Changes

Fixed edit check in backend not allowing edit via edit.own after soft deny
Same code used for frontend
#### Testing Instructions

(check is the same for frontend / backend)

at backend articles manager, 
at frontend views that show the edit button

make sure that people that should be allowed to edit can do and others can not
