### PR TITLE
Typecast the profiler's memory marks to floats

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -533,7 +533,7 @@ class PlgSystemDebug extends JPlugin
 		foreach (JProfiler::getInstance('Application')->getMarks() as $mark)
 		{
 			$totalTime += $mark->time;
-			$totalMem += $mark->memory;
+			$totalMem += (float) $mark->memory;
 			$htmlMark = sprintf(
 				JText::_('PLG_DEBUG_TIME') . ': <span class="label label-time">%.2f&nbsp;ms</span> / <span class="label label-default">%.2f&nbsp;ms</span>'
 				. ' ' . JText::_('PLG_DEBUG_MEMORY') . ': <span class="label label-memory">%0.3f MB</span> / <span class="label label-default">%0.2f MB</span>'
@@ -601,7 +601,7 @@ class PlgSystemDebug extends JPlugin
 			);
 
 			$barsMem[] = (object) array(
-				'width' => round($mark->memory / ($totalMem / 100), 4),
+				'width' => round((float) $mark->memory / ($totalMem / 100), 4),
 				'class' => $barClassMem,
 				'tip' => $mark->tip . ' ' . round($mark->memory, 3) . '  MB',
 			);


### PR DESCRIPTION
### Summary of Changes

On PHP 7.1 a `A non-numeric value encountered` warning is raised on these lines.  The values are used for arithmetic operations so need to be numeric types first.

The issue is caused because `JProfiler::mark()` creates mark objects that prefix the time and memory values with a "+" or "-" symbol and the "+" symbol isn't allowed with numeric types.  Since these aren't explicitly typecasted before the arithmetic operation (either by us or by PHP), it seems a change in 7.1 causes these new warnings.
### Testing Instructions

Enable debug mode and the debug plugin.  It should still work with correct output pre- and post- patch.  If running a PHP 7.1 environment, you should be able to confirm the warning goes away.
### Documentation Changes Required

N/A
