### PR TITLE
[unit tests] 1 second less

### DIFF
--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -223,7 +223,7 @@ class JFactoryTest extends TestCaseDatabase
 		JFactory::$language = $this->getMockLanguage();
 
 		$date = JFactory::getDate('now');
-		sleep(2);
+		usleep(1);
 		$date2 = JFactory::getDate('now');
 
 		$this->assertThat(

--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -223,7 +223,7 @@ class JFactoryTest extends TestCaseDatabase
 		JFactory::$language = $this->getMockLanguage();
 
 		$date = JFactory::getDate('now');
-		usleep(1);
+		sleep(1);
 		$date2 = JFactory::getDate('now');
 
 		$this->assertThat(


### PR DESCRIPTION
### Summary of Changes

Reduce unit tests time a little further, but removing to 1 seconds sleep in `JFactoryTest::testGetDateNow`  (one line changed).
### Testing Instructions

Unit tested passed.
Code review
### Documentation Changes Required

None.
