### PR TITLE
Specifying template causes incorrect data to be used

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -520,7 +520,12 @@ final class JApplicationSite extends JApplicationCms
 				{
 					if ($tmpl->template == $template_override)
 					{
-						$template->template = $template_override;
+						$template = $tmpl;
+
+						$registry = new Registry;
+						$registry->loadString($template->params);
+						$template->params = $registry;
+
 						break;
 					}
 				}


### PR DESCRIPTION
### Summary of Changes

The frontend supports overriding the active template by passing a `template=` query parameter.  However, when this is passed, only the template name is overridden, ignoring all other data associated with the template (i.e. its params).  This is also inconsistent with our fallback behavior onto Beez3 when the specified or configured template cannot be found which does use that template's full configuration object.  This is corrected.
### Testing Instructions

Pre-patch, with Protostar as the active template, make a request to `index.php?template=beez3` and in the Beez3 index.php file add this line: `var_dump($this->params)`

You should have the Protostar template's parameters here.  Apply the patch and refresh the page, you should now have the Beez3 template's parameters.
### Documentation Changes Required

N/A
