### PR TITLE
Moving the libs to use language strings as names

### DIFF
--- a/administrator/manifests/libraries/fof.xml
+++ b/administrator/manifests/libraries/fof.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="library" version="2.5" method="upgrade">
-	<name>LIB_FOF</name>
+	<name>FOF</name>
 	<libraryname>fof</libraryname>
 	<description>LIB_FOF_XML_DESCRIPTION</description>
 	<creationDate>2015-04-22 13:15:32</creationDate>

--- a/administrator/manifests/libraries/fof.xml
+++ b/administrator/manifests/libraries/fof.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="library" version="2.5" method="upgrade">
-    <name>FOF</name>
+	<name>LIB_FOF</name>
 	<libraryname>fof</libraryname>
 	<description>LIB_FOF_XML_DESCRIPTION</description>
 	<creationDate>2015-04-22 13:15:32</creationDate>

--- a/administrator/manifests/libraries/idna_convert.xml
+++ b/administrator/manifests/libraries/idna_convert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="library" version="3.1">
-	<name>LIB_IDNA="IDNA Convert"</name>
+	<name>LIB_IDNA</name>
 	<libraryname>idna_convert</libraryname>
 	<version>0.8.0</version>
 	<description>LIB_IDNA_XML_DESCRIPTION</description>

--- a/administrator/manifests/libraries/idna_convert.xml
+++ b/administrator/manifests/libraries/idna_convert.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="library" version="3.1">
-	<name>IDNA Convert</name>
+	<name>LIB_IDNA="IDNA Convert"</name>
 	<libraryname>idna_convert</libraryname>
 	<version>0.8.0</version>
 	<description>LIB_IDNA_XML_DESCRIPTION</description>

--- a/administrator/manifests/libraries/joomla.xml
+++ b/administrator/manifests/libraries/joomla.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="library" version="3.1">
-	<name>Joomla! Platform</name>
+	<name>LIB_JOOMLA</name>
 	<libraryname>joomla</libraryname>
 	<version>13.1</version>
 	<description>LIB_JOOMLA_XML_DESCRIPTION</description>

--- a/administrator/manifests/libraries/phpass.xml
+++ b/administrator/manifests/libraries/phpass.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="library" version="3.2" method="upgrade">
-	<name>PHPass</name>
+	<name>LIB_PHPASS</name>
 	<libraryname>phpass</libraryname>
 	<description>LIB_PHPASS_XML_DESCRIPTION</description>
 	<creationDate>2004-2006</creationDate>

--- a/administrator/manifests/libraries/phputf8.xml
+++ b/administrator/manifests/libraries/phputf8.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="library" version="3.1">
-	<name>phputf8</name>
+	<name>LIB_PHPUTF8</name>
 	<libraryname>phputf8</libraryname>
 	<version>0.5</version>
 	<description>LIB_PHPUTF8_XML_DESCRIPTION</description>

--- a/language/en-GB/en-GB.lib_fof.sys.ini
+++ b/language/en-GB/en-GB.lib_fof.sys.ini
@@ -3,4 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+LIB_FOF="FOF"
 LIB_FOF_XML_DESCRIPTION="Framework-on-Framework (FOF) - A rapid component development framework for Joomla!"

--- a/language/en-GB/en-GB.lib_fof.sys.ini
+++ b/language/en-GB/en-GB.lib_fof.sys.ini
@@ -3,5 +3,4 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-LIB_FOF="FOF"
 LIB_FOF_XML_DESCRIPTION="Framework-on-Framework (FOF) - A rapid component development framework for Joomla!"

--- a/language/en-GB/en-GB.lib_idna_convert.sys.ini
+++ b/language/en-GB/en-GB.lib_idna_convert.sys.ini
@@ -3,5 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+LIB_IDNA="IDNA Convert"
 LIB_IDNA_XML_DESCRIPTION="The class idna_convert allows to convert internationalised domain names (see RFC 3490, 3491, 3492 and 3454 for details) as they can be used with various registries worldwide to be translated between their original (localised) form and their encoded form as it will be used in the DNS (Domain Name System)."
 

--- a/language/en-GB/en-GB.lib_joomla.sys.ini
+++ b/language/en-GB/en-GB.lib_joomla.sys.ini
@@ -3,5 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+LIB_JOOMLA="Joomla! Platform"
 LIB_JOOMLA_XML_DESCRIPTION="The Joomla! Platform is the Core of the Joomla! Content Management System."
 

--- a/language/en-GB/en-GB.lib_phpass.sys.ini
+++ b/language/en-GB/en-GB.lib_phpass.sys.ini
@@ -3,4 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+LIB_PHPASS="PHPass"
 LIB_PHPASS_XML_DESCRIPTION="phpass is a portable password hashing framework for use in PHP applications. The preferred (most secure) hashing method supported by phpass is the OpenBSD-style bcrypt (known in PHP as CRYPT_BLOWFISH), with a fallback to BSDI-style extended DES-based hashes (known in PHP as CRYPT_EXT_DES) and a last resort fallback to an MD5-based variable iteration count password hashing method implemented in phpass itself."

--- a/language/en-GB/en-GB.lib_phpass.sys.ini
+++ b/language/en-GB/en-GB.lib_phpass.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-LIB_PHPASS="PHPass"
+LIB_PHPASS="phpass"
 LIB_PHPASS_XML_DESCRIPTION="phpass is a portable password hashing framework for use in PHP applications. The preferred (most secure) hashing method supported by phpass is the OpenBSD-style bcrypt (known in PHP as CRYPT_BLOWFISH), with a fallback to BSDI-style extended DES-based hashes (known in PHP as CRYPT_EXT_DES) and a last resort fallback to an MD5-based variable iteration count password hashing method implemented in phpass itself."

--- a/language/en-GB/en-GB.lib_phputf8.sys.ini
+++ b/language/en-GB/en-GB.lib_phputf8.sys.ini
@@ -3,5 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
+LIB_PHPUTF8="phputf8"
 LIB_PHPUTF8_XML_DESCRIPTION="Classes for UTF-8."
 


### PR DESCRIPTION
Pull Request for Issue #11595 .
### Summary of Changes

This is a follow up on #11595 it uses the last change that the names can be translated.
### Testing Instructions

-install 3.6.2
- go to com_installer -> manage -> manage
- select the type `Library`
- see all items are translated (no language string)
- install https://github.com/zero-24/joomla-cms/archive/using_langugestring.zip
- go to com_installer -> manage -> manage
- select the type `Library`
- see all items are still translated (no language string)
### Documentation Changes Required

None
