### PR TITLE
Fix routing for non-sef menu items

### DIFF
--- a/libraries/cms/component/router/rules/standard.php
+++ b/libraries/cms/component/router/rules/standard.php
@@ -62,7 +62,11 @@ class JComponentRouterRulesStandard implements JComponentRouterRulesInterface
 		// Get the views and the currently active query vars
 		$views = $this->router->getViews();
 		$active = $this->router->menu->getActive();
-		$vars = array_merge($active->query, $vars);
+
+		if ($active)
+		{
+			$vars = array_merge($active->query, $vars);
+		}
 
 		// We don't have a view or its not a view of this component! We stop here
 		if (!isset($vars['view']) || !isset($views[$vars['view']]))


### PR DESCRIPTION
Pull Request for additional comments part of Issue #9953
### Summary of Changes

Fix fatal error in some menu items with the new router
### Testing Instructions

Navigate to `component/contact/categories` (e.g. `http://localhost/~george/joomla-cms/component/contact/categories` for my localhost). Before patch in 3.7.x you get a fatal error. After patch the page loads as expected. Note it doesn't matter if you have new routing enabled or not (i personally had it off for all components except articles to replicate).
### Documentation Changes Required

None
