### PR TITLE
Fix of an error "Call to a member function getType() on null"

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -96,7 +96,7 @@ class PlgSystemSef extends JPlugin
 		$buffer = $this->app->getBody();
 
 		// For feeds we need to search for the URL with domain.
-		$prefix = $this->app->getDocument()->getType() === 'feed' ? JUri::root() : '';
+		$prefix = JFactory::getDocument()->getType() === 'feed' ? JUri::root() : '';
 
 		// Replace index.php URI by SEF URI.
 		if (strpos($buffer, 'href="' . $prefix . 'index.php?') !== false)

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -33,7 +33,7 @@ class PlgSystemSef extends JPlugin
 	 */
 	public function onAfterDispatch()
 	{
-		$doc = $this->app->getDocument();
+		$doc = JFactory::getDocument();
 
 		if (!$this->app->isSite() || $doc->getType() !== 'html')
 		{


### PR DESCRIPTION
### Summary of Changes

Sometimes, when a page does not exist, we can see an error `Call to a member function getType() on null`. The PR is a fix.
