### PR TITLE
regression: Check whether the paths have been loaded, fix #11812

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -181,12 +181,17 @@ abstract class JModuleHelper
 		{
 			$lang = JFactory::getLanguage();
 
+			$coreLanguageDirectory      = JPATH_BASE;
+			$extensionLanguageDirectory = dirname($path);
+
+			$langPaths = $lang->getPaths();
+
 			// Only load the module's language file if it hasn't been already
-			if (!$lang->getPaths($module->module))
+			if (!$langPaths || (!isset($langPaths[$coreLanguageDirectory]) && !isset($langPaths[$extensionLanguageDirectory])))
 			{
 				// 1.5 or Core then 1.6 3PD
-				$lang->load($module->module, JPATH_BASE, null, false, true) ||
-					$lang->load($module->module, dirname($path), null, false, true);
+				$lang->load($module->module, $coreLanguageDirectory, null, false, true) ||
+					$lang->load($module->module, $extensionLanguageDirectory, null, false, true);
 			}
 
 			$content = '';


### PR DESCRIPTION
Pull Request for Issue #11812
### Summary of Changes

Further refine the loaded check to validate the extension has explicitly not been loaded previously or if it has whether the same paths will attempt to be loaded.
### Testing Instructions

See #11812
### Documentation Changes Required

This introduces three new variables which will scope creep into modules; `$coreLanguageDirectory`, `$extensionLanguageDirectory`, and `$langPaths`.  None of these variables are used after the module is included so there is no concern of them already being used in a module and being overwritten and breaking something later.
