### PR TITLE
Deprecate JFacebook classes

### DIFF
--- a/libraries/joomla/facebook/album.php
+++ b/libraries/joomla/facebook/album.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Album class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/album/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/album/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookAlbum extends JFacebookObject
 {

--- a/libraries/joomla/facebook/checkin.php
+++ b/libraries/joomla/facebook/checkin.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Checkin class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/checkin/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/checkin/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookCheckin extends JFacebookObject
 {

--- a/libraries/joomla/facebook/comment.php
+++ b/libraries/joomla/facebook/comment.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Comment class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/Comment/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/Comment/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookComment extends JFacebookObject
 {

--- a/libraries/joomla/facebook/event.php
+++ b/libraries/joomla/facebook/event.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API User class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/event/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/event/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookEvent extends JFacebookObject
 {

--- a/libraries/joomla/facebook/facebook.php
+++ b/libraries/joomla/facebook/facebook.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for interacting with a Facebook API instance.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebook
 {

--- a/libraries/joomla/facebook/group.php
+++ b/libraries/joomla/facebook/group.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Group class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/group/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/group/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookGroup extends JFacebookObject
 {

--- a/libraries/joomla/facebook/link.php
+++ b/libraries/joomla/facebook/link.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Link class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/link/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/link/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookLink extends JFacebookObject
 {

--- a/libraries/joomla/facebook/note.php
+++ b/libraries/joomla/facebook/note.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Note class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/note/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/note/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookNote extends JFacebookObject
 {

--- a/libraries/joomla/facebook/oauth.php
+++ b/libraries/joomla/facebook/oauth.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for generating Facebook API access token.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookOAuth extends JOAuth2Client
 {

--- a/libraries/joomla/facebook/object.php
+++ b/libraries/joomla/facebook/object.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Facebook API object class for the Joomla Platform.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 abstract class JFacebookObject
 {

--- a/libraries/joomla/facebook/photo.php
+++ b/libraries/joomla/facebook/photo.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Photo class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/photo/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/photo/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookPhoto extends JFacebookObject
 {

--- a/libraries/joomla/facebook/post.php
+++ b/libraries/joomla/facebook/post.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Post class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/post/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/post/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookPost extends JFacebookObject
 {

--- a/libraries/joomla/facebook/status.php
+++ b/libraries/joomla/facebook/status.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Status class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/status/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/status/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookStatus extends JFacebookObject
 {

--- a/libraries/joomla/facebook/user.php
+++ b/libraries/joomla/facebook/user.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API User class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/user/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/user/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookUser extends JFacebookObject
 {

--- a/libraries/joomla/facebook/video.php
+++ b/libraries/joomla/facebook/video.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Facebook API Video class for the Joomla Platform.
  *
- * @see    http://developers.facebook.com/docs/reference/api/video/
- * @since  13.1
+ * @see         http://developers.facebook.com/docs/reference/api/video/
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/facebook` package via Composer instead
  */
 class JFacebookVideo extends JFacebookObject
 {


### PR DESCRIPTION
#### Summary of Changes

Similar to #11587 this deprecates the `JFacebook` class chain in favor of its Framework counterpart.  This enables a decision to be made at 4.0 with regards to whether this package should even be shipped or it be used as a library by developers who need this functionality.

Additionally, IIRC this package was originally written against v1 of Facebook's Graph API and [is mostly unmaintained](https://github.com/joomla/joomla-cms/commits/staging/libraries/joomla/facebook) since then so it may not even be usable with the current supported versions of the API.
#### Testing Instructions

Maintainer decision
#### Documentation Changes Required

N/A, this package is not documented in the CMS workspace
