### PR TITLE
Add categoriesContext property to JModelAdmin

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -94,6 +94,14 @@ abstract class JModelAdmin extends JModelForm
 	protected $associationsContext = null;
 
 	/**
+	 * The context used for the categories.
+	 *
+	 * @var     string
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $categoriesContext = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  $config  An optional associative array of configuration settings.


### PR DESCRIPTION
#### Summary of Changes

This PR adds a new property to JModelAdmin `categoriesContext`.

The porpose of this new property is to be able to define the categories context (aka extension) in the item model.

This is useful when you have several items with categories in the same component. Examples:
- com_mycomponent
  - Item 1
  - Categories for Item 1 (context: com_mycomponent.item1)
  - Item 2
  - Categories for Item 2 (context: com_mycomponent.item2)
  - Item 3
  - Categories for Item 3 (context: com_mycomponent.item3)

If empty or null one assume we are using the default context for that component, ie, the component (ex: com_mycomponent).
#### Testing Instructions

Just a new property. Code review.
#### Documentation Changes Required

Don't really know...
#### Notes

mantainers, if ok i can add this property to all models that use categories for code consistency.

This is needed for the GsoC multilingual project where we need to know when a component uses several items, if those each of those items support categories and with what context.
