### PR TITLE
JavaScript Tests - Change jQuery UI version to 1.9.2

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,10 +13,11 @@ module.exports = function (config) {
 		// list of files / patterns to load in the browser
 		files: [
 			{pattern: 'tests/javascript/node_modules/jquery/dist/jquery.min.js', included: false},
-			{pattern: 'tests/javascript/node_modules/jquery-ui-bundle/jquery-ui.min.js', included: false},
 			{pattern: 'tests/javascript/node_modules/jasmine-jquery/lib/jasmine-jquery.js', included: false},
 			{pattern: 'tests/javascript/node_modules/text/text.js', included: false},
 			{pattern: 'media/jui/js/bootstrap.min.js', included: false},
+			{pattern: 'media/jui/js/jquery.ui.core.min.js', included: false},
+			{pattern: 'media/jui/js/jquery.ui.sortable.min.js', included: false},
 			{pattern: 'media/system/js/*.js', included: false},
 			{pattern: 'tests/javascript/**/fixture.html', included: false},
 			{pattern: 'tests/javascript/**/spec.js', included: false},

--- a/tests/javascript/package.json
+++ b/tests/javascript/package.json
@@ -16,7 +16,6 @@
 		"jasmine-core": "^2.4.1",
 		"jasmine-jquery": "^2.1.1",
 		"jquery": "^1.12.4",
-		"jquery-ui-bundle": "^1.11.4",
 		"karma": "^0.13.22",
 		"karma-coverage": "^1.0.0",
 		"karma-firefox-launcher": "^0.1.7",

--- a/tests/javascript/test-main.js
+++ b/tests/javascript/test-main.js
@@ -37,14 +37,14 @@ require.config({
 		'libs/validate': {
 			deps: ['jquery']
 		},
-		'libs/combobox': {
-			deps: ['jquery']
+		'libs/subform-repeatable': {
+			deps: ['jquery', 'jui', 'jui-sortable']
 		},
 		'libs/sendtestmail': {
 			deps: ['jquery']
 		},
-		'libs/subform-repeatable': {
-			deps: ['jquery', 'jui', 'jui-sortable']
+		'libs/combobox': {
+			deps: ['jquery']
 		}
 	},
 

--- a/tests/javascript/test-main.js
+++ b/tests/javascript/test-main.js
@@ -18,7 +18,8 @@ require.config({
 
 	paths: {
 		'jquery': 'tests/javascript/node_modules/jquery/dist/jquery.min',
-		'jui': 'tests/javascript/node_modules/jquery-ui-bundle/jquery-ui.min',
+		'jui': 'media/jui/js/jquery.ui.core.min',
+		'jui-sortable': 'media/jui/js/jquery.ui.sortable.min',
 		'bootstrap': 'media/jui/js/bootstrap.min',
 		'jasmineJquery': 'tests/javascript/node_modules/jasmine-jquery/lib/jasmine-jquery',
 		'libs': 'media/system/js',
@@ -29,20 +30,21 @@ require.config({
 	shim: {
 		jasmineJquery: ['jquery'],
 		bootstrap: ['jquery'],
+		'jui-sortable': ['jquery'],
 		'libs/repeatable': {
 			deps: ['bootstrap', 'jquery']
 		},
 		'libs/validate': {
 			deps: ['jquery']
 		},
-		'libs/subform-repeatable': {
-			deps: ['jquery', 'jui']
+		'libs/combobox': {
+			deps: ['jquery']
 		},
 		'libs/sendtestmail': {
 			deps: ['jquery']
-		},		
-		'libs/combobox': {
-			deps: ['jquery']
+		},
+		'libs/subform-repeatable': {
+			deps: ['jquery', 'jui', 'jui-sortable']
 		}
 	},
 


### PR DESCRIPTION
Pull Request for Issue #11775 .
### Summary of Changes

Removed the jquery-ui-bundle node package and used the existing jQuery UI libraries in Joomla instead.
### Testing Instructions

See if the Travis build passes. If you want to run it locally, please take a look at the documentation available [here](https://docs.joomla.org/Running_JavaScript_Tests_for_the_Joomla_CMS).
Also go through the code changes.
