### PR TITLE
Replace Help Popup for Help modal

### DIFF
--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -10,12 +10,23 @@
 defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
+JHtml::_('jquery.framework');
 
-$doTask = $displayData['doTask'];
-$text   = $displayData['text'];
-
+echo JHtml::_(
+	'bootstrap.renderModal',
+	'ModalHelp',
+	array(
+		'title'      => $displayData['title'],
+		'url'        => $displayData['url'],
+		'height'     => '400px',
+		'width'      => '800px',
+		'bodyHeight' => '70',
+		'modalWidth' => '80',
+		'footer'     => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>',
+	)
+);
 ?>
-<button onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-small">
+<button href="#ModalHelp" data-toggle="modal" role="button" rel="help" class="btn btn-small">
 	<span class="icon-question-sign"></span>
-	<?php echo $text; ?>
+	<?php echo $displayData['text']; ?>
 </button>

--- a/libraries/cms/toolbar/button/help.php
+++ b/libraries/cms/toolbar/button/help.php
@@ -39,7 +39,8 @@ class JToolbarButtonHelp extends JToolbarButton
 		// Store all data to the options array for use with JLayout
 		$options = array();
 		$options['text']   = JText::_('JTOOLBAR_HELP');
-		$options['doTask'] = $this->_getCommand($ref, $com, $override, $component);
+		$options['url']    = JHelp::createUrl($ref, $com, $override, $component);
+		$options['title']  = JText::_('JHELP', true);
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('joomla.toolbar.help');
@@ -72,6 +73,8 @@ class JToolbarButtonHelp extends JToolbarButton
 	 * @return  string   JavaScript command string
 	 *
 	 * @since   3.0
+	 *
+	 * @deprecated  4.0  Replaced by a modal.
 	 */
 	protected function _getCommand($ref, $com, $override, $component)
 	{


### PR DESCRIPTION
Pull Request for Improvement.
### Summary of Changes

The title says it all Replace Help Popup for Help modal.

![modal-help](https://cloud.githubusercontent.com/assets/9630530/18138832/90be79ac-6fa6-11e6-8ea5-6c05463a38da.gif)
### Testing Instructions

Apply patch and test the "Help" buttons in the backend views.
### Documentation Changes Required

None.
