### PR TITLE
Fix for 'enter' keystroke cancelling article

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/form/field/user.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/user.php
@@ -87,7 +87,7 @@ JHtml::script('jui/fielduser.min.js', false, true, false, false, true);
 				array(
 					'title'  => JText::_('JLIB_FORM_CHANGE_USER'),
 					'closeButton' => true,
-					'footer' => '<button class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</button>'
+					'footer' => '<button class="btn" data-dismiss="modal"></button>'
 				)
 			); ?>
 		<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #11765 .
### Summary of Changes

Strangely the issue appears to be related to the 'user' field (Publishing tab), specifically a hidden cancel button which is rendered from an override in the Isis template. Removing the 'cancel' text resolves the issue however this points to the correct solution been elsewhere. Anyone more familiar with the Isis template I suspect would have a better solution?
### Testing Instructions
1. Create a new article
2. Add an article title
3. Click the alias field (or any text field), add text (or not).
4. Hit 'enter' key

**Before patch**
Article is cancelled, navigating back to article manager.

**After patch**
Nothing
