### PR TITLE
Deprecated getControlGroup com_newsfeed

### DIFF
--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -55,8 +55,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<div class="row-fluid">
 			<div class="span9">
 				<div class="form-vertical">
-					<?php echo $this->form->getControlGroup('link'); ?>
-					<?php echo $this->form->getControlGroup('description'); ?>
+					<?php echo $this->form->renderField('link'); ?>
+					<?php echo $this->form->renderField('description'); ?>
 				</div>
 			</div>
 			<div class="span3">
@@ -68,9 +68,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('JGLOBAL_FIELDSET_IMAGE_OPTIONS')); ?>
 		<div class="row-fluid">
 			<div class="span6">
-					<?php echo $this->form->getControlGroup('images'); ?>
+					<?php echo $this->form->renderField('images'); ?>
 					<?php foreach ($this->form->getGroup('images') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
+						<?php echo $field->renderField(); ?>
 					<?php endforeach; ?>
 				</div>
 			</div>


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php) and `getControlGroup` of [JField](https://github.com/joomla/joomla-cms/blob/979e5ef659ba5d6c2851a7401dc90e54ece7eeb4/libraries/joomla/form/field.php)
com_newsfeed part
### Testing Instructions
- Take a look at the component Newsfeed (edit and new)
- Patch
- Take a look again , nothing changed
