### PR TITLE
Multilanguage: Language filter corrections

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_languagefilter.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_languagefilter.ini
@@ -5,7 +5,7 @@
 
 PLG_SYSTEM_LANGUAGEFILTER="System - Language Filter"
 PLG_SYSTEM_LANGUAGEFILTER_BROWSER_SETTINGS="Browser Settings"
-PLG_SYSTEM_LANGUAGEFILTER_FIELD_ALTERNATE_META_DESC="Add alternative meta tags for menu items with associated menu items in other languages."
+PLG_SYSTEM_LANGUAGEFILTER_FIELD_ALTERNATE_META_DESC="Add alternative meta tags for items with associated items in other languages."
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_ALTERNATE_META_LABEL="Add Alternate Meta Tags"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_AUTOMATIC_CHANGE_DESC="This option will automatically change the content language used in the Frontend when a user site language is changed."
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_AUTOMATIC_CHANGE_LABEL="Automatic Language Change"
@@ -13,7 +13,7 @@ PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_DESC="Language cookies can be set to expi
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_COOKIE_LABEL="Cookie Lifetime"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_DETECT_BROWSER_DESC="Choose site default language or try to detect the browser settings language. It will default to site language if browser settings can't be found."
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_DETECT_BROWSER_LABEL="Language Selection for new Visitors"
-PLG_SYSTEM_LANGUAGEFILTER_FIELD_ITEM_ASSOCIATIONS_DESC="This option will allow item associations when switching from one language to another."
+PLG_SYSTEM_LANGUAGEFILTER_FIELD_ITEM_ASSOCIATIONS_DESC="This option will allow item associations when switching from one language to another. Default home menu items are always associated."
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_ITEM_ASSOCIATIONS_LABEL="Item Associations"
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_XDEFAULT_DESC="This option will add x-default meta tag to improve SEO."
 PLG_SYSTEM_LANGUAGEFILTER_FIELD_XDEFAULT_LABEL="Add x-default Meta Tag"

--- a/plugins/system/languagefilter/languagefilter.xml
+++ b/plugins/system/languagefilter/languagefilter.xml
@@ -61,7 +61,6 @@
 					description="PLG_SYSTEM_LANGUAGEFILTER_FIELD_ALTERNATE_META_DESC"
 					default="1"
 					class="btn-group btn-group-yesno"
-					showon="item_associations:1"
 					>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
@@ -74,7 +73,7 @@
 					description="PLG_SYSTEM_LANGUAGEFILTER_FIELD_XDEFAULT_DESC"
 					default="1"
 					class="btn-group btn-group-yesno"
-					showon="item_associations:1[AND]alternate_meta:1"
+					showon="alternate_meta:1"
 					>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
@@ -86,7 +85,7 @@
 					label="PLG_SYSTEM_LANGUAGEFILTER_FIELD_XDEFAULT_LANGUAGE_LABEL"
 					description="PLG_SYSTEM_LANGUAGEFILTER_FIELD_XDEFAULT_LANGUAGE_DESC"
 					default="default"
-					showon="item_associations:1[AND]alternate_meta:1[AND]xdefault:1"
+					showon="alternate_meta:1[AND]xdefault:1"
 					>
 					<option value="default">PLG_SYSTEM_LANGUAGEFILTER_OPTION_DEFAULT_LANGUAGE</option>
 				</field>


### PR DESCRIPTION
This PR corrects some language strings and field display as 
1. Home menu items are always associated, whatever the Item Associations setting
2. Associations do not only concern menu items
3. Therefore Adding Alternate Meta Tags should also be available when Items Associations is set to No

You should get after patch:
![screen shot 2016-08-19 at 08 39 46](https://cloud.githubusercontent.com/assets/869724/17801219/05c1b196-65e9-11e6-97cb-891b8053cb99.png)

![screen shot 2016-08-19 at 08 40 05](https://cloud.githubusercontent.com/assets/869724/17801225/0dbaee94-65e9-11e6-9ed8-9c3230511129.png)

![screen shot 2016-08-19 at 08 36 24](https://cloud.githubusercontent.com/assets/869724/17801262/2f5087da-65e9-11e6-86ca-9d7ef32d5d8c.png)

@andrepereiradasilva @alikon 
