### PR TITLE
Reduce use of JFactory::getConfig() where practical

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -412,8 +412,7 @@ class JApplicationAdministrator extends JApplicationCms
 		$this->set('themeFile', $file . '.php');
 
 		// Safety check for when configuration.php root_user is in use.
-		$config = JFactory::getConfig();
-		$rootUser = $config->get('root_user');
+		$rootUser = $this->get('root_user');
 
 		if (property_exists('JConfig', 'root_user')
 			&& (JFactory::getUser()->get('username') == $rootUser || JFactory::getUser()->id === (string) $rootUser))

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -401,8 +401,7 @@ final class JApplicationSite extends JApplicationCms
 	 */
 	public static function getRouter($name = 'site', array $options = array())
 	{
-		$config = JFactory::getConfig();
-		$options['mode'] = $config->get('sef');
+		$options['mode'] = JFactory::getConfig()->get('sef');
 
 		return parent::getRouter($name, $options);
 	}

--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -38,7 +38,7 @@ class JErrorPage
 				$app = JFactory::getApplication();
 
 				// If site is offline and it's a 404 error, just go to index (to see offline message, instead of 404)
-				if ($error->getCode() == '404' && JFactory::getConfig()->get('offline') == 1)
+				if ($error->getCode() == '404' && $app->get('offline') == 1)
 				{
 					$app->redirect('index.php');
 				}

--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -86,11 +86,13 @@ class JFormFieldCaptcha extends JFormField
 	{
 		$result = parent::setup($element, $value, $group);
 
-		$default = JFactory::getConfig()->get('captcha');
+		$app = JFactory::getApplication();
 
-		if (JFactory::getApplication()->isSite())
+		$default = $app->get('captcha');
+
+		if ($app->isSite())
 		{
-			$default = JFactory::getApplication()->getParams()->get('captcha', JFactory::getConfig()->get('captcha'));
+			$default = $app->getParams()->get('captcha', $default);
 		}
 
 		$plugin = $this->element['plugin'] ?

--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -298,8 +298,7 @@ class JFormFieldEditor extends JFormFieldTextarea
 			// Create the JEditor instance based on the given editor.
 			if (is_null($editor))
 			{
-				$conf = JFactory::getConfig();
-				$editor = $conf->get('editor');
+				$editor = JFactory::getConfig()->get('editor');
 			}
 
 			$this->editor = JEditor::getInstance($editor);

--- a/libraries/cms/form/rule/captcha.php
+++ b/libraries/cms/form/rule/captcha.php
@@ -35,11 +35,12 @@ class JFormRuleCaptcha extends JFormRule
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
-		$plugin = JFactory::getConfig()->get('captcha');
+		$app    = JFactory::getApplication();
+		$plugin = $app->get('captcha');
 
-		if (JFactory::getApplication()->isSite())
+		if ($app->isSite())
 		{
-			$plugin = JFactory::getApplication()->getParams()->get('captcha', JFactory::getConfig()->get('captcha'));
+			$plugin = $app->getParams()->get('captcha', $plugin);
 		}
 
 		$namespace = $element['namespace'] ?: $form->getName();

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -52,8 +52,7 @@ abstract class JHtmlBehavior
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
-			$config = JFactory::getConfig();
-			$debug = $config->get('debug');
+			$debug = JDEBUG;
 		}
 
 		if ($type != 'core' && empty(static::$loaded[__METHOD__]['core']))
@@ -678,13 +677,13 @@ abstract class JHtmlBehavior
 		}
 
 		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
-		if (JFactory::getConfig()->get('session_handler') != 'database')
+		if (JFactory::getApplication()->get('session_handler') != 'database')
 		{
 			$refresh_time = 300000;
 		}
 		else
 		{
-			$life_time    = JFactory::getConfig()->get('lifetime') * 60000;
+			$life_time    = JFactory::getApplication()->get('lifetime') * 60000;
 			$refresh_time = ($life_time <= 60000) ? 45000 : $life_time - 60000;
 
 			// The longest refresh period is one hour to prevent integer overflow.

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -222,8 +222,7 @@ abstract class JHtmlBootstrap
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
-			$config = JFactory::getConfig();
-			$debug = (boolean) $config->get('debug');
+			$debug = JDEBUG;
 		}
 
 		JHtml::_('script', 'jui/bootstrap.min.js', false, true, false, false, $debug);

--- a/libraries/cms/html/formbehavior.php
+++ b/libraries/cms/html/formbehavior.php
@@ -47,8 +47,7 @@ abstract class JHtmlFormbehavior
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
-			$config = JFactory::getConfig();
-			$debug  = (boolean) $config->get('debug');
+			$debug = JDEBUG;
 		}
 
 		// Default settings

--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -46,8 +46,7 @@ abstract class JHtmlJquery
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
-			$config = JFactory::getConfig();
-			$debug  = (boolean) $config->get('debug');
+			$debug = (boolean) JFactory::getConfig()->get('debug');
 		}
 
 		JHtml::_('script', 'jui/jquery.min.js', false, true, false, false, $debug);
