### PR TITLE
Prepared Statement Support for PDO MySQL; backport tests

### DIFF
--- a/libraries/joomla/database/query/pdomysql.php
+++ b/libraries/joomla/database/query/pdomysql.php
@@ -12,10 +12,109 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Query Building Class.
  *
- * @package     Joomla.Platform
- * @subpackage  Database
- * @since       3.4
+ * @since  3.4
  */
-class JDatabaseQueryPdomysql extends JDatabaseQueryMysqli
+class JDatabaseQueryPdomysql extends JDatabaseQueryMysqli implements JDatabaseQueryPreparable
 {
+	/**
+	 * Holds key / value pair of bound objects.
+	 *
+	 * @var    mixed
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $bounded = array();
+
+	/**
+	 * Method to add a variable to an internal array that will be bound to a prepared SQL statement before query execution. Also
+	 * removes a variable that has been bounded from the internal bounded array when the passed in value is null.
+	 *
+	 * @param   string|integer  $key            The key that will be used in your SQL query to reference the value. Usually of
+	 *                                          the form ':key', but can also be an integer.
+	 * @param   mixed           &$value         The value that will be bound. The value is passed by reference to support output
+	 *                                          parameters such as those possible with stored procedures.
+	 * @param   integer         $dataType       Constant corresponding to a SQL datatype.
+	 * @param   integer         $length         The length of the variable. Usually required for OUTPUT parameters.
+	 * @param   array           $driverOptions  Optional driver options to be used.
+	 *
+	 * @return  JDatabaseQueryPdomysql
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function bind($key = null, &$value = null, $dataType = PDO::PARAM_STR, $length = 0, $driverOptions = array())
+	{
+		// Case 1: Empty Key (reset $bounded array)
+		if (empty($key))
+		{
+			$this->bounded = array();
+
+			return $this;
+		}
+
+		// Case 2: Key Provided, null value (unset key from $bounded array)
+		if (is_null($value))
+		{
+			if (isset($this->bounded[$key]))
+			{
+				unset($this->bounded[$key]);
+			}
+
+			return $this;
+		}
+
+		$obj = new stdClass;
+
+		$obj->value = &$value;
+		$obj->dataType = $dataType;
+		$obj->length = $length;
+		$obj->driverOptions = $driverOptions;
+
+		// Case 3: Simply add the Key/Value into the bounded array
+		$this->bounded[$key] = $obj;
+
+		return $this;
+	}
+
+	/**
+	 * Retrieves the bound parameters array when key is null and returns it by reference. If a key is provided then that item is
+	 * returned.
+	 *
+	 * @param   mixed  $key  The bounded variable key to retrieve.
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function &getBounded($key = null)
+	{
+		if (empty($key))
+		{
+			return $this->bounded;
+		}
+
+		if (isset($this->bounded[$key]))
+		{
+			return $this->bounded[$key];
+		}
+	}
+
+	/**
+	 * Clear data from the query or a specific clause of the query.
+	 *
+	 * @param   string  $clause  Optionally, the name of the clause to clear, or nothing to clear the whole query.
+	 *
+	 * @return  JDatabaseQueryPdomysql  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clear($clause = null)
+	{
+		switch ($clause)
+		{
+			case null:
+				$this->bounded = array();
+				break;
+		}
+
+		return parent::clear($clause);
+	}
 }

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -634,6 +634,36 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	}
 
 	/**
+	 * Test the JDatabaseDriverPdomysql::execute()execute method with a prepared statement
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testExecutePreparedStatement()
+	{
+		$id          = 5;
+		$title       = 'testTitle';
+		$startDate   = '2014-08-17 00:00:00';
+		$description = 'Testing';
+
+		/** @var JDatabaseQueryPdomysql $query */
+		$query = self::$driver->getQuery(true);
+		$query->setQuery(
+			"REPLACE INTO `jos_dbtest` SET `id` = :id, `title` = :title, `start_date` = :startDate, `description` = :description"
+		);
+		$query->bind('id', $id, PDO::PARAM_INT);
+		$query->bind('title', $title);
+		$query->bind('startDate', $startDate);
+		$query->bind('description', $description);
+
+		self::$driver->setQuery($query);
+
+		$this->assertInstanceOf('PDOStatement', self::$driver->execute());
+		$this->assertEquals(5, self::$driver->insertid(), $this->equalTo(5));
+	}
+
+	/**
 	 * Tests the renameTable method.
 	 *
 	 * @return  void

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseQueryPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseQueryPdomysqlTest.php
@@ -1,0 +1,1092 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Database
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+/**
+ * Test class for JDatabaseQueryPdomysql.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JDatabaseQueryPdomysqlTest extends TestCase
+{
+	/**
+	 * @var    JDatabaseDriver  A mock of the DatabaseDriver object for testing purposes.
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $dbo;
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestNullDate()
+	{
+		return array(
+			// Quoted, expected
+			array(true, "'_0000-00-00 00:00:00_'"),
+			array(false, "0000-00-00 00:00:00"),
+		);
+	}
+
+	/**
+	 * Data for the testNullDate test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestQuote()
+	{
+		return array(
+			// Text, escaped, expected
+			array('text', false, '\'text\''),
+		);
+	}
+
+	/**
+	 * Data for the testJoin test.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTestJoin()
+	{
+		return array(
+			// $type, $conditions
+			array('', 		'b ON b.id = a.id'),
+			array('INNER',	'b ON b.id = a.id'),
+			array('OUTER',	'b ON b.id = a.id'),
+			array('LEFT',	'b ON b.id = a.id'),
+			array('RIGHT',	'b ON b.id = a.id'),
+		);
+	}
+
+	/**
+	 * A mock callback for the database escape method.
+	 *
+	 * We use this method to ensure that DatabaseQuery's escape method uses the
+	 * the database object's escape method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function mockEscape($text)
+	{
+		return "{$text}";
+	}
+
+	/**
+	 * A mock callback for the database quoteName method.
+	 *
+	 * We use this method to ensure that DatabaseQuery's quoteName method uses the
+	 * the database object's quoteName method.
+	 *
+	 * @param   string  $text  The input text.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function mockQuoteName($text)
+	{
+		return '"' . $text . '"';
+	}
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->dbo = $this->getMockDatabase('pdomysql');
+
+		// Mock the escape method to ensure the API is calling the DBO's escape method.
+		$this->assignMockCallbacks(
+			$this->dbo,
+			array('escape' => array($this, 'mockEscape'))
+		);
+	}
+
+	/**
+	 * Test for the SqliteQuery::__string method for a 'select' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelect()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select('a.id')
+			->from('a')
+			->innerJoin('b ON b.id = a.id')
+			->where('b.id = 1')
+			->group('a.id')
+				->having('COUNT(a.id) > 3')
+			->order('a.id');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . "SELECT a.id" .
+				PHP_EOL . "FROM a" .
+				PHP_EOL . "INNER JOIN b ON b.id = a.id" .
+				PHP_EOL . "WHERE b.id = 1" .
+				PHP_EOL . "GROUP BY a.id" .
+				PHP_EOL . "HAVING COUNT(a.id) > 3" .
+				PHP_EOL . "ORDER BY a.id"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseQueryPdomysql::__string method for a 'update' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringUpdate()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->update('#__foo AS a')
+			->join('INNER', 'b ON b.id = a.id')
+			->set('a.id = 2')
+			->where('b.id = 1');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(
+				PHP_EOL . "UPDATE #__foo AS a" .
+				PHP_EOL . "INNER JOIN b ON b.id = a.id" .
+				PHP_EOL . "SET a.id = 2" .
+				PHP_EOL . "WHERE b.id = 1"
+			),
+			'Tests for correct rendering.'
+		);
+	}
+
+	/**
+	 * Test for year extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringYear()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->year($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT YEAR("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for month extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringMonth()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->month($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT MONTH("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for day extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringDay()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->day($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT DAY("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for hour extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringHour()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->hour($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT HOUR("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for minute extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringMinute()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->minute($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT MINUTE("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for seconds extraction from date.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSecond()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$q->select($q->second($q->quoteName('col')))->from('table');
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . 'SELECT SECOND("col")' . PHP_EOL . 'FROM table')
+		);
+	}
+
+	/**
+	 * Test for INSERT INTO clause with subquery.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringInsert_subquery()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$subq = new JDatabaseQueryPdomysql($this->dbo);
+		$subq->select('col2')->where('a=1');
+
+		$q->insert('table')->columns('col')->values($subq);
+
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "INSERT INTO table" . PHP_EOL . "(col)" . PHP_EOL . "(" . PHP_EOL . "SELECT col2" . PHP_EOL . "WHERE a=1)")
+		);
+
+		$q->clear();
+		$q->insert('table')->columns('col')->values('3');
+		$this->assertThat(
+			(string) $q,
+			$this->equalTo(PHP_EOL . "INSERT INTO table" . PHP_EOL . "(col) VALUES " . PHP_EOL . "(3)")
+		);
+	}
+
+	/**
+	 * Test for the castAsChar method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testCastAsChar()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->castAsChar('123'),
+			$this->equalTo('123'),
+			'The default castAsChar behaviour is quote the input.'
+		);
+	}
+
+	/**
+	 * Test for the charLength method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testCharLength()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->charLength('a.title'),
+			$this->equalTo('CHAR_LENGTH(a.title)')
+		);
+	}
+
+	/**
+	 * Test chaining.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testChaining()
+	{
+		$q = $this->dbo->getQuery(true)->select('foo');
+
+		$this->assertThat(
+			$q,
+			$this->isInstanceOf('JDatabaseQuery')
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing all types and clauses).
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testClear_all()
+	{
+		$properties = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'limit',
+			'offset',
+		);
+
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		// First pass - set the values.
+		foreach ($properties as $property)
+		{
+			TestReflection::setValue($q, $property, $property);
+		}
+
+		// Clear the whole query.
+		$q->clear();
+
+		// Check that all properties have been cleared
+		foreach ($properties as $property)
+		{
+			$this->assertThat(
+				$q->$property,
+				$this->equalTo(null)
+			);
+		}
+
+		// And check that the type has been cleared.
+		$this->assertThat(
+			$q->type,
+			$this->equalTo(null)
+		);
+	}
+
+	/**
+	 * Test for the clear method (clearing each clause).
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testClear_clause()
+	{
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+			'limit',
+		);
+
+		// Test each clause.
+		foreach ($clauses as $clause)
+		{
+			$q = new JDatabaseQueryPdomysql($this->dbo);
+
+			// Set the clauses
+			foreach ($clauses as $clause2)
+			{
+				TestReflection::setValue($q, $clause2, $clause2);
+			}
+
+			// Clear the clause.
+			$q->clear($clause);
+
+			// Check that clause was cleared.
+			$this->assertThat(
+				$q->$clause,
+				$this->equalTo(null)
+			);
+
+			// Check the state of the other clauses.
+			foreach ($clauses as $clause2)
+			{
+				if ($clause != $clause2)
+				{
+					$this->assertThat(
+						$q->$clause2,
+						$this->equalTo($clause2),
+						"Clearing '$clause' resulted in '$clause2' having a value of " . $q->$clause2 . '.'
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Test for the clear method (clearing each query type).
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testClear_type()
+	{
+		$types = array(
+			'select',
+			'delete',
+			'update',
+			'insert',
+			'limit',
+		);
+
+		$clauses = array(
+			'from',
+			'join',
+			'set',
+			'where',
+			'group',
+			'having',
+			'order',
+			'columns',
+			'values',
+		);
+
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		// Set the clauses.
+		foreach ($clauses as $clause)
+		{
+			TestReflection::setValue($q, $clause, $clause);
+		}
+
+		// Check that all properties have been cleared
+		foreach ($types as $type)
+		{
+			// Set the type.
+			TestReflection::setValue($q, $type, $type);
+
+			// Clear the type.
+			$q->clear($type);
+
+			// Check the type has been cleared.
+			$this->assertThat(
+				$q->$type,
+				$this->equalTo(null)
+			);
+
+			// Now check the claues have not been affected.
+			foreach ($clauses as $clause)
+			{
+				$this->assertThat(
+					$q->$clause,
+					$this->equalTo($clause)
+				);
+			}
+		}
+	}
+
+	/**
+	 * Test for "concatenate" words.
+	 *
+	 * @return  void
+	 */
+	public function testConcatenate()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar')),
+			$this->equalTo('CONCAT(foo,bar)'),
+			'Tests without separator.'
+		);
+
+		$this->assertThat(
+			$q->concatenate(array('foo', 'bar'), ' and '),
+			$this->equalTo("CONCAT_WS('_ and _', foo, bar)"),
+			'Tests without separator.'
+		);
+	}
+
+	/**
+	 * Test for FROM clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testFrom()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->from('#__foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->from('#__bar');
+
+		$this->assertThat(
+			trim($q->from),
+			$this->equalTo('FROM #__foo,#__bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for GROUP clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testGroup()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->group('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->group('bar');
+
+		$this->assertThat(
+			trim($q->group),
+			$this->equalTo('GROUP BY foo,bar'),
+			'Tests rendered value after second use.'
+		);
+	}
+
+	/**
+	 * Test for HAVING clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testHaving()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->having('COUNT(foo) > 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 AND COUNT(bar) > 2'),
+			'Tests rendered value after second use.'
+		);
+
+		// Reset the field to test the glue.
+		TestReflection::setValue($q, 'having', null);
+		$q->having('COUNT(foo) > 1', 'OR');
+		$q->having('COUNT(bar) > 2');
+
+		$this->assertThat(
+			trim($q->having),
+			$this->equalTo('HAVING COUNT(foo) > 1 OR COUNT(bar) > 2'),
+			'Tests rendered value with OR glue.'
+		);
+	}
+
+	/**
+	 * Test for INNER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testInnerJoin()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$q2 = new JDatabaseQueryPdomysql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->innerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('INNER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for JOIN clause using dataprovider to test all types of join.
+	 *
+	 * @param   string  $type        Type of JOIN, could be INNER, OUTER, LEFT, RIGHT
+	 * @param   string  $conditions  Join condition
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @dataProvider  dataTestJoin
+	 */
+	public function testJoin($type, $conditions)
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->join('INNER', 'foo ON foo.id = bar.id'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->join[0]),
+			$this->equalTo('INNER JOIN foo ON foo.id = bar.id'),
+			'Tests that first join renders correctly.'
+		);
+
+		$q->join('OUTER', 'goo ON goo.id = car.id');
+
+		$this->assertThat(
+			trim($q->join[1]),
+			$this->equalTo('OUTER JOIN goo ON goo.id = car.id'),
+			'Tests that second join renders correctly.'
+		);
+	}
+
+	/**
+	 * Test for LEFT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLeftJoin()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$q2 = new JDatabaseQueryPdomysql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->leftJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('LEFT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $quoted    The value of the quoted argument.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @dataProvider  dataTestNullDate
+	 */
+	public function testNullDate($quoted, $expected)
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->nullDate($quoted),
+			$this->equalTo($expected),
+			'The nullDate method should be a proxy for the JDatabase::getNullDate method.'
+		);
+	}
+
+	/**
+	 * Test for ORDER clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testOrder()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->order('column'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column'),
+			'Tests rendered value.'
+		);
+
+		$q->order('col2');
+		$this->assertThat(
+			trim($q->order),
+			$this->equalTo('ORDER BY column,col2'),
+			'Tests rendered value.'
+		);
+	}
+
+	/**
+	 * Test for OUTER JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testOuterJoin()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$q2 = new JDatabaseQueryPdomysql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->outerJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('OUTER', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @param   boolean  $text      The value to be quoted.
+	 * @param   boolean  $escape    True to escape the string, false to leave it unchanged.
+	 * @param   string   $expected  The expected result.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @dataProvider  dataTestQuote
+	 */
+	public function testQuote($text, $escape, $expected)
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->quote('test'),
+			$this->equalTo("'_test_'"),
+			'The quote method should be a proxy for the DatabaseDriver::quote method.'
+		);
+	}
+
+	/**
+	 * Tests the quoteName method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testQuoteName()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->quoteName('test'),
+			$this->equalTo('"test"'),
+			'The quoteName method should be a proxy for the DatabaseDriver::quoteName method.'
+		);
+	}
+
+	/**
+	 * Test for RIGHT JOIN clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testRightJoin()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$q2 = new JDatabaseQueryPdomysql($this->dbo);
+		$condition = 'foo ON foo.id = bar.id';
+
+		$this->assertThat(
+			$q->rightJoin($condition),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$q2->join('RIGHT', $condition);
+
+		$this->assertThat(
+			$q->join,
+			$this->equalTo($q2->join),
+			'Tests that innerJoin is an alias for join.'
+		);
+	}
+
+	/**
+	 * Test for SELECT clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testSelect()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->select('foo'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			$q->type,
+			$this->equalTo('select'),
+			'Tests the type property is set correctly.'
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo'),
+			'Tests the select element is set correctly.'
+		);
+
+		$q->select('bar');
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar'),
+			'Tests the second use appends correctly.'
+		);
+
+		$q->select(
+			array(
+				'goo', 'car'
+			)
+		);
+
+		$this->assertThat(
+			trim($q->select),
+			$this->equalTo('SELECT foo,bar,goo,car'),
+			'Tests the second use appends correctly.'
+		);
+	}
+
+	/**
+	 * Test for WHERE clause using a simple condition and with glue for second one.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testWhere()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$this->assertThat(
+			$q->where('foo = 1'),
+			$this->identicalTo($q),
+			'Tests chaining.'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1'),
+			'Tests rendered value.'
+		);
+
+		// Add another column.
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			)
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE foo = 1 AND bar = 2 AND goo = 3'),
+			'Tests rendered value after second use and array input.'
+		);
+
+		// Clear the where
+		TestReflection::setValue($q, 'where', null);
+		$q->where(
+			array(
+				'bar = 2',
+				'goo = 3',
+			),
+			'OR'
+		);
+
+		$this->assertThat(
+			trim($q->where),
+			$this->equalTo('WHERE bar = 2 OR goo = 3'),
+			'Tests rendered value with glue.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQueryPdomysql::escape method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testEscape()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			$q->escape('foo'),
+			$this->equalTo('foo')
+		);
+	}
+
+	/**
+	 * Test for LIMIT and OFFSET clause.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testSetLimitAndOffset()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+		$q->setLimit('5', '10');
+
+		$this->assertThat(
+			trim(TestReflection::getValue($q, 'limit')),
+			$this->equalTo('5'),
+			'Tests limit was set correctly.'
+		);
+
+		$this->assertThat(
+			trim(TestReflection::getValue($q, 'offset')),
+			$this->equalTo('10'),
+			'Tests offset was set correctly.'
+		);
+	}
+
+	/**
+	 * Tests the JDatabaseQueryPdomysql::processLimit method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testProcessLimit()
+	{
+		$q = new JDatabaseQueryPdomysql($this->dbo);
+
+		$this->assertThat(
+			trim($q->processLimit('SELECT foo FROM bar', 5, 10)),
+			$this->equalTo('SELECT foo FROM bar LIMIT 10, 5'),
+			'Tests rendered value.'
+		);
+	}
+}


### PR DESCRIPTION
Pull Request porting joomla-framework/database@66035e44f523bb0259aadb0e544fc8cf63e686d2.
### Summary of Changes

This implements prepared statement support for the PDO MySQL driver.  The base PDO driver class inherently supports prepared statements for all PDO based objects but the query builder class must implement the required interface for this to work.

Additionally, the unit test class for the query object is backported from the Framework.
### Testing Instructions

The prepared statement API really isn't documented because none of the drivers that the CMS application supports use this feature, until now.  With that said, the best demonstration of how to use it for PDO can be found in the added unit test case for the driver itself.  Testing existing code on a PDO MySQL environment by replacing values with bound parameters as demonstrated in the test case should suffice for this.  As an example, you could update `JComponentHelper::load()` to use this code snippet:

``` php
// The bind method uses references for the second argument, so we need to make this a variable
$type = 'component';

$db = JFactory::getDbo();
$query = $db->getQuery(true)
    ->select('extension_id AS id, element AS "option", params, enabled')
    ->from('#__extensions')
    ->where($db->quoteName('type') . ' = :component')
    ->bind('component', $type);
$db->setQuery($query);
```
### Documentation Changes Required

N/A; the prepared statement API is only documented via the automatically generated API documentation
