### PR TITLE
Add deprecation logging for class aliases

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -6,12 +6,12 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-JLoader::registerAlias('JRegistry',           '\\Joomla\\Registry\\Registry');
-JLoader::registerAlias('JRegistryFormat',     '\\Joomla\\Registry\\AbstractRegistryFormat');
-JLoader::registerAlias('JRegistryFormatIni',  '\\Joomla\\Registry\\Format\\Ini');
-JLoader::registerAlias('JRegistryFormatJson', '\\Joomla\\Registry\\Format\\Json');
-JLoader::registerAlias('JRegistryFormatPhp',  '\\Joomla\\Registry\\Format\\Php');
-JLoader::registerAlias('JRegistryFormatXml',  '\\Joomla\\Registry\\Format\\Xml');
-JLoader::registerAlias('JStringInflector',    '\\Joomla\\String\\Inflector');
-JLoader::registerAlias('JStringNormalise',    '\\Joomla\\String\\Normalise');
-JLoader::registerAlias('JApplicationWebClient', '\\Joomla\\Application\\Web\\WebClient');
+JLoader::registerAlias('JRegistry',           '\\Joomla\\Registry\\Registry', '4.0');
+JLoader::registerAlias('JRegistryFormat',     '\\Joomla\\Registry\\AbstractRegistryFormat', '4.0');
+JLoader::registerAlias('JRegistryFormatIni',  '\\Joomla\\Registry\\Format\\Ini', '4.0');
+JLoader::registerAlias('JRegistryFormatJson', '\\Joomla\\Registry\\Format\\Json', '4.0');
+JLoader::registerAlias('JRegistryFormatPhp',  '\\Joomla\\Registry\\Format\\Php', '4.0');
+JLoader::registerAlias('JRegistryFormatXml',  '\\Joomla\\Registry\\Format\\Xml', '4.0');
+JLoader::registerAlias('JStringInflector',    '\\Joomla\\String\\Inflector', '4.0');
+JLoader::registerAlias('JStringNormalise',    '\\Joomla\\String\\Normalise', '4.0');
+JLoader::registerAlias('JApplicationWebClient', '\\Joomla\\Application\\Web\\WebClient', '4.0');

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -65,6 +65,14 @@ abstract class JLoader
 	protected static $namespaces = array();
 
 	/**
+	 * Holds a reference for all deprecated aliases (mainly for use by a logging platform).
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $deprecatedAliases = array();
+
+	/**
 	 * Method to discover classes of a given type in a given path.
 	 *
 	 * @param   string   $classPrefix  The class name prefix to use for discovery.
@@ -127,6 +135,18 @@ abstract class JLoader
 	public static function getClassList()
 	{
 		return self::$classes;
+	}
+
+	/**
+	 * Method to get the list of deprecated class aliases.
+	 *
+	 * @return  array  An associative array with deprecated class alias data.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getDeprecatedAliases()
+	{
+		return self::$deprecatedAliases;
 	}
 
 	/**
@@ -316,14 +336,15 @@ abstract class JLoader
 	 * Offers the ability for "just in time" usage of `class_alias()`.
 	 * You cannot overwrite an existing alias.
 	 *
-	 * @param   string  $alias     The alias name to register.
-	 * @param   string  $original  The original class to alias.
+	 * @param   string          $alias     The alias name to register.
+	 * @param   string          $original  The original class to alias.
+	 * @param   string|boolean  $version   The version in which the alias will no longer be present.
 	 *
 	 * @return  boolean  True if registration was successful. False if the alias already exists.
 	 *
 	 * @since   3.2
 	 */
-	public static function registerAlias($alias, $original)
+	public static function registerAlias($alias, $original, $version = false)
 	{
 		if (!isset(self::$classAliases[$alias]))
 		{
@@ -342,6 +363,12 @@ abstract class JLoader
 			else
 			{
 				self::$classAliasesInverse[$original][] = $alias;
+			}
+
+			// If given a version, log this alias as deprecated
+			if ($version)
+			{
+				self::$deprecatedAliases[] = array('old' => $alias, 'new' => $original, 'version' => $version);
 			}
 
 			return true;

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -156,6 +156,21 @@ class PlgSystemDebug extends JPlugin
 		// Prepare disconnect handler for SQL profiling.
 		$db = JFactory::getDbo();
 		$db->addDisconnectHandler(array($this, 'mysqlDisconnectHandler'));
+
+		// Log deprecated class aliases
+		foreach (JLoader::getDeprecatedAliases() as $deprecation)
+		{
+			JLog::add(
+				sprintf(
+					'%1$s has been aliased to %2$s and the former class name is deprecated. The alias will be removed in %3$s.',
+					$deprecation['old'],
+					$deprecation['new'],
+					$deprecation['version']
+				),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
#### Summary of Changes

There is presently no mechanism in the system to alert developers to the fact that classes have been aliased other than reviewing GitHub pull requests.  This adds a mechanism that allows aliases to be flagged as deprecated and logged as such.  This also deprecates all existing aliases to be removed at 4.0.
#### Testing Instructions

Turn on the "Log Deprecated API" option in the debug mode and navigate the CMS.  You should get a `deprecated.php` log file and the first messages from each request should be the deprecation messages for all of the class aliases.
#### Documentation Changes Required

N/A
