### PR TITLE
Deprecated Form getControlGroup / getControlGroups - com_menus

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -94,24 +94,24 @@ $tmpl = $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
 		<div class="row-fluid">
 			<div class="span9">
 				<?php
-				echo $this->form->getControlGroup('type');
+				echo $this->form->renderField('type');
 
 				if ($this->item->type == 'alias')
 				{
-					echo $this->form->getControlGroups('aliasoptions');
+					echo $this->form->renderFieldset('aliasoptions');
 				}
 
-				echo $this->form->getControlGroups('request');
+				echo $this->form->renderFieldset('request');
 
 				if ($this->item->type == 'url')
 				{
 					$this->form->setFieldAttribute('link', 'readonly', 'false');
 				}
 
-				echo $this->form->getControlGroup('link');
+				echo $this->form->renderField('link');
 
-				echo $this->form->getControlGroup('browserNav');
-				echo $this->form->getControlGroup('template_style_id');
+				echo $this->form->renderField('browserNav');
+				echo $this->form->renderField('template_style_id');
 				?>
 			</div>
 			<div class="span3">


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` and `getControlGroups` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php)
com_menus part
### Testing Instructions
- Take a look at the component Menus : Item (edit and new)
- Patch
- Take a look again , nothing changed 
