### PR TITLE
Fix enter key triggering cancel button on forms

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default_batch_footer.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 
 defined('_JEXEC') or die;
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-client-id').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-client-id').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('banner.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -94,9 +94,9 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				'height'      => '370px',
 				'width'       => '300px',
 				'modalWidth'  => '40',
-				'footer'      => '<button class="btn" data-dismiss="modal" type="button"'
+				'footer'      => '<a class="btn" data-dismiss="modal" type="button"'
 						. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("COM_BANNERS_CANCEL") . '</button>'
+						. JText::_("COM_BANNERS_CANCEL") . '</a>'
 						. '<button class="btn btn-success" type="button"'
 						. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#exportBtn\').click();">'
 						. JText::_("COM_BANNERS_TRACKS_EXPORT") . '</button>',

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -201,8 +201,8 @@ class JFormFieldModal_Category extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
 			)
 		);
 
@@ -220,9 +220,9 @@ class JFormFieldModal_Category extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 						. ' onclick="jQuery(\'#categoryEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_footer.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('category.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -198,8 +198,8 @@ class JFormFieldModal_Contact extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
 			)
 		);
 
@@ -217,9 +217,9 @@ class JFormFieldModal_Contact extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 						. ' onclick="jQuery(\'#contactEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch_footer.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('contact.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -198,8 +198,8 @@ class JFormFieldModal_Article extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
 			)
 		);
 
@@ -217,9 +217,9 @@ class JFormFieldModal_Article extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 						. ' onclick="jQuery(\'#articleEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_content/views/articles/tmpl/default_batch_footer.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-user-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('article.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -124,8 +124,8 @@ echo JHtml::_(
 	'imagePreview',
 	array(
 		'title' => JText::_('COM_MEDIA_PREVIEW'),
-		'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+		'footer' => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 	),
 	'<div id="image" style="text-align:center;"><img id="imagePreviewSrc" src="../media/jui/img/alpha.png" alt="preview" style="max-width:100%; max-height:300px;"/></div>'
 );
@@ -135,8 +135,8 @@ echo JHtml::_(
 	'videoPreview',
 	array(
 		'title' => JText::_('COM_MEDIA_PREVIEW'),
-		'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+		'footer' => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 	),
 	'<div id="videoPlayer" style="z-index: -100;"><video id="mejsPlayer" style="height: 250px;"/></div>'
 );

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -96,8 +96,8 @@ class JFormFieldMenutype extends JFormFieldList
 				'height'     => '300px',
 				'modalWidth' => '80',
 				'bodyHeight' => '70',
-				'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+				'footer'     => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 			)
 		);
 		$html[] = '<input class="input-small" type="hidden" name="' . $this->name . '" value="'

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -144,9 +144,9 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 						'width'       => '800px',
 						'bodyHeight'  => '70',
 						'modalWidth'  => '80',
-						'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 								. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 								. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 								. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -10,9 +10,9 @@ defined('_JEXEC') or die;
 
 $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <?php if (strlen($menuType) && $menuType != '*') : ?>
 	<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
 		<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -187,9 +187,9 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 													'width'       => '800px',
 													'bodyHeight'  => '70',
 													'modalWidth'  => '80',
-													'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+													'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 															. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-															. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+															. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 															. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 															. ' onclick="jQuery(\'#moduleEdit' . $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 															. JText::_("JSAVE") . '</button>'
@@ -216,9 +216,9 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 											'width'       => '800px',
 											'bodyHeight'  => '70',
 											'modalWidth'  => '80',
-											'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+											'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 													. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#closeBtn\').click();">'
-													. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+													. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 													. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 													. ' onclick="jQuery(\'#moduleAddModal iframe\').contents().find(\'#saveBtn\').click();">'
 													. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-position-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('module.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -198,8 +198,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>',
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
 			)
 		);
 
@@ -217,9 +217,9 @@ class JFormFieldModal_Newsfeed extends JFormField
 				'width'       => '800px',
 				'bodyHeight'  => '70',
 				'modalWidth'  => '80',
