### PR TITLE
[JAccess] Improve ACL asset preloading performance/memory consumption

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -212,13 +212,13 @@ class JAccess
 		if ($isDefault && !self::$componentsPreloaded)
 		{
 			// Mark in the profiler.
-			JDEBUG ? JProfiler::getInstance('Application')->mark('Start JAccess::preload(components)') : null;
+			JDEBUG ? JProfiler::getInstance('Application')->mark('Start JAccess::preload (all components)') : null;
 
 			self::preloadComponents();
 			self::$componentsPreloaded = true;
 
 			// Mark in the profiler.
-			JDEBUG ? JProfiler::getInstance('Application')->mark('Finish JAccess::preload(components)') : null;
+			JDEBUG ? JProfiler::getInstance('Application')->mark('Finish JAccess::preload (all components)') : null;
 		}
 
 		// Quick short circuit for default case
@@ -239,12 +239,12 @@ class JAccess
 		{
 			if (!isset(self::$preloadedAssetTypes[$assetType]) || $reload)
 			{
-				JDEBUG ? JProfiler::getInstance('Application')->mark('Start JAccess Preloading Process (' . $assetType . ')') : null;
+				JDEBUG ? JProfiler::getInstance('Application')->mark('Start JAccess::preload (' . $assetType . ')') : null;
 
 				self::preloadPermissions($assetType);
 				self::$preloadedAssetTypes[$assetType] = true;
 
-				JDEBUG ? JProfiler::getInstance('Application')->mark('Finish JAccess Preloading Process (' . $assetType . ')') : null;
+				JDEBUG ? JProfiler::getInstance('Application')->mark('Finish JAccess::preload (' . $assetType . ')') : null;
 			}
 		}
 

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -481,6 +481,12 @@ class JAccess
 		$extensionName = self::getExtensionNameFromAsset($asset);
 		$assetType     = self::getAssetType($asset);
 
+		// Make sure the components assets are preloaded.
+		if (!self::$componentsPreloaded)
+		{
+			self::preload('components');
+		}
+
 		!JDEBUG ?: JProfiler::getInstance('Application')->mark('Before JAccess::getAssetRules (' . $asset . ')');
 
 		// Almost all calls should have recursive set to true so we'll get to take advantage of preloading.

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -350,13 +350,13 @@ class JUser extends JObject
 	 * object and optionally an access extension object
 	 *
 	 * @param   string  $action     The name of the action to check for permission.
-	 * @param   string  $assetname  The name of the asset on which to perform the action.
+	 * @param   string  $assetName  The name of the asset on which to perform the action.
 	 *
 	 * @return  boolean  True if authorised
 	 *
 	 * @since   11.1
 	 */
-	public function authorise($action, $assetname = null)
+	public function authorise($action, $assetName = null)
 	{
 		// Make sure we only check for core.admin once during the run.
 		if ($this->isRoot === null)
@@ -364,8 +364,7 @@ class JUser extends JObject
 			$this->isRoot = false;
 
 			// Check for the configuration file failsafe.
-			$config = JFactory::getConfig();
-			$rootUser = $config->get('root_user');
+			$rootUser = JFactory::getConfig()->get('root_user');
 
 			// The root_user variable can be a numeric user ID or a username.
 			if (is_numeric($rootUser) && $this->id > 0 && $this->id == $rootUser)
@@ -376,22 +375,13 @@ class JUser extends JObject
 			{
 				$this->isRoot = true;
 			}
-			else
+			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin', 'root.1'))
 			{
-				// Get all groups against which the user is mapped.
-				$identities = $this->getAuthorisedGroups();
-				array_unshift($identities, $this->id * -1);
-
-				if (JAccess::getAssetRules(1)->allow('core.admin', $identities))
-				{
-					$this->isRoot = true;
-
-					return true;
-				}
+				$this->isRoot = true;
 			}
 		}
 
-		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetname);
+		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetName);
 	}
 
 	/**

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -364,8 +364,7 @@ class JUser extends JObject
 			$this->isRoot = false;
 
 			// Check for the configuration file failsafe.
-			$config = JFactory::getConfig();
-			$rootUser = $config->get('root_user');
+			$rootUser = JFactory::getConfig()->get('root_user');
 
 			// The root_user variable can be a numeric user ID or a username.
 			if (is_numeric($rootUser) && $this->id > 0 && $this->id == $rootUser)
@@ -376,7 +375,7 @@ class JUser extends JObject
 			{
 				$this->isRoot = true;
 			}
-			else
+			elseif ($this->id > 0)
 			{
 				// Get all groups against which the user is mapped.
 				$identities = $this->getAuthorisedGroups();


### PR DESCRIPTION
### Summary of Changes

Improve ACL asset preloading performance/memory consumption.
#### Before

![image](https://cloud.githubusercontent.com/assets/9630530/18472422/576f8926-79af-11e6-8739-25e0abaabae3.png)
#### After

![image](https://cloud.githubusercontent.com/assets/9630530/18472428/5f5ca736-79af-11e6-8e3c-281ac7b4836e.png)
### Testing Instructions
1. Code review
2. Use latest staging and apply patch
3. Turn on debug mode and debug system plugin
4. Check the profiler in several frontend/backend pages and notice the more ACL checks are done the more is the performance improvements.
5. Check if ACL permissions work fine (do multiple tests). Make sure there are no ACL breachs after this.

The performance improvements are particular higher when logged in with a non-root user and a lot of modules (since in this cases there are a lot of ACL checks).
### Documentation Changes Required

None.
