### PR TITLE
Use JHtmlBootstrap in front-end editing

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -153,10 +153,10 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo $this->form->renderField('metakey'); ?>
 			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
-			<input type="hidden" name="task" value="" />
-			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
 			<?php echo JHtml::_("bootstrap.endTabSet"); ?>
 
+			<input type="hidden" name="task" value="" />
+			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 	</form>

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -65,104 +65,98 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php endif; ?>
 		</div>
 		<fieldset>
-			<ul class="nav nav-tabs">
-				<li class="active"><a href="#editor" data-toggle="tab"><?php echo JText::_('COM_CONTENT_ARTICLE_CONTENT') ?></a></li>
-				<?php if ($params->get('show_urls_images_frontend') ) : ?>
-				<li><a href="#images" data-toggle="tab"><?php echo JText::_('COM_CONTENT_IMAGES_AND_URLS') ?></a></li>
+			<?php echo JHtml::_("bootstrap.startTabSet", "myTab", array("active" => "editor")); ?>
+
+			<?php echo JHtml::_("bootstrap.addTab", "myTab", "editor", JText::_("COM_CONTENT_ARTICLE_CONTENT")); ?>
+				<?php echo $this->form->renderField('title'); ?>
+
+				<?php if (is_null($this->item->id)) : ?>
+					<?php echo $this->form->renderField('alias'); ?>
 				<?php endif; ?>
-				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-				<li><a href="#params-<?php echo $name; ?>" data-toggle="tab"><?php echo JText::_($fieldSet->label); ?></a></li>
-				<?php endforeach; ?>
-				<li><a href="#publishing" data-toggle="tab"><?php echo JText::_('COM_CONTENT_PUBLISHING') ?></a></li>
-				<li><a href="#language" data-toggle="tab"><?php echo JText::_('JFIELD_LANGUAGE_LABEL') ?></a></li>
-				<li><a href="#metadata" data-toggle="tab"><?php echo JText::_('COM_CONTENT_METADATA') ?></a></li>
-			</ul>
 
