### PR TITLE
New method for retrieving the strings from the store

### DIFF
--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -368,7 +368,9 @@ class JText
 					. ' Use the %2$s::getScriptStrings() method to get the strings from the JavaScript language store instead.',
 					__METHOD__,
 					__CLASS__
-				)
+				),
+				JLog::WARNING,
+				'deprecated'
 			);
 		}
 

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -67,7 +67,7 @@ class JText
 
 		if ($script)
 		{
-			self::$strings[$string] = $lang->_($string, $jsSafe, $interpretBackSlashes);
+			static::$strings[$string] = $lang->_($string, $jsSafe, $interpretBackSlashes);
 
 			return $string;
 		}
@@ -129,7 +129,7 @@ class JText
 		{
 			foreach ($string_parts as $i => $str)
 			{
-				self::$strings[$str] = $string_parts[$i];
+				static::$strings[$str] = $string_parts[$i];
 			}
 		}
 
@@ -155,14 +155,12 @@ class JText
 	 */
 	public static function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true, $script = false)
 	{
-		$lang = JFactory::getLanguage();
-
-		if ($lang->hasKey($string . '_' . $alt))
+		if (JFactory::getLanguage()->hasKey($string . '_' . $alt))
 		{
 			$string .= '_' . $alt;
 		}
 
-		return self::_($string, $jsSafe, $interpretBackSlashes, $script);
+		return static::_($string, $jsSafe, $interpretBackSlashes, $script);
 	}
 
 	/**
@@ -242,7 +240,7 @@ class JText
 
 			if (array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script'])
 			{
-				self::$strings[$key] = call_user_func_array('sprintf', $args);
+				static::$strings[$key] = call_user_func_array('sprintf', $args);
 
 				return $key;
 			}
@@ -296,7 +294,7 @@ class JText
 
 			if (array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script'])
 			{
-				self::$strings[$string] = call_user_func_array('sprintf', $args);
+				static::$strings[$string] = call_user_func_array('sprintf', $args);
 
 				return $string;
 			}
@@ -362,6 +360,18 @@ class JText
 	 */
 	public static function script($string = null, $jsSafe = false, $interpretBackSlashes = true)
 	{
+		if ($string === null)
+		{
+			JLog::add(
+				sprintf(
+					'As of __DEPLOY_VERSION__, passing a null value for the first argument of %1$s() is deprecated and will not be supported in 4.0.'
+					. ' Use the %2$s::getScriptStrings() method to get the strings from the JavaScript language store instead.',
+					__METHOD__,
+					__CLASS__
+				)
+			);
+		}
+
 		if (is_array($jsSafe))
 		{
 			if (array_key_exists('interpretBackSlashes', $jsSafe))
@@ -383,12 +393,24 @@ class JText
 		if ($string !== null)
 		{
 			// Normalize the key and translate the string.
-			self::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
+			static::$strings[strtoupper($string)] = JFactory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 
 			// Load core.js dependency
 			JHtml::_('behavior.core');
 		}
 
-		return self::$strings;
+		return static::getScriptStrings();
+	}
+
+	/**
+	 * Get the strings that have been loaded to the JavaScript language store.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getScriptStrings()
+	{
+		return static::$strings;
 	}
 }


### PR DESCRIPTION
### Summary of Changes

`JText::script()` violates SRP by acting as a setter and getter for the internal storage array of strings for use with JavaScript.  This PR deprecates the getter portion of this method in favor of a new API method to get these strings and will raise a deprecation notice when the current getter behavior is used.

At 4.0, `JText::script()` will have its method signature changed to require a string is always passed and will only act as a setter for the storage array.
### Testing Instructions

Uses of `JText::script()` with no parameters should cause a deprecation message to be logged.  The new `JText::getScriptStrings()` should return the contents of the internal storage array.
### Documentation Changes Required

N/A, `JText::script()` is only documented via the automatically generated API documentation.