-				'footer'      => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
 						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
 						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_footer.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-category-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value='';document.getElementById('batch-tag-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('newsfeed.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" data-dismiss="modal" type="button" onclick="document.getElementById('batch_urls').value='';">
+<a class="btn" data-dismiss="modal" type="button" onclick="document.getElementById('batch_urls').value='';">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('links.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch_footer.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-tag-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('tag.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/components/com_users/views/users/tmpl/default_batch_footer.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_footer.php
@@ -9,9 +9,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button class="btn" type="button" onclick="document.getElementById('batch-group-id').value=''" data-dismiss="modal">
+<a class="btn" type="button" onclick="document.getElementById('batch-group-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
-</button>
+</a>
 <button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('user.batch');">
 	<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 </button>

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -42,7 +42,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		'width'       => '800px',
 		'bodyHeight'  => '70',
 		'modalWidth'  => '80',
-		'footer'      => '<button class="btn" data-dismiss="modal" type="button" aria-hidden="true">'
-				. JText::_('JTOOLBAR_CLOSE') . '</button>',
+		'footer'      => '<a class="btn" data-dismiss="modal" type="button" aria-hidden="true">'
+				. JText::_('JTOOLBAR_CLOSE') . '</a>',
 	)
 );

--- a/administrator/templates/hathor/html/com_banners/tracks/default.php
+++ b/administrator/templates/hathor/html/com_banners/tracks/default.php
@@ -129,9 +129,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				'url'         => JRoute::_('index.php?option=com_banners&amp;view=download&amp;tmpl=component'),
 				'width'       => '100%',
 				'height'      => '300px',
-				'footer'      => '<button class="btn" data-dismiss="modal" type="button"'
+				'footer'      => '<a class="btn" data-dismiss="modal" type="button"'
 						. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("COM_BANNERS_CANCEL") . '</button>'
+						. JText::_("COM_BANNERS_CANCEL") . '</a>'
 						. '<button class="btn btn-success" type="button"'
 						. ' onclick="jQuery(\'#downloadModal iframe\').contents().find(\'#exportBtn\').click();">'
 						. JText::_("COM_BANNERS_TRACKS_EXPORT") . '</button>',

--- a/administrator/templates/hathor/html/com_menus/menus/default.php
+++ b/administrator/templates/hathor/html/com_menus/menus/default.php
@@ -161,8 +161,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 										'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 										'height' => '300px',
 										'width' => '800px',
-										'footer' => '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
-											. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+										'footer' => '<a class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
+											. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 											. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#module'
 											. $module->id . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 											. JText::_("JSAVE") . '</button>'
@@ -181,8 +181,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 								'title' => JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'),
 								'height' => '500px',
 								'width' => '800px',
-								'footer' => '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
-									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+								'footer' => '<a class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
+									. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 								)
 						); ?>
 					<?php endif; ?>

--- a/administrator/templates/isis/html/layouts/joomla/form/field/user.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/user.php
@@ -87,7 +87,7 @@ JHtml::script('jui/fielduser.min.js', false, true, false, false, true);
 				array(
 					'title'  => JText::_('JLIB_FORM_CHANGE_USER'),
 					'closeButton' => true,
-					'footer' => '<button class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</button>'
+					'footer' => '<a class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>'
 				)
 			); ?>
 		<?php endif; ?>

--- a/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
+++ b/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
@@ -32,8 +32,8 @@ echo JHtml::_(
 		'title'  => JText::_('COM_CONTENTHISTORY_MODAL_TITLE'),
 		'height' => '300px',
 		'width'  => '800px',
-		'footer' => '<button class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
-			. JText::_("JTOOLBAR_CLOSE") . '</button>'
+		'footer' => '<a class="btn" type="button" data-dismiss="modal" aria-hidden="true">'
+			. JText::_("JTOOLBAR_CLOSE") . '</a>'
 	)
 );
 ?>

--- a/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
+++ b/templates/protostar/html/layouts/joomla/form/field/contenthistory.php
@@ -52,8 +52,8 @@ echo JHtml::_(
 		'title'  => $label,
 		'height' => '300px',
 		'width'  => '800px',
-		'footer' => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+		'footer' => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
+			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
 	)
 );
 

--- a/templates/protostar/html/layouts/joomla/form/field/user.php
+++ b/templates/protostar/html/layouts/joomla/form/field/user.php
@@ -87,7 +87,7 @@ JHtml::script('jui/fielduser.min.js', false, true, false, false, true);
 				array(
 					'title'  => JText::_('JLIB_FORM_CHANGE_USER'),
 					'closeButton' => true,
-					'footer' => '<button type="button" class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</button>'
+					'footer' => '<a type="button" class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>'
 				)
 			); ?>
 		<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #11765 .
### Summary of Changes

Change button tag to a
### Testing Instructions

Create a new article
Add an article title
Click the alias field (or any text field), add text (or not).
Hit 'enter' key
#### Before patch

Article is cancelled, navigating back to article manager.
#### After patch

Nothing
### Documentation Changes Required

None
