### PR TITLE
[com_menus] Add keepalive behaviour when edit/create a menu item

### DIFF
--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -16,6 +16,7 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.tabstate');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('behavior.keepalive');
 
 JText::script('ERROR');
 JText::script('JGLOBAL_VALIDATION_FORM_FAILED');


### PR DESCRIPTION
Pull Request for Improvement.
### Summary of Changes

Add keepalive behaviour when edit/create a menu item to preserve the session when creating/editing a menu item.
### Testing Instructions

Simple change for me only code review is needed, but for test:
- Before applying patch create/edit a menu item, view html source (Ctrl + U) and check that this code (or similiar) is not there. Hint: search (Ctrl + F) for `com_ajax`

``` js
window.setInterval(function(){var r;try{r=window.XMLHttpRequest?new XMLHttpRequest():new ActiveXObject("Microsoft.XMLHTTP")}catch(e){}if(r){r.open("GET","/administrator/index.php?option=com_ajax&format=json",true);r.send(null)}},840000);
```
- Now apply the patch
- Repeat step 1 and check the code is there.
### Documentation Changes Required

None.
