### PR TITLE
Add line and file to the exception message when debug is ON

### DIFF
--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -54,7 +54,10 @@ $app = JFactory::getApplication();
 					<?php $this->setError($this->_error->getPrevious()); ?>
 					<?php while ($loop === true) : ?>
 						<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-						<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+						<p>
+							<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+							<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+						</p>
 						<?php echo $this->renderBacktrace(); ?>
 						<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 					<?php endwhile; ?>

--- a/administrator/templates/hathor/error.php
+++ b/administrator/templates/hathor/error.php
@@ -36,7 +36,12 @@ $app = JFactory::getApplication();
 		</h1>
 	</div>
 	<div>
-		<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+		<p>
+			<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+			<?php if ($this->debug) : ?>
+				<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+			<?php endif; ?>
+		</p>
 		<p><a href="index.php"><?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
 		<?php if ($this->debug) : ?>
 			<div>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -224,6 +224,9 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 					<h1 class="page-header"><?php echo JText::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
 					<blockquote>
 						<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
+						<?php if ($this->debug) : ?>
+							<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+						<?php endif; ?>
 					</blockquote>
 					<?php if ($this->debug) : ?>
 						<div>

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -239,7 +239,10 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 								<?php $this->setError($this->_error->getPrevious()); ?>
 								<?php while ($loop === true) : ?>
 									<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-									<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+									<p>
+										<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+										<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+									</p>
 									<?php echo $this->renderBacktrace(); ?>
 									<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 								<?php endwhile; ?>

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -29,7 +29,12 @@ defined('_JEXEC') or die;
 		</tr>
 		<tr>
 			<td style="text-align: center;">
-				<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+				<p>
+					<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+					<?php if ($this->debug) : ?>
+						<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+					<?php endif; ?>
+				</p>
 				<p><a href="<?php echo JRoute::_('index.php'); ?>"><?php echo JText::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a></p>
 				<?php if ($this->debug) : ?>
 					<div>

--- a/administrator/templates/system/error.php
+++ b/administrator/templates/system/error.php
@@ -47,7 +47,10 @@ defined('_JEXEC') or die;
 							<?php $this->setError($this->_error->getPrevious()); ?>
 							<?php while ($loop === true) : ?>
 								<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-								<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+								<p>
+									<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+									<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+								</p>
 								<?php echo $this->renderBacktrace(); ?>
 								<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 							<?php endwhile; ?>

--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -143,8 +143,12 @@ $navposition = $params->get('navposition');
 							<h3>
 								<?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?>
 							</h3>
-							<h2>#<?php echo $this->error->getCode(); ?>&nbsp;<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+							<h2>
+								#<?php echo $this->error->getCode(); ?>&nbsp;<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
 							</h2>
+							<?php if ($this->debug) : ?>
+								<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+							<?php endif; ?>
 							<br />
 						</div><!-- end errorboxbody -->
 					</div><!-- end wrapper2 -->
@@ -160,7 +164,10 @@ $navposition = $params->get('navposition');
 							<?php $this->setError($this->_error->getPrevious()); ?>
 							<?php while ($loop === true) : ?>
 								<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-								<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+								<p>
+									<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+									<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+								</p>
 								<?php echo $this->renderBacktrace(); ?>
 								<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 							<?php endwhile; ?>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -157,6 +157,9 @@ else
 						<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 						<blockquote>
 							<span class="label label-inverse"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8');?>
+							<?php if ($this->debug) : ?>
+								<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+							<?php endif; ?>
 						</blockquote>
 						<?php if ($this->debug) : ?>
 							<div>
@@ -169,7 +172,10 @@ else
 									<?php $this->setError($this->_error->getPrevious()); ?>
 									<?php while ($loop === true) : ?>
 										<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-										<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+										<p>
+											<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+											<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+										</p>
 										<?php echo $this->renderBacktrace(); ?>
 										<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 									<?php endwhile; ?>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -54,7 +54,12 @@ $app = JFactory::getApplication();
 			</ul>
 			<p><?php echo JText::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
 			<div id="techinfo">
-			<p><?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+			<p>
+				<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+				<?php if ($this->debug) : ?>
+					<br/><?php echo htmlspecialchars($this->error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->error->getLine(); ?>
+				<?php endif; ?>
+			</p>
 			<?php if ($this->debug) : ?>
 				<div>
 					<?php echo $this->renderBacktrace(); ?>
@@ -66,7 +71,10 @@ $app = JFactory::getApplication();
 						<?php $this->setError($this->_error->getPrevious()); ?>
 						<?php while ($loop === true) : ?>
 							<p><strong><?php echo JText::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-							<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+							<p>
+								<?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+								<br/><?php echo htmlspecialchars($this->_error->getFile(), ENT_QUOTES, 'UTF-8');?>:<?php echo $this->_error->getLine(); ?>
+							</p>
 							<?php echo $this->renderBacktrace(); ?>
 							<?php $loop = $this->setError($this->_error->getPrevious()); ?>
 						<?php endwhile; ?>


### PR DESCRIPTION
Pull Request for Issue #10732
### Summary of Changes

This PR adds the last file and line,
of the file at which the error was thrown
**when debug is ON**

A backtrace without it was added by this PR (when debug is ON)
https://github.com/joomla/joomla-cms/pull/10964
### Testing Instructions

Cause an exception to be thrown at a file

The file and line, should show up in the error message (when debug is ON)
### Documentation Changes Required
