### PR TITLE
Initialize $result in addAttachment(), in case $path is an empty array

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -451,6 +451,8 @@ class JMail extends PHPMailer
 			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
 			try
 			{
+				$result = true;
+
 				if (is_array($path))
 				{
 					if (!empty($name) && count($path) != count($name))


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Initialize $result in addAttachment(), in case $path is an empty array, to avoid PHP tossing an "Undefined variable" warning.
### Testing Instructions

Read the code
### Documentation Changes Required

Nope
