### PR TITLE
remove platform include

### DIFF
--- a/tests/unit/suites/libraries/joomla/JPlatformTest.php
+++ b/tests/unit/suites/libraries/joomla/JPlatformTest.php
@@ -6,8 +6,6 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-include_once JPATH_PLATFORM . '/platform.php';
-
 /**
  * JPlatformTest
  *


### PR DESCRIPTION
# Executive summary

This is a fixes a problem that came up after merging PR #10841. In 10841 the file platform was moved into the subdirectory joomla but the tests are still loading the file from the libraries folder. We don’t need to load the file at all so I removed the explicit loading of the file.
# Testing instruction
- Apply patch
- Check if travis/jenkins are happy

Can merged on Review @mbabker 
