### PR TITLE
Add button class on disabled extension module

### DIFF
--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -141,7 +141,9 @@ $colSpan = $clientId === 1 ? 9 : 10;
 								?>
 							<?php else : ?>
 								<?php // Extension is not enabled, show a message that indicates this. ?>
-								<button class="btn-micro hasTooltip" title="<?php echo JText::_('COM_MODULES_MSG_MANAGE_EXTENSION_DISABLED'); ?>"><i class="icon-ban-circle"></i></button>
+								<button class="btn btn-micro hasTooltip" title="<?php echo JText::_('COM_MODULES_MSG_MANAGE_EXTENSION_DISABLED'); ?>">
+									<i class="icon-ban-circle"></i>
+								</button>
 							<?php endif; ?>
 							</div>
 						</td>


### PR DESCRIPTION
When the component is disabled and have modules, you see a warning on the modules view. But its missing a btn class for the bootstrap style.

![button](https://cloud.githubusercontent.com/assets/876623/18349724/fa805bd0-75d2-11e6-8666-16f2bf7532c1.jpg)
### Test instructions:

install cb or other component that have a module
disable the component
Go to modules
see the correct button style
