### PR TITLE
Fix creation performance of form element menuparent, (slow down in menu item edit form, for item that belongs to large menu)

### DIFF
--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -39,7 +39,7 @@ class JFormFieldMenuParent extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT(a.id) AS value, a.title AS text, a.level')
+			->select('DISTINCT(a.id) AS value, a.title AS text, a.level, a.lft')
 			->from('#__menu AS a');
 
 		// Filter by menu type.

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -39,7 +39,7 @@ class JFormFieldMenuParent extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.level')
+			->select('DISTINCT(a.id) AS value, a.title AS text, a.level')
 			->from('#__menu AS a');
 
 		// Filter by menu type.
@@ -68,7 +68,6 @@ class JFormFieldMenuParent extends JFormFieldList
 		}
 
 		$query->where('a.published != -2')
-			->group('a.id, a.title, a.level, a.lft, a.rgt, a.menutype, a.parent_id, a.published')
 			->order('a.lft ASC');
 
 		// Get the options.

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -40,8 +40,7 @@ class JFormFieldMenuParent extends JFormFieldList
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select('a.id AS value, a.title AS text, a.level')
-			->from('#__menu AS a')
-			->join('LEFT', $db->quoteName('#__menu') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+			->from('#__menu AS a');
 
 		// Filter by menu type.
 		if ($menuType = $this->form->getValue('menutype'))


### PR DESCRIPTION
Fix creation performance of **form element menuparent**
- used in menu item edit form
### Summary of Changes

Remove unused left join in getOptions for menuparent form element

No reason because for it being there because
1. Join is left
2. The results of the join are not used anywhere neither in select nor where and not in any other clause
3. There is no PHP code that adds some usage of it under some condition
### Testing Instructions

Visit menu item edit form and, check parent menuitem form field is as before
### Documentation Changes Required
