### PR TITLE
Allow also viewable ordering fields

### DIFF
--- a/media/jui/js/sortablelist.js
+++ b/media/jui/js/sortablelist.js
@@ -217,36 +217,36 @@
 				if (ui.originalPosition.top > ui.position.top) //if item moved up
 				{
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[name="order[]"]:hidden', ui.item).attr('value', parseInt($('[type=text]:hidden', ui.item.next()).attr('value')));
+						$('[name="order[]"]', ui.item).attr('value', parseInt($('[type=text]', ui.item.next()).attr('value')));
 					}
 					$(range).each(function () {
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){
 							if (_top > ui.item.position().top && _top < ui.originalPosition.top + ui.item.outerHeight()) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) + 1;
 								} else {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) - 1;
 								}
 
-								$('[name="order[]"]:hidden', $(this)).attr('value', newValue);
+								$('[name="order[]"]', $(this)).attr('value', newValue);
 							}
 						}
 					});
 				} else if (ui.originalPosition.top < ui.position.top) {
 					if (ui.item.position().top != ui.originalPosition.top){
-						$('[name="order[]"]:hidden', ui.item).attr('value', parseInt($('[name="order[]"]:hidden', ui.item.prev()).attr('value')));
+						$('[name="order[]"]', ui.item).attr('value', parseInt($('[name="order[]"]', ui.item.prev()).attr('value')));
 					}
 					$(range).each(function () {
 						var _top = $(this).position().top;
 						if ( ui.item.get(0) !== $(this).get(0)){
 							if (_top < ui.item.position().top && _top >= ui.originalPosition.top) {
 								if (sortDir == 'asc') {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) - 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) - 1;
 								} else {
-									var newValue = parseInt($('[name="order[]"]:hidden', $(this)).attr('value')) + 1;
+									var newValue = parseInt($('[name="order[]"]', $(this)).attr('value')) + 1;
 								}
-								$('[name="order[]"]:hidden', $(this)).attr('value', newValue);
+								$('[name="order[]"]', $(this)).attr('value', newValue);
 							}
 						}
 


### PR DESCRIPTION
#### Summary of Changes

A combination of two PRs #7368 and the commit for #5731 broke the ability to have visible ordering fields. This PR will fix the problem.
#### Testinstructions
- Install a fof component with visible ordering fields (I have used admin-tools-pro, URL-Redirection) add some items and try to order with drag/drop and with changing the number in the field. This should fail.
- Apply patch
- Try it again and it should now work. 
- Test also ordering in the article manager and category manager
