### PR TITLE
Load the library language files before the initialise event

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -292,9 +292,6 @@ class JApplicationAdministrator extends JApplicationCms
 
 		// Finish initialisation
 		parent::initialiseApp($options);
-
-		// Load Library language
-		$this->getLanguage()->load('lib_joomla', JPATH_ADMINISTRATOR);
 	}
 
 	/**

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -646,6 +646,9 @@ class JApplicationCms extends JApplicationWeb
 		// Register the language object with JFactory
 		JFactory::$language = $this->getLanguage();
 
+		// Load the library language files
+		$this->loadLibraryLanguage();
+
 		// Set user specific editor.
 		$user = JFactory::getUser();
 		$editor = $user->getParam('editor', $this->get('editor'));
@@ -689,6 +692,18 @@ class JApplicationCms extends JApplicationWeb
 	public function isSite()
 	{
 		return $this->getClientId() === 0;
+	}
+
+	/**
+	 * Load the library language files for the application
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadLibraryLanguage()
+	{
+		$this->getLanguage()->load('lib_joomla', JPATH_ADMINISTRATOR);
 	}
 
 	/**

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -679,7 +679,17 @@ final class JApplicationSite extends JApplicationCms
 
 		// Finish initialisation
 		parent::initialiseApp($options);
+	}
 
+	/**
+	 * Load the library language files for the application
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadLibraryLanguage()
+	{
 		/*
 		 * Try the lib_joomla file in the current language (without allowing the loading of the file in the default language)
 		 * Fallback to the default language if necessary


### PR DESCRIPTION
### Summary of Changes

The library language files are being loaded after the system plugins are imported and the `onAfterInitialise` event is dispatched.  Move this loading to before the plugins are loaded and dispatched.
### Testing Instructions

Language files are still loaded correctly.
### Documentation Changes Required

If anyone has a custom CMS application subclass with a `loadLibraryLanguage()` method and the signature doesn't match what's added here, they'll get notices.
