### PR TITLE
Inclusion of the installer plugins causes Bootstrap to load

### DIFF
--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -8,8 +8,6 @@
  */
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 /**
  * FolderInstaller Plugin.
  *

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('bootstrap.tooltip');
+
 $app = JFactory::getApplication('administrator');
 
 JFactory::getDocument()->addScriptDeclaration('

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 /**
  * PackageInstaller Plugin.
  *

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('bootstrap.tooltip');
+
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbuttonpackage = function()
 	{

--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JHtml::_('bootstrap.tooltip');
+
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbuttonurl = function()
 	{

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -8,8 +8,6 @@
  */
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 /**
  * UrlFolderInstaller Plugin.
  *


### PR DESCRIPTION
### Summary of Changes

The installer plugins added with 3.6.0 are arbitrarily calling `JHtml::_('bootstrap.tooltip')` as soon as the plugins are included because the method calls are outside the class declaration.  This is unacceptable, the media loading should be done in the correct place.
### Testing Instructions

Whatever's using tooltips should still work fine.
### Documentation Changes Required

Whatever workflow allowed this media load statement to be accepted in this spot needs to be corrected.
