### PR TITLE
[UX Imp] Show file extension when renaming a file

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+
 ?>
 <div id="template-manager-rename" class="form-horizontal">
 	<div class="control-group">
@@ -17,7 +18,10 @@ defined('_JEXEC') or die;
 			</label>
 		</div>
 		<div class="controls">
-			<input class="input-xlarge" type="text" name="new_name" required />
+			<div class="input-append">
+				<input class="input-xlarge" type="text" name="new_name" required />
+				<span class="add-on">.<?php echo JFile::getExt($this->fileName); ?></span>
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Pull Request for Issue #11773 
### Summary of Changes

This PR appends the extension of the file after the input field to show the user that they do not need to manually type it in, and thus avoid confusion or errors:
### Testing Instructions

**Before:**
![before](https://cloud.githubusercontent.com/assets/2019801/17938186/ceb31e3c-6a1c-11e6-9900-27a4c2b4ab1b.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/2019801/17938197/d8beec4e-6a1c-11e6-84e1-0c68fe8574b7.png)
