### PR TITLE
Needed for GSOC: Adding id in menu item edit array

### DIFF
--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -3,13 +3,14 @@
 	<fieldset>
 		<field
 			name="id"
-			type="text"
-			class="readonly"
+			type="hidden"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			description="JGLOBAL_FIELD_ID_DESC"
+			class="readonly"
 			default="0"
 			filter="int"
-			readonly="true"/>
+			readonly="true"
+		/>
 
 		<field
 			name="title"

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -118,6 +118,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
 				<?php
 				// Set main fields.
 				$this->fields = array(
+					'id',
 					'menutype',
 					'parent_id',
 					'menuordering',
@@ -125,8 +126,7 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
 					'home',
 					'access',
 					'language',
-					'note'
-
+					'note',
 				);
 
 				if ($this->item->type != 'component')


### PR DESCRIPTION
We do need the id of the menu item in the `$this->fields = array(` in a menu item edit.php) for the GSOC multilingual project.
It was missing anyway to display the id in the page.

After patch, the readonly field will display:
![screen shot 2016-08-09 at 07 59 50](https://cloud.githubusercontent.com/assets/869724/17506254/9ecc5056-5e07-11e6-95ee-826096c8138e.png)

Can be merged on review.
@andrepereiradasilva @alikon @jreys 
@wilsonge
