### PR TITLE
CS after merge https://github.com/joomla/joomla-cms/pull/7540

### DIFF
--- a/components/com_config/model/modules.php
+++ b/components/com_config/model/modules.php
@@ -12,13 +12,10 @@ defined('_JEXEC') or die;
 /**
  * Config Module model.
  *
- * @package     Joomla.Site
- * @subpackage  com_config
- * @since       3.2
+ * @since  3.2
  */
 class ConfigModelModules extends ConfigModelForm
 {
-
 	/**
 	 * Method to auto-populate the model state.
 	 *
@@ -120,13 +117,13 @@ class ConfigModelModules extends ConfigModelForm
 	/**
 	 * Method to get list of module positions in current template
 	 *
-	 * @return array
+	 * @return  array
 	 *
-	 * @since 3.2
+	 * @since   3.2
 	 */
 	public function getPositions()
 	{
-		$lang            = JFactory::getLanguage();
+		$lang         = JFactory::getLanguage();
 		$templateName = JFactory::getApplication()->getTemplate();
 
 		// Load templateDetails.xml file
@@ -165,7 +162,7 @@ class ConfigModelModules extends ConfigModelForm
 		// Add custom position to options
 		$customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 
-		$editPositions = true;
+		$editPositions   = true;
 		$customPositions = self::getActivePositions(0, $editPositions);
 		$templateGroups[$customGroupText] = self::createOptionGroup($customGroupText, $customPositions);
 
@@ -179,15 +176,17 @@ class ConfigModelModules extends ConfigModelForm
 	 * @param   boolean  $editPositions  Allow to edit the positions
 	 *
 	 * @return  array  A list of positions
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getActivePositions($clientId, $editPositions = false)
 	{
-		$db		= JFactory::getDbo();
-		$query	= $db->getQuery(true)
-			->select('DISTINCT(position)')
-			->from('#__modules')
-			->where($db->quoteName('client_id') . ' = ' . (int) $clientId)
-			->order('position');
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select('DISTINCT position')
+			->from($db->quoteName('#__modules'))
+			->where($db->quoteName('client_id') . ' = ' . $db->quote($clientId))
+			->order($db->quoteName('position'));
 
 		$db->setQuery($query);
 
@@ -210,11 +209,11 @@ class ConfigModelModules extends ConfigModelForm
 		{
 			if (!$position && !$editPositions)
 			{
-				$options[]	= JHtml::_('select.option', 'none', ':: ' . JText::_('JNONE') . ' ::');
+				$options[] = JHtml::_('select.option', 'none', ':: ' . JText::_('JNONE') . ' ::');
 			}
 			else
 			{
-				$options[]	= JHtml::_('select.option', $position, $position);
+				$options[] = JHtml::_('select.option', $position, $position);
 			}
 		}
 
@@ -229,7 +228,7 @@ class ConfigModelModules extends ConfigModelForm
 	 *
 	 * @return  object  The option as an object (stdClass instance)
 	 *
-	 * @since   3.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	private static function createOption($value = '', $text = '')
 	{
@@ -253,7 +252,7 @@ class ConfigModelModules extends ConfigModelForm
 	 *
 	 * @return  array  Return the new group as an array
 	 *
-	 * @since   3.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	private static function createOptionGroup($label = '', $options = array())
 	{

--- a/components/com_config/model/modules.php
+++ b/components/com_config/model/modules.php
@@ -185,7 +185,7 @@ class ConfigModelModules extends ConfigModelForm
 		$query = $db->getQuery(true)
 			->select('DISTINCT position')
 			->from($db->quoteName('#__modules'))
-			->where($db->quoteName('client_id') . ' = ' . $db->quote($clientId))
+			->where($db->quoteName('client_id') . ' = ' . (int) $clientId)
 			->order($db->quoteName('position'));
 
 		$db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #7540 @rdeutz 
### Summary of Changes

CS after merge: https://github.com/joomla/joomla-cms/pull/7540#event-771234651
### Testing Instructions

Edit the index.php of the protostar template and rename the module position in line 177 from
`<jdoc:include type="modules" name="position-8" style="xhtml" />`

to

`<jdoc:include type="modules" name="test123" style="xhtml" />`

Now go to the module and create a new custom module and place it in position test123 (it wont be on the list you have to manually enter it)

Go to global configuration and make sure that you have "Mouse-over Edit Icons for" set for modules

Go to the front end of the site and check the new module is displayed and then log in

Hover over the module and you get an icon to let you open the module for editing. Change the module title and press save. The module will have been saved in a different position.

Now apply the patch. Go to module manager and put the module back into test123 and repeat

You will now see that when you edit the module you will see at the bottom of the list of module positions a section "Active positions" and test123 is there. Dont change the position. Edit the title and sabe the module. The module will have been saved in the same position
### Documentation Changes Required

None
