### PR TITLE
App class configuration references

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -628,9 +628,6 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	protected function initialiseApp($options = array())
 	{
-		// Set the configuration in the API.
-		$this->config = JFactory::getConfig();
-
 		// Check that we were given a language in the array (since by default may be blank).
 		if (isset($options['language']))
 		{

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -242,7 +242,7 @@ class JApplicationCli extends JApplicationBase
 	 * for your specific application.
 	 *
 	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
-	 *                          in JPATH_BASE will be used.
+	 *                          in JPATH_CONFIGURATION will be used.
 	 * @param   string  $class  The class name to instantiate.
 	 *
 	 * @return  mixed   Either an array or object to be loaded into the configuration object.
@@ -254,12 +254,11 @@ class JApplicationCli extends JApplicationBase
 		// Instantiate variables.
 		$config = array();
 
-		if (empty($file) && defined('JPATH_BASE'))
+		if (empty($file))
 		{
-			$file = JPATH_BASE . '/configuration.php';
+			$file = JPATH_CONFIGURATION . '/configuration.php';
 
-			// Applications can choose not to have any configuration data
-			// by not implementing this method and not having a config file.
+			// Applications can choose not to have any configuration data by not implementing this method and not having a config file.
 			if (!file_exists($file))
 			{
 				$file = '';

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -884,7 +884,7 @@ class JApplicationWeb extends JApplicationBase
 	 * for your specific application.
 	 *
 	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
-	 *                          in JPATH_BASE will be used.
+	 *                          in JPATH_CONFIGURATION will be used.
 	 * @param   string  $class  The class name to instantiate.
 	 *
 	 * @return  mixed   Either an array or object to be loaded into the configuration object.
@@ -897,9 +897,9 @@ class JApplicationWeb extends JApplicationBase
 		// Instantiate variables.
 		$config = array();
 
-		if (empty($file) && defined('JPATH_ROOT'))
+		if (empty($file))
 		{
-			$file = JPATH_ROOT . '/configuration.php';
+			$file = JPATH_CONFIGURATION . '/configuration.php';
 
 			// Applications can choose not to have any configuration data
 			// by not implementing this method and not having a config file.


### PR DESCRIPTION
### Summary of Changes

This changes the default paths that the base CLI and web applications use to lookup configuration files to use the `JPATH_CONFIGURATION` path constant which is in line with how the rest of the CMS is configured.

This also removes overloading the configuration object created by the application.  This actually causes some configuration values set by the parent constructors to be lost.
### Testing Instructions

The `JConfig` object is still correctly read into the application class' `$config` store and downstream uses continue to read the configuration data from this source correctly.
### Documentation Changes Required

N/A
