### PR TITLE
[protostar offline] use JAuthenticationHelper for getting the available Two Factor Auth Methods

### DIFF
--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -9,9 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JLoader::register('UsersHelper', JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php');
-
-$twofactormethods = UsersHelper::getTwoFactorMethods();
+$twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 $app              = JFactory::getApplication();
 $doc              = JFactory::getDocument();
 $this->language   = $doc->language;


### PR DESCRIPTION
### Summary of Changes

Use JAuthenticationHelper for getting the available TwoFactorMethods in protostar template.
### Testing Instructions

Mainly code review.

But you can also apply patch, enable two factor authentication, set site to offline with protostar template and check the "secret key" input is there.
### Documentation Changes Required

None.
