### PR TITLE
[Installation] These are "warning" not "message" ...

### DIFF
--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -153,7 +153,7 @@ class InstallationModelLanguages extends JModelBase
 				$message = JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . JText::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				JFactory::getApplication()->enqueueMessage($message);
+				JFactory::getApplication()->enqueueMessage($message, 'warning');
 
 				continue;
 			}
@@ -167,7 +167,7 @@ class InstallationModelLanguages extends JModelBase
 				$message = JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . JText::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				JFactory::getApplication()->enqueueMessage($message);
+				JFactory::getApplication()->enqueueMessage($message, 'warning');
 
 				continue;
 			}
@@ -182,7 +182,7 @@ class InstallationModelLanguages extends JModelBase
 				$message = JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_INSTALL_LANGUAGE', $language->name);
 				$message .= ' ' . JText::_('INSTL_DEFAULTLANGUAGE_TRY_LATER');
 
-				JFactory::getApplication()->enqueueMessage($message);
+				JFactory::getApplication()->enqueueMessage($message, 'warning');
 
 				continue;
 			}


### PR DESCRIPTION
### Summary of Changes

Changes the message type from "message" (default) to "warning" when unable to install a language in the instalation process.

Before
![image](https://cloud.githubusercontent.com/assets/9630530/17980265/5fbad13e-6af6-11e6-9e95-acea4d0d734d.png)

After
![image](https://cloud.githubusercontent.com/assets/9630530/17980286/7837d7fc-6af6-11e6-9bd3-c8099cdb0d19.png)
### Testing Instructions

Code review.
### Documentation Changes Required

none.
