### PR TITLE
make sure difference is under a minute

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
@@ -25,6 +25,10 @@ class JHtmlDateTest extends PHPUnit_Framework_TestCase
 	 */
 	public function dataTestRelative()
 	{
+		$now1 = new JDate('now');
+		sleep(1);
+		$now2 = new JDate('now');
+
 		return array(
 			// Element order: result, date, unit, time
 			// result - 1 hour ago
@@ -58,7 +62,9 @@ class JHtmlDateTest extends PHPUnit_Framework_TestCase
 			// Result - Less than a minute ago
 			array(
 				'JLIB_HTML_DATE_RELATIVE_LESSTHANAMINUTE',
-				new JDate('now'),
+				$now1,
+				null,
+				$now2
 			)
 		);
 	}


### PR DESCRIPTION
Jenkins is failing on test because the time difference is bigger as expected
### Summary of Changes

This PR makes sure the time stamps are under minute.
### Testing Instructions

Unit test JHtmlDateTest::testRelative shouldn't fail
