### PR TITLE
Menu item link for TinyMCE

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$app = JFactory::getApplication();
+
+if ($app->isSite())
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
+// Include the component HTML helpers.
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
+JHtml::_('behavior.core');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('formbehavior.chosen', 'select');
+
+// Special case for the search field tooltip.
+$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
+JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
+
+$function  = $app->input->getCmd('function', 'jSelectMenuitem');
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+?>
+<div class="container-popup">
+
+	<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items&layout=modal&tmpl=component&function=' . $function . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+
+		<div class="clearfix"></div>
+
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
+			<table class="table table-striped table-condensed">
+				<thead>
+					<tr>
+						<th width="1%" class="center nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
+						</th>
+						<th class="title">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+						</th>
+						<th width="1%" class="nowrap hidden-phone">
+						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+						</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="6">
+							<?php echo $this->pagination->getListFooter(); ?>
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>
+				<?php
+				$iconStates = array(
+					-2 => 'icon-trash',
+					0 => 'icon-unpublish',
+					1 => 'icon-publish',
+					2 => 'icon-archive',
+				);
+				?>
+				<?php foreach ($this->items as $i => $item) : ?>
+					<?php if ($item->language && JLanguageMultilang::isEnabled())
+					{
+						$tag = strlen($item->language);
+						if ($tag == 5)
+						{
+							$lang = substr($item->language, 0, 2);
+						}
+						elseif ($tag == 6)
+						{
+							$lang = substr($item->language, 0, 3);
+						}
+						else {
+							$lang = "";
+						}
+					}
+					elseif (!JLanguageMultilang::isEnabled())
+					{
+						$lang = "";
+					}
+					?>
+
+					<tr class="row<?php echo $i % 2; ?>">
+						<td class="center">
+							<span class="<?php echo $iconStates[$this->escape($item->{'a.published'})]; ?>"></span>
+						</td>
+						<td>
+							<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', '<?php echo str_replace('/administrator', '', JRoute::_('index.php?Itemid=' . $item->id)); ?>', '<?php echo $this->escape($lang); ?>');">
+								<?php echo $this->escape($item->title); ?></a>
+
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="small">
+							<?php if ($item->language == '*'): ?>
+								<?php echo JText::alt('JALL', 'language'); ?>
+							<?php else:?>
+								<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
+							<?php endif;?>
+						</td>
+
+						<td class="nowrap small hidden-phone">
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<?php echo JHtml::_('form.token'); ?>
+
+	</form>
+</div>

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_menus
  *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menulink.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menulink.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_MENULINK_BUTTON_MENU="Menu item"
+PLG_MENULINK_XML_DESCRIPTION="Displays a button to make it possible to insert links to menu items into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENULINK="Button - Menu item link"

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_menulink.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_menulink.sys.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_MENULINK_XML_DESCRIPTION="Displays a button to make it possible to insert links to menu items into an Article. Displays a popup allowing you to choose the menu item."
+PLG_EDITORS-XTD_MENULINK="Button - Menu item link"
+

--- a/plugins/editors-xtd/menulink/menulink.php
+++ b/plugins/editors-xtd/menulink/menulink.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Editors-xtd.article
+ * @subpackage  Editors-xtd.menulink
  *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 /**
- * Editor Article buton
+ * Editor Article button
  *
  * @since  1.5
  */

--- a/plugins/editors-xtd/menulink/menulink.php
+++ b/plugins/editors-xtd/menulink/menulink.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Editor Article buton
+ *
+ * @since  1.5
+ */
+class PlgButtonMenulink extends JPlugin
+{
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  3.1
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Display the button
+	 *
+	 * @param   string  $name  The name of the button to add
+	 *
+	 * @return array A four element array of (article_id, article_title, category_id, object)
+	 */
+	public function onDisplay($name)
+	{
+		/*
+		 * Javascript to insert the link
+		 * View element calls jSelectArticle when an article is clicked
+		 * jSelectArticle creates the link tag, sends it to the editor,
+		 * and closes the select frame.
+		 */
+		$js = "
+		function jSelectMenuitem(id, title, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			jInsertEditorText(tag, '" . $name . "');
+			jModalClose();
+		}";
+
+		$doc = JFactory::getDocument();
+		$doc->addScriptDeclaration($js);
+
+		/*
+		 * Use the built-in element view to select the article.
+		 * Currently uses blank class.
+		 */
+		$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;editor='
+		. $name . '&amp;' . JSession::getFormToken() . '=1';
+
+		$button = new JObject;
+		$button->modal = true;
+		$button->class = 'btn';
+		$button->link = $link;
+		$button->text = JText::_('PLG_MENULINK_BUTTON_MENU');
+		$button->name = 'file-add';
+		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+
+		return $button;
+	}
+}

--- a/plugins/editors-xtd/menulink/menulink.php
+++ b/plugins/editors-xtd/menulink/menulink.php
@@ -29,10 +29,17 @@ class PlgButtonMenulink extends JPlugin
 	 *
 	 * @param   string  $name  The name of the button to add
 	 *
-	 * @return array A four element array of (article_id, article_title, category_id, object)
+	 * @return array A four element array of (menu_id, menu_title, link, language)
 	 */
 	public function onDisplay($name)
 	{
+		$app = JFactory::getApplication();
+
+		/* Load plugin button only in the backend */
+		if ($app->isSite())
+		{
+			return;
+		}
 		/*
 		 * Javascript to insert the link
 		 * View element calls jSelectArticle when an article is clicked

--- a/plugins/editors-xtd/menulink/menulink.xml
+++ b/plugins/editors-xtd/menulink/menulink.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.1" type="plugin" group="editors-xtd" method="upgrade">
+	<name>plg_editors-xtd_menulink</name>
+	<author>Joomla! Project</author>
+	<creationDate>September 2016</creationDate>
+	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>1.0.0</version>
+	<description>PLG_MENULINK_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="menulink">menulink.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_editors-xtd_menulink.ini</language>
+		<language tag="en-GB">en-GB.plg_editors-xtd_menulink.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
### Summary of Changes

This is a new feature that adds the missing menu item link to the TinyMCE editor. With this button it is possible to add a link to a menu item the same way as the article link button. 
NOTE: This button is only available in the backend of Joomla in the TinyMCE editor.
### Testing Instructions
- Add the patch and go to: Extension -> Manage -> Discover
- Discover, install and activate the plugin
- Go to article an click the button "Menu item" in TinyMCE
- select a menu item and save the article 
- Test the link in the frontend to see if the menu item link works
