### PR TITLE
return 403 instead of a 404 for a not accessible category

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -344,6 +344,7 @@ class ContentModelCategory extends JModelList
 				$params = $this->state->params;
 				$options = array();
 				$options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
+				$options['access']     = $params->get('check_access_rights', 1);
 			}
 			else
 			{

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -111,10 +111,17 @@ class JViewCategory extends JViewLegacy
 		$params = $app->getParams();
 
 		// Get some data from the models
-		$state      = $this->get('State');
-		$category   = $this->get('Category');
-		$children   = $this->get('Children');
-		$parent     = $this->get('Parent');
+		$model       = $this->getModel();
+		$state       = $model->get('State');
+		$paramsModel = $model->getState('params');
+		
+		$paramsModel->set('check_access_rights', 0);
+		$model->setState('params', $paramsModel);
+		
+		$category    = $this->get('Category');
+		$children    = $this->get('Children');
+		$parent      = $this->get('Parent');
+
 		if ($category == false)
 		{
 			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
@@ -123,6 +130,14 @@ class JViewCategory extends JViewLegacy
 		if ($parent == false)
 		{
 			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+		}
+		
+		// Check whether category access level allows access.
+		$groups = $user->getAuthorisedViewLevels();
+		
+		if (!in_array($category->access, $groups))
+		{
+			return JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
 		$items      = $this->get('Items');
@@ -134,14 +149,6 @@ class JViewCategory extends JViewLegacy
 			JError::raiseError(500, implode("\n", $errors));
 
 			return false;
-		}
-
-		// Check whether category access level allows access.
-		$groups = $user->getAuthorisedViewLevels();
-
-		if (!in_array($category->access, $groups))
-		{
-			return JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));
 		}
 
 		// Setup the category parameters.


### PR DESCRIPTION
## PR for issue #5466
## Executive summary

This PR modifies the process when checking a category in JViewCategory. It allows to skip the access rights checks in the first place to differentiate between a not existing category and  a category a user hasn’t the access rights to access. The part of checking the access right was something that couldn’t be reached because for a not accessible category 

```
$this->get('Category') 
```

was always false.
## Background information

As discussed in the issue, if you have a menu item set to publish and the category assigned to that category is set to registered you will get a 404. I agree that this is not the right return code. But I don’t agree that the right behavior is to show a login. In this case I think 403 is that right return code. Anything above this is a new feature. Just because we have a redirect to login for articles doesn’t mean we need that for categories also.
## Backwards compatibility

Shouldn’t be a problem, but not 100% sure 
## Translation impact

nothing
## Testing instruction
- Install a clean Joomla with test data
- Set Category "Park Blog" access level to registered
- Don’t change articles access level
- On front-end: > All Front End Views > clicking on "Article Category Blog"

You will get a 404
- Apply patch and try again

You will get a 403

Need also testing with some 3rd part code
