### PR TITLE
Change selector for input order field

### DIFF
--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -217,36 +217,36 @@
 				if (ui.originalPosition.top > ui.position.top) //if item moved up
 				{
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[name="order[]"]:hidden', ui.item).attr('value', parseInt($('[type=text]:hidden', ui.item.next()).attr('value')));
+						$('[name="order[]"]', ui.item).attr('value', parseInt($('[type=text]', ui.item.next()).attr('value')));
 					}
 					$(range).each(function () {
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){
 							if (_top > ui.item.position().top && _top < ui.originalPosition.top + ui.item.outerHeight()) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) + 1;
 								} else {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) - 1;
 								}
 
-								$('[name="order[]"]:hidden', $(this)).attr('value', newValue);
+								$('[name="order[]"]', $(this)).attr('value', newValue);
 							}
 						}
 					});
 				} else if (ui.originalPosition.top < ui.position.top) {
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[name="order[]"]:hidden', ui.item).attr('value', parseInt($('[name="order[]"]:hidden', ui.item.prev()).attr('value')));
+						$('[name="order[]"]', ui.item).attr('value', parseInt($('[name="order[]"]', ui.item.prev()).attr('value')));
 					}
 					$(range).each(function () {
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){
 							if (_top < ui.item.position().top && _top >= ui.originalPosition.top) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) - 1;
 								} else {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) + 1;
 								}
-								$('[name="order[]"]:hidden', $(this)).attr('value', newValue);
+								$('[name="order[]"]', $(this)).attr('value', newValue);
 							}
 						}
 


### PR DESCRIPTION
#### Summary of Changes

Commit 93f90efa6949f21e3e735b11b2afd7eb8b312156 had the exact opposite
effect of what was advertised, i.e. it made it **impossible** to use
visible ordering input fields when using the drag'n'drop reordering.
This has broken –among other things– FOF 2.x which is part of core
Joomla!. It's worth noting that BEFORE this commit it was actually
possible to have visible reordering fields and I was in fact using them
in FOF 2 (which is included in Joomla! itself) since 2014. So, basically,
you guys broke Joomla! because you didn't test that the commit does
what it says it does instead of what the commiter thought his commit
does. TEST. BEFORE. COMMITING!!!

Interestingly, the _actual_ problem @sebastienheraud was trying to solve
was in fact solved by the changes @alexvanniel did in gh-5731  This would
have been all too well if gh-5731 hadn't kept the `:hidden` specifiers
from commit 93f90efa6949f21e3e735b11b2afd7eb8b312156 which had introduced
a regression.

My changes keep the ACTUAL problem's fix from gh-5731 and remove the
regression introduced in 93f90efa6949f21e3e735b11b2afd7eb8b312156
#### Testing Instructions

I am not providing any on the grounds that you blindly accepted commit
93f90efa6949f21e3e735b11b2afd7eb8b312156 and gh-5731 without testing.

Since this fixes FOF 2 which is part of Joomla! I expect you to merge it
anyway.

For what it's worth, I have tested this PR with all of my components using
both FOF 2 and FOF 3. Before the PR drag'n'drop reordering with visible order
fields was impossible: the row would move but the value in the ordering field
remained the same. After the PR drag'n'drop reordering with visible order works
as expected: the row would move AND the value in the ordering field changed.

I also tested with com_content. Before AND after the change you can drag'n'drop
reorder just fine. **PLEASE DO TEST WITH CORE COMPONENTS YOURSELVES!** We
must be sure that no core component breaks with this change. Also, please do
test with third party components for the same reason. Let's do this the right way.
#### Documentation Changes Required

None. This PR fixes what you guys had already broken.
