### PR TITLE
Add Microseconds to JDate('now')

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -107,7 +107,7 @@ class JDate extends DateTime
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
 		// If now, add the microseconds to date.
-		$date = $date === 'now' ? DateTime::createFromFormat('U.u', microtime(true))->format('Y-m-d H:i:s.u') : $date;
+		$date = $date === 'now' ? parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u') : $date;
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -24,7 +24,7 @@ defined('JPATH_PLATFORM') or die;
  * @property-read  string   $hour          H - 24-hour format of an hour with leading zeros.
  * @property-read  string   $minute        i - Minutes with leading zeros.
  * @property-read  string   $second        s - Seconds with leading zeros.
- * @property-read  string   $second        u - Microseconds with leading zeros.
+ * @property-read  string   $microsecond   u - Microseconds with leading zeros.
  * @property-read  string   $month         m - Numeric representation of a month, with leading zeros.
  * @property-read  string   $ordinal       S - English ordinal suffix for the day of the month, 2 characters.
  * @property-read  string   $week          W - Numeric representation of the day of the week.

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -107,11 +107,7 @@ class JDate extends DateTime
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
 		// If now, add the microseconds to date.
-		if ($date === 'now')
-		{
-			$now  = parent::createFromFormat('U.u', microtime(true), $tz);
-			$date = $now->format('Y-m-d H:i:s.u');
-		}
+		$date = $date === 'now' ? DateTime::createFromFormat('U.u', microtime(true))->format('Y-m-d H:i:s.u') : $date;
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -24,6 +24,7 @@ defined('JPATH_PLATFORM') or die;
  * @property-read  string   $hour          H - 24-hour format of an hour with leading zeros.
  * @property-read  string   $minute        i - Minutes with leading zeros.
  * @property-read  string   $second        s - Seconds with leading zeros.
+ * @property-read  string   $second        u - Microseconds with leading zeros.
  * @property-read  string   $month         m - Numeric representation of a month, with leading zeros.
  * @property-read  string   $ordinal       S - English ordinal suffix for the day of the month, 2 characters.
  * @property-read  string   $week          W - Numeric representation of the day of the week.
@@ -104,6 +105,14 @@ class JDate extends DateTime
 		// If the date is numeric assume a unix timestamp and convert it.
 		date_default_timezone_set('UTC');
 		$date = is_numeric($date) ? date('c', $date) : $date;
+
+		// If now, add the microseconds to date.
+		if ($date === 'now')
+		{
+			$now   = microtime(true);
+			$micro = sprintf("%06d", ($now - floor($now)) * 1000000);
+			$date  = date('Y-m-d H:i:s.' . $micro, $now);
+		}
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -109,9 +109,8 @@ class JDate extends DateTime
 		// If now, add the microseconds to date.
 		if ($date === 'now')
 		{
-			$now   = microtime(true);
-			$micro = sprintf("%06d", ($now - floor($now)) * 1000000);
-			$date  = date('Y-m-d H:i:s.' . $micro, $now);
+			$now  = parent::createFromFormat('U.u', microtime(true), $tz);
+			$date = $now->format('Y-m-d H:i:s.u');
 		}
 
 		// Call the DateTime constructor.


### PR DESCRIPTION
### Summary of Changes

As discussed in https://github.com/joomla/joomla-cms/pull/11888 this PR adds the microsconds when creating a JDate('now') so 'now' is really 'now' and not with a delay up to 0.99(9) seconds.
### Testing Instructions
- Add to protostar/isis index.php the following code.

``` php
$date1 = new JDate('now'); usleep(1000); $date2 = new JDate('now');
$app->enqueueMessage($date1->format('Y-m-d H:i:s.u') . '<br />' . $date2->format('Y-m-d H:i:s.u'), 'notice');
```
- Reload page. Before patch the dates are equal with 0 microseconds.

![image](https://cloud.githubusercontent.com/assets/9630530/18206140/42880b54-711d-11e6-8107-85c40900976c.png)
- Apply patch. You should see the dates are different and you should see the microsecond in the notice message.
- Test if Joomla works fine.

![image](https://cloud.githubusercontent.com/assets/9630530/18205957/979df456-711c-11e6-80a5-d2b3ed4ad9ec.png)
### Documentation Changes Required

This page in the docs should probably be updated https://docs.joomla.org/How_to_use_JDate
