### PR TITLE
[plg_authentication_joomla] use JAuthenticationHelper for getting the available Two Factor Auth Methods

### DIFF
--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -90,9 +90,7 @@ class PlgAuthenticationJoomla extends JPlugin
 		// Check the two factor authentication
 		if ($response->status == JAuthentication::STATUS_SUCCESS)
 		{
-			JLoader::register('UsersHelper', JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php');
-
-			$methods = UsersHelper::getTwoFactorMethods();
+			$methods = JAuthenticationHelper::getTwoFactorMethods();
 
 			if (count($methods) <= 1)
 			{


### PR DESCRIPTION
### Summary of Changes

Same as done in https://github.com/joomla/joomla-cms/pull/11667, but this time for the plg_authentication_joomla.
### Testing Instructions

Mainly code review, but to actually test it:
1. Use latest staging 
2. Apply patch
3. Try to use 2FA to login in backend and frontend (check "How to test 2FA" ibn the end of the PR description)
4. Code review
### Documentation Changes Required

None.
### How to test 2FA
- Enable Google Authenticator two factor authentication plugin: Extensions > Plugins (twofactorauth)
- Create a dummy user and configure it to use with Google Authenticator: Users > Manage > Edit (2FA tab)

Note: you can use a chrome plugin for configuring and using 2FA, for instance https://chrome.google.com/webstore/detail/authenticator/bhghoamapcdpbohphigoooaddinpkbai
