### PR TITLE
[JLanguage] Do not run the load language file method twice in the default language

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -731,7 +731,7 @@ class JLanguage
 
 		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
 		// with $default set to true
-		if (!$this->debug && $lang != $this->default && $default)
+		if (!$this->debug && ($lang != $this->default) && $default)
 		{
 			$this->load($extension, $basePath, $this->default, false, true);
 		}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -723,16 +723,17 @@ class JLanguage
 	 */
 	public function load($extension = 'joomla', $basePath = JPATH_BASE, $lang = null, $reload = false, $default = true)
 	{
-		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
-		// with $default set to true
-		if (!$this->debug && ($lang != $this->default) && $default)
-		{
-			$this->load($extension, $basePath, $this->default, false, true);
-		}
-
+		// If language is null set as the current language.
 		if (!$lang)
 		{
 			$lang = $this->lang;
+		}
+
+		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
+		// with $default set to true
+		if (!$this->debug && $lang != $this->default && $default)
+		{
+			$this->load($extension, $basePath, $this->default, false, true);
 		}
 
 		$path = self::getLanguagePath($basePath, $lang);


### PR DESCRIPTION
### Summary of Changes

When loading language files for the en-GB language `JLanguage::load` method is trying to load the en-GB files two times when it only needs to do that one time.

This PR intends to corrects that.
### Testing Instructions
- Code review
- Use latest staging
- Enable debug global option and system debug plugin
- Add, before and after  `JLanguage::load` (https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/language/language.php#L724) method a profiler mark like this:

``` php
    public function load($extension = 'joomla', $basePath = JPATH_BASE, $lang = null, $reload = false, $default = true)
    {
        !JDEBUG ?: JProfiler::getInstance('Application')->mark('');

        // Code removed for brevity

        !JDEBUG ?: JProfiler::getInstance('Application')->mark('<strong>Loaded</strong> ' . str_replace(JPATH_ROOT, '', $filename));

        return $result;
    }
```
- Check in the debug plugin "Profile Information" that the `load` method is being called **two times** in en-GB for each language file.
  ![image](https://cloud.githubusercontent.com/assets/9630530/18390749/63495844-76a3-11e6-846b-0364147ef201.png)
- Apply patch
- Add the profiler marks again to the file
- Check in the debug plugin "Profile Information" that the `load` method is being called **one time** for en-GB for each language file.
  ![image](https://cloud.githubusercontent.com/assets/9630530/18390857/c47a6fa4-76a3-11e6-8199-57022762414b.png)
- Check if all language are still loaded correctly across joomla
### Documentation Changes Required

None.
