### PR TITLE
Language filter alternate meta tags default value should be 1

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -691,7 +691,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		$doc = JFactory::getDocument();
 
-		if ($this->app->isSite() && $this->params->get('alternate_meta') && $doc->getType() == 'html')
+		if ($this->app->isSite() && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
 		{
 			$languages = $this->lang_codes;
 			$homes = JLanguageMultilang::getSiteHomePages();

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -691,7 +691,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		$doc = JFactory::getDocument();
 
-		if ($this->app->isSite() && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
+		if ($this->app->isSite() && $this->params->get('item_associations', 1) && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
 		{
 			$languages = $this->lang_codes;
 			$homes = JLanguageMultilang::getSiteHomePages();

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -691,7 +691,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	{
 		$doc = JFactory::getDocument();
 
-		if ($this->app->isSite() && $this->params->get('item_associations', 1) && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
+		if ($this->app->isSite() && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
 		{
 			$languages = $this->lang_codes;
 			$homes = JLanguageMultilang::getSiteHomePages();


### PR DESCRIPTION
### Summary of Changes

Language filter alternate meta tags parameter default is 1 so make it 1 as default also in the code.
### Testing Instructions

Code review.
See also https://github.com/joomla/joomla-cms/blob/staging/plugins/system/languagefilter/languagefilter.xml#L57
### Documentation Changes Required

None.
