### PR TITLE
[RFC] New generic content parser.

### DIFF
--- a/libraries/joomla/string/parser.php
+++ b/libraries/joomla/string/parser.php
@@ -17,8 +17,8 @@ defined('_JEXEC') or die;
  *
  * Code syntax:
  *   $parser = (new JStringParser())
- *       ->registerToken('a', function(JStringTokenInterface $token, $content) { return 'replacement'; }, true)
- *       ->registerToken('b', function(JStringTokenInterface $token, $content) { return 'replacement'; }, false)
+ *       ->register('a', function(JStringTokenInterface $token, $content) { return 'replacement'; }, true)
+ *       ->register('b', function(JStringTokenInterface $token, $content) { return 'replacement'; }, false)
  *       ;
  *   $output = $parser->translate($content);
  *
@@ -76,7 +76,7 @@ class JStringParser
 	 * If there are characters before the next "real" token, return them in a TokenString object.
 	 * If there are no further "real" tokens, return the remaining characters in a TokenString object.
 	 *
-	 * @return  TokenInterface | null
+	 * @return  JStringToken | null
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
@@ -143,7 +143,7 @@ class JStringParser
 				return new JStringTokenEnd($tokenDefn);
 			}
 
-			return new JStringTokenBegin($tokenDefn, $tokenParams == '' ? array() : explode($this->paramSeparator, $tokenParams));
+			return new JStringTokenBegin($tokenName, $tokenDefn, $tokenParams == '' ? array() : explode($this->paramSeparator, $tokenParams));
 		}
 		while (true);
 
