### PR TITLE
Cleanup some form class tests

### DIFF
--- a/tests/unit/suites/libraries/cms/form/field/JFormFieldHeadertagTest.php
+++ b/tests/unit/suites/libraries/cms/form/field/JFormFieldHeadertagTest.php
@@ -25,26 +25,16 @@ class JFormFieldHeadertagTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetInput()
 	{
-		$form = new JForm('form1');
-
-		$this->assertThat(
-			$form->load('<form><field name="headertag" type="headertag" label="Header Tag" description="Header Tag listing" /></form>'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' XML string should load successfully.'
-		);
-
-		$field = new JFormFieldHeadertag($form);
-
-		$this->assertThat(
-			$field->setup($form->getXml()->field, 'value'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The setup method should return true.'
+		$field = new JFormFieldHeadertag;
+		$field->setup(
+			new SimpleXMLElement('<field name="headertag" type="headertag" label="Header Tag" description="Header Tag listing" />'),
+			'value'
 		);
 
 		$this->assertContains(
 			'<option value="h3">h3</option>',
 			$field->input,
-			'Line:' . __LINE__ . ' The getInput method should return an option with the header tags, verify H3 tag is in list.'
+			'The getInput method should return an option with the header tags, verify H3 tag is in list.'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/form/field/JFormFieldHelpsiteTest.php
+++ b/tests/unit/suites/libraries/cms/form/field/JFormFieldHelpsiteTest.php
@@ -73,27 +73,16 @@ class JFormFieldHelpsiteTest extends TestCase
 	 */
 	public function testGetInput()
 	{
-		$form = new JForm('form1');
-
-		$this->assertThat(
-			$form->load('<form><field name="helpsite" type="helpsite" label="Help Site" description="Help Site listing" /></form>'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' XML string should load successfully.'
-		);
-
-
-		$field = new JFormFieldHelpsite($form);
-
-		$this->assertThat(
-			$field->setup($form->getXml()->field, 'value'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The setup method should return true.'
+		$field = new JFormFieldHelpsite;
+		$field->setup(
+			new SimpleXMLElement('<field name="helpsite" type="helpsite" label="Help Site" description="Help Site listing" />'),
+			'value'
 		);
 
 		$this->assertContains(
 			'<option value="https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}">',
 			$field->input,
-			'Line:' . __LINE__ . ' The getInput method should return an option with a link to the help site.'
+			'The getInput method should return an option with a link to the help site.'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/form/field/JFormFieldModuletagTest.php
+++ b/tests/unit/suites/libraries/cms/form/field/JFormFieldModuletagTest.php
@@ -25,26 +25,16 @@ class JFormFieldModuletagTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testGetInput()
 	{
-		$form = new JForm('form1');
-
-		$this->assertThat(
-			$form->load('<form><field name="moduletag" type="moduletag" label="Module Tag" description="Module Tag listing" /></form>'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' XML string should load successfully.'
-		);
-
-		$field = new JFormFieldModuletag($form);
-
-		$this->assertThat(
-			$field->setup($form->getXml()->field, 'value'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The setup method should return true.'
+		$field = new JFormFieldModuletag;
+		$field->setup(
+			new SimpleXMLElement('<field name="moduletag" type="moduletag" label="Module Tag" description="Module Tag listing" />'),
+			'value'
 		);
 
 		$this->assertContains(
 			'<option value="nav">nav</option>',
 			$field->input,
-			'Line:' . __LINE__ . ' The getInput method should return an option with various opening tags, verify nav tag is in list.'
+			'The getInput method should return an option with various opening tags, verify nav tag is in list.'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/field/JFormFieldCategoryTest.php
+++ b/tests/unit/suites/libraries/joomla/form/field/JFormFieldCategoryTest.php
@@ -34,13 +34,10 @@ class JFormFieldCategoryTest extends TestCaseDatabase
 	 */
 	public function testGetInput()
 	{
-		$field = new JFormFieldCategory();
-
-		$this->assertTrue(
-			$field->setup(
-				new SimpleXmlElement('<field name="category" type="category" extension="com_content" />'),
-				'value'
-			)
+		$field = new JFormFieldCategory;
+		$field->setup(
+			new SimpleXmlElement('<field name="category" type="category" extension="com_content" />'),
+			'value'
 		);
 
 		$this->assertNotEmpty(

--- a/tests/unit/suites/libraries/joomla/form/field/JFormFieldComponentLayoutTest.php
+++ b/tests/unit/suites/libraries/joomla/form/field/JFormFieldComponentLayoutTest.php
@@ -35,13 +35,10 @@ class JFormFieldComponentLayoutTest extends TestCaseDatabase
 	 */
 	public function testGetInput()
 	{
-		$field = new JFormFieldComponentlayout();
-
-		$this->assertTrue(
-			$field->setup(
-				new SimpleXmlElement('<field name="componentlayout" type="componentlayout" extension="com_content" client_id="0" view="blog" />'),
-				'value'
-			)
+		$field = new JFormFieldComponentlayout;
+		$field->setup(
+			new SimpleXmlElement('<field name="componentlayout" type="componentlayout" extension="com_content" client_id="0" view="blog" />'),
+			'value'
 		);
 
 		$this->assertNotEmpty(

--- a/tests/unit/suites/libraries/joomla/form/field/JFormFieldModuleLayoutTest.php
+++ b/tests/unit/suites/libraries/joomla/form/field/JFormFieldModuleLayoutTest.php
@@ -36,12 +36,9 @@ class JFormFieldModuleLayoutTest extends TestCaseDatabase
 	public function testGetInput()
 	{
 		$field = new JFormFieldModulelayout();
-
-		$this->assertTrue(
-			$field->setup(
-				new SimpleXmlElement('<field name="modulelayout" type="modulelayout" module="mod_finder" client_id="0" />'),
-				'value'
-			)
+		$field->setup(
+			new SimpleXmlElement('<field name="modulelayout" type="modulelayout" module="mod_finder" client_id="0" />'),
+			'value'
 		);
 
 		$this->assertNotEmpty(

--- a/tests/unit/suites/libraries/joomla/form/rule/JFormRuleBooleanTest.php
+++ b/tests/unit/suites/libraries/joomla/form/rule/JFormRuleBooleanTest.php
@@ -8,92 +8,68 @@
  */
 
 /**
- * Test class for JFormRuleBoolean.
- *
- * @package     Joomla.UnitTest
- * @subpackage  Form
- * @since       11.1
+ * Test class for JFormRuleBoolean
  */
 class JFormRuleBooleanTest extends TestCase
 {
 	/**
-	 * Test the JFormRuleBoolean::test method.
+	 * Data provider for the failure test case
 	 *
-	 * @return void
+	 * @return  array
 	 */
-	public function testBoolean()
+	public function casesRuleFailure()
+	{
+		return array(
+			'bogus'                  => array('bogus'),
+			'0_anything'             => array('0_anything'),
+			'anything_1_anything'    => array('anything_1_anything'),
+			'anything_true_anything' => array('anything_true_anything'),
+			'anything_false'         => array('anything_false'),
+		);
+	}
+
+	/**
+	 * Data provider for the success test case
+	 *
+	 * @return  array
+	 */
+	public function casesRuleSuccess()
+	{
+		return array(
+			'integer zero' => array(0),
+			'string zero'  => array('0'),
+			'integer one'  => array(1),
+			'string one'   => array('1'),
+			'string true'  => array('true'),
+			'string false' => array('false'),
+		);
+	}
+
+	/**
+	 * @testdox  The boolean rule fails values that do not represent boolean values
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailure
+	 */
+	public function testRuleFailure($value)
 	{
 		$rule = new JFormRuleBoolean;
-		$xml = simplexml_load_string('<form><field name="foo" /></form>');
 
-		// Test fail conditions.
+		$this->assertFalse($rule->test(new SimpleXMLElement('<form><field name="foo" /></form>'), $value));
+	}
 
-		$this->assertThat(
-			$rule->test($xml->field, 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+	/**
+	 * @testdox  The boolean rule passes values that represent boolean values
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccess
+	 */
+	public function testRuleSuccess($value)
+	{
+		$rule = new JFormRuleBoolean;
 
-		$this->assertThat(
-			$rule->test($xml->field, '0_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 'anything_1_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 'anything_true_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 'anything_false'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-
-		// Test pass conditions.
-
-		$this->assertThat(
-			$rule->test($xml->field, 0),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, '0'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 1),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, '1'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 'true'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-
-		$this->assertThat(
-			$rule->test($xml->field, 'false'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
+		$this->assertTrue($rule->test(new SimpleXMLElement('<form><field name="foo" /></form>'), $value));
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/rule/JFormRuleColorTest.php
+++ b/tests/unit/suites/libraries/joomla/form/rule/JFormRuleColorTest.php
@@ -8,78 +8,67 @@
  */
 
 /**
- * Test class for JFormRuleColor.
- *
- * @package     Joomla.UnitTest
- * @subpackage  Form
- * @since       11.1
+ * Test class for JFormRuleColor
  */
 class JFormRuleColorTest extends TestCase
 {
 	/**
-	 * Test the JFormRuleColor::test method.
+	 * Data provider for the failure test case
 	 *
-	 * @return void
+	 * @return  array
 	 */
-	public function testColor()
-	{
-		$rule = new JFormRuleColor;
-		$xml = simplexml_load_string('<form><field name="color" /></form>');
-
-		// Test fail conditions.
-		$this->assertThat(
-			$rule->test($xml->field[0], 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-
-		// Test pass conditions.
-		$this->assertThat(
-			$rule->test($xml->field[0], '#000000'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The basic rule should pass and return true.'
-		);
-	}
-
-	/**
-	 * Test...
-	 *
-	 * @return array
-	 */
-	public function colorData()
+	public function casesRuleFailure()
 	{
 		return array(
-			array('#000000', true),
-			array('#', false),
-			array('#000', true),
-			array('#FFFFFF', true),
-			array('#EEE', true),
-			array('#A0A0A0', true),
-			array('#GGGGGG', false),
-			array('FFFFFF', false),
-			array('#GGG', false),
-			array('', false)
+			'bogus'        => array('bogus'),
+			'#GGGGGG'      => array('#GGGGGG'),
+			'FFFFFF'       => array('FFFFFF'),
+			'#GGG'         => array('#GGG'),
+			'empty string' => array(''),
 		);
 	}
 
 	/**
-	 * Test...
+	 * Data provider for the success test case
 	 *
-	 * @param   string  $color           @todo
-	 * @param   string  $expectedResult  @todo
-	 *
-	 * @dataProvider colorData
-	 *
-	 * @return void
+	 * @return  array
 	 */
-	public function testColorData($color, $expectedResult)
+	public function casesRuleSuccess()
+	{
+		return array(
+			'#000000' => array('#000000'),
+			'#000'    => array('#000'),
+			'#FFFFFF' => array('#FFFFFF'),
+			'#EEE'    => array('#EEE'),
+			'#A0A0A0' => array('#A0A0A0'),
+		);
+	}
+
+	/**
+	 * @testdox  The color rule fails values that are not valid hexadecimal color codes
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailure
+	 */
+	public function testRuleFailure($value)
 	{
 		$rule = new JFormRuleColor;
-		$xml = simplexml_load_string('<form><field name="color1" /></form>');
-		$this->assertThat(
-			$rule->test($xml->field[0], $color),
-			$this->equalTo($expectedResult),
-			$color . ' should have returned ' . ($expectedResult ? 'true' : 'false') . ' but did not'
-		);
+
+		$this->assertFalse($rule->test(new SimpleXMLElement('<form><field name="color" /></form>'), $value));
+	}
+
+	/**
+	 * @testdox  The color rule passes values that are valid hexadecimal color codes
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccess
+	 */
+	public function testRuleSuccess($value)
+	{
+		$rule = new JFormRuleColor;
+
+		$this->assertTrue($rule->test(new SimpleXMLElement('<form><field name="color" /></form>'), $value));
 	}
 }

--- a/tests/unit/suites/libraries/joomla/form/rule/JFormRuleTelTest.php
+++ b/tests/unit/suites/libraries/joomla/form/rule/JFormRuleTelTest.php
@@ -8,262 +8,249 @@
  */
 
 /**
- * Test class for JFormRuleTel.
- *
- * @package     Joomla.UnitTest
- * @subpackage  Form
- * @since       11.1
+ * Test class for JFormRuleTel
  */
-class JFormRuleTelTest extends TestCase
+class JFormRuleTelTest extends PHPUnit_Framework_TestCase
 {
 	/**
-	 * Test the JFormRuleTel::test method.
+	 * Data provider for the failure test case on the NANP format
 	 *
-	 * @return void
+	 * @return  array
 	 */
-	public function testTel()
+	public function casesRuleFailureNanp()
+	{
+		return array(
+			'bogus'               => array('bogus'),
+			'123451234512'        => array('123451234512'),
+			'anything_5555555555' => array('anything_5555555555'),
+			'5555555555_anything' => array('5555555555_anything'),
+		);
+	}
+
+	/**
+	 * Data provider for the failure test case on the ITU-T format
+	 *
+	 * @return  array
+	 */
+	public function casesRuleFailureItuT()
+	{
+		return array(
+			'bogus'                => array('bogus'),
+			'123451234512'         => array('123451234512'),
+			'anything_5555555555'  => array('anything_5555555555'),
+			'5555555555_anything'  => array('5555555555_anything'),
+			'1 2 3 4 5 6 '         => array('1 2 3 4 5 6 '),
+			'5552345678'           => array('5552345678'),
+			'anything_555.5555555' => array('anything_555.5555555'),
+			'555.5555555_anything' => array('555.5555555_anything'),
+		);
+	}
+
+	/**
+	 * Data provider for the failure test case on the EPP format
+	 *
+	 * @return  array
+	 */
+	public function casesRuleFailureEpp()
+	{
+		return array(
+			'bogus'                => array('bogus'),
+			'12345123451234512345' => array('12345123451234512345'),
+			'123.1234'             => array('123.1234'),
+			'23.1234'              => array('23.1234'),
+			'3.1234'               => array('3.1234'),
+		);
+	}
+
+	/**
+	 * Data provider for the failure test case for no specified plan
+	 *
+	 * @return  array
+	 */
+	public function casesRuleFailureNoPlan()
+	{
+		return array(
+			'bogus'                    => array('bogus'),
+			'anything_555.5555555'     => array('anything_555.5555555'),
+			'555.5555555x555_anything' => array('555.5555555x555_anything'),
+			'555.'                     => array('555.'),
+			'1 2 3 4 5 6 '             => array('1 2 3 4 5 6 '),
+		);
+	}
+
+	/**
+	 * Data provider for the success test case on the NANP format
+	 *
+	 * @return  array
+	 */
+	public function casesRuleSuccessNanp()
+	{
+		return array(
+			'(555) 234-5678'  => array('(555) 234-5678'),
+			'1-555-234-5678'  => array('1-555-234-5678'),
+			'+1-555-234-5678' => array('+1-555-234-5678'),
+			'555-234-5678'    => array('555-234-5678'),
+			'1 555 234 5678'  => array('1 555 234 5678'),
+		);
+	}
+
+	/**
+	 * Data provider for the success test case on the ITU-T format
+	 *
+	 * @return  array
+	 */
+	public function casesRuleSuccessItuT()
+	{
+		return array(
+			'+555 234 5678'     => array('+555 234 5678'),
+			'+123 555 234 5678' => array('+123 555 234 5678'),
+			'+2 52 34 55'       => array('+2 52 34 55'),
+			'+5552345678'       => array('+5552345678'),
+		);
+	}
+
+	/**
+	 * Data provider for the success test case on the EPP format
+	 *
+	 * @return  array
+	 */
+	public function casesRuleSuccessEpp()
+	{
+		return array(
+			'+123.1234'   => array('+123.1234'),
+			'+23.1234'    => array('+23.1234'),
+			'+3.1234'     => array('+3.1234'),
+			'+3.1234x555' => array('+3.1234x555'),
+		);
+	}
+
+	/**
+	 * Data provider for the success test case for no specified plan
+	 *
+	 * @return  array
+	 */
+	public function casesRuleSuccessNoPlan()
+	{
+		return array(
+			'555 234 5678'      => array('555 234 5678'),
+			'+123 555 234 5678' => array('+123 555 234 5678'),
+			'+2 52 34 55'       => array('+2 52 34 55'),
+			'5552345678'        => array('5552345678'),
+			'+5552345678'       => array('+5552345678'),
+			'1 2 3 4 5 6 7'     => array('1 2 3 4 5 6 7'),
+			'123451234512'      => array('123451234512'),
+		);
+	}
+
+	/**
+	 * @testdox  The tel rule fails values that do not pass NANP guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailureNanp
+	 */
+	public function testRuleFailureNanp($value)
 	{
 		$rule = new JFormRuleTel;
-		$xml = simplexml_load_string('<form><field name="tel1" plan="NANP" />
-			<field name="tel2" plan="ITU-T" /><field name="tel3" plan="EPP" />
-			<field name="tel4" /></form>');
 
-		// Test fail conditions NANP.
-		$this->assertThat(
-			$rule->test($xml->field[0], 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '123451234512'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], 'anything_5555555555'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '5555555555_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+		$this->assertFalse($rule->test(new SimpleXMLElement('<field name="tel" plan="NANP" />'), $value));
+	}
 
-		// Test fail conditions ITU-T.
-		$this->assertThat(
-			$rule->test($xml->field[1], 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '123451234512'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], 'anything_5555555555'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '5555555555_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '1 2 3 4 5 6 '),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '5552345678'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], 'anything_555.5555555'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '555.5555555_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+	/**
+	 * @testdox  The tel rule fails values that do not pass ITU-T guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailureItuT
+	 */
+	public function testRuleFailureItuT($value)
+	{
+		$rule = new JFormRuleTel;
 
-		// Test fail conditions EPP.
-		$this->assertThat(
-			$rule->test($xml->field[2], 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '12345123451234512345'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '123.1234'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '23.1234'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '3.1234'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+		$this->assertFalse($rule->test(new SimpleXMLElement('<field name="tel" plan="ITU-T" />'), $value));
+	}
 
-		// Test fail conditions no plan.
-		$this->assertThat(
-			$rule->test($xml->field[3], 'bogus'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+	/**
+	 * @testdox  The tel rule fails values that do not pass EPP guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailureEpp
+	 */
+	public function testRuleFailureEpp($value)
+	{
+		$rule = new JFormRuleTel;
 
-		$this->assertThat(
-			$rule->test($xml->field[3], 'anything_555.5555555'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '555.5555555x555_anything'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '.5555555'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '555.'),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '1 2 3 4 5 6 '),
-			$this->isFalse(),
-			'Line:' . __LINE__ . ' The rule should fail and return false.'
-		);
+		$this->assertFalse($rule->test(new SimpleXMLElement('<field name="tel" plan="EPP" />'), $value));
+	}
 
-		// Test pass conditions.
-		// For NANP
-		$this->assertThat(
-			$rule->test($xml->field[0], '(555) 234-5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '1-555-234-5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '+1-555-234-5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '555-234-5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '1-555-234-5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[0], '1 555 234 5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
+	/**
+	 * @testdox  The tel rule fails values that do not pass when no plan is specified
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleFailureNoPlan
+	 */
+	public function testRuleFailureNoPlan($value)
+	{
+		$rule = new JFormRuleTel;
 
-		// For ITU-T
-		$this->assertThat(
-			$rule->test($xml->field[1], '+555 234 5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '+123 555 234 5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '+2 52 34 55'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[1], '+5552345678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
+		$this->assertFalse($rule->test(new SimpleXMLElement('<field name="tel" />'), $value));
+	}
 
-		// For EPP
-		$this->assertThat(
-			$rule->test($xml->field[2], '+123.1234'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '+23.1234'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '+3.1234'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[2], '+3.1234x555'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
+	/**
+	 * @testdox  The tel rule passes values that meet NANP guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccessNanp
+	 */
+	public function testRuleSuccessNanp($value)
+	{
+		$rule = new JFormRuleTel;
 
-		// For no plan
-		$this->assertThat(
-			$rule->test($xml->field[3], '555 234 5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '+123 555 234 5678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '+2 52 34 55'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '5552345678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '+5552345678'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '1 2 3 4 5 6 7'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
-		$this->assertThat(
-			$rule->test($xml->field[3], '123451234512'),
-			$this->isTrue(),
-			'Line:' . __LINE__ . ' The rule should pass and return true.'
-		);
+		$this->assertTrue($rule->test(new SimpleXMLElement('<field name="tel" plan="NANP" />'), $value));
+	}
+
+	/**
+	 * @testdox  The tel rule passes values that meet ITU-T guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccessItuT
+	 */
+	public function testRuleSuccessItuT($value)
+	{
+		$rule = new JFormRuleTel;
+
+		$this->assertTrue($rule->test(new SimpleXMLElement('<field name="tel" plan="ITU-T" />'), $value));
+	}
+
+	/**
+	 * @testdox  The tel rule passes values that meet EPP guidelines
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccessEpp
+	 */
+	public function testRuleSuccessEpp($value)
+	{
+		$rule = new JFormRuleTel;
+
+		$this->assertTrue($rule->test(new SimpleXMLElement('<field name="tel" plan="EPP" />'), $value));
+	}
+
+	/**
+	 * @testdox  The tel rule passes values that pass when no plan is specified
+	 *
+	 * @param   mixed  $value  The value to test
+	 *
+	 * @dataProvider  casesRuleSuccessNoPlan
+	 */
+	public function testRuleSuccessNoPlan($value)
+	{
+		$rule = new JFormRuleTel;
+
+		$this->assertTrue($rule->test(new SimpleXMLElement('<field name="tel" />'), $value));
 	}
 }


### PR DESCRIPTION
### Summary of Changes

For the field tests, they aren't testing the field's setup method or being loaded into `JForm`, simplify these tests so they running the minimal code necessary and only testing one thing.

For the rule tests, they are rewritten to make use of data providers with named test cases and the tests split from one long test method to smaller methods; this should make reading and following these tests much easier.
### Testing Instructions

Unit tests pass
### Documentation Changes Required

N/A
