### PR TITLE
Add comments regarding class abstraction

### DIFF
--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -156,6 +156,7 @@ abstract class JApplicationBase extends AbstractApplication
 	 * @return  void
 	 *
 	 * @since   3.4 (CMS)
+	 * @deprecated  4.0  The default concrete implementation of doExecute() will be removed, subclasses will need to provide their own implementation.
 	 */
 	protected function doExecute()
 	{

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -16,6 +16,7 @@ use Joomla\Registry\Registry;
  * Base class for a Joomla! command line application.
  *
  * @since  11.4
+ * @note   As of 4.0 this class will be abstract
  */
 class JApplicationCli extends JApplicationBase
 {
@@ -281,19 +282,5 @@ class JApplicationCli extends JApplicationBase
 		}
 
 		return $config;
-	}
-
-	/**
-	 * Method to run the application routines.  Most likely you will want to instantiate a controller
-	 * and execute it, or perform some sort of task directly.
-	 *
-	 * @return  void
-	 *
-	 * @codeCoverageIgnore
-	 * @since   11.3
-	 */
-	protected function doExecute()
-	{
-		// Your application routines go here.
 	}
 }

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -16,6 +16,7 @@ use Joomla\String\StringHelper;
  * Base class for a Joomla! Web application.
  *
  * @since  11.4
+ * @note   As of 4.0 this class will be abstract
  */
 class JApplicationWeb extends JApplicationBase
 {
@@ -290,21 +291,6 @@ class JApplicationWeb extends JApplicationBase
 
 		// Trigger the onAfterRespond event.
 		$this->triggerEvent('onAfterRespond');
-	}
-
-	/**
-	 * Method to run the Web application routines.  Most likely you will want to instantiate a controller
-	 * and execute it, or perform some sort of action that populates a JDocument object so that output
-	 * can be rendered to the client.
-	 *
-	 * @return  void
-	 *
-	 * @codeCoverageIgnore
-	 * @since   11.3
-	 */
-	protected function doExecute()
-	{
-		// Your application routines go here.
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This deprecates the concrete implementation of the application class' `doExecute()` method in the `JApplicationBase` class; this was added as a B/C measure when we made the legacy `JApplication` class extend from here.  The method is abstract in the Framework's base application class, the CMS' default classes implement this abstract method, and anyone building custom app classes should be able to implement it by 4.0.

The extended empty `doExecute()` methods are removed from the CLI and web application classes; it's the same as what's presently in `JApplicationBase` anyway.

This also notes that the base CLI and web application classes will become abstract as of 4.0.  This is in line with a change that was made in the Platform before it shifted toward the Framework and matches the current declaration of the Framework classes.  These two classes do not do anything useful without being extended anyway.
### Testing Instructions

Code review and maintainer decision
### Documentation Changes Required

N/A; all changes are documented inline.
