### PR TITLE
Simplify Travis CI testing by only using mysql root

### DIFF
--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -11,10 +11,8 @@ set -e
 composer install
 
 # Setup databases for testing
-if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql -e 'create database joomla_ut;'; fi
-if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then mysql joomla_ut < "$BASE/tests/unit/schema/mysql.sql"; fi
-if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root -e 'create database joomla_ut;'; fi
-if [[ $TRAVIS_PHP_VERSION = hhvm ]]; then mysql -u root joomla_ut < "$BASE/tests/unit/schema/mysql.sql"; fi
+mysql -u root -e 'create database joomla_ut;'
+mysql -u root joomla_ut < "$BASE/tests/unit/schema/mysql.sql"
 psql -c 'create database joomla_ut;' -U postgres
 psql -d joomla_ut -a -f "$BASE/tests/unit/schema/postgresql.sql"
 


### PR DESCRIPTION
Pull Request for Simplify Travis CI testing by only using mysql root .
### Summary of Changes

Simplify Travis CI testing by only using mysql root

This eliminates the HHVM and non-HHVM specific mysql database creations. By using only the root option we have a simpler testing setup. 
### Testing Instructions

merge by code review
### Documentation Changes Required

none
