### PR TITLE
[tabs state] quote jQuery selectors

### DIFF
--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -23,11 +23,11 @@ jQuery(function($) {
         }
 
         function activateTab(href) {
-            $('a[data-toggle="tab"][href=' + href + ']').tab('show');
+            $('a[data-toggle="tab"][href="' + href + '"]').tab('show');
         }
 
         function hasTab(href) {
-            return $('a[data-toggle="tab"][href=' + href + ']').length;
+            return $('a[data-toggle="tab"][href="' + href + '"]').length;
         }
 
         // Array with active tabs hrefs


### PR DESCRIPTION
### Summary of Changes

Since https://github.com/joomla/joomla-cms/pull/9935 we need to quote jQuery selectors.
So, this PR, quotes jQuery selectors in tabs state jquery.
### Testing Instructions

Code review.
### Documentation Changes Required

None.
