### PR TITLE
Fix no menu item pages giving wrong links

### DIFF
--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -55,7 +55,13 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 	 */
 	public function preprocess(&$query)
 	{
-		if (isset($query['Itemid']) && $this->router->menu->getActive() && $query['Itemid'] != $this->router->menu->getActive()->id)
+		/**
+		 * If the active item id is not the same as the supplied item id or we have a supplied item id and no active
+		 * menu item then we just use the supplied menu item and continue
+		 */
+		if (isset($query['Itemid'])
+			&& (($this->router->menu->getActive() && $query['Itemid'] != $this->router->menu->getActive()->id)
+			|| ($this->router->menu->getActive() === null)))
 		{
 			return;
 		}

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -198,6 +198,11 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase {
 		$this->object->preprocess($query);
 		$this->assertEquals(array('Itemid' => '47'), $query);
 
+		// If we inject a item id and we have no active menu item we should get the injected item id
+		$query = array('Itemid' => '50');
+		$this->object->preprocess($query);
+		$this->assertEquals(array('Itemid' => '50'), $query);
+
 		// Test if the correct default item is used based on the language
 		$query = array('lang' => 'en-GB');
 		$this->object->preprocess($query);


### PR DESCRIPTION
Pull Request for Issue #9950 .
### Summary of Changes

Fixes bug of URL's when you are on a page with no active menu item. Hat tip to @joeforjoomla for pointing me to the right place!
### Testing Instructions

Navigate to a page with no menu item (e.g. `http://localhost/~george/joomla-cms/component/tags`) and try and use a menu item. Note that before patch they either contain an incorrect URL or simply the wrong URL. They now contain the correct URL
### Documentation Changes Required

None
