### PR TITLE
Respect current template in XTD image button

### DIFF
--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -30,8 +30,15 @@ class MediaController extends JControllerLegacy
 	{
 		JPluginHelper::importPlugin('content');
 
+		$app      = JFactory::getApplication();
 		$vType    = JFactory::getDocument()->getType();
-		$vName    = $this->input->get('view', 'media');
+		$vName    = $this->input->get('view', 'media', 'string');
+
+		if ($app->isSite())
+		{
+			$template = $this->input->get('template', 'protostar', 'string');
+			$app->setTemplate($template);
+		}
 
 		switch ($vName)
 		{
@@ -48,7 +55,6 @@ class MediaController extends JControllerLegacy
 				break;
 
 			case 'mediaList':
-				$app     = JFactory::getApplication();
 				$mName   = 'list';
 				$vLayout = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 'word');
 

--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -36,8 +36,8 @@ class MediaController extends JControllerLegacy
 
 		if ($app->isSite())
 		{
-			$template = $this->input->get('template', $app->getTemplate(), 'string');
-			$app->setTemplate($template);
+			$template = $this->input->get('template', '', 'string');
+			$app->setTemplate(($template != '') ? $template : $app->getTemplate());
 
 		}
 

--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -36,8 +36,9 @@ class MediaController extends JControllerLegacy
 
 		if ($app->isSite())
 		{
-			$template = $this->input->get('template', 'protostar', 'string');
+			$template = $this->input->get('template', $app->getTemplate(), 'string');
 			$app->setTemplate($template);
+
 		}
 
 		switch ($vName)

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -35,9 +35,10 @@ class PlgButtonImage extends JPlugin
 	 */
 	public function onDisplay($name, $asset, $author)
 	{
-		$app = JFactory::getApplication();
-		$user = JFactory::getUser();
+		$app       = JFactory::getApplication();
+		$user      = JFactory::getUser();
 		$extension = $app->input->get('option');
+		$template  = $app->getTemplate();
 
 		if ($asset == '')
 		{
@@ -51,7 +52,8 @@ class PlgButtonImage extends JPlugin
 			||	(count($user->getAuthorisedCategories($extension, 'core.edit')) > 0)
 			||	(count($user->getAuthorisedCategories($extension, 'core.edit.own')) > 0 && $author == $user->id))
 		{
-			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset=' . $asset . '&amp;author=' . $author;
+			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset='
+				. $asset . '&amp;author=' . $author . '&template=' . $template;
 
 			$button = new JObject;
 			$button->modal = true;

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -53,7 +53,7 @@ class PlgButtonImage extends JPlugin
 			||	(count($user->getAuthorisedCategories($extension, 'core.edit.own')) > 0 && $author == $user->id))
 		{
 			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset='
-				. $asset . '&amp;author=' . $author . '&template=' . $template;
+				. $asset . '&amp;author=' . $author . '&amp;template=' . $template;
 
 			$button = new JObject;
 			$button->modal = true;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/11967.
#### Steps to reproduce the issue

Create a site using the beez template
Create an article and add it to a menu item and use the protostar template for that menu item
In the front end login and edit the article
Select the insert image from the wysiwyg toolbar to open the image select modal
#### Expected result

The modal opens in an iframe and is using the assigned protostar template
#### Actual result

The modal opens in an iframe and is using the default template for the site - in this case beez
#### Testing

Repeat the above step once you have applied this patch with patchtester
