### PR TITLE
3.7.0: New Feature=>editor-xtd to insert menu items links in content

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -347,6 +347,7 @@ class JoomlaInstallerScript
 			array('plugin', 'folderinstaller', 'installer', 0),
 			array('plugin', 'urlinstaller', 'installer', 0),
 			array('plugin', 'phpversioncheck', 'quickicon', 0),
+			array('plugin', 'menu', 'editors-xtd', 0),
 
 			// Templates
 			array('template', 'beez3', '', 0),

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-22.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-22.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-22.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-22.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-22.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-22.sql
@@ -1,0 +1,6 @@
+SET IDENTITY_INSERT #__extensions  ON;
+
+INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-22.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-22.sql
@@ -1,6 +1,6 @@
-SET IDENTITY_INSERT #__extensions  ON;
+SET IDENTITY_INSERT [#__extensions]  ON;
 
-INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
-SET IDENTITY_INSERT #__extensions  OFF;
+SET IDENTITY_INSERT [#__extensions]  OFF;

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EDITORS-XTD_MENU="Button - Menu"
+PLG_MENU_BUTTON_MENU="Menu"
+PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu items links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
-PLG_MENU_BUTTON_MENU="Menu"
-PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENU_BUTTON_MENU="Menu"
+PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
 PLG_MENU_BUTTON_MENU="Menu"
-PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu items links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
-PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EDITORS-XTD_MENU="Button - Menu"
+PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu items links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menu.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_MENU="Button - Menu"
-PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu items links into an Article. Displays a popup allowing you to choose the menu item."
+PLG_MENU_XML_DESCRIPTION="Displays a button to make it possible to insert menu item links into an Article. Displays a popup allowing you to choose the menu item."

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -141,6 +141,8 @@
 		<filename>en-GB.plg_editors-xtd_article.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_image.ini</filename>
 		<filename>en-GB.plg_editors-xtd_image.sys.ini</filename>
+		<filename>en-GB.plg_editors-xtd_menu.ini</filename>
+		<filename>en-GB.plg_editors-xtd_menu.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_module.ini</filename>
 		<filename>en-GB.plg_editors-xtd_module.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_pagebreak.ini</filename>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -615,6 +615,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (456, 'plg_installer_folderinstaller', 'plugin', 'folderinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 2, 0),
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 3, 0),
 (458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -614,7 +614,8 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (455, 'plg_installer_packageinstaller', 'plugin', 'packageinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 1, 0),
 (456, 'plg_installer_folderinstaller', 'plugin', 'folderinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 2, 0),
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 3, 0),
-(458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1009,7 +1009,9 @@ SELECT 456, 'plg_installer_folderinstaller', 'plugin', 'folderinstaller', 'insta
 UNION ALL
 SELECT 457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 3, 0
 UNION ALL
-SELECT 458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
+UNION ALL
+SELECT 453, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '1900-01-01 00:00:00', 0, 0

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1011,7 +1011,7 @@ SELECT 457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer',
 UNION ALL
 SELECT 458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 453, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 INSERT [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '1900-01-01 00:00:00', 0, 0

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.menu
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Editor menu buton
+ *
+ * @since  3.7
+ */
+class PlgButtonMenu extends JPlugin
+{
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  3.7
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Display the button
+	 *
+	 * @param   string  $name  The name of the button to add
+	 *
+	 * @since  3.7
+	 * @return array
+	 */
+	public function onDisplay($name)
+	{
+		/*
+		 * Javascript to insert the link
+		 * View element calls jSelectMenuItem when a menu item is clicked
+		 * jSelectMenuItem creates the link tag, sends it to the editor,
+		 * and closes the select frame.
+		 */
+		$js = "
+		function jSelectMenuItem(id, title, tree, object, uri, language)
+		{
+			var thislang = '';
+			if (language !== '')
+			{
+				var thislang = '&lang=';
+			}
+			var tag = '<a href=\"' + uri + thislang + language + '\">' + title + '</a>';
+			jInsertEditorText(tag, '" . $name . "');
+			jModalClose();
+		}";
+
+		$doc = JFactory::getDocument();
+		$doc->addScriptDeclaration($js);
+
+		/*
+		 * Use the built-in element view to select the menu item.
+		 * Currently uses blank class.
+		 */
+		$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+
+		$button          = new JObject;
+		$button->modal   = true;
+		$button->class   = 'btn';
+		$button->link    = $link;
+		$button->text    = JText::_('PLG_MENU_BUTTON_MENU');
+		$button->name    = 'file-add';
+		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+
+		return $button;
+	}
+}

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Editor menu buton
  *
- * @since  3.7
+ * @since  __DEPLOY_VERSION__
  */
 class PlgButtonMenu extends JPlugin
 {
@@ -20,7 +20,7 @@ class PlgButtonMenu extends JPlugin
 	 * Load the language file on instantiation.
 	 *
 	 * @var    boolean
-	 * @since  3.7
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $autoloadLanguage = true;
 
@@ -29,7 +29,7 @@ class PlgButtonMenu extends JPlugin
 	 *
 	 * @param   string  $name  The name of the button to add
 	 *
-	 * @since  3.7
+	 * @since  __DEPLOY_VERSION__
 	 * @return array
 	 */
 	public function onDisplay($name)

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -66,8 +66,8 @@ class PlgButtonMenu extends JPlugin
 		$button->modal   = true;
 		$button->class   = 'btn';
 		$button->link    = $link;
-		$button->text    = JText::_('PLG_MENU_BUTTON_MENU');
-		$button->name    = 'file-add';
+		$button->text    = JText::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
+		$button->name    = 'share-alt';
 		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
 		return $button;

--- a/plugins/editors-xtd/menu/menu.xml
+++ b/plugins/editors-xtd/menu/menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.7" type="plugin" group="editors-xtd" method="upgrade">
+	<name>plg_editors-xtd_menu</name>
+	<author>Joomla! Project</author>
+	<creationDate>August 2016</creationDate>
+	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.7.0</version>
+	<description>PLG_MENU_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="menu">menu.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_editors-xtd_menu.ini</language>
+		<language tag="en-GB">en-GB.plg_editors-xtd_menu.sys.ini</language>
+	</languages>
+</extension>

--- a/plugins/editors-xtd/menu/menu.xml
+++ b/plugins/editors-xtd/menu/menu.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.7.0</version>
+	<version>__DEPLOY_VERSION__</version>
 	<description>PLG_MENU_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="menu">menu.php</filename>

--- a/plugins/editors-xtd/menu/menu.xml
+++ b/plugins/editors-xtd/menu/menu.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>__DEPLOY_VERSION__</version>
-	<description>PLG_MENU_XML_DESCRIPTION</description>
+	<description>PLG_EDITORS-XTD_MENU_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="menu">menu.php</filename>
 	</files>


### PR DESCRIPTION
Grace to the new modals for menu items, we can now add a new editor-xtd to insert menu items links in content.

Instructions:
Install a 3.7.0 (not necessary to patch first with https://github.com/joomla/joomla-cms/pull/11694 but modal title would look better)
Patch with this PR.
Discover the new plugin. Enable it.

Edit an article or create a new one
The editor now shows a new button "Menu"

![screen shot 2016-08-22 at 10 33 48](https://cloud.githubusercontent.com/assets/869724/17848692/18bc215a-6855-11e6-897a-8d83bdb71f0a.png)

depending if the site is multilingual or not, the language will be appended to the link when the menu item is tagged to a specific content language.

By toggling the editor you should get:
`<p><a href="index.php?Itemid=111">newsfeed category menu</a></p>`
or
`<p><a href="index.php?Itemid=107&amp;lang=fr-FR">menu article fr-FR</a></p>`

test the results in frontend.
