### PR TITLE
Improve JHtmlDate::relative() and its tests

### DIFF
--- a/libraries/cms/html/date.php
+++ b/libraries/cms/html/date.php
@@ -33,7 +33,7 @@ abstract class JHtmlDate
 		if (is_null($time))
 		{
 			// Get now
-			$time = JFactory::getDate('now');
+			$time = new JDate('now');
 		}
 
 		// Get the difference in seconds between now and the time

--- a/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
@@ -14,7 +14,7 @@
  * @subpackage  Html
  * @since       3.1
  */
-class JHtmlDateTest extends TestCase
+class JHtmlDateTest extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * Test data for the testRelative method
@@ -30,42 +30,36 @@ class JHtmlDateTest extends TestCase
 			// result - 1 hour ago
 			array(
 				'JLIB_HTML_DATE_RELATIVE_HOURS',
-				JFactory::getDate('2011-10-18 11:00:00'),
+				new JDate('2011-10-18 11:00:00'),
 				null,
-				JFactory::getDate('2011-10-18 12:00:00')
+				new JDate('2011-10-18 12:00:00')
 			),
 			// Result - 10 days ago
 			array(
 				'JLIB_HTML_DATE_RELATIVE_DAYS',
-				JFactory::getDate('2011-10-08 12:00:00'),
+				new JDate('2011-10-08 12:00:00'),
 				'day',
-				JFactory::getDate('2011-10-18 12:00:00')
+				new JDate('2011-10-18 12:00:00')
 			),
 			// Result - 3 weeks ago
 			array(
 				'JLIB_HTML_DATE_RELATIVE_WEEKS',
-				JFactory::getDate('2011-09-27 12:00:00'),
+				new JDate('2011-09-27 12:00:00'),
 				'week',
-				JFactory::getDate('2011-10-18 12:00:00')
+				new JDate('2011-10-18 12:00:00')
 			),
 			// Result - 10 minutes ago
 			array(
 				'JLIB_HTML_DATE_RELATIVE_MINUTES',
-				JFactory::getDate('2011-10-18 11:50:00'),
+				new JDate('2011-10-18 11:50:00'),
 				'minute',
-				JFactory::getDate('2011-10-18 12:00:00')
+				new JDate('2011-10-18 12:00:00')
 			),
-
-			/*
-			 Cannot test this result while running the full suite
-			 because the getDate function returns the time the suite starts testing
-
-			 result - Less than a minute ago
+			// Result - Less than a minute ago
 			array(
-			'JLIB_HTML_DATE_RELATIVE_LESSTHANAMINUTE',
-			JFactory::getDate('now'),
+				'JLIB_HTML_DATE_RELATIVE_LESSTHANAMINUTE',
+				new JDate('now'),
 			)
-			*/
 		);
 	}
 
@@ -85,9 +79,6 @@ class JHtmlDateTest extends TestCase
 	 */
 	public function testRelative($result, $date, $unit = null, $time = null)
 	{
-		$this->assertThat(
-			JHtml::_('date.relative', $date, $unit, $time),
-			$this->equalTo($result)
-		);
+		$this->assertEquals($result, JHtmlDate::relative($date, $unit, $time));
 	}
 }


### PR DESCRIPTION
### Summary of Changes

`JHtmlDate::relative()` will compare a time against "now" if a comparison time is not injected, however previously this would test against a `JDate` object pulled from the `JFactory::$dates` cache which could cause minor unexpected results on a long running process (specifically if comparing a time under a minute in difference, see the now uncommented unit test case).  The method will now always use a new `JDate` instance for "now" instead of pulling a potentially cached object.

`JHtmlDateTest` is improved by:
- Creating new `JDate` instances instead of polluting the global cache by calling `JFactory::getDate()`
- Running the test case for "less than a minute ago" since cached objects are no longer used
- Direct calling the method instead of relying on the `JHtml::_()` method resolver (causes additional unneeded code to be ran and tested)
### Testing Instructions

The return values for `JHtmlDate::relative()` will return as compared to when the method is triggered.  No longer does it compare against the time the "now" object was stored to `JFactory::$dates`.  This may cause a difference of seconds on some comparisons, this would be especially noticeable in a longer running process.
### Documentation Changes Required

N/A
