### PR TITLE
MSSQL: use error code instead of SQLSTATE

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -382,10 +382,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				if (stristr(strtolower($field->Type), "nvarchar"))
-				{
-					$field->Default = "";
-				}
+				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|\)\)|\))$))/i", '', $field->Default);
 				$result[$field->Field] = $field;
 			}
 		}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -1125,7 +1125,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	{
 		$errors = sqlsrv_errors();
 
-		return $errors[0]['SQLSTATE'];
+		return $errors[0]['code'];
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -382,7 +382,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($fields as $field)
 			{
-				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|\)\)|\))$))/i", '', $field->Default);
+				$field->Default = preg_replace("/(^(\(\(|\('|\(N'|\()|(('\)|(?<!\()\)\)|\))$))/i", '', $field->Default);
 				$result[$field->Field] = $field;
 			}
 		}


### PR DESCRIPTION
Change to use native error code for exceptions instead of the driver specific SQLSTATE value because this value is not always am integer
