### PR TITLE
Update for pull request # 5929

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -57,6 +57,12 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function __toString()
 	{
+		// Call the group function one final time to ensure we can get all coulumns for table joins.
+		if ($this->group)
+		{
+			$this->group($this->group->getElements());
+		}
+
 		$query = '';
 
 		switch ($this->type)

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -409,7 +409,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			foreach ($this->join as $join)
 			{
 
-				$joinStr = trim(preg_replace("/.*\sJOIN/i","" ,(string)$join));
+				$joinStr = trim(preg_replace("/.*\sJOIN\s/i","" ,(string)$join));
 
 				if (strpos($joinStr,' AS ') !== false)
 				{
@@ -448,9 +448,11 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 		$selectCols = trim(str_replace(" ", "", preg_replace("/,?$/", "", $selectCols)));
 
 		// Get an array to compare against
-		$selectCols = explode(",", $selectCols);
+
+		$selectCols =  $selectCols ? explode(",", $selectCols) : array();
 
 		// Find all alias.* and fill with proper table column names
+
 		foreach ($selectCols as $key => $aliasColName)
 		{
 			if (preg_match("/.+\*/", $aliasColName, $match))
@@ -463,6 +465,13 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 				// Get the table name
 				$tableColumns = preg_grep("/{$aliasStar}\.+/", $cols);
+				$columns = array_merge($columns, $tableColumns);
+			}
+			elseif(!$this->join && $aliasColName == '*')
+			{
+				// Unset the array key
+				unset($selectCols[$key]);
+				$tableColumns = preg_grep("/{$table}\.+/", $cols);
 				$columns = array_merge($columns, $tableColumns);
 			}
 		}

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -467,7 +467,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				$tableColumns = preg_grep("/{$aliasStar}\.+/", $cols);
 				$columns = array_merge($columns, $tableColumns);
 			}
-			elseif(!$this->join && $aliasColName == '*')
+			elseif (!$this->join && $aliasColName == '*')
 			{
 				// Unset the array key
 				unset($selectCols[$key]);

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -417,7 +417,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			foreach ($this->join as $join)
 			{
 
-				$joinStr = trim(preg_replace("/.*\sJOIN\s/i","", (string) $join));
+				$joinStr = trim(preg_replace("/.*\sJOIN\s/i", "", (string) $join));
 
 				if (strpos($joinStr, ' AS ') !== false)
 				{

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -383,21 +383,23 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 		// Get the _formatted_ FROM string and remove everything except `table AS alias`
 		$fromStr = str_replace(array("[", "]"), "", str_replace("#__", $this->db->getPrefix(), str_replace("FROM ", "", (string) $this->from)));
+
 		// Remove any trailing whitespaces
 		$fromStr = trim($fromStr);
+
 		// Start setting up an array of alias => table
 		$table = $alias = $fromStr;
-		if (strpos($fromStr,' AS ') !== false)
+		if (strpos($fromStr, ' AS ') !== false)
 		{
-			 list($table, $alias) = preg_split("/\sAS\s/i", $fromStr);
+			list($table, $alias) = preg_split("/\sAS\s/i", $fromStr);
 		}
-		elseif (preg_match("/\b\s+/i",$fromStr))
+		elseif (preg_match("/\b\s+/i", $fromStr))
 		{
-			  list($table, $alias) = preg_split("/\b\s+/i", $fromStr);
+			list($table, $alias) = preg_split("/\b\s+/i", $fromStr);
 		}
 		else
 		{
-			 $table = $alias = $fromStr;
+			$table = $alias = $fromStr;
 		}
 		$tmpCols = $this->db->getTableColumns(trim($table));
 		$cols = array();
@@ -415,9 +417,9 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			foreach ($this->join as $join)
 			{
 
-				$joinStr = trim(preg_replace("/.*\sJOIN\s/i","" ,(string)$join));
+				$joinStr = trim(preg_replace("/.*\sJOIN\s/i","", (string) $join));
 
-				if (strpos($joinStr,' AS ') !== false)
+				if (strpos($joinStr, ' AS ') !== false)
 				{
 					$joinTbl = str_replace("#__", $this->db->getPrefix(), str_replace("]", "", preg_replace("/^(.+?\sAS\s[^\s]*).*/i", "$1", $joinStr)));
 

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -409,7 +409,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			foreach ($this->join as $join)
 			{
 
-				$joinStr = trim(preg_replace("/.*JOIN/i","" ,(string)$join));
+				$joinStr = trim(preg_replace("/.*\sJOIN/i","" ,(string)$join));
 
 				if (strpos($joinStr,' AS ') !== false)
 				{


### PR DESCRIPTION
Pull Request for Issue #11279

### Summary of Changes
Although this pull request #5929 did a great Job of fixing issues caused by MySQL specific queries using a group by clause, there were still a few issues left.

This pull request was created to address those issues:

1. It kind of fell over when queries used an alias for columns and tables without using the 'AS' keyword. Although it is good practice to use the AS keyword, it is not compulsory.
2. No support for 'SELECT ALL GROUP BY' queries on a single table such as 'SELECT * from Mytable GROUP BY catid'
3. Failed to get table fields when the table prefix is hardcoded  in the query or explicitly already given by the direct use of  $db->getPrefix().
4. No check to see if the query contains any joins before trying to get columns for any join tables.
5. The 'select' and 'join' functions of the JDatabaseQuery object can be called any number of times and in any order. So this means currently depending on what point the group function is called you may or may not have the complete select and join table lists.


Changes applied in this PR fixes issues #11278 and #11279

### Testing Instructions

### Documentation Changes Required
