### PR TITLE
Admin app - JString -> StringHelper

### DIFF
--- a/administrator/components/com_admin/models/help.php
+++ b/administrator/components/com_admin/models/help.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Admin Component Help Model
  *
@@ -173,8 +175,7 @@ class AdminModelHelp extends JModelLegacy
 			// Strip the extension
 			$file = preg_replace('#\.xml$|\.html$#', '', $file);
 
-			if ($help_search
-				&& JString::strpos(JString::strtolower(strip_tags($buffer)), JString::strtolower($help_search)) === false)
+			if ($help_search && StringHelper::strpos(StringHelper::strtolower(strip_tags($buffer)), StringHelper::strtolower($help_search)) === false)
 			{
 				continue;
 			}

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -1238,8 +1239,8 @@ class CategoriesModelCategory extends JModelAdmin
 
 		while ($table->load(array('alias' => $alias, 'parent_id' => $parent_id)))
 		{
-			$title = JString::increment($title);
-			$alias = JString::increment($alias, 'dash');
+			$title = StringHelper::increment($title);
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('ContactHelper', JPATH_ADMINISTRATOR . '/components/com_contact/helpers/contact.php');
@@ -647,10 +648,10 @@ class ContactModelContact extends JModelAdmin
 		{
 			if ($name == $table->name)
 			{
-				$name = JString::increment($name);
+				$name = StringHelper::increment($name);
 			}
 
-			$alias = JString::increment($alias, 'dash');
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($name, $alias);

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Contact Table class.
@@ -185,7 +186,7 @@ class ContactTableContact extends JTable
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters.
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = StringHelper::str_ireplace($bad_characters, "", $this->metakey);
 
 			// Create array using commas as delimiter.
 			$keys = explode(',', $after_clean);
@@ -209,7 +210,7 @@ class ContactTableContact extends JTable
 		{
 			// Only process if not empty
 			$bad_characters = array("\"", "<", ">");
-			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
+			$this->metadesc = StringHelper::str_ireplace($bad_characters, "", $this->metadesc);
 		}
 
 		return true;

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 JLoader::register('FinderIndexerParser', __DIR__ . '/parser.php');
 JLoader::register('FinderIndexerStemmer', __DIR__ . '/stemmer.php');
@@ -62,7 +63,7 @@ class FinderIndexerHelper
 	public static function tokenize($input, $lang, $phrase = false)
 	{
 		static $cache;
-		$store = JString::strlen($input) < 128 ? md5($input . '::' . $lang . '::' . $phrase) : null;
+		$store = StringHelper::strlen($input) < 128 ? md5($input . '::' . $lang . '::' . $phrase) : null;
 
 		// Check if the string has been tokenized already.
 		if ($store && isset($cache[$store]))
@@ -89,7 +90,7 @@ class FinderIndexerHelper
 		 *  7. Replace the assorted single quotation marks with the ASCII standard single quotation.
 		 *  8. Remove multiple space characters and replaces with a single space.
 		 */
-		$input = JString::strtolower($input);
+		$input = StringHelper::strtolower($input);
 		$input = preg_replace('#[^\pL\pM\pN\p{Pi}\p{Pf}\'+-.,]+#mui', ' ', $input);
 		$input = preg_replace('#(^|\s)[+-.,]+([\pL\pM]+)#mui', ' $1', $input);
 		$input = preg_replace('#([\pL\pM\pN]+)[+-.,]+(\s|$)#mui', '$1 ', $input);
@@ -98,7 +99,7 @@ class FinderIndexerHelper
 		$input = preg_replace('#(^|\s)[\p{Pi}\p{Pf}]+(\s|$)#mui', ' ', $input);
 		$input = preg_replace('#[' . $quotes . ']+#mui', '\'', $input);
 		$input = preg_replace('#\s+#mui', ' ', $input);
-		$input = JString::trim($input);
+		$input = StringHelper::trim($input);
 
 		// Explode the normalized string to get the terms.
 		$terms = explode(' ', $input);
@@ -120,7 +121,7 @@ class FinderIndexerHelper
 				// Split apart any groups of Chinese characters.
 				for ($j = 0; $j < $charCount; $j++)
 				{
-					$tSplit = JString::str_ireplace($charMatches[0][$j], '', $terms[$i], false);
+					$tSplit = StringHelper::str_ireplace($charMatches[0][$j], '', $terms[$i], false);
 
 					if (!empty($tSplit))
 					{
@@ -215,12 +216,12 @@ class FinderIndexerHelper
 	public static function stem($token, $lang)
 	{
 		// Trim apostrophes at either end of the token.
-		$token = JString::trim($token, '\'');
+		$token = StringHelper::trim($token, '\'');
 
 		// Trim everything after any apostrophe in the token.
-		if (($pos = JString::strpos($token, '\'')) !== false)
+		if (($pos = StringHelper::strpos($token, '\'')) !== false)
 		{
-			$token = JString::substr($token, 0, $pos);
+			$token = StringHelper::substr($token, 0, $pos);
 		}
 
 		// Stem the token if we have a valid stemmer to use.
@@ -374,7 +375,7 @@ class FinderIndexerHelper
 			else
 			{
 				// Get the language key using string position.
-				$data[$lang] = JString::substr($lang, 0, JString::strpos($lang, '-'));
+				$data[$lang] = StringHelper::substr($lang, 0, StringHelper::strpos($lang, '-'));
 			}
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
 JLoader::register('FinderIndexerParser', __DIR__ . '/parser.php');
 JLoader::register('FinderIndexerStemmer', __DIR__ . '/stemmer.php');
@@ -338,7 +340,7 @@ abstract class FinderIndexer
 							$string = substr($buffer, 0, $ls);
 
 							// Adjust the buffer based on the last space for the next iteration and trim.
-							$buffer = JString::trim(substr($buffer, $ls));
+							$buffer = StringHelper::trim(substr($buffer, $ls));
 						}
 						// No space character was found.
 						else

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 JLoader::register('FinderIndexerHelper', __DIR__ . '/helper.php');
@@ -665,10 +666,10 @@ class FinderIndexerQuery
 	protected function processDates($date1, $date2, $when1, $when2)
 	{
 		// Clean up the inputs.
-		$date1 = JString::trim(JString::strtolower($date1));
-		$date2 = JString::trim(JString::strtolower($date2));
-		$when1 = JString::trim(JString::strtolower($when1));
-		$when2 = JString::trim(JString::strtolower($when2));
+		$date1 = StringHelper::trim(StringHelper::strtolower($date1));
+		$date2 = StringHelper::trim(StringHelper::strtolower($date2));
+		$when1 = StringHelper::trim(StringHelper::strtolower($when1));
+		$when2 = StringHelper::trim(StringHelper::strtolower($when2));
 
 		// Get the time offset.
 		$offset = JFactory::getApplication()->get('offset');
@@ -677,7 +678,7 @@ class FinderIndexerQuery
 		$whens = array('before', 'after', 'exact');
 
 		// The value of 'today' is a special case that we need to handle.
-		if ($date1 === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
+		if ($date1 === StringHelper::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 		{
 			$date1 = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 		}
@@ -694,7 +695,7 @@ class FinderIndexerQuery
 		}
 
 		// The value of 'today' is a special case that we need to handle.
-		if ($date2 === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
+		if ($date2 === StringHelper::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 		{
 			$date2 = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 		}
@@ -730,9 +731,9 @@ class FinderIndexerQuery
 	{
 		// Clean up the input string.
 		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
-		$input = JString::strtolower($input);
+		$input = StringHelper::strtolower($input);
 		$input = preg_replace('#\s+#mi', ' ', $input);
-		$input = JString::trim($input);
+		$input = StringHelper::trim($input);
 		$debug = JFactory::getConfig()->get('debug_lang');
 
 		/*
@@ -749,7 +750,7 @@ class FinderIndexerQuery
 		foreach (FinderIndexerTaxonomy::getBranchTitles() as $branch)
 		{
 			// Add the pattern.
-			$patterns[$branch] = JString::strtolower(JText::_(FinderHelperLanguage::branchSingular($branch)));
+			$patterns[$branch] = StringHelper::strtolower(JText::_(FinderHelperLanguage::branchSingular($branch)));
 		}
 
 		// Container for search terms and phrases.
@@ -801,7 +802,7 @@ class FinderIndexerQuery
 						$whens = array('before', 'after', 'exact');
 
 						// The value of 'today' is a special case that we need to handle.
-						if ($value === JString::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
+						if ($value === StringHelper::strtolower(JText::_('COM_FINDER_QUERY_FILTER_TODAY')))
 						{
 							$value = JFactory::getDate('now', $offset)->format('%Y-%m-%d');
 						}
@@ -850,7 +851,7 @@ class FinderIndexerQuery
 				// Clean up the input string again.
 				$input = str_replace($matches[0], '', $input);
 				$input = preg_replace('#\s+#mi', ' ', $input);
-				$input = JString::trim($input);
+				$input = StringHelper::trim($input);
 			}
 		}
 
@@ -858,7 +859,7 @@ class FinderIndexerQuery
 		 * Extract the tokens enclosed in double quotes so that we can handle
 		 * them as phrases.
 		 */
-		if (JString::strpos($input, '"') !== false)
+		if (StringHelper::strpos($input, '"') !== false)
 		{
 			$matches = array();
 
@@ -873,21 +874,21 @@ class FinderIndexerQuery
 				foreach ($matches[1] as $key => $match)
 				{
 					// Find the complete phrase in the input string.
-					$pos = JString::strpos($input, $matches[0][$key]);
-					$len = JString::strlen($matches[0][$key]);
+					$pos = StringHelper::strpos($input, $matches[0][$key]);
+					$len = StringHelper::strlen($matches[0][$key]);
 
 					// Add any terms that are before this phrase to the stack.
-					if (JString::trim(JString::substr($input, 0, $pos)))
+					if (StringHelper::trim(StringHelper::substr($input, 0, $pos)))
 					{
-						$terms = array_merge($terms, explode(' ', JString::trim(JString::substr($input, 0, $pos))));
+						$terms = array_merge($terms, explode(' ', StringHelper::trim(StringHelper::substr($input, 0, $pos))));
 					}
 
 					// Strip out everything up to and including the phrase.
-					$input = JString::substr($input, $pos + $len);
+					$input = StringHelper::substr($input, $pos + $len);
 
 					// Clean up the input string again.
 					$input = preg_replace('#\s+#mi', ' ', $input);
-					$input = JString::trim($input);
+					$input = StringHelper::trim($input);
 
 					// Get the number of words in the phrase.
 					$parts = explode(' ', $match);
@@ -963,9 +964,9 @@ class FinderIndexerQuery
 
 		// An array of our boolean operators. $operator => $translation
 		$operators = array(
-			'AND' => JString::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_AND')),
-			'OR' => JString::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_OR')),
-			'NOT' => JString::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_NOT'))
+			'AND' => StringHelper::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_AND')),
+			'OR' => StringHelper::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_OR')),
+			'NOT' => StringHelper::strtolower(JText::_('COM_FINDER_QUERY_OPERATOR_NOT'))
 		);
 
 		// If language debugging is enabled you need to ignore the debug strings in matching.

--- a/administrator/components/com_finder/helpers/indexer/token.php
+++ b/administrator/components/com_finder/helpers/indexer/token.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Token class for the Finder indexer package.
  *
@@ -107,7 +109,7 @@ class FinderIndexerToken
 			$this->numeric = false;
 			$this->common = false;
 			$this->phrase = true;
-			$this->length = JString::strlen($this->term);
+			$this->length = StringHelper::strlen($this->term);
 
 			/*
 			 * Calculate the weight of the token.
@@ -126,7 +128,7 @@ class FinderIndexerToken
 			$this->numeric = (is_numeric($this->term) || (bool) preg_match('#^[0-9,.\-\+]+$#', $this->term));
 			$this->common = $this->numeric ? false : FinderIndexerHelper::isCommon($this->term, $lang);
 			$this->phrase = false;
-			$this->length = JString::strlen($this->term);
+			$this->length = StringHelper::strlen($this->term);
 
 			/*
 			 * Calculate the weight of the token.

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 jimport('joomla.filesystem.path');
@@ -1664,10 +1665,10 @@ class MenusModelItem extends JModelAdmin
 		{
 			if ($title == $table->title)
 			{
-				$title = JString::increment($title);
+				$title = StringHelper::increment($title);
 			}
 
-			$alias = JString::increment($alias, 'dash');
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -483,7 +484,7 @@ class ModulesModelModule extends JModelAdmin
 
 		while ($table->load(array('position' => $position, 'title' => $title)))
 		{
-			$title = JString::increment($title);
+			$title = StringHelper::increment($title);
 		}
 
 		return array($title);

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 JLoader::register('NewsfeedsHelper', JPATH_ADMINISTRATOR . '/components/com_newsfeeds/helpers/newsfeeds.php');
 
@@ -568,9 +569,9 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 		{
 			if ($name == $table->name)
 			{
-				$name = JString::increment($name);
+				$name = StringHelper::increment($name);
 			}
-			$alias = JString::increment($alias, 'dash');
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($name, $alias);

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Newsfeed Table class.
  *
@@ -79,7 +81,7 @@ class NewsfeedsTableNewsfeed extends JTable
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = StringHelper::str_ireplace($bad_characters, "", $this->metakey);
 
 			// Create array using commas as delimiter
 			$keys = explode(',', $after_clean);
@@ -103,7 +105,7 @@ class NewsfeedsTableNewsfeed extends JTable
 		{
 			// Only process if not empty
 			$bad_characters = array("\"", "<", ">");
-			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
+			$this->metadesc = StringHelper::str_ireplace($bad_characters, "", $this->metadesc);
 		}
 
 		return true;

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Search component helper.
  *
@@ -73,10 +75,10 @@ class SearchHelper
 		}
 
 		// Check for words to ignore.
-		$aterms = explode(' ', JString::strtolower($searchword));
+		$aterms = explode(' ', StringHelper::strtolower($searchword));
 
 		// First case is single ignored word.
-		if (count($aterms) == 1 && in_array(JString::strtolower($searchword), $search_ignore))
+		if (count($aterms) == 1 && in_array(StringHelper::strtolower($searchword), $search_ignore))
 		{
 			$ignored = true;
 		}
@@ -86,7 +88,7 @@ class SearchHelper
 
 		foreach ($aterms as $aterm)
 		{
-			if (JString::strlen($aterm) < $lower_limit)
+			if (StringHelper::strlen($aterm) < $lower_limit)
 			{
 				$search_ignore[] = $aterm;
 			}
@@ -120,14 +122,14 @@ class SearchHelper
 		// Limit searchword to a maximum of characters.
 		$upper_limit = $lang->getUpperLimitSearchWord();
 
-		if (JString::strlen($searchword) > $upper_limit)
+		if (StringHelper::strlen($searchword) > $upper_limit)
 		{
-			$searchword  = JString::substr($searchword, 0, $upper_limit - 1);
+			$searchword  = StringHelper::substr($searchword, 0, $upper_limit - 1);
 			$restriction = true;
 		}
 
 		// Searchword must contain a minimum of characters.
-		if ($searchword && JString::strlen($searchword) < $lang->getLowerLimitSearchWord())
+		if ($searchword && StringHelper::strlen($searchword) < $lang->getLowerLimitSearchWord())
 		{
 			$searchword  = '';
 			$restriction = true;
@@ -219,7 +221,7 @@ class SearchHelper
 			{
 				$term = self::remove_accents($term);
 
-				if (JString::stristr($text, $term) !== false)
+				if (StringHelper::stristr($text, $term) !== false)
 				{
 					return true;
 				}
@@ -261,14 +263,14 @@ class SearchHelper
 		$lang        = JFactory::getLanguage();
 		$length      = $lang->getSearchDisplayedCharactersNumber();
 		$ltext       = self::remove_accents($text);
-		$textlen     = JString::strlen($ltext);
-		$lsearchword = JString::strtolower(self::remove_accents($searchword));
+		$textlen     = StringHelper::strlen($ltext);
+		$lsearchword = StringHelper::strtolower(self::remove_accents($searchword));
 		$wordfound   = false;
 		$pos         = 0;
 
 		while ($wordfound === false && $pos < $textlen)
 		{
-			if (($wordpos = @JString::strpos($ltext, ' ', $pos + $length)) !== false)
+			if (($wordpos = @StringHelper::strpos($ltext, ' ', $pos + $length)) !== false)
 			{
 				$chunk_size = $wordpos - $pos;
 			}
@@ -277,8 +279,8 @@ class SearchHelper
 				$chunk_size = $length;
 			}
 
-			$chunk     = JString::substr($ltext, $pos, $chunk_size);
-			$wordfound = JString::strpos(JString::strtolower($chunk), $lsearchword);
+			$chunk     = StringHelper::substr($ltext, $pos, $chunk_size);
+			$wordfound = StringHelper::strpos(StringHelper::strtolower($chunk), $lsearchword);
 
 			if ($wordfound === false)
 			{
@@ -288,17 +290,17 @@ class SearchHelper
 
 		if ($wordfound !== false)
 		{
-			return (($pos > 0) ? '...&#160;' : '') . JString::substr($text, $pos, $chunk_size) . '&#160;...';
+			return (($pos > 0) ? '...&#160;' : '') . StringHelper::substr($text, $pos, $chunk_size) . '&#160;...';
 		}
 		else
 		{
-			if (($wordpos = @JString::strpos($text, ' ', $length)) !== false)
+			if (($wordpos = @StringHelper::strpos($text, ' ', $length)) !== false)
 			{
-				return JString::substr($text, 0, $wordpos) . '&#160;...';
+				return StringHelper::substr($text, 0, $wordpos) . '&#160;...';
 			}
 			else
 			{
-				return JString::substr($text, 0, $length);
+				return StringHelper::substr($text, 0, $length);
 			}
 		}
 	}

--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Tags Component Tag Model
@@ -447,8 +448,8 @@ class TagsModelTag extends JModelAdmin
 
 		while ($table->load(array('alias' => $alias, 'parent_id' => $parent_id)))
 		{
-			$title = ($table->title != $title) ? $title : JString::increment($title);
-			$alias = JString::increment($alias, 'dash');
+			$title = ($table->title != $title) ? $title : StringHelper::increment($title);
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Tags table
@@ -118,7 +119,7 @@ class TagsTableTag extends JTableNested
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = StringHelper::str_ireplace($bad_characters, "", $this->metakey);
 
 			// Create array using commas as delimiter
 			$keys = explode(',', $after_clean);
@@ -142,7 +143,7 @@ class TagsTableTag extends JTableNested
 		{
 			// Only process if not empty
 			$bad_characters = array("\"", "<", ">");
-			$this->metadesc = JString::str_ireplace($bad_characters, "", $this->metadesc);
+			$this->metadesc = StringHelper::str_ireplace($bad_characters, "", $this->metadesc);
 		}
 		// Not Null sanity check
 		$date = JFactory::getDate();

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -238,7 +239,7 @@ class TemplatesModelStyle extends JModelAdmin
 
 		while ($table->load(array('title' => $title)))
 		{
-			$title = JString::increment($title);
+			$title = StringHelper::increment($title);
 		}
 
 		return $title;

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -319,7 +320,7 @@ class UsersModelGroup extends JModelAdmin
 		{
 			if ($title == $table->title)
 			{
-				$title = JString::increment($title);
+				$title = StringHelper::increment($title);
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Phase out use of the deprecated `JString` class in the admin app in favor of its parent `Joomla\String\StringHelper`
### Testing Instructions

The backend continues to function as normal.
### Documentation Changes Required

N/A
