### PR TITLE
Added Feature items filter to mod_articles_news

### DIFF
--- a/language/en-GB/en-GB.mod_articles_news.ini
+++ b/language/en-GB/en-GB.mod_articles_news.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_ARTICLES_NEWS="Articles - Newsflash"
+MOD_ARTICLES_NEWS_FIELD_FEATURED_DESC="Show or hide articles designated as featured."
+MOD_ARTICLES_NEWS_FIELD_FEATURED_LABEL="Featured Articles"
 MOD_ARTICLES_NEWS_FIELD_CATEGORY_DESC="Select Articles from a specific Category or a set of Categories. If no selection will show all categories as default."
 MOD_ARTICLES_NEWS_FIELD_IMAGES_DESC="Display Article images."
 MOD_ARTICLES_NEWS_FIELD_IMAGES_LABEL="Show Images"
@@ -27,4 +29,5 @@ MOD_ARTICLES_NEWS_READMORE="Read more ..."
 MOD_ARTICLES_NEWS_READMORE_REGISTER="Register to Read More"
 MOD_ARTICLES_NEWS_TITLE_HEADING="Header Level"
 MOD_ARTICLES_NEWS_TITLE_HEADING_DESCRIPTION="Select the desired HTML header level for the Article titles."
+MOD_ARTICLES_NEWS_VALUE_ONLY_SHOW_FEATURED="Only show Featured Articles"
 MOD_ARTICLES_NEWS_XML_DESCRIPTION="The Article Newsflash Module will display a fixed number of Articles from a specific Category or a set of Categories."

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -58,6 +58,20 @@ abstract class ModArticlesNewsHelper
 		// Filter by language
 		$model->setState('filter.language', $app->getLanguageFilter());
 
+		//  Featured switch
+		switch ($params->get('show_featured'))
+		{
+			case '1' :
+				$model->setState('filter.featured', 'only');
+				break;
+			case '0' :
+				$model->setState('filter.featured', 'hide');
+				break;
+			default :
+				$model->setState('filter.featured', 'show');
+				break;
+		}
+		
 		// Set ordering
 		$ordering = $params->get('ordering', 'a.publish_up');
 		$model->setState('list.ordering', $ordering);

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -120,6 +120,18 @@
 				/>
 
 				<field
+					name="show_featured"
+					type="list"
+					label="MOD_ARTICLES_NEWS_FIELD_FEATURED_LABEL"
+					description="MOD_ARTICLES_NEWS_FIELD_FEATURED_DESC"
+					default=""
+					>
+					<option value="">JSHOW</option>
+					<option value="0">JHIDE</option>
+					<option value="1">MOD_ARTICLES_NEWS_VALUE_ONLY_SHOW_FEATURED</option>
+				</field>
+
+				<field
 					name="ordering"
 					type="list"
 					label="MOD_ARTICLES_NEWS_FIELD_ORDERING_LABEL"


### PR DESCRIPTION
Pull Request for Issue #11539 .
#### Summary of Changes

The feature item filter was already available for the
mod_articles_latest module, but that is just a list.
All code was slightly modified from the mod_articles_latest module.
#### Testing Instructions
- Login to the joomla administrator
- Add the module Articles - Newsflash 
- You should now see a filter parameter for featured
#### Documentation Changes Required

https://help.joomla.org/proxy/index.php?keyref=Help36:Extensions_Module_Manager_Articles_Newsflash 
Should be updated to include the featured articles filter
Just copy and paste what is here: https://help.joomla.org/proxy/index.php?keyref=Help36:Extensions_Module_Manager_Latest_News
