### PR TITLE
[com_contact] add missing `row` class

### DIFF
--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -44,7 +44,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 				<?php if (in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 					<?php if ($this->items[$i]->published == 0) : ?>
-						<li class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
+						<li class="row system-unpublished cat-list-row<?php echo $i % 2; ?>">
 					<?php else: ?>
 						<li class="row cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -39,26 +39,32 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	</fieldset>
 	<?php endif; ?>
 
-		<ul class="category list-striped">
+	<table class="category table table-striped table-bordered table-hover">
+		<tbody>
 			<?php foreach ($this->items as $i => $item) : ?>
 
 				<?php if (in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 					<?php if ($this->items[$i]->published == 0) : ?>
-						<li class="row system-unpublished cat-list-row<?php echo $i % 2; ?>">
+						<tr class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
 					<?php else: ?>
-						<li class="row cat-list-row<?php echo $i % 2; ?>" >
+						<tr class="cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>
 
+					<td>
+
 					<?php if ($this->params->get('show_image_heading')) : ?>
+						<?php $contact_width = 7; ?>
 						<div class="span2 col-md-2">
 							<?php if ($this->items[$i]->image) : ?>
 								<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
 									<?php echo JHtml::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?></a>
 							<?php endif; ?>
 						</div>
+					<?php else : ?>
+						<?php $contact_width = 9; ?>
 					<?php endif; ?>
 
-					<div class="list-title span7 col-md-7">
+					<div class="list-title span<?php echo $contact_width; ?> col-md-<?php echo $contact_width; ?>">
 						<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
 							<?php echo $item->name; ?></a>
 						<?php if ($this->items[$i]->published == 0) : ?>
@@ -102,10 +108,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					</div>
 
 					<?php echo $item->event->afterDisplayContent; ?>
-				</li>
+
+					</td>
+				</tr>
+
 				<?php endif; ?>
 			<?php endforeach; ?>
-		</ul>
+		</tbody>
+	</table>
 
 		<?php if ($this->params->get('show_pagination', 2)) : ?>
 		<div class="pagination">


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Add missing css class `row`  to the file '/components/com_contact/views/category/tmpl/default_items.php' for unpublished contacts.
### Testing Instructions

On admin panel:
1) Create some test contacts, unpublish a few of them.
2) Create test menu item of type 'Contacts' - 'List Contacts in a Category'.
3) Set the style 'protostar' as default.
On site:
1) Login as administrator.
2) Go to the test page.
![image](https://cloud.githubusercontent.com/assets/20832832/17886221/71cd4614-6929-11e6-902c-7894c8a9e9bb.png)
### Documentation Changes Required

None
