### PR TITLE
JavaScript Tests - Change jQuery version to 1.12.4

### DIFF
--- a/tests/javascript/package.json
+++ b/tests/javascript/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"jasmine-core": "^2.4.1",
 		"jasmine-jquery": "^2.1.1",
-		"jquery": "^2.2.3",
+		"jquery": "^1.12.4",
 		"jquery-ui-bundle": "^1.11.4",
 		"karma": "^0.13.22",
 		"karma-coverage": "^1.0.0",


### PR DESCRIPTION
Pull Request for Issue #11602 .
### Summary of Changes

Changed the jQuery version used in JavaScript tests to 1.12.4 to match with the jQuery version used in Joomla.
### Testing Instructions

See if the Travis build passes. If you want to run it locally, please take a look at the documentation available [here](https://docs.joomla.org/Running_JavaScript_Tests_for_the_Joomla_CMS).
Also go through the code change.
