### PR TITLE
Restore the functionality of JToolBarHelper::spacer('50px');

### DIFF
--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -13,4 +13,4 @@ $class = $displayData['class'];
 $style = $displayData['style'];
 
 ?>
-<div class="btn-group <?php echo $class; ?>"<?php echo $style; ?>></div>
+<div class="btn-wrapper <?php echo $class; ?>"<?php echo $style; ?>></div>

--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -8,3 +8,9 @@
  */
 
 defined('JPATH_BASE') or die;
+
+$class = $displayData['class'];
+$style = $displayData['style'];
+
+?>
+<div class="btn-group <?php echo $class; ?>"<?php echo $style; ?>></div>


### PR DESCRIPTION
Pull Request for Issue found in the german forum https://forum.joomla.de/index.php/Thread/2505-Abstand-zwischen-task-buttons
### Summary of Changes

This restores the seperator / spacer functionality this is broken since arround 2014
### Testing Instructions
- install joomla
- go to https://github.com/joomla/joomla-cms/blob/3.6.2/administrator/components/com_content/views/articles/view.html.php#L122
- Add this line `JToolBarHelper::spacer('50px');`
- go to the articles page in the backend.
- we would expect a space of 50px between the `edit` and the `publish` button
- nothing is there.
- apply this patch
- see it is working now

![image](https://cloud.githubusercontent.com/assets/2596554/18232771/4ebf8530-72d7-11e6-9e53-472615c23868.png)
### Documentation Changes Required

None
