### PR TITLE
3.7.0: Using the new modal_menu field in various core places

### DIFF
--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -89,19 +89,21 @@ class JFormFieldModal_Menu extends JFormField
 
 			if (isset($this->element['language']))
 			{
-				$clearField = htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8');
+				$clearField = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
 			}
 			else
 			{
 				if ((string) $this->element->option['value'] == '')
 				{
-					$clearField =  htmlspecialchars(JText::_($this->element->option, true), ENT_COMPAT, 'UTF-8');
+					$clearField =  JText::_($this->element->option, true);
 				}
 				else
 				{
-					$clearField = htmlspecialchars(JText::_('JDEFAULT', true), ENT_COMPAT, 'UTF-8');
+					$clearField = JText::_('JDEFAULT', true);
 				}
 			}
+
+			$clearField = htmlspecialchars($clearField, ENT_QUOTES, 'UTF-8');
 
 			$script[] = '	function jClearMenu(id) {';
 			$script[] = '		document.getElementById(id + "_id").value = "";';

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -91,16 +91,13 @@ class JFormFieldModal_Menu extends JFormField
 			{
 				$clearField = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
 			}
+			elseif ((string) $this->element->option['value'] == '')
+			{
+				$clearField =  JText::_($this->element->option, true);
+			}
 			else
 			{
-				if ((string) $this->element->option['value'] == '')
-				{
-					$clearField =  JText::_($this->element->option, true);
-				}
-				else
-				{
-					$clearField = JText::_('JDEFAULT', true);
-				}
+				$clearField = JText::_('JDEFAULT', true);
 			}
 
 			$clearField = htmlspecialchars($clearField, ENT_QUOTES, 'UTF-8');
@@ -169,16 +166,13 @@ class JFormFieldModal_Menu extends JFormField
 			{
 				$title = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
 			}
