### PR TITLE
[newsfeed modal field] Adds Create News Feed button and other improvements

### DIFF
--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -204,15 +204,15 @@ class JFormFieldModal_Newsfeed extends JFormField
 					'width'       => '800px',
 					'bodyHeight'  => '70',
 					'modalWidth'  => '80',
-					'footer'      => '<a role="button" class="btn btn-cancel" aria-hidden="true"'
+					'footer'      => '<a role="button" class="btn" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'add\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
-							. '<a role="button" class="btn btn-save btn-primary hidden" aria-hidden="true"'
+							. '<a role="button" class="btn btn-primary" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'add\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JSAVE") . '</a>'
-							. '<a role="button" class="btn btn-apply btn-success" aria-hidden="true"'
+							. '<a role="button" class="btn btn-success" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'add\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JAPPLY") . '</a>',
@@ -236,15 +236,15 @@ class JFormFieldModal_Newsfeed extends JFormField
 					'width'       => '800px',
 					'bodyHeight'  => '70',
 					'modalWidth'  => '80',
-					'footer'      => '<a role="button" class="btn btn-cancel" aria-hidden="true"'
+					'footer'      => '<a role="button" class="btn" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \'' . $this->id
 							. '\', \'edit\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
-							. '<a role="button" class="btn btn-save btn-primary" aria-hidden="true"'
+							. '<a role="button" class="btn btn-primary" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'edit\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JSAVE") . '</a>'
-							. '<a role="button" class="btn btn-apply btn-success" aria-hidden="true"'
+							. '<a role="button" class="btn btn-success" aria-hidden="true"'
 							. ' onclick="window.processModalEdit(this, \''
 							. $this->id . '\', \'edit\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
 							. JText::_("JAPPLY") . '</a>',

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -33,8 +33,10 @@ class JFormFieldModal_Newsfeed extends JFormField
 	 */
 	protected function getInput()
 	{
-		$allowEdit  = ((string) $this->element['edit'] == 'true') ? true : false;
-		$allowClear = ((string) $this->element['clear'] != 'false') ? true : false;
+		$allowNew    = ((string) $this->element['new'] == 'true');
+		$allowEdit   = ((string) $this->element['edit'] == 'true');
+		$allowClear  = ((string) $this->element['clear'] != 'false');
+		$allowSelect = ((string) $this->element['select'] != 'false');
 
 		// Load language
 		JFactory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
@@ -42,88 +44,50 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// The active newsfeed id field.
 		$value = (int) $this->value > 0 ? (int) $this->value : '';
 
-		// Build the script.
-		$script = array();
+		// Create the modal id.
+		$modalId = 'Newsfeed_' . $this->id;
 
-		// Select button script
-		$script[] = '	function jSelectNewsfeed_' . $this->id . '(id, name, object) {';
-		$script[] = '		document.getElementById("' . $this->id . '_id").value = id;';
-		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
+		// Add the modal field script to the document head.
+		JHtml::_('jquery.framework');
+		JHtml::_('script', 'system/modal-fields.js', false, true);
 
-		if ($allowEdit)
+		// Script to proxy the select modal function to the modal-fields.js file.
+		if ($allowSelect)
 		{
-			$script[] = '		if (id == "' . (int) $this->value . '") {';
-			$script[] = '			jQuery("#' . $this->id . '_edit").removeClass("hidden");';
-			$script[] = '		} else {';
-			$script[] = '			jQuery("#' . $this->id . '_edit").addClass("hidden");';
-			$script[] = '		}';
+			static $scriptSelect = null;
+
+			if (is_null($scriptSelect))
+			{
+				$scriptSelect = array();
+			}
+
+			if (!isset($scriptSelect[$this->id]))
+			{
+				JFactory::getDocument()->addScriptDeclaration("
+				function jSelectNewsfeed_" . $this->id . "(id, title, object) {
+					window.processModalSelect('Newsfeed', '" . $this->id . "', id, title, '', object);
+				}
+				");
+
+				$scriptSelect[$this->id] = true;
+			}
 		}
-
-		if ($allowClear)
-		{
-			$script[] = '		jQuery("#' . $this->id . '_clear").removeClass("hidden");';
-		}
-
-		$script[] = '		jQuery("#newsfeedSelect' . $this->id . 'Modal").modal("hide");';
-
-		if ($this->required)
-		{
-			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_id"));';
-			$script[] = '		document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
-		}
-
-		$script[] = '	}';
-
-		// Edit button script
-		$script[] = '	function jEditNewsfeed_' . $value . '(name) {';
-		$script[] = '		document.getElementById("' . $this->id . '_name").value = name;';
-		$script[] = '	}';
-
-		// Clear button script
-		static $scriptClear;
-
-		if ($allowClear && !$scriptClear)
-		{
-			$scriptClear = true;
-
-			$script[] = '	function jClearNewsfeed(id) {';
-			$script[] = '		document.getElementById(id + "_id").value = "";';
-			$script[] = '		document.getElementById(id + "_name").value = "'
-				. htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '";';
-			$script[] = '		jQuery("#"+id + "_clear").addClass("hidden");';
-			$script[] = '		if (document.getElementById(id + "_edit")) {';
-			$script[] = '			jQuery("#"+id + "_edit").addClass("hidden");';
-			$script[] = '		}';
-			$script[] = '		return false;';
-			$script[] = '	}';
-		}
-
-		// Add the script to the document head.
-		JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
 		// Setup variables for display.
-		$html = array();
-
-		$linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component'
-			. '&amp;function=jSelectNewsfeed_' . $this->id;
-
-		$linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component'
-			. '&amp;task=newsfeed.edit'
-			. '&amp;function=jEditNewsfeed_' . $value;
+		$linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+		$linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+		$modalTitle    = JText::_('COM_NEWSFEEDS_CHANGE_FEED');
 
 		if (isset($this->element['language']))
 		{
 			$linkNewsfeeds .= '&amp;forcedLanguage=' . $this->element['language'];
 			$linkNewsfeed  .= '&amp;forcedLanguage=' . $this->element['language'];
-			$modalTitle     = JText::_('COM_NEWSFEEDS_CHANGE_FEED') . ' &#8212; ' . $this->element['label'];
-		}
-		else
-		{
-			$modalTitle     = JText::_('COM_NEWSFEEDS_CHANGE_FEED');
+			$modalTitle    .= ' &#8212; ' . $this->element['label'];
 		}
 
-		$urlSelect = $linkNewsfeeds . '&amp;' . JSession::getFormToken() . '=1';
-		$urlEdit   = $linkNewsfeed . '&amp;id=' . $value . '&amp;' . JSession::getFormToken() . '=1';
+		$urlSelect = $linkNewsfeeds . '&amp;function=jSelectNewsfeed_' . $this->id;
+		$urlEdit   = $linkNewsfeed . '&amp;task=newsfeed.edit&amp;id=\' + document.getElementById("' . $this->id . '_id").value + \'';
+		$urlNew    = $linkNewsfeed . '&amp;task=newsfeed.add';
 
 		if ($value)
 		{
@@ -144,36 +108,49 @@ class JFormFieldModal_Newsfeed extends JFormField
 			}
 		}
 
-		if (empty($title))
-		{
-			$title = JText::_('COM_NEWSFEEDS_SELECT_A_FEED');
-		}
-
-		$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+		$title = empty($title) ? JText::_('COM_NEWSFEEDS_SELECT_A_FEED') : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
 		// The current newsfeed display field.
-		$html[] = '<span class="input-append">';
-		$html[] = '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html  = '<span class="input-append">';
+		$html .= '<input class="input-medium" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
 
 		// Select newsfeed button
-		$html[] = '<a'
-			. ' class="btn hasTooltip"'
-			. ' data-toggle="modal"'
-			. ' role="button"'
-			. ' href="#newsfeedSelect' . $this->id . 'Modal"'
-			. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED') . '">'
-			. '<span class="icon-file"></span> ' . JText::_('JSELECT')
-			. '</a>';
+		if ($allowSelect)
+		{
+			$html .= '<a'
+				. ' class="btn hasTooltip' . ($value ? ' hidden' : '') . '"'
+				. ' id="' . $this->id . '_select"'
+				. ' data-toggle="modal"'
+				. ' role="button"'
+				. ' href="#ModalSelect' . $modalId . '"'
+				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED') . '">'
+				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '</a>';
+		}
+
+		// New newsfeed button
+		if ($allowNew)
+		{
+			$html .= '<a'
+				. ' class="btn hasTooltip' . ($value ? ' hidden' : '') . '"'
+				. ' id="' . $this->id . '_new"'
+				. ' data-toggle="modal"'
+				. ' role="button"'
+				. ' href="#ModalNew' . $modalId . '"'
+				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_NEW_NEWSFEED') . '">'
+				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '</a>';
+		}
 
 		// Edit newsfeed button
 		if ($allowEdit)
 		{
-			$html[] = '<a'
+			$html .= '<a'
 				. ' class="btn hasTooltip' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_edit"'
 				. ' data-toggle="modal"'
 				. ' role="button"'
-				. ' href="#newsfeedEdit' . $value . 'Modal"'
+				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') . '">'
 				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
@@ -182,64 +159,106 @@ class JFormFieldModal_Newsfeed extends JFormField
 		// Clear newsfeed button
 		if ($allowClear)
 		{
-			$html[] = '<button'
+			$html .= '<a'
 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
 				. ' id="' . $this->id . '_clear"'
-				. ' onclick="return jClearNewsfeed(\'' . $this->id . '\')">'
+				. ' href="#"'
+				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
 				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
-				. '</button>';
+				. '</a>';
 		}
 
-		$html[] = '</span>';
+		$html .= '</span>';
 
 		// Select newsfeed modal
-		$html[] = JHtml::_(
-			'bootstrap.renderModal',
-			'newsfeedSelect' . $this->id . 'Modal',
-			array(
-				'title'       => $modalTitle,
-				'url'         => $urlSelect,
-				'height'      => '400px',
-				'width'       => '800px',
-				'bodyHeight'  => '70',
-				'modalWidth'  => '80',
-				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
-			)
-		);
+		if ($allowSelect)
+		{
+			$html .= JHtml::_(
+				'bootstrap.renderModal',
+				'ModalSelect' . $modalId,
+				array(
+					'title'       => $modalTitle,
+					'url'         => $urlSelect,
+					'height'      => '400px',
+					'width'       => '800px',
+					'bodyHeight'  => '70',
+					'modalWidth'  => '80',
+					'footer'      => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
+				)
+			);
+		}
 
-		// Edit newsfeed modal
-		$html[] = JHtml::_(
-			'bootstrap.renderModal',
-			'newsfeedEdit' . $value . 'Modal',
-			array(
-				'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
-				'backdrop'    => 'static',
-				'keyboard'    => false,
-				'closeButton' => false,
-				'url'         => $urlEdit,
-				'height'      => '400px',
-				'width'       => '800px',
-				'bodyHeight'  => '70',
-				'modalWidth'  => '80',
-				'footer'      => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
-						. '<button type="button" class="btn btn-primary" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
-						. JText::_("JSAVE") . '</button>'
-						. '<button type="button" class="btn btn-success" aria-hidden="true"'
-						. ' onclick="jQuery(\'#newsfeedEdit' . $value . 'Modal iframe\').contents().find(\'#applyBtn\').click();">'
-						. JText::_("JAPPLY") . '</button>',
-			)
-		);
+		// New newsfeed modal
+		if ($allowNew)
+		{
+			$html .= JHtml::_(
+				'bootstrap.renderModal',
+				'ModalNew' . $modalId,
+				array(
+					'title'       => JText::_('COM_NEWSFEEDS_NEW_NEWSFEED'),
+					'backdrop'    => 'static',
+					'keyboard'    => false,
+					'closeButton' => false,
+					'url'         => $urlNew,
+					'height'      => '400px',
+					'width'       => '800px',
+					'bodyHeight'  => '70',
+					'modalWidth'  => '80',
+					'footer'      => '<a role="button" class="btn btn-cancel" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'add\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
+							. '<a role="button" class="btn btn-save btn-primary hidden" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'add\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JSAVE") . '</a>'
+							. '<a role="button" class="btn btn-apply btn-success" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'add\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JAPPLY") . '</a>',
+				)
+			);
+		}
+
+		// Edit newsfeed modal.
+		if ($allowEdit)
+		{
+			$html .= JHtml::_(
+				'bootstrap.renderModal',
+				'ModalEdit' . $modalId,
+				array(
+					'title'       => JText::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
+					'backdrop'    => 'static',
+					'keyboard'    => false,
+					'closeButton' => false,
+					'url'         => $urlEdit,
+					'height'      => '400px',
+					'width'       => '800px',
+					'bodyHeight'  => '70',
+					'modalWidth'  => '80',
+					'footer'      => '<a role="button" class="btn btn-cancel" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \'' . $this->id
+							. '\', \'edit\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
+							. '<a role="button" class="btn btn-save btn-primary" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'edit\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JSAVE") . '</a>'
+							. '<a role="button" class="btn btn-apply btn-success" aria-hidden="true"'
+							. ' onclick="window.processModalEdit(this, \''
+							. $this->id . '\', \'edit\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
+							. JText::_("JAPPLY") . '</a>',
+				)
+			);
+		}
 
 		// Add class='required' for client side validation
 		$class = $this->required ? ' class="required modal-value"' : '';
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name . '"'
+			. '" data-text="' . htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
 
-		return implode("\n", $html);
+		return $html;
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -533,6 +533,8 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 					$field->addAttribute('language', $tag);
 					$field->addAttribute('label', $language->title);
 					$field->addAttribute('translate_label', 'false');
+					$field->addAttribute('select', 'true');
+					$field->addAttribute('new', 'true');
 					$field->addAttribute('edit', 'true');
 					$field->addAttribute('clear', 'true');
 				}

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -27,6 +27,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		if (task == "newsfeed.cancel" || document.formvalidator.isValid(document.getElementById("newsfeed-form"))) {
 			Joomla.submitform(task, document.getElementById("newsfeed-form"));
 
+			// @deprecated 4.0  The following js is not needed since __DEPLOY_VERSION__.
 			if (task !== "newsfeed.apply")
 			{
 				window.parent.jQuery("#newsfeedEdit' . $this->item->id . 'Modal").modal("hide");
@@ -104,5 +105,6 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/modal.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 
+// @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since __DEPLOY_VERSION__.
 $function  = JFactory::getApplication()->input->getCmd('function', 'jEditNewsfeed_' . (int) $this->item->id);
 
 // Function to update input title when changed

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -79,6 +79,11 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
 			}
 		}
+		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
+		else if ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		{
+			$this->form->setFieldAttribute('language', 'readonly', 'true');
+		}
 
 		$this->addToolbar();
 		parent::display($tpl);

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -65,8 +65,19 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 
 		if ($this->getLayout() == 'modal')
 		{
-			$this->form->setFieldAttribute('language', 'readonly', 'true');
-			$this->form->setFieldAttribute('catid', 'readonly', 'true');
+			// If we are forcing a language in modal (used for associations).
+			if ($forcedLanguage = JFactory::getApplication()->input->get('forcedLanguage', '', 'cmd'))
+			{
+				// Set the language field to the forcedLanguage and disable changing it.
+				$this->form->setValue('language', null, $forcedLanguage);
+				$this->form->setFieldAttribute('language', 'readonly', 'true');
+
+				// Only allow to select categories with All language or with the forced language.
+				$this->form->setFieldAttribute('catid', 'language', '*,' . $forcedLanguage);
+
+				// Only allow to select tags with All language or with the forced language.
+				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
+			}
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -80,7 +80,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 			}
 		}
 		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		else if ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.xml
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.xml
@@ -19,8 +19,10 @@
 				description="COM_NEWSFEEDS_FIELD_SELECT_FEED_DESC"
 				label="COM_NEWSFEEDS_FIELD_SELECT_FEED_LABEL"
 				required="true"
