### PR TITLE
Reduce waiting time (sleep) in the cache tests

### DIFF
--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -115,7 +115,7 @@ abstract class TestCaseCache extends TestCase
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(5);
+		sleep(3);
 
 		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
 	}

--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -111,13 +111,31 @@ abstract class TestCaseCache extends TestCase
 	{
 		$data = 'testData';
 
-		$this->handler->_lifetime = 2;
+		$this->handler->_lifetime = 0.1;
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(3);
+		// Test whether data was stored.
+		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
-		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
+		// Wait for lifetime.
+		usleep($this->handler->_lifetime * 1000000);
+
+		// Timer and testing interval (in seconds)
+		$timer    = 0;
+		$interval = 0.05;
+
+		do
+		{
+			$cache = $this->handler->get($this->id, $this->group);
+
+			usleep($interval * 1000000);
+
+			$timer += $interval;
+		}
+		while ($cache && $timer < 5);
+
+		$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -73,11 +73,12 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 		do
 		{
-			$cache = $this->handler->get($this->id, $this->group);
+			$timer += $interval;
 
 			usleep($interval * 1000000);
 
-			$timer += $interval;
+			$cache  = $this->handler->get($this->id, $this->group);
+
 		}
 		while ($cache && $timer < 3);
 

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -64,6 +64,9 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
+		// Test whether data was stored.
+		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
+
 		// Timer and max time (in seconds)
 		$timer    = 0;
 		$maxTime  = 3;

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -60,31 +60,9 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 		$cacheLiteInstance = TestReflection::getValue('JCacheStorageCachelite', 'CacheLiteInstance');
 		$cacheLiteInstance->_lifeTime = 0.1;
 
-		$data = 'testData';
+		// For parent class
+		$this->handler->_lifetime = &$cacheLiteInstance->_lifeTime;
 
-		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
-
-		// Test whether data was stored.
-		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
-
-		// Wait for lifetime.
-		usleep($cacheLiteInstance->_lifeTime * 1000000);
-
-		// Timer and testing interval (in seconds)
-		$timer    = 0;
-		$interval = 0.05;
-
-		do
-		{
-			$cache = $this->handler->get($this->id, $this->group);
-
-			usleep($interval * 1000000);
-
-			$timer += $interval;
-
-		}
-		while ($cache && $timer < 5);
-
-		$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
+		parent::testCacheTimeout();
 	}
 }

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -58,14 +58,29 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 	{
 		/** @var Cache_Lite $cacheLiteInstance */
 		$cacheLiteInstance = TestReflection::getValue('JCacheStorageCachelite', 'CacheLiteInstance');
-		$cacheLiteInstance->_lifeTime = 2;
+		$cacheLiteInstance->_lifeTime = 0.1;
 
 		$data = 'testData';
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(3);
+		// Timer and max time (in seconds)
+		$timer    = 0;
+		$maxTime  = 3;
 
-		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
+		// Testing interval (in seconds)
+		$interval = 0.1;
+
+		do
+		{
+			$cache = $this->handler->get($this->id, $this->group);
+
+			usleep($interval * 1000000);
+
+			$timer += $interval;
+		}
+		while ($cache && $timer < 3);
+
+		$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
 	}
 }

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -64,7 +64,7 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(5);
+		sleep(3);
 
 		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
 	}

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -67,11 +67,8 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 		// Test whether data was stored.
 		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
-		// Timer and max time (in seconds)
+		// Timer and testing interval (in seconds)
 		$timer    = 0;
-		$maxTime  = 3;
-
-		// Testing interval (in seconds)
 		$interval = 0.1;
 
 		do

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -73,11 +73,10 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 		do
 		{
-			$timer += $interval;
-
 			usleep($interval * 1000000);
 
-			$cache = $this->handler->get($this->id, $this->group);
+			$timer += $interval;
+			$cache  = $this->handler->get($this->id, $this->group);
 
 		}
 		while ($cache && $timer < 3);

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -72,7 +72,7 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 		// Timer and testing interval (in seconds)
 		$timer    = 0;
-		$interval = 0.1;
+		$interval = 0.05;
 
 		do
 		{

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -77,7 +77,7 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 
 			usleep($interval * 1000000);
 
-			$cache  = $this->handler->get($this->id, $this->group);
+			$cache = $this->handler->get($this->id, $this->group);
 
 		}
 		while ($cache && $timer < 3);

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageCacheliteTest.php
@@ -67,19 +67,23 @@ class JCacheStorageCacheliteTest extends TestCaseCache
 		// Test whether data was stored.
 		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
+		// Wait for lifetime.
+		usleep($cacheLiteInstance->_lifeTime * 1000000);
+
 		// Timer and testing interval (in seconds)
 		$timer    = 0;
 		$interval = 0.1;
 
 		do
 		{
+			$cache = $this->handler->get($this->id, $this->group);
+
 			usleep($interval * 1000000);
 
 			$timer += $interval;
-			$cache  = $this->handler->get($this->id, $this->group);
 
 		}
