### PR TITLE
Frontend: New module order field isn't displayed

### DIFF
--- a/components/com_modules/modules.php
+++ b/components/com_modules/modules.php
@@ -10,11 +10,18 @@
 defined('_JEXEC') or die;
 
 // Load the required admin language files
-$lang = JFactory::getLanguage();
+$lang   = JFactory::getLanguage();
+$app    = JFactory::getApplication();
+$config = array();
 $lang->load('joomla', JPATH_ADMINISTRATOR);
 $lang->load('com_modules', JPATH_ADMINISTRATOR);
 
+if ($app->input->get('task') === 'module.orderPosition')
+{
+	$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+}
+
 // Trigger the controller
-$controller = JControllerLegacy::getInstance('Modules');
-$controller->execute(JFactory::getApplication()->input->get('task'));
+$controller = JControllerLegacy::getInstance('Modules', $config);
+$controller->execute($app->input->get('task'));
 $controller->redirect();


### PR DESCRIPTION
Pull Request for Issue #12031 .
### Summary of Changes

Fix the path to the controller if the task is moduleOrdering
### Testing Instructions
- Login into fronted
- Click the Edit module-button of a module
- Look at the field Ordering
### Documentation Changes Required

None, bug fix
