### PR TITLE
[com_contact] Move event trigger to correct place

### DIFF
--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -10,17 +10,18 @@
 defined('_JEXEC') or die;
 
 $cparams = JComponentHelper::getParams('com_media');
-
+$tparams = $this->params;
 jimport('joomla.html.html.bootstrap');
 ?>
+
 <div class="contact<?php echo $this->pageclass_sfx?>" itemscope itemtype="https://schema.org/Person">
-	<?php if ($this->params->get('show_page_heading')) : ?>
+	<?php if ($tparams->get('show_page_heading')) : ?>
 		<h1>
-			<?php echo $this->escape($this->params->get('page_heading')); ?>
+			<?php echo $this->escape($tparams->get('page_heading')); ?>
 		</h1>
 	<?php endif; ?>
 
-	<?php if ($this->contact->name && $this->params->get('show_name')) : ?>
+	<?php if ($this->contact->name && $tparams->get('show_name')) : ?>
 		<div class="page-header">
 			<h2>
 				<?php if ($this->item->published == 0) : ?>
@@ -31,8 +32,8 @@ jimport('joomla.html.html.bootstrap');
 		</div>
 	<?php endif; ?>
 
-	<?php $show_contact_category = $this->params->get('show_contact_category'); ?>
-	
+	<?php $show_contact_category = $tparams->get('show_contact_category'); ?>
+
 	<?php if ($show_contact_category == 'show_no_link') : ?>
 		<h3>
 			<span class="contact-category"><?php echo $this->contact->category_title; ?></span>
@@ -48,47 +49,39 @@ jimport('joomla.html.html.bootstrap');
 
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 
-	<?php if ($this->params->get('show_contact_list') && count($this->contacts) > 1) : ?>
+	<?php if ($tparams->get('show_contact_list') && count($this->contacts) > 1) : ?>
 		<form action="#" method="get" name="selectForm" id="selectForm">
 			<?php echo JText::_('COM_CONTACT_SELECT_CONTACT'); ?>
-			<?php echo JHtml::_('select.genericlist', $this->contacts, 'id', 'class="inputbox" onchange="document.location.href = this.value"', 'link', 'name', $this->contact->link);?>
+			<?php echo JHtml::_('select.genericlist', $this->contacts, 'id', 'class="inputbox" onchange="document.location.href = this.value"', 'link', 'name', $this->contact->link); ?>
 		</form>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+	<?php if ($tparams->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>
 
 	<?php echo $this->item->event->beforeDisplayContent; ?>
+	
+	<?php $presentation_style = $tparams->get('presentation_style'); ?>
 
- 	<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($presentation_style == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'basic-details')); ?>
-	<?php endif; ?>
-
-	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic-details')); ?>
-	<?php endif; ?>
-
-	<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
-	<?php endif; ?>
-
-	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+	<?php elseif ($presentation_style == 'tabs') : ?>
+		<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic-details')); ?>
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic-details', JText::_('COM_CONTACT_DETAILS')); ?>
+	<?php elseif ($presentation_style == 'plain') : ?>
+		<?php echo '<h3>' . JText::_('COM_CONTACT_DETAILS') . '</h3>'; ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('presentation_style') == 'plain'):?>
-		<?php  echo '<h3>' . JText::_('COM_CONTACT_DETAILS') . '</h3>';  ?>
-	<?php endif; ?>
-
-	<?php if ($this->contact->image && $this->params->get('show_image')) : ?>
+	<?php if ($this->contact->image && $tparams->get('show_image')) : ?>
 		<div class="thumbnail pull-right">
 			<?php echo JHtml::_('image', $this->contact->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('align' => 'middle', 'itemprop' => 'image')); ?>
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->contact->con_position && $this->params->get('show_position')) : ?>
+	<?php if ($this->contact->con_position && $tparams->get('show_position')) : ?>
 		<dl class="contact-position dl-horizontal">
 			<dd itemprop="jobTitle">
 				<?php echo $this->contact->con_position; ?>
@@ -98,111 +91,90 @@ jimport('joomla.html.html.bootstrap');
 
 	<?php echo $this->loadTemplate('address'); ?>
 
-	<?php if ($this->params->get('allow_vcard')) :	?>
-		<?php echo JText::_('COM_CONTACT_DOWNLOAD_INFORMATION_AS');?>
+	<?php if ($tparams->get('allow_vcard')) : ?>
+		<?php echo JText::_('COM_CONTACT_DOWNLOAD_INFORMATION_AS'); ?>
 		<a href="<?php echo JRoute::_('index.php?option=com_contact&amp;view=contact&amp;id=' . $this->contact->id . '&amp;format=vcf'); ?>">
