### PR TITLE
Fix error in mergeHeadData method for html document

### DIFF
--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -219,7 +219,7 @@ class JDocumentHtml extends JDocument
 		}
 
 		$this->_links = (isset($data['links']) && !empty($data['links']) && is_array($data['links']))
-			? array_unique(array_merge($this->_links, $data['links']))
+			? array_unique(array_merge($this->_links, $data['links']), SORT_REGULAR)
 			: $this->_links;
 		$this->_styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets']) && is_array($data['styleSheets']))
 			? array_merge($this->_styleSheets, $data['styleSheets'])

--- a/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
+++ b/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
@@ -33,6 +33,11 @@ class JDocumentHtmlTest extends TestCase
 				'relation' => 'Start',
 				'relType' => 'rel',
 				'attribs' => array()
+			),
+			'index.php?option=com_test' => array(
+				'relation' => 'End',
+				'relType' => 'rel',
+				'attribs' => array()
 			)
 		),
 		'styleSheets' => array(


### PR DESCRIPTION
### Summary of Changes

This PR does two things:
- extend tests in order to display the error in php Travis tests.
- fix the error generated by `array_unique` function
### Testing Instructions

How to reproduce notices?

``` php
$html = new JDocumentHtml();
$html->addHeadLink('http://www.example.com', 'Start');
$html->addHeadLink('http://www.example.com/end', 'End');
$html->mergeHeadData($html->getHeadData());
```

generates several:

```
PHP Notice:  Array to string conversion in /home/[...]/libraries/joomla/document/html.php on line 222
```

And `$html->_links` contain only first link.

After patch this notice disappears and links contain all links.
### Documentation Changes Required

No
