### PR TITLE
[Cache] memcache fix for J3.6.2, memcache(-d) performance improvements, less connections, add support for 'platform specific caching'

### DIFF
--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -22,7 +22,7 @@ psql -d joomla_ut -a -f "$BASE/tests/unit/schema/postgresql.sql"
 # - ./build/travis/php-apache.sh
 # Enable additional PHP extensions
 
-if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
+if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcache.ini"; fi
 if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
 if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -254,6 +254,18 @@ class JCacheStorage
 	}
 
 	/**
+	 * Flush all existing items in storage.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function flush()
+	{
+		return true;
+	}
+
+	/**
 	 * Garbage collect expired cache data
 	 *
 	 * @return  boolean

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -93,6 +93,31 @@ class JCacheStorageMemcache extends JCacheStorage
 	}
 
 	/**
+	 * Get a cache_id string from an id/group pair
+	 *
+	 * @param   string  $id     The cache data id
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  string   The cache_id string
+	 *
+	 * @since   11.1
+	 */
+	protected function _getCacheId($id, $group)
+	{
+		$prefix   = JCache::getPlatformPrefix();
+		$length   = strlen($prefix);
+		$cache_id = parent::_getCacheId($id, $group);
+
+		if ($length)
+		{
+			// Memcache use suffix instead of prefix
+			$cache_id = substr($cache_id, $length) . strrev($prefix);
+		}
+
+		return $cache_id;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -122,7 +122,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$data = array();
 
-		if (!empty($keys))
+		if (is_array($keys))
 		{
 			foreach ($keys as $key)
 			{
@@ -178,7 +178,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$index = static::$_db->get($this->_hash . '-index');
 
-		if ($index === false)
+		if (!is_array($index))
 		{
 			$index = array();
 		}
@@ -217,18 +217,16 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$index = static::$_db->get($this->_hash . '-index');
 
-		if ($index === false)
+		if (is_array($index))
 		{
-			$index = array();
-		}
-
-		foreach ($index as $key => $value)
-		{
-			if ($value->name == $cache_id)
+			foreach ($index as $key => $value)
 			{
-				unset($index[$key]);
-				static::$_db->set($this->_hash . '-index', $index, 0, 0);
-				break;
+				if ($value->name == $cache_id)
+				{
+					unset($index[$key]);
+					static::$_db->set($this->_hash . '-index', $index, 0, 0);
+					break;
+				}
 			}
 		}
 
@@ -259,7 +257,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$index = static::$_db->get($this->_hash . '-index');
 
-		if ($index !== false)
+		if (is_array($index))
 		{
 			$secret = $this->_hash;
 

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -279,6 +279,23 @@ class JCacheStorageMemcache extends JCacheStorage
 	}
 
 	/**
+	 * Flush all existing items in storage.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function flush()
+	{
+		if (!$this->lockindex())
+		{
+			return false;
+		}
+
+		return static::$_db->flush();
+	}
+
+	/**
 	 * Test to see if the storage handler is available.
 	 *
 	 * @return  boolean

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -177,7 +177,11 @@ class JCacheStorageMemcache extends JCacheStorage
 		}
 
 		$index = static::$_db->get($this->_hash . '-index');
-		$index = $index ? $index : array();
+
+		if ($index === false)
+		{
+			$index = array();
+		}
 
 		$tmparr       = new stdClass;
 		$tmparr->name = $cache_id;
@@ -212,7 +216,11 @@ class JCacheStorageMemcache extends JCacheStorage
 		}
 
 		$index = static::$_db->get($this->_hash . '-index');
-		$index = $index ? $index : array();
+
+		if ($index === false)
+		{
+			$index = array();
+		}
 
 		foreach ($index as $key => $value)
 		{

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -259,11 +259,11 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		if (is_array($index))
 		{
-			$secret = $this->_hash;
+			$prefix = $this->_hash . '-cache-' . $group . '-';
 
 			foreach ($index as $key => $value)
 			{
-				if (strpos($value->name, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+				if (strpos($value->name, $prefix) === 0 xor $mode != 'group')
 				{
 					static::$_db->delete($value->name);
 					unset($index[$key]);
@@ -320,7 +320,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	 */
 	public function lock($id, $group, $locktime)
 	{
-		$returning             = new stdClass;
+		$returning = new stdClass;
 		$returning->locklooped = false;
 
 		$looptime = $locktime * 10;
@@ -333,7 +333,8 @@ class JCacheStorageMemcache extends JCacheStorage
 		{
 			$lock_counter = 0;
 
-			// Loop until you find that the lock has been released. That implies that data get from other thread has finished
+			// Loop until you find that the lock has been released.
+			// That implies that data get from other thread has finished.
 			while ($data_lock === false)
 			{
 				if ($lock_counter > $looptime)

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -31,7 +31,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	 * @var    boolean
 	 * @since  11.1
 	 */
-	protected $_persistent = false;
+	protected static $_persistent = false;
 
 	/**
 	 * Payload compression level
@@ -39,7 +39,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	 * @var    integer
 	 * @since  11.1
 	 */
-	protected $_compress = 0;
+	protected static $_compress = 0;
 
 	/**
 	 * Constructor
@@ -52,7 +52,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	{
 		parent::__construct($options);
 
-		if (static::isSupported() && static::$_db === null)
+		if (static::$_db === null)
 		{
 			$this->getConnection();
 		}
@@ -68,28 +68,36 @@ class JCacheStorageMemcache extends JCacheStorage
 	 */
 	protected function getConnection()
 	{
-		$config            = JFactory::getConfig();
-		$this->_persistent = $config->get('memcache_persist', true);
-		$this->_compress   = $config->get('memcache_compress', false) == false ? 0 : MEMCACHE_COMPRESSED;
+		if (!static::isSupported())
+		{
+			throw new RuntimeException('Memcache Extension is not available');
+		}
+
+		$config = JFactory::getConfig();
+
+		$host = $config->get('memcache_server_host', 'localhost');
+		$port = $config->get('memcache_server_port', 11211);
 
 		// Create the memcache connection
 		static::$_db = new Memcache;
-		static::$_db->addserver($config->get('memcache_server_host', 'localhost'), $config->get('memcache_server_port', 11211), $this->_persistent);
 
-		$memcachetest = @static::$_db->connect($server['host'], $server['port']);
+		// If memcache object is static then $_persistent and $_compress too
+		static::$_persistent = $config->get('memcache_persist', true);
+		static::$_compress   = $config->get('memcache_compress', false) ? MEMCACHE_COMPRESSED : 0;
 
-		if ($memcachetest == false)
+		if (static::$_persistent)
 		{
-			throw new RuntimeException('Could not connect to memcache server', 404);
+			$result = @static::$_db->pconnect($host, $port);
+		}
+		else
+		{
+			$result = @static::$_db->connect($host, $port);
 		}
 
-		// Memcahed has no list keys, we do our own accounting, initialise key index
-		if (static::$_db->get($this->_hash . '-index') === false)
+		if (!$result)
 		{
-			static::$_db->set($this->_hash . '-index', array(), $this->_compress, 0);
+			throw new RuntimeException('Could not connect to memcache server');
 		}
-
-		return;
 	}
 
 	/**
@@ -177,25 +185,17 @@ class JCacheStorageMemcache extends JCacheStorage
 		}
 
 		$index = static::$_db->get($this->_hash . '-index');
-
-		if ($index === false)
-		{
-			$index = array();
-		}
+		$index = $index ? $index : array();
 
 		$tmparr       = new stdClass;
 		$tmparr->name = $cache_id;
 		$tmparr->size = strlen($data);
 
 		$index[] = $tmparr;
-		static::$_db->replace($this->_hash . '-index', $index, 0, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0, 0);
 		$this->unlockindex();
 
-		// Prevent double writes, write only if it doesn't exist else replace
-		if (!static::$_db->replace($cache_id, $data, $this->_compress, $this->_lifetime))
-		{
-			static::$_db->set($cache_id, $data, $this->_compress, $this->_lifetime);
-		}
+		static::$_db->set($cache_id, $data, static::$_compress, $this->_lifetime);
 
 		return true;
 	}
@@ -220,23 +220,18 @@ class JCacheStorageMemcache extends JCacheStorage
 		}
 
 		$index = static::$_db->get($this->_hash . '-index');
-
-		if ($index === false)
-		{
-			$index = array();
-		}
+		$index = $index ? $index : array();
 
 		foreach ($index as $key => $value)
 		{
 			if ($value->name == $cache_id)
 			{
 				unset($index[$key]);
+				static::$_db->set($this->_hash . '-index', $index, 0, 0);
+				break;
 			}
-
-			break;
 		}
 
-		static::$_db->replace($this->_hash . '-index', $index, 0, 0);
 		$this->unlockindex();
 
 		return static::$_db->delete($cache_id);
@@ -264,23 +259,22 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$index = static::$_db->get($this->_hash . '-index');
 
-		if ($index === false)
+		if ($index !== false)
 		{
-			$index = array();
-		}
+			$secret = $this->_hash;
 
-		$secret = $this->_hash;
-
-		foreach ($index as $key => $value)
-		{
-			if (strpos($value->name, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			foreach ($index as $key => $value)
 			{
-				static::$_db->delete($value->name, 0);
-				unset($index[$key]);
+				if (strpos($value->name, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+				{
+					static::$_db->delete($value->name);
+					unset($index[$key]);
+				}
 			}
+
+			static::$_db->set($this->_hash . '-index', $index, 0, 0);
 		}
 
-		static::$_db->replace($this->_hash . '-index', $index, 0, 0);
 		$this->unlockindex();
 
 		return true;
@@ -295,20 +289,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	 */
 	public static function isSupported()
 	{
-		// First check if the PHP requirements are met
-		$supported = extension_loaded('memcache') && class_exists('Memcache');
-
-		if (!$supported)
-		{
-			return false;
-		}
-
-		// Now check if we can connect to the specified Memcache server
-		$config = JFactory::getConfig();
-
-		$memcache = new Memcache;
-
-		return @$memcache->connect($config->get('memcache_server_host', 'localhost'), $config->get('memcache_server_port', 11211));
+		return extension_loaded('memcache') && class_exists('Memcache');
 	}
 
 	/**
@@ -331,27 +312,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 		$cache_id = $this->_getCacheId($id, $group);
 
-		if (!$this->lockindex())
-		{
-			return false;
-		}
-
-		$index = static::$_db->get($this->_hash . '-index');
-
-		if ($index === false)
-		{
-			$index = array();
-		}
-
-		$tmparr       = new stdClass;
-		$tmparr->name = $cache_id;
-		$tmparr->size = 1;
-
-		$index[] = $tmparr;
-		static::$_db->replace($this->_hash . '-index', $index, 0, 0);
-		$this->unlockindex();
-
-		$data_lock = static::$_db->add($cache_id . '_lock', 1, false, $locktime);
+		$data_lock = static::$_db->add($cache_id . '_lock', 1, 0, $locktime);
 
 		if ($data_lock === false)
 		{
@@ -362,15 +323,15 @@ class JCacheStorageMemcache extends JCacheStorage
 			{
 				if ($lock_counter > $looptime)
 				{
-					$returning->locked = false;
-					$returning->locklooped = true;
 					break;
 				}
 
 				usleep(100);
-				$data_lock = static::$_db->add($cache_id . '_lock', 1, false, $locktime);
+				$data_lock = static::$_db->add($cache_id . '_lock', 1, 0, $locktime);
 				$lock_counter++;
 			}
+
+			$returning->locklooped = true;
 		}
 
 		$returning->locked = $data_lock;
@@ -391,32 +352,6 @@ class JCacheStorageMemcache extends JCacheStorage
 	public function unlock($id, $group = null)
 	{
 		$cache_id = $this->_getCacheId($id, $group) . '_lock';
-
-		if (!$this->lockindex())
-		{
-			return false;
-		}
-
-		$index = static::$_db->get($this->_hash . '-index');
-
-		if ($index === false)
-		{
-			$index = array();
-		}
-
-		foreach ($index as $key => $value)
-		{
-			if ($value->name == $cache_id)
-			{
-				unset($index[$key]);
-			}
-
-			break;
-		}
-
-		static::$_db->replace($this->_hash . '-index', $index, 0, 0);
-		$this->unlockindex();
-
 		return static::$_db->delete($cache_id);
 	}
 
@@ -430,7 +365,7 @@ class JCacheStorageMemcache extends JCacheStorage
 	protected function lockindex()
 	{
 		$looptime  = 300;
-		$data_lock = static::$_db->add($this->_hash . '-index_lock', 1, false, 30);
+		$data_lock = static::$_db->add($this->_hash . '-index_lock', 1, 0, 30);
 
 		if ($data_lock === false)
 		{
@@ -442,11 +377,10 @@ class JCacheStorageMemcache extends JCacheStorage
 				if ($lock_counter > $looptime)
 				{
 					return false;
-					break;
 				}
 
 				usleep(100);
-				$data_lock = static::$_db->add($this->_hash . '-index_lock', 1, false, 30);
+				$data_lock = static::$_db->add($this->_hash . '-index_lock', 1, 0, 30);
 				$lock_counter++;
 			}
 		}

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -79,13 +79,10 @@ class JCacheStorageMemcached extends JCacheStorage
 			static::$_db = new Memcached($this->_hash);
 			$servers = static::$_db->getServerList();
 
-			if ($servers)
+			if ($servers && ($servers[0]['host'] != $host || $servers[0]['port'] != $port))
 			{
-				if ($servers[0]['host'] != $host || $servers[0]['host'] != $port)
-				{
-					static::$_db->resetServerList();
-					$servers = array();
-				}
+				static::$_db->resetServerList();
+				$servers = array();
 			}
 
 			if (!$servers)

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -113,6 +113,31 @@ class JCacheStorageMemcached extends JCacheStorage
 	}
 
 	/**
+	 * Get a cache_id string from an id/group pair
+	 *
+	 * @param   string  $id     The cache data id
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  string   The cache_id string
+	 *
+	 * @since   11.1
+	 */
+	protected function _getCacheId($id, $group)
+	{
+		$prefix   = JCache::getPlatformPrefix();
+		$length   = strlen($prefix);
+		$cache_id = parent::_getCacheId($id, $group);
+
+		if ($length)
+		{
+			// Memcached use suffix instead of prefix
+			$cache_id = substr($cache_id, $length) . strrev($prefix);
+		}
+
+		return $cache_id;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -295,6 +295,23 @@ class JCacheStorageMemcached extends JCacheStorage
 	}
 
 	/**
+	 * Flush all existing items in storage.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function flush()
+	{
+		if (!$this->lockindex())
+		{
+			return false;
+		}
+
+		return static::$_db->flush();
+	}
+
+	/**
 	 * Test to see if the storage handler is available.
 	 *
 	 * @return  boolean

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -64,7 +64,7 @@ class JCacheStorageMemcached extends JCacheStorage
 	{
 		if (!static::isSupported())
 		{
-			throw new RuntimeException('Memcache Extension is not available');
+			throw new RuntimeException('Memcached Extension is not available');
 		}
 
 		$config = JFactory::getConfig();

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -90,12 +90,6 @@ class JCacheStorageMemcached extends JCacheStorage
 		}
 
 		static::$_db->setOption(Memcached::OPT_COMPRESSION, $this->_compress);
-
-		// Memcached has no list keys, we do our own accounting, initialise key index
-		if (static::$_db->get($this->_hash . '-index') === false)
-		{
-			static::$_db->set($this->_hash . '-index', array(), 0);
-		}
 	}
 
 	/**
@@ -196,7 +190,7 @@ class JCacheStorageMemcached extends JCacheStorage
 		$tmparr->size = strlen($data);
 
 		$index[] = $tmparr;
-		static::$_db->replace($this->_hash . '-index', $index, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0);
 		$this->unlockindex();
 
 		// Prevent double writes, write only if it doesn't exist else replace
@@ -244,7 +238,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			break;
 		}
 
-		static::$_db->replace($this->_hash . '-index', $index, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0);
 		$this->unlockindex();
 
 		return static::$_db->delete($cache_id);
@@ -288,7 +282,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			}
 		}
 
-		static::$_db->replace($this->_hash . '-index', $index, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0);
 		$this->unlockindex();
 
 		return true;
@@ -374,7 +368,7 @@ class JCacheStorageMemcached extends JCacheStorage
 		$tmparr->size = 1;
 
 		$index[] = $tmparr;
-		static::$_db->replace($this->_hash . '-index', $index, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0);
 
 		$this->unlockindex();
 
@@ -442,7 +436,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			break;
 		}
 
-		static::$_db->replace($this->_hash . '-index', $index, 0);
+		static::$_db->set($this->_hash . '-index', $index, 0);
 		$this->unlockindex();
 
 		return static::$_db->delete($cache_id);

--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -62,7 +62,9 @@ abstract class TestCaseCache extends TestCase
 
 		if ($this->handler instanceof JCacheStorage)
 		{
+			// Deprecated, temporary have to stay because flush method is not implemented in all storages.
 			$this->handler->clean($this->group);
+			$this->handler->flush();
 		}
 
 		parent::tearDown();


### PR DESCRIPTION
Pull Request for Issue (Not yet)
#### Summary

Cache storage memcache from J3.6.2 is not working.
This PR fix that.

I also add the same changes to memcached.

This is part of  another (more optimized) PR #10565. 
#### Summary of Changes

[UPDATED]

1) Fix compression issue.
Before only first instance of memcache can set compression to true on `getConnection` method.
Next instances did not call `getConnection` and then did not use compression at all.
Move `$this->_compress = ...` to consctructor.

https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aR47

2) Check `static::$_db === null` before `isSupported()`. 
If connection exists then skip call `isSupported` and do not create useless connections.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL55

3) Fix persistent connection. Remove test connection which break persistent.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL79

4) Remove race condition. We do not need to initiate empty list.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL89

5) Joomla uses only one memcache server. Remove `replace` and use only `set` method.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL194

6) Fix `remove` method. Search in all list instead of in first item only.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL236

7) Do not test connection in `isSupported` method https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL311
- In global configuration we should have an option to set another custom port if default does not work.

8) Do not lock twice. Do not call `lockindex` for `lock`/'unlock' method.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL334
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aL395

9) Fix `locklooped`.
https://github.com/joomla/joomla-cms/pull/11565/files#diff-8104780960bee59ef8a377ffd818797aR375

https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/cache/controller/callback.php#L99

10) Override `_getCacheId($id, $group)` for memcache(-d).
If `Platform specific caching` in `Global Configuration->Cache Settings` is enabled 
then mobile (user agent) user without that patch could not delete/see all cache data.
#### Testing Instructions

1) On Joomla 3.6.2 or newer try to use Cache handler MemcachE and MemcacheD
2) Test Joomla  with memcachE and MemcacheD handler on J 3.6.2 (without and with patch)
3) Check Backend->Cache Clear page.

(Optional)
Check how many connection (in memcached stats) generates joomla before patch and after patch.
After patch there should be less connections.
#### Other method to test.

https://github.com/joomla/joomla-cms/pull/11565#issuecomment-240566785
