### PR TITLE
Unable to update from a clean 2.5.28  to 3.X

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.0.0.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.0.0.sql
@@ -11,7 +11,6 @@ ALTER TABLE `#__content` DROP COLUMN `parentid`;
 ALTER TABLE `#__newsfeeds` DROP COLUMN `filename`;
 ALTER TABLE `#__menu` DROP COLUMN `ordering`;
 ALTER TABLE `#__session` DROP COLUMN `usertype`;
-ALTER TABLE `#__users` DROP COLUMN `usertype`;
 ALTER TABLE `#__updates` DROP COLUMN `categoryid`;
 
 UPDATE `#__extensions` SET protected = 0 WHERE


### PR DESCRIPTION
Unable to update from a clean 2.5.28  to 3.5.1
### Summary of Changes

removed the double sql
`ALTER TABLE '#__users' DROP COLUMN 'usertype';`
### Testing Instructions

update from a clean 2.5.28  to 3.5.1 on mysql
