### PR TITLE
Avoid trying to load a module's language file multiple times

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -181,9 +181,13 @@ abstract class JModuleHelper
 		{
 			$lang = JFactory::getLanguage();
 
-			// 1.5 or Core then 1.6 3PD
-			$lang->load($module->module, JPATH_BASE, null, false, true) ||
-				$lang->load($module->module, dirname($path), null, false, true);
+			// Only load the module's language file if it hasn't been already
+			if (!$lang->getPaths($module->module))
+			{
+				// 1.5 or Core then 1.6 3PD
+				$lang->load($module->module, JPATH_BASE, null, false, true) ||
+					$lang->load($module->module, dirname($path), null, false, true);
+			}
 
 			$content = '';
 			ob_start();


### PR DESCRIPTION
### Summary of Changes

Depending on how many times a module gets used on a page, its language files may attempt to be loaded multiple times.  Because of the internal loading of the default language, depending on where a language file is located the load method will go through at least a couple of loops resulting in a bunch of extra processing.  Example:

<img width="869" alt="screen shot 2016-08-20 at 4 43 29 pm" src="https://cloud.githubusercontent.com/assets/368545/17834059/2767ea50-66f6-11e6-9aca-2e51099fc5f0.png">

By checking if the files have been loaded first, we can cut back on the number of loops that get made here.  Example:

<img width="863" alt="screen shot 2016-08-20 at 4 46 48 pm" src="https://cloud.githubusercontent.com/assets/368545/17834067/4b88a14a-66f6-11e6-9b31-792c172fe525.png">
### Testing Instructions

The module's language files are still loaded correctly.
### Documentation Changes Required

N/A
