### PR TITLE
[4.0] B/C Break - Typehint callables

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -128,44 +128,37 @@ abstract class JHtml
 
 		$toCall = array($className, $func);
 
-		if (is_callable($toCall))
-		{
-			static::register($key, $toCall);
-			$args = func_get_args();
-
-			// Remove function name from arguments
-			array_shift($args);
-
-			return static::call($toCall, $args);
-		}
-		else
+		if (!is_callable($toCall))
 		{
 			throw new InvalidArgumentException(sprintf('%s::%s not found.', $className, $func), 500);
 		}
+
+		static::register($key, $toCall);
+		$args = func_get_args();
+
+		// Remove function name from arguments
+		array_shift($args);
+
+		return static::call($toCall, $args);
 	}
 
 	/**
 	 * Registers a function to be called with a specific key
 	 *
-	 * @param   string  $key       The name of the key
-	 * @param   string  $function  Function or method
+	 * @param   string    $key       The name of the key
+	 * @param   callable  $function  Function or method
 	 *
 	 * @return  boolean  True if the function is callable
 	 *
 	 * @since   1.6
 	 */
-	public static function register($key, $function)
+	public static function register($key, callable $function)
 	{
 		list($key) = static::extract($key);
 
-		if (is_callable($function))
-		{
-			static::$registry[$key] = $function;
+		static::$registry[$key] = $function;
 
-			return true;
-		}
-
-		return false;
+		return true;
 	}
 
 	/**
@@ -219,13 +212,8 @@ abstract class JHtml
 	 * @since   1.6
 	 * @throws  InvalidArgumentException
 	 */
