### PR TITLE
Сode optimization from issue #11643

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -821,7 +821,7 @@ class JApplicationCms extends JApplicationWeb
 
 			foreach ($authorisations as $authorisation)
 			{
-				if ((int)$authorisation->status & $denied_states)
+				if ((int) $authorisation->status & $denied_states)
 				{
 					// Trigger onUserAuthorisationFailure Event.
 					$this->triggerEvent('onUserAuthorisationFailure', array((array) $authorisation));

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -817,12 +817,11 @@ class JApplicationCms extends JApplicationWeb
 			 * This permits authentication plugins blocking the user.
 			 */
 			$authorisations = $authenticate->authorise($response, $options);
+			$denied_states = JAuthentication::STATUS_EXPIRED | JAuthentication::STATUS_DENIED;
 
 			foreach ($authorisations as $authorisation)
 			{
-				$denied_states = array(JAuthentication::STATUS_EXPIRED, JAuthentication::STATUS_DENIED);
-
-				if (in_array($authorisation->status, $denied_states))
+				if ((int)$authorisation->status & $denied_states)
 				{
 					// Trigger onUserAuthorisationFailure Event.
 					$this->triggerEvent('onUserAuthorisationFailure', array((array) $authorisation));


### PR DESCRIPTION
Pull Request for Issue #11643.
### Summary of Changes

1) `array(...)` and `in_array(...)` replaced with more effective in that case bitwise operations.
2) initialization of `$denied_states` move before of the cycle.

Modifications of code are trivial and should not lead to side effects.
### Testing Instructions

1) Create two test users e.g. 'test1' and 'test2'.
2) Set user 'test2' as blocked (set 'Accout Details' - 'Block this User' to 'Yes').
3) Try to login as user 'test1'. You should can do this.
4) Try to login as user 'test2'. You should get message "Login denied! Your account has either been blocked or you have not activated it yet." (JERROR_NOLOGIN_BLOCKED).
### Documentation Changes Required

Not needed.
