### PR TITLE
Also allow use of IEC Binary prefix system for JHtmlNumber::bytes

### DIFF
--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -22,30 +22,44 @@ abstract class JHtmlNumber
 	 *
 	 * By default, the proper format will automatically be chosen.
 	 * However, one of the allowed unit types (viz. 'b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB') may also be used instead.
+	 * IEC standard unit types ('KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB') can be used as well.
 	 *
 	 * @param   string   $bytes      The number of bytes. Can be either numeric or suffixed format: 32M, 60K, 12G or 812b
-	 * @param   string   $unit       The type of unit to return. Special: Blank string '' for no unit and 'auto' to choose automatically (default)
+	 * @param   string   $unit       The type of unit to return, few special values are:
+	 *                               Blank string '' for no unit,
+	 *                               'auto' to choose automatically (default)
+	 *                               'binary' to choose automatically but use binary unit prefix
 	 * @param   integer  $precision  The number of digits to be used after the decimal place.
+	 * @param   bool     $iec        Whether to be aware of IEC standards. IEC prefixes are always acceptable in input.
+	 *                               When IEC is ON:  KiB = 1024 B, KB = 1000 B
+	 *                               When IEC is OFF: KiB = 1024 B, KB = 1024 B
 	 *
 	 * @return  string   The number of bytes in the proper units.
 	 *
 	 * @since   1.6
+	 * @see     https://en.wikipedia.org/wiki/Binary_prefix
 	 */
-	public static function bytes($bytes, $unit = 'auto', $precision = 2)
+	public static function bytes($bytes, $unit = 'auto', $precision = 2, $iec = false)
 	{
 		/*
-		 * Allowed 123.45, 123.45 M, 123.45 MB, 1.2345E+12MB, 1.2345E+12 MB etc.
-		 * i.e. – Any number in decimal digits or in sci. notation, optional space, optional 1-2 letter unit suffix
+		 * Allowed 123.45, 123.45 M, 123.45 Mi, 123.45 MB, 123.45 MiB, 1.2345E+12MB, 1.2345E+12 MB , 1.2345E+12 MiB etc.
+		 * i.e. – Any number in decimal digits or in sci. notation, optional space, optional 1-3 letter unit suffix
 		 */
 		if (is_numeric($bytes))
 		{
 			$oBytes = $bytes;
-			$oUnit  = null;
 		}
 		else
 		{
-			preg_match('/(.*?)\s?([KMGTPEZY]?B?)$/i', trim($bytes), $matches);
+			preg_match('/(.*?)\s?((?:[KMGTPEZY]i?)?B?)$/i', trim($bytes), $matches);
 			list(, $oBytes, $oUnit) = $matches;
+
+			if ($oUnit && is_numeric($oBytes))
+			{
+				$oBase  = $iec && strpos($oUnit, 'i') === false ? 1000 : 1024;
+				$factor = pow($oBase, stripos('BKMGTPEZY', $oUnit[0]));
+				$oBytes = $oBytes * $factor;
+			}
 		}
 
 		if (empty($oBytes) || !is_numeric($oBytes))
@@ -53,8 +67,7 @@ abstract class JHtmlNumber
 			return 0;
 		}
 
-		$factor = $oUnit ? pow(1024, stripos('BKMGTPEZY', $oUnit[0])) : 1;
-		$oBytes = round($oBytes * $factor);
+		$oBytes = round($oBytes);
 
 		// If no unit is requested return early
 		if ($unit === '')
@@ -62,17 +75,36 @@ abstract class JHtmlNumber
 			return (string) $oBytes;
 		}
 
-		$suffixes = array('b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
-
-		// Default automatic method
-		$i = floor(log($oBytes, 1024));
+		$stdSuffixes = array('b', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB');
+		$iecSuffixes = array('b', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB');
 
 		// User supplied method
-		if ($unit !== 'auto' && in_array($unit, $suffixes))
+		if (in_array($unit, $iecSuffixes))
 		{
-			$i = array_search($unit, $suffixes, true);
+			$base   = 1024;
+			$i      = array_search($unit, $iecSuffixes, true);
+			$suffix = $unit;
+		}
+		elseif (in_array($unit, $stdSuffixes))
+		{
+			$base   = $iec ? 1000 : 1024;
+			$i      = array_search($unit, $stdSuffixes, true);
+			$suffix = $unit;
+		}
+		elseif ($unit == 'binary')
+		{
+			$base   = 1024;
+			$i      = (int) floor(log($oBytes, $base));
+			$suffix = $iecSuffixes[$i];
+		}
+		else
+		{
+			// Default method
+			$base   = $iec ? 1000 : 1024;
+			$i      = (int) floor(log($oBytes, $base));
+			$suffix = $stdSuffixes[$i];
 		}
 
-		return round($oBytes / pow(1024, $i), (int) $precision) . ' ' . $suffixes[$i];
+		return round($oBytes / pow($base, $i), (int) $precision) . ' ' . $suffix;
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
@@ -158,6 +158,63 @@ class JHtmlNumberTest extends TestCase
 				'1.0752E+4 MB',
 				'GB'
 			),
+
+			// Test IEC aware input
+			array(
+				'1024000',
+				'1024 KB',
+				'',
+				2,
+				true
+			),
+			array(
+				'1048576',
+				'1024 KiB',
+				'',
+				2,
+				true
+			),
+
+			// Test IEC aware output with automatic unit
+			array(
+				'1 MB',
+				1000 * 1000,
+				'auto',
+				2,
+				true
+			),
+
+			// Test automatic binary units output
+			array(
+				'1 MiB',
+				1024 * 1024,
+				'binary',
+				2,
+				true
+			),
+			array(
+				'1 MiB',
+				1024 * 1024,
+				'binary',
+				2,
+				false
+			),
+
+			// Test IEC aware specific unit output
+			array(
+				'1000 KiB',
+				'1024 KB',
+				'KiB',
+				2,
+				true
+			),
+			array(
+				'1048.58 kB',
+				'1024 KiB',
+				'kB',
+				2,
+				true
+			),
 		);
 	}
 
