### PR TITLE
Deprecated Form getControlGroup / getControlGroups - com_banner

### DIFF
--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -56,16 +56,16 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'details', JText::_('COM_BANNERS_BANNER_DETAILS')); ?>
 		<div class="row-fluid">
 			<div class="span9">
-				<?php echo $this->form->getControlGroup('type'); ?>
+				<?php echo $this->form->renderField('type'); ?>
 				<div id="image">
-					<?php echo $this->form->getControlGroups('image'); ?>
+					<?php echo $this->form->renderFieldset('image'); ?>
 				</div>
 				<div id="custom">
-					<?php echo $this->form->getControlGroup('custombannercode'); ?>
+					<?php echo $this->form->renderField('custombannercode'); ?>
 				</div>
 				<?php
-				echo $this->form->getControlGroup('clickurl');
-				echo $this->form->getControlGroup('description');
+				echo $this->form->renderField('clickurl');
+				echo $this->form->renderField('description');
 				?>
 			</div>
 			<div class="span3">
@@ -75,7 +75,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'otherparams', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS')); ?>
-		<?php echo $this->form->getControlGroups('otherparams'); ?>
+		<?php echo $this->form->renderFieldset('otherparams'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('JGLOBAL_FIELDSET_PUBLISHING')); ?>
@@ -84,7 +84,7 @@ JFactory::getDocument()->addScriptDeclaration('
 				<?php echo JLayoutHelper::render('joomla.edit.publishingdata', $this); ?>
 			</div>
 			<div class="span6">
-				<?php echo $this->form->getControlGroups('metadata'); ?>
+				<?php echo $this->form->renderFieldset('metadata'); ?>
 			</div>
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -35,12 +35,12 @@ JFactory::getDocument()->addScriptDeclaration('
 		<div class="row-fluid">
 			<div class="span9">
 				<?php
-				echo $this->form->getControlGroup('contact');
-				echo $this->form->getControlGroup('email');
-				echo $this->form->getControlGroup('purchase_type');
-				echo $this->form->getControlGroup('track_impressions');
-				echo $this->form->getControlGroup('track_clicks');
-				echo $this->form->getControlGroups('extra');
+				echo $this->form->renderField('contact');
+				echo $this->form->renderField('email');
+				echo $this->form->renderField('purchase_type');
+				echo $this->form->renderField('track_impressions');
+				echo $this->form->renderField('track_clicks');
+				echo $this->form->renderFieldset('extra');
 				?>
 			</div>
 			<div class="span3">
@@ -50,7 +50,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'metadata', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS')); ?>
-		<?php echo $this->form->getControlGroups('metadata'); ?>
+		<?php echo $this->form->renderFieldset('metadata'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` and `getControlGroups` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php)
com_banner part
### Testing Instructions
- Take a look at the component Banner : Client (edit and new) and Banner (edit and new)
- Patch
- Take a look again , nothing changed 
