### PR TITLE
com_banners remove menu link

### DIFF
--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -92,7 +92,7 @@
 			description="COM_BANNERS_FIELD_DESCRIPTION_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak,module,article"
+			hide="readmore,pagebreak,module,article,menu"
 		/>
 
 		<field

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -92,7 +92,7 @@
 			description="COM_BANNERS_FIELD_DESCRIPTION_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak,module,article,menu"
+			hide="readmore,pagebreak,module,article,contact,menu"
 		/>
 
 		<field


### PR DESCRIPTION
When creating a banner there is a wysiwyg editor for a description. This is only displayed in the admin so there is no need for the insert-menu editor-xtd plugin to be loaded as it wont produce anything useful. This simple PR removes the "insert menu" from the editor toolbar.

NOTE this is 3.7.x not staging
