### PR TITLE
Remove deprecated modal instance

### DIFF
--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -126,7 +126,7 @@ class ModulesViewModules extends JViewLegacy
 		if ($user->authorise('core.create', 'com_modules') && $user->authorise('core.edit', 'com_modules')
 			&& $user->authorise('core.edit.state', 'com_modules'))
 		{
-			JHtml::_('bootstrap.modal', 'collapseModal');
+			JHtml::_('bootstrap.renderModal', 'collapseModal');
 			$title = JText::_('JTOOLBAR_BATCH');
 
 			// Instantiate a new JLayoutFile instance and render the batch button


### PR DESCRIPTION
### Summary of Changes

`JHtml::_('bootstrap.modal')` has been deprecated for some time in favour of the other modal function `JHtml::_('bootstrap.renderModal')` as it was buggy (e.g. https://github.com/joomla/joomla-cms/pull/6918)

This PR removes this last instance of it's use in core
### Testing Instructions

Check the batch modal can still be opened and used.
### Documentation Changes Required

None
