### PR TITLE
Deprecate JGithub classes

### DIFF
--- a/libraries/joomla/github/account.php
+++ b/libraries/joomla/github/account.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Account class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubAccount extends JGithubObject
 {

--- a/libraries/joomla/github/commits.php
+++ b/libraries/joomla/github/commits.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Commits class for the Joomla Platform.
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubCommits extends JGithubObject
 {

--- a/libraries/joomla/github/forks.php
+++ b/libraries/joomla/github/forks.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Forks class for the Joomla Platform.
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubForks extends JGithubObject
 {

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -36,7 +36,8 @@ use Joomla\Registry\Registry;
  * @property-read  JGithubHooks       $hooks       Deprecated GitHub API object for hooks.
  * @property-read  JGithubMeta        $meta        Deprecated GitHub API object for meta.
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithub
 {

--- a/libraries/joomla/github/hooks.php
+++ b/libraries/joomla/github/hooks.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Hooks class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubHooks extends JGithubObject
 {

--- a/libraries/joomla/github/http.php
+++ b/libraries/joomla/github/http.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * HTTP client class for connecting to a GitHub instance.
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubHttp extends JHttp
 {

--- a/libraries/joomla/github/meta.php
+++ b/libraries/joomla/github/meta.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Meta class.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubMeta extends JGithubObject
 {

--- a/libraries/joomla/github/milestones.php
+++ b/libraries/joomla/github/milestones.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Milestones class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubMilestones extends JGithubObject
 {

--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * GitHub API object class for the Joomla Platform.
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 abstract class JGithubObject
 {

--- a/libraries/joomla/github/package.php
+++ b/libraries/joomla/github/package.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API package class for the Joomla Platform.
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 abstract class JGithubPackage extends JGithubObject
 {

--- a/libraries/joomla/github/package/activity.php
+++ b/libraries/joomla/github/package/activity.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity class for the Joomla Platform.
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @documentation  https://developer.github.com/v3/activity/
  *

--- a/libraries/joomla/github/package/activity/events.php
+++ b/libraries/joomla/github/package/activity/events.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/activity/events/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageActivityEvents extends JGithubPackage
 {

--- a/libraries/joomla/github/package/activity/notifications.php
+++ b/libraries/joomla/github/package/activity/notifications.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/activity/notifications/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageActivityNotifications extends JGithubPackage
 {

--- a/libraries/joomla/github/package/activity/starring.php
+++ b/libraries/joomla/github/package/activity/starring.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/activity/starring/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageActivityStarring extends JGithubPackage
 {

--- a/libraries/joomla/github/package/activity/watching.php
+++ b/libraries/joomla/github/package/activity/watching.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/activity/watching/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageActivityWatching extends JGithubPackage
 {

--- a/libraries/joomla/github/package/authorization.php
+++ b/libraries/joomla/github/package/authorization.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/oauth/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageAuthorization extends JGithubPackage
 {

--- a/libraries/joomla/github/package/data.php
+++ b/libraries/joomla/github/package/data.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * https://developer.github.com/v3/git/
  * Git DB API

--- a/libraries/joomla/github/package/data/blobs.php
+++ b/libraries/joomla/github/package/data/blobs.php
@@ -18,7 +18,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/blobs/
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageDataBlobs extends JGithubPackage
 {

--- a/libraries/joomla/github/package/data/commits.php
+++ b/libraries/joomla/github/package/data/commits.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/commits/
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageDataCommits extends JGithubPackage
 {

--- a/libraries/joomla/github/package/data/refs.php
+++ b/libraries/joomla/github/package/data/refs.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/refs/
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageDataRefs extends JGithubPackage
 {

--- a/libraries/joomla/github/package/data/tags.php
+++ b/libraries/joomla/github/package/data/tags.php
@@ -16,7 +16,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/tags/
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageDataTags extends JGithubPackage
 {

--- a/libraries/joomla/github/package/data/trees.php
+++ b/libraries/joomla/github/package/data/trees.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/git/trees/
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageDataTrees extends JGithubPackage
 {

--- a/libraries/joomla/github/package/gists.php
+++ b/libraries/joomla/github/package/gists.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/gists
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @property-read  JGithubPackageGistsComments  $comments  GitHub API object for gist comments.
  */

--- a/libraries/joomla/github/package/gists/comments.php
+++ b/libraries/joomla/github/package/gists/comments.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/gists/comments/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageGistsComments extends JGithubPackage
 {

--- a/libraries/joomla/github/package/gitignore.php
+++ b/libraries/joomla/github/package/gitignore.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  * @documentation https://developer.github.com/v3/gitignore/
  * @documentation https://github.com/github/gitignore
  *
- * @since  12.4
+ * @since       12.4
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageGitignore extends JGithubPackage
 {

--- a/libraries/joomla/github/package/issues.php
+++ b/libraries/joomla/github/package/issues.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @property-read  JGithubPackageIssuesAssignees   $assignees   GitHub API object for assignees.
  * @property-read  JGithubPackageIssuesComments    $comments    GitHub API object for comments.

--- a/libraries/joomla/github/package/issues/assignees.php
+++ b/libraries/joomla/github/package/issues/assignees.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues/assignees/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageIssuesAssignees extends JGithubPackage
 {

--- a/libraries/joomla/github/package/issues/comments.php
+++ b/libraries/joomla/github/package/issues/comments.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues/comments/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageIssuesComments extends JGithubPackage
 {

--- a/libraries/joomla/github/package/issues/events.php
+++ b/libraries/joomla/github/package/issues/events.php
@@ -18,7 +18,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues/events/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageIssuesEvents extends JGithubPackage
 {

--- a/libraries/joomla/github/package/issues/labels.php
+++ b/libraries/joomla/github/package/issues/labels.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues/labels/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageIssuesLabels extends JGithubPackage
 {

--- a/libraries/joomla/github/package/issues/milestones.php
+++ b/libraries/joomla/github/package/issues/milestones.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/issues/milestones/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageIssuesMilestones extends JGithubPackage
 {

--- a/libraries/joomla/github/package/markdown.php
+++ b/libraries/joomla/github/package/markdown.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/markdown
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageMarkdown extends JGithubPackage
 {

--- a/libraries/joomla/github/package/orgs.php
+++ b/libraries/joomla/github/package/orgs.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity class for the Joomla Platform.
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @documentation  https://developer.github.com/v3/orgs/
  *

--- a/libraries/joomla/github/package/orgs/members.php
+++ b/libraries/joomla/github/package/orgs/members.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/orgs/members/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageOrgsMembers extends JGithubPackage
 {

--- a/libraries/joomla/github/package/orgs/teams.php
+++ b/libraries/joomla/github/package/orgs/teams.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/orgs/teams/
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageOrgsTeams extends JGithubPackage
 {

--- a/libraries/joomla/github/package/pulls.php
+++ b/libraries/joomla/github/package/pulls.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/pulls
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @property-read  JGithubPackagePullsComments  $comments  GitHub API object for comments.
  */

--- a/libraries/joomla/github/package/pulls/comments.php
+++ b/libraries/joomla/github/package/pulls/comments.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/pulls/comments/
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackagePullsComments extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories.php
+++ b/libraries/joomla/github/package/repositories.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API Activity class for the Joomla Platform.
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  *
  * @documentation  https://developer.github.com/v3/repos
  *

--- a/libraries/joomla/github/package/repositories/collaborators.php
+++ b/libraries/joomla/github/package/repositories/collaborators.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/collaborators
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesCollaborators extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/comments.php
+++ b/libraries/joomla/github/package/repositories/comments.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/comments
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesComments extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/commits.php
+++ b/libraries/joomla/github/package/repositories/commits.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/commits
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesCommits extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/contents.php
+++ b/libraries/joomla/github/package/repositories/contents.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/contents
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesContents extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/downloads.php
+++ b/libraries/joomla/github/package/repositories/downloads.php
@@ -18,7 +18,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/downloads
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesDownloads extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/forks.php
+++ b/libraries/joomla/github/package/repositories/forks.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/forks
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesForks extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/hooks.php
+++ b/libraries/joomla/github/package/repositories/hooks.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/hooks
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesHooks extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/keys.php
+++ b/libraries/joomla/github/package/repositories/keys.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/keys
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesKeys extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/merging.php
+++ b/libraries/joomla/github/package/repositories/merging.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/merging
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesMerging extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/statistics.php
+++ b/libraries/joomla/github/package/repositories/statistics.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/statistics
  *
- * @since  3.3 (CMS)
+ * @since       3.3 (CMS)
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesStatistics  extends JGithubPackage
 {

--- a/libraries/joomla/github/package/repositories/statuses.php
+++ b/libraries/joomla/github/package/repositories/statuses.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/statuses
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageRepositoriesStatuses extends JGithubPackage
 {

--- a/libraries/joomla/github/package/search.php
+++ b/libraries/joomla/github/package/search.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/search
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageSearch extends JGithubPackage
 {

--- a/libraries/joomla/github/package/users.php
+++ b/libraries/joomla/github/package/users.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/users
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageUsers extends JGithubPackage
 {

--- a/libraries/joomla/github/package/users/emails.php
+++ b/libraries/joomla/github/package/users/emails.php
@@ -17,7 +17,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/users/emails
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageUsersEmails extends JGithubPackage
 {

--- a/libraries/joomla/github/package/users/followers.php
+++ b/libraries/joomla/github/package/users/followers.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/users/followers
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageUsersFollowers extends JGithubPackage
 {

--- a/libraries/joomla/github/package/users/keys.php
+++ b/libraries/joomla/github/package/users/keys.php
@@ -14,7 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @documentation https://developer.github.com/v3/repos/users/keys
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubPackageUsersKeys extends JGithubPackage
 {

--- a/libraries/joomla/github/refs.php
+++ b/libraries/joomla/github/refs.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @since  11.3
+ * @since       11.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubRefs extends JGithubObject
 {

--- a/libraries/joomla/github/statuses.php
+++ b/libraries/joomla/github/statuses.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * GitHub API References class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/github` package via Composer instead
  */
 class JGithubStatuses extends JGithubObject
 {


### PR DESCRIPTION
#### Summary of Changes

The social packages that ship with the CMS that are also part of the Framework stack are for the most part duplicated code with feature parity and as such there really isn't a need to maintain two versions of almost 100% identical code.  Unfortunately, we can't just simply proxy these packages over as was done with `JRegistry` because the underlying HTTP adapter code has some structural differences in favor of configuration injection versus reading from something like `JFactory::getConfig()`, however feature parity can be achieved as CMS 4.0 and Framework 2.0 are released making it easier to easily use the same code/features from one source.

Therefore, I propose to start deprecating the social packages as they exist in the CMS today with the plan to remove them in 4.0.  This also in theory enables the CMS to NOT ship these packages in 4.0 in favor of developers pulling them as dependencies in their workspaces and packaging things up themselves, or just simply shipping the Framework versions of these packages (if they continue to exist).  As with all of our existing libraries extensions though, and any extensions which may have integrated a Composer based workflow into their systems, the infrastructure for that would need to be better defined in the CMS APIs.  Nonetheless that shouldn't be a showstopper to this being reviewed.
#### Testing Instructions

Maintainer decision
#### Documentation Changes Required

N/A, this package is not documented in the CMS workspace
