### PR TITLE
Load template language files if able in JDocumentError

### DIFF
--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -149,6 +149,16 @@ class JDocumentError extends JDocument
 		$this->debug = isset($params['debug']) ? $params['debug'] : false;
 		$this->error = $this->_error;
 
+		// Load the language file for the template if able
+		if (JFactory::$language)
+		{
+			$lang = JFactory::getLanguage();
+	
+			// 1.5 or core then 1.6
+			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
+				|| $lang->load('tpl_' . $template, $directory . '/' . $template, null, false, true);
+		}
+
 		// Load
 		$data = $this->_loadTemplate($directory . '/' . $template, $file);
 


### PR DESCRIPTION
### Summary of Changes

Depending on where in the order of operations things are at, it's possible to hit the error page before anything loads the template's language files.  And `JDocumentError` isn't loading them either, which can cause untranslated strings to appear.  So, load the files if we are able to do so (i.e. a `JLanguage` object is set to the factory; we won't try to load `JLanguage` into the factory in case that's the cause of the error).
### Testing Instructions

Find a template with language strings in its error page; the core templates have this.  For the frontend app, add a `throw new RuntimeException('Testing language PR');` line in to `JApplicationSite::doExecute()` after it's called the `initialiseApp()` method.  Pre-patch, it may or may not have translated strings (I couldn't duplicate this consistently locally but we hit it on the volunteers portal).  Post-patch, it should most likely be translated (it only wouldn't if the error triggering the error page came from instantiating `JLanguage` basically).
### Documentation Changes Required

N/A
