### PR TITLE
Fix Media field lightbox in subform

### DIFF
--- a/media/system/css/modal.css
+++ b/media/system/css/modal.css
@@ -13,7 +13,7 @@
  */
 
 #sbox-overlay {
-	position: absolute;
+	position: fixed;
 	background-color: #000;
 	left: 0px;
 	top: 0px;


### PR DESCRIPTION
Pull Request for Issue #11755
#### Summary of Changes

This PR fixes a media field lightbox issue when additional subforms are added extending the page height. This results in the lightbox background no longer filling the page. Setting the lightbox background div (#sbox-overlay) to 'fixed' ensures the background remains within the viewport regardless of the page height.
#### Testing Instructions

Create ../modules/mod_login/text.xml to which add the following...

```
<?xml version="1.0" encoding="UTF-8"?>
<form>
    <fieldset name="images" class="image-subform">
        <field name="image" type="media" default="" label="Label1"  description="Desc1" size="30" />
        <field name="text" type="textarea" filter="raw" rows="10" cols="42" default="" label="Label2" description="Desc2" />
    </fieldset>
</form>
```

Add the following to the mod_login.xml file:

```
<field name="subformtest" type="subform" formsource="modules/mod_login/text.xml" class="advancedSelect" min="1" max="50" multiple="true" layout="joomla.form.field.subform.repeatable" groupByFieldset="true" label="Image(s)" description="Add image(s) to display in gallery" />
```

Then in the Module Manager, open the Login module. Add a number of subforms extending the page height. Click 'Select' in the last subform.

**Before patch**

![screen1](https://cloud.githubusercontent.com/assets/2803503/17894096/14cb3234-6940-11e6-9eb6-67487f21ea82.jpg)

**After Patch**

![screen2](https://cloud.githubusercontent.com/assets/2803503/17894107/1dee6ed0-6940-11e6-8d94-e65b6382a23c.jpg)
