### PR TITLE
"More Articles ..." text don't appear

### DIFF
--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-
+<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
 <ol class="nav nav-tabs nav-stacked">
 	<?php foreach ($this->link_items as &$item) : ?>
 		<li>

--- a/components/com_content/views/featured/tmpl/default_links.php
+++ b/components/com_content/views/featured/tmpl/default_links.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
+<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
 <ol class="nav nav-tabs nav-stacked">
 <?php foreach ($this->link_items as &$item) : ?>
 	<li>


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Fix in the "Featured Articles" menu item the text "More Articles ..." don't appear after some article intro (5) and the box with links to other articles.
### Testing Instructions

Create 6 or more "Featured article", create the "Articles--> Featured Articles" menu item, the text "More Articles ..." don't appear after some article intro (5) and the box with links to other articles. 

After the patch the text "More Articles ..." from COM_CONTENT_MORE_ARTICLES (/language/en-GB/en-GB.com_content.ini)  appear.

![example](http://www.alexred.com/joomla/featured.png)
### Documentation Changes Required
