### PR TITLE
Fix right click hiding topnav dropdown

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -161,9 +161,12 @@
 			$(document)
 				.off('click.data-api.dropdown', _clearMenus)
 				.on('click.data-api.dropdown', function(e) {
-					// call the handler only when not right-click
-					e.button === 2 || _clearMenus()
-					emptyMenu.empty().hide();
+					e.button === 2 || _clearMenus();
+
+					if (!$('#menu').find('> li').hasClass('open'))
+					{
+						emptyMenu.empty().hide();
+					}
 				});
 
 			$.fn.Jvisible = function(partial,hidden)

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -69,8 +69,8 @@
 		/**
 		 * Append submenu items to empty UL on hover allowing a scrollable dropdown
 		 */
-		if ($w.width() > 767) {
-
+		if ($w.width() > 767)
+		{
 			var menuScroll = $('#menu > li > ul'),
 				emptyMenu  = $('#nav-empty');
 
@@ -86,9 +86,12 @@
 					scrollMenuWidth  = $dropdownMenu.width() + 15,
 					maxHeight        = windowHeight - (linkHeight + statusHeight + (menuOuterHeight - menuHeight) + 20);
 
-				if (maxHeight < menuHeight) {
+				if (maxHeight < menuHeight)
+				{
 					$dropdownMenu.css('width', scrollMenuWidth);
-				} else if (maxHeight > menuHeight) {
+				}
+				else if (maxHeight > menuHeight)
+				{
 					$dropdownMenu.css('width', 'auto');
 				}
 
@@ -149,11 +152,19 @@
 
 			});
 
-			$(document).on('click', function() {
+			// obtain a reference to the original handler
+			var _clearMenus = $._data(document, 'events').click.filter(function (el) {
+				return el.namespace === 'data-api.dropdown' && el.selector === undefined
+			})[0].handler;
 
-				emptyMenu.empty().hide();
-
-			});
+			// disable the old listener
+			$(document)
+				.off('click.data-api.dropdown', _clearMenus)
+				.on('click.data-api.dropdown', function(e) {
+					// call the handler only when not right-click
+					e.button === 2 || _clearMenus()
+					emptyMenu.empty().hide();
+				});
 
 			$.fn.Jvisible = function(partial,hidden)
 			{


### PR DESCRIPTION
Pull Request for Issue #11457 
### Summary of Changes

This PR fixes the right click event hiding the dropdown menu, on Firefox (Windows)
### Testing Instructions

Apply the patch. Once done, open one of the topnav dropdown and right click. It shouldn't hide the dropdown:

![joomla](https://cloud.githubusercontent.com/assets/2019801/18269694/10fad3a8-7421-11e6-8400-6809d2b4c7de.gif)
### Documentation Changes Required

**None**

/cc: @fr56 @yild @ggppdk 
