### PR TITLE
[RFC] Normalization and new metadata for languages (international_name and native_name)

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -11,6 +11,8 @@
 	<description>en-GB administrator language</description>
 	<metadata>
 		<name>English (en-GB)</name>
+		<international_name>English (United Kingdom)</international_name>
+		<native_name>English (United Kingdom)</native_name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.6" client="administrator" type="language" method="upgrade">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.6.3</version>
 	<creationDate>August 2016</creationDate>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <extension type="package" version="3.6" method="upgrade">
-	<name>English (en-GB) Language Pack</name>
+	<name>English (en-GB) Language Package</name>
 	<packagename>en-GB</packagename>
 	<version>3.6.3.1</version>
 	<creationDate>August 2016</creationDate>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile
-	version="3.6"
-	client="installation">
-	<name>English (United Kingdom)</name>
+<metafile version="3.6" client="installation">
+	<name>English (en-GB)</name>
 	<version>3.6.3</version>
 	<creationDate>August 2016</creationDate>
 	<author>Joomla! Project</author>
@@ -12,7 +10,9 @@
 		<filename>en-GB.ini</filename>
 	</files>
 	<metadata>
-		<name>English (United Kingdom)</name>
+		<name>English (en-GB)</name>
+		<international_name>English (United Kingdom)</international_name>
+		<native_name>English (United Kingdom)</native_name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 	</metadata>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -618,10 +618,10 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (504, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":"","logoFile":""}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(600, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(601, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+(802, 'English (en-GB) Language Package', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 -- --------------------------------------------------------
 
@@ -1209,7 +1209,7 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
 --
 
 INSERT INTO `#__languages` (`lang_id`, `lang_code`, `title`, `title_native`, `sef`, `image`, `description`, `metakey`, `metadesc`, `sitename`, `published`, `access`, `ordering`) VALUES
-(1, 'en-GB', 'English (UK)', 'English (UK)', 'en', 'en_gb', '', '', '', '', 1, 1, 1);
+(1, 'en-GB', 'English (United Kingdom)', 'English (United Kingdom)', 'en', 'en_gb', '', '', '', '', 1, 1, 1);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -624,8 +624,8 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 
 -- Languages
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(600, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+(601, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Files Extensions
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
@@ -633,7 +633,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 
 -- Packages
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(802, 'English (en-GB) Language Package', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 SELECT setval('#__extensions_extension_id_seq', 10000, false);
 
@@ -1145,7 +1145,7 @@ CREATE INDEX "#__languages_idx_access" ON "#__languages" ("access");
 -- Dumping data for table #__languages
 --
 INSERT INTO "#__languages" ("lang_id", "lang_code", "title", "title_native", "sef", "image", "description", "metakey", "metadesc", "sitename", "published", "access", "ordering") VALUES
-(1, 'en-GB', 'English (UK)', 'English (UK)', 'en', 'en_gb', '', '', '', '', 1, 1, 1);
+(1, 'en-GB', 'English (United Kingdom)', 'English (United Kingdom)', 'en', 'en_gb', '', '', '', '', 1, 1, 1);
 
 SELECT setval('#__languages_lang_id_seq', 2, false);
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1024,9 +1024,9 @@ SELECT 507, 'isis', 'template', 'isis', '', 1, 1, 1, 0, '', '{"templateColor":""
 
 -- Languages
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 600, 'English (United Kingdom)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
+SELECT 600, 'English (en-GB)', 'language', 'en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 601, 'English (United Kingdom)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 601, 'English (en-GB)', 'language', 'en-GB', '', 1, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 -- Files Extensions
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
@@ -1034,7 +1034,7 @@ SELECT 700, 'files_joomla', 'file', 'joomla', '', 0, 1, 1, 1, '', '', '', '', 0,
 
 -- Packages
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 802, 'English (United Kingdom)', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 802, 'English (en-GB) Language Package', 'package', 'pkg_en-GB', '', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions] OFF;
 
@@ -2010,7 +2010,7 @@ CREATE UNIQUE INDEX [idx_access] ON [#__languages]
 SET IDENTITY_INSERT [#__languages] ON;
 
 INSERT INTO [#__languages] ([lang_id], [lang_code], [title], [title_native], [sef], [image], [description], [metakey], [metadesc], [sitename], [published], [access], [ordering])
-SELECT 1, 'en-GB', 'English (UK)', 'English (UK)', 'en', 'en_gb', '', '', '', '', 1, 1, 1;
+SELECT 1, 'en-GB', 'English (United Kingdom)', 'English (United Kingdom)', 'en', 'en_gb', '', '', '', '', 1, 1, 1;
 
 SET IDENTITY_INSERT [#__languages] OFF;
 

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -11,6 +11,8 @@
 	<description>en-GB site language</description>
 	<metadata>
 		<name>English (en-GB)</name>
+		<international_name>English (United Kingdom)</international_name>
+		<native_name>English (United Kingdom)</native_name>
 		<tag>en-GB</tag>
 		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension version="3.6" client="site" type="language" method="upgrade">
-	<name>English (United Kingdom)</name>
+	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.6.3</version>
 	<creationDate>August 2016</creationDate>

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -1074,7 +1074,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 		$weekEnd = '0,6';
 
 		$option1 = array(
-			'name'     => 'English (en-GB)',
+			'name'     => 'English (United Kingdom)',
 			'tag'      => 'en-GB',
 			'rtl'      => '0',
 			'locale'   => $localeString,
@@ -1154,7 +1154,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	{
 		$dir = __DIR__ . '/data/language';
 		$option = array(
-			'name'     => 'English (en-GB)',
+			'name'     => 'English (United Kingdom)',
 			'tag'      => 'en-GB',
 			'rtl'      => '0',
 			'locale'   => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england,' .

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -1184,7 +1184,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testParseXMLLanguageFile()
 	{
 		$option = array(
-			'name'     => 'English (en-GB)',
+			'name'     => 'English (United Kingdom)',
 			'tag'      => 'en-GB',
 			'rtl'      => '0',
 			'locale'   => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain,' .

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -1041,12 +1041,14 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 		// In this case, returns array with default language
 		// - same operation of get method with metadata property
 		$options = array(
-			'name' => 'English (en-GB)',
-			'tag' => 'en-GB',
-			'rtl' => '0',
-			'locale' => $localeString,
-			'firstDay' => '0',
-			'weekEnd' => '0,6'
+			'name'               => 'English (en-GB)',
+			'international_name' => 'English (United Kingdom)',
+			'native_name'        => 'English (United Kingdom)',
+			'tag'                => 'en-GB',
+			'rtl'                => '0',
+			'locale'             => $localeString,
+			'firstDay'           => '0',
+			'weekEnd'            => '0,6',
 		);
 
 		// Language exists, returns array with values
@@ -1072,12 +1074,12 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 		$weekEnd = '0,6';
 
 		$option1 = array(
-			'name' => 'English (United Kingdom)',
-			'tag' => 'en-GB',
-			'rtl' => '0',
-			'locale' => $localeString,
+			'name'     => 'English (en-GB)',
+			'tag'      => 'en-GB',
+			'rtl'      => '0',
+			'locale'   => $localeString,
 			'firstDay' => '0',
-			'weekEnd' => $weekEnd
+			'weekEnd'  => $weekEnd
 		);
 
 		$listCompareEqual1 = array(
@@ -1152,13 +1154,13 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	{
 		$dir = __DIR__ . '/data/language';
 		$option = array(
-			'name' => 'English (United Kingdom)',
-			'tag' => 'en-GB',
-			'rtl' => '0',
-			'locale' => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england,' .
+			'name'     => 'English (en-GB)',
+			'tag'      => 'en-GB',
+			'rtl'      => '0',
+			'locale'   => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england,' .
 				' great britain, uk, united kingdom, united-kingdom',
 			'firstDay' => '0',
-			'weekEnd' => '0,6'
+			'weekEnd'  => '0,6'
 		);
 
 		$expected = array(
@@ -1182,13 +1184,13 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testParseXMLLanguageFile()
 	{
 		$option = array(
-			'name' => 'English (United Kingdom)',
-			'tag' => 'en-GB',
-			'rtl' => '0',
-			'locale' => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain,' .
+			'name'     => 'English (en-GB)',
+			'tag'      => 'en-GB',
+			'rtl'      => '0',
+			'locale'   => 'en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain,' .
 				' uk, united kingdom, united-kingdom',
 			'firstDay' => '0',
-			'weekEnd' => '0,6'
+			'weekEnd'  => '0,6'
 		);
 
 		$path = __DIR__ . '/data/language/en-GB/en-GB.xml';


### PR DESCRIPTION
### Summary of Changes

While dealing with https://github.com/joomla/joomla-cms/pull/11867 it became clear to me the names of the languages extensions/packages need some normallization.

If you install all language packages you will notice there isn't really little normallization of this, which difficults any automation process needed to done in the core and also IMHO is not good for UX.

A language have a lot of xml files, and all of this have names for the language, example for english:
- [Installation Language MetaFile](https://github.com/joomla/joomla-cms/blob/staging/installation/language/en-GB/en-GB.xml)
- [Site Language MetaFile](https://github.com/joomla/joomla-cms/blob/staging/language/en-GB/en-GB.xml)
- [Site Language Manifest](https://github.com/joomla/joomla-cms/blob/staging/language/en-GB/install.xml)
- [Admin Language MetaFile](https://github.com/joomla/joomla-cms/blob/staging/administrator/language/en-GB/en-GB.xml)
- [Admin Language Manifest](https://github.com/joomla/joomla-cms/blob/staging/administrator/language/en-GB/install.xml)
- [Language Package Manifest](https://github.com/joomla/joomla-cms/blob/staging/administrator/manifests/packages/pkg_en-GB.xml)

So this proposal is to start normalizing all language packages (starting with english en-GB here).

Keep in mind this is an effort to normalize and only a proposal, and i could be missign something, any contribution to this discussion is appreciated.
### So what are the changes proposed?

What i propose is the following:
1. All xx-XX.xml and install.xml xml `name` element would get the same value, i.e. the language in english following the language code, in english would be _English (en-GB)_.
2. The installation/site/admin xx-XX.xml `metadata`-> `name` element would get the same value as above.
3. The pkg_xx-XX.xml `name` element would get the same value as above + Language Package, in english would be _English (en-GB) Language Package_.
4. Two new metadata elements would be created in the xx-XX.xml files: `native_name` and `international_name`
   - `international_name`: in english would be _English (United Kingdom)_
   - `native_name`: in english would be _English (United Kingdom)_

So we would have 3 names for each language, some examples:

| Name | International Name | Native Name |
| --- | --- | --- |
| English (en-GB) | English (United Kingdom) | English (United Kingdom) |
| Portuguese (pt-PT) | Portuguese (Portugal) | Português Europeu |
| Portuguese (pt-BR) | Portuguese (Brazilian) | Português do Brasil |
| Arabic (ar-AA) | Arabic (Unitag) | اللغة العربية بالكود الموحد |
| German (de-DE) | German (Germany) | _don't know native german :)_ |
| German (de-CH) | German (Switzerland) | _don't know native german :)_ |
| Sinhala (si-LK) | Sinhala (Sri Lanka) | සිංහල (ශ්‍රී ලංකාව) |
### Testing Instructions

Code review.
### Documentation Changes Required

The documentation on creating language packages would need to be updated.
Translation Coordenation Team would have to agree and transmit this normalization and new metada to language package translation coordenation.
