### PR TITLE
Fix wrong PHP doc type in JHelperTags

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -383,7 +383,7 @@ class JHelperTags extends JHelper
 	/**
 	 * Method to get a list of tags for an item, optionally with the tag data.
 	 *
-	 * @param   integer  $contentType  Content type alias. Dot separated.
+	 * @param   string   $contentType  Content type alias. Dot separated.
 	 * @param   integer  $id           Id of the item to retrieve tags for.
 	 * @param   boolean  $getTagData   If true, data from the tags table will be included, defaults to true.
 	 *


### PR DESCRIPTION
Pull Request .
### Summary of Changes

Change the type of the variable to match actual implementation.
### Testing Instructions

None
### Documentation Changes Required

No
