### PR TITLE
[installation] Add javascript message titles and ajax errors strings

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -467,8 +467,8 @@ final class InstallationApplicationWeb extends JApplicationCms
 			$lang = JFactory::getLanguage();
 
 			// Load joomla lib language strings.
-			$lang->load('joomla', JPATH_SITE) || $this->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
-			$lang->load('lib_joomla', JPATH_SITE) || $this->getLanguage()->load('lib_joomla', JPATH_ADMINISTRATOR);
+			$lang->load('joomla', JPATH_SITE) || $lang->load('joomla', JPATH_ADMINISTRATOR);
+			$lang->load('lib_joomla', JPATH_SITE) || $lang->load('lib_joomla', JPATH_ADMINISTRATOR);
 
 			$type = $this->input->get('format', 'html', 'word');
 

--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -466,6 +466,10 @@ final class InstallationApplicationWeb extends JApplicationCms
 		{
 			$lang = JFactory::getLanguage();
 
+			// Load joomla lib language strings.
+			$lang->load('joomla', JPATH_SITE) || $this->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
+			$lang->load('lib_joomla', JPATH_SITE) || $this->getLanguage()->load('lib_joomla', JPATH_ADMINISTRATOR);
+
 			$type = $this->input->get('format', 'html', 'word');
 
 			$attributes = array(

--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -466,10 +466,6 @@ final class InstallationApplicationWeb extends JApplicationCms
 		{
 			$lang = JFactory::getLanguage();
 
-			// Load joomla lib language strings.
-			$lang->load('joomla', JPATH_SITE) || $lang->load('joomla', JPATH_ADMINISTRATOR);
-			$lang->load('lib_joomla', JPATH_SITE) || $lang->load('lib_joomla', JPATH_ADMINISTRATOR);
-
 			$type = $this->input->get('format', 'html', 'word');
 
 			$attributes = array(

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -326,3 +326,16 @@ POSTGRESQL="PostgreSQL"
 SQLAZURE="Microsoft SQL Azure"
 SQLITE="SQLite"
 SQLSRV="Microsoft SQL Server"
+
+; Javascript message titles
+ERROR="Error"
+MESSAGE="Message"
+NOTICE="Notice"
+WARNING="Warning"
+
+; Javascript ajax error messages
+JLIB_JS_AJAX_ERROR_CONNECTION_ABORT="A connection abort has occurred while fetching the JSON data."
+JLIB_JS_AJAX_ERROR_NO_CONTENT="No content was returned."
+JLIB_JS_AJAX_ERROR_OTHER="An error has occurred while fetching the JSON data: HTTP %s status code."
+JLIB_JS_AJAX_ERROR_PARSE="A parse error has occurred while processing the following JSON data:<br/><code style="_QQ_"color:inherit;white-space:pre-wrap;padding:0;margin:0;border:0;background:inherit;"_QQ_">%s</code>"
+JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data."

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -19,6 +19,20 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 JHtml::_('script', 'installation/template/js/installation.js');
 
+
+// Load JavaScript message titles
+JText::script('ERROR');
+JText::script('WARNING');
+JText::script('NOTICE');
+JText::script('MESSAGE');
+
+// Add strings for JavaScript error translations.
+JText::script('JLIB_JS_AJAX_ERROR_CONNECTION_ABORT');
+JText::script('JLIB_JS_AJAX_ERROR_NO_CONTENT');
+JText::script('JLIB_JS_AJAX_ERROR_OTHER');
+JText::script('JLIB_JS_AJAX_ERROR_PARSE');
+JText::script('JLIB_JS_AJAX_ERROR_TIMEOUT');
+
 // Load the JavaScript translated messages
 JText::script('INSTL_PROCESS_BUSY');
 JText::script('INSTL_FTP_SETTINGS_CORRECT');


### PR DESCRIPTION
### Summary of Changes

Add javascript message titles and ajax errors strings to installation tempalte.

You will notice that now all installation warning, error, notices and message have title like in the rest of joomla.
![image](https://cloud.githubusercontent.com/assets/9630530/17981419/90706f1e-6afb-11e6-93d5-6f7c0cbefc59.png)
### Testing Instructions

Code review.
### Documentation Changes Required

None.
