### PR TITLE
[database] Remove the defaulting to the root account in mysql & mysqli

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -45,7 +45,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 		// Get some basic values from the options.
 		$options['host'] = (isset($options['host'])) ? $options['host'] : 'localhost';
-		$options['user'] = (isset($options['user'])) ? $options['user'] : 'root';
+		$options['user'] = (isset($options['user'])) ? $options['user'] : '';
 		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
 		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
 		$options['select'] = (isset($options['select'])) ? (bool) $options['select'] : true;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -76,7 +76,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	{
 		// Get some basic values from the options.
 		$options['host']     = (isset($options['host'])) ? $options['host'] : 'localhost';
-		$options['user']     = (isset($options['user'])) ? $options['user'] : 'root';
+		$options['user']     = (isset($options['user'])) ? $options['user'] : '';
 		$options['password'] = (isset($options['password'])) ? $options['password'] : '';
 		$options['database'] = (isset($options['database'])) ? $options['database'] : '';
 		$options['select']   = (isset($options['select'])) ? (bool) $options['select'] : true;


### PR DESCRIPTION
Pull Request for Issue #11878 
### Summary of Changes

There is no need to default to `root` as no public webserver should allow access via root and empty pw.
Also no other cms database class defaults to root if it is not set. they just default to empty.
### Testing Instructions
- Install Joomla using this package: https://github.com/zero-24/joomla-cms/archive/default_root.zip
- make sure the install works
- navigate to the backend and freontend
- meke sure they work too.
### Documentation Changes Required

None.
