### PR TITLE
Deprecated getControlGroup - com_content

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -109,14 +109,14 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('COM_CONTENT_FIELDSET_URLS_AND_IMAGES')); ?>
 			<div class="row-fluid form-horizontal-desktop">
 				<div class="span6">
-					<?php echo $this->form->getControlGroup('images'); ?>
+					<?php echo $this->form->renderField('images'); ?>
 					<?php foreach ($this->form->getGroup('images') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
+						<?php echo $field->renderField(); ?>
 					<?php endforeach; ?>
 				</div>
 				<div class="span6">
 					<?php foreach ($this->form->getGroup('urls') as $field) : ?>
-						<?php echo $field->getControlGroup(); ?>
+						<?php echo $field->renderField(); ?>
 					<?php endforeach; ?>
 				</div>
 			</div>


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php) and `getControlGroup` of [JField](https://github.com/joomla/joomla-cms/blob/979e5ef659ba5d6c2851a7401dc90e54ece7eeb4/libraries/joomla/form/field.php)
com_content part
### Testing Instructions
- Take a look at the component Content : Article (edit and new)
- Patch
- Take a look again , nothing changed
