### PR TITLE
[plg_content_vote|pagebreak] Load language files only when needed

### DIFF
--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -136,9 +136,16 @@ abstract class JPlugin extends JEvent
 			$extension = 'Plg_' . $this->_type . '_' . $this->_name;
 		}
 
-		$lang = JFactory::getLanguage();
+		$extension = strtolower($extension);
+		$lang      = JFactory::getLanguage();
 
-		return $lang->load(strtolower($extension), $basePath, null, false, true)
-			|| $lang->load(strtolower($extension), JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
+		// If language already loaded, don't load it again.
+		if ($lang->getPaths($extension))
+		{
+			return true;
+		}
+
+		return $lang->load($extension, $basePath, null, false, true)
+			|| $lang->load($extension, JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
 	}
 }

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -29,12 +29,12 @@ jimport('joomla.utilities.utility');
 class PlgContentPagebreak extends JPlugin
 {
 	/**
-	 * Load the language file on instantiation.
+	 * Flag to check if the language file is loaded.
 	 *
 	 * @var    boolean
-	 * @since  3.1
+	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $autoloadLanguage = true;
+	protected $languageLoaded = false;
 
 	/**
 	 * Plugin that adds a pagebreak into the text and truncates text at that point
@@ -98,6 +98,13 @@ class PlgContentPagebreak extends JPlugin
 			$row->text = preg_replace($regex, '', $row->text);
 
 			return;
+		}
+
+		// Load plugin language files only when needed (ex: not needed if no system-pagebreak class exists).
+		if (!$this->languageLoaded)
+		{
+			$this->loadLanguage();
+			$this->languageLoaded = true;
 		}
 
 		// Find all instances of plugin and put in $matches.

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -29,14 +29,6 @@ jimport('joomla.utilities.utility');
 class PlgContentPagebreak extends JPlugin
 {
 	/**
-	 * Flag to check if the language file is loaded.
-	 *
-	 * @var    boolean
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected $languageLoaded = false;
-
-	/**
 	 * Plugin that adds a pagebreak into the text and truncates text at that point
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin.
@@ -101,11 +93,7 @@ class PlgContentPagebreak extends JPlugin
 		}
 
 		// Load plugin language files only when needed (ex: not needed if no system-pagebreak class exists).
-		if (!$this->languageLoaded)
-		{
-			$this->loadLanguage();
-			$this->languageLoaded = true;
-		}
+		$this->loadLanguage();
 
 		// Find all instances of plugin and put in $matches.
 		$matches = array();

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -17,14 +17,6 @@ defined('_JEXEC') or die;
 class PlgContentVote extends JPlugin
 {
 	/**
-	 * Flag to check if the language file is loaded.
-	 *
-	 * @var    boolean
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected $languageLoaded = false;
-
-	/**
 	 * Displays the voting area if in an article
 	 *
 	 * @param   string   $context  The context of the content being passed to the plugin
@@ -50,11 +42,7 @@ class PlgContentVote extends JPlugin
 		if (!empty($params) && $params->get('show_vote', null))
 		{
 			// Load plugin language files only when needed (ex: they are not needed if show_vote is not active).
-			if (!$this->languageLoaded)
-			{
-				$this->loadLanguage();
-				$this->languageLoaded = true;
-			}
+			$this->loadLanguage();
 
 			$rating = (int) @$row->rating;
 

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -17,12 +17,12 @@ defined('_JEXEC') or die;
 class PlgContentVote extends JPlugin
 {
 	/**
-	 * Load the language file on instantiation.
+	 * Flag to check if the language file is loaded.
 	 *
 	 * @var    boolean
-	 * @since  3.1
+	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $autoloadLanguage = true;
+	protected $languageLoaded = false;
 
 	/**
 	 * Displays the voting area if in an article
@@ -49,6 +49,13 @@ class PlgContentVote extends JPlugin
 
 		if (!empty($params) && $params->get('show_vote', null))
 		{
+			// Load plugin language files only when needed (ex: they are not needed if show_vote is not active).
+			if (!$this->languageLoaded)
+			{
+				$this->loadLanguage();
+				$this->languageLoaded = true;
+			}
+
 			$rating = (int) @$row->rating;
 
 			$view = JFactory::getApplication()->input->getString('view', '');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11714 (part 2).
### Summary of Changes

Only load the plg_content_pagebreak and plg_content_vote languages files when they are needed.
Example: don't load them if the show_vote is not active or there is no pagebreak class.

For more info see #11714
### Testing Instructions
#### Reproduce
- Use latest staging
- Enable plugin content vote and plugin content pagebreak
- Enable debug and debug lang in global config
- Enable debug system plugin with all options activated
- Go to frontend and check the debug console
- Notice `JROOT/administrator/language/en-GB/en-GB.plg_content_vote.ini` and `JROOT/administrator/language/en-GB/en-GB.plg_content_pagebreak.ini` language file is loaded no matter what page you are (even in backend pages they are loaded).

![image](https://cloud.githubusercontent.com/assets/9630530/17861044/70613d78-6887-11e6-8550-a0844a83d3e2.png)
#### Test patch
- Apply patch
- Repeat the steps above and checkthe two language files are NOT loaded (except when needed). 
- Check plugin work as before if language files are required to load (ex: show_vote enabled / article with pagebreak, etc).
### Documentation Changes Required

None.
