### PR TITLE
Cleanup in JHtml tests

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBehaviorTest.php
@@ -46,6 +46,11 @@ class JHtmlBehaviorTest extends TestCase
 		JFactory::$application = $this->getMockCmsApp();
 		JFactory::$document = $this->getMockDocument();
 
+		// We generate a random template name so that we don't collide or hit anything
+		JFactory::$application->expects($this->any())
+			->method('getTemplate')
+			->willReturn('mytemplate' . rand(1, 10000));
+
 		$this->backupServer = $_SERVER;
 
 		$_SERVER['HTTP_HOST'] = 'example.com';
@@ -78,7 +83,7 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function getFrameworkData()
 	{
-		$data = array(
+		return array(
 			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true))),
 			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true),
 			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true)), false, false),
@@ -86,8 +91,6 @@ class JHtmlBehaviorTest extends TestCase
 			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, false),
 			array(array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true, 'more' => true)), true, true)
 		);
-
-		return $data;
 	}
 
 	/**
@@ -104,25 +107,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testFramework($expected, $extras = false, $debug = null)
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::framework($extras, $debug);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::framework($extras, $debug);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The framework behavior is not loaded with all expected dependencies'
 		);
 	}
 
@@ -135,12 +125,10 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function getCaptionData()
 	{
-		$data = array(
+		return array(
 			array(array('JHtmlBehavior::caption' => array('img.caption' => true))),
 			array(array('JHtmlBehavior::caption' => array('img.caption2' => true)), 'img.caption2'),
 		);
-
-		return $data;
 	}
 
 	/**
@@ -156,25 +144,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testCaption($expected, $selector = 'img.caption')
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::caption($selector);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::caption($selector);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The caption behavior is not loaded with all expected dependencies'
 		);
 	}
 
@@ -187,25 +162,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testFormvalidation()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::formvalidation();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::formvalidation();
 		$this->assertEquals(
 			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::formvalidator' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The form validation behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -218,25 +180,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testSwitcher()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::switcher();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::switcher();
 		$this->assertEquals(
 			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::framework' => array('core' => true), 'JHtmlBehavior::switcher' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The switcher behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -249,25 +198,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testCombobox()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::combobox();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::combobox();
 		$this->assertEquals(
 			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::combobox' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The combobox behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -330,25 +266,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testTooltip($expected, $selector = '.hasTooltip', $params = array())
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::tooltip($selector, $params);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::tooltip($selector, $params);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The tooltip behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -411,25 +334,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testModal($expected, $selector = 'a.modal', $params = array())
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::modal($selector, $params);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::modal($selector, $params);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The modal behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -474,25 +384,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testMultiselect($expected, $id = 'adminForm')
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::multiselect($id);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::multiselect($id);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The multiselect behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -534,25 +431,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testTree($expected, $id, $params = array(), $root = array())
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::tree($id, $params, $root);
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::tree($id, $params, $root);
 		$this->assertEquals(
 			$expected,
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The tree behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -565,25 +449,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testCalendar()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::calendar();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::calendar();
 		$this->assertEquals(
 			array('JHtmlBehavior::calendar' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The calendar behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -596,25 +467,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testColorpicker()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::colorpicker();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::colorpicker();
 		$this->assertEquals(
 			array('JHtmlBehavior::colorpicker' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The colorpicker behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -627,18 +485,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testKeepalive()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::keepalive();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not) to return a value from getTemplate
-		JFactory::$application->expects($this->any())
-			->method('getTemplate')
-			->willReturn($template);
-
-		JHtmlBehaviorInspector::keepalive();
 		$this->assertEquals(
 			array('JHtmlBehavior::keepalive' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The keepalive behavior is not loaded with all dependencies'
 		);
 	}
 
@@ -651,25 +503,12 @@ class JHtmlBehaviorTest extends TestCase
 	 */
 	public function testNoFrames()
 	{
-		// We generate a random template name so that we don't collide or hit anything//
-		$template = 'mytemplate' . rand(1, 10000);
+		JHtmlBehavior::noframes();
 
-		// We create a stub (not a mock because we don't enforce whether it is called or not)
-		// to return a value from getTemplate
-		$mock = $this->getMock('myMockObject', array('getTemplate', 'setHeader'));
-		$mock->expects($this->any())
-			->method('getTemplate')
-			->will($this->returnValue($template));
-
-		// @todo We need to mock this.
-		$mock->input = new JInput;
-
-		JFactory::$application = $mock;
-
-		JHtmlBehaviorInspector::noframes();
 		$this->assertEquals(
 			array('JHtmlBehavior::core' => true, 'JHtmlBehavior::noframes' => true),
-			JHtmlBehaviorInspector::getLoaded()
+			JHtmlBehaviorInspector::getLoaded(),
+			'The no frames behavior is not loaded with all dependencies'
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlBootstrapTest.php
@@ -529,10 +529,7 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndSlide()
 	{
-		$this->assertThat(
-			JHtml::_('bootstrap.endSlide'),
-			$this->equalTo('</div></div></div>')
-		);
+		$this->assertEquals('</div></div></div>', JHtmlBootstrap::endSlide());
 	}
 
 	/**
@@ -584,10 +581,7 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndTabSet()
 	{
-		$this->assertEquals(
-			JHtml::_('bootstrap.endTabSet'),
-			"\n</div>"
-		);
+		$this->assertEquals("\n</div>", JHtmlBootstrap::endTabSet());
 	}
 
 	/**
@@ -648,10 +642,7 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndTab()
 	{
-		$this->assertEquals(
-			JHtml::_('bootstrap.endTab'),
-			"\n</div>"
-		);
+		$this->assertEquals("\n</div>", JHtmlBootstrap::endTabSet());
 	}
 
 	/**
@@ -663,10 +654,7 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndPane()
 	{
-		$this->assertEquals(
-			JHtml::_('bootstrap.endTabSet'),
-			"\n</div>"
-		);
+		$this->assertEquals('</div>', JHtmlBootstrap::endPane());
 	}
 
 	/**
@@ -678,10 +666,7 @@ class JHtmlBootstrapTest extends TestCase
 	 */
 	public function testEndPanel()
 	{
-		$this->assertEquals(
-			JHtml::_('bootstrap.endTab'),
-			"\n</div>"
-		);
+		$this->assertEquals('</div>', JHtmlBootstrap::endPanel());
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/html/JHtmlFormTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlFormTest.php
@@ -34,7 +34,7 @@ class JHtmlFormTest extends TestCase
 	 */
 	protected function setUp()
 	{
-		parent::setup();
+		parent::setUp();
 
 		$this->saveFactoryState();
 
@@ -78,7 +78,7 @@ class JHtmlFormTest extends TestCase
 		$token = JSession::getFormToken();
 
 		$this->assertThat(
-			JHtml::_('form.token'),
+			JHtmlForm::token(),
 			$this->equalTo('<input type="hidden" name="' . $token . '" value="1" />')
 		);
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
@@ -42,10 +42,7 @@ class JHtmlMenuTest extends TestCaseDatabase
 	 */
 	public function testMenus()
 	{
-		$this->assertThat(
-			JHtml::_('select.options', JHtml::_('menu.menus'), 'value', 'text'),
-			$this->stringContains('<option value="mainmenu">Main Menu</option>')
-		);
+		$this->assertContains('<option value="mainmenu">Main Menu</option>', JHtmlSelect::options(JHtmlMenu::menus(), 'value', 'text'));
 	}
 
 	/**
@@ -57,9 +54,9 @@ class JHtmlMenuTest extends TestCaseDatabase
 	 */
 	public function testMenuitems()
 	{
-		$this->assertThat(
-			JHtml::_('select.options', JHtml::_('menu.menuitems'), array('published' => '1')),
-			$this->stringContains('<option value="mainmenu.435">- Home</option>')
+		$this->assertContains(
+			'<option value="mainmenu.435">- Home</option>',
+			JHtmlSelect::options(JHtmlMenu::menuitems(), array('published' => '1'))
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
@@ -239,9 +239,6 @@ class JHtmlNumberTest extends TestCase
 	 */
 	public function testBytes($result, $bytes, $unit = 'auto', $precision = 2, $iec = false)
 	{
-		$this->assertThat(
-			JHtml::_('number.bytes', $bytes, $unit, $precision, $iec),
-			$this->equalTo($result)
-		);
+		$this->assertEquals($result, JHtmlNumber::bytes($bytes, $unit, $precision, $iec));
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
@@ -334,14 +334,14 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 		{
 			$this->assertEquals(
 				$expected,
-				JHtml::_('select.genericlist', $data, $name, $attribs)
+				JHtmlSelect::genericlist($data, $name, $attribs)
 			);
 		}
 		else
 		{
 			$this->assertEquals(
 				$expected,
-				JHtml::_('select.genericlist', $data, $name, $attribs, $optKey, $optText, $selected, $idtag, $translate)
+				JHtmlSelect::genericlist($data, $name, $attribs, $optKey, $optText, $selected, $idtag, $translate)
 			);
 		}
 	}
@@ -383,7 +383,7 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 	{
 		$this->assertEquals(
 			(object) $expected,
-			JHtml::_('select.option', $value, $text, $optKey, $optText, $disable)
+			JHtmlSelect::option($value, $text, $optKey, $optText, $disable)
 		);
 	}
 
@@ -435,7 +435,7 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 	{
 		$this->assertEquals(
 			$expected,
-			JHtml::_('select.options', $arr, $optKey, $optText, $selected, $translate)
+			JHtmlSelect::options($arr, $optKey, $optText, $selected, $translate)
 		);
 	}
 
@@ -471,14 +471,14 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 		{
 			$this->assertEquals(
 				$expected,
-				JHtml::_('select.radiolist', (object) $data, $name, $attribs)
+				JHtmlSelect::radiolist((object) $data, $name, $attribs)
 			);
 		}
 		else
 		{
 			$this->assertEquals(
 				$expected,
-				JHtml::_('select.radiolist', (object) $data, $name, $attribs, $optKey, $optText, $selected, $idtag, $translate)
+				JHtmlSelect::radiolist((object) $data, $name, $attribs, $optKey, $optText, $selected, $idtag, $translate)
 			);
 		}
 	}

--- a/tests/unit/suites/libraries/cms/html/JHtmlStringTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlStringTest.php
@@ -400,10 +400,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testAbridge($text, $length, $intro, $expected)
 	{
-		$this->assertThat(
-			JHtml::_('string.abridge', $text, $length, $intro),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, JHtmlString::abridge($text, $length, $intro));
 	}
 
 	/**
@@ -422,10 +419,7 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testTruncate($text, $length, $noSplit, $allowedHtml, $expected)
 	{
-		$this->assertThat(
-			JHtml::_('string.truncate', $text, $length, $noSplit, $allowedHtml),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, JHtmlString::truncate($text, $length, $noSplit, $allowedHtml));
 	}
 
 	/**
@@ -443,9 +437,6 @@ class JHtmlStringTest extends PHPUnit_Framework_TestCase
 	 */
 	public function testTruncateComplex($html, $maxLength, $noSplit, $expected)
 	{
-		$this->assertThat(
-			JHtml::_('string.truncateComplex', $html, $maxLength, $noSplit),
-			$this->equalTo($expected)
-		);
+		$this->assertEquals($expected, JHtmlString::truncateComplex($html, $maxLength, $noSplit));
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1530,7 +1530,7 @@ class JHtmlTest extends TestCase
 				);
 
 				$this->assertContains(
-					'DHTML Date\\/Time Selector',
+					'jQuery(document).ready(function($) {Calendar.setup({',
 					JFactory::getDocument()->_script['text/javascript'],
 					'Line:' . __LINE__ . ' Inline JS for the calendar should be loaded'
 				);


### PR DESCRIPTION
### Summary of Changes
- Direct call methods instead of going through `JHtml::_()`
- DRY up `JHtmlBehaviorTest`
- Test expected methods in `JHtmlBootstrapTest`
- Fix `JHtmlTest::testCalendar()` testing for a string that does not get included inline
### Testing Instructions

Unit tests pass
### Documentation Changes Required

N/A
