### PR TITLE
Dismiss alert on iOs doesnt work - Add cursor:pointer;

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -2823,6 +2823,7 @@ input[type="submit"].btn.btn-mini {
 	top: -2px;
 	right: -21px;
 	line-height: 18px;
+	cursor: pointer;
 }
 .alert-success {
 	background-color: #dff0d8;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -2823,6 +2823,7 @@ input[type="submit"].btn.btn-mini {
 	top: -2px;
 	right: -21px;
 	line-height: 18px;
+	cursor: pointer;
 }
 .alert-success {
 	background-color: #dff0d8;

--- a/media/jui/less/alerts.less
+++ b/media/jui/less/alerts.less
@@ -29,6 +29,7 @@
   top: -2px;
   right: -21px;
   line-height: @baseLineHeight;
+  cursor:pointer;
 }
 
 

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2841,6 +2841,7 @@ input[type="submit"].btn.btn-mini {
 	top: -2px;
 	right: -21px;
 	line-height: 18px;
+	cursor: pointer;
 }
 .alert-success {
 	background-color: #dff0d8;


### PR DESCRIPTION
Pull Request for Issue # .
This is for #11939 

Close Button on iOs doesn´t work

Bug in Bootstrap: Alerts are not closeable on iOs

### Summary of Changes
Added cursor:pointer; to alerts.less and bootstrap_rtl.less to have the altert message be close-able on iOs too.

### Testing Instructions
Please test on iOs (not Chrome emulation or something else)
Before applying the patch:
Type in wrong login credentials using Joomla! Protostar Template.
Try to dismiss the alert by tapping on the close button.
- Nothing will happen

After applying the patch:
Login again with wrong credentials
Try to dismiss the altert
Alert should close now.

### Documentation Changes Required

![image](https://cloud.githubusercontent.com/assets/828371/18250769/73c28c52-7385-11e6-8bb4-b2a4a394f5a7.png)


