### PR TITLE
Fix the doc blocks for the JS Tests

### DIFF
--- a/tests/javascript/caption/spec-setup.js
+++ b/tests/javascript/caption/spec-setup.js
@@ -1,12 +1,13 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
-
 define(['jquery', 'text!testsRoot/caption/fixtures/fixture.html', 'libs/caption'], function ($, fixture) {
 	$('body').append(fixture);
 

--- a/tests/javascript/caption/spec.js
+++ b/tests/javascript/caption/spec.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/core/spec-setup.js
+++ b/tests/javascript/core/spec-setup.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/core/spec.js
+++ b/tests/javascript/core/spec.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/permissions/spec-setup.js
+++ b/tests/javascript/permissions/spec-setup.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/permissions/spec.js
+++ b/tests/javascript/permissions/spec.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/repeatable/spec-setup.js
+++ b/tests/javascript/repeatable/spec-setup.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/repeatable/spec.js
+++ b/tests/javascript/repeatable/spec.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/validate/spec-setup.js
+++ b/tests/javascript/validate/spec-setup.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 

--- a/tests/javascript/validate/spec.js
+++ b/tests/javascript/validate/spec.js
@@ -1,9 +1,11 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
- * @since       3.6
+ *
+ * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
 


### PR DESCRIPTION
### Summary of Changes

Just update the merged doc blocks for the JS tests to match the PHP Doc Blocks.

old

```
/**
 * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
 * @license     GNU General Public License version 2 or later; see LICENSE.txt
 * @package     Joomla
 * @subpackage  JavaScript Tests
 * @since       3.6
 * @version     1.0.0
 */
```

new

```
/**
 * @package     Joomla.Tests
 * @subpackage  JavaScript Tests
 *
 * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
 * @license     GNU General Public License version 2 or later; see LICENSE.txt
 *
 * @since       __DEPLOY_VERSION__
 * @version     1.0.0
 */
```
### Testing Instructions

Just code review
### Documentation Changes Required

none
