### PR TITLE
When RSS feed for COM_FINDER is enabled, feed displayed via menu item alias give Error 500

### DIFF
--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -84,7 +84,7 @@ class FinderViewSearch extends JViewLegacy
 			$item->title       = $result->title;
 			$item->link        = JRoute::_($result->route);
 			$item->description = $result->description;
-			$item->date        = (int) $result->start_date ? JHtml::date($result->start_date, 'l d F Y') : $result->indexdate;
+			$item->date        = (int) $result->start_date ? JHtml::date($result->start_date, 'U') : $result->indexdate;
 
 			// Get the taxonomy data.
 			$taxonomy = $result->getTaxonomy();


### PR DESCRIPTION
Pull Request for Issue #10961 .

#### Summary of Changes
 The error appears only when we don't use the US-date.I changed in (U) to use timestamp conversion in localized datetime is done in another file. Tested in German, English and French

#### Testing Instructions
Open the following url on your installation while your system is on another language than english. It should display a RSS feed. It's unsuccessful if joomla displays an error message

index.php?option=com_finder&format=feed&type=rss&
@icampus