### PR TITLE
[Force HTTPS] Allow also 401 code because of http authentication

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -140,7 +140,7 @@ class ConfigModelApplication extends ConfigModelForm
 				$response = JHttpFactory::getHttp($options)->get('https://' . $host . JUri::root(true) . '/', array('Host' => $host), 10);
 
 				// If available in HTTPS check also the status code.
-				if (!in_array($response->code, array(200, 503, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310), true))
+				if (!in_array($response->code, array(200, 503, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 401), true))
 				{
 					throw new RuntimeException('HTTPS version of the site returned an invalid HTTP status code.');
 				}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11735.
### Summary of Changes

Allow to save "Force HTTPS" "Administrator Only" or "Entire Site" if server behind Basic HTTP Authentication.
### Testing Instructions
- Put the website behind Basic HTTP Authentication.
- Go to global config and change try to "Force HTTPS" "Administrator Only" or "Entire Site", try to save.
- Result: Warning not possible
- Apply patch
- Try again, now you can save with no issues.
### Documentation Changes Required

None.
