### PR TITLE
Set login/logout form actions to "index.php"

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
 ?>
-<form action="<?php echo JRoute::_(htmlspecialchars(JUri::getInstance()->toString()), true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
 	<?php if ($params->get('pretext')) : ?>
 		<div class="pretext">
 			<p><?php echo $params->get('pretext'); ?></p>

--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 ?>
-<form action="<?php echo JRoute::_(htmlspecialchars(JUri::getInstance()->toString(), ENT_COMPAT, 'UTF-8'), true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-vertical">
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-vertical">
 <?php if ($params->get('greeting')) : ?>
 	<div class="login-greeting">
 	<?php if ($params->get('name') == 0) : ?>


### PR DESCRIPTION
Login and Logout form actions set to "index.php", in doing so undoing the change made Dec 8, 2014.

Reason for this change is that `JRoute::_()` doesn't honor the third parameter (the "usesecure" flag) when a complete URL is passed, this is due to the following lines in that method:

```
if (!is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0))
{
        return $url;
}
```

Assume that `http://www.example.org/index.php` is the current URL which is passed as a string as first parameter to `JRoute::_()`. A string is not an array, there is no "&" in the string (so `strpos()` returns `false` which is not identical to "0") and the substring "index.php" doesn't start at position 0 in the string. Therefore the given URL is returned without any modifications, here: no changing of the scheme to HTTPS if the flag "usesecure" is set.

It is no problem to pass simply "index.php" here as action since the real target after logging in is passed in the hidden field "return".
#### Testing Instructions

For testing this change you need a current Joomla installation with the sample data installed.

**Preparations**
- log in to the administration
- **important**: check that caching is disabled, if not disable it and clear the site cache
- open "Extensions", "Modules"
- search for all site modules containing the string "login" - you should find 3 such modules
- open the "Login Form" module (this should be positioned at "position-7")
- change "Encrypt Login Form" to "Yes" and save the settings

**Status Quo**
- open the site homepage using HTTP
- locate the login form in the bottom right of the page
- check the login form action, it should be something like `http://<server>/index.php`
- log in using any valid user and password
- you're still visiting the site via HTTP
- log out and close the site homepage

**Changes**
- install this PR
- open the site homepage using HTTP
- locate the login form and check the login form action, now it should be something like `https://<server>/index.php`
- log in using any valid user and password
- you should now visit the site via HTTPS, the current page is probably the user profile (this is somewhat unexpected, but this is another issue to be fixed separately)
- go the the site homepage
- locate the logout form and check the logout form action, it should be something like `https://<server>/index.php`
- log out, afterwards you still visit the site via HTTPS (this again is another issue to be fixed separately)
- close the site homepage