@@ -258,17 +258,49 @@ class JStringParser
 	/**
 	 * Register the definition of a token.
 	 *
-	 * @param   string    $name      A token name to look for.
-	 * @param   callable  $callback  A callable that will return the replacement string.
-	 * @param   boolean   $simple    True for a simple token; false for a block token.
+	 * @param   string                  $name        Token name.
+	 * @param   JStringTokenDefinition  $definition  Token definition.
 	 *
 	 * @return  This object for method chaining.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function registerToken($name, callable $callback, $simple = true)
+	public function register($name, JStringTokenDefinition $definition)
 	{
-		$this->tokens[JString::strtolower($name)] = new JStringTokenDefinition($name, $callback, $simple);
+		$this->tokens[JString::strtolower($name)] = $definition;
+
+		return $this;
+	}
+
+	/**
+	 * Is token registered?
+	 *
+	 * @param   string  $name  A token name to check.
+	 *
+	 * @return  boolean
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function isRegistered($name)
+	{
+		return isset($this->tokens[JString::strtolower($name)]);
+	}
+
+	/**
+	 * Unregister the definition of a token.
+	 *
+	 * @param   string    $name     A token name to look for.
+	 *
+	 * @return  This object for method chaining.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function unregister($name)
+	{
+		if ($this->isRegistered($name))
+		{
+			unset($this->tokens[JString::strtolower($name)]);
+		}
 
 		return $this;
 	}

--- a/libraries/joomla/string/parser.php
+++ b/libraries/joomla/string/parser.php
@@ -31,7 +31,7 @@ defined('_JEXEC') or die;
  * Block tags may also be nested:
  *   {c} something {b} something else {/b} something more {/c}
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 class JStringParser
 {

--- a/libraries/joomla/string/parser.php
+++ b/libraries/joomla/string/parser.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * A simple multi-byte aware content parser.
+ *
+ * This is a simple recursive-descent parser and the token syntax was specifically chosen to allow
+ * straightforward prediction parsing that does not require the construction of a parse tree.
+ *
+ * Code syntax:
+ *   $parser = (new JStringParser())
+ *       ->registerToken('a', function(JStringTokenInterface $token, $content) { return 'replacement'; }, true)
+ *       ->registerToken('b', function(JStringTokenInterface $token, $content) { return 'replacement'; }, false)
+ *       ;
+ *   $output = $parser->translate($content);
+ *
+ * Token syntax:
+ *   Simple tags: {a [params]}
+ *   Block tags: {b [params]} something {/b}
+ *
+ * Block tags may encompass content containing simple tags:
+ *   {b} something {a} something else {/b}
+ * Block tags may also be nested:
+ *   {c} something {b} something else {/b} something more {/c}
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class JStringParser
+{
+	/**
+	 * Array of registered token definitions.
+	 */
+	private $tokens = array();
+
+	/**
+	 * The content being parsed.
+	 */
+	private $content = '';
+
+	/**
+	 * Length of content string being parsed.
+	 */
+	private $contentLength = 0;
+
+	/**
+	 * Lookahead token.
+	 */
+	private $lookahead = null;
+
+	/**
+	 * Position of the next token in the content.
+	 */
+	private $position = 0;
+
+	/**
+	 * Start of token string.
+	 */
+	private $startOfToken = '{';
+
+	/**
+	 * End of token string.
+	 */
+	private $endOfToken = '}';
+
+	/**
+	 * Parameter separator string.
+	 */
+	private $paramSeparator = ',';
+
+	/**
+	 * Return the next token from the input.
+	 *
+	 * If there are characters before the next "real" token, return them in a TokenString object.
+	 * If there are no further "real" tokens, return the remaining characters in a TokenString object.
+	 *
+	 * @return  TokenInterface | null
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	private function getNextToken()
+	{
+		$localPosition = $this->position;
+		$matches = array();
+		$pattern = '/' . $this->startOfToken . '(.+)' . $this->endOfToken . '/U';
+
+		do
+		{
+			// Look for a possible token.
+			preg_match($pattern, JString::substr($this->content, $localPosition), $matches, PREG_OFFSET_CAPTURE);
+
+			// No more tokens, so stop looking.
+			if (empty($matches))
+			{
+				break;
+			}
+
+			// Determine the position of the open brace.  Note that the offsets returned by preg_replace
+			// are not multi-byte aware, so we have to do a bit of work to get the correct figure.
+			$start = $localPosition + JString::strlen(substr($this->content, 0, $matches[0][1]));
+
+			// Determine the position of the close brace.
+			$end   = $start + JString::strlen($matches[0][0]) - 1;
+
+			// Parse the token itself into a name and an optional string of parameters.
+			$parts = explode(' ', $matches[1][0], 2);
+			$tokenName = JString::strtolower($parts[0]);
+			$tokenParams = isset($parts[1]) ? $parts[1] : '';
+
+			$endToken = false;
+
+			// Is this an end token?
+			if (substr($tokenName, 0, 1) == '/')
+			{
+				$endToken = true;
+				$tokenName = JString::substr($tokenName, 1);
+			}
+
+			// Is the token name registered?  If not, continue searching for tokens.
+			if (!isset($this->tokens[$tokenName]))
+			{
+				$localPosition = $end + 1;
+
+				continue;
+			}
+
+			// If there are characters prior to the token, we return them as a string object first.
+			if ($start > $this->position)
+			{
+				$lexeme = new JStringTokenString(JString::substr($this->content, $this->position, $start - $this->position));
+				$this->position = $start;
+
+				return $lexeme;
+			}
+
+			// Otherwise, we're going to return the token.
+			$tokenDefn = $this->tokens[$tokenName];
+			$this->position = $end + 1;
+
+			if ($endToken)
+			{
+				return new JStringTokenEnd($tokenDefn);
+			}
+
+			return new JStringTokenBegin($tokenDefn, $tokenParams == '' ? array() : explode($this->paramSeparator, $tokenParams));
+		}
+		while (true);
+
+		// No more tokens and no more characters so return null.
+		if ($this->position >= $this->contentLength)
+		{
+			return;
+		}
+
+		// No more tokens so return remaining characters as a string object.
+		$lexeme = new JStringTokenString(JString::substr($this->content, $this->position, $this->contentLength - $this->position));
+		$this->position = $this->contentLength;
+
+		return $lexeme;
+	}
+
+	/**
+	 * Match the next token from the input.
+	 *
+	 * If the next token matches what we expect, then return the output from it.
+	 * Otherwise we have an error, but we silently return a null.
+	 *
+	 * @param   string  $expectedTokenType  Type of token expected.
+	 *
+	 * @return  string | null
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	private function match($expectedTokenType)
+	{
+		if ($this->lookahead instanceof $expectedTokenType)
+		{
+			$output = $this->lookahead->getValue();
+			$this->lookahead = $this->getNextToken();
+
+			return $output;
+		}
+	}
+
+	/**
+	 * Handles the list production rule:
+	 *    list ::= string | string token list
+	 * Note that the string element may be empty.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	private function parseList()
+	{
+		$output = '';
+
+		// Expecting a string, which could be empty.
+		if ($this->lookahead instanceof JStringTokenString)
+		{
+			$output .= $this->match('JStringTokenString');
+		}
+
+		// Expecting a begin (simple or block) token.
+		if ($this->lookahead instanceof JStringTokenBegin)
+		{
+			$output .= $this->parseToken();
+		}
+
+		// If the next token is a string then we have another list.
+		if ($this->lookahead instanceof JStringTokenString)
+		{
+			$output .= $this->parseList();
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Handles the token production rule:
+	 *    token ::= simple | begin list end
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	private function parseToken()
+	{
+		// If the token is simple, we're done.
+		if ($this->lookahead->isSimple())
+		{
+			return $this->match('JStringTokenBegin');
+		}
+
+		// Save the begin block token for later.
+		$tokenBegin = $this->lookahead;
+
+		// Match the begin block token.
+		$this->match('JStringTokenBegin');
+
+		// Parse the string between the begin and end tokens.
+		$output = $this->parseList();
+
+		// Expecting an end block token.
+		if ($this->lookahead instanceof JStringTokenEnd)
+		{
+			// Process the string through the begin block token.
+			$output = $tokenBegin->getValue($output);
+
+			// Match the end block token.
+			$this->match('JStringTokenEnd');
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Register the definition of a token.
+	 *
+	 * @param   string    $name      A token name to look for.
+	 * @param   callable  $callback  A callable that will return the replacement string.
+	 * @param   boolean   $simple    True for a simple token; false for a block token.
+	 *
+	 * @return  This object for method chaining.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function registerToken($name, callable $callback, $simple = true)
+	{
+		$this->tokens[JString::strtolower($name)] = new JStringTokenDefinition($name, $callback, $simple);
+
+		return $this;
+	}
+
+	/**
+	 * Syntax-directed translation of a string.
+	 *
+	 * Production rules:
+	 *    list       ::= string | string token list
+	 *    token      ::= simple | beginBlock list endBlock
+	 *    simple     ::= startOfToken name endOfToken | startOfToken name space params endOfToken
+	 *    beginBlock ::= startOfToken name endOfToken | startOfToken name space params endOfToken
+	 *    endBlock   ::= startOfToken / name endOfToken
+	 *    params     ::= param | param , params
+	 *    string     ::= any sequence of zero or more characters not including startOfToken
+	 *    name       ::= any sequence of at least one non-space character
+	 *    param      ::= any sequence of zero or more characters except , and endOfToken
+	 *
+	 * Note: Format of an individual param is not defined.
+	 *
+	 * @param   string  $content  Content to be parsed and translated.
+	 * @param   array   $options  Optional array of options.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function translate($content, $options = array())
+	{
+		$this->content		  = $content;
+		$this->contentLength  = JString::strlen($content);
+		$this->position		  = 0;
+		$this->lookahead	  = null;
+		$this->startOfToken	  = isset($options['startOfToken'])   ? $options['startOfToken']   : '{';
+		$this->endOfToken	  = isset($options['endOfToken'])     ? $options['endOfToken']     : '}';
+		$this->paramSeparator = isset($options['paramSeparator']) ? $options['paramSeparator'] : ',';
+
+		$output = '';
+
+		// Start by looking for the first token.
+		$this->lookahead = $this->getNextToken();
+
+		// Loop until we've processed all the tokens.
+		do
+		{
+			$output .= $this->parseList();
+		}
+		while ($this->position < $this->contentLength);
+
+		return $output;
+	}
+}
+

--- a/libraries/joomla/string/parser.php
+++ b/libraries/joomla/string/parser.php
@@ -61,14 +61,9 @@ class JStringParser
 	private $position = 0;
 
 	/**
-	 * Start of token string.
+	 * Regular expression to match a simple or block token.
 	 */
