### PR TITLE
[joomla update captive] use JAuthenticationHelper::getTwoFactorMethods()

### DIFF
--- a/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
+++ b/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
-JLoader::register('ModLoginHelper', JPATH_ADMINISTRATOR . '/modules/mod_login/helper.php');
-
-$twofactormethods = ModLoginHelper::getTwoFactorMethods();
+$twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 
 ?>
 <div class="alert alert-warning">


### PR DESCRIPTION
### Summary of Changes

Same as done in https://github.com/joomla/joomla-cms/pull/11667 and https://github.com/joomla/joomla-cms/pull/11684, but this time for the com_joomlaupdate "Upload & Install".
### Testing Instructions

Mainly code review, but to actually test it:
1. Use latest staging 
2. Apply patch
3. Try to use 2FA to login in backend and frontend (check "How to test 2FA" in the end of the PR description)
4. Use https://github.com/joomla/joomla-cms/releases/download/3.6.2/Joomla_3.6.2-Stable-Update_Package.zip and try to update joomla wuth "Update & Install"
5. Code review
### Documentation Changes Required

None.
### How to test 2FA
- Enable Google Authenticator two factor authentication plugin: Extensions > Plugins (twofactorauth)
- Create a dummy user and configure it to use with Google Authenticator: Users > Manage > Edit (2FA tab)

Note: you can use a chrome plugin for configuring and using 2FA, for instance https://chrome.google.com/webstore/detail/authenticator/bhghoamapcdpbohphigoooaddinpkbai