-			<div class="tab-content">
-				<div class="tab-pane active" id="editor">
-					<?php echo $this->form->renderField('title'); ?>
+				<?php echo $this->form->getInput('articletext'); ?>
+			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
-					<?php if (is_null($this->item->id)) : ?>
-						<?php echo $this->form->renderField('alias'); ?>
-					<?php endif; ?>
-
-					<?php echo $this->form->getInput('articletext'); ?>
-				</div>
-				<?php if ($params->get('show_urls_images_frontend')): ?>
-				<div class="tab-pane" id="images">
-					<?php echo $this->form->renderField('image_intro', 'images'); ?>
-					<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
-					<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
-					<?php echo $this->form->renderField('float_intro', 'images'); ?>
-					<?php echo $this->form->renderField('image_fulltext', 'images'); ?>
-					<?php echo $this->form->renderField('image_fulltext_alt', 'images'); ?>
-					<?php echo $this->form->renderField('image_fulltext_caption', 'images'); ?>
-					<?php echo $this->form->renderField('float_fulltext', 'images'); ?>
-					<?php echo $this->form->renderField('urla', 'urls'); ?>
-					<?php echo $this->form->renderField('urlatext', 'urls'); ?>
-					<div class="control-group">
-						<div class="controls">
-							<?php echo $this->form->getInput('targeta', 'urls'); ?>
-						</div>
-					</div>
-					<?php echo $this->form->renderField('urlb', 'urls'); ?>
-					<?php echo $this->form->renderField('urlbtext', 'urls'); ?>
-					<div class="control-group">
-						<div class="controls">
-							<?php echo $this->form->getInput('targetb', 'urls'); ?>
-						</div>
-					</div>
-					<?php echo $this->form->renderField('urlc', 'urls'); ?>
-					<?php echo $this->form->renderField('urlctext', 'urls'); ?>
-					<div class="control-group">
-						<div class="controls">
-							<?php echo $this->form->getInput('targetc', 'urls'); ?>
-						</div>
+			<?php if ($params->get('show_urls_images_frontend')): ?>
+			<?php echo JHtml::_("bootstrap.addTab", "myTab", "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
+				<?php echo $this->form->renderField('image_intro', 'images'); ?>
+				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
+				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
+				<?php echo $this->form->renderField('float_intro', 'images'); ?>
+				<?php echo $this->form->renderField('image_fulltext', 'images'); ?>
+				<?php echo $this->form->renderField('image_fulltext_alt', 'images'); ?>
+				<?php echo $this->form->renderField('image_fulltext_caption', 'images'); ?>
+				<?php echo $this->form->renderField('float_fulltext', 'images'); ?>
+				<?php echo $this->form->renderField('urla', 'urls'); ?>
+				<?php echo $this->form->renderField('urlatext', 'urls'); ?>
+				<div class="control-group">
+					<div class="controls">
+						<?php echo $this->form->getInput('targeta', 'urls'); ?>
 					</div>
 				</div>
+				<?php echo $this->form->renderField('urlb', 'urls'); ?>
+				<?php echo $this->form->renderField('urlbtext', 'urls'); ?>
+				<div class="control-group">
+					<div class="controls">
+						<?php echo $this->form->getInput('targetb', 'urls'); ?>
+					</div>
+				</div>
+				<?php echo $this->form->renderField('urlc', 'urls'); ?>
+				<?php echo $this->form->renderField('urlctext', 'urls'); ?>
+				<div class="control-group">
+					<div class="controls">
+						<?php echo $this->form->getInput('targetc', 'urls'); ?>
+					</div>
+				</div>
+			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php endif; ?>
+
+			<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
+				<?php echo JHtml::_("bootstrap.addTab", "myTab", "params-" . $name, JText::_($fieldSet->label)); ?>
+					<?php foreach ($this->form->getFieldset($name) as $field) : ?>
+						<?php echo $field->renderField(); ?>
+					<?php endforeach; ?>
+				<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php endforeach; ?>
+
+			<?php echo JHtml::_("bootstrap.addTab", "myTab", "publishing", JText::_("COM_CONTENT_PUBLISHING")); ?>
+				<?php echo $this->form->renderField('catid'); ?>
+				<?php echo $this->form->renderField('tags'); ?>
+				<?php if ($params->get('save_history', 0)) : ?>
+					<?php echo $this->form->renderField('version_note'); ?>
 				<?php endif; ?>
-				<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-					<div class="tab-pane" id="params-<?php echo $name; ?>">
-						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-							<?php echo $field->renderField(); ?>
-						<?php endforeach; ?>
-					</div>
-				<?php endforeach; ?>
-				<div class="tab-pane" id="publishing">
-					<?php echo $this->form->renderField('catid'); ?>
-					<?php echo $this->form->renderField('tags'); ?>
-					<?php if ($params->get('save_history', 0)) : ?>
-						<?php echo $this->form->renderField('version_note'); ?>
-					<?php endif; ?>
-					<?php echo $this->form->renderField('created_by_alias'); ?>
-					<?php if ($this->item->params->get('access-change')) : ?>
-						<?php echo $this->form->renderField('state'); ?>
-						<?php echo $this->form->renderField('featured'); ?>
-						<?php echo $this->form->renderField('publish_up'); ?>
-						<?php echo $this->form->renderField('publish_down'); ?>
-					<?php endif; ?>
-					<?php echo $this->form->renderField('access'); ?>
-					<?php if (is_null($this->item->id)):?>
-						<div class="control-group">
-							<div class="control-label">
-							</div>
-							<div class="controls">
-								<?php echo JText::_('COM_CONTENT_ORDERING'); ?>
-							</div>
+				<?php echo $this->form->renderField('created_by_alias'); ?>
+				<?php if ($this->item->params->get('access-change')) : ?>
+					<?php echo $this->form->renderField('state'); ?>
+					<?php echo $this->form->renderField('featured'); ?>
+					<?php echo $this->form->renderField('publish_up'); ?>
+					<?php echo $this->form->renderField('publish_down'); ?>
+				<?php endif; ?>
+				<?php echo $this->form->renderField('access'); ?>
+				<?php if (is_null($this->item->id)):?>
+					<div class="control-group">
+						<div class="control-label">
 						</div>
-					<?php endif; ?>
-				</div>
-				<div class="tab-pane" id="language">
-					<?php echo $this->form->renderField('language'); ?>
-				</div>
-				<div class="tab-pane" id="metadata">
-					<?php echo $this->form->renderField('metadesc'); ?>
-					<?php echo $this->form->renderField('metakey'); ?>
+						<div class="controls">
+							<?php echo JText::_('COM_CONTENT_ORDERING'); ?>
+						</div>
+					</div>
+				<?php endif; ?>
+			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
-				</div>
-			</div>
+			<?php echo JHtml::_("bootstrap.addTab", "myTab", "language", JText::_("JFIELD_LANGUAGE_LABEL")); ?>
+				<?php echo $this->form->renderField('language'); ?>
+			<?php echo JHtml::_("bootstrap.endTab"); ?>
+
+			<?php echo JHtml::_("bootstrap.addTab", "myTab", "metadata", JText::_("COM_CONTENT_METADATA")); ?>
+				<?php echo $this->form->renderField('metadesc'); ?>
+				<?php echo $this->form->renderField('metakey'); ?>
+			<?php echo JHtml::_("bootstrap.endTab"); ?>
+
+			<input type="hidden" name="task" value="" />
+			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
+			<?php echo JHtml::_("bootstrap.endTabSet"); ?>
+
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 	</form>

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -65,9 +65,9 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php endif; ?>
 		</div>
 		<fieldset>
-			<?php echo JHtml::_("bootstrap.startTabSet", "myTab", array("active" => "editor")); ?>
+			<?php echo JHtml::_("bootstrap.startTabSet", "com-content-form", array("active" => "editor")); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "myTab", "editor", JText::_("COM_CONTENT_ARTICLE_CONTENT")); ?>
+			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "editor", JText::_("COM_CONTENT_ARTICLE_CONTENT")); ?>
 				<?php echo $this->form->renderField('title'); ?>
 
 				<?php if (is_null($this->item->id)) : ?>
