### PR TITLE
Fixed an obvious typo in the debug plugin

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -360,7 +360,7 @@ class PlgSystemDebug extends JPlugin
 			return __METHOD__ . ' -- Unknown method: ' . $fncName . '<br />';
 		}
 
-		$html = '';
+		$html = array();
 
 		$js = "toggleContainer('dbg_container_" . $item . "');";
 


### PR DESCRIPTION
#### Summary of Changes

The $html is instantiated as a string while it is actually used as an array. So should be instantiated as an array.
#### Testing Instructions
1. Enable debug mode in Joomla
2. Make sure debug mode still works

Although I think this can be done on code review.
#### Documentation Changes Required

None
