### PR TITLE
Deprecate JGoogle classes

### DIFF
--- a/libraries/joomla/google/auth.php
+++ b/libraries/joomla/google/auth.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Google authentication class abstract
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 abstract class JGoogleAuth
 {

--- a/libraries/joomla/google/auth/oauth2.php
+++ b/libraries/joomla/google/auth/oauth2.php
@@ -11,12 +11,11 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
 
-jimport('joomla.oauth.v2client');
-
 /**
  * Google OAuth authentication class
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleAuthOauth2 extends JGoogleAuth
 {

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google API data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 abstract class JGoogleData
 {

--- a/libraries/joomla/google/data/adsense.php
+++ b/libraries/joomla/google/data/adsense.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Adsense data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataAdsense extends JGoogleData
 {

--- a/libraries/joomla/google/data/calendar.php
+++ b/libraries/joomla/google/data/calendar.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Calendar data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataCalendar extends JGoogleData
 {

--- a/libraries/joomla/google/data/picasa.php
+++ b/libraries/joomla/google/data/picasa.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Picasa data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPicasa extends JGoogleData
 {

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Picasa data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPicasaAlbum extends JGoogleData
 {

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Picasa data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPicasaPhoto extends JGoogleData
 {

--- a/libraries/joomla/google/data/plus.php
+++ b/libraries/joomla/google/data/plus.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google+ data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPlus extends JGoogleData
 {

--- a/libraries/joomla/google/data/plus/activities.php
+++ b/libraries/joomla/google/data/plus/activities.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google+ data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPlusActivities extends JGoogleData
 {

--- a/libraries/joomla/google/data/plus/comments.php
+++ b/libraries/joomla/google/data/plus/comments.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google+ data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPlusComments extends JGoogleData
 {

--- a/libraries/joomla/google/data/plus/people.php
+++ b/libraries/joomla/google/data/plus/people.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google+ data class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleDataPlusPeople extends JGoogleData
 {

--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -11,12 +11,11 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
 
-jimport('joomla.environment.uri');
-
 /**
  * Google API object class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 abstract class JGoogleEmbed
 {

--- a/libraries/joomla/google/embed/analytics.php
+++ b/libraries/joomla/google/embed/analytics.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Google Analytics embed class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleEmbedAnalytics extends JGoogleEmbed
 {

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Google Maps embed class for the Joomla Platform.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogleEmbedMaps extends JGoogleEmbed
 {

--- a/libraries/joomla/google/google.php
+++ b/libraries/joomla/google/google.php
@@ -17,7 +17,8 @@ use Joomla\Registry\Registry;
  * @property-read  JGoogleData    $data    Google API object for data.
  * @property-read  JGoogleEmbed   $embed   Google API object for embed generation.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/google` package via Composer instead
  */
 class JGoogle
 {


### PR DESCRIPTION
#### Summary of Changes

Similar to #11587 this deprecates the `JGoogle` class chain in favor of its Framework counterpart.  This enables a decision to be made at 4.0 with regards to whether this package should even be shipped or it be used as a library by developers who need this functionality.
#### Testing Instructions

Maintainer decision
#### Documentation Changes Required

N/A, this package is not documented in the CMS workspace
