### PR TITLE
[plg_system_stats] Load plugin language files only when needed

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -44,14 +44,6 @@ class PlgSystemStats extends JPlugin
 	protected $app;
 
 	/**
-	 * Load plugin language files automatically
-	 *
-	 * @var    boolean
-	 * @since  3.5
-	 */
-	protected $autoloadLanguage = false;
-
-	/**
 	 * Database object
 	 *
 	 * @var    JDatabaseDriver
@@ -100,7 +92,7 @@ class PlgSystemStats extends JPlugin
 		}
 
 		// Load plugin language files only when needed (ex: they are not needed in site client).
-		parent::loadLanguage();
+		$this->loadLanguage();
 
 		JHtml::_('jquery.framework');
 		JHtml::script('plg_system_stats/stats.js', false, true, false);

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -49,7 +49,7 @@ class PlgSystemStats extends JPlugin
 	 * @var    boolean
 	 * @since  3.5
 	 */
-	protected $autoloadLanguage = true;
+	protected $autoloadLanguage = false;
 
 	/**
 	 * Database object
@@ -98,6 +98,9 @@ class PlgSystemStats extends JPlugin
 		{
 			return;
 		}
+
+		// Load plugin language files only when needed (if plugin enabled and user in administrator client).
+		parent::loadLanguage();
 
 		JHtml::_('jquery.framework');
 		JHtml::script('plg_system_stats/stats.js', false, true, false);

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -99,7 +99,7 @@ class PlgSystemStats extends JPlugin
 			return;
 		}
 
-		// Load plugin language files only when needed (if plugin enabled and user in administrator client).
+		// Load plugin language files only when needed (ex: they are not needed in site client).
 		parent::loadLanguage();
 
 		JHtml::_('jquery.framework');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11714.
### Summary of Changes

Only load the plg_system_stats languages files where they are needed.
Example: don't load them on frontend.

For more info see https://github.com/joomla/joomla-cms/issues/11714
### Testing Instructions
#### Reproduce
- Use latest staging
- Enable plugin system stats
- Enable debug and debug lang in global config
- Enable debug system plugin with all options activated
- Go to frontend and check the debug console
- Notice `JROOT/administrator/language/en-GB/en-GB.plg_system_stats.ini` language file is loaded.
#### Test patch
- Apply patch
- Repeat the steps above and check `JROOT/administrator/language/en-GB/en-GB.plg_system_stats.ini` language file is NOT loaded.
- Check plugin work as before in admin.
### Documentation Changes Required

None.
