### PR TITLE
[travis] Disable hhvm unit tests until things are solved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-      env: RUN_UNIT_TESTS == "no" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
+      env: RUN_UNIT_TESTS="no" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: 7.1
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-      env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
+      env: $RUN_UNIT_TESTS == "no" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: 7.1
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - mysql
         - postgresql
         - redis-server
-      env: $RUN_UNIT_TESTS == "no" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
+      env: RUN_UNIT_TESTS == "no" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
     - php: 7.1
     - php: hhvm


### PR DESCRIPTION
### Summary of Changes

hhvm tests in travis are taking around 4:30 in every commit to do ... basicly ... nothing.
You notices this delay clearly when there are several commits in the queue for tests: https://travis-ci.org/joomla/joomla-cms/pull_requests

![image](https://cloud.githubusercontent.com/assets/9630530/17913659/96c85944-6993-11e6-8fbe-547859d2f66d.png)

This PR disables them until issues with hhvm can be solved.
### Testing Instructions

Unit tests passed and hhvm takes less than 4 minutes.
### Documentation Changes Required

None.