-	protected static function call($function, $args)
+	protected static function call(callable $function, $args)
 	{
-		if (!is_callable($function))
-		{
-			throw new InvalidArgumentException('Function not supported', 500);
-		}
-
 		// PHP 5.3 workaround
 		$temp = array();
 

--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -407,7 +407,7 @@ class JRouter
 	 *
 	 * @since   1.5
 	 */
-	public function attachBuildRule($callback, $stage = self::PROCESS_DURING)
+	public function attachBuildRule(callable $callback, $stage = self::PROCESS_DURING)
 	{
 		if (!array_key_exists('build' . $stage, $this->_rules))
 		{
@@ -430,7 +430,7 @@ class JRouter
 	 *
 	 * @since   1.5
 	 */
-	public function attachParseRule($callback, $stage = self::PROCESS_DURING)
+	public function attachParseRule(callable $callback, $stage = self::PROCESS_DURING)
 	{
 		if (!array_key_exists('parse' . $stage, $this->_rules))
 		{

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -43,43 +43,18 @@ class JCacheControllerCallback extends JCacheController
 	/**
 	 * Executes a cacheable callback if not found in cache else returns cached output and result
 	 *
-	 * @param   mixed    $callback    Callback or string shorthand for a callback
-	 * @param   array    $args        Callback arguments
-	 * @param   mixed    $id          Cache ID
-	 * @param   boolean  $wrkarounds  True to use wrkarounds
-	 * @param   array    $woptions    Workaround options
+	 * @param   callable  $callback    Callback or string shorthand for a callback
+	 * @param   array     $args        Callback arguments
+	 * @param   mixed     $id          Cache ID
+	 * @param   boolean   $wrkarounds  True to use wrkarounds
+	 * @param   array     $woptions    Workaround options
 	 *
 	 * @return  mixed  Result of the callback
 	 *
 	 * @since   11.1
 	 */
-	public function get($callback, $args = array(), $id = false, $wrkarounds = false, $woptions = array())
+	public function get(callable $callback, $args = array(), $id = false, $wrkarounds = false, $woptions = array())
 	{
-		// Normalize callback
-		if (is_array($callback))
-		{
-			// We have a standard php callback array -- do nothing
-		}
-		elseif (strstr($callback, '::'))
-		{
-			// This is shorthand for a static method callback classname::methodname
-			list ($class, $method) = explode('::', $callback);
-			$callback = array(trim($class), trim($method));
-		}
-		elseif (strstr($callback, '->'))
-		{
-			/*
-			 * This is a really not so smart way of doing this... we provide this for backward compatability but this
-			 * WILL! disappear in a future version.  If you are using this syntax change your code to use the standard
-			 * PHP callback array syntax: <https://secure.php.net/callback>
-			 *
-			 * We have to use some silly global notation to pull it off and this is very unreliable
-			 */
-			list ($object_123456789, $method) = explode('->', $callback);
-			global $$object_123456789;
-			$callback = array($$object_123456789, $method);
-		}
-
 		if (!$id)
 		{
 			// Generate an ID

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -687,7 +687,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 *
 	 * @since   CMS 3.1.2
 	 */
-	public function addDisconnectHandler($callable)
+	public function addDisconnectHandler(callable $callable)
 	{
 		$this->disconnectHandlers[] = $callable;
 	}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -424,7 +424,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setTransliterator($function)
+	public function setTransliterator(callable $function)
 	{
 		$previous = $this->transliterator;
 		$this->transliterator = $function;
@@ -474,7 +474,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setPluralSuffixesCallback($function)
+	public function setPluralSuffixesCallback(callable $function)
 	{
 		$previous = $this->pluralSuffixesCallback;
 		$this->pluralSuffixesCallback = $function;
@@ -522,7 +522,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setIgnoredSearchWordsCallback($function)
+	public function setIgnoredSearchWordsCallback(callable $function)
 	{
 		$previous = $this->ignoredSearchWordsCallback;
 		$this->ignoredSearchWordsCallback = $function;
@@ -570,7 +570,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setLowerLimitSearchWordCallback($function)
+	public function setLowerLimitSearchWordCallback(callable $function)
 	{
 		$previous = $this->lowerLimitSearchWordCallback;
 		$this->lowerLimitSearchWordCallback = $function;
@@ -616,7 +616,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setUpperLimitSearchWordCallback($function)
+	public function setUpperLimitSearchWordCallback(callable $function)
 	{
 		$previous = $this->upperLimitSearchWordCallback;
 		$this->upperLimitSearchWordCallback = $function;
@@ -664,7 +664,7 @@ class JLanguage
 	 *
 	 * @since   11.1
 	 */
-	public function setSearchDisplayedCharactersNumberCallback($function)
+	public function setSearchDisplayedCharactersNumberCallback(callable $function)
 	{
 		$previous = $this->searchDisplayedCharactersNumberCallback;
 		$this->searchDisplayedCharactersNumberCallback = $function;

--- a/libraries/src/Cms/Application/EventAware.php
+++ b/libraries/src/Cms/Application/EventAware.php
@@ -48,7 +48,7 @@ trait EventAware
 	 *
 	 * @since   4.0
 	 */
-	public function registerEvent($event, $handler)
+	public function registerEvent($event, callable $handler)
 	{
 		try
 		{

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -189,11 +189,6 @@ class JHtmlTest extends TestCase
 			->method('mockFunction');
 
 		JHtml::_('prefix.register.testfunction');
-
-		$this->assertFalse(
-			JHtml::register('prefix.register.missingtestfunction', array($registered, 'missingFunction')),
-			'Registering a missing method should fail.'
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

For methods requiring a valid callback to be injected, use PHP 5.4's `callable` typehinting to indicate this versus relying on the methods to implement checks internally (and in some cases there are no checks, making it possible to break other things if incorrect objects are injected).  This improves the code structure and API by explicitly declaring requirements and allowing the PHP engine to test them.
### Outstanding Issues

This will introduce a new warning to the UI:

``` sh
Warning: Declaration of JCacheControllerCallback::get(callable $callback, $args = Array, $id = false, $wrkarounds = false, $woptions = Array) should be compatible with JCacheController::get($id, $group = NULL)
```

This has always been an issue with the `JCacheController` classes.  `JCacheController` aims to be a usable generic controller and each of the subclasses has a different signature for the `get()` method.  This API needs to be looked at and a way of handling the different method signatures needs to be found.
### Testing Instructions

With the exception of the above mentioned warning, the CMS should continue to function as normal.  Some examples of areas that would break with this patch applied:
- Code using the cache API with the callback controller (the component and plugin helpers both do this)
- Registering custom or overloaded `JHtml` helper methods
- Custom router rules
- Registering event handlers
- Registering disconnect handlers for the database drivers
- Registering custom handlers for various `JLanguage` features (some language packages are doing this with their localise classes)
### Documentation Changes Required

Docs listing B/C breaking changes should include this pull request indicating that the method signatures for the methods changed here will require updating in subclasses.