+			elseif ((string) $this->element->option['value'] == '')
+			{
+				$title = JText::_($this->element->option, true);
+			}
 			else
 			{
-				if ((string) $this->element->option['value'] == '')
-				{
-					$title = JText::_($this->element->option, true);
-				}
-				else
-				{
-					$title = JText::_('JDEFAULT');
-				}
+				$title = JText::_('JDEFAULT');
 			}
 		}
 

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -130,7 +130,7 @@ class JFormFieldModal_Menu extends JFormField
 		{
 			$linkItems .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkItem  .= '&amp;forcedLanguage=' . $this->element['language'];
-			$modalTitle = JText::_('COM_MENUS_CHANGE_MENUITEM') . ' (' . $this->element['label'] . ')';
+			$modalTitle = JText::_('COM_MENUS_CHANGE_MENUITEM') . ' &#8212; ' . $this->element['label'];
 		}
 		else
 		{

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -87,10 +87,25 @@ class JFormFieldModal_Menu extends JFormField
 		{
 			$scriptClear = true;
 
+			if (isset($this->element['language']))
+			{
+				$clearField = htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8');
+			}
+			else
+			{
+				if ((string) $this->element->option['value'] == '')
+				{
+					$clearField =  htmlspecialchars(JText::_($this->element->option, true), ENT_COMPAT, 'UTF-8');
+				}
+				else
+				{
+					$clearField = htmlspecialchars(JText::_('JDEFAULT', true), ENT_COMPAT, 'UTF-8');
+				}
+			}
+
 			$script[] = '	function jClearMenu(id) {';
 			$script[] = '		document.getElementById(id + "_id").value = "";';
-			$script[] = '		document.getElementById(id + "_name").value = "' .
-				htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8') . '";';
+			$script[] = '		document.getElementById(id + "_name").value = "' . $clearField . '";';
 			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
 			$script[] = '		if (document.getElementById(id + "_edit")) {';
 			$script[] = '			jQuery("#"+id + "_edit").addClass("hidden");';
@@ -116,6 +131,11 @@ class JFormFieldModal_Menu extends JFormField
 		{
 			$linkItems .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkItem  .= '&amp;forcedLanguage=' . $this->element['language'];
+			$modalTitle = JText::_('COM_MENUS_CHANGE_MENUITEM') . ' (' . $this->element['label'] . ')';
+		}
+		else
+		{
+			$modalTitle = JText::_('COM_MENUS_CHANGE_MENUITEM');
 		}
 
 		$urlSelect = $linkItems . '&amp;' . JSession::getFormToken() . '=1';
@@ -143,7 +163,21 @@ class JFormFieldModal_Menu extends JFormField
 
 		if (empty($title))
 		{
-			$title = JText::_('COM_MENUS_SELECT_A_MENUITEM');
+			if (isset($this->element['language']))
+			{
+				$title = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
+			}
+			else
+			{
+				if ((string) $this->element->option['value'] == '')
+				{
+					$title = JText::_($this->element->option, true);
+				}
+				else
+				{
+					$title = JText::_('JDEFAULT');
+				}
+			}
 		}
 
 		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
@@ -194,7 +228,7 @@ class JFormFieldModal_Menu extends JFormField
 			'bootstrap.renderModal',
 			'menuSelect' . $this->id . 'Modal',
 			array(
-				'title'       => JText::_('COM_MENUS_CHANGE_MENUITEM'),
+				'title'       => $modalTitle,
 				'url'         => $urlSelect,
 				'height'      => '400px',
 				'width'       => '800px',

--- a/administrator/components/com_menus/models/forms/item_alias.xml
+++ b/administrator/components/com_menus/models/forms/item_alias.xml
@@ -5,10 +5,13 @@
 	<fields name="params">
 
 		<fieldset name="aliasoptions">
-			<field name="aliasoptions" type="menuitem"
+			<field name="aliasoptions" type="modal_menu"
 				description="COM_MENUS_ITEM_FIELD_ALIAS_MENU_DESC"
 				label="COM_MENUS_ITEM_FIELD_ALIAS_MENU_LABEL"
-				required="true" />
+				required="true"
+				edit="true"
+				clear="false"
+			/>
 		</fieldset>
 
 		<fieldset name="menu-options"

--- a/components/com_users/views/login/tmpl/default.xml
+++ b/components/com_users/views/login/tmpl/default.xml
@@ -42,11 +42,13 @@
 
 		<field
 			name="login_redirect_menuitem"
-			type="menuitem"
+			type="modal_menu"
 			disable="separator,alias,heading,url"
 			label="COM_USERS_FIELD_LOGIN_REDIRECTMENU_LABEL"
 			description="COM_USERS_FIELD_LOGIN_REDIRECTMENU_DESC"
 			showon="loginredirectchoice:1"
+			edit="true"
+			clear="true"
 		>
 			<option value="">JDEFAULT</option>
 		</field>
@@ -111,11 +113,13 @@
 		
 		<field
 			name="logout_redirect_menuitem"
-			type="menuitem"
+			type="modal_menu"
 			disable="separator,alias,heading,url"
 			label="COM_USERS_FIELD_LOGOUT_REDIRECTMENU_LABEL"
 			description="COM_USERS_FIELD_LOGOUT_REDIRECTMENU_DESC"
 			showon="logoutredirectchoice:1"
+			edit="true"
+			clear="true"
 		>
 			<option value="">JDEFAULT</option>
 		</field>

--- a/components/com_users/views/login/tmpl/logout.xml
+++ b/components/com_users/views/login/tmpl/logout.xml
@@ -23,10 +23,12 @@
 		<fieldset name="basic" label="COM_MENUS_BASIC_FIELDSET_LABEL">
 			<field
 				name="logout"
-				type="menuitem"
+				type="modal_menu"
 				disable="separator,alias,heading,url"
 				label="JFIELD_LOGOUT_REDIRECT_PAGE_LABEL"
 				description="JFIELD_LOGOUT_REDIRECT_PAGE_DESC"
+				edit="true"
+				clear="true"
 			>
 				<option value="">JDEFAULT</option>
 			</field>

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -21,7 +21,9 @@
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_LOGIN" />
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="basic"
+				addfieldpath="/administrator/components/com_menus/models/fields">
+			>
 				<field
 					name="pretext"
 					type="textarea"
@@ -44,20 +46,24 @@
 
 				<field
 					name="login"
-					type="menuitem"
+					type="modal_menu"
 					label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
 					description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
 					disable="separator,alias,heading,url"
+					edit="true"
+					clear="true"
 					>
 					<option value="">JDEFAULT</option>
 				</field>
 
 				<field
 					name="logout"
-					type="menuitem"
+					type="modal_menu"
 					label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
 					description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC"
 					disable="separator,alias,heading,url"
+					edit="true"
+					clear="true"
 					>
 					<option value="">JDEFAULT</option>
 				</field>

--- a/modules/mod_menu/mod_menu.xml
+++ b/modules/mod_menu/mod_menu.xml
@@ -21,7 +21,9 @@
 	<help key="JHELP_EXTENSIONS_MODULE_MANAGER_MENU" />
 	<config>
 		<fields name="params">
-			<fieldset name="basic">
+			<fieldset name="basic"
+				addfieldpath="/administrator/components/com_menus/models/fields">
+			>
 				<field
 					name="menutype"
 					type="menu"
@@ -31,9 +33,11 @@
 
 				<field
 					name="base"
-					type="menuitem"
+					type="modal_menu"
 					label="MOD_MENU_FIELD_ACTIVE_LABEL"
 					description="MOD_MENU_FIELD_ACTIVE_DESC"
+					edit="true"
+					clear="true"
 					>
 					<option value="">JCURRENT</option>
 				</field>


### PR DESCRIPTION
This PR completes https://github.com/joomla/joomla-cms/commit/1f4826895c7c8df3f4663240f5ed0ad7115c1685
By implementing the new `modal_menu` field in various places in core.

**Menu item Alias**

![screen shot 2016-08-20 at 17 15 31](https://cloud.githubusercontent.com/assets/869724/17832025/c31bcb80-66f9-11e6-9853-2f49c8edfd74.png)

**Menu item Login form:** login redirect and logout redirect

![screen shot 2016-08-20 at 17 17 16](https://cloud.githubusercontent.com/assets/869724/17832032/0a3bdcee-66fa-11e6-92bf-5c45d846b83c.png)

**Menu Item Logout**

![screen shot 2016-08-20 at 17 18 41](https://cloud.githubusercontent.com/assets/869724/17832036/2e3004e0-66fa-11e6-8cb4-c2eb1d297a41.png)

**Module mod_login (frontend)** for login and logout redirect

![screen shot 2016-08-20 at 17 21 21](https://cloud.githubusercontent.com/assets/869724/17832050/8f881296-66fa-11e6-89dc-d053e3a65cdd.png)

**Module mod_menu (frontend)** Base Item

![screen shot 2016-08-20 at 17 23 05](https://cloud.githubusercontent.com/assets/869724/17832077/ce45ae4e-66fa-11e6-8db8-8af48676431d.png)

Remarks:
1. The code adapts itself to the `<option value="">STRING_CONSTANT</option>` in the field.
i.e. when JDEFAULT or JCURRENT is used.

``` php
                <field
                    name="login"
                    type="modal_menu"
                    label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
                    description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
                    disable="separator,alias,heading,url"
                    edit="true"
                    clear="true"
                    >
                    <option value="">JDEFAULT</option>
                </field>
```

Here when JCURRENT is used (See screenshots above when it is JDEFAULT):

![screen shot 2016-08-20 at 17 33 25](https://cloud.githubusercontent.com/assets/869724/17832148/510ec6fc-66fc-11e6-9830-1a8362a1b244.png)
1. For multilanguage Associations, it keeps `COM_MENUS_SELECT_A_MENUITEM`

![screen shot 2016-08-20 at 17 28 52](https://cloud.githubusercontent.com/assets/869724/17832118/aa80272c-66fb-11e6-9941-11fe282e86e7.png)
1. When selecting a menu item through the modal, we now display the forced language concerned in the title of the modal when we make associations:

![screen shot 2016-08-20 at 17 31 02](https://cloud.githubusercontent.com/assets/869724/17832130/e635434c-66fb-11e6-90b1-a530e5d504c5.png)

**TODO:** 
1. Add also the language name to the modal title when using forced language in other core components.
2. Add a new editors-xtd letting enter menu item links in content via new button in the editor (Already done here, will post soon)
