### PR TITLE
Test fixes

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
@@ -43,6 +43,7 @@ class JHtmlBootstrapTest extends TestCase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$config = $this->getMockConfig();
 		JFactory::$document = $this->getMockDocument();
 
 		$this->backupServer = $_SERVER;

--- a/tests/unit/suites/libraries/cms/html/JHtmlFormbehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlFormbehaviorTest.php
@@ -38,6 +38,7 @@ class JHtmlFormbehaviorTest extends TestCase
 		parent::setUp();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$config = $this->getMockConfig();
 		JFactory::$document = $this->getMockDocument();
 
 		$this->backupServer = $_SERVER;

--- a/tests/unit/suites/libraries/cms/html/JHtmlJqueryTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlJqueryTest.php
@@ -44,6 +44,7 @@ class JHtmlJqueryTest extends TestCase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$config = $this->getMockConfig();
 		JFactory::$document = $this->getMockDocument();
 
 		$this->backupServer = $_SERVER;

--- a/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaPhotoTest.php
+++ b/tests/unit/suites/libraries/joomla/google/JGoogleDataPicasaPhotoTest.php
@@ -322,7 +322,7 @@ class JGoogleDataPicasaPhotoTest extends TestCase
 	 */
 	public function testSetTime()
 	{
-		$time = $this->object->setTime('FIX')->getTime();
+		$time = $this->object->setTime(0)->getTime();
 		$this->assertEquals($time, 0);
 	}
 


### PR DESCRIPTION
### Summary of Changes
- Tests in `JHtml` classes are flaky because the configuration is not mocked; if the "live" config is used and in debug mode this can cause test failures due to the wrong file being loaded
- Fix for PHP 7.1 - Backports https://github.com/joomla-framework/google-api/commit/43e6400b22aeb30f52d77123ad1b47f7820e8ed6 to fix the test case incorrectly injecting a string value when the method is expecting an integer
### Testing Instructions
- Unit tests continue to pass
### Documentation Changes Required

N/A
