### PR TITLE
Remove duplicate enqueueMessages

### DIFF
--- a/administrator/components/com_finder/views/index/view.html.php
+++ b/administrator/components/com_finder/views/index/view.html.php
@@ -87,7 +87,12 @@ class FinderViewIndex extends JViewLegacy
 		// Check for plugin state
 		if (!$this->pluginState['plg_content_finder']->enabled)
 		{
-			JFactory::getApplication()->enqueueMessage(JText::_('COM_FINDER_INDEX_PLUGIN_CONTENT_NOT_ENABLED'), 'warning');
+			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . FinderHelper::getFinderPluginId());
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_FINDER_INDEX_PLUGIN_CONTENT_NOT_ENABLED', $link), 'warning');
+		}
+		elseif ($this->get('TotalIndexed') === 0)
+		{
+			JFactory::getApplication()->enqueueMessage(JText::_('COM_FINDER_INDEX_NO_DATA') . '  ' . JText::_('COM_FINDER_INDEX_TIP'), 'notice');
 		}
 
 		// Check for errors.
@@ -96,16 +101,6 @@ class FinderViewIndex extends JViewLegacy
 			JError::raiseError(500, implode("\n", $errors));
 
 			return false;
-		}
-
-		if (!$this->pluginState['plg_content_finder']->enabled)
-		{
-			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . FinderHelper::getFinderPluginId());
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_FINDER_INDEX_PLUGIN_CONTENT_NOT_ENABLED', $link), 'warning');
-		}
-		elseif ($this->get('TotalIndexed') === 0)
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('COM_FINDER_INDEX_NO_DATA') . '  ' . JText::_('COM_FINDER_INDEX_TIP'), 'notice');
 		}
 
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -53,11 +53,18 @@ class RedirectViewLinks extends JViewLegacy
 		}
 		elseif ($this->enabled && !$this->collect_urls_enabled)
 		{
-			$app->enqueueMessage(JText::_('COM_REDIRECT_PLUGIN_ENABLED') . JText::_('COM_REDIRECT_COLLECT_URLS_DISABLED'), 'notice');
+			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
+			$app->enqueueMessage(JText::_('COM_REDIRECT_PLUGIN_ENABLED') . JText::sprintf('COM_REDIRECT_COLLECT_URLS_DISABLED', $link), 'notice');
+		}
+		elseif (!$this->collect_urls_enabled)
+		{
+			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_REDIRECT_COLLECT_URLS_DISABLED', $link), 'notice');
 		}
 		else
 		{
-			$app->enqueueMessage(JText::_('COM_REDIRECT_PLUGIN_DISABLED'), 'error');
+			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_REDIRECT_PLUGIN_DISABLED', $link), 'warning');
 		}
 
 		// Check for errors.
@@ -66,17 +73,6 @@ class RedirectViewLinks extends JViewLegacy
 			JError::raiseError(500, implode("\n", $errors));
 
 			return false;
-		}
-
-		if (!$this->enabled)
-		{
-			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_REDIRECT_PLUGIN_DISABLED', $link), 'warning');
-		}
-		elseif (!$this->collect_urls_enabled)
-		{
-			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
-			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_REDIRECT_COLLECT_URLS_DISABLED', $link), 'notice');
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_search/views/searches/view.html.php
+++ b/administrator/components/com_search/views/searches/view.html.php
@@ -45,11 +45,11 @@ class SearchViewSearches extends JViewLegacy
 		// Check if plugin is enabled
 		if ($this->enabled)
 		{
-			$app->enqueueMessage(JText::_('COM_SEARCH_LOGGING_ENABLED'), 'notice');
+			JFactory::getApplication()->enqueueMessage(JText::_('COM_SEARCH_LOGGING_ENABLED'), 'notice');
 		}
 		else
 		{
-			$app->enqueueMessage(JText::_('COM_SEARCH_LOGGING_DISABLED'), 'error');
+			JFactory::getApplication()->enqueueMessage(JText::_('COM_SEARCH_LOGGING_DISABLED'), 'warning');
 		}
 
 		// Check for errors.
@@ -60,16 +60,8 @@ class SearchViewSearches extends JViewLegacy
 			return false;
 		}
 
-		if ($this->enabled)
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('COM_SEARCH_LOGGING_ENABLED'), 'notice');
-		}
-		else
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('COM_SEARCH_LOGGING_DISABLED'), 'warning');
-		}
-
 		$this->addToolbar();
+
 		parent::display($tpl);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #12017 
### Summary of Changes

The conditional statements determining which message should be enqueued were incorrect and thus displaying multiple. In addition to that, the link to the plugin pages was resulting in a bad gateway (`administrator/%s`) because no link was being pushed through `sprintf`, which this PR also fixes.
### Testing Instructions

Apply the patch.
- **com_redirect**
- Only 1 message telling you the status of the Redirect plugin will be shown.
- The "_Redirect System Plugin_" link will work as expected.

---
- **com_finder**
- Only 1 message telling you the status of the Smart Search plugin will be shown.
- The "_Smart Search Content Plugin_" link will work as expected.

---
- **com_search**
- Only 1 message telling you the status of the Smart Search plugin will be shown.
### Documentation Changes Required

None
