### PR TITLE
Fix unittest on cache - 5 seconds less

### DIFF
--- a/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
@@ -442,19 +442,30 @@ class JCacheTest extends TestCase
 	 */
 	public function testGc()
 	{
-		$this->object = JCache::getInstance('output', array('lifetime' => 2, 'defaultgroup' => ''));
+		$options = array('storage' => 'file', 'defaultgroup' => '');
+		$this->object = JCache::getInstance('output', $options);
+		$this->object->setCaching(true);
+		$this->object->setLifeTime(2/60); // Real 2 seconds
 
 		$this->object->store($this->testData_A, 42, '');
+
+		sleep(2);
+
 		$this->object->store($this->testData_B, 43, '');
 
-		sleep(5);
+		sleep(1);
+
+		$this->object->cache->_getStorage()->_now = time();
 
 		$this->object->gc();
 
 		$this->assertFalse(
 			$this->object->get(42, '')
 		);
-		$this->assertFalse(
+
+		// To be sure that cache is working
+		$this->assertEquals(
+			$this->testData_B,
 			$this->object->get(43, '')
 		);
 	}


### PR DESCRIPTION
### Summary of Changes
Currently `JCacheTest->testGc()` method work with cache disabled, without configured storage, but take 5 seconds.

Changes:
- enable caching
- set storage to file
- remove `sleep(5)` and use `TestReflection` to change modification time of cached file.
- After garbage collection:
  - add test for file exists before check cache data. File storage deletes expired file on `get` method so we have to check file exists before `get` to be sure that `gc` works as expected.
  - add additional test for non expired data

### Testing Instructions

Travis passed.
Require code review.

### Documentation Changes Required
None