### PR TITLE
Deprecate JOpenstreetmap classes

### DIFF
--- a/libraries/joomla/openstreetmap/changesets.php
+++ b/libraries/joomla/openstreetmap/changesets.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Openstreetmap API Changesets class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapChangesets extends JOpenstreetmapObject
 {

--- a/libraries/joomla/openstreetmap/elements.php
+++ b/libraries/joomla/openstreetmap/elements.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Openstreetmap API Elements class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapElements extends JOpenstreetmapObject
 {

--- a/libraries/joomla/openstreetmap/gps.php
+++ b/libraries/joomla/openstreetmap/gps.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Openstreetmap API GPS class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapGps extends JOpenstreetmapObject
 {

--- a/libraries/joomla/openstreetmap/info.php
+++ b/libraries/joomla/openstreetmap/info.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Openstreetmap API Info class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapInfo extends JOpenstreetmapObject
 {

--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for generating Openstreetmap API access token.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapOauth extends JOAuth1Client
 {

--- a/libraries/joomla/openstreetmap/object.php
+++ b/libraries/joomla/openstreetmap/object.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Openstreetmap API object class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 abstract class JOpenstreetmapObject
 {

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for interact with Openstreetmap API.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmap
 {

--- a/libraries/joomla/openstreetmap/user.php
+++ b/libraries/joomla/openstreetmap/user.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die();
 /**
  * Openstreetmap API User class for the Joomla Platform
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/openstreetmap` package via Composer instead
  */
 class JOpenstreetmapUser extends JOpenstreetmapObject
 {


### PR DESCRIPTION
#### Summary of Changes

Similar to #11587 this deprecates the `JOpenstreetmap` class chain in favor of its Framework counterpart.  This enables a decision to be made at 4.0 with regards to whether this package should even be shipped or it be used as a library by developers who need this functionality.
#### Testing Instructions

Maintainer decision
#### Documentation Changes Required

N/A, this package is not documented in the CMS workspace
