### PR TITLE
Change radio to list in single article menu item options

### DIFF
--- a/components/com_content/views/article/tmpl/default.xml
+++ b/components/com_content/views/article/tmpl/default.xml
@@ -33,8 +33,7 @@
 
 		<field
 			name="show_title"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_TITLE_LABEL"
 			description="JGLOBAL_SHOW_TITLE_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -44,8 +43,7 @@
 
 		<field
 			name="link_titles"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_LINKED_TITLES_LABEL"
 			description="JGLOBAL_LINKED_TITLES_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -55,8 +53,7 @@
 
 		<field 
 			name="show_intro" 
-			type="radio"
-			class="btn-group"
+			type="list"
 			description="JGLOBAL_SHOW_INTRO_DESC"
 			label="JGLOBAL_SHOW_INTRO_LABEL">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -66,8 +63,7 @@
 
 		<field
 			name="info_block_position"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL"
 			description="COM_CONTENT_FIELD_INFOBLOCK_POSITION_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -78,8 +74,7 @@
 
 		<field
 			name="info_block_show_title"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="COM_CONTENT_FIELD_INFOBLOCK_TITLE_LABEL"
 			description="COM_CONTENT_FIELD_INFOBLOCK_TITLE_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -89,8 +84,7 @@
 
 		<field
 			name="show_category"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_CATEGORY_LABEL"
 			description="JGLOBAL_SHOW_CATEGORY_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -100,8 +94,7 @@
 
 		<field
 			name="link_category"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_LINK_CATEGORY_LABEL"
 			description="JGLOBAL_LINK_CATEGORY_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -111,8 +104,7 @@
 
 		<field
 			name="show_parent_category"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
 			description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -122,8 +114,7 @@
 
 		<field
 			name="link_parent_category"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 			description="JGLOBAL_LINK_PARENT_CATEGORY_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -133,8 +124,7 @@
 
 		<field
 			name="show_author"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_AUTHOR_LABEL"
 			description="JGLOBAL_SHOW_AUTHOR_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -144,8 +134,7 @@
 
 		<field
 			name="link_author"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_LINK_AUTHOR_LABEL"
 			description="JGLOBAL_LINK_AUTHOR_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -155,8 +144,7 @@
 
 		<field
 			name="show_create_date"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
 			description="JGLOBAL_SHOW_CREATE_DATE_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -166,8 +154,7 @@
 
 		<field
 			name="show_modify_date"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
 			description="JGLOBAL_SHOW_MODIFY_DATE_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -177,8 +164,7 @@
 
 		<field
 			name="show_publish_date"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
 			description="JGLOBAL_SHOW_PUBLISH_DATE_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -188,8 +174,7 @@
 
 		<field
 			name="show_item_navigation"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_NAVIGATION_LABEL"
 			description="JGLOBAL_SHOW_NAVIGATION_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -199,8 +184,7 @@
 
 		<field
 			name="show_vote"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_VOTE_LABEL"
 			description="JGLOBAL_SHOW_VOTE_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -210,8 +194,7 @@
 
 		<field
 			name="show_icons"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_ICONS_LABEL"
 			description="JGLOBAL_SHOW_ICONS_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -221,8 +204,7 @@
 
 		<field
 			name="show_print_icon"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 			description="JGLOBAL_SHOW_PRINT_ICON_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -232,8 +214,7 @@
 
 		<field
 			name="show_email_icon"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
 			description="JGLOBAL_SHOW_EMAIL_ICON_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -243,8 +224,7 @@
 
 		<field
 			name="show_hits"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_HITS_LABEL"
 			description="JGLOBAL_SHOW_HITS_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -254,8 +234,7 @@
 
 		<field
 			name="show_tags"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_TAGS_LABEL"
 			description="JGLOBAL_SHOW_TAGS_DESC">
 			<option	value="">JGLOBAL_USE_GLOBAL</option>
@@ -265,8 +244,7 @@
 
 		<field
 			name="show_noauth"
-			type="radio"
-			class="btn-group"
+			type="list"
 			label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
 			description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
@@ -275,9 +253,8 @@
 		</field>
 		<field
 			name="urls_position"
-			type="radio"
-			class="btn-group"
-		    	label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
+			type="list"
+			label="COM_CONTENT_FIELD_URLSPOSITION_LABEL"
 			description="COM_CONTENT_FIELD_URLSPOSITION_DESC">
 			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">COM_CONTENT_FIELD_OPTION_ABOVE</option>


### PR DESCRIPTION
Pull Request for Issue #11262 .
### Summary of Changes

Change the options tab to use list instead of radio options. This makes it consistent with all the other similar views AND enables #11911 to work on this view as well
### Testing Instructions

Create a new menu item single article and check the options tab - it is bootstrap radio buttons
Apply the PR
Create a new menu item single article and check the options tab - it is now list selects
### Documentation Changes Required

None (maybe screenshots)
