### PR TITLE
Add 'collapsed' class to accordion slide heading

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -672,13 +672,14 @@ abstract class JHtmlBootstrap
 	public static function addSlide($selector, $text, $id, $class = '')
 	{
 		$in = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] == $id) ? ' in' : '';
+		$collapsed = (static::$loaded[__CLASS__ . '::startAccordion'][$selector]['active'] !== $id) ? ' collapsed' : '';
 		$parent = static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] ?
 			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class = (!empty($class)) ? ' ' . $class : '';
 
 		$html = '<div class="accordion-group' . $class . '">'
 			. '<div class="accordion-heading">'
-			. '<strong><a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="accordion-toggle">'
+			. '<strong><a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="accordion-toggle' . $collapsed . '">'
 			. $text
 			. '</a></strong>'
 			. '</div>'


### PR DESCRIPTION
### Summary of Changes

Adding the class `collapsed` to an initially collapsed accordion slide header.
### Testing Instructions

Set up a single contact menuitem and set the "Display Format" to "Sliders". Now inspect the header of the collapsed accordion slider ("Contact Form"). It will look like this:
![before](https://cloud.githubusercontent.com/assets/1018684/18130747/9df4dcbc-6f90-11e6-91ed-66dc1ac57c73.PNG)
Once you open the slider and close it again, it will have a `collapsed` class added to the anchor tag by the JavaScript.
![after](https://cloud.githubusercontent.com/assets/1018684/18130832/e4b1ffd6-6f90-11e6-812c-ca81bf6b8b1b.PNG)

After applying this PR, reload the page and check again, now you should see the `collapsed` class directly without first opening and closing the slider. But obviously only for collapsed sliders :smile: 
### Documentation Changes Required

None.
