### PR TITLE
Replace deprecated JObject with new stdClass()

### DIFF
--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -19,7 +19,7 @@ $user       = JFactory::getUser();
 $userId     = $user->get('id');
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
-$params     = (isset($this->state->params)) ? $this->state->params : new JObject;
+$params     = (isset($this->state->params)) ? $this->state->params : new stdClass();
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=clients'); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-sidebar-container" class="span2">

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -148,7 +148,7 @@ abstract class FinderIndexer
 		// If the state is empty, load the values for the first time.
 		if (empty($data))
 		{
-			$data = new JObject;
+			$data = new stdClass();
 
 			// Load the default configuration options.
 			$data->options = JComponentHelper::getParams('com_finder');
@@ -202,7 +202,7 @@ abstract class FinderIndexer
 	public static function setState($data)
 	{
 		// Check the state object.
-		if (empty($data) || !$data instanceof JObject)
+		if (empty($data) || !$data instanceof stdClass)
 		{
 			return false;
 		}

--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -390,7 +390,7 @@ class FinderIndexerResult
 		$branch = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,_]+#mui', ' ', $branch);
 
 		// Create the taxonomy node.
-		$node = new JObject;
+		$node = new stdClass();
 		$node->title = $title;
 		$node->state = (int) $state;
 		$node->access = (int) $access;

--- a/administrator/components/com_finder/helpers/indexer/taxonomy.php
+++ b/administrator/components/com_finder/helpers/indexer/taxonomy.php
@@ -78,7 +78,7 @@ class FinderIndexerTaxonomy
 		 * state has changed or because the branch does not exist. Let's figure
 		 * out which case is true and deal with it.
 		 */
-		$branch = new JObject;
+		$branch = new stdClass();
 
 		if (empty($result))
 		{
@@ -158,7 +158,7 @@ class FinderIndexerTaxonomy
 		 * state has changed or because the node does not exist. Let's figure
 		 * out which case is true and deal with it.
 		 */
-		$node = new JObject;
+		$node = new stdClass();
 
 		if (empty($result))
 		{
@@ -213,7 +213,7 @@ class FinderIndexerTaxonomy
 		$db->execute();
 		$id = (int) $db->loadResult();
 
-		$map = new JObject;
+		$map = new stdClass();
 		$map->link_id = (int) $linkId;
 		$map->node_id = (int) $nodeId;
 

--- a/administrator/components/com_finder/models/statistics.php
+++ b/administrator/components/com_finder/models/statistics.php
@@ -19,7 +19,7 @@ class FinderModelStatistics extends JModelLegacy
 	/**
 	 * Method to get the component statistics
 	 *
-	 * @return  JObject  The component statistics
+	 * @return  object  The component statistics
 	 *
 	 * @since   2.5
 	 */
@@ -28,7 +28,7 @@ class FinderModelStatistics extends JModelLegacy
 		// Initialise
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
-		$data = new JObject;
+		$data = new stdClass();
 
 		$query->select('COUNT(term_id)')
 			->from($db->quoteName('#__finder_terms'));

--- a/administrator/components/com_languages/models/language.php
+++ b/administrator/components/com_languages/models/language.php
@@ -108,7 +108,7 @@ class LanguagesModelLanguage extends JModelAdmin
 		}
 
 		$properties = $table->getProperties(1);
-		$value      = JArrayHelper::toObject($properties, 'JObject');
+		$value      = JArrayHelper::toObject($properties);
 
 		return $value;
 	}

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -111,7 +111,7 @@ class MediaControllerFile extends JControllerLegacy
 		// Trigger the onContentBeforeSave event.
 		JPluginHelper::importPlugin('content');
 		$dispatcher  = JEventDispatcher::getInstance();
-		$object_file = new stdClass($file);
+		$object_file = new JObject($file);
 		$object_file->filepath = $filepath;
 		$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -111,7 +111,7 @@ class MediaControllerFile extends JControllerLegacy
 		// Trigger the onContentBeforeSave event.
 		JPluginHelper::importPlugin('content');
 		$dispatcher  = JEventDispatcher::getInstance();
-		$object_file = new JObject($file);
+		$object_file = new stdClass($file);
 		$object_file->filepath = $filepath;
 		$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 

--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -142,7 +142,7 @@ class MediaControllerFile extends JControllerLegacy
 			}
 
 			// Trigger the onContentBeforeSave event.
