### PR TITLE
Fix early exit from foreach in JForm::removeGroup

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -916,11 +916,9 @@ class JForm
 		{
 			$dom = dom_import_simplexml($element);
 			$dom->parentNode->removeChild($dom);
-
-			return true;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -896,7 +896,7 @@ class JForm
 	 *
 	 * @param   string  $group  The dot-separated form group path for the group to remove.
 	 *
-	 * @return  boolean  True on success, false otherwise.
+	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  UnexpectedValueException


### PR DESCRIPTION
### Summary of Changes

Removed unconditional `return` statement from foreach loop

The method is supposed to remove all instances of <fields> element but it exits the loop on first iteration only. Looks like a quick copy-paste from removeField may have caused this.
### Testing Instructions
#### Form XML `form.xml`:

``` xml
<form>
    <fields name="group1">
        <field name="field1"/>
    </fields>
    <fieldset name="set1">
        <fields name="group1">
            <field name="field2"/>
        </fields>
    </fieldset>
</form>
```

``` php
$form = new JForm('Test');

$form->load('form.xml');
$form->removeGroup('group1');

print_r($form);
```

**Expected**:
This should remove all `fields` nodes with name **group1**

**Actual**:
Only the first group is removed before patch. After patch this should remove all as expected.
### Documentation Changes Required

None
