### PR TITLE
Added "collapsed" to closed slides accordion-toggle class

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -672,13 +672,14 @@ abstract class JHtmlBootstrap
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
 		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? ' in' : '';
+		$collapsed = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? '' : ' collapsed';
 		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ?
 			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
 		$html = '<div class="accordion-group' . $class . '">'
 			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="accordion-toggle">'
+			. '<strong><a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="accordion-toggle' . $collapsed . '">'
 			. $text
 			. '</a></strong>'
 			. '</div>'


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Added "collapsed" to closed slides accordion-toggle class. This class is added by Javascript during user-interaction when a slide closes and removed when it opens:
https://github.com/joomla/joomla-cms/blob/staging/media/jui/js/bootstrap.js#L630-L641

It could be used by templates for different styling of the title of closed/opend slides which requires this class when the page is loaded. If it is not added by PHP, the templates must add it self with Javascript during page load.
### Testing Instructions

Create Slides (open and closed) and look at the class of the slides title (accordion-toggle)
### Documentation Changes Required
