### PR TITLE
Cleanup JDateTest

### DIFF
--- a/tests/unit/suites/libraries/joomla/date/JDateTest.php
+++ b/tests/unit/suites/libraries/joomla/date/JDateTest.php
@@ -14,8 +14,15 @@
  * @subpackage  Date
  * @since       11.3
  */
-class JDateTest extends TestCaseDatabase
+class JDateTest extends TestCase
 {
+	/**
+	 * Backup of the date format in use by JDate
+	 *
+	 * @var  string
+	 */
+	private $format;
+
 	/**
 	 * Object under test
 	 *
@@ -23,6 +30,41 @@ class JDateTest extends TestCaseDatabase
 	 * @since  11.3
 	 */
 	protected $object;
+
+	/**
+	 * Sets up the fixture.
+	 *
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->format = JDate::$format;
+
+		$this->object = new JDate('12/20/2007 11:44:56', 'America/New_York');
+	}
+
+	/**
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   3.6
+	 */
+	protected function tearDown()
+	{
+		unset($this->object);
+
+		JDate::$format = $this->format;
+
+		parent::tearDown();
+	}
 
 	/**
 	 * Test Cases for __construct
@@ -33,25 +75,13 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function cases__construct()
 	{
-		date_default_timezone_set('UTC');
-
-		return array(
+		$cases = array(
 			'basic' => array(
 				'12/23/2008 13:45',
 				null,
 				'Tue 12/23/2008 13:45',
 			),
-			'unix' => array(
-				strtotime('12/26/2008 13:45'),
-				null,
-				'Fri 12/26/2008 13:45',
-			),
 			'tzCT' => array(
-				'12/23/2008 13:45',
-				'US/Central',
-				'Tue 12/23/2008 13:45',
-			),
-			"tzCT" => array(
 				'12/23/2008 13:45',
 				'US/Central',
 				'Tue 12/23/2008 13:45',
@@ -62,6 +92,22 @@ class JDateTest extends TestCaseDatabase
 				'Tue 12/23/2008 13:45',
 			),
 		);
+
+		// Backup the default timezone before continuing - Using the system timezone apparently causes test failures
+		$timezone = new DateTimeZone(date_default_timezone_get());
+
+		date_default_timezone_set('UTC');
+
+		$cases['unix'] = array(
+			strtotime('12/26/2008 13:45'),
+			null,
+			'Fri 12/26/2008 13:45',
+		);
+
+		// Restore the timezone
+		date_default_timezone_set($timezone->getName());
+
+		return $cases;
 	}
 
 	/**
@@ -468,36 +514,6 @@ class JDateTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Sets up the fixture.
-	 *
-	 * This method is called before a test is executed.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	protected function setUp()
-	{
-		// Note: do not extend parent setUp method
-
-		$this->object = new JDate('12/20/2007 11:44:56', 'America/New_York');
-	}
-
-	/**
-	 * This method is called after a test is executed.
-	 *
-	 * @return  void
-	 *
-	 * @see     PHPUnit_Framework_TestCase::tearDown()
-	 * @since   3.6
-	 */
-	protected function tearDown()
-	{
-		unset($this->object);
-		// Note: we do not extend/call parent tearDown() method as per setUp()
-	}
-
-	/**
 	 * Testing the Constructor
 	 *
 	 * @param   string  $date          What time should be set?
@@ -520,7 +536,7 @@ class JDateTest extends TestCaseDatabase
 		);
 
  		$this->assertThat(
- 			$jdate->format('D m/d/Y H:i', true),
+ 			$jdate->format('D m/d/Y H:i', true, false),
  			$this->equalTo($expectedTime)
  		);
 	}
@@ -558,8 +574,6 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function test__toString()
 	{
-		JDate::$format = 'Y-m-d H:i:s';
-
 		$jdate = new JDate('2000-01-01 00:00:00');
 
 		$this->assertThat(
@@ -587,10 +601,7 @@ class JDateTest extends TestCaseDatabase
 			JDate::$format = $format;
 		}
 
-		$this->assertThat(
-			$this->object->__toString(),
-			$this->equalTo($expectedTime)
-		);
+		$this->assertEquals($expectedTime, (string) $this->object);
 	}
 
 	/**
@@ -603,17 +614,9 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testGetInstance()
 	{
-		$this->assertThat(
-			JDate::getInstance(),
-			$this->isInstanceOf('JDate')
-		);
+		$this->assertInstanceOf('JDate', JDate::getInstance());
 
-		JDate::$format = 'Y-m-d H:i:s';
-
-		$this->assertThat(
-			(string) JDate::getInstance('2000-01-01 00:00:00'),
-			$this->equalTo('2000-01-01 00:00:00')
-		);
+		$this->assertEquals('2000-01-01 00:00:00', (string) JDate::getInstance('2000-01-01 00:00:00'));
 	}
 
 	/**
@@ -632,25 +635,10 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testGetOffsetFromGmt($tz, $setTime, $hours, $expected)
 	{
-		if (is_null($tz))
-		{
-			$testJDate = new JDate($setTime);
-		}
-		else
-		{
-			$testJDate = new JDate($setTime, $tz);
-		}
+		$testJDate = new JDate($setTime, $tz);
+		$offset    = $testJDate->getOffsetFromGmt($hours);
 
-		if (is_null($hours))
-		{
-			$offset = $testJDate->getOffsetFromGmt();
-		}
-		else
-		{
-			$offset = $testJDate->getOffsetFromGmt($hours);
-		}
-
-		$this->assertThat($offset, $this->equalTo($expected));
+		$this->assertEquals($expected, $offset);
 	}
 
 	/**
@@ -668,10 +656,7 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testFormat($format, $local, $expected)
 	{
-		$this->assertThat(
-			$this->object->format($format, $local),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, $this->object->format($format, $local, false));
 	}
 
 	/**
@@ -690,23 +675,9 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testToRFC822($tz, $setTime, $local, $expected)
 	{
-		$language = JFactory::getLanguage();
-		$debug = $language->setDebug(true);
+		$testJDate = new JDate($setTime, $tz);
 
-		if (is_null($tz))
-		{
-			$testJDate = new JDate($setTime);
-		}
-		else
-		{
-			$testJDate = new JDate($setTime, $tz);
-		}
-
-		$this->assertThat(
-			$testJDate->toRFC822($local),
-			$this->equalTo($expected)
-		);
-		$language->setDebug($debug);
+		$this->assertEquals($expected, $testJDate->toRFC822($local));
 	}
 
 	/**
@@ -725,19 +696,9 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testToISO8601($tz, $setTime, $local, $expected)
 	{
-		if (is_null($tz))
-		{
-			$testJDate = new JDate($setTime);
-		}
-		else
-		{
-			$testJDate = new JDate($setTime, $tz);
-		}
+		$testJDate = new JDate($setTime, $tz);
 
-		$this->assertThat(
-			$testJDate->toISO8601($local),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, $testJDate->toISO8601($local));
 	}
 
 	/**
@@ -756,19 +717,9 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testToSql($tz, $setTime, $local, $expected)
 	{
-		if (is_null($tz))
-		{
-			$testJDate = new JDate($setTime);
-		}
-		else
-		{
-			$testJDate = new JDate($setTime, $tz);
-		}
+		$testJDate = new JDate($setTime, $tz);
 
-		$this->assertThat(
-			$testJDate->toSql($local),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, $testJDate->toSql($local, $this->getMockDatabase()));
 	}
 
 	/**
@@ -786,19 +737,9 @@ class JDateTest extends TestCaseDatabase
 	 */
 	public function testToUnix($tz, $setTime, $expected)
 	{
-		if (is_null($tz))
-		{
-			$testJDate = new JDate($setTime);
-		}
-		else
-		{
-			$testJDate = new JDate($setTime, $tz);
-		}
+		$testJDate = new JDate($setTime, $tz);
 
-		$this->assertThat(
-			$testJDate->toUnix(),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, $testJDate->toUnix());
 	}
 
 	/**
@@ -816,9 +757,7 @@ class JDateTest extends TestCaseDatabase
 	public function testSetTimezone($tz, $expected)
 	{
 		$this->object->setTimezone(new DateTimeZone($tz));
-		$this->assertThat(
-			$this->object->format('r', true),
-			$this->equalTo($expected)
-		);
+
+		$this->assertEquals($expected, $this->object->format('r', true));
 	}
 }


### PR DESCRIPTION
### Summary of Changes

The current test class pollutes the global state by:
- Changing the default system timezone for the process without restoring the original value
- Loading objects into `JFactory` without resetting state
- Changing the static `$format` variable of `JDate`

The current test class can be considered flaky because:
- It does not mock `JLanguage` and is therefore reliant on the system environment variables; if the test class is run with a non-English language configured it would fail

The test class is rewritten to:
- Restore global state when it makes changes
- No longer extend `TestCaseDatabase`; a database connection is NOT required for this test class
- Inject a mock database into the `toSql` tests instead of relying on a database connection from `JFactory`
- Instructs all tests dealing with formatting to NOT translate the values (this one is more tricky than injecting a mock language instance into `JFactory`; the system mock we have by default simply returns the string it is given so it is pretty much reliant on a "real" `JLanguage` instance)
### Testing Instructions

Ensure the unit tests pass
### Documentation Changes Required

N/A
