### PR TITLE
[admin mod_login] only load chosen if needed

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -11,8 +11,12 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
-JHtml::_('formbehavior.chosen');
 
+// Load chosen if we have language selector, ie, more than one administrator language installed and enabled.
+if ($langs)
+{
+	JHtml::_('formbehavior.chosen');
+}
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="form-login" class="form-inline">
 	<fieldset class="loginform">

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
 // Load chosen if we have language selector, ie, more than one administrator language installed and enabled.
 if ($langs)
 {
-	JHtml::_('formbehavior.chosen', '.advancedSelect', null, array('disable_search_threshold' => 0 ));
+	JHtml::_('formbehavior.chosen', '.advancedSelect');
 }
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="form-login" class="form-inline">

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
 // Load chosen if we have language selector, ie, more than one administrator language installed and enabled.
 if ($langs)
 {
-	JHtml::_('formbehavior.chosen');
+	JHtml::_('formbehavior.chosen', 'advancedSelect', null, array('disable_search_threshold' => 0 ));
 }
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="form-login" class="form-inline">

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
 // Load chosen if we have language selector, ie, more than one administrator language installed and enabled.
 if ($langs)
 {
-	JHtml::_('formbehavior.chosen', 'advancedSelect', null, array('disable_search_threshold' => 0 ));
+	JHtml::_('formbehavior.chosen', '.advancedSelect', null, array('disable_search_threshold' => 0 ));
 }
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="form-login" class="form-inline">


### PR DESCRIPTION
### Summary of Changes

Simple change.
We only need chosen in admin mod_login for the language select (when we have more than 1 admin language) so we only need to load it them.
### Testing Instructions

Code review, or:
1. Apply patch
2. Have two or more languages installed and enabled
3. Check if the language select field in the admin login is styled with chosen.
### Documentation Changes Required

None.
