### PR TITLE
Regression: Normalising head links and correcting hreflang for menu items associations

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -74,7 +74,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if (!empty($base))
 		{
-			$buffer .= $tab . '<base href="' . $base . '" />' . $lnEnd;
+			$buffer .= $tab . '<base href="' . urldecode($base) . '" />' . $lnEnd;
 		}
 
 		// Generate META tags (needs to happen as early as possible in the head)

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -74,7 +74,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if (!empty($base))
 		{
-			$buffer .= $tab . '<base href="' . urldecode($base) . '" />' . $lnEnd;
+			$buffer .= $tab . '<base href="' . $base . '" />' . $lnEnd;
 		}
 
 		// Generate META tags (needs to happen as early as possible in the head)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -445,7 +445,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			if ($lang_code === $this->default_lang)
 			{
 				$redirectHttpCode = 301;
-			
+
 				// We cannot cache this redirect in browser. 301 is cachable by default so we need to force to not cache it in browsers.
 				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
@@ -453,7 +453,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				$this->app->setHeader('Pragma', 'no-cache');
 				$this->app->sendHeaders();
 			}
-			
+
 			// Redirect to language.
 			$this->app->redirect($redirectUri, $redirectHttpCode);
 		}
@@ -747,7 +747,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Current language link
 					case ($i == $this->current_lang):
-						$language->link = JUri::getInstance()->toString(array('path', 'query'));
+						$language->link = urldecode(JUri::getInstance()->toString(array('path', 'query')));
 						break;
 
 					// Component association

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -705,7 +705,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			if ($active)
 			{
 				$active_link  = JRoute::_($active->link . '&Itemid=' . $active->id, false);
-				$current_link = urldecode(JUri::getInstance()->toString(array('path', 'query')));
+				$current_link = JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()));
 
 				// Load menu associations
 				if ($active_link == $current_link)
@@ -747,7 +747,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Current language link
 					case ($i == $this->current_lang):
-						$language->link = urldecode(JUri::getInstance()->toString(array('path', 'query')));
+						$currentRelativeUrl = JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()));
+						$language->link = JUri::getInstance()->toString(array('scheme', 'host', 'port')) . $currentRelativeUrl;
 						break;
 
 					// Component association
@@ -758,6 +759,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Menu items association
 					// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
 					case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
+
 						$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
 						break;
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -693,19 +693,20 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($this->app->isSite() && $this->params->get('alternate_meta', 1) && $doc->getType() == 'html')
 		{
-			$languages = $this->lang_codes;
-			$homes = JLanguageMultilang::getSiteHomePages();
-			$menu = $this->app->getMenu();
-			$active = $menu->getActive();
-			$levels = JFactory::getUser()->getAuthorisedViewLevels();
+			$languages             = $this->lang_codes;
+			$homes                 = JLanguageMultilang::getSiteHomePages();
+			$menu                  = $this->app->getMenu();
+			$active                = $menu->getActive();
+			$levels                = JFactory::getUser()->getAuthorisedViewLevels();
 			$remove_default_prefix = $this->params->get('remove_default_prefix', 0);
-			$server = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
-			$is_home = false;
+			$server                = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
+			$is_home               = false;
+			$currentInternalUrl    = 'index.php?' . http_build_query($this->app->getRouter()->getVars());
 
 			if ($active)
 			{
-				$active_link  = JRoute::_($active->link . '&Itemid=' . $active->id, false);
-				$current_link = JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()));
+				$active_link  = JRoute::_($active->link . '&Itemid=' . $active->id);
+				$current_link = JRoute::_($currentInternalUrl);
 
 				// Load menu associations
 				if ($active_link == $current_link)
@@ -747,8 +748,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 					// Current language link
 					case ($i == $this->current_lang):
-						$currentRelativeUrl = JRoute::_('index.php?' . http_build_query($this->app->getRouter()->getVars()));
-						$language->link = JUri::getInstance()->toString(array('scheme', 'host', 'port')) . $currentRelativeUrl;
+						$language->link = JRoute::_($currentInternalUrl);
 						break;
 
 					// Component association

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -704,8 +704,8 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			if ($active)
 			{
-				$active_link = JRoute::_($active->link . '&Itemid=' . $active->id, false);
-				$current_link = JUri::getInstance()->toString(array('path', 'query'));
+				$active_link  = JRoute::_($active->link . '&Itemid=' . $active->id, false);
+				$current_link = urldecode(JUri::getInstance()->toString(array('path', 'query')));
 
 				// Load menu associations
 				if ($active_link == $current_link)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11759
### Summary of Changes

Adding urldecode for the $base as as for the languagefilter component associations
EDIT: took off that in final PR
### Testing Instructions

Enable unicode alias in global configuration. 
Multilingual site.
Enable Item associations on the language filter plugin  as well as Alternate meta tags
Associate items. One of the items should have some utf8 glyph in its alias.
Display the items one after the other, each time looking source for the hreflang produced (and the `<base` link when the item with utf8 alias is displayed)

The results are different: one hreflang (and <base in one case) is percent encoded, the other is not.

Patch: all links are now pure UTF8. No more percent encoding.

Instead of

```
<link href="http://localhost:8888/testwindows/trunkgitnew/fr/instructions-multilangue/33-ultimes-v%C3%A9rifications.html" rel="alternate" hreflang="fr-FR" />
<link href="http://localhost:8888/testwindows/trunkgitnew/en/multi-lingual-steps-by-steps/34-last-checks.html" rel="alternate" hreflang="en-GB" />
```

You will now get 

```
<link href="http://localhost:8888/testwindows/trunkgitnew/fr/instructions-multilangue/33-ultimes-vérifications.html" rel="alternate" hreflang="fr-FR" />
<link href="http://localhost:8888/testwindows/trunkgitnew/en/multi-lingual-steps-by-steps/34-last-checks.html" rel="alternate" hreflang="en-GB" />
```

when displaying one or the other associated item.

The base link will now be full utf8, example:
`<base href="http://localhost:8888/testwindows/trunkgitnew/fr/instructions-multilangue/33-ultimes-vérifications.html" />`
### Documentation Changes Required

None
