### PR TITLE
Obviously, this should be an array.

### DIFF
--- a/libraries/joomla/http/transport/stream.php
+++ b/libraries/joomla/http/transport/stream.php
@@ -135,7 +135,7 @@ class JHttpTransportStream implements JHttpTransport
 		}
 
 		// Build the headers string for the request.
-		$headerEntries = null;
+		$headerEntries = array();
 
 		if (isset($headers))
 		{


### PR DESCRIPTION
Pull Request for Issue # .
#### Summary of Changes

A variable was initialized as null which should only ever be an array.
It could cause problems when using a proxy and the stream transport because the variable might end up being passed to `implode` which is expecting an array.
#### Testing Instructions

In order to test this, you must have a proxy configured and you must use the stream transport which means disabling php's curl extension. I would suggest approving this based on code review instead since it's very simple and obvious. 
#### Documentation Changes Required

I'm sure none.