-	private $startOfToken = '{';
-
-	/**
-	 * End of token string.
-	 */
-	private $endOfToken = '}';
+	private $pattern = '';
 
 	/**
 	 * Parameter separator string.
@@ -89,12 +84,11 @@ class JStringParser
 	{
 		$localPosition = $this->position;
 		$matches = array();
-		$pattern = '/' . $this->startOfToken . '(.+)' . $this->endOfToken . '/U';
 
 		do
 		{
 			// Look for a possible token.
-			preg_match($pattern, JString::substr($this->content, $localPosition), $matches, PREG_OFFSET_CAPTURE);
+			preg_match($this->pattern, JString::substr($this->content, $localPosition), $matches, PREG_OFFSET_CAPTURE);
 
 			// No more tokens, so stop looking.
 			if (empty($matches))
@@ -308,9 +302,12 @@ class JStringParser
 		$this->contentLength  = JString::strlen($content);
 		$this->position		  = 0;
 		$this->lookahead	  = null;
-		$this->startOfToken	  = isset($options['startOfToken'])   ? $options['startOfToken']   : '{';
-		$this->endOfToken	  = isset($options['endOfToken'])     ? $options['endOfToken']     : '}';
 		$this->paramSeparator = isset($options['paramSeparator']) ? $options['paramSeparator'] : ',';
+
+		// Construct regular expression to match a simple or block token.
+		$startOfToken  = isset($options['startOfToken'])   ? $options['startOfToken']   : '{';
+		$endOfToken	   = isset($options['endOfToken'])     ? $options['endOfToken']     : '}';
+		$this->pattern = '/' . $startOfToken . '(.+)' . $endOfToken . '/U';
 
 		$output = '';
 

--- a/libraries/joomla/string/parser.php
+++ b/libraries/joomla/string/parser.php
@@ -331,7 +331,7 @@ class JStringParser
 	/**
 	 * Unregister the definition of a token.
 	 *
-	 * @param   string    $name     A token name to look for.
+	 * @param   string  $name  A token name to look for.
 	 *
 	 * @return  This object for method chaining.
 	 *

--- a/libraries/joomla/string/token.php
+++ b/libraries/joomla/string/token.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Token interface.
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 abstract class JStringToken
 {

--- a/libraries/joomla/string/token.php
+++ b/libraries/joomla/string/token.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Token interface.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+abstract class JStringToken
+{
+	/**
+	 * Token definition object.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $tokenDefinition = null;
+
+	/**
+	 * String content.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $content = '';
+
+	/**
+	 * Parameters.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $params = array();
+
+	/**
+	 * Return the name of the token.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getName()
+	{
+		return is_null($this->tokenDefinition) ? '' : $this->tokenDefinition->name;
+	}
+
+	/**
+	 * Return the parameters associated with the token.
+	 *
+	 * @return  array
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getParams()
+	{
+		return $this->params;
+	}
+
+	/**
+	 * Return the translated value of the token.
+	 *
+	 * @param   string  $content  Possible content to be translated.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getValue($content = '')
+	{
+		return $content;
+	}
+}
+

--- a/libraries/joomla/string/token.php
+++ b/libraries/joomla/string/token.php
@@ -17,6 +17,13 @@ defined('_JEXEC') or die;
 abstract class JStringToken
 {
 	/**
+	 * Name of the token..
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $name = '';
+
+	/**
 	 * Token definition object.
 	 *
 	 * @since __DEPLOY_VERSION__
@@ -46,7 +53,7 @@ abstract class JStringToken
 	 */
 	public function getName()
 	{
-		return is_null($this->tokenDefinition) ? '' : $this->tokenDefinition->name;
+		return $this->name;
 	}
 
 	/**

--- a/libraries/joomla/string/token/begin.php
+++ b/libraries/joomla/string/token/begin.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * A simple token or the beginning of a block token.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class JStringTokenBegin extends JStringToken
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   JStringTokenDefinition  $tokenDefinition  Token definition object.
+	 * @param   array                   $params           String representing parameters.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function __construct(JStringTokenDefinition $tokenDefinition, array $params)
+	{
+		$this->tokenDefinition = $tokenDefinition;
+		$this->params = $params;
+	}
+
+	/**
+	 * Return the translated value of the token.
+	 *
+	 * @param   string  $content  Possible content to be translated.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getValue($content = '')
+	{
+		$callback = $this->tokenDefinition->callback;
+
+		return $callback($this, $content);
+	}
+
+	/**
+	 * Is this token simple or the beginning of a block?
+	 *
+	 * @return  boolean
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function isSimple()
+	{
+		return (boolean) $this->tokenDefinition->simple;
+	}
+}
+

--- a/libraries/joomla/string/token/begin.php
+++ b/libraries/joomla/string/token/begin.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * A simple token or the beginning of a block token.
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 class JStringTokenBegin extends JStringToken
 {

--- a/libraries/joomla/string/token/begin.php
+++ b/libraries/joomla/string/token/begin.php
@@ -19,13 +19,15 @@ class JStringTokenBegin extends JStringToken
 	/**
 	 * Constructor.
 	 *
+	 * @param   string                  $name             Name of the token.
 	 * @param   JStringTokenDefinition  $tokenDefinition  Token definition object.
 	 * @param   array                   $params           String representing parameters.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function __construct(JStringTokenDefinition $tokenDefinition, array $params)
+	public function __construct($name, JStringTokenDefinition $tokenDefinition, array $params)
 	{
+		$this->name = $name;
 		$this->tokenDefinition = $tokenDefinition;
 		$this->params = $params;
 	}
@@ -41,9 +43,21 @@ class JStringTokenBegin extends JStringToken
 	 */
 	public function getValue($content = '')
 	{
+		$value    = $this->tokenDefinition->bound;
 		$callback = $this->tokenDefinition->callback;
+		$layout   = $this->tokenDefinition->layout;
 
-		return $callback($this, $content);
+		if (is_callable($callback))
+		{
+			$value = $callback($this, $content, $value);
+		}
+
+		if ($layout instanceof JLayoutFile)
+		{
+			$value = $layout->render($value);
+		}
+
+		return $value;
 	}
 
 	/**
@@ -55,7 +69,7 @@ class JStringTokenBegin extends JStringToken
 	 */
 	public function isSimple()
 	{
-		return (boolean) $this->tokenDefinition->simple;
+		return (boolean) $this->tokenDefinition->isSimple();
 	}
 }
 

