### PR TITLE
[fix]No default access level set for Guest in testing sample data

### DIFF
--- a/installation/sql/mysql/sample_testing.sql
+++ b/installation/sql/mysql/sample_testing.sql
@@ -11,9 +11,13 @@ TRUNCATE `#__menu`;
 TRUNCATE `#__menu_types`;
 TRUNCATE `#__modules`;
 TRUNCATE `#__modules_menu`;
-TRUNCATE `#__usergroups`;
 TRUNCATE `#__tags`;
+TRUNCATE `#__usergroups`;
+TRUNCATE `#__viewlevels`;
 
+--
+-- Dumping data for table #__assets
+--
 INSERT IGNORE INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`, `title`, `rules`) VALUES
 (1, 0, 1, 437, 0, 'root.1', 'Root Asset', '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1},"core.create":{"6":1,"3":1},"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1},"core.edit.own":{"6":1,"3":1}}'),
 (2, 1, 2, 3, 1, 'com_admin', 'com_admin', '{}'),
@@ -773,6 +777,14 @@ INSERT IGNORE INTO `#__usergroups` (`id`, `parent_id`, `lft`, `rgt`, `title`) VA
 (10, 3, 14, 15, 'Shop Suppliers (Example)'),
 (12, 2, 17, 18, 'Customer Group (Example)'),
 (13, 1, 2, 3, 'Guest');
+
+INSERT IGNORE INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
+(1, 'Public', 0, '[1]'),
+(2, 'Registered', 2, '[6,2,8]'),
+(3, 'Special', 4, '[6,3,8]'),
+(4, 'Customer Access Level (Example)', 3, '[6,3,12]'),
+(5, 'Guest', 1, '[13]'),
+(6, 'Super Users', 5, '[8]');
 
 INSERT IGNORE INTO `#__tags` (`id`, `parent_id`, `lft`, `rgt`, `level`, `path`, `title`, `alias`, `note`, `description`, `published`, `checked_out`, `checked_out_time`, `access`, `params`, `metadesc`, `metakey`, `metadata`, `created_user_id`, `created_time`, `created_by_alias`, `modified_user_id`, `modified_time`, `images`, `urls`, `hits`, `language`, `version`, `publish_up`, `publish_down`) VALUES
 (1, 0, 0, 9, 0, '', 'ROOT', 'root', '', '', 1, 0, '0000-00-00 00:00:00', 1, '{}', '', '', '', 0, '2011-01-01 00:00:01', '', 0, '0000-00-00 00:00:00', '', '', 0, '*', 1, '0000-00-00 00:00:00', '0000-00-00 00:00:00'),

--- a/installation/sql/postgresql/sample_testing.sql
+++ b/installation/sql/postgresql/sample_testing.sql
@@ -6,6 +6,7 @@ TRUNCATE "#__modules" RESTART IDENTITY;
 TRUNCATE "#__modules_menu" RESTART IDENTITY;
 TRUNCATE "#__tags" RESTART IDENTITY;
 TRUNCATE "#__usergroups" RESTART IDENTITY;
+TRUNCATE "#__viewlevels" RESTART IDENTITY;
 
 --
 -- Dumping data for table #__assets
@@ -845,3 +846,16 @@ INSERT INTO "#__usergroups" VALUES
 (13,1,2,3,'Guest');
 
 SELECT setval('#__usergroups_id_seq', max(id)) FROM #__usergroups;
+
+--
+-- Dumping data for table #__viewlevels
+--
+INSERT INTO "#__viewlevels" VALUES
+(1,'Public',0,'[1]'),
+(2,'Registered',2,'[6,2,8]'),
+(3,'Special',4,'[6,3,8]'),
+(4,'Customer Access Level (Example)',3,'[6,3,12]'),
+(5,'Guest',1,'[13]'),
+(6,'Super Users',5,'[8]');
+
+SELECT setval('#__viewlevels_id_seq', max(id)) FROM #__viewlevels;

--- a/installation/sql/sqlazure/sample_testing.sql
+++ b/installation/sql/sqlazure/sample_testing.sql
@@ -1198,8 +1198,9 @@ SET IDENTITY_INSERT [#__viewlevels] ON;
 
 INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (1, 'Public', 0, '[1]');
 INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (2, 'Registered', 2, '[6,2,8]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 3, '[6,3,8]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 1, '[9]');
-INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 4, '[8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (3, 'Special', 4, '[6,3,8]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (4, 'Customer Access Level (Example)', 3, '[6,3,12]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (5, 'Guest', 1, '[13]');
+INSERT [#__viewlevels] ([id], [title], [ordering], [rules]) VALUES (6, 'Super Users', 5, '[8]');
 
 SET IDENTITY_INSERT [#__viewlevels] OFF;


### PR DESCRIPTION
Pull Request for Issue #11660 .
### Summary of Changes

fix missing sql commands
### Testing Instructions

install 3.6.3-dev (staging)
install with testing sample data
confirm that the Guest usergroup is not mapped
install this branch https://github.com/zero-24/joomla-cms/archive/testing_sampledata_fix.zip
install with testing sample data
confirm that the Guest usergroup is mapped now
### Documentation Changes Required

None, just JBS Tesint sample data that is not shipped with the CMS anymore.