@@ -92,8 +91,7 @@ abstract class JHtmlJquery
 		// If no debugging value is set, use the configuration setting
 		if ($debug === null)
 		{
-			$config = JFactory::getConfig();
-			$debug  = (boolean) $config->get('debug');
+			$debug = JDEBUG;
 		}
 
 		// Load each of the requested components

--- a/libraries/cms/installer/helper.php
+++ b/libraries/cms/installer/helper.php
@@ -32,8 +32,6 @@ abstract class JInstallerHelper
 	 */
 	public static function downloadPackage($url, $target = false)
 	{
-		$config = JFactory::getConfig();
-
 		// Capture PHP errors
 		$track_errors = ini_get('track_errors');
 		ini_set('track_errors', true);
@@ -78,14 +76,16 @@ abstract class JInstallerHelper
 			$target = trim($flds[0], '"');
 		}
 
+		$tmpPath = JFactory::getConfig()->get('tmp_path');
+
 		// Set the target path if not given
 		if (!$target)
 		{
-			$target = $config->get('tmp_path') . '/' . self::getFilenameFromUrl($url);
+			$target = $tmpPath . '/' . self::getFilenameFromUrl($url);
 		}
 		else
 		{
-			$target = $config->get('tmp_path') . '/' . basename($target);
+			$target = $tmpPath . '/' . basename($target);
 		}
 
 		// Write buffer to file

