### PR TITLE
Revert "Performance gain - new featured article"

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -241,7 +241,7 @@ class ContentModelArticle extends JModelAdmin
 		// Reorder the articles within the category so the new article is first
 		if (empty($table->id))
 		{
-			$table->ordering = $table->getNextOrder('catid = ' . (int) $table->catid . ' AND state >= 0');
+			$table->reorder('catid = ' . (int) $table->catid . ' AND state >= 0');
 		}
 	}
 
@@ -672,12 +672,10 @@ class ContentModelArticle extends JModelAdmin
 
 				// Featuring.
 				$tuples = array();
-				$ordering = $table->getNextOrder();
 
 				foreach ($new_featured as $pk)
 				{
-					$tuples[] = $pk . ', ' . $ordering;
-					$ordering++;
+					$tuples[] = $pk . ', 0';
 				}
 
 				if (count($tuples))
@@ -699,6 +697,8 @@ class ContentModelArticle extends JModelAdmin
 
 			return false;
 		}
+
+		$table->reorder();
 
 		$this->cleanCache();
 


### PR DESCRIPTION
PR for issue #11103 
#### Summery of Changes

The PLT decided to revert #8576 because it is a B/C break
#### Testing instructions
- Apply patch
- You need a category view with articles
- Set the the secondary ordering in Articles options to „Ordering“
- Set the the secondary ordering for the menu to „Use Global“
- Create a new Article
#### Expected result

The new Article should be listed first in the frontend category view
