### PR TITLE
[com_contact] add missing `row` class (V2)

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3690,7 +3690,8 @@ fieldset.uploadform {
 	background-color: #f5f5f5;
 }
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3349,7 +3349,8 @@ fieldset.uploadform {
 }
 
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .row-striped .row-fluid [class*="span"] {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -5995,7 +5995,8 @@ hr.hr-condensed {
 	background-color: #f5f5f5;
 }
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5995,7 +5995,8 @@ hr.hr-condensed {
 	background-color: #f5f5f5;
 }
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -39,14 +39,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	</fieldset>
 	<?php endif; ?>
 
-		<ul class="category list-striped">
+		<ul class="category row-striped">
 			<?php foreach ($this->items as $i => $item) : ?>
 
 				<?php if (in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 					<?php if ($this->items[$i]->published == 0) : ?>
-						<li class="system-unpublished cat-list-row<?php echo $i % 2; ?>">
+						<li class="row-fluid system-unpublished cat-list-row<?php echo $i % 2; ?>">
 					<?php else: ?>
-						<li class="row cat-list-row<?php echo $i % 2; ?>" >
+						<li class="row-fluid cat-list-row<?php echo $i % 2; ?>" >
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_image_heading')) : ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -50,15 +50,18 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endif; ?>
 
 					<?php if ($this->params->get('show_image_heading')) : ?>
+						<?php $contact_width = 7; ?>
 						<div class="span2 col-md-2">
 							<?php if ($this->items[$i]->image) : ?>
 								<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
 									<?php echo JHtml::_('image', $this->items[$i]->image, JText::_('COM_CONTACT_IMAGE_DETAILS'), array('class' => 'contact-thumbnail img-thumbnail')); ?></a>
 							<?php endif; ?>
 						</div>
+					<?php else : ?>
+						<?php $contact_width = 9; ?>
 					<?php endif; ?>
 
-					<div class="list-title span7 col-md-7">
+					<div class="list-title span<?php echo $contact_width; ?> col-md-<?php echo $contact_width; ?>">
 						<a href="<?php echo JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)); ?>">
 							<?php echo $item->name; ?></a>
 						<?php if ($this->items[$i]->published == 0) : ?>

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -77,29 +77,29 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<?php if ($this->params->get('show_email_headings')) : ?>
 								<?php echo $item->email_to; ?><br />
 						<?php endif; ?>
-						<?php if ($this->params->get('show_suburb_headings') AND !empty($item->suburb)) : ?>
+						<?php if ($this->params->get('show_suburb_headings') && !empty($item->suburb)) : ?>
 							<?php echo $item->suburb . ', '; ?>
 						<?php endif; ?>
 
-						<?php if ($this->params->get('show_state_headings') AND !empty($item->state)) : ?>
+						<?php if ($this->params->get('show_state_headings') && !empty($item->state)) : ?>
 							<?php echo $item->state . ', '; ?>
 						<?php endif; ?>
 
-						<?php if ($this->params->get('show_country_headings') AND !empty($item->country)) : ?>
+						<?php if ($this->params->get('show_country_headings') && !empty($item->country)) : ?>
 							<?php echo $item->country; ?><br />
 						<?php endif; ?>
 					</div>
 
 					<div class="span3 col-md-3">
-						<?php if ($this->params->get('show_telephone_headings') AND !empty($item->telephone)) : ?>
+						<?php if ($this->params->get('show_telephone_headings') && !empty($item->telephone)) : ?>
 							<?php echo JText::sprintf('COM_CONTACT_TELEPHONE_NUMBER', $item->telephone); ?><br />
 						<?php endif; ?>
 
-						<?php if ($this->params->get('show_mobile_headings') AND !empty ($item->mobile)) : ?>
+						<?php if ($this->params->get('show_mobile_headings') && !empty ($item->mobile)) : ?>
 								<?php echo JText::sprintf('COM_CONTACT_MOBILE_NUMBER', $item->mobile); ?><br />
 						<?php endif; ?>
 
-						<?php if ($this->params->get('show_fax_headings') AND !empty($item->fax) ) : ?>
+						<?php if ($this->params->get('show_fax_headings') && !empty($item->fax) ) : ?>
 							<?php echo JText::sprintf('COM_CONTACT_FAX_NUMBER', $item->fax); ?><br />
 						<?php endif; ?>
 					</div>

--- a/media/jui/css/bootstrap-extended.css
+++ b/media/jui/css/bootstrap-extended.css
@@ -255,7 +255,8 @@ hr.hr-condensed {
 	background-color: #f5f5f5;
 }
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -263,7 +263,8 @@ hr.hr-condensed {
 }
 
 .row-striped .row-fluid {
-	width: 97%; // lower than 100% since we have padding
+	width: 100%;
+	box-sizing: border-box; // box-sizing since we don't care about padding
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -5984,7 +5984,8 @@ hr.hr-condensed {
 	background-color: #f5f5f5;
 }
 .row-striped .row-fluid {
-	width: 97%;
+	width: 100%;
+	box-sizing: border-box;
 }
 .row-striped .row-fluid [class*="span"] {
 	min-height: 10px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -673,9 +673,3 @@ body.modal-open {
 li {
 	word-wrap: break-word;
 }
-
-/* Striped Row */
-.row-striped .row-fluid {
-	width: 100%;
-	box-sizing: border-box;
-}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -673,3 +673,9 @@ body.modal-open {
 li {
 	word-wrap: break-word;
 }
+
+/* Striped Row */
+.row-striped .row-fluid {
+	width: 100%;
+	box-sizing: border-box;
+}


### PR DESCRIPTION
Pull Request to replace https://github.com/joomla/joomla-cms/pull/11753
### Summary of Changes

This PR fixes the width for `.row-striped .row-fluid { }` and buckled rows on `com_contact`, **without** having to change the HTML markup
### Testing Instructions

See here: https://github.com/joomla/joomla-cms/pull/11753
### Results

**Before patch:**
![before](https://cloud.githubusercontent.com/assets/2019801/18004163/0940135c-6b8a-11e6-8b86-27699a4cd7e2.png)

**After patch:**
![after](https://cloud.githubusercontent.com/assets/2019801/18004169/0c8815a0-6b8a-11e6-8534-9e54ab01d972.png)