-			$object_file = new JObject($file);
+			$object_file = new stdClass($file);
 			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 
 			if (in_array(false, $result, true))
@@ -249,7 +249,7 @@ class MediaControllerFile extends JControllerLegacy
 			}
 
 			$fullPath = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $folder, $path)));
-			$object_file = new JObject(array('filepath' => $fullPath));
+			$object_file = new stdClass(array('filepath' => $fullPath));
 
 			if (is_file($object_file->filepath))
 			{

--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -83,7 +83,7 @@ class MediaControllerFolder extends JControllerLegacy
 				}
 
 				$fullPath = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $folder, $path)));
-				$object_file = new stdClass(array('filepath' => $fullPath));
+				$object_file = new JObject(array('filepath' => $fullPath));
 
 				if (is_file($object_file->filepath))
 				{
@@ -188,7 +188,7 @@ class MediaControllerFolder extends JControllerLegacy
 			if (!is_dir($path) && !is_file($path))
 			{
 				// Trigger the onContentBeforeSave event.
-				$object_file = new stdClass(array('filepath' => $path));
+				$object_file = new JObject(array('filepath' => $path));
 				JPluginHelper::importPlugin('content');
 				$dispatcher = JEventDispatcher::getInstance();
 				$result     = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file, true));

--- a/administrator/components/com_media/controllers/folder.php
+++ b/administrator/components/com_media/controllers/folder.php
@@ -83,7 +83,7 @@ class MediaControllerFolder extends JControllerLegacy
 				}
 
 				$fullPath = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $folder, $path)));
-				$object_file = new JObject(array('filepath' => $fullPath));
+				$object_file = new stdClass(array('filepath' => $fullPath));
 
 				if (is_file($object_file->filepath))
 				{
@@ -188,7 +188,7 @@ class MediaControllerFolder extends JControllerLegacy
 			if (!is_dir($path) && !is_file($path))
 			{
 				// Trigger the onContentBeforeSave event.
-				$object_file = new JObject(array('filepath' => $path));
+				$object_file = new stdClass(array('filepath' => $path));
 				JPluginHelper::importPlugin('content');
 				$dispatcher = JEventDispatcher::getInstance();
 				$result     = $dispatcher->trigger('onContentBeforeSave', array('com_media.folder', &$object_file, true));

--- a/administrator/components/com_media/models/list.php
+++ b/administrator/components/com_media/models/list.php
@@ -135,7 +135,7 @@ class MediaModelList extends JModelLegacy
 			{
 				if (is_file($basePath . '/' . $file) && substr($file, 0, 1) != '.' && strtolower($file) !== 'index.html')
 				{
-					$tmp = new JObject;
+					$tmp = new stdClass();
 					$tmp->name = $file;
 					$tmp->title = $file;
 					$tmp->path = str_replace(DIRECTORY_SEPARATOR, '/', JPath::clean($basePath . '/' . $file));
@@ -211,7 +211,7 @@ class MediaModelList extends JModelLegacy
 		{
 			foreach ($folderList as $folder)
 			{
-				$tmp = new JObject;
+				$tmp = new stdClass();
 				$tmp->name = basename($folder);
 				$tmp->path = str_replace(DIRECTORY_SEPARATOR, '/', JPath::clean($basePath . '/' . $folder));
 				$tmp->path_relative = str_replace($mediaBase, '', $tmp->path);

--- a/administrator/components/com_media/views/imageslist/view.html.php
+++ b/administrator/components/com_media/views/imageslist/view.html.php
@@ -59,7 +59,7 @@ class MediaViewImagesList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_folder = new JObject;
+			$this->_tmp_folder = new stdClass();
 		}
 	}
 
@@ -80,7 +80,7 @@ class MediaViewImagesList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_img = new JObject;
+			$this->_tmp_img = new stdClass();
 		}
 	}
 }

--- a/administrator/components/com_media/views/medialist/view.html.php
+++ b/administrator/components/com_media/views/medialist/view.html.php
@@ -82,7 +82,7 @@ class MediaViewMediaList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_folder = new JObject;
+			$this->_tmp_folder = new stdClass();
 		}
 	}
 
