### PR TITLE
Change message type to error when download of update package fails

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -53,6 +53,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 			JFactory::getApplication()->setUserState('com_joomlaupdate.file', null);
 			$url = 'index.php?option=com_joomlaupdate';
 			$message = JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_DOWNLOADFAILED');
+			$messageType = 'error';
 		}
 
 		$this->setRedirect($url, $message, $messageType);


### PR DESCRIPTION
### Summary of Changes

When the download of the package by the updater failed a message is added, currently that is a green info message. This PR changes it to a red error message.

<img width="1479" alt="screenshot 2016-08-25 16 14 31" src="https://cloud.githubusercontent.com/assets/897638/17972530/55ae4bba-6adf-11e6-9565-86eb04923f9e.png">

After:

<img width="1480" alt="screenshot 2016-08-25 16 15 09" src="https://cloud.githubusercontent.com/assets/897638/17972541/61819262-6adf-11e6-8bd8-2e3672469e02.png">
### Testing Instructions

Just review code
### Documentation Changes Required

None
