### PR TITLE
Active Tab fix 

### DIFF
--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -11,9 +11,8 @@
 jQuery(function($) {
     var loadTabs = function() {
         function saveActiveTab(href) {
-            if (activeTabsHrefs === null) {
-                activeTabsHrefs = [];
-            }
+            // Reset the local Storage
+            activeTabsHrefs = [];
 
             // Save clicked tab href to the array
             activeTabsHrefs.push(href);
@@ -37,6 +36,7 @@ jQuery(function($) {
         var $tabs = $('a[data-toggle="tab"]');
 
         $tabs.on('click', function(e) {
+            console.log($(e.target).attr('href'));
             saveActiveTab($(e.target).attr('href'));
         });
 

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -36,7 +36,6 @@ jQuery(function($) {
         var $tabs = $('a[data-toggle="tab"]');
 
         $tabs.on('click', function(e) {
-            console.log($(e.target).attr('href'));
             saveActiveTab($(e.target).attr('href'));
         });
 


### PR DESCRIPTION
Pull Request for Issue #11648
### Summary of Changes

Do not keep adding tabs, active should be only one
### Testing Instructions

Apply patch and navigate to administrator area on views with tabs and reload pages after selecting different tab. The active tab should be always the last selected.
### Documentation Changes Required

None