@@ -166,18 +223,24 @@ class JHtmlNumberTest extends TestCase
 	 *
 	 * @param   string   $result     The expected result to match against.
 	 * @param   string   $bytes      The number of bytes. Can be either numeric or suffixed format: 32M, 60K, 12G or 812b
-	 * @param   string   $unit       The type of unit to return. Special: Blank string '' for no unit and 'auto' to choose automatically (default)
+	 * @param   string   $unit       The type of unit to return, few special values are:
+	 *                               Blank string '' for no unit,
+	 *                               'auto' to choose automatically (default)
+	 *                               'binary' to choose automatically but use binary unit prefix
 	 * @param   integer  $precision  The number of digits to be used after the decimal place.
+	 * @param   bool     $iec        Whether to be aware of IEC standards. IEC prefixes are always acceptable in input.
+	 *                               When IEC is ON:  KiB = 1024 B, KB = 1000 B
+	 *                               When IEC is OFF: KiB = 1024 B, KB = 1024 B
 	 *
 	 * @return  void
 	 *
 	 * @since        3.1
 	 * @dataProvider dataTestBytes
 	 */
-	public function testBytes($result, $bytes, $unit = 'auto', $precision = 2)
+	public function testBytes($result, $bytes, $unit = 'auto', $precision = 2, $iec = false)
 	{
 		$this->assertThat(
-			JHtml::_('number.bytes', $bytes, $unit, $precision),
+			JHtml::_('number.bytes', $bytes, $unit, $precision, $iec),
 			$this->equalTo($result)
 		);
 	}


### PR DESCRIPTION
### Summary of Changes

This PR is in succession with #11026.
With this patch the developers will be able to make use of IEC Binary prefixes for bytes calculation.

To be able to read `1 KB` as `1000 bytes`, you'd need to pass `true` as the last/4th argument to `JHtmlNumber::bytes` which will make the call IEC aware. Otherwise the function should behave same as previously without any B/C break, and stick to real world standard only.

This patch also makes you able to parse values which are already in IEC format like `1.5 GiB`, earlier this would return `0` as IEC prefixes were not supported.

To allow return value with automatic unit selection `auto` unit was already being used, and its still the same. To use automatic unit selection with IEC binary prefixed units the value `binary` should be used.

Newly supported units are: **KiB, MiB, GiB, TiB, PiB, EiB, ZiB, YiB**
### Testing Instructions
1. Test all the values mentioned in https://github.com/joomla/joomla-cms/pull/11026#issue-163841476
2. Additionally test the newly supported values as below:

``` php
echo JHtml::_('number.bytes', '1024 KB', '', 2, true). "\n";
echo JHtml::_('number.bytes', '1024 KiB', '', 2, true). "\n";
echo JHtml::_('number.bytes', 1000 * 1000, 'auto', 2, true). "\n";
echo JHtml::_('number.bytes', 1024 * 1024, 'binary', 2, true). "\n";
echo JHtml::_('number.bytes', 1024 * 1024, 'binary', 2, false). "\n";
echo JHtml::_('number.bytes', '1024 KB', 'KiB', 2, true). "\n";
echo JHtml::_('number.bytes', '1024 KiB', 'kB', 2, true). "\n";
```

This should return

```
1024000
1048576
1 MB
1 MiB
1 MiB
1000 KiB
1048.58 kB
```

When testing keep in mind the following:
- When IEC awareness is ON:  1 KiB = 1024 B, 1 KB = 1000 B
- When IEC awareness is OFF: 1 KiB = 1024 B, 1 KB = 1024 B
### Documentation Changes Required

The above note should be added to the documentation. I too can do that myself with appropriate guidance.
