### PR TITLE
fix problem with accordions using parent option

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -633,7 +633,8 @@ abstract class JHtmlBootstrap
 				$script[] = "\t.on('hidden', " . $onHidden . ")";
 			}
 
-			$parents = array_key_exists(__METHOD__, static::$loaded) ? array_column(static::$loaded[__METHOD__],'parent') : array();
+			$parents = array_key_exists(__METHOD__, static::$loaded) ? array_column(static::$loaded[__METHOD__], 'parent') : array();
+
 			if ($opt['parent'] && empty(array_filter($parents)))
 			{
 				$script[] = "

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -633,6 +633,19 @@ abstract class JHtmlBootstrap
 				$script[] = "\t.on('hidden', " . $onHidden . ")";
 			}
 
+			$parents = array_key_exists(__METHOD__, static::$loaded) ? array_column(static::$loaded[__METHOD__],'parent') : array();
+			if ($opt['parent'] && empty(array_filter($parents)))
+			{
+				$script[] = "
+					$(document).on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {
+						var \$this   = $(this), href
+						var parent  = \$this.attr('data-parent')
+						var \$parent = parent && $(parent)
+
+						if (\$parent) \$parent.find('[data-toggle=collapse][data-parent=' + parent + ']').not(\$this).addClass('collapsed')
+					})";
+			}
+
 			$script[] = "});";
 
 			// Attach accordion to document

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -633,9 +633,9 @@ abstract class JHtmlBootstrap
 				$script[] = "\t.on('hidden', " . $onHidden . ")";
 			}
 
-			$parents = array_key_exists(__METHOD__, static::$loaded) ? array_column(static::$loaded[__METHOD__], 'parent') : array();
+			$parents = array_key_exists(__METHOD__, static::$loaded) ? array_filter(array_column(static::$loaded[__METHOD__], 'parent')) : array();
 
-			if ($opt['parent'] && empty(array_filter($parents)))
+			if ($opt['parent'] && empty($parents))
 			{
 				$script[] = "
 					$(document).on('click.collapse.data-api', '[data-toggle=collapse]', function (e) {


### PR DESCRIPTION
Pull Request for Issue #11956 .
### Summary of Changes

Now `accordion-toggle` of slides which where collapsed by opening an other slide in an accordion with the option parent set to the id of the accordion gets the class `collapsed`.
### Testing Instructions

For making the testing simple I've created a component :).
Download and install https://github.com/Minei3oat/com_test .
The component contains a single view with two accordions which contains five slides. The style of the component will show `accordion-toggle`s with class `collapsed` green and without red. This makes it easy to see the difference.
Now open a slide which is not open. The open slide will close, but its `accordion-toggle` don't gets the class `collapsed` as it gets when you close the slide yourself.
After applying this patch the class `collapsed` will get asseigned.
### Documentation Changes Required

none
