### PR TITLE
Properly update associations during saving

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -593,14 +593,31 @@ class CategoriesModelCategory extends JModelAdmin
 				JError::raiseNotice(403, JText::_('COM_CATEGORIES_ERROR_ALL_LANGUAGE_ASSOCIATED'));
 			}
 
-			$associations[$table->language] = $table->id;
-
-			// Deleting old association for these items
-			$db = $this->getDbo();
+			// Get associationskey for edited item
+			$db    = $this->getDbo();
 			$query = $db->getQuery(true)
-				->delete('#__associations')
+				->select($db->quoteName('key'))
+				->from($db->quoteName('#__associations'))
 				->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext))
-				->where($db->quoteName('id') . ' IN (' . implode(',', $associations) . ')');
+				->where($db->quoteName('id') . ' = ' . (int) $table->id);
+			$db->setQuery($query);
+			$old_key = $db->loadResult();
+
+			// Deleting old associations for the associated items
+			$query = $db->getQuery(true)
+				->delete($db->quoteName('#__associations'))
+				->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext));
+
+			if ($associations)
+			{
+				$query->where('(' . $db->quoteName('id') . ' IN (' . implode(',', $associations) . ') OR '
+					. $db->quoteName('key') . ' = ' . $db->quote($old_key) . ')');
+			}
+			else
+			{
+				$query->where($db->quoteName('key') . ' = ' . $db->quote($old_key));
+			}
+
 			$db->setQuery($query);
 
 			try
@@ -614,7 +631,13 @@ class CategoriesModelCategory extends JModelAdmin
 				return false;
 			}
 
-			if (!$all_language && count($associations))
+			// Adding self to the association
+			if (!$all_language)
+			{
+				$associations[$table->language] = (int) $table->id;
+			}
+
+			if (count($associations) > 1)
 			{
 				// Adding new association for these items
 				$key = md5(json_encode($associations));

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1402,14 +1402,31 @@ class MenusModelItem extends JModelAdmin
 				JError::raiseNotice(403, JText::_('COM_MENUS_ERROR_ALL_LANGUAGE_ASSOCIATED'));
 			}
 
-			$associations[$table->language] = $table->id;
-
-			// Deleting old association for these items
-			$db = $this->getDbo();
+			// Get associationskey for edited item
+			$db    = $this->getDbo();
 			$query = $db->getQuery(true)
-				->delete('#__associations')
-				->where('context=' . $db->quote($this->associationsContext))
-				->where('id IN (' . implode(',', $associations) . ')');
+				->select($db->quoteName('key'))
+				->from($db->quoteName('#__associations'))
+				->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext))
+				->where($db->quoteName('id') . ' = ' . (int) $table->id);
+			$db->setQuery($query);
+			$old_key = $db->loadResult();
+
+			// Deleting old associations for the associated items
+			$query = $db->getQuery(true)
+				->delete($db->quoteName('#__associations'))
+				->where($db->quoteName('context') . ' = ' . $db->quote($this->associationsContext));
+
+			if ($associations)
+			{
+				$query->where('(' . $db->quoteName('id') . ' IN (' . implode(',', $associations) . ') OR '
+					. $db->quoteName('key') . ' = ' . $db->quote($old_key) . ')');
+			}
+			else
+			{
+				$query->where($db->quoteName('key') . ' = ' . $db->quote($old_key));
+			}
+
 			$db->setQuery($query);
 
 			try
@@ -1423,7 +1440,13 @@ class MenusModelItem extends JModelAdmin
 				return false;
 			}
 
-			if (!$all_language && count($associations) > 1)
+			// Adding self to the association
+			if (!$all_language)
+			{
+				$associations[$table->language] = (int) $table->id;
+			}
+
+			if (count($associations) > 1)
 			{
 				// Adding new association for these items
 				$key = md5(json_encode($associations));


### PR DESCRIPTION
Pull Request for Issue #11871.

The associations are not properly updated when making changes:
- Removing an associated item doesn't remove it from the database `#__associations` table.
- Setting the item language to `All` clears all other associations.
### Summary of Changes

`JModelAdmin::save` now deletes all associations for the currently saved item based on its association key plus if present on the associated items ids.
If language is set to `All`, the saved item isn't added to the `$associations` array anymore. However it now always saves the associations, regardless of the language of the saved item.
### Testing Instructions

From the original issue:

> Multingual site with associations enabled.
> 3 content languages
> 
> Create an article in each content language and associate them.
> 
> Then edit one of these articles and change its language to ALL.
> The article saves with this correct warning:
> 
> A content item set to All languages can't be associated. Associations have not been set.
> The problem is that the 2 other articles are no more associated between them.

Additionally test with at least 4 content languages:
1. Associate an item to 3 other items and save
2. Remove the association of two items and save
3. Expected result would be to only have the remaining two items associated but you get 2 pairs of associations now, the removed ones build one (unexpected) and the saved one builds another one (expected).
Apply patch and try again and you should only get the saved pair. The removed ones aren't associated to anything anymore.

Also test other cases like removing all associations.
### Documentation Changes Required

None
