### PR TITLE
Remove JTable warning and add a comment

### DIFF
--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -291,7 +291,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 			if (!class_exists($tableClass))
 			{
 				/*
-				* If we were unable to find the class file in the JTable include paths. Return false.
+				* If unable to find the class file in the JTable include paths. Return false.
 				* The warning JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND has been removed in __DEPLOY_VERSION__.
 				* In 4.0 an Exception (type to be determined) will be thrown.
 				* For more info see https://github.com/joomla/joomla-cms/issues/11570

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -290,8 +290,12 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 			if (!class_exists($tableClass))
 			{
-				// If we were unable to find the class file in the JTable include paths, raise a warning and return false.
-				JLog::add(JText::sprintf('JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND', $type), JLog::WARNING, 'jerror');
+				/*
+				* If we were unable to find the class file in the JTable include paths. Return false.
+				* The warning JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND has been removed in __DEPLOY_VERSION__.
+				* In 4.0 an Exception (type to be determined) will be thrown.
+				* For more info see https://github.com/joomla/joomla-cms/issues/11570
+				*/
 
 				return false;
 			}


### PR DESCRIPTION
Pull request for issue https://github.com/joomla/joomla-cms/issues/11570
#### Summary of Changes

Removes warning from JTable when table file is not found.
Adds a comment in the code that in 4.0 an Exception will be trown.
#### Testing Instructions
1. Add to isis index.php

``` php
$table = JTable::getInstance('bla', 'Table', array('dbo' => JFactory::getDbo()));
```
1. Check the warning.
2. Apply patch
3. Check no warning now 

For more info: see https://github.com/joomla/joomla-cms/issues/11570
#### Documentation Changes Required

None
