### PR TITLE
[com_plugins] User not allowed to core.manage? Use 403 php custom exception (instead of a 404 JError)

### DIFF
--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -12,7 +12,9 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	JLoader::register('JControllerExceptionNotAllowed', JPATH_PLATFORM . '/joomla/controller/exception/notallowed.php');
+
+	throw new JControllerExceptionNotAllowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller = JControllerLegacy::getInstance('Plugins');

--- a/administrator/components/com_plugins/plugins.php
+++ b/administrator/components/com_plugins/plugins.php
@@ -12,9 +12,7 @@ JHtml::_('behavior.tabstate');
 
 if (!JFactory::getUser()->authorise('core.manage', 'com_plugins'))
 {
-	JLoader::register('JControllerExceptionNotAllowed', JPATH_PLATFORM . '/joomla/controller/exception/notallowed.php');
-
-	throw new JControllerExceptionNotAllowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
+	throw new JControllerExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller = JControllerLegacy::getInstance('Plugins');

--- a/libraries/joomla/controller/exception/notallowed.php
+++ b/libraries/joomla/controller/exception/notallowed.php
@@ -14,6 +14,6 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  __DEPLOY_VERSION__
  */
-class JControllerExceptionNotAllowed extends RuntimeException
+class JControllerExceptionNotallowed extends RuntimeException
 {
 }

--- a/libraries/joomla/controller/exception/notallowed.php
+++ b/libraries/joomla/controller/exception/notallowed.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Controller
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception class defining an not allowed controller access
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JControllerExceptionNotAllowed extends RuntimeException
+{
+}


### PR DESCRIPTION
Pull Request for Improvement.
#### Summary of Changes

Replace com_plugins existing 404 JError for a 403 php exception when the user does not have access to "Access Administration Interface" (core.manage).

Also adds a custom exception `JControllerExceptionNotallowed` for this effect.
##### Before

![image](https://cloud.githubusercontent.com/assets/9630530/17372250/f2d6984e-599a-11e6-8016-3aa75863ff66.png)
##### After

![image](https://cloud.githubusercontent.com/assets/9630530/17372276/0d4a5b7a-599b-11e6-9bdf-02beaefa567e.png)
#### Testing Instructions
1. Use latest staging
2. Create a user and add it to "Administrator" group
3. Go to com_plugins and set "Access Administration Interface" (core.manage) to "Denied" for "Administrator" group
4. Login with the Administrator user in a private window and go to /administrator/index.php?option=com_plugins
5. See the red message (Before)
6. Apply patch
7. Repeat step 4, you'll see now a 403 error (After).

When/If merged i can do it for the other components.

thanks @mbabker 
