### PR TITLE
Contact default parameter (images, filter,  pagination)

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -659,7 +659,7 @@
 			type="radio"
 			label="JGLOBAL_FILTER_FIELD_LABEL"
 			description="JGLOBAL_FILTER_FIELD_DESC"
-			default="1"
+			default="0"
 			class="btn-group btn-group-yesno"
 			>
 			<option value="1">JSHOW</option>
@@ -671,7 +671,7 @@
 			type="radio"
 			label="JGLOBAL_DISPLAY_SELECT_LABEL"
 			description="JGLOBAL_DISPLAY_SELECT_DESC"
-			default="1"
+			default="0"
 			class="btn-group btn-group-yesno"
 			>
 			<option value="1">JSHOW</option>
@@ -695,7 +695,7 @@
 			type="radio"
 			label="COM_CONTACT_FIELD_CONFIG_SHOW_IMAGE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SHOW_IMAGE_DESC"
-			default="1"
+			default="0"
 			class="btn-group btn-group-yesno"
 			>
 			<option value="1">JSHOW</option>


### PR DESCRIPTION
Pull Request for Issue #10901 .
### Summary of Changes

Set hide by default the parameter which have no effect until the first saving
### Testing Instructions

Set hide by default the parameter which have no effect until the first saving: Filter Field, Display Select, Image, in the TAB "List Layouts" for the Contacts: Options
### Documentation Changes Required

the old PR  #10902 and  #10912  seems inadeguate for the team  :(