+				select="true"
+				new="true"
 				edit="true"
-				clear="false"
+				clear="true"
 			/>
 		</fieldset>
 	</fields>


### PR DESCRIPTION
Pull Request for Improvement.
### Summary of Changes

This PR is the sequence of https://github.com/joomla/joomla-cms/pull/11830 but for now for newsfeed modal.

For list of changes see https://github.com/joomla/joomla-cms/pull/11830 (same changes, but for newsfeed now).

Similiar PR: 
- Article: https://github.com/joomla/joomla-cms/pull/11830
- Category: https://github.com/joomla/joomla-cms/pull/11857
- Contact: https://github.com/joomla/joomla-cms/pull/11858
- Newsfeed: https://github.com/joomla/joomla-cms/pull/11862 (this one)
### Animated Gif (click to view in full screen)

![modal-newsfeed](https://cloud.githubusercontent.com/assets/9630530/18131118/907dab24-6f89-11e6-97e0-84da0df6e14e.gif)
### Testing Instructions
- Use latest staging
- Apply patch https://github.com/joomla/joomla-cms/pull/11830 and then this patch
- Create a Menu item Single News Feed  type
- Test all the "Edit", "Create", "Select" and "Clear" buttons  (as animated gif)
- In a multilanguage install edit a news feed and try the modal button in the associations tab
- Test all the "Edit", "Create", "Select" and "Clear" buttons.
- Code review to check all is ok.
### Documentation Changes Required

None.
