### PR TITLE
Replace deprecated JFactory::getUri()

### DIFF
--- a/plugins/twofactorauth/totp/totp.php
+++ b/plugins/twofactorauth/totp/totp.php
@@ -104,7 +104,7 @@ class PlgTwofactorauthTotp extends JPlugin
 
 		// These are used by Google Authenticator to tell accounts apart
 		$username = JFactory::getUser($user_id)->username;
-		$hostname = JFactory::getUri()->getHost();
+		$hostname = JUri::getInstance()->getHost();
 
 		// This is the URL to the QR code for Google Authenticator
 		$url = $totp->getUrl($username, $hostname, $secret);


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Based on these docs: https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_3_and_Joomla_Platform_12.2#JRequest JRequest is deprecated
### Testing Instructions

Since I don't have a Yubikey I don't know how to test this. Only thing I could do is to set error reporting to maximum and enable the plugin. No error messages were displayed.
### Documentation Changes Required

Replace deprecated JFactory::getUri() with JUri::getInstance
