### PR TITLE
[isis login] Only add debug css if debug plugin is enabled

### DIFF
--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -90,7 +90,7 @@ $doc->addStyleDeclaration("
 	}");
 
 // Check if debug is on
-if ($app->get('debug_lang', 1) || $app->get('debug', 1))
+if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 1) || $app->get('debug', 1)))
 {
 	$doc->addStyleDeclaration("
 	.view-login .container {

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -90,7 +90,7 @@ $doc->addStyleDeclaration("
 	}");
 
 // Check if debug is on
-if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 1) || $app->get('debug', 1)))
+if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) || $app->get('debug', 0)))
 {
 	$doc->addStyleDeclaration("
 	.view-login .container {


### PR DESCRIPTION
### Summary of Changes

Very simple change.
This PR makes sure that debug plugin is enabled to add the debug css code on isis login.
Also corrects debug and debug_lang default values.
### Testing Instructions
- Enable debug or/and debug language in global config, but DO NOT enable debug system plugin
- Log out and notice the admin login user/pass box as moved for the top of the screen and there are no links/copyright at the bottom of screen
  ![image](https://cloud.githubusercontent.com/assets/9630530/17839353/0889be8c-67dd-11e6-86f4-713162df48bb.png)
- Apply patch
- Go to login again. All is fine
- Code review
### Documentation Changes Required

None.
