### PR TITLE
Pull configuration values from the session for the keepalive behavior

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -677,14 +677,16 @@ abstract class JHtmlBehavior
 			return;
 		}
 
+		$session = JFactory::getSession();
+
 		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
-		if (JFactory::getConfig()->get('session_handler') != 'database')
+		if ($session->storeName != 'database')
 		{
 			$refresh_time = 300000;
 		}
 		else
 		{
-			$life_time    = JFactory::getConfig()->get('lifetime') * 60000;
+			$life_time    = $session->getExpire() * 1000;
 			$refresh_time = ($life_time <= 60000) ? 45000 : $life_time - 60000;
 
 			// The longest refresh period is one hour to prevent integer overflow.
@@ -694,14 +696,12 @@ abstract class JHtmlBehavior
 			}
 		}
 
+		$url = JUri::base(true) . '/index.php';
+
 		// If we are in the frontend or logged in as a user, we can use the ajax component to reduce the load
 		if (JFactory::getApplication()->isSite() || !JFactory::getUser()->guest)
 		{
-			$url = JUri::base(true) . '/index.php?option=com_ajax&format=json';
-		}
-		else
-		{
-			$url = JUri::base(true) . '/index.php';
+			$url .= '?option=com_ajax&format=json';
 		}
 
 		$script = 'window.setInterval(function(){';

--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -45,6 +45,7 @@ class JHtmlBehaviorTest extends TestCase
 
 		JFactory::$application = $this->getMockCmsApp();
 		JFactory::$document = $this->getMockDocument();
+		JFactory::$session = $this->getMockSession();
 
 		$this->backupServer = $_SERVER;
 


### PR DESCRIPTION
### Summary of Changes

A `JSession` instance may have different values than those in the global configuration, so for the keepalive behavior, this should reference the active session configuration.
### Testing Instructions

Keepalive continues to be configured correctly.
### Documentation Changes Required

N/A
