### PR TITLE
Fix the update cachtime description Fixes #11147

### DIFF
--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -5,7 +5,7 @@
 
 COM_INSTALLER="Installer"
 COM_INSTALLER_AUTHOR_INFORMATION="Author Information"
-COM_INSTALLER_CACHETIMEOUT_DESC="For how many hours should Joomla cache update information. This is also the Cachetime for the Update Notification Plugin, if enabled"
+COM_INSTALLER_CACHETIMEOUT_DESC="For how many hours should Joomla cache update information. This is also the cache time for the Update Notification Plugin, if enabled"
 COM_INSTALLER_CACHETIMEOUT_LABEL="Updates Caching (in hours)"
 COM_INSTALLER_CONFIGURATION="Installer: Options"
 COM_INSTALLER_CONFIRM_UNINSTALL="Are you sure you want to uninstall? Confirming will permanently delete the selected item(s)!"

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -5,7 +5,7 @@
 
 COM_INSTALLER="Installer"
 COM_INSTALLER_AUTHOR_INFORMATION="Author Information"
-COM_INSTALLER_CACHETIMEOUT_DESC="For how many hours should Joomla cache extension update information."
+COM_INSTALLER_CACHETIMEOUT_DESC="For how many hours should Joomla cache update information. This is also the Cachetime for the Update Notification Plugin, if enabled"
 COM_INSTALLER_CACHETIMEOUT_LABEL="Updates Caching (in hours)"
 COM_INSTALLER_CONFIGURATION="Installer: Options"
 COM_INSTALLER_CONFIRM_UNINSTALL="Are you sure you want to uninstall? Confirming will permanently delete the selected item(s)!"


### PR DESCRIPTION
Pull Request for Issue #11147 .
### Summary of Changes

This implements @brianteeman 's suggestion and a additional sentence for the update plugin based on
https://github.com/joomla/joomla-cms/issues/11147#issuecomment-238562822
### Testing Instructions

Apply this patch
go to the com_installer config
see the changed tooltip for the setting `Updates Caching (in Hours)`
### Documentation Changes Required

None
