### PR TITLE
A11Y categories article count

### DIFF
--- a/components/com_content/views/categories/tmpl/default_items.php
+++ b/components/com_content/views/categories/tmpl/default_items.php
@@ -31,6 +31,7 @@ if (count($this->items[$this->parent->id]) > 0 && $this->maxLevelcat != 0) :
 				<?php echo $this->escape($item->title); ?></a>
 				<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
 					<span class="badge badge-info tip hasTooltip" title="<?php echo JHtml::tooltipText('COM_CONTENT_NUM_ITEMS_TIP'); ?>">
+						<?php echo JText::_('COM_CONTENT_NUM_ITEMS'); ?>&nbsp;
 						<?php echo $item->numitems; ?>
 					</span>
 				<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes

The Problem: Jaws does not read title tags into the span tag. So the screenreader will only read the number and not the title which discribes the number. Jaws is the most used screenreader in Germany. A lot of blind people reported me this issue.
This is the missing part of PullRequest #7910.
### Testing Instructions

To create the issue:
-> Create a testinstallation with test content and click on Articles Categories. Use a template without overrides
-> Let JAWS read this and you will not hear the title tag.
-> Now apply the patch and you will see the text article count infront the number.

![pullrequest](https://cloud.githubusercontent.com/assets/9247264/17837840/4c600928-67be-11e6-85c7-3b9c6bde5ec4.PNG)
### Documentation Changes Required

none
Markus
