### PR TITLE
Deprecated Form getControlGroup - com_modules

### DIFF
--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -228,7 +228,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			</div>
 			<div class="span3">
 				<fieldset class="form-vertical">
-					<?php echo $this->form->getControlGroup('showtitle'); ?>
+					<?php echo $this->form->renderField('showtitle'); ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('position'); ?>


### PR DESCRIPTION
Removing the use of deprecated function `getControlGroup` of [JForm](https://github.com/joomla/joomla-cms/blob/68e7b4426a6b40d9096ef1d13a156ea06a763f62/libraries/joomla/form/form.php)
com_modules part
### Testing Instructions
- Take a look at the component Modules: edit and new
- Patch
- Take a look again , nothing changed