--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -243,10 +243,9 @@ final class JVersion
 	 */
 	public function generateMediaVersion()
 	{
-		$date   = new JDate;
-		$config = JFactory::getConfig();
+		$date = new JDate;
 
-		return md5($this->getLongVersion() . $config->get('secret') . $date->toSql());
+		return md5($this->getLongVersion() . JFactory::getConfig()->get('secret') . $date->toSql());
 	}
 
 	/**
@@ -267,9 +266,6 @@ final class JVersion
 
 		if ($mediaVersion === null)
 		{
-			$config = JFactory::getConfig();
-			$debugEnabled = $config->get('debug', 0);
-
 			// Get the joomla library params
 			$params = JLibraryHelper::getParams('joomla');
 
@@ -277,7 +273,7 @@ final class JVersion
 			$mediaVersion = $params->get('mediaversion', '');
 
 			// Refresh assets in debug mode or when the media version is not set
-			if ($debugEnabled || empty($mediaVersion))
+			if (JDEBUG || empty($mediaVersion))
 			{
 				$mediaVersion = $this->generateMediaVersion();
 

--- a/libraries/joomla/cache/storage/redis.php
+++ b/libraries/joomla/cache/storage/redis.php
@@ -63,16 +63,15 @@ class JCacheStorageRedis extends JCacheStorage
 			return false;
 		}
 
-		$config = JFactory::getConfig();
-		$app    = JFactory::getApplication();
+		$app = JFactory::getApplication();
 
-		$this->_persistent = $config->get('redis_persist', true);
+		$this->_persistent = $app->get('redis_persist', true);
 
 		$server = array(
-			'host' => $config->get('redis_server_host', 'localhost'),
-			'port' => $config->get('redis_server_port', 6379),
-			'auth' => $config->get('redis_server_auth', null),
-			'db'   => (int) $config->get('redis_server_db', null),
+			'host' => $app->get('redis_server_host', 'localhost'),
+			'port' => $app->get('redis_server_port', 6379),
+			'auth' => $app->get('redis_server_auth', null),
+			'db'   => (int) $app->get('redis_server_db', null),
 		);
 
 		static::$_redis = new Redis;

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -364,8 +364,7 @@ class JUser extends JObject
 			$this->isRoot = false;
 
 			// Check for the configuration file failsafe.
-			$config = JFactory::getConfig();
-			$rootUser = $config->get('root_user');
+			$rootUser = JFactory::getConfig()->get('root_user');
 
 			// The root_user variable can be a numeric user ID or a username.
 			if (is_numeric($rootUser) && $this->id > 0 && $this->id == $rootUser)

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -13,8 +13,8 @@ defined('_JEXEC') or die;
 $params   = $displayData->params;
 $basePath = $params->get('basePath', 'media/editors/codemirror/');
 $modePath = $params->get('modePath', 'media/editors/codemirror/mode/%N/%N');
-$extJS    = JFactory::getConfig()->get('debug') ? '.js' : '.min.js';
-$extCSS   = JFactory::getConfig()->get('debug') ? '.css' : '.min.css';
+$extJS    = JDEBUG ? '.js' : '.min.js';
+$extCSS   = JDEBUG ? '.css' : '.min.css';
 
 JHtml::_('script', $basePath . 'lib/codemirror' . $extJS);
 JHtml::_('script', $basePath . 'lib/addons' . $extJS);

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -36,15 +36,15 @@ class PlgSystemLogout extends JPlugin
 	{
 		parent::__construct($subject, $config);
 
-		$input = JFactory::getApplication()->input;
+		$app   = JFactory::getApplication();
+		$input = $app->input;
 		$hash  = JApplicationHelper::getHash('PlgSystemLogout');
 
-		if (JFactory::getApplication()->isSite() && $input->cookie->getString($hash))
+		if ($app->isSite() && $input->cookie->getString($hash))
 		{
 			// Destroy the cookie.
-			$conf = JFactory::getConfig();
-			$cookie_domain = $conf->get('cookie_domain', '');
-			$cookie_path   = $conf->get('cookie_path', '/');
+			$cookie_domain = $app->get('cookie_domain', '');
+			$cookie_path   = $app->get('cookie_path', '/');
 			setcookie($hash, false, time() - 86400, $cookie_path, $cookie_domain);
 
 			// Set the error handler for E_ALL to be the class handleError method.
@@ -64,13 +64,15 @@ class PlgSystemLogout extends JPlugin
 	 */
 	public function onUserLogout($user, $options = array())
 	{
-		if (JFactory::getApplication()->isSite())
+		$app = JFactory::getApplication();
+
+		if ($app->isSite())
 		{
 			// Create the cookie.
 			$hash = JApplicationHelper::getHash('PlgSystemLogout');
-			$conf = JFactory::getConfig();
-			$cookie_domain = $conf->get('cookie_domain', '');
-			$cookie_path   = $conf->get('cookie_path', '/');
+
+			$cookie_domain = $app->get('cookie_domain', '');
+			$cookie_path   = $app->get('cookie_path', '/');
 			setcookie($hash, true, time() + 86400, $cookie_path, $cookie_domain);
 		}
 

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -537,8 +537,6 @@ class PlgSystemStats extends JPlugin
 	 */
 	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
 	{
-		$conf = JFactory::getConfig();
-
 		foreach ($clearGroups as $group)
 		{
 			foreach ($cacheClients as $client_id)
@@ -547,8 +545,7 @@ class PlgSystemStats extends JPlugin
 				{
 					$options = array(
 						'defaultgroup' => $group,
-						'cachebase'    => ($client_id) ? JPATH_ADMINISTRATOR . '/cache' :
-							$conf->get('cache_path', JPATH_SITE . '/cache')
+						'cachebase'    => ($client_id) ? JPATH_ADMINISTRATOR . '/cache' : $this->app->get('cache_path', JPATH_SITE . '/cache')
 					);
 
 					$cache = JCache::getInstance('callback', $options);

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -239,9 +239,8 @@ class PlgUserJoomla extends JPlugin
 		$instance->setLastVisit();
 
 		// Add "user state" cookie used for reverse caching proxies like Varnish, Nginx etc.
-		$conf          = JFactory::getConfig();
-		$cookie_domain = $conf->get('cookie_domain', '');
-		$cookie_path   = $conf->get('cookie_path', '/');
+		$cookie_domain = $this->app->get('cookie_domain', '');
+		$cookie_path   = $this->app->get('cookie_path', '/');
 
 		if ($this->app->isSite())
 		{
@@ -303,9 +302,8 @@ class PlgUserJoomla extends JPlugin
 		}
 
 		// Delete "user state" cookie used for reverse caching proxies like Varnish, Nginx etc.
-		$conf          = JFactory::getConfig();
-		$cookie_domain = $conf->get('cookie_domain', '');
-		$cookie_path   = $conf->get('cookie_path', '/');
+		$cookie_domain = $this->app->get('cookie_domain', '');
+		$cookie_path   = $this->app->get('cookie_path', '/');
 
 		if ($this->app->isSite())
 		{

--- a/tests/unit/suites/libraries/joomla/cache/JCacheStorageTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheStorageTest.php
@@ -66,6 +66,11 @@ class JCacheStorageTest extends TestCase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+
+		// Mock the returns on JApplicationCms::get() to use the default values
+		JFactory::$application->expects($this->any())
+			->method('get')
+			->willReturnArgument(1);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageRedisTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/storage/JCacheStorageRedisTest.php
@@ -27,6 +27,11 @@ class JCacheStorageRedisTest extends TestCaseCache
 
 		parent::setUp();
 
+		// Mock the returns on JApplicationCms::get() to use the default values
+		JFactory::$application->expects($this->any())
+			->method('get')
+			->willReturnArgument(1);
+
 		$this->handler = new JCacheStorageRedis;
 
 		// Override the lifetime because the JCacheStorage API multiplies it by 60 (converts minutes to seconds)


### PR DESCRIPTION
### Summary of Changes

The data loaded from `JFactory::getConfig()` is already injected into the application object, so in places where we are already referencing the application object, we can skip referencing data out of another object.  We can also save a little memory and not put a reference to the object in memory when only using it once.

We also have a `JDEBUG` constant which defines if the application is globally set to debug mode, use that as practical over referencing the configuration data.
### Testing Instructions

The correct configuration values continue to be referenced in the changed locations.
### Documentation Changes Required

N/A
