### PR TITLE
fixed showon for conditions pointing on btn-group

### DIFF
--- a/templates/protostar/js/template.js
+++ b/templates/protostar/js/template.js
@@ -38,6 +38,7 @@
 					label.addClass('active btn-success');
 				}
 				input.prop('checked', true);
+				input.trigger('change');
 			}
 		});
 		$(".btn-group input[checked=checked]").each(function()


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Protostar: Now the conditions of `showon` related to `btn-group` were checked after the status of the `btn-group` changed.
### Testing Instructions

Template: Protostar

Take a frontend form and add an `showon` attribute pointing to a `btn-group` field.
For example I edited the [form for editing an article in frontend](https://github.com/joomla/joomla-cms/blob/staging/components/com_content/models/forms/article.xml).
1. There I added an `showon="featured:1"` to the field `state`.  =>  The field `state` is only shown if the field `featured` has the value `1`.
2. Change the `type` of the field `featured` to `radio`.  =>  The field `state` is only shown if the field `featured` has the value `1`.
3. Change the class of the field `featured` to `btn-group`.  
   The fields now should have this Code:

``` XML
        <field
            id="state"
            name="state"
            type="list"
            label="JSTATUS"
            description="JFIELD_PUBLISHED_DESC"
            class="inputbox"
            size="1"
            default="1"
            showon="featured:1">
            <option
                value="1">
                JPUBLISHED</option>
            <option
                value="0">
                JUNPUBLISHED</option>
            <option
                value="2">
                JARCHIVED</option>
            <option
                value="-2">
                JTRASHED</option>
        </field>

        <field
            id="featured"
            name="featured"
            type="radio"
            label="JGLOBAL_FIELD_FEATURED_LABEL"
            description="JGLOBAL_FIELD_FEATURED_DESC"
            class="btn-group"
            default="0"
        >
            <option value="0">JNO</option>
            <option value="1">JYES</option>
        </field>
```
### With this pull request

The field `state` is only shown if the field `featured` has the value `1`.
### Without this pull request

The field `state` is only shown if the field `featured` has the initial value `1`. Changing the value of the field `featured` doesn't show/hide the field `state`.
### Documentation Changes Required

None

btw: Why is this code not in an central js file so that changes applied to it will update the feature in all templates which uses the file instead of applying changes to all templates js files?  
I've copied the code from the Isis template where the same code is used and all works like expected.
