### PR TITLE
[GsoC] JTable and db fields alias

### DIFF
--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -19,6 +19,20 @@ use Joomla\Registry\Registry;
 class ContactTableContact extends JTable
 {
 	/**
+	 * Mapping of database columns alias.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_columnAlias = array(
+		'title'            => 'name',
+		'created_time'     => 'created',
+		'created_user_id'  => 'created_by',
+		'modified_time'    => 'modified',
+		'modified_user_id' => 'modified_by',
+	);
+
+	/**
 	 * Ensure the params and metadata in json encoded in the bind method
 	 *
 	 * @var    array

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -17,6 +17,21 @@ defined('_JEXEC') or die;
 class NewsfeedsTableNewsfeed extends JTable
 {
 	/**
+	 * Mapping of database columns alias.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_columnAlias = array(
+		'title'            => 'name',
+		'state'            => 'published',
+		'created_time'     => 'created',
+		'created_user_id'  => 'created_by',
+		'modified_time'    => 'modified',
+		'modified_user_id' => 'modified_by',
+	);
+
+	/**
 	 * Ensure the params, metadata and images are json encoded in the bind method
 	 *
 	 * @var    array

--- a/libraries/legacy/table/category.php
+++ b/libraries/legacy/table/category.php
@@ -19,6 +19,17 @@ use Joomla\Registry\Registry;
 class JTableCategory extends JTableNested
 {
 	/**
+	 * Mapping of database columns alias.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_columnAlias = array(
+		'state'    => 'published',
+		'ordering' => 'lft',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -20,6 +20,19 @@ use Joomla\Registry\Registry;
 class JTableContent extends JTable
 {
 	/**
+	 * Mapping of database columns alias.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_columnAlias = array(
+		'created_time'     => 'created',
+		'created_user_id'  => 'created_by',
+		'modified_time'    => 'modified',
+		'modified_user_id' => 'modified_by',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -19,6 +19,17 @@ use Joomla\Registry\Registry;
 class JTableMenu extends JTableNested
 {
 	/**
+	 * Mapping of database columns alias.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_columnAlias = array(
+		'state'    => 'published',
+		'ordering' => 'lft',
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.


### PR DESCRIPTION
### Summary of Changes

In GsoC multilingual project we need to know the names of the db fields of the components item types.
The problem is the core (and 3º party) uses different names for the db fields in each components item types.

Fortunally there is already a `_columnAlias` JTable property that is not being used and can be used for that mapping.
So this PR uses that property in JTable for components in the core that use associations (com_contact, com_content, com_categories, com_newsfeeds and com_menus).
### Testing Instructions

Apply patch all behaves normally. Business as usual.
Code review.
### Documentation Changes Required

None.
### Notes

In the project is used here: https://github.com/joomla-projects/gsoc16_improved-multi-lingual/blob/staging/administrator/components/com_associations/helpers/associations.php#L121-L143 to get the component item type db fields.

For chosing which should be the primary field names, i followed the same logic as the UCM_content table fields (https://github.com/joomla/joomla-cms/blob/staging/installation/sql/mysql/joomla.sql#L1677).