--- a/libraries/joomla/string/token/block.php
+++ b/libraries/joomla/string/token/block.php
@@ -10,22 +10,22 @@
 defined('_JEXEC') or die;
 
 /**
- * An end token.
+ * Block-type token type definition.
  *
  * @since  __DEPLOY_VERSION__
  */
-class JStringTokenEnd extends JStringToken
+class JStringTokenBlock extends JStringTokenDefinition
 {
 	/**
-	 * Constructor.
+	 * Is this token simple or the beginning of a block?
 	 *
-	 * @param   JStringTokenDefinition  $tokenDefinition  Token definition object.
+	 * @return  boolean
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function __construct(JStringTokenDefinition $tokenDefinition)
+	public function isSimple()
 	{
-		$this->tokenDefinition = $tokenDefinition;
+		return false;
 	}
 }
 

--- a/libraries/joomla/string/token/definition.php
+++ b/libraries/joomla/string/token/definition.php
@@ -40,7 +40,7 @@ abstract class JStringTokenDefinition
 	/**
 	 * Constructor.
 	 *
-	 * @param   mixed     $bound     An optional value or callable to bind to the token.
+	 * @param   mixed  $bound  An optional value or callable to bind to the token.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */

--- a/libraries/joomla/string/token/definition.php
+++ b/libraries/joomla/string/token/definition.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Token type definition.
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 class JStringTokenDefinition
 {

--- a/libraries/joomla/string/token/definition.php
+++ b/libraries/joomla/string/token/definition.php
@@ -14,47 +14,80 @@ defined('_JEXEC') or die;
  *
  * @since  __DEPLOY_VERSION__
  */
-class JStringTokenDefinition
+abstract class JStringTokenDefinition
 {
 	/**
-	 * Name of the token.  Example "loadposition".
+	 * Bound variable.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public $name = '';
+	public $bound = null;
 
 	/**
-	 * Function that will be called to translate the token.
+	 * Callback.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
 	public $callback = null;
 
 	/**
-	 * Flag which is set to indicate that this token is simple.
-	 *
-	 * A simple token looks like {name} and will be replaced in its entirety.
-	 * A block token has a matching end block token which looks like {/name}.
-	 * The begin and end block tokens and everything in between will be replaced.
+	 * JLayoutFile object.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public $simple = true;
+	public $layout = null;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param   string    $name      Token name.
-	 * @param   callable  $callback  Callable which will return the replacement string.
-	 * @param   boolean   $simple    True if token is simple; false if token is block.
+	 * @param   mixed     $bound     An optional value or callable to bind to the token.
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function __construct($name, callable $callback, $simple = true)
+	public function __construct($bound = null)
 	{
-		$this->name = JString::strtolower($name);
+		$this->bound	= $bound;
+	}
+
+	/**
+	 * Assign a callback function.
+	 *
+	 * @param   callable  $callback  An optional callback function.
+	 *
+	 * @return  This object for method chaining.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function callback(callable $callback = null)
+	{
 		$this->callback = $callback;
-		$this->simple = (boolean) $simple;
+
+		return $this;
+	}
+
+	/**
+	 * Is this token simple or the beginning of a block?
+	 *
+	 * @return  boolean
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	abstract public function isSimple();
+
+	/**
+	 * Assign a layout function.
+	 *
+	 * @param   JLayout  $layout  An optional layout to bind to the token.
+	 *
+	 * @return  This object for method chaining.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function layout(JLayout $layout = null)
+	{
+		$this->layout = $layout;
+
+		return $this;
 	}
 }
 

--- a/libraries/joomla/string/token/definition.php
+++ b/libraries/joomla/string/token/definition.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Token type definition.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class JStringTokenDefinition
+{
+	/**
+	 * Name of the token.  Example "loadposition".
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public $name = '';
+
+	/**
+	 * Function that will be called to translate the token.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public $callback = null;
+
+	/**
+	 * Flag which is set to indicate that this token is simple.
+	 *
+	 * A simple token looks like {name} and will be replaced in its entirety.
+	 * A block token has a matching end block token which looks like {/name}.
+	 * The begin and end block tokens and everything in between will be replaced.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public $simple = true;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   string    $name      Token name.
+	 * @param   callable  $callback  Callable which will return the replacement string.
+	 * @param   boolean   $simple    True if token is simple; false if token is block.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function __construct($name, callable $callback, $simple = true)
+	{
+		$this->name = JString::strtolower($name);
+		$this->callback = $callback;
+		$this->simple = (boolean) $simple;
+	}
+}
+

--- a/libraries/joomla/string/token/end.php
+++ b/libraries/joomla/string/token/end.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * An end token.
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 class JStringTokenEnd extends JStringToken
 {

--- a/libraries/joomla/string/token/end.php
+++ b/libraries/joomla/string/token/end.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * An end token.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class JStringTokenEnd extends JStringToken
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   JStringTokenDefinition  $tokenDefinition  Token definition object.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function __construct(JStringTokenDefinition $tokenDefinition)
+	{
+		$this->tokenDefinition = $tokenDefinition;
+	}
+
+	/**
+	 * Return the name of the token.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getName()
+	{
+		return $this->tokenDefinition->name;
+	}
+}
+

--- a/libraries/joomla/string/token/simple.php
+++ b/libraries/joomla/string/token/simple.php
@@ -10,22 +10,22 @@
 defined('_JEXEC') or die;
 
 /**
- * An end token.
+ * Simple token type definition.
  *
  * @since  __DEPLOY_VERSION__
  */
-class JStringTokenEnd extends JStringToken
+class JStringTokenSimple extends JStringTokenDefinition
 {
 	/**
-	 * Constructor.
+	 * Is this token simple or the beginning of a block?
 	 *
-	 * @param   JStringTokenDefinition  $tokenDefinition  Token definition object.
+	 * @return  boolean
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function __construct(JStringTokenDefinition $tokenDefinition)
+	public function isSimple()
 	{
-		$this->tokenDefinition = $tokenDefinition;
+		return true;
 	}
 }
 

--- a/libraries/joomla/string/token/string.php
+++ b/libraries/joomla/string/token/string.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  String
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * A string token.
+ *
+ * @since __DEPLOY_VERSION__
+ */
+class JStringTokenString extends JStringToken
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   string  $content  String to be represented as a token.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function __construct($content)
+	{
+		$this->content = $content;
+	}
+
+	/**
+	 * Return the translated value of the token.
+	 *
+	 * @param   string  $content  Possible content to be translated.
+	 *
+	 * @return  string
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public function getValue($content = '')
+	{
+		return $this->content;
+	}
+}
+

--- a/libraries/joomla/string/token/string.php
+++ b/libraries/joomla/string/token/string.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * A string token.
  *
- * @since __DEPLOY_VERSION__
+ * @since  __DEPLOY_VERSION__
  */
 class JStringTokenString extends JStringToken
 {

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -47,76 +47,40 @@ class PlgContentLoadmodule extends JPlugin
 			return true;
 		}
 
-		// Expression to search for (positions)
-		$regex = '/{loadposition\s(.*?)}/i';
-		$style = $this->params->def('style', 'none');
+		// Get a content parser.
+		$parser = new JStringParser();
 
-		// Expression to search for(modules)
-		$regexmod = '/{loadmodule\s(.*?)}/i';
-		$stylemod = $this->params->def('style', 'none');
-
-		// Find all instances of plugin and put in $matches for loadposition
-		// $matches[0] is full pattern match, $matches[1] is the position
-		preg_match_all($regex, $article->text, $matches, PREG_SET_ORDER);
-
-		// No matches, skip this
-		if ($matches)
-		{
-			foreach ($matches as $match)
+		// Register the loadposition token.
+		// Syntax: {loadposition <module-position>[,<style>]}
+		$parser->registerToken(
+			'loadposition',
+			function(JStringToken $token)
 			{
-				$matcheslist = explode(',', $match[1]);
+				$tokenParams = $token->getParams();
+				$position = trim($tokenParams[0]);
+				$style = isset($tokenParams[1]) ? trim($tokenParams[1]) : $this->params->def('style', 'none');
 
-				// We may not have a module style so fall back to the plugin default.
-				if (!array_key_exists(1, $matcheslist))
-				{
-					$matcheslist[1] = $style;
-				}
-
-				$position = trim($matcheslist[0]);
-				$style    = trim($matcheslist[1]);
-
-				$output = $this->_load($position, $style);
-
-				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
-				$article->text = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $article->text, 1);
-				$style = $this->params->def('style', 'none');
+				return addcslashes($this->_load($position, $style), '\\$');
 			}
-		}
+		);
 
-		// Find all instances of plugin and put in $matchesmod for loadmodule
-		preg_match_all($regexmod, $article->text, $matchesmod, PREG_SET_ORDER);
-
-		// If no matches, skip this
-		if ($matchesmod)
-		{
-			foreach ($matchesmod as $matchmod)
+		// Register the loadmodule token.
+		// Syntax: {loadmodule <module-type>[,<module-title>[,<style>]]}
+		$parser->registerToken(
+			'loadmodule',
+			function(JStringToken $token)
 			{
-				$matchesmodlist = explode(',', $matchmod[1]);
+				$tokenParams = $token->getParams();
+				$moduleName = trim($tokenParams[0]);
+				$moduleTitle = isset($tokenParams[1]) ? htmlspecialchars_decode(trim($tokenParams[1])) : '';
+				$style = isset($tokenParams[2]) ? trim($tokenParams[2]) : $this->params->def('style', 'none');
 
-				// We may not have a specific module so set to null
-				if (!array_key_exists(1, $matchesmodlist))
-				{
-					$matchesmodlist[1] = null;
-				}
-
-				// We may not have a module style so fall back to the plugin default.
-				if (!array_key_exists(2, $matchesmodlist))
-				{
-					$matchesmodlist[2] = $stylemod;
-				}
-
-				$module = trim($matchesmodlist[0]);
-				$name   = htmlspecialchars_decode(trim($matchesmodlist[1]));
-				$stylemod  = trim($matchesmodlist[2]);
-
-				// $match[0] is full pattern match, $match[1] is the module,$match[2] is the title
-				$output = $this->_loadmod($module, $name, $stylemod);
-
-				// We should replace only first occurrence in order to allow positions with the same name to regenerate their content:
-				$article->text = preg_replace(addcslashes("|$matchmod[0]|", '()'), addcslashes($output, '\\$'), $article->text, 1);
-				$stylemod = $this->params->def('style', 'none');
+				return addcslashes($this->_loadmod($moduleName, $moduleTitle, $style), '\\$');
 			}
-		}
+		);
+
+		// Parse and translate the content.
+		$article->text = $parser->translate($article->text);
 	}
 
 	/**

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -52,31 +52,35 @@ class PlgContentLoadmodule extends JPlugin
 
 		// Register the loadposition token.
 		// Syntax: {loadposition <module-position>[,<style>]}
-		$parser->registerToken(
+		$parser->register(
 			'loadposition',
-			function(JStringToken $token)
-			{
-				$tokenParams = $token->getParams();
-				$position = trim($tokenParams[0]);
-				$style = isset($tokenParams[1]) ? trim($tokenParams[1]) : $this->params->def('style', 'none');
+			(new JStringTokenSimple)->callback(
+				function(JStringToken $token)
+				{
+					$tokenParams = $token->getParams();
+					$position = trim($tokenParams[0]);
+					$style = isset($tokenParams[1]) ? trim($tokenParams[1]) : $this->params->def('style', 'none');
 
-				return addcslashes($this->_load($position, $style), '\\$');
-			}
+					return addcslashes($this->_load($position, $style), '\\$');
+				}
+			)
 		);
 
 		// Register the loadmodule token.
 		// Syntax: {loadmodule <module-type>[,<module-title>[,<style>]]}
-		$parser->registerToken(
+		$parser->register(
 			'loadmodule',
-			function(JStringToken $token)
-			{
-				$tokenParams = $token->getParams();
-				$moduleName = trim($tokenParams[0]);
-				$moduleTitle = isset($tokenParams[1]) ? htmlspecialchars_decode(trim($tokenParams[1])) : '';
-				$style = isset($tokenParams[2]) ? trim($tokenParams[2]) : $this->params->def('style', 'none');
+			(new JStringTokenSimple)->callback(
+				function(JStringToken $token)
+				{
+					$tokenParams = $token->getParams();
+					$moduleName = trim($tokenParams[0]);
+					$moduleTitle = isset($tokenParams[1]) ? htmlspecialchars_decode(trim($tokenParams[1])) : '';
+					$style = isset($tokenParams[2]) ? trim($tokenParams[2]) : $this->params->def('style', 'none');
 
-				return addcslashes($this->_loadmod($moduleName, $moduleTitle, $style), '\\$');
-			}
+					return addcslashes($this->_loadmod($moduleName, $moduleTitle, $style), '\\$');
+				}
+			)
 		);
 
 		// Parse and translate the content.

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -48,7 +48,7 @@ class PlgContentLoadmodule extends JPlugin
 		}
 
 		// Get a content parser.
-		$parser = new JStringParser();
+		$parser = new JStringParser;
 
 		// Register the loadposition token.
 		// Syntax: {loadposition <module-position>[,<style>]}


### PR DESCRIPTION
Work on the new Custom Fields feature for Joomla 3.7 has highlighted the need to define a common "core supported" syntax for embedding codes within content that can be replaced dynamically using the content plugins.  At present, the loadmodule plugin is the only content plugin in the core distribution that does this kind of tag replacement.  Since the loadmodule plugin has been around for many years, it has been extensively copied by third-party developers and many, although not all, have stayed with, or close to, the informally defined syntax that loadmodule supports.

For example, to embed a module position called "myposition" into an article using the "mychrome" style, you would insert the following string into the article:

`{loadposition myposition,mychrome}`

The new Custom Fields feature requires a more sophisticated syntax and initially this was achieved by importing the Mustache (sic) library (https://mustache.github.io/).  However, this has a notably different syntax from the one established by the loadmodule precedent and the question arose as to whether that was the right direction for the Joomla project to follow.

In my opinion, it would be better to try to stay close to the existing syntax established by loadmodule, adding only backwards-compatible extensions to the syntax to support the new custom fields feature.

Most third-party developers tend to follow "core standards" so the core distribution tends to set a precedent which then becomes a de facto, albeit often undocumented standard.  So it is important that the syntax that we come up with meets some basic objectives:
- The syntax should be simple enough for non-technical end-users to grasp in the majority of use-cases.
- The API should be simple enough for modestly skilled developers to easily create content plugins that implement the standard.
- The implementation should cater for multi-byte character sets.
- The implementation should be efficient.  In practice this means minimal use of regular expressions.
### Summary of Changes

This pull request is offered as a potential solution that meets these objectives.  It comprises some additional classes in the Joomla string library and a refactoring of the loadmodule plugin to make use of it.
### Testing Instructions

If you fancy testing it then please check that the loadmodule plugin behaves exactly as it did previously.  In particular, please test with multi-byte characters to make sure I have that handled properly.

Please also try to create your own content plugins using the library and see how you get on.
### Documentation Changes Required

The syntax supported by the library is described below and this description could be used as the basis for the documentation should the PR be accepted.
#### Simple tokens

To use the parser you follow these steps in your content plugin code:
- instantiate a JStringParser object.
- make one or more calls to the registerToken method so as to associate with each token a callback function that will return the string that will replace the token whenever it is encountered in the content.  This is explained in more detail below.
- call the translate method which will replace all the tokens encountered in the content by calling the relevant callbacks.

For example, the following code appears in the loadmodule plugin:

```
// Get a content parser.
$parser = new JStringParser;

// Register the loadposition token.
$parser->registerToken(
    'loadposition',
    function(JStringToken $token)
    {
        $tokenParams = $token->getParams();
        $position = trim($tokenParams[0]);
        $style = isset($tokenParams[1]) ? trim($tokenParams[1]) : $this->params->def('style', 'none');

        return addcslashes($this->_load($position, $style), '\\$');
    }
);
```

The callback function takes a JStringToken object which allows access to the token definition that was registered by the registerToken method as well as to the specific parameters associated with the token in the input.

Notice that the token parameters are assumed to be a comma-separated list, but the parser makes no further assumptions about the syntax of the parameters.  The parameters are made available to the callback function through the $token->getParams() array.

With this setup out of the way, the following code performs the actual content parsing and translation:

```
// Parse the content.
$article->text = $parser->translate($article->text);
```
#### Block tokens

The parser also supports a block syntax that is rich enough to support the custom fields extension.  Here's an example:

`<li>{field alias=something}{field-label}: {field-value}{/field}</li>`

In this case we have a couple of simple tokens, field-label and field-value, surrounded by a begin-end pair of block tokens.  The begin block token takes a single argument, which in this case contains an equals sign, although the parser does not attempt to understand it and will simply pass it to the callback function as the string "alias=something" in $token->getParams()[0].

Here is some pseudo-code that will handle the above syntax:

```
// Define a context variable.
$context = '';

// Get a content parser.
$parser = new JStringParser();

// Register the simple tokens.
$parser->registerToken(
    'field-label',
    function(JStringToken $token) use (&$context)
    {
        // Set $label to the label for the current field defined by $context.
        return $label;
    }
);

$parser->registerToken(
    'field-value',
    function(JStringToken $token) use (&$context)
    {
        // Set $value to the value of the current field defined by $context.
        return $value;
    }
);

// Register the block token
$parser->registerToken(
    'field',
    function(JStringToken $token, $content) use (&$context)
    {
        $tokenParams = $token->getParams();

        // Set the context for any contained tokens.
        $context = $tokenParams[0];

        return $content;
    }
);

// Parse the content.
$article->text = $parser->translate($article->text);
```

The first point to notice about the above code is that you indicate whether a token is a simple token or a block token by the third argument passed to the registerToken method.  By default this is true, meaning that the token is a simple one.  If you want to register a block token you must pass false as the third argument.

The second point to notice is that the callback function for the block token ("field") takes an additional argument.  The first argument is a JStringToken as before, but the second argument will be passed the already processed string extracted from between the begin and end tokens.  For example, suppose we have this content:

`This is a field: {field article-id}Article ID{/field}`

Then $content will be passed the string "Article ID" when the callback is called.  However, if the string between the begin and end tokens contains other tokens, then these will already have been processed before the callback is called.  So if we have this content:

`This is a field: {field article-id}{field-label}: {field-value}{/field}`

And if we assume the callback for the "field-label" token always returns the string "Label" and the callback for the "field-value" token always returns the string "Value", then $content will be passed the string "Label: Value" rather than "{field-label}: {field-value}".

The third point to note is the use of the $context variable to pass context from the block token callback to any callbacks handling tokens within the block.  In the above example, the {field-label} and {field-value} will presumably depend on the "article-id" parameter in the {field article-id} token, so the $context variable is used to pass that context between the callbacks.  Although a simple string variable is shown in the example code above, the $context variable can be anything.  For example, if you need to support nested block tokens it would make sense for $context to be a stack of contexts; perhaps an array which is pushed and popped appropriately.  You may, of course, use multiple variables in the use clauses if you need to pass more context information around.
#### Other notes
- Token names are case-insensitive.
- If you call registerToken with a token name that is already registered, then your definition will replace the earlier one.
- You can define your own start-of-token and end-of-token strings by passing options in an array to the translator.  This could actually be used to define a "micro-syntax" that exists only without an outer pair of block tokens.  You can also define your own parameter separator too.  See the code for the details.
- The implementation tries hard to ignore obviously incorrect token usage.  For example, a begin block token without a matching end block token should result in the begin block token being ignored, but the content is otherwise "unharmed" and no errors or exceptions are thrown.  Similarly, unmatched opening or closing braces, and unregistered tokens are passed unchanged into the output.
#### Formal syntax definition

The parser supports the syntax defined by the following production rules:

```
list       ::= string | string token list
token      ::= simple | beginBlock list endBlock
simple     ::= startOfToken name endOfToken | startOfToken name space params endOfToken
beginBlock ::= startOfToken name endOfToken | startOfToken name space params endOfToken
endBlock   ::= startOfToken / name endOfToken
params     ::= param | param paramSeparator params
string     ::= any sequence of zero or more characters not including startOfToken
name       ::= any sequence of at least one non-space character
param      ::= any sequence of zero or more characters except paramSeparator and endOfToken

```
