### PR TITLE
addAttachment(array()) produces PHP Notice

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -451,6 +451,9 @@ class JMail extends PHPMailer
 			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
 			try
 			{
+				// Defaults $result to false if anything fails below
+				$result = false;
+
 				if (is_array($path))
 				{
 					if (!empty($name) && count($path) != count($name))


### PR DESCRIPTION
#### Summary of Changes

I've set $result as false by default in the addAttachment() method.
#### Testing Instructions

`JFactory::getMailer()->addAttachment(array());` will show a PHP Notice:

Notice: Undefined variable: result in /libraries/joomla/mail/mail.php on line 479

I've bumped my head against a wall for so long until I figured this out; $result never gets initialized because the array has 0 elements and this part won't run:

``` php
foreach ($path as $key => $file)
{
    if (!empty($name))
    {
        $result = parent::addAttachment($file, $name[$key], $encoding, $type);
    }
    else
    {
        $result = parent::addAttachment($file, $name, $encoding, $type);
    }
}
```

So we'll end up with an unset $result here:

``` php
if ($result === false)
```
#### Documentation Changes Required

None
