### PR TITLE
Don't crash on non JSON value string

### DIFF
--- a/media/jui/js/cms-uncompressed.js
+++ b/media/jui/js/cms-uncompressed.js
@@ -42,7 +42,11 @@ if (jQuery) {
 					// Convert to array to allow multiple values in the field (e.g. type=list multiple) and normalize as string
 					if (!(typeof itemval === 'object'))
 					{
-						itemval = JSON.parse('["' + itemval + '"]');
+						try{
+							itemval = JSON.parse('["' + itemval + '"]');
+						}catch(ex){
+							itemval = [itemval];
+						}
 					}
 
 					// Test if any of the values of the field exists in showon conditions


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Error handling
### Testing Instructions

unstandard / ?wrong value: C:\xampp2\htdocs\modules\mod_djmegamenu\themes/classic
### Documentation Changes Required

it crash on wrong value, eg:
<option value="C:\xampp2\htdocs\modules\mod_djmegamenu\themes/classic" selected="selected">C:\xampp2\htdocs\modules\mod_djmegamenu\themes/classic</option>

//Code from djmegamenu (free) module admin
