### PR TITLE
Added drone.io ci-server for running JavaScript tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,7 @@
 build:
   image: yveshoppe/joomla-systemtests:latest
   commands:
+    - apt-get install npm
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
     - sleep 3

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,14 @@
+build:
+  image: yveshoppe/joomla-systemtests:latest
+  commands:
+    - export DISPLAY=:0
+    - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
+    - sleep 3
+    - fluxbox  > /dev/null 2>&1 &
+    - cd tests/javascript
+    - npm install
+    - cd ../..
+    - tests/javascript/node_modules/karma/bin/karma start karma.conf.js --single-run
+  clone:
+    depth: 1
+    path: repo

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,7 @@ build:
   image: yveshoppe/joomla-systemtests:latest
   commands:
     - apt-get install nodejs npm
+    - ln -s /usr/bin/nodejs /usr/bin/node
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
     - sleep 3

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 build:
   image: yveshoppe/joomla-systemtests:latest
   commands:
-    - apt-get install npm
+    - apt-get install nodejs npm
     - export DISPLAY=:0
     - Xvfb -screen 0 1024x768x24 -ac +extension GLX +render -noreset > /dev/null 2>&1 &
     - sleep 3


### PR DESCRIPTION
### Summary of Changes

This PR adds a .drone.yml (similar to travis.yml) to integrate Joomla's drone.io continuous integration server. Currently only the JavaScript tests are run.
### Testing Instructions

Review drone.io log
### Documentation Changes Required

None

<img width="1425" alt="screenshot 2016-08-29 20 36 38" src="https://cloud.githubusercontent.com/assets/897638/18062723/523e346c-6e28-11e6-8244-d4d169a2b39b.png">

<img width="797" alt="screenshot 2016-08-29 20 37 41" src="https://cloud.githubusercontent.com/assets/897638/18062749/728ac06e-6e28-11e6-8fb8-387a7381b2df.png">

// cc @rdeutz 
