### PR TITLE
Adding CDATA to description in en-GB language package manifest.

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -8,7 +8,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<description>en-GB administrator language</description>
+	<description><![CDATA[en-GB administrator language]]></description>
 	<metadata>
 		<name>English (en-GB)</name>
 		<tag>en-GB</tag>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -12,7 +12,7 @@
 	<url>https://github.com/joomla/joomla-cms</url>
 	<packager>Joomla! Project</packager>
 	<packagerurl>www.joomla.org</packagerurl>
-	<description>en-GB language pack</description>
+	<description><![CDATA[en-GB language pack]]></description>
 	<files>
 		<folder type="language" client="site" id="en-GB">site_en-GB</folder>
 		<folder type="language" client="administrator" id="en-GB">admin_en-GB</folder>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -8,7 +8,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<description>en-GB site language</description>
+	<description><![CDATA[en-GB site language]]></description>
 	<metadata>
 		<name>English (en-GB)</name>
 		<tag>en-GB</tag>


### PR DESCRIPTION
In Crowdin, when a translator tries to add a CDATA tag to the description it will be blocked because it isn't present in the source string. This PR adds it to the source string so the translators have an easier life on Crowdin.
### Summary of Changes

Adds `<![CDATA[ ... ]]>` to the `<description>` tag in the en-GB package manifest.
### Testing Instructions
1. Go to Extension Manager -> Manager and filter for "eng" to get the en-GB packages.
2. Select all three of them and click "Refresh Cache".
3. Check the tooltips that they still work as expected.
### Documentation Changes Required

None
