### PR TITLE
Code optimization for generating pathway

### DIFF
--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -106,11 +106,9 @@ class ContactViewCategory extends JViewCategory
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -342,11 +342,9 @@ class ContactViewContact extends JViewLegacy
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -344,7 +344,7 @@ class ContactViewContact extends JViewLegacy
 
 			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
+				$pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -225,11 +225,9 @@ class ContentViewArticle extends JViewLegacy
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -227,7 +227,7 @@ class ContentViewArticle extends JViewLegacy
 
 			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
+				$pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -280,11 +280,9 @@ class ContentViewCategory extends JViewCategory
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -85,11 +85,9 @@ class NewsfeedsViewCategory extends JViewCategory
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 	}

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -271,7 +271,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 
 			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
+				$pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -269,11 +269,9 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 				$category = $category->getParent();
 			}
 
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
+			for ($i = count($path) - 1; $i > -1; --$i)
 			{
-				$pathway->addItem($item['title'], $item['link']);
+				$this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Some 'view.html.php' files contain this code to generate `pathway` (data for breadcrumbs):

```
$path = array_reverse($path);

foreach ($path as $item)
{
    $this->pathway->addItem($item['title'], $item['link']);
}
```

I suggest to replace that with more efficient code:

```
for ($i = count($path) - 1; $i > -1; --$i)
{
    $this->pathway->addItem($path[$i]['title'], $path[$i]['link']);
}
```

An array `$path` is not used after this code fragment, so we can leave it non-reversed and iterate from end to start.

Modifications of code are trivial and should not lead to side effects.
### Testing Instructions

On the administration panel:
1) Create if not exists and public a module of type 'Breadcrumbs'.
2) Create test structures of categories for articles, contacts, news feeds.
3) Create test articles, contacts, news feeds and move them to test categories.
4) Create test menu items of types 'Articles - Category list', 'Contacts - List Contacts in a Category',  'News Feeds - List News Feeds in a Category' for appropriate root test categories.
On the site:
1) Open the test pages for categories, articles, contacts, news feeds and make screen shots.
2) Apply the patch.
3) Re-open the test pages for categories, articles, contacts, news feeds and make screen shots. There must be no differences.
### Documentation Changes Required

None
