### PR TITLE
Order stylesheet attributes the same as link attributes

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -132,7 +132,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate stylesheet links
 		foreach ($document->_styleSheets as $strSrc => $strAttr)
 		{
-			$buffer .= $tab . '<link rel="stylesheet" href="' . $strSrc . '"';
+			$buffer .= $tab . '<link href="' . $strSrc . '" rel="stylesheet"';
 
 			if (!is_null($strAttr['mime']) && (!$document->isHtml5() || !in_array($strAttr['mime'], $defaultCssMimes)))
 			{


### PR DESCRIPTION
### Summary of Changes

In a complete OCD move, this changes the order of the `<link>` attributes for stylesheets to match the order used for links in the section above this.  There is seriously no other benefit than it being consistent for both types now and calming the OCD of people like me who notice these things.
### Testing Instructions

Pre-patch, you'll have something like this:

``` html
<link href="/templates/joomla/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
<link rel="stylesheet" href="https://cdn.joomla.org/template/css/template_2.1.0.min.css" />
```

Post-patch, it'll be like this:

``` html
<link href="/templates/joomla/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
<link href="https://cdn.joomla.org/template/css/template_2.1.0.min.css" rel="stylesheet" />
```
### Documentation Changes Required

N/A
