### PR TITLE
Remove legacy browsers Frame Breaking js code usage and deprecate it

### DIFF
--- a/administrator/components/com_login/views/login/tmpl/default.php
+++ b/administrator/components/com_login/views/login/tmpl/default.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('behavior.noframes');
-
 /**
  * Get the login modules
  * If you want to use a completely different login module change the value of name

--- a/administrator/components/com_login/views/login/view.html.php
+++ b/administrator/components/com_login/views/login/view.html.php
@@ -16,4 +16,26 @@ defined('_JEXEC') or die;
  */
 class LoginViewLogin extends JViewLegacy
 {
+  /**
+	 * Display the view.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse.
+	 *
+	 * @return  void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function display($tpl = null)
+	{
+		/**
+		 * To prevent clickjacking, only allow the login form to be used inside a frame in the same origin.
+		 * So send a X-Frame-Options HTTP Header with the SAMEORIGIN value.
+		 * 
+		 * @see https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet
+		 *      https://tools.ietf.org/html/rfc7034
+		 */
+		JFactory::getApplication()->setHeader('X-Frame-Options', 'SAMEORIGIN');
+
+		return parent::display($tpl);
+	}
 }

--- a/administrator/components/com_login/views/login/view.html.php
+++ b/administrator/components/com_login/views/login/view.html.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
  */
 class LoginViewLogin extends JViewLegacy
 {
-  /**
+  	/**
 	 * Display the view.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse.

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -20,8 +20,6 @@ $frontEndUri->setScheme(((int) JFactory::getApplication()->get('force_ssl', 0) =
 // jQuery needed by template.js
 JHtml::_('jquery.framework');
 
-JHtml::_('behavior.noframes');
-
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -800,28 +800,6 @@ abstract class JHtmlBehavior
 			return;
 		}
 
-		// Include core
-		static::core();
-
-		// Include jQuery
-		JHtml::_('jquery.framework');
-
-		$js = 'jQuery(function () {
-			if (top == self) {
-				document.documentElement.style.display = "block";
-			}
-			else
-			{
-				top.location = self.location;
-			}
-
-			// Firefox fix
-			jQuery("input[autofocus]").focus();
-		})';
-		$document = JFactory::getDocument();
-		$document->addStyleDeclaration('html { display:none }');
-		$document->addScriptDeclaration($js);
-
 		JFactory::getApplication()->setHeader('X-Frame-Options', 'SAMEORIGIN');
 
 		static::$loaded[__METHOD__] = true;

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -791,19 +791,46 @@ abstract class JHtmlBehavior
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated  4.0  Add a X-Frame-Options HTTP Header with the SAMEORIGIN value instead.
 	 */
 	public static function noframes()
 	{
+		JLog::add(__METHOD__ . ' is deprecated, add a X-Frame-Options HTTP Header with the SAMEORIGIN value instead.', JLog::WARNING, 'deprecated');
+
 		// Only load once
 		if (isset(static::$loaded[__METHOD__]))
 		{
 			return;
 		}
 
+		// Include core
+		static::core();
+
+		// Include jQuery
+		JHtml::_('jquery.framework');
+
+		$js = 'jQuery(function () {
+			if (top == self) {
+				document.documentElement.style.display = "block";
+			}
+			else
+			{
+				top.location = self.location;
+			}
+
+			// Firefox fix
+			jQuery("input[autofocus]").focus();
+		})';
+		$document = JFactory::getDocument();
+		$document->addStyleDeclaration('html { display:none }');
+		$document->addScriptDeclaration($js);
+
 		JFactory::getApplication()->setHeader('X-Frame-Options', 'SAMEORIGIN');
 
 		static::$loaded[__METHOD__] = true;
 	}
+
 
 	/**
 	 * Internal method to get a JavaScript object notation string from an array

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -831,7 +831,6 @@ abstract class JHtmlBehavior
 		static::$loaded[__METHOD__] = true;
 	}
 
-
 	/**
 	 * Internal method to get a JavaScript object notation string from an array
 	 *


### PR DESCRIPTION
### Summary of Changes

Remove Legacy Browser (IE 7 and older)  Frame Breaking Script.

Since Joomla 3.x only support IE8+ and modern browsers this code have no effect anymore because all this browsers support the `X-Frame-Options` header that already does this.

See https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet

This code was only used in admin com_login page:
- isis: https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_login/views/login/tmpl/default.php#L12
- hathor: https://github.com/joomla/joomla-cms/blob/staging/administrator/templates/hathor/login.php#L23

So this PR deprecates the behaviour.noframes and in replace adds and HTTP Header in com_login admin view html file.
### Testing Instructions
1. Apply patch
2. Admin login in isis and hathor work without issues and have the `X-Frame-Options` HTTP header
3. Code review
### Documentation Changes Required

None.
