### PR TITLE
JFile - error fix "Cannot pass parameter 2 by reference"

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -377,7 +377,7 @@ class JFile
 	 * Write contents to a file
 	 *
 	 * @param   string   $file         The full file path
-	 * @param   string   &$buffer      The buffer to write
+	 * @param   string   $buffer      The buffer to write
 	 * @param   boolean  $use_streams  Use streams
 	 *
 	 * @return  boolean  True on success
@@ -443,7 +443,7 @@ class JFile
 	 * Append contents to a file
 	 *
 	 * @param   string   $file         The full file path
-	 * @param   string   &$buffer      The buffer to write
+	 * @param   string   $buffer      The buffer to write
 	 * @param   boolean  $use_streams  Use streams
 	 *
 	 * @return  boolean  True on success

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -377,7 +377,7 @@ class JFile
 	 * Write contents to a file
 	 *
 	 * @param   string   $file         The full file path
-	 * @param   string   $buffer      The buffer to write
+	 * @param   string   $buffer       The buffer to write
 	 * @param   boolean  $use_streams  Use streams
 	 *
 	 * @return  boolean  True on success
@@ -443,7 +443,7 @@ class JFile
 	 * Append contents to a file
 	 *
 	 * @param   string   $file         The full file path
-	 * @param   string   $buffer      The buffer to write
+	 * @param   string   $buffer       The buffer to write
 	 * @param   boolean  $use_streams  Use streams
 	 *
 	 * @return  boolean  True on success

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -384,7 +384,7 @@ class JFile
 	 *
 	 * @since   11.1
 	 */
-	public static function write($file, &$buffer, $use_streams = false)
+	public static function write($file, $buffer, $use_streams = false)
 	{
 		@set_time_limit(ini_get('max_execution_time'));
 
@@ -450,7 +450,7 @@ class JFile
 	 *
 	 * @since   3.6.0
 	 */
-	public static function append($file, &$buffer, $use_streams = false)
+	public static function append($file, $buffer, $use_streams = false)
 	{
 		@set_time_limit(ini_get('max_execution_time'));
 


### PR DESCRIPTION
### Summary of Changes

If you pass a string to methods `JFile::append` or `JFile::write`, you will have an error `Cannot pass parameter 2 by reference`.
### Testing Instructions

`$string = 'Simple string';`
`JFile::write('/var/www/site/text.txt', $string);`

It works, whereas the following causes the error:

`JFile::write('/var/www/site/text.txt', 'Simple string');`

`Cannot pass parameter 2 by reference`

I think, it is not compatible with `php7`, so I propose to change the code, because it is not necessary to pass the buffer by reference in these methods.
