### PR TITLE
[com_users][fix] User profil changes and password reset won't work if logout menu exists and no login menu is shown

### DIFF
--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -69,8 +69,10 @@ class UsersRouter extends JComponentRouterBase
 				// Check to see if we have found the login menu item.
 				if (empty($login) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'login'))
 				{
-					if (isset($items[$i]->query['layout']) && ($items[$i]->query['layout'] != 'logout') )
+					if (!empty($items[$i]->query['layout']) && ($items[$i]->query['layout'] != 'logout'))
+					{
 						$login = $items[$i]->id;
+					}
 				}
 
 				// Check to see if we have found the registration menu item.

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -69,7 +69,8 @@ class UsersRouter extends JComponentRouterBase
 				// Check to see if we have found the login menu item.
 				if (empty($login) && !empty($items[$i]->query['view']) && ($items[$i]->query['view'] == 'login'))
 				{
-					$login = $items[$i]->id;
+					if (isset($items[$i]->query['layout']) && ($items[$i]->query['layout'] != 'logout') )
+						$login = $items[$i]->id;
 				}
 
 				// Check to see if we have found the registration menu item.


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

com_users/router.php
### Testing Instructions

Joomla 3.6.2, no specific module/extension/plugin
1. create a logout menu
2. create a login menu that will disappear when you are logged in (shown if the user is "invited")
3. set "force password reset" to yes on one user 
4. login with this user
5. user profile is displayed but you cannot access the passord change form.
### Documentation Changes Required: no

If a logout menu item exists, users can not access to profil changes.

It means that the "force password reset" function won't work either.

com_users/Router.php creates a default link index.php/logout/profile?layout=edit that won't work, it blocks profile changes button et stays on profile display form. 

The problem is that logout menu creates the following link :
index.php?option=com_users&view=login&layout=logout&task=user.menulogout

and the router just checks view=login, ignoring the view part of the link.

A "cleaner" solution could be to change the logout menu to become index.php?option=com_users&view=logout.

Pascal