-		while ($cache && $timer < 3);
+		while ($cache && $timer < 5);
 
 		$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
 	}

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -49,20 +49,23 @@ class JCacheStorageFileTest extends TestCaseCache
 		// Test whether data was stored.
 		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
+		// Wait for lifetime.
+		usleep($this->handler->_lifetime * 1000000);
+
 		// Timer and testing interval (in seconds)
 		$timer    = 0;
 		$interval = 0.1;
 
 		do
 		{
+			$this->handler->_now = time();
+			$cache = $this->handler->get($this->id, $this->group);
+
 			usleep($interval * 1000000);
 
 			$timer += $interval;
-
-			$this->handler->_now = time();
-			$cache = $this->handler->get($this->id, $this->group);
 		}
-		while ($cache && $timer < 3);
+		while ($cache && $timer < 5);
 		
         	$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
 	}

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -46,6 +46,9 @@ class JCacheStorageFileTest extends TestCaseCache
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
+		// Test whether data was stored.
+		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
+
 		// Timer and max time (in seconds)
 		$timer    = 0;
 		$maxTime  = 3;

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -30,7 +30,7 @@ class JCacheStorageFileTest extends TestCaseCache
 		$this->handler = new JCacheStorageFile(array('cachebase' => JPATH_CACHE));
 
 		// Override the lifetime because the JCacheStorage API multiplies it by 60 (converts minutes to seconds)
-		$this->handler->_lifetime = 0.1;
+		$this->handler->_lifetime = 2;
 	}
 
 	/**
@@ -49,24 +49,9 @@ class JCacheStorageFileTest extends TestCaseCache
 		// Test whether data was stored.
 		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
-		// Wait for lifetime.
-		usleep($this->handler->_lifetime * 1000000);
+		// If we add only lifetime then the cache still be valid
+		$this->handler->_now += 1 + $this->handler->_lifetime;
 
-		// Timer and testing interval (in seconds)
-		$timer    = 0;
-		$interval = 0.05;
-
-		do
-		{
-			$this->handler->_now = time();
-			$cache = $this->handler->get($this->id, $this->group);
-
-			usleep($interval * 1000000);
-
-			$timer += $interval;
-		}
-		while ($cache && $timer < 5);
-		
-        	$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
+		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
 	}
 }

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -30,7 +30,7 @@ class JCacheStorageFileTest extends TestCaseCache
 		$this->handler = new JCacheStorageFile(array('cachebase' => JPATH_CACHE));
 
 		// Override the lifetime because the JCacheStorage API multiplies it by 60 (converts minutes to seconds)
-		$this->handler->_lifetime = 2;
+		$this->handler->_lifetime = 0.1;
 	}
 
 	/**
@@ -46,10 +46,24 @@ class JCacheStorageFileTest extends TestCaseCache
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(3);
+		// Timer and max time (in seconds)
+		$timer    = 0;
+		$maxTime  = 3;
 
-		$this->handler->_now = time();
+		// Testing interval (in seconds)
+		$interval = 0.1;
 
-		$this->assertFalse($this->handler->get($this->id, $this->group), 'No data should be returned from the cache store when expired.');
+		do
+		{
+			usleep($interval * 1000000);
+
+			$timer += $interval;
+
+			$this->handler->_now = time();
+			$cache = $this->handler->get($this->id, $this->group);
+		}
+		while ($cache && $timer < 3);
+		
+        	$this->assertFalse($cache, 'No data should be returned from the cache store when expired.');
 	}
 }

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -46,7 +46,7 @@ class JCacheStorageFileTest extends TestCaseCache
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
-		sleep(5);
+		sleep(3);
 
 		$this->handler->_now = time();
 

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -54,7 +54,7 @@ class JCacheStorageFileTest extends TestCaseCache
 
 		// Timer and testing interval (in seconds)
 		$timer    = 0;
-		$interval = 0.1;
+		$interval = 0.05;
 
 		do
 		{

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageFileTest.php
@@ -49,11 +49,8 @@ class JCacheStorageFileTest extends TestCaseCache
 		// Test whether data was stored.
 		$this->assertEquals($data, $this->handler->get($this->id, $this->group), 'Some data should be available in lifetime.');
 
-		// Timer and max time (in seconds)
+		// Timer and testing interval (in seconds)
 		$timer    = 0;
-		$maxTime  = 3;
-
-		// Testing interval (in seconds)
 		$interval = 0.1;
 
 		do


### PR DESCRIPTION
### Summary of Changes

Reduce time of tests for travis and etc.
For my laptop (file, apcu, memcache, memcached):

```
php libraries/vendor/phpunit/phpunit/phpunit tests/unit/suites/libraries/joomla/cache
```

Before patch:
Time: **23.24** seconds, Memory: 10.00MB

After patch:
Time: **15.26** seconds, Memory: 10.00MB
### Testing Instructions

Code review, Travis and Jenkins tests only.
