### PR TITLE
Handle the case that JFolder::files returns 'false'

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1145,13 +1145,15 @@ class Installer extends \JAdapter
 
 				if ($schemapath !== '')
 				{
-					$files = str_replace('.sql', '', \JFolder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$'));
-					usort($files, 'version_compare');
+					$files = \JFolder::files($this->getPath('extension_root') . '/' . $schemapath, '\.sql$');
 
-					if (!count($files))
+					if (empty($files))
 					{
 						return $update_count;
 					}
+
+					$files = str_replace('.sql', '', $files);
+					usort($files, 'version_compare');
 
 					$query = $db->getQuery(true)
 						->select('version_id')


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Basically, check that we actually got a list of files before trying to work on it as an array. 
`JFolder::files()` may return `false` in some cases. So we need to check that before using its response as an array. 
### Testing Instructions

To expose the error, I guess you need to install an extension whose manifest file specifies a schemapath which does not exist. So, yes, this bug only really shows up when the extension to be installed has something wrong with it. What will happen is that `JFolder::files()` will return `false` which is passed to str_replace. I'm not sure what gets returned at that point but it's definitely not an array as expected. That return value will be passed to `usort`, `count`, `foreach`, and `end` as if it were an array. These will generate warnings. 

After applying this fix, the function should exit when `JFolder::files()` return `false` or empty array. No warnings.
### Documentation Changes Required

Nope.
