### PR TITLE
Deprecated Form getControlGroup - com_tags

### DIFF
--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -38,7 +38,7 @@ $this->ignore_fieldsets = array('jmetadata');
 		<div class="row-fluid">
 			<div class="span9">
 				<div class="form-vertical">
-					<?php echo $this->form->getControlGroup('description'); ?>
+					<?php echo $this->form->renderField('description'); ?>
 				</div>
 			</div>
 			<div class="span3">


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php)
com_tags part
### Testing Instructions
- Take a look at the component Tags : edit and new
- Patch
- Take a look again , nothing changed