-		<?php echo JText::_('COM_CONTACT_VCARD');?></a>
+		<?php echo JText::_('COM_CONTACT_VCARD'); ?></a>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($presentation_style == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.endSlide'); ?>
-	<?php endif; ?>
-
-	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+	<?php elseif ($presentation_style == 'tabs') : ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
-
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($tparams->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-form', JText::_('COM_CONTACT_EMAIL_FORM')); ?>
+		<?php elseif ($presentation_style == 'plain') : ?>
+			<?php echo '<h3>' . JText::_('COM_CONTACT_EMAIL_FORM') . '</h3>'; ?>
 		<?php endif; ?>
 
-		<?php if ($this->params->get('presentation_style') == 'plain'): ?>
-			<?php echo '<h3>' . JText::_('COM_CONTACT_EMAIL_FORM') . '</h3>';  ?>
-		<?php endif; ?>
+		<?php echo $this->loadTemplate('form'); ?>
 
-		<?php  echo $this->loadTemplate('form');  ?>
-
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
-		<?php endif; ?>
-
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_links')) : ?>
+	<?php if ($tparams->get('show_links')) : ?>
 		<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
-
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($tparams->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
-		<?php endif; ?>
-
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-articles', JText::_('JGLOBAL_ARTICLES')); ?>
-		<?php endif; ?>
-
-		<?php if ($this->params->get('presentation_style') == 'plain'):?>
-			<?php echo '<h3>' . JText::_('JGLOBAL_ARTICLES') . '</h3>';  ?>
+		<?php elseif ($presentation_style == 'plain') : ?>
+			<?php echo '<h3>' . JText::_('JGLOBAL_ARTICLES') . '</h3>'; ?>
 		<?php endif; ?>
 
 		<?php echo $this->loadTemplate('articles'); ?>
 
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
-		<?php endif; ?>
-
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
-
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($tparams->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE')); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'plain'):?>
-			<?php echo '<h3>' . JText::_('COM_CONTACT_PROFILE') . '</h3>';  ?>
+		<?php elseif ($presentation_style == 'plain') : ?>
+			<?php echo '<h3>' . JText::_('COM_CONTACT_PROFILE') . '</h3>'; ?>
 		<?php endif; ?>
 
 		<?php echo $this->loadTemplate('profile'); ?>
 
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 	<?php endif; ?>
 
-	<?php if ($this->contact->misc && $this->params->get('show_misc')) : ?>
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($this->contact->misc && $tparams->get('show_misc')) : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-misc', JText::_('COM_CONTACT_OTHER_INFORMATION')); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'plain'):?>
-			<?php echo '<h3>' . JText::_('COM_CONTACT_OTHER_INFORMATION') . '</h3>';  ?>
+		<?php elseif ($presentation_style == 'plain') : ?>
+			<?php echo '<h3>' . JText::_('COM_CONTACT_OTHER_INFORMATION') . '</h3>'; ?>
 		<?php endif; ?>
 
 		<div class="contact-miscinfo">
 			<dl class="dl-horizontal">
 				<dt>
-					<span class="<?php echo $this->params->get('marker_class'); ?>">
-					<?php echo $this->params->get('marker_misc'); ?>
+					<span class="<?php echo $tparams->get('marker_class'); ?>">
+					<?php echo $tparams->get('marker_misc'); ?>
 					</span>
 				</dt>
 				<dd>
@@ -213,20 +185,18 @@ jimport('joomla.html.html.bootstrap');
 			</dl>
 		</div>
 
-		<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+		<?php if ($presentation_style == 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.endSlide'); ?>
-		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+		<?php elseif ($presentation_style == 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
-
 	<?php endif; ?>
 
-	<?php if ($this->params->get('presentation_style') == 'sliders') : ?>
+	<?php if ($presentation_style == 'sliders') : ?>
 		<?php echo JHtml::_('bootstrap.endAccordion'); ?>
-	<?php endif; ?>
-	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
+	<?php elseif ($presentation_style == 'tabs') : ?>
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<?php endif; ?>
+
 	<?php echo $this->item->event->afterDisplayContent; ?>
 </div>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -31,15 +31,13 @@ jimport('joomla.html.html.bootstrap');
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_contact_category') == 'show_no_link') : ?>
+	<?php $show_contact_category = $this->params->get('show_contact_category'); ?>
+	
+	<?php if ($show_contact_category == 'show_no_link') : ?>
 		<h3>
 			<span class="contact-category"><?php echo $this->contact->category_title; ?></span>
 		</h3>
-	<?php endif; ?>
-
-	<?php echo $this->item->event->afterDisplayTitle; ?>
-
-	<?php if ($this->params->get('show_contact_category') == 'show_with_link') : ?>
+	<?php elseif ($show_contact_category == 'show_with_link') : ?>
 		<?php $contactLink = ContactHelperRoute::getCategoryRoute($this->contact->catid); ?>
 		<h3>
 			<span class="contact-category"><a href="<?php echo $contactLink; ?>">
@@ -47,6 +45,8 @@ jimport('joomla.html.html.bootstrap');
 			</span>
 		</h3>
 	<?php endif; ?>
+
+	<?php echo $this->item->event->afterDisplayTitle; ?>
 
 	<?php if ($this->params->get('show_contact_list') && count($this->contacts) > 1) : ?>
 		<form action="#" method="get" name="selectForm" id="selectForm">


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

1) Event trigger of the event `afterDisplayTitle` is in the wrong place — when option 'show_contact_category' is 'show_with_link' it triggers BEFORE of displaying the title.

2) The option 'show_contact_category' can't be simultaneously 'show_no_link' and 'show_with_link', two `if` replaced with `if` - `elseif`.
### Testing Instructions

1) Create a test contact.
2) Create test contact category, place test contacts to it.
3) Create test menu item of type 'Contacts' - 'Single Contact' for the test contact.
4) Set option 'Contact Display Options' - 'Contact Category' of the test menu item to value 'Show Without Link'. There must be no difference for page of test contact.
5) Set option 'Contact Display Options' - 'Contact Category' of the test menu item to value 'Show With Link'. There must be no difference for page of test contact unless you use event `afterDisplayTitle`.
### Documentation Changes Required

None
