### PR TITLE
Separate login and logout forms in beez3 template

### DIFF
--- a/templates/beez3/html/mod_login/default.php
+++ b/templates/beez3/html/mod_login/default.php
@@ -12,88 +12,67 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 ?>
-<?php if ($type == 'logout') : ?>
-	<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form">
-	<?php if ($params->get('greeting')) : ?>
-		<div class="login-greeting">
-		<?php if ($params->get('name') == 0) : ?>
-			<?php echo JText::sprintf('MOD_LOGIN_HINAME', htmlspecialchars($user->get('name'), ENT_COMPAT, 'UTF-8')); ?>
-		<?php else : ?>
-		 	<?php echo JText::sprintf('MOD_LOGIN_HINAME', htmlspecialchars($user->get('username'), ENT_COMPAT, 'UTF-8')); ?>
-		<?php endif; ?>
-		</div>
-	<?php endif; ?>
-	<div class="logout-button">
-		<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGOUT'); ?>" />
-		<input type="hidden" name="option" value="com_users" />
-		<input type="hidden" name="task" value="user.logout" />
-		<input type="hidden" name="return" value="<?php echo $return; ?>" />
-		<?php echo JHtml::_('form.token'); ?>
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" >
+<?php if ($params->get('pretext')) : ?>
+	<div class="pretext">
+	<p><?php echo $params->get('pretext'); ?></p>
 	</div>
-	</form>
-<?php else : ?>
-	<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" >
-	<?php if ($params->get('pretext')) : ?>
-		<div class="pretext">
-		<p><?php echo $params->get('pretext'); ?></p>
-		</div>
-	<?php endif; ?>
-	<fieldset class="userdata">
-	<p id="form-login-username">
-		<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?></label>
-		<input id="modlgn-username" type="text" name="username" class="inputbox"  size="18" />
-	</p>
-	<p id="form-login-password">
-		<label for="modlgn-passwd"><?php echo JText::_('JGLOBAL_PASSWORD') ?></label>
-		<input id="modlgn-passwd" type="password" name="password" class="inputbox" size="18" />
-	</p>
-	<?php if (count($twofactormethods) > 1) : ?>
-		<div id="form-login-secretkey" class="control-group">
-			<div class="controls">
-				<?php if (!$params->get('usetext')) : ?>
-					<div class="input-prepend input-append">
-						<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
-					</div>
-				<?php else: ?>
-					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
-					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
-				<?php endif; ?>
-			</div>
-		</div>
-	<?php endif; ?>
-	<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
-		<p id="form-login-remember">
-			<label for="modlgn-remember"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME') ?></label>
-			<input id="modlgn-remember" type="checkbox" name="remember" class="inputbox" value="yes"/>
-		</p>
-	<?php endif; ?>
-	<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGIN') ?>" />
-	<input type="hidden" name="option" value="com_users" />
-	<input type="hidden" name="task" value="user.login" />
-	<input type="hidden" name="return" value="<?php echo $return; ?>" />
-	<?php echo JHtml::_('form.token'); ?>
-	<ul>
-		<li>
-			<a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
-			<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>
-		</li>
-		<li>
-			<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
-			<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
-		</li>
-		<?php if (JComponentHelper::getParams('com_users')->get('allowUserRegistration')) : ?>
-			<li>
-				<a href="<?php echo JRoute::_('index.php?option=com_users&view=registration'); ?>">
-					<?php echo JText::_('MOD_LOGIN_REGISTER'); ?></a>
-			</li>
-		<?php endif; ?>
-	</ul>
-	<?php if ($params->get('posttext')) : ?>
-		<div class="posttext">
-			<p><?php echo $params->get('posttext'); ?></p>
-		</div>
-	<?php endif; ?>
-	</fieldset>
-	</form>
 <?php endif; ?>