@@ -103,7 +103,7 @@ class MediaViewMediaList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_img = new JObject;
+			$this->_tmp_img = new stdClass();
 		}
 	}
 
@@ -124,7 +124,7 @@ class MediaViewMediaList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_doc = new JObject;
+			$this->_tmp_doc = new stdClass();
 		}
 	}
 
@@ -145,7 +145,7 @@ class MediaViewMediaList extends JViewLegacy
 		}
 		else
 		{
-			$this->_tmp_video = new JObject;
+			$this->_tmp_video = new stdClass();
 		}
 	}
 }

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -131,7 +131,7 @@ class MenusModelMenu extends JModelForm
 		}
 
 		$properties = $table->getProperties(1);
-		$value      = JArrayHelper::toObject($properties, 'JObject');
+		$value      = JArrayHelper::toObject($properties);
 
 		return $value;
 	}

--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -101,7 +101,7 @@ class MenusModelMenutypes extends JModelLegacy
 	 * Method to create the reverse lookup for link-to-name.
 	 * (can be used from onAfterGetMenuTypeOptions handlers)
 	 *
-	 * @param   JObject  $option  with request array or string and title public variables
+	 * @param   object  $option  with request array or string and title public variables
 	 *
 	 * @return  void
 	 *
@@ -174,7 +174,7 @@ class MenusModelMenutypes extends JModelLegacy
 		if (!empty($menu['options']) && $menu['options'] == 'none')
 		{
 			// Create the menu option for the component.
-			$o = new JObject;
+			$o = new stdClass();
 			$o->title       = (string) $menu['name'];
 			$o->description = (string) $menu['msg'];
 			$o->request     = array('option' => $component);
@@ -207,7 +207,7 @@ class MenusModelMenutypes extends JModelLegacy
 				if ($child->getName() == 'option')
 				{
 					// Create the menu option for the component.
-					$o = new JObject;
+					$o = new stdClass();
 					$o->title       = (string) $child['name'];
 					$o->description = (string) $child['msg'];
 					$o->request     = array('option' => $component, (string) $optionsNode['var'] => (string) $child['value']);
@@ -217,7 +217,7 @@ class MenusModelMenutypes extends JModelLegacy
 				elseif ($child->getName() == 'default')
 				{
 					// Create the menu option for the component.
-					$o = new JObject;
+					$o = new stdClass();
 					$o->title       = (string) $child['name'];
 					$o->description = (string) $child['msg'];
 					$o->request     = array('option' => $component);
@@ -305,7 +305,7 @@ class MenusModelMenutypes extends JModelLegacy
 										if ($child->getName() == 'option')
 										{
 											// Create the menu option for the component.
-											$o = new JObject;
+											$o = new stdClass();
 											$o->title       = (string) $child['name'];
 											$o->description = (string) $child['msg'];
 											$o->request     = array('option' => $component, 'view' => $view, (string) $optionsNode['var'] => (string) $child['value']);
@@ -315,7 +315,7 @@ class MenusModelMenutypes extends JModelLegacy
 										elseif ($child->getName() == 'default')
 										{
 											// Create the menu option for the component.
-											$o = new JObject;
+											$o = new stdClass();
 											$o->title       = (string) $child['name'];
 											$o->description = (string) $child['msg'];
 											$o->request     = array('option' => $component, 'view' => $view);
@@ -439,7 +439,7 @@ class MenusModelMenutypes extends JModelLegacy
 				$layout = basename($layout, '.xml');
 
 				// Create the menu option for the layout.
-				$o = new JObject;
+				$o = new stdClass();
 				$o->title       = ucfirst($layout);
 				$o->description = '';
 				$o->request     = array('option' => $component, 'view' => $view);

--- a/administrator/components/com_menus/views/menutypes/view.html.php
+++ b/administrator/components/com_menus/views/menutypes/view.html.php
@@ -33,28 +33,28 @@ class MenusViewMenutypes extends JViewLegacy
 
 		// Adding System Links
 		$list = array();
-		$o = new JObject;
+		$o = new stdClass();
 		$o->title = 'COM_MENUS_TYPE_EXTERNAL_URL';
 		$o->type = 'url';
 		$o->description  = 'COM_MENUS_TYPE_EXTERNAL_URL_DESC';
 		$o->request = null;
 		$list[] = $o;
 
-		$o = new JObject;
+		$o = new stdClass();
 		$o->title = 'COM_MENUS_TYPE_ALIAS';
 		$o->type = 'alias';
 		$o->description = 'COM_MENUS_TYPE_ALIAS_DESC';
 		$o->request = null;
 		$list[] = $o;
 
-		$o = new JObject;
+		$o = new stdClass();
 		$o->title = 'COM_MENUS_TYPE_SEPARATOR';
 		$o->type = 'separator';
 		$o->description = 'COM_MENUS_TYPE_SEPARATOR_DESC';
 		$o->request = null;
 		$list[] = $o;
 
-		$o = new JObject;
+		$o = new stdClass();
 		$o->title = 'COM_MENUS_TYPE_HEADING';
 		$o->type = 'heading';
 		$o->description = 'COM_MENUS_TYPE_HEADING_DESC';

--- a/administrator/components/com_messages/models/config.php
+++ b/administrator/components/com_messages/models/config.php
@@ -49,7 +49,7 @@ class MessagesModelConfig extends JModelForm
 	 */
 	public function &getItem()
 	{
-		$item = new JObject;
+		$item = new stdClass();
 
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -691,9 +691,9 @@ class ModulesModelModule extends JModelAdmin
 				}
 			}
 
-			// Convert to the JObject before adding other data.
+			// Convert to an object before adding other data.
 			$properties        = $table->getProperties(1);
-			$this->_cache[$pk] = JArrayHelper::toObject($properties, 'JObject');
+			$this->_cache[$pk] = JArrayHelper::toObject($properties);
 
 			// Convert the params field to an array.
 			$registry = new Registry;

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -97,11 +97,11 @@ class PluginsHelper
 	 * @param   string  $templateBaseDir  Base path to the template directory.
 	 * @param   string  $templateDir      Template directory.
 	 *
-	 * @return  JObject
+	 * @return  object
 	 */
 	public function parseXMLTemplateFile($templateBaseDir, $templateDir)
 	{
-		$data = new JObject;
+		$data = new stdClass();
 
 		// Check of the xml file exists.
 		$filePath = JPath::clean($templateBaseDir . '/templates/' . $templateDir . '/templateDetails.xml');

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -97,11 +97,11 @@ class PluginsHelper
 	 * @param   string  $templateBaseDir  Base path to the template directory.
 	 * @param   string  $templateDir      Template directory.
 	 *
-	 * @return  object
+	 * @return  JObject
 	 */
 	public function parseXMLTemplateFile($templateBaseDir, $templateDir)
 	{
-		$data = new stdClass();
+		$data = new JObject();
 
 		// Check of the xml file exists.
 		$filePath = JPath::clean($templateBaseDir . '/templates/' . $templateDir . '/templateDetails.xml');

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -161,9 +161,9 @@ class PluginsModelPlugin extends JModelAdmin
 				return false;
 			}
 
-			// Convert to the JObject before adding other data.
+			// Convert to an object before adding other data.
 			$properties = $table->getProperties(1);
-			$this->_cache[$pk] = JArrayHelper::toObject($properties, 'JObject');
+			$this->_cache[$pk] = JArrayHelper::toObject($properties);
 
 			// Convert the params field to an array.
 			$registry = new Registry;

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -109,11 +109,11 @@ class TemplatesHelper
 	 * @param   string  $templateBaseDir  TODO
 	 * @param   string  $templateDir      TODO
 	 *
-	 * @return  boolean|JObject
+	 * @return  boolean|object
 	 */
 	public static function parseXMLTemplateFile($templateBaseDir, $templateDir)
 	{
-		$data = new JObject;
+		$data = new stdClass();
 
 		// Check of the xml file exists
 		$filePath = JPath::clean($templateBaseDir . '/templates/' . $templateDir . '/templateDetails.xml');

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -347,9 +347,9 @@ class TemplatesModelStyle extends JModelAdmin
 				return false;
 			}
 
-			// Convert to the JObject before adding other data.
+			// Convert to an object before adding other data.
 			$properties        = $table->getProperties(1);
-			$this->_cache[$pk] = JArrayHelper::toObject($properties, 'JObject');
+			$this->_cache[$pk] = JArrayHelper::toObject($properties);
 
 			// Convert the params field to an array.
 			$registry = new Registry;

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -113,7 +113,7 @@ class UsersModelGroup extends JModelAdmin
 	 */
 	protected function preprocessForm(JForm $form, $data, $group = '')
 	{
-		$obj = is_array($data) ? JArrayHelper::toObject($data, 'JObject') : $data;
+		$obj = is_array($data) ? JArrayHelper::toObject($data) : $data;
 
 		if (isset($obj->parent_id) && $obj->parent_id == 0 && $obj->id > 0)
 		{

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -84,7 +84,7 @@ class ContentModelForm extends ContentModelArticle
 		}
 
 		$properties = $table->getProperties(1);
-		$value = ArrayHelper::toObject($properties, 'JObject');
+		$value = ArrayHelper::toObject($properties);
 
 		// Convert attrib field to Registry.
 		$value->params = new Registry;

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -288,9 +288,9 @@ class TagsModelTag extends JModelList
 						}
 					}
 
-					// Convert the JTable to a clean JObject.
+					// Convert the JTable to a clean object.
 					$properties = $table->getProperties(1);
-					$this->item[] = ArrayHelper::toObject($properties, 'JObject');
+					$this->item[] = ArrayHelper::toObject($properties);
 				}
 				catch (RuntimeException $e)
 				{

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -37,7 +37,7 @@ class JHelperContent
 	 * @param   integer  $id          The item ID.
 	 * @param   string   $assetName   The asset name
 	 *
-	 * @return  JObject
+	 * @return  object
 	 *
 	 * @since   3.1
 	 * @deprecated  3.2  Use JHelperContent::getActions() instead
@@ -49,7 +49,7 @@ class JHelperContent
 
 		// Reverted a change for version 2.5.6
 		$user   = JFactory::getUser();
-		$result = new JObject;
+		$result = new stdClass();
 
 		$path = JPATH_ADMINISTRATOR . '/components/' . $assetName . '/access.xml';
 
@@ -86,7 +86,7 @@ class JHelperContent
 	 * @param   string   $section    The access section name.
 	 * @param   integer  $id         The item ID.
 	 *
-	 * @return  JObject
+	 * @return  object
 	 *
 	 * @since   3.2
 	 */
@@ -101,7 +101,7 @@ class JHelperContent
 		}
 
 		$user   = JFactory::getUser();
-		$result = new JObject;
+		$result = new stdClass();
 
 		$path = JPATH_ADMINISTRATOR . '/components/' . $component . '/access.xml';
 

--- a/libraries/cms/html/content.php
+++ b/libraries/cms/html/content.php
@@ -31,7 +31,7 @@ abstract class JHtmlContent
 	{
 		if ($params === null)
 		{
-			$params = new JObject;
+			$params = new stdClass();
 		}
 
 		$article = new stdClass;

--- a/libraries/cms/html/contentlanguage.php
+++ b/libraries/cms/html/contentlanguage.php
@@ -56,7 +56,7 @@ abstract class JHtmlContentLanguage
 
 		if ($all)
 		{
-			$all_option = array(new JObject(array('value' => '*', 'text' => $translate ? JText::alt('JALL', 'language') : 'JALL_LANGUAGE')));
+			$all_option = array(new stdClass(array('value' => '*', 'text' => $translate ? JText::alt('JALL', 'language') : 'JALL_LANGUAGE')));
 
 			return array_merge($all_option, static::$items);
 		}

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -174,16 +174,16 @@ class JAccessRules
 	/**
 	 * Get the allowed actions for an identity.
 	 *
-	 * @param   mixed  $identity  An integer representing the identity or an array of identities
+	 * @param   mixed   $identity  An integer representing the identity or an array of identities
 	 *
-	 * @return  JObject  Allowed actions for the identity or identities
+	 * @return  object  Allowed actions for the identity or identities
 	 *
 	 * @since   11.1
 	 */
 	public function getAllowed($identity)
 	{
 		// Sweep for the allowed actions.
-		$allowed = new JObject;
+		$allowed = new stdClass();
 
 		foreach ($this->data as $name => &$action)
 		{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -151,9 +151,9 @@ class JForm
 				// Handle a Registry.
 				$data = $data->toArray();
 			}
-			elseif ($data instanceof JObject)
+			elseif ($data instanceof stdClass)
 			{
-				// Handle a JObject.
+				// Handle an Object.
 				$data = $data->getProperties();
 			}
 			else

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -901,7 +901,7 @@ abstract class JModelAdmin extends JModelForm
 
 		// Convert to the JObject before adding other data.
 		$properties = $table->getProperties(1);
-		$item = JArrayHelper::toObject($properties, 'JObject');
+		$item = JArrayHelper::toObject($properties);
 
 		if (property_exists($item, 'params'))
 		{

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -53,7 +53,7 @@ abstract class JModelLegacy extends JObject
 	/**
 	 * A state object
 	 *
-	 * @var    JObject
+	 * @var    object
 	 * @since  12.2
 	 */
 	protected $state;
@@ -247,7 +247,7 @@ abstract class JModelLegacy extends JObject
 		}
 		else
 		{
-			$this->state = new JObject;
+			$this->state = new stdClass();
 		}
 
 		// Set the model dbo

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -53,7 +53,7 @@ abstract class JModelLegacy extends JObject
 	/**
 	 * A state object
 	 *
-	 * @var    object
+	 * @var    JRegistry
 	 * @since  12.2
 	 */
 	protected $state;
@@ -247,7 +247,7 @@ abstract class JModelLegacy extends JObject
 		}
 		else
 		{
-			$this->state = new stdClass();
+			$this->state = new JRegistry();
 		}
 
 		// Set the model dbo

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -61,7 +61,7 @@ class PlgButtonArticle extends JPlugin
 		 */
 		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button = new JObject;
+		$button = new stdClass();
 		$button->modal = true;
 		$button->class = 'btn';
 		$button->link = $link;

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -53,7 +53,7 @@ class PlgButtonImage extends JPlugin
 		{
 			$link = 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;e_name=' . $name . '&amp;asset=' . $asset . '&amp;author=' . $author;
 
-			$button = new JObject;
+			$button = new stdClass();
 			$button->modal = true;
 			$button->class = 'btn';
 			$button->link = $link;

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -41,7 +41,7 @@ class PlgButtonModule extends JPlugin
 		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
 				. $name . '&amp;' . JSession::getFormToken() . '=1';
 
-		$button          = new JObject;
+		$button          = new stdClass();
 		$button->modal   = true;
 		$button->class   = 'btn';
 		$button->link    = $link;

--- a/plugins/editors-xtd/pagebreak/pagebreak.php
+++ b/plugins/editors-xtd/pagebreak/pagebreak.php
@@ -35,7 +35,7 @@ class PlgButtonPagebreak extends JPlugin
 	{
 		$link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
 
-		$button          = new JObject;
+		$button          = new stdClass();
 		$button->modal   = true;
 		$button->class   = 'btn';
 		$button->link    = $link;

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -55,7 +55,7 @@ class PlgButtonReadmore extends JPlugin
 
 		$doc->addScriptDeclaration($js);
 
-		$button          = new JObject;
+		$button          = new stdClass();
 		$button->modal   = false;
 		$button->class   = 'btn';
 		$button->onclick = 'insertReadmore(\'' . $name . '\');return false;';


### PR DESCRIPTION
### Summary of Changes

`JObject` is deprecated and will be removed in J4.x. This PR removes the majority of references to `JObject` in favour of `new stdClass()`.

**Note:**
I haven't touched class extending, such as `JMenuNode extends JObject` as again, not sure how this would be done.
### Testing Instructions

Code review.
### Documentation Changes Required

None
