### PR TITLE
Deprecate JTwitter classes

### DIFF
--- a/libraries/joomla/twitter/block.php
+++ b/libraries/joomla/twitter/block.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Block class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterBlock extends JTwitterObject
 {

--- a/libraries/joomla/twitter/directmessages.php
+++ b/libraries/joomla/twitter/directmessages.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Direct Messages class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterDirectmessages extends JTwitterObject
 {

--- a/libraries/joomla/twitter/favorites.php
+++ b/libraries/joomla/twitter/favorites.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Favorites class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterFavorites extends JTwitterObject
 {

--- a/libraries/joomla/twitter/friends.php
+++ b/libraries/joomla/twitter/friends.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Friends class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterFriends extends JTwitterObject
 {

--- a/libraries/joomla/twitter/help.php
+++ b/libraries/joomla/twitter/help.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Help class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterHelp extends JTwitterObject
 {

--- a/libraries/joomla/twitter/lists.php
+++ b/libraries/joomla/twitter/lists.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Lists class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterLists extends JTwitterObject
 {

--- a/libraries/joomla/twitter/oauth.php
+++ b/libraries/joomla/twitter/oauth.php
@@ -14,12 +14,13 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for generating Twitter API access token.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterOAuth extends JOAuth1Client
 {
 	/**
-	* @var Registry  Options for the JTwitterOauth object.
+	* @var    Registry  Options for the JTwitterOauth object.
 	* @since  12.3
 	*/
 	protected $options;

--- a/libraries/joomla/twitter/object.php
+++ b/libraries/joomla/twitter/object.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Twitter API object class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 abstract class JTwitterObject
 {

--- a/libraries/joomla/twitter/places.php
+++ b/libraries/joomla/twitter/places.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Places & Geo class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterPlaces extends JTwitterObject
 {

--- a/libraries/joomla/twitter/profile.php
+++ b/libraries/joomla/twitter/profile.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Profile class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterProfile extends JTwitterObject
 {

--- a/libraries/joomla/twitter/search.php
+++ b/libraries/joomla/twitter/search.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Search class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwittersearch extends JTwitterObject
 {

--- a/libraries/joomla/twitter/statuses.php
+++ b/libraries/joomla/twitter/statuses.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Statuses class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterStatuses extends JTwitterObject
 {

--- a/libraries/joomla/twitter/trends.php
+++ b/libraries/joomla/twitter/trends.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Trends class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterTrends extends JTwitterObject
 {

--- a/libraries/joomla/twitter/twitter.php
+++ b/libraries/joomla/twitter/twitter.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for interacting with a Twitter API instance.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitter
 {

--- a/libraries/joomla/twitter/users.php
+++ b/libraries/joomla/twitter/users.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Twitter API Users class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/twitter` package via Composer instead
  */
 class JTwitterUsers extends JTwitterObject
 {


### PR DESCRIPTION
#### Summary of Changes

Similar to #11587 this deprecates the `JTwitter` class chain in favor of its Framework counterpart.  This enables a decision to be made at 4.0 with regards to whether this package should even be shipped or it be used as a library by developers who need this functionality.
#### Testing Instructions

Maintainer decision
#### Documentation Changes Required

N/A, this package is not documented in the CMS workspace
