### PR TITLE
Fix performance retrieving menu items in menus helper, e.g. when creating "Select page" filter in modules manager

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -159,8 +159,7 @@ class MenusHelper
 					  a.checked_out,
 					  a.language,
 					  a.lft')
-			->from('#__menu AS a')
-			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+			->from('#__menu AS a');
 
 		if (JLanguageMultilang::isEnabled())
 		{


### PR DESCRIPTION
Pull Request for Issue #10997

Fixes performance of **creating" Select Page" filter (= menu item filter) in modules manager**
### Summary of Changes

Removed unused left join, joining menu items table with itself for no reason

No reason because
1. Join is **LEFT**
2. The results of the join are not used anywhere
- neither in **SELECT clause** nor **WHERE clause** and not in **any other clause**
- There **is no PHP code** that adds some usage of it **under some condition**

There is already another (different) self-join for the table on the lft/rgt, similar to the one removed when we limit  to a specific parent parent
### Testing Instructions

Visit module manager and open search filters, the "Select page" filter should be same as before, and behave as before
### Documentation Changes Required

none
