### PR TITLE
[unit tests] Just need to check one microsecond now (3.7.x Branch)

### DIFF
--- a/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlDateTest.php
@@ -26,7 +26,7 @@ class JHtmlDateTest extends PHPUnit_Framework_TestCase
 	public function dataTestRelative()
 	{
 		$now1 = new JDate('now');
-		sleep(1);
+		usleep(1);
 		$now2 = new JDate('now');
 
 		return array(

--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -223,7 +223,7 @@ class JFactoryTest extends TestCaseDatabase
 		JFactory::$language = $this->getMockLanguage();
 
 		$date = JFactory::getDate('now');
-		sleep(1);
+		usleep(1);
 		$date2 = JFactory::getDate('now');
 
 		$this->assertThat(


### PR DESCRIPTION
### Summary of Changes

Since https://github.com/joomla/joomla-cms/commit/417a6a63da3205d986320d1e77dd5ee0bb3f7fee (merged in the 3.7.x branch) `JDate('now')` return the current date with microseconds in the 3.7.x. branch there is no need to wait for 1 second.

So this PR makes `JDate('now')` tests wait just one microsecond (is enough to get different dates), instead of a whole second, and with that gaining 2 extra second of performance in every unit tests.
### Testing Instructions

Unit tests pass.
Very simple code review.
### Documentation Changes Required

None.
