### PR TITLE
Improvement: Adding the forced language in the modal title for Articles

### DIFF
--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -115,6 +115,11 @@ class JFormFieldModal_Article extends JFormField
 		{
 			$linkArticles .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkArticle  .= '&amp;forcedLanguage=' . $this->element['language'];
+			$modalTitle    = JText::_('COM_CONTENT_CHANGE_ARTICLE') . ' &#8212; ' . $this->element['label'];
+		}
+		else
+		{
+			$modalTitle    = JText::_('COM_CONTENT_CHANGE_ARTICLE');
 		}
 
 		$urlSelect = $linkArticles . '&amp;' . JSession::getFormToken() . '=1';
@@ -192,7 +197,7 @@ class JFormFieldModal_Article extends JFormField
 			'bootstrap.renderModal',
 			'articleSelect' . $this->id . 'Modal',
 			array(
-				'title'       => JText::_('COM_CONTENT_CHANGE_ARTICLE'),
+				'title'       => $modalTitle,
 				'url'         => $urlSelect,
 				'height'      => '400px',
 				'width'       => '800px',


### PR DESCRIPTION
Similar to #11718 and #11717
Multilingual site
After patch when selecting an article in the Associations tab we will get the following modal

![screen shot 2016-08-23 at 07 21 19](https://cloud.githubusercontent.com/assets/869724/17881187/acaa6b02-6903-11e6-9caa-88f84e4493e6.png)

@jreys @brianteeman @andrepereiradasilva @jeckodevelopment 
