### PR TITLE
Remove update sites only on successful uninstallation

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -661,7 +661,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	 *
 	 * @param   integer  $id  The unique extension id of the component to uninstall
 	 *
-	 * @return  mixed  Return value for uninstall method in component uninstall file
+	 * @return  boolean  True on success
 	 *
 	 * @since   3.1
 	 */

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -461,7 +461,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	 *
 	 * @param   string  $eid  The tag of the language to uninstall
 	 *
-	 * @return  mixed  Return value for uninstall method in component uninstall file
+	 * @return  boolean  True on success
 	 *
 	 * @since   3.1
 	 */

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -128,7 +128,7 @@ class PlgExtensionJoomla extends JPlugin
 	 *
 	 * @param   JInstaller  $installer  Installer instance
 	 * @param   integer     $eid        Extension id
-	 * @param   integer     $result     Installation result
+	 * @param   boolean     $result     Installation result
 	 *
 	 * @return  void
 	 *
@@ -136,9 +136,10 @@ class PlgExtensionJoomla extends JPlugin
 	 */
 	public function onExtensionAfterUninstall($installer, $eid, $result)
 	{
-		if ($eid)
+		// If we have a valid extension ID and the extension was successfully uninstalled wipe out any
+		// update sites for it
+		if ($eid && $result)
 		{
-			// Wipe out any update_sites_extensions links
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->delete('#__update_sites_extensions')


### PR DESCRIPTION
Pull Request for Issue #11908.
### Summary of Changes

Only remove update sites for an extension on uninstall if it was successfully uninstalled
### Testing Instructions

Go to Extensions > Manage > Update Site
Confirm you have a aupddate site for joomla update component
Go to Extensions > Manage > Manager
Search for joomla update
See the extension is blocked, but select it and try to unistall it
Check you get a warning message
Go to Extensions > Manage > Update Site
Confirm you don't have a update site for joomla update component -> Bug!
Apply Patch and repeat steps. Update site remains
### Documentation Changes Required

None
