### PR TITLE
Adding default accesslevel to menu item

### DIFF
--- a/administrator/components/com_menus/models/forms/item.xml
+++ b/administrator/components/com_menus/models/forms/item.xml
@@ -135,7 +135,6 @@
 			id="access"
 			label="JFIELD_ACCESS_LABEL"
 			description="JFIELD_ACCESS_DESC"
-			default="1"
 			filter="integer"/>
 
 

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -593,7 +593,7 @@ class MenusModelItem extends JModelAdmin
 			$filters = JFactory::getApplication()->getUserState('com_menus.items.filter');
 			$data['published'] = (isset($filters['published']) ? $filters['published'] : null);
 			$data['language'] = (isset($filters['language']) ? $filters['language'] : null);
-			$data['access'] = (isset($filters['access']) ? $filters['access'] : null);
+			$data['access'] = (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'));
 		}
 
 		if (isset($data['menutype']) && !$this->getState('item.menutypeid'))


### PR DESCRIPTION
Pull Request for Issue #11317 .
### Summary of Changes

Removing useless default value for the accesslevel in the form xml and adding default value from global config to new menu items.
### Testing Instructions
- Change the default accesslevel to something else than "Published" (eg to "Registered") in the global configuration.
- Create a new menu item and check that the accesslevel is what you set in the global configuration.
### Documentation Changes Required

Nope.