@@ -78,7 +78,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
 			<?php if ($params->get('show_urls_images_frontend')): ?>
-			<?php echo JHtml::_("bootstrap.addTab", "myTab", "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
+			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
 				<?php echo $this->form->renderField('image_intro', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
@@ -112,14 +112,14 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php endif; ?>
 
 			<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-				<?php echo JHtml::_("bootstrap.addTab", "myTab", "params-" . $name, JText::_($fieldSet->label)); ?>
+				<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "params-" . $name, JText::_($fieldSet->label)); ?>
 					<?php foreach ($this->form->getFieldset($name) as $field) : ?>
 						<?php echo $field->renderField(); ?>
 					<?php endforeach; ?>
 				<?php echo JHtml::_("bootstrap.endTab"); ?>
 			<?php endforeach; ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "myTab", "publishing", JText::_("COM_CONTENT_PUBLISHING")); ?>
+			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "publishing", JText::_("COM_CONTENT_PUBLISHING")); ?>
 				<?php echo $this->form->renderField('catid'); ?>
 				<?php echo $this->form->renderField('tags'); ?>
 				<?php if ($params->get('save_history', 0)) : ?>
@@ -144,11 +144,11 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php endif; ?>
 			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "myTab", "language", JText::_("JFIELD_LANGUAGE_LABEL")); ?>
+			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "language", JText::_("JFIELD_LANGUAGE_LABEL")); ?>
 				<?php echo $this->form->renderField('language'); ?>
 			<?php echo JHtml::_("bootstrap.endTab"); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "myTab", "metadata", JText::_("COM_CONTENT_METADATA")); ?>
+			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "metadata", JText::_("COM_CONTENT_METADATA")); ?>
 				<?php echo $this->form->renderField('metadesc'); ?>
 				<?php echo $this->form->renderField('metakey'); ?>
 			<?php echo JHtml::_("bootstrap.endTab"); ?>


### PR DESCRIPTION
#### Summary of Changes

This PR replaces the hard coded bootstrap tabs in com_content.form with `JHtml::_("bootstrap.tab")`. The advantage of this change is that we can override this library to use Bootstrap 3 for example.
#### Testing Instructions
1. Log in on the front-end and edit an article
2. Make sure all the tabs are working correctly
3. Apply this PR
4. Make sure all the tabs are still working correctly
