### PR TITLE
adding a lang-associated class to language choice module for language…

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -125,7 +125,6 @@ abstract class ModLanguagesHelper
 					{
 						$itemid = $associations[$language->lang_code];
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
-						$language->associated = true;
 					}
 					else
 					{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -97,6 +97,8 @@ abstract class ModLanguagesHelper
 			else
 			{
 				$language->active = ($language->lang_code == $lang->getTag());
+				// This is a default
+				$language->associated = false;
 
 				// Fetch language rtl
 				// If loaded language get from current JLanguage metadata
@@ -116,11 +118,13 @@ abstract class ModLanguagesHelper
 					if (isset($cassociations[$language->lang_code]))
 					{
 						$language->link = JRoute::_($cassociations[$language->lang_code] . '&lang=' . $language->sef);
+						$language->associated = true;
 					}
 					elseif (isset($associations[$language->lang_code]) && $menu->getItem($associations[$language->lang_code]))
 					{
 						$itemid = $associations[$language->lang_code];
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
+						$language->associated = true;
 					}
 					else
 					{

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -97,6 +97,7 @@ abstract class ModLanguagesHelper
 			else
 			{
 				$language->active = ($language->lang_code == $lang->getTag());
+
 				// This is a default
 				$language->associated = false;
 

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -43,7 +43,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 		<ul class="<?php echo $params->get('lineheight', 1) ? 'lang-block' : 'lang-inline'; ?> dropdown-menu" dir="<?php echo JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($params->get('show_active', 0) || !$language->active) : ?>
-				<li class="<?php echo $language->active ? 'lang-active' : ''; ?>" >
+				<li class="<?php echo $language->active ? 'lang-active' : ($language->associated ? 'lang-associated' : ''); ?>" >
 				<a href="<?php echo $language->link;?>">
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 						<?php echo $language->title_native; ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -57,7 +57,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 	<?php foreach ($list as $language) : ?>
 		<?php if ($params->get('show_active', 0) || !$language->active) : ?>
-			<li class="<?php echo $language->active ? 'lang-active' : ''; ?>" dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<li class="<?php echo $language->active ? 'lang-active' : ($language->associated ? 'lang-associated' : ''); ?>" dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo $language->link; ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>

--- a/templates/beez3/html/mod_languages/default.php
+++ b/templates/beez3/html/mod_languages/default.php
@@ -29,7 +29,7 @@ JHtml::_('stylesheet', 'mod_languages/template.css', array(), true);
 	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 	<?php foreach ($list as $language) : ?>
 		<?php if ($params->get('show_active', 0) || !$language->active) : ?>
-			<li class="<?php echo $language->active ? 'lang-active' : ''; ?>" dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<li class="<?php echo $language->active ? 'lang-active' : ($language->associated ? 'lang-associated' : ''); ?>" dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo $language->link; ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>


### PR DESCRIPTION
Pull Request for Issue #11792.
### Summary of Changes

In language module, Add a "lang-associated" class to languages that have a content associated to current content.

Note that this PR just provide the class, but does not use it in css (as it's already the case with the "lang-active" class). 

Combined with a specific css (up to the template) this can help the visitor guess that changing language will take it to some other content (the parent menu or the homepage)

An example after using opacity in css to mark the difference with protostar (EN is active, FR is associated but not IT):

![ml-lang-switcher-01](https://cloud.githubusercontent.com/assets/144788/18292430/657bd87a-748d-11e6-8487-6f298674575b.png)

![ml-lang-switcher-02](https://cloud.githubusercontent.com/assets/144788/18292541/19576684-748e-11e6-9bac-737fb07cb25d.png)
### Testing Instructions
- In a multilinguale site, add a category with associations in different languages (but not all), an article and associations in different languages (but not all).
- optionally add  this custom css to your template:
  
  ``` css
  
  .lang-inline a {
  opacity: .5;
  }
  
  .lang-inline .lang-active a, .lang-inline .lang-associated a {
  opacity: 1;
  }
  ```
- Add the language switcher module to your site (using flags).
- Go to category / article with association. Verify language module entries corresponding to associated languages have the "lang-associated" class
- change language switcher module settings to display languages
- Go to category / article with association and verify again
- Change template to beez
- Go to category / article with association and verify again

You can use this dataset : 
[joomla-ml-sample-sql.zip](https://github.com/joomla/joomla-cms/files/456582/joomla-ml-sample-sql.zip)
it provides a en/fr/it site where main page is fully associated, while a category named glossary is only associated with french. Articles inside glossary are either associated with french (joomla / cms) or with none (free and opensource)
login: test@example.com / test
### Documentation Changes Required

I don't think (but I'm quite new to joomla)
