### PR TITLE
remove unneeded space from btn-group/radio/checkboxes

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1045,10 +1045,6 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
-.controls > .radio:first-child,
-.controls > .checkbox:first-child {
-	padding-top: 5px;
-}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1632,6 +1628,13 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;
@@ -8116,6 +8119,9 @@ th .tooltip-inner {
 .controls .btn-group.btn-group-yesno > .btn {
 	min-width: 84px;
 	padding: 2px 12px;
+}
+.form-horizontal .controls .btn-group.btn-group-yesno {
+	padding-top: 2px;
 }
 .img-preview > img {
 	max-height: 100%;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1045,6 +1045,10 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 5px;
+}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1628,13 +1632,6 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
-}
-.form-horizontal .controls > .radio:first-child,
-.form-horizontal .controls > .checkbox:first-child {
-	padding-top: 5px;
-}
-.form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;
@@ -8120,9 +8117,6 @@ th .tooltip-inner {
 	min-width: 84px;
 	padding: 2px 12px;
 }
-.form-horizontal .controls .btn-group.btn-group-yesno {
-	padding-top: 2px;
-}
 .img-preview > img {
 	max-height: 100%;
 }
@@ -8824,6 +8818,20 @@ textarea.noResize {
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio.btn-group-yesno:first-child {
+	padding-top: 2px;
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8821,14 +8821,14 @@ textarea.noResize {
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .form-horizontal .controls > .radio:first-child,
 .form-horizontal .controls > .checkbox:first-child {
 	padding-top: 5px;
 }
 .form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1045,10 +1045,6 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
-.controls > .radio:first-child,
-.controls > .checkbox:first-child {
-	padding-top: 5px;
-}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1632,6 +1628,13 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;
@@ -8116,6 +8119,9 @@ th .tooltip-inner {
 .controls .btn-group.btn-group-yesno > .btn {
 	min-width: 84px;
 	padding: 2px 12px;
+}
+.form-horizontal .controls .btn-group.btn-group-yesno {
+	padding-top: 2px;
 }
 .img-preview > img {
 	max-height: 100%;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1045,6 +1045,10 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 5px;
+}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1628,13 +1632,6 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
-}
-.form-horizontal .controls > .radio:first-child,
-.form-horizontal .controls > .checkbox:first-child {
-	padding-top: 5px;
-}
-.form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;
@@ -8120,9 +8117,6 @@ th .tooltip-inner {
 	min-width: 84px;
 	padding: 2px 12px;
 }
-.form-horizontal .controls .btn-group.btn-group-yesno {
-	padding-top: 2px;
-}
 .img-preview > img {
 	max-height: 100%;
 }
@@ -8824,4 +8818,18 @@ textarea.noResize {
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio.btn-group-yesno:first-child {
+	padding-top: 2px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8821,14 +8821,14 @@ textarea.noResize {
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .form-horizontal .controls > .radio:first-child,
 .form-horizontal .controls > .checkbox:first-child {
 	padding-top: 5px;
 }
 .form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1871,7 +1871,7 @@ textarea.noResize {
 /* Remove unneeded space between label and field in vertical forms */
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 
 	.form-horizontal & {
 		padding-top: 5px;
@@ -1880,7 +1880,7 @@ textarea.noResize {
 
 /* Align btn-group to label */
 .form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 
 /* Align btn-group-yesno to label */

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1218,9 +1218,6 @@ th .tooltip-inner {
 	min-width: 84px;
 	padding: 2px 12px;
 }
-.form-horizontal .controls .btn-group.btn-group-yesno {
-	padding-top: 2px;
-}
 .img-preview > img {
 	max-height: 100%;
 }
@@ -1869,4 +1866,24 @@ textarea.noResize {
 	    border-radius: 3px;
 	    padding: 15px;
 	}
+}
+
+/* Remove unneeded space between label and field in vertical forms */
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+
+	.form-horizontal & {
+		padding-top: 5px;
+	}
+}
+
+/* Align btn-group to label */
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+
+/* Align btn-group-yes to label */
+.form-horizontal .controls > .radio.btn-group-yesno:first-child {
+	padding-top: 2px;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1218,6 +1218,9 @@ th .tooltip-inner {
 	min-width: 84px;
 	padding: 2px 12px;
 }
+.form-horizontal .controls .btn-group.btn-group-yesno {
+	padding-top: 2px;
+}
 .img-preview > img {
 	max-height: 100%;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1883,7 +1883,7 @@ textarea.noResize {
 	padding-top: 0px;
 }
 
-/* Align btn-group-yes to label */
+/* Align btn-group-yesno to label */
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -232,6 +232,12 @@ textarea {
   margin-left: -20px;
 }
 
+// Move the options list down to align with labels
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+  padding-top: 5px; // has to be padding because margin collaspes
+}
+
 // Radios and checkboxes on same line
 // TODO v3: Convert .inline to .control-inline
 .radio.inline,
@@ -660,16 +666,6 @@ legend + .control-group {
     *margin-left: 0;
     &:first-child {
       *padding-left: @horizontalComponentOffset;
-    }
-
-    // Move the options list down to align with labels
-    > .radio:first-child,
-    > .checkbox:first-child {
-      padding-top: 5px; // has to be padding because margin collaspes
-    }
-    // Move the btn-group down to align with labels
-    > .radio.btn-group:first-child {
-      padding-top: 2px; // has to be padding because margin collaspes
     }
   }
   // Remove bottom margin on block level help text since that's accounted for on .control-group

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -232,12 +232,6 @@ textarea {
   margin-left: -20px;
 }
 
-// Move the options list down to align with labels
-.controls > .radio:first-child,
-.controls > .checkbox:first-child {
-  padding-top: 5px; // has to be padding because margin collaspes
-}
-
 // Radios and checkboxes on same line
 // TODO v3: Convert .inline to .control-inline
 .radio.inline,
@@ -666,6 +660,16 @@ legend + .control-group {
     *margin-left: 0;
     &:first-child {
       *padding-left: @horizontalComponentOffset;
+    }
+
+    // Move the options list down to align with labels
+    > .radio:first-child,
+    > .checkbox:first-child {
+      padding-top: 5px; // has to be padding because margin collaspes
+    }
+    // Move the btn-group down to align with labels
+    > .radio.btn-group:first-child {
+      padding-top: 2px; // has to be padding because margin collaspes
     }
   }
   // Remove bottom margin on block level help text since that's accounted for on .control-group

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1063,6 +1063,10 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 5px;
+}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1670,13 +1674,6 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
-}
-.form-horizontal .controls > .radio:first-child,
-.form-horizontal .controls > .checkbox:first-child {
-	padding-top: 5px;
-}
-.form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;
@@ -7659,6 +7656,17 @@ body.modal-open {
 }
 #users-profile-custom label {
 	display: inline;
+}
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
 }
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1063,10 +1063,6 @@ textarea::-webkit-input-placeholder {
 	float: left;
 	margin-left: -20px;
 }
-.controls > .radio:first-child,
-.controls > .checkbox:first-child {
-	padding-top: 5px;
-}
 .radio.inline,
 .checkbox.inline {
 	display: inline-block;
@@ -1674,6 +1670,13 @@ legend + .control-group {
 }
 .form-horizontal .controls:first-child {
 	*padding-left: 180px;
+}
+.form-horizontal .controls > .radio:first-child,
+.form-horizontal .controls > .checkbox:first-child {
+	padding-top: 5px;
+}
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
 }
 .form-horizontal .help-block {
 	margin-bottom: 0;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7659,14 +7659,14 @@ body.modal-open {
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .form-horizontal .controls > .radio:first-child,
 .form-horizontal .controls > .checkbox:first-child {
 	padding-top: 5px;
 }
 .form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -655,6 +655,21 @@ body.modal-open {
 	display: inline;
 }
 
+/* Remove unneeded space between label and field in vertical forms */
+.controls > .radio:first-child,
+.controls > .checkbox:first-child {
+	padding-top: 0px;
+
+	.form-horizontal & {
+		padding-top: 5px;
+	}
+}
+
+/* Align btn-group to label */
+.form-horizontal .controls > .radio.btn-group:first-child {
+	padding-top: 0px;
+}
+
 /* Corrects the modals padding */
 .field-media-wrapper .modal .modal-body {
 	padding: 5px 10px;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -658,7 +658,7 @@ body.modal-open {
 /* Remove unneeded space between label and field in vertical forms */
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 
 	.form-horizontal & {
 		padding-top: 5px;
@@ -667,7 +667,7 @@ body.modal-open {
 
 /* Align btn-group to label */
 .form-horizontal .controls > .radio.btn-group:first-child {
-	padding-top: 0px;
+	padding-top: 0;
 }
 
 /* Corrects the modals padding */


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In vertical from there was unneeded space between the label and some controls (`radio`, `checkboxes`) under it.
Removed `padding-top` of `btn-group` to align with label.
Added `2px` `padding-top` to `btn-group-yesno` in isis to compensate `2px` less `padding-top` of each button to have the buttons aligned with the label.

### Testing Instructions
Look at some vertical forms in backend (Isis) and frontend (Protostar):
There is `5px` more space between the label and the `radio` (`btn-group` as well because it is type radio) / `checkboxes` field than other fields. After aplying this PR the additional space should disapear.  
Look at some horizontal forms in backend (Isis) and frontend (Protostar):
Before the PR the text of `btn-group` is not aligned to the text of the label. After aplying this PR it should be.  
![change](https://cloud.githubusercontent.com/assets/19623046/19287647/e26db228-9002-11e6-8f1d-1e5f4c807c78.png)


### Documentation Changes Required
none