### PR TITLE
Move travis phpunit test preparations into a bash script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: php
 env:
   global:
     - RUN_PHPCS="no"
+    - RUN_UNIT_TESTS="yes"
     - RUN_JAVASCRIPT_TESTS="no"
     - INSTALL_MEMCACHE="yes"
     - INSTALL_MEMCACHED="yes"
@@ -16,7 +17,7 @@ matrix:
   include:
     - node_js: 6.1
       sudo: true
-      env: RUN_JAVASCRIPT_TESTS="yes"
+      env: RUN_JAVASCRIPT_TESTS="yes" RUN_UNIT_TESTS="no"
     - php: 5.3
       env: INSTALL_APC="yes"
     - php: 5.4
@@ -57,25 +58,7 @@ before_script:
   # JavaScript tests
   - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash tests/javascript/travis-tests.sh $PWD; fi
   # Make sure all dev dependencies are installed
-  - composer install
-  # Set up databases for testing
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql -e 'create database joomla_ut;'; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < tests/unit/schema/mysql.sql; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root -e 'create database joomla_ut;'; fi
-  - if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < tests/unit/schema/mysql.sql; fi
-  - psql -c 'create database joomla_ut;' -U postgres
-  - psql -d joomla_ut -a -f tests/unit/schema/postgresql.sql
-  # Set up Apache
-  # - ./build/travis/php-apache.sh
-  # Enable additional PHP extensions
-  - if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
-  - if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
-  - if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini; fi
-  - if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
-  - if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
-  - if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
-  - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
-  - if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat build/travis/phpenv/redis.ini >> /etc/hhvm/php.ini; fi
+  - if [[ $RUN_UNIT_TESTS == "yes" ]]; then bash tests/unit/unit-tests.sh $PWD; fi
 
 script:
   - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - if [[ $RUN_UNIT_TESTS == "yes" ]]; then bash tests/unit/unit-tests.sh $PWD; fi
 
 script:
-  - libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml
+  - if [[ $RUN_UNIT_TESTS == "yes" ]]; then libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml; fi
   - if [[ $RUN_PHPCS == "yes" ]]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .; fi
   - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then tests/javascript/node_modules/karma/bin/karma start karma.conf.js --single-run ; fi
 

--- a/tests/unit/unit-tests.sh
+++ b/tests/unit/unit-tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script for preparing the unit tests
+# Script for preparing the unit tests in Joomla!
 
 BASE="$1"
 
@@ -10,21 +10,21 @@ composer install
 
 # Setup databases for testing
 if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql -e 'create database joomla_ut;'; fi
-if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < tests/unit/schema/mysql.sql; fi
+if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < "$BASE/tests/unit/schema/mysql.sql"; fi
 if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root -e 'create database joomla_ut;'; fi
-if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < tests/unit/schema/mysql.sql; fi
+if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < "$BASE/tests/unit/schema/mysql.sql"; fi
 psql -c 'create database joomla_ut;' -U postgres
-psql -d joomla_ut -a -f tests/unit/schema/postgresql.sql
+psql -d joomla_ut -a -f "$BASE/tests/unit/schema/postgresql.sql"
 
 # Set up Apache
 # - ./build/travis/php-apache.sh
 # Enable additional PHP extensions
 
-if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
-if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
-if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini; fi
-if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
-if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
+if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
+if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
+if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini"; fi
+if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
+if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
-if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
-if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat build/travis/phpenv/redis.ini >> /etc/hhvm/php.ini; fi
+if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add "$BASE/build/travis/phpenv/redis.ini"; fi
+if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat "$BASE/build/travis/phpenv/redis.ini" >> /etc/hhvm/php.ini; fi

--- a/tests/unit/unit-tests.sh
+++ b/tests/unit/unit-tests.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Script for preparing the unit tests in Joomla!
 
+# Path to the Joomla! installation
 BASE="$1"
 
+# Abort travis execution if setup fails
 set -e
 
 # Make sure all dev dependencies are installed

--- a/tests/unit/unit-tests.sh
+++ b/tests/unit/unit-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Script for preparing the unit tests
+
+BASE="$1"
+
+set -e
+
+# Make sure all dev dependencies are installed
+composer install
+
+# Setup databases for testing
+if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql -e 'create database joomla_ut;'; fi
+if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < tests/unit/schema/mysql.sql; fi
+if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root -e 'create database joomla_ut;'; fi
+if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < tests/unit/schema/mysql.sql; fi
+psql -c 'create database joomla_ut;' -U postgres
+psql -d joomla_ut -a -f tests/unit/schema/postgresql.sql
+
+# Set up Apache
+# - ./build/travis/php-apache.sh
+# Enable additional PHP extensions
+
+if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
+if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add build/travis/phpenv/memcached.ini; fi
+if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini; fi
+if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
+if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini; fi
+if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
+if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-add build/travis/phpenv/redis.ini; fi
+if [[ $INSTALL_REDIS == "yes" && $TRAVIS_PHP_VERSION = hhvm ]]; then cat build/travis/phpenv/redis.ini >> /etc/hhvm/php.ini; fi


### PR DESCRIPTION
Pull Request for #11420.
#### Summary of Changes

As asked by @rdeutz in #11420 phpunit tests should not be executed when running the javascript tests. In order to achieve that we need to clean up the .travis.yml and move the tests setup to a separate bash script.

This also has the advantage that the formatting and execution workflow can be improved over the one liners we have because of travis now. (Not done with this PR)
#### Testing Instructions

Review and check the travis log
#### Documentation Changes Required

None 
