### PR TITLE
Select images as well in smart search

### DIFF
--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -344,7 +344,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 
 		// Check if we can use the supplied SQL query.
 		$query = $query instanceof JDatabaseQuery ? $query : $db->getQuery(true)
-			->select('a.id, a.title, a.alias, a.introtext AS summary, a.fulltext AS body')
+			->select('a.id, a.title, a.alias, a.introtext AS summary, a.fulltext AS body, a.images as images')
 			->select('a.state, a.catid, a.created AS start_date, a.created_by')
 			->select('a.created_by_alias, a.modified, a.modified_by, a.attribs AS params')
 			->select('a.metakey, a.metadesc, a.metadata, a.language, a.access, a.version, a.ordering')


### PR DESCRIPTION
#### Summary of Changes

When you use smart search, it would be great if you could show item images as well in the result list, it enables much nicer styling and possibly even reusing your blog views etc. The change is quite trivial, just one additional field is selected from the table, and I don't think it has any performance impact.
#### Testing Instructions

To test, I guess it's enough to make sure that the smart search works the same as before. If you'd like see images, you'd have to make a template override.
