### PR TITLE
Fixed Ordering is not working when search filter is applied in plugin list view at backend

### DIFF
--- a/administrator/components/com_plugins/models/plugins.php
+++ b/administrator/components/com_plugins/models/plugins.php
@@ -146,7 +146,8 @@ class PluginsModelPlugins extends JModelList
 				}
 			}
 
-			$direction = ($this->getState('list.direction') == 'desc') ? -1 : 1;
+			$orderingDirection = strtolower($this->getState('list.direction'));
+			$direction         = ($orderingDirection == 'desc') ? -1 : 1;
 			JArrayHelper::sortObjects($result, $ordering, $direction, true, true);
 
 			$total = count($result);


### PR DESCRIPTION
### Summary of Changes

Fixed ordering when search filter is applied in plugin list view at administration side.
### Testing Instructions

Use search filter in plugin list view at administration side.
Try to sort records using Id or any another options in ordering dropdown.
Without applying this patch records are sorted in ascending order by default and other ordering options are not working.
After applying this patch ordering options are working fine.
