### PR TITLE
Fix the doc blocks for the new JS Tests [2]

### DIFF
--- a/tests/javascript/caption/spec-setup.js
+++ b/tests/javascript/caption/spec-setup.js
@@ -8,6 +8,7 @@
  * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
+
 define(['jquery', 'text!testsRoot/caption/fixtures/fixture.html', 'libs/caption'], function ($, fixture) {
 	$('body').append(fixture);
 

--- a/tests/javascript/sendtestmail/spec-setup.js
+++ b/tests/javascript/sendtestmail/spec-setup.js
@@ -9,7 +9,6 @@
  * @version     1.0.0
  */
 
-
 define(['jquery', 'text!testsRoot/sendtestmail/fixtures/fixture.html', 'libs/sendtestmail', 'libs/core'], function ($, fixture) {
 	$('body').append(fixture);
 

--- a/tests/javascript/sendtestmail/spec-setup.js
+++ b/tests/javascript/sendtestmail/spec-setup.js
@@ -1,11 +1,14 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
+ *
  * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
+
 
 define(['jquery', 'text!testsRoot/sendtestmail/fixtures/fixture.html', 'libs/sendtestmail', 'libs/core'], function ($, fixture) {
 	$('body').append(fixture);

--- a/tests/javascript/sendtestmail/spec.js
+++ b/tests/javascript/sendtestmail/spec.js
@@ -1,11 +1,14 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
+ *
  * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
+
 
 define(['jquery', 'testsRoot/sendtestmail/spec-setup', 'jasmineJquery'], function ($) {
 	describe('Sendtestmail', function () {

--- a/tests/javascript/sendtestmail/spec.js
+++ b/tests/javascript/sendtestmail/spec.js
@@ -9,7 +9,6 @@
  * @version     1.0.0
  */
 
-
 define(['jquery', 'testsRoot/sendtestmail/spec-setup', 'jasmineJquery'], function ($) {
 	describe('Sendtestmail', function () {
 		beforeAll(function() {

--- a/tests/javascript/switcher/spec-setup.js
+++ b/tests/javascript/switcher/spec-setup.js
@@ -1,11 +1,14 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
+ *
  * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */
+
 
 define(['jquery', 'text!testsRoot/switcher/fixtures/fixture.html', 'libs/switcher'], function ($, fixture) {
 	$('body').append(fixture);

--- a/tests/javascript/switcher/spec.js
+++ b/tests/javascript/switcher/spec.js
@@ -1,8 +1,10 @@
 /**
+ * @package     Joomla.Tests
+ * @subpackage  JavaScript Tests
+ *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @package     Joomla
- * @subpackage  JavaScript Tests
+ *
  * @since       __DEPLOY_VERSION__
  * @version     1.0.0
  */


### PR DESCRIPTION
### Summary of Changes

Just update the merged doc blocks for the JS tests to match the PHP Doc Blocks.

old

```
/**
 * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
 * @license     GNU General Public License version 2 or later; see LICENSE.txt
 * @package     Joomla
 * @subpackage  JavaScript Tests
 * @since       3.6
 * @version     1.0.0
 */
```

new

```
/**
 * @package     Joomla.Tests
 * @subpackage  JavaScript Tests
 *
 * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
 * @license     GNU General Public License version 2 or later; see LICENSE.txt
 *
 * @since       __DEPLOY_VERSION__
 * @version     1.0.0
 */
```
### Testing Instructions

Just code review
### Documentation Changes Required

none
