### PR TITLE
[postgresql] - wrong group by in Menus: Items  with multilanguage on

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -253,7 +253,7 @@ class MenusModelItems extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name');
+				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.title');
 		}
 
 		// Join over the extensions


### PR DESCRIPTION
Pull Request for Issue  discovered testing GSoC2016 - multilingual project.
#### Summary of Changes

fixed group by clause to be more SQL agnostic
#### Testing Instructions
- postgresql
- Install current staging with  basic native multilingual site creation option
- extra steps install a couple of languages
- Activate the multilingual feature
- go to menu  All Menu Items or  Main Menu or  Main Menu (en-GB) or....
#### Expected Result

a list of menu items
#### Actual Result

sql error
#### Documentation Changes Required

none
