### PR TITLE
Allow registering callback functions for the debug console

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -83,6 +83,14 @@ class PlgSystemDebug extends JPlugin
 	protected $app;
 
 	/**
+	 * Container for callback functions to be triggered when rendering the console.
+	 *
+	 * @var    callable[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private static $displayCallbacks = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe.
@@ -306,9 +314,54 @@ class PlgSystemDebug extends JPlugin
 			}
 		}
 
+		foreach (self::$displayCallbacks as $name => $callable)
+		{
+			$html[] = $this->displayCallback($name, $callable);
+		}
+
 		$html[] = '</div>';
 
 		echo str_replace('</body>', implode('', $html) . '</body>', $contents);
+	}
+
+	/**
+	 * Add a display callback to be rendered with the debug console.
+	 *
+	 * @param   string    $name      The name of the callable, this is used to generate the section title.
+	 * @param   callable  $callable  The callback function to be added.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidArgumentException
+	 */
+	public static function addDisplayCallback($name, $callable)
+	{
+		// TODO - When PHP 5.4 is the minimum the parameter should be typehinted "callable" and this check removed
+		if (!is_callable($callable))
+		{
+			throw new InvalidArgumentException('A valid callback function must be given.');
+		}
+
+		self::$displayCallbacks[$name] = $callable;
+
+		return true;
+	}
+
+	/**
+	 * Remove a registered display callback
+	 *
+	 * @param   string  $name  The name of the callable.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function removeDisplayCallback($name)
+	{
+		unset(self::$displayCallbacks[$name]);
+
+		return true;
 	}
 
 	/**
@@ -388,6 +441,38 @@ class PlgSystemDebug extends JPlugin
 
 		$html[] = '<div ' . $style . ' class="dbg-container" id="dbg_container_' . $item . '">';
 		$html[] = $this->$fncName();
+		$html[] = '</div>';
+
+		return implode('', $html);
+	}
+
+	/**
+	 * Display method for callback functions.
+	 *
+	 * @param   string    $name      The name of the callable.
+	 * @param   callable  $callable  The callable function.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function displayCallback($name, $callable)
+	{
+		$title = JText::_('PLG_DEBUG_' . strtoupper($name));
+
+		$html = array();
+
+		$js = "toggleContainer('dbg_container_" . $name . "');";
+
+		$class = 'dbg-header';
+
+		$html[] = '<div class="' . $class . '" onclick="' . $js . '"><a href="javascript:void(0);"><h3>' . $title . '</h3></a></div>';
+
+		// @todo set with js.. ?
+		$style = ' style="display: none;"';
+
+		$html[] = '<div ' . $style . ' class="dbg-container" id="dbg_container_' . $name . '">';
+		$html[] = call_user_func($callable);
 		$html[] = '</div>';
 
 		return implode('', $html);


### PR DESCRIPTION
### Summary of Changes

Allow extensions to register a callable function to be triggered when the debug console is rendered.  This gives a hook to allow extensions to add data to the console.
### Testing Instructions

Somewhere after the debug plugin is instantiated, add the following code:

``` php
// Only register when in debug mode and the debug plugin is enabled
if (JDEBUG && JPluginHelper::isEnabled('system', 'debug'))
{
    PlgSystemDebug::addDisplayCallback('test', function () { return 'Testing new debug console feature!' });
}
```

Now when viewing the page and you have debug mode and the debug plugin enabled, you should have a new section on the console with a title `PLG_DEBUG_TEST` (this is a translatable key) and opening the section should have the text from our anonymous function used for testing here.
### Documentation Changes Required

Document the new API methods:
- `PlgSystemDebug::addDisplayCallback()` which takes two parameters:
  - `$name` is the name of the callable function, it's used as an identifier for the various markup elements and to create the language key to translate the title
  - `$callable` is a valid callable function (anything which passes PHP 5.4's `callable` typehint or the `is_callable()` method will suffice here)
- `PlgSystemDebug::removeDisplayCallback()` which takes one parameter:
  - `$name` is the name of the callable function to be removed

Document the callable's functionality:
- The callback function receives no parameters from the debug plugin and is expected to return a string (this should be HTML); this string is what is rendered in the debug console

Document how to translate the title:
- The language key is a compound key, `JText::_('PLG_DEBUG_' . strtoupper($name))`, so the name you give your callable should be in a format allowed with the language parser
- Add this key to your language files, for example with the above code snippet we should have a `PLG_DEBUG_TEST="Testing New Feature"` key somewhere
