### PR TITLE
Throw Exceptions in JSessionStorage::getInstance() versus jexit()

### DIFF
--- a/libraries/joomla/session/exception/unsupported.php
+++ b/libraries/joomla/session/exception/unsupported.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Session
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception class defining an unsupported session storage object
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JSessionExceptionUnsupported extends RuntimeException
+{
+}

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -19,7 +19,7 @@ defined('JPATH_PLATFORM') or die;
 abstract class JSessionStorage
 {
 	/**
-	 * @var    array  JSessionStorage instances container.
+	 * @var    JSessionStorage[]  JSessionStorage instances container.
 	 * @since  11.3
 	 */
 	protected static $instances = array();
@@ -45,6 +45,7 @@ abstract class JSessionStorage
 	 * @return  JSessionStorage
 	 *
 	 * @since   11.1
+	 * @throws  JSessionExceptionUnsupported
 	 */
 	public static function getInstance($name = 'none', $options = array())
 	{
@@ -61,8 +62,7 @@ abstract class JSessionStorage
 
 				if (!file_exists($path))
 				{
-					// No attempt to die gracefully here, as it tries to close the non-existing session
-					jexit('Unable to load session storage class: ' . $name);
+					throw new JSessionExceptionUnsupported('Unable to load session storage class: ' . $name);
 				}
 
 				require_once $path;
@@ -70,16 +70,14 @@ abstract class JSessionStorage
 				// The class should now be loaded
 				if (!class_exists($class))
 				{
-					// No attempt to die gracefully here, as it tries to close the non-existing session
-					jexit('Unable to load session storage class: ' . $name);
+					throw new JSessionExceptionUnsupported('Unable to load session storage class: ' . $name);
 				}
 			}
 
 			// Validate the session storage is supported on this platform
 			if (!$class::isSupported())
 			{
-				// No attempt to die gracefully here, as it tries to close the non-existing session
-				jexit(sprintf('The %s Session Storage is not supported on this platform.', $name));
+				throw new JSessionExceptionUnsupported(sprintf('The %s Session Storage is not supported on this platform.', $name));
 			}
 
 			self::$instances[$name] = new $class($options);


### PR DESCRIPTION
#### Summary of Changes

Instead of exiting the application completely when we are unable to get a session storage object, throw exceptions.  The code commented inline the exit was intentional because the processing would try to close a non-existing session, however since there isn't a way with Joomla's API to start a session without a successful return from this instance there wouldn't be a session to close.
#### Testing Instructions

Set the `$session_handler` var in your configuration to "xcache" and try to load Joomla.  You should get a "Error displaying the error page: Application Instantiation Error: The xcache Session Storage is not supported on this platform." message which means this message was displayed via `JErrorPage::render()`.  There's no change in behavior for functional configurations.
#### Documentation Changes Required

N/A, there is no extra documentation beyond the API docs for this method.
