### PR TITLE
[com_contact] - moved the captchaEnabled var from default to view

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -12,23 +12,11 @@ defined('_JEXEC') or die;
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 
-$captchaEnabled = false;
-
-$captchaSet = $this->params->get('captcha', JFactory::getApplication()->get('captcha', '0'));
-
-foreach (JPluginHelper::getPlugin('captcha') as $plugin)
-{
-	if ($captchaSet === $plugin->name)
-	{
-		$captchaEnabled = true;
-		break;
-	}
-}
 ?>
 <div class="contact-form">
 	<form id="contact-form" action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-validate form-horizontal well">
 		<?php foreach ($this->form->getFieldsets() as $fieldset): ?>
-			<?php if ($fieldset->name === 'captcha' && !$captchaEnabled) : ?>
+			<?php if ($fieldset->name === 'captcha' && !$this->captchaEnabled) : ?>
 				<?php continue; ?>
 			<?php endif; ?>
 			<?php $fields = $this->form->getFieldset($fieldset->name); ?>

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -50,6 +50,14 @@ class ContactViewContact extends JViewLegacy
 	protected $return_page;
 
 	/**
+	 * Should we show a captcha form for the submission of the contact request?
+	 *
+	 * @var   bool
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $captchaEnabled = false;
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -288,8 +296,17 @@ class ContactViewContact extends JViewLegacy
 
 		$model = $this->getModel();
 		$model->hit();
-		$this->_prepareDocument();
 
+		foreach (JPluginHelper::getPlugin('captcha') as $plugin)
+		{
+			if ($captchaSet === $plugin->name)
+			{
+				$this->captchaEnabled = true;
+				break;
+			}
+		}
+
+		$this->_prepareDocument();
 		return parent::display($tpl);
 	}
 

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -297,6 +297,8 @@ class ContactViewContact extends JViewLegacy
 		$model = $this->getModel();
 		$model->hit();
 
+		$captchaSet = $params->get('captcha', JFactory::getApplication()->get('captcha', '0'));
+
 		foreach (JPluginHelper::getPlugin('captcha') as $plugin)
 		{
 			if ($captchaSet === $plugin->name)


### PR DESCRIPTION
as suggested by @wilsonge  https://github.com/joomla/joomla-cms/pull/10976#issuecomment-244575113 in the pr #10976 that allow the use of captcha when submitting an article, this is the same "cosmetic" change for com_contact
### Summary of Changes

moved the `captchaEnabled` var from the `default_form.php` file to the `view.html.php` file
### Testing Instructions

captcha work as before