+<fieldset class="userdata">
+<p id="form-login-username">
+	<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME') ?></label>
+	<input id="modlgn-username" type="text" name="username" class="inputbox"  size="18" />
+</p>
+<p id="form-login-password">
+	<label for="modlgn-passwd"><?php echo JText::_('JGLOBAL_PASSWORD') ?></label>
+	<input id="modlgn-passwd" type="password" name="password" class="inputbox" size="18" />
+</p>
+<?php if (count($twofactormethods) > 1) : ?>
+	<div id="form-login-secretkey" class="control-group">
+		<div class="controls">
+			<?php if (!$params->get('usetext')) : ?>
+				<div class="input-prepend input-append">
+					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
+					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+				</div>
+			<?php else: ?>
+				<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY') ?></label>
+				<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" />
+			<?php endif; ?>
+		</div>
+	</div>
+<?php endif; ?>
+<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
+	<p id="form-login-remember">
+		<label for="modlgn-remember"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME') ?></label>
+		<input id="modlgn-remember" type="checkbox" name="remember" class="inputbox" value="yes"/>
+	</p>
+<?php endif; ?>
+<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGIN') ?>" />
+<input type="hidden" name="option" value="com_users" />
+<input type="hidden" name="task" value="user.login" />
+<input type="hidden" name="return" value="<?php echo $return; ?>" />
+<?php echo JHtml::_('form.token'); ?>
+<ul>
+	<li>
+		<a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>">
+		<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>
+	</li>
+	<li>
+		<a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>">
+		<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_USERNAME'); ?></a>
+	</li>
+	<?php if (JComponentHelper::getParams('com_users')->get('allowUserRegistration')) : ?>
+		<li>
+			<a href="<?php echo JRoute::_('index.php?option=com_users&view=registration'); ?>">
+			<?php echo JText::_('MOD_LOGIN_REGISTER'); ?></a>
+		</li>
+	<?php endif; ?>
+</ul>
+<?php if ($params->get('posttext')) : ?>
+	<div class="posttext">
+		<p><?php echo $params->get('posttext'); ?></p>
+	</div>
+<?php endif; ?>
+</fieldset>
+</form>

--- a/templates/beez3/html/mod_login/default_logout.php
+++ b/templates/beez3/html/mod_login/default_logout.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Templates.beez3
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// no direct access
+defined('_JEXEC') or die;
+
+JHtml::_('behavior.keepalive');
+?>
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form">
+<?php if ($params->get('greeting')) : ?>
+	<div class="login-greeting">
+	<?php if ($params->get('name') == 0) : ?>
+		<?php echo JText::sprintf('MOD_LOGIN_HINAME', htmlspecialchars($user->get('name'), ENT_COMPAT, 'UTF-8')); ?>
+	<?php else : ?>
+	 	<?php echo JText::sprintf('MOD_LOGIN_HINAME', htmlspecialchars($user->get('username'), ENT_COMPAT, 'UTF-8')); ?>
+	<?php endif; ?>
+	</div>
+<?php endif; ?>
+<div class="logout-button">
+	<input type="submit" name="Submit" class="button" value="<?php echo JText::_('JLOGOUT'); ?>" />
+	<input type="hidden" name="option" value="com_users" />
+	<input type="hidden" name="task" value="user.logout" />
+	<input type="hidden" name="return" value="<?php echo $return; ?>" />
+	<?php echo JHtml::_('form.token'); ?>
+</div>
+</form>


### PR DESCRIPTION
About 4 years ago the login and logout forms have been separated in `modules/mod_login/tmpl`, but this separation never made its way into the beez3 template. This PR will change this...
#### Testing Instructions

For testing this change you need a current Joomla installation with the sample data installed.

**Status Quo**
- open the site homepage
- locate the menu "A Deep Menu" (on the right side, scroll down)
- click on "Using Joomla!"
- again locate the menu "A Deep Menu" and click on "Using Extensions"
- click on the "Templates" link in the middle of the screen
- click on the "Home Page" link below "Beez 20" in the middle of the screen
- the next page is shown using the "beez3" template
- scroll down and locate the "Login Form" (on the left side)
- notice that the text "Log in" at the button is blue
- log in using any valid user name and password
- again scroll down and locate the "Login Form" (same place as before)
- notice that the text "Log out" at the button is black
- press the "Log out" button
- click on the "Beez 2" link in the breadcrumb line

**Changes**
- install this PR
- click on the "Home page" link in the article area (I assume that you're still at the page from the end of the "Status Quo" test instructions)
- again locate the "Login form" and notice that it looks as before, including the blue "Log in" text
- log in using any valid user name and password
- again scroll down and locate the "Login Form"
- notice that the logout form looks nearly the same as before, the only change is that the "Log out" text is now blue
- press the "Log out" button
