### PR TITLE
Remove need for debug mode to be enabled

### DIFF
--- a/administrator/components/com_users/views/debuggroup/view.html.php
+++ b/administrator/components/com_users/views/debuggroup/view.html.php
@@ -52,7 +52,7 @@ class UsersViewDebuggroup extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Access check.
-		if (!JFactory::getUser()->authorise('core.manage', 'com_users') || !JFactory::getConfig()->get('debug'))
+		if (!JFactory::getUser()->authorise('core.manage', 'com_users'))
 		{
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}

--- a/administrator/components/com_users/views/debuguser/view.html.php
+++ b/administrator/components/com_users/views/debuguser/view.html.php
@@ -52,7 +52,7 @@ class UsersViewDebuguser extends JViewLegacy
 	public function display($tpl = null)
 	{
 		// Access check.
-		if (!JFactory::getUser()->authorise('core.manage', 'com_users') || !JFactory::getConfig()->get('debug'))
+		if (!JFactory::getUser()->authorise('core.manage', 'com_users'))
 		{
 			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
 		}


### PR DESCRIPTION
### Summary of Changes

Trying to access the debug user/group reports fails unless you have the site in debug mode.  Though we only show the links to these pages when debug's enabled, there's no reason to block access to the views completely.
### Testing Instructions

With debug disabled, direct access `administrator/index.php?option=com_users&view=debuguser&user_id=<user_id>` and `administrator/index.php?option=com_users&view=debuggroup&group_id=<group_id>` will fail if you don't pass the ACL check or if the site is not in debug mode.  After the patch, only the ACL check will block this view.
### Documentation Changes Required

N/A
