### PR TITLE
Fix for #11521 : Isis admin menu on small viewport width devices

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -66,111 +66,119 @@
 
 		});
 
+
 		/**
 		 * Append submenu items to empty UL on hover allowing a scrollable dropdown
 		 */
-		var menuScroll = $('#menu > li > ul'),
-			emptyMenu  = $('#nav-empty');
+		if ($w.width() > 768) {
 
-		$('#menu > li').on('click mouseenter', function() {
+			var menuScroll = $('#menu > li > ul'),
+				emptyMenu  = $('#nav-empty');
 
-			// Set max-height (and width if scroll) for dropdown menu, depending of window height
-			var $dropdownMenu    = $(this).children('ul'),
-				windowHeight     = $w.height(),
-				linkHeight       = $(this).outerHeight(true),
-				statusHeight     = $('#status').outerHeight(true),
-				menuHeight       = $dropdownMenu.height(),
-				menuOuterHeight  = $dropdownMenu.outerHeight(true),
-				scrollMenuWidth  = $dropdownMenu.width() + 15,
-				maxHeight        = windowHeight - (linkHeight + statusHeight + (menuOuterHeight - menuHeight) + 20);
+			$('#menu > li').on('click mouseenter', function() {
 
-			if (maxHeight < menuHeight) {
-				$dropdownMenu.css('width', scrollMenuWidth);
-			} else if (maxHeight > menuHeight) {
-				$dropdownMenu.css('width', 'auto');
-			}
+				// Set max-height (and width if scroll) for dropdown menu, depending of window height
+				var $dropdownMenu    = $(this).children('ul'),
+					windowHeight     = $w.height(),
+					linkHeight       = $(this).outerHeight(true),
+					statusHeight     = $('#status').outerHeight(true),
+					menuHeight       = $dropdownMenu.height(),
+					menuOuterHeight  = $dropdownMenu.outerHeight(true),
+					scrollMenuWidth  = $dropdownMenu.width() + 15,
+					maxHeight        = windowHeight - (linkHeight + statusHeight + (menuOuterHeight - menuHeight) + 20);
 
-			$dropdownMenu.css('max-height', maxHeight);
+				if (maxHeight < menuHeight) {
+					$dropdownMenu.css('width', scrollMenuWidth);
+				} else if (maxHeight > menuHeight) {
+					$dropdownMenu.css('width', 'auto');
+				}
 
-			// Get the submenu position
-			linkWidth        = $(this).outerWidth(true);
-			menuWidth        = $dropdownMenu.width();
-			linkPaddingLeft  = $(this).children('a').css('padding-left');
-			offsetLeft       = Math.round($(this).offset().left) - parseInt(linkPaddingLeft);
+				$dropdownMenu.css('max-height', maxHeight);
 
-			emptyMenu.empty().hide();
+				// Get the submenu position
+				linkWidth        = $(this).outerWidth(true);
+				menuWidth        = $dropdownMenu.width();
+				linkPaddingLeft  = $(this).children('a').css('padding-left');
+				offsetLeft       = Math.round($(this).offset().left) - parseInt(linkPaddingLeft);
 
-		});
+				emptyMenu.empty().hide();
 
-		menuScroll.find('.dropdown-submenu > a').on('mouseover', function() {
+			});
 
-			var $self           = $(this),
-				dropdown        = $self.next('ul'),
-				submenuWidth    = dropdown.outerWidth(),
-				offsetTop       = $self.offset().top,
-				linkPaddingTop  = parseInt(dropdown.css('padding-top')) + parseInt($(this).css('padding-top')),
-				scroll          = $w.scrollTop() + linkPaddingTop;
+			menuScroll.find('.dropdown-submenu > a').on('mouseover', function() {
 
-			// Set the submenu position
-			if ($('html').attr('dir') == 'rtl')
+				var $self           = $(this),
+					dropdown        = $self.next('ul'),
+					submenuWidth    = dropdown.outerWidth(),
+					offsetTop       = $self.offset().top,
+					linkPaddingTop  = parseInt(dropdown.css('padding-top')) + parseInt($(this).css('padding-top')),
+					scroll          = $w.scrollTop() + linkPaddingTop;
+
+				// Set the submenu position
+				if ($('html').attr('dir') == 'rtl')
+				{
+					emptyMenu.css({
+						top : offsetTop - scroll,
+						left: offsetLeft - (menuWidth - linkWidth) - submenuWidth
+					});
+				}
+				else
+				{
+					emptyMenu.css({
+						top : offsetTop - scroll,
+						left: offsetLeft + menuWidth
+					});
+				}
+
+				// Append items to empty <ul> and show it
+				dropdown.hide();
+				emptyMenu.show().html(dropdown.html());
+
+				// Check if the full element is visible. If not, adjust the position
+				if (emptyMenu.Jvisible() !== true)
+				{
+					emptyMenu.css({
+						top : ($w.height() - emptyMenu.outerHeight()) - $('#status').height()
+					});
+				}
+
+			});
+
+			menuScroll.find('a.no-dropdown').on('mouseenter', function() {
+
+				emptyMenu.empty().hide();
+
+			});
+
+			$(document).on('click', function() {
+
+				emptyMenu.empty().hide();
+
+			});
+
+			$.fn.Jvisible = function(partial,hidden)
 			{
-				emptyMenu.css({
-					top : offsetTop - scroll,
-					left: offsetLeft - (menuWidth - linkWidth) - submenuWidth
-				});
-			}
-			else
-			{
-				emptyMenu.css({
-					top : offsetTop - scroll,
-					left: offsetLeft + menuWidth
-				});
-			}
+				if (this.length < 1)
+				{
+					return;
+				}
 
-			// Append items to empty <ul> and show it
-			dropdown.hide();
-			emptyMenu.show().html(dropdown.html());
+				var $t = this.length > 1 ? this.eq(0) : this,
+					t  = $t.get(0)
 
-			// Check if the full element is visible. If not, adjust the position
-			if (emptyMenu.Jvisible() !== true)
-			{
-				emptyMenu.css({
-					top : ($w.height() - emptyMenu.outerHeight()) - $('#status').height()
-				});
-			}
+				var viewTop         = $w.scrollTop(),
+					viewBottom      = (viewTop + $w.height()) - $('#status').height(),
+					offset          = $t.offset(),
+					_top            = offset.top,
+					_bottom         = _top + $t.height(),
+					compareTop      = partial === true ? _bottom : _top,
+					compareBottom   = partial === true ? _top : _bottom;
 
-		});
-		menuScroll.find('a.no-dropdown').on('mouseenter', function() {
+				return !!t.offsetWidth * t.offsetHeight && ((compareBottom <= viewBottom) && (compareTop >= viewTop));
+			};
 
-			emptyMenu.empty().hide();
+		}
 
-		});
-		$(document).on('click', function() {
-
-			emptyMenu.empty().hide();
-
-		});
-
-		$.fn.Jvisible = function(partial,hidden)
-		{
-			if (this.length < 1)
-			{
-				return;
-			}
-
-			var $t = this.length > 1 ? this.eq(0) : this,
-				t  = $t.get(0)
-
-			var viewTop         = $w.scrollTop(),
-				viewBottom      = (viewTop + $w.height()) - $('#status').height(),
-				offset          = $t.offset(),
-				_top            = offset.top,
-				_bottom         = _top + $t.height(),
-				compareTop      = partial === true ? _bottom : _top,
-				compareBottom   = partial === true ? _top : _bottom;
-
-			return !!t.offsetWidth * t.offsetHeight && ((compareBottom <= viewBottom) && (compareTop >= viewTop));
-		};
 
 		/**
 		 * USED IN: All views with toolbar and sticky bar enabled

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -66,7 +66,6 @@
 
 		});
 
-
 		/**
 		 * Append submenu items to empty UL on hover allowing a scrollable dropdown
 		 */

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -70,7 +70,7 @@
 		/**
 		 * Append submenu items to empty UL on hover allowing a scrollable dropdown
 		 */
-		if ($w.width() > 768) {
+		if ($w.width() > 767) {
 
 			var menuScroll = $('#menu > li > ul'),
 				emptyMenu  = $('#nav-empty');


### PR DESCRIPTION
Pull Request for Issue #11521 .
#### Summary of Changes

Do not run auto-scolling script on small devices ( < 768px)
#### Testing Instructions
- Apply patch
- Clear browser cache
- Test usability of admin main menu on mobile (iPhone, Android...), or on screen resized with a width smaller than 768px (to have main Hamburger icon menu).
- Nothing should be changed when width is higger than 767px (auto-scrolling)
