### PR TITLE
Display h1 header instead of h2

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -46,9 +46,9 @@ JHtml::_('behavior.caption');
 	<?php if ($params->get('show_title') || $params->get('show_author')) : ?>
 	<div class="page-header">
 		<?php if ($params->get('show_title')) : ?>
-			<h2 itemprop="headline">
+			<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1' ?> itemprop="headline">
 				<?php echo $this->escape($this->item->title); ?>
-			</h2>
+			</<?php echo $tag ?>>
 		<?php endif; ?>
 		<?php if ($this->item->state == 0) : ?>
 			<span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span>


### PR DESCRIPTION
### Summary of Changes

When the page header is not shown, and the article title is shown, we have a `h2` tag, instead of `h1`. This PR checks if the h1 tag is already there, if so, the article title will have the h2 tag. If the page header is hidden, the `h1` tag is displayed.
