### PR TITLE
Grid within well changed to row-fluid (image modal)

### DIFF
--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -65,7 +65,7 @@ JFactory::getDocument()->addScriptDeclaration(
 		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
 
 		<div class="well">
-			<div class="row">
+			<div class="row-fluid">
 				<div class="span6 control-group">
 					<div class="control-label">
 						<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
@@ -91,7 +91,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				<?php endif;?>
 			</div>
 			<?php if (!$this->state->get('field.id')):?>
-				<div class="row">
+				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">
 							<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
@@ -109,7 +109,7 @@ JFactory::getDocument()->addScriptDeclaration(
 						</div>
 					</div>
 				</div>
-				<div class="row">
+				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">
 							<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>


### PR DESCRIPTION
2 column grid in the media modal appearing in single column
### Summary of Changes

Bootstrap 2.3 does not support a grid within a well using 'row'. Changed to 'row-fluid'.
### Testing Instructions

Navigate to article editor and  add image

Edit: Issue found running Windows in Firefox and Chrome however not in IE.

**Before**
![well-imageform-before](https://cloud.githubusercontent.com/assets/2803503/18377767/dcc09842-7660-11e6-88cd-47d4a1c6111e.png)

**After**
![well-imageform-after](https://cloud.githubusercontent.com/assets/2803503/18377772/e570b1c0-7660-11e6-95d8-7010cf15bb91.png)
### Documentation Changes Required

None
