### PR TITLE
Solve PHP Notice when saving as copy a menu item

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1381,7 +1381,7 @@ class MenusModelItem extends JModelAdmin
 		if ($assoc)
 		{
 			// Adding self to the association
-			$associations = isset($associations) ? $data['associations'] : array();
+			$associations = isset($data['associations']) ? $data['associations'] : array();
 
 			// Unset any invalid associations
 			$associations = Joomla\Utilities\ArrayHelper::toInteger($associations);

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1381,7 +1381,7 @@ class MenusModelItem extends JModelAdmin
 		if ($assoc)
 		{
 			// Adding self to the association
-			$associations = $data['associations'];
+			$associations = isset($associations) ? $data['associations'] : array();
 
 			// Unset any invalid associations
 			$associations = Joomla\Utilities\ArrayHelper::toInteger($associations);


### PR DESCRIPTION
### Summary of Changes

There is a PHP Notice (check php error logs) when saving a menu as copy a menu item.
### Testing Instructions
1. In multilingual joomla install with associations open any menu item and save as copy. Now check your php log and you will have a php notice there `PHP Notice:  Undefined index: associations in /path/to/joomla/administrator/components/com_menus/models/item.php on line 1384`
2. Apply patch
3. Repeat step 1. No PHP Notice
### Documentation Changes Required

None
### Notes

Found in GsoC multilingual

If this ok will do the same for the other components that have the same issue.
