### PR TITLE
Adding Options Button

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -311,6 +311,12 @@ class MenusViewItems extends JViewLegacy
 			JToolbarHelper::trash('items.trash');
 		}
 
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			JToolbarHelper::divider();
+			JToolbarHelper::preferences('com_menus');
+		}
+
 		JToolbarHelper::help('JHELP_MENUS_MENU_ITEM_MANAGER');
 	}
 


### PR DESCRIPTION
Simple PR to add a missing "Options" button to the Menu Manager
### Summary of Changes

Adds the Options button to the Menu Manager -> Menu Items view.
### Testing Instructions
1. Check the "menu items" view and verify that there is no "Options" button like in the "menus" view.
2. Apply PR and check the same view again.
3. Test the new button :smile: 
### Documentation Changes Required

None
