### PR TITLE
[cache] Catch cache storage exception

### DIFF
--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -192,15 +192,17 @@ class JCache
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
-		// Get the storage
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->get($id, $group, $this->_options['checkTime']);
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->get($id, $group, $this->_options['checkTime']);
 	}
 
 	/**
@@ -217,15 +219,17 @@ class JCache
 			return false;
 		}
 
-		// Get the storage
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->getAll();
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->getAll();
 	}
 
 	/**
@@ -249,15 +253,18 @@ class JCache
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
-		// Get the storage and store the cached data
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->store($id, $group, $data);
+			// Get the storage
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->store($id, $group, $data);
 	}
 
 	/**
@@ -275,15 +282,17 @@ class JCache
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
-		// Get the storage
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->remove($id, $group);
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->remove($id, $group);
 	}
 
 	/**
@@ -304,15 +313,17 @@ class JCache
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
-		// Get the storage handler
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->clean($group, $mode);
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->clean($group, $mode);
 	}
 
 	/**
@@ -324,15 +335,17 @@ class JCache
 	 */
 	public function gc()
 	{
-		// Get the storage handler
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			return $handler->gc();
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
 		}
 
-		return false;
+		return $handler->gc();
 	}
 
 	/**
@@ -351,7 +364,7 @@ class JCache
 		$returning = new stdClass;
 		$returning->locklooped = false;
 
-		if (!$this->getCaching())
+		if (!$this->getCaching() || $this->_options['locking'] !== true)
 		{
 			$returning->locked = false;
 
@@ -368,19 +381,26 @@ class JCache
 		 * Allow storage handlers to perform locking on their own
 		 * NOTE drivers with lock need also unlock or unlocking will fail because of false $id
 		 */
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception) && $this->_options['locking'] == true)
+		try
 		{
-			$locked = $handler->lock($id, $group, $locktime);
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			$returning->locked = false;
 
-			if ($locked !== false)
-			{
-				return $locked;
-			}
+			return $returning;
 		}
 
-		// Fallback
+		$locked = $handler->lock($id, $group, $locktime);
+
+		if ($locked !== false)
+		{
+			return $locked;
+		}
+
+		// Fallback, current storage does not have implemented own lock method
 		$curentlifetime = $this->_options['lifetime'];
 
 		// Set lifetime to locktime for storing in children
@@ -389,28 +409,24 @@ class JCache
 		$looptime = $locktime * 10;
 		$id2      = $id . '_lock';
 
-		if ($this->_options['locking'] == true)
-		{
-			$data_lock = $this->get($id2, $group);
-		}
-		else
-		{
-			$data_lock         = false;
-			$returning->locked = false;
-		}
+		$data_lock = $this->get($id2, $group);
 
 		if ($data_lock !== false)
 		{
 			$lock_counter = 0;
 
-			// Loop until you find that the lock has been released. That implies that data get from other thread has finished
+			$returning->locklooped = true;
+
+			// Loop until you find that the lock has been released.
+			// That implies that data get from other thread has finished.
 			while ($data_lock !== false)
 			{
 				if ($lock_counter > $looptime)
 				{
+					// Timeout
 					$returning->locked = false;
-					$returning->locklooped = true;
-					break;
+
+					return $returning;
 				}
 
 				usleep(100);
@@ -419,10 +435,7 @@ class JCache
 			}
 		}
 
-		if ($this->_options['locking'] == true)
-		{
-			$returning->locked = $this->store(1, $id2, $group);
-		}
+		$returning->locked = $this->store(1, $id2, $group);
 
 		// Revert lifetime to previous one
 		$this->_options['lifetime'] = $curentlifetime;
@@ -452,26 +465,26 @@ class JCache
 		// Get the default group
 		$group = ($group) ? $group : $this->_options['defaultgroup'];
 
-		// Allow handlers to perform unlocking on their own
-		$handler = $this->_getStorage();
-
-		if (!($handler instanceof Exception))
+		try
 		{
-			$unlocked = $handler->unlock($id, $group);
+			$handler = $this->_getStorage();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			return false;
+		}
 
-			if ($unlocked !== false)
-			{
-				return $unlocked;
-			}
+		// Allow handlers to perform unlocking on their own
+		$unlocked = $handler->unlock($id, $group);
+
+		if ($unlocked !== false)
+		{
+			return $unlocked;
 		}
 
 		// Fallback
-		if ($this->getCaching())
-		{
-			$unlock = $this->remove($id . '_lock', $group);
-		}
-
-		return $unlock;
+		return $this->remove($id . '_lock', $group);
 	}
 
 	/**
@@ -480,6 +493,7 @@ class JCache
 	 * @return  JCacheStorage
 	 *
 	 * @since   11.1
+	 * @throws  RuntimeException
 	 */
 	public function &_getStorage()
 	{


### PR DESCRIPTION
### Summary of Changes

Do not block backend or frontend if cache handler stop working.

This is another version of #10815.
### Testing Instructions

**Instruction say to first apply PR and test then remove PR and test again (simple way), but you can do it backwards.**

1) Install the newest version of Joomla (3.6.2 or 3.6.3-dev)
2) In Global Configuration enable cache and set `Cache Handler` to  "File"
3) Now everything is working
4) Apply that PR.
5) Change file permission for directory `cache/` and `administrator/cache`, remove write access for all.  Set permission as 555 (or r-xr-xr-x)
6) Check administrator page and front end page.
7) Only notice about cache problem should be displayed but joomla works normal.
8) Revert patch
9) Back end now display "The file Cache Storage is not supported on this platform. " and you can not change anything.
On front page you see only raw text:

> Error displaying the error page: The file Cache Storage is not supported on this platform.: The file Cache Storage is not supported on this platform.
### Documentation Changes Required

No
