### PR TITLE
com_search category does not display Creation date in results

### DIFF
--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -154,13 +154,13 @@ class PlgSearchCategories extends JPlugin
 		$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
 		$case_when .= ' ELSE ';
 		$case_when .= $a_id . ' END as slug';
-		$query->select('a.title, a.description AS text, \'\' AS created, \'2\' AS browsernav, a.id AS catid, ' . $case_when)
+		$query->select('a.title, a.description AS text, a.created_time AS created, \'2\' AS browsernav, a.id AS catid, ' . $case_when)
 			->from('#__categories AS a')
 			->where(
 				'(a.title LIKE ' . $text . ' OR a.description LIKE ' . $text . ') AND a.published IN (' . implode(',', $state) . ') AND a.extension = '
 				. $db->quote('com_content') . 'AND a.access IN (' . $groups . ')'
 			)
-			->group('a.id, a.title, a.description, a.alias')
+			->group('a.id, a.title, a.description, a.alias, a.created_time')
 			->order($order);
 
 		if ($app->isSite() && JLanguageMultilang::isEnabled())


### PR DESCRIPTION
Pull Request for Issue #11783 
### Summary of Changes

added the `created_time` query in the plugins/search/categories/categories.php
### Testing Instructions

Create a com_search menu item and set Created Date to Show in its Options.
Search  for a word present in a category description and also in an article.

Before patch: the Created date does not display for the category.
After patch it does:

![screen shot 2016-08-26 at 07 33 21](https://cloud.githubusercontent.com/assets/869724/17995287/b944e8a6-6b60-11e6-9f78-1b3384885b7f.png)
