### PR TITLE
Solve PHP Notice when saving as copy a category

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -572,7 +572,7 @@ class CategoriesModelCategory extends JModelAdmin
 		if ($assoc)
 		{
 			// Adding self to the association
-			$associations = $data['associations'];
+			$associations = isset($data['associations']) ? $data['associations'] : array();
 
 			// Unset any invalid associations
 			$associations = Joomla\Utilities\ArrayHelper::toInteger($associations);


### PR DESCRIPTION
Patch similar to #11647 for category
### Summary of Changes

There is a PHP Notice (check php error logs) when saving as copy a category.
### Testing Instructions
1. In multilingual joomla install with associations open any category and save as copy. Now check your php log and you will have a php notice there PHP Notice: Undefined index: associations in ROOT/administrator/components/com_categories/models/category.php on line 575
2. Apply patch
3. Repeat step 1. No PHP Notice

Other components use the default in `JModelAdmin`.

@andrepereiradasilva @jreys @jeckodevelopment @alikon 
