### PR TITLE
Site app & Plugins - JString -> StringHelper

### DIFF
--- a/components/com_contact/models/rules/contactemail.php
+++ b/components/com_contact/models/rules/contactemail.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 JFormHelper::loadRuleClass('email');
 
@@ -47,7 +48,7 @@ class JFormRuleContactEmail extends JFormRuleEmail
 		{
 			foreach (explode(';', $banned) as $item)
 			{
-				if ($item != '' && JString::stristr($value, $item) !== false)
+				if ($item != '' && StringHelper::stristr($value, $item) !== false)
 				{
 					return false;
 				}

--- a/components/com_contact/models/rules/contactemailmessage.php
+++ b/components/com_contact/models/rules/contactemailmessage.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * JFormRule for com_contact to make sure the message body contains no banned word.
@@ -40,7 +41,7 @@ class JFormRuleContactEmailMessage extends JFormRule
 		{
 			foreach (explode(';', $banned) as $item)
 			{
-				if ($item != '' && JString::stristr($value, $item) !== false)
+				if ($item != '' && StringHelper::stristr($value, $item) !== false)
 				{
 					return false;
 				}

--- a/components/com_contact/models/rules/contactemailsubject.php
+++ b/components/com_contact/models/rules/contactemailsubject.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * JFormRule for com_contact to make sure the subject contains no banned word.
@@ -40,7 +41,7 @@ class JFormRuleContactEmailSubject extends JFormRule
 		{
 			foreach (explode(';', $banned) as $item)
 			{
-				if ($item != '' && JString::stristr($value, $item) !== false)
+				if ($item != '' && StringHelper::stristr($value, $item) !== false)
 				{
 					return false;
 				}

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -501,7 +502,7 @@ class ContentModelArticles extends JModelList
 		if ((is_object($params)) && ($params->get('filter_field') != 'hide') && ($filter = $this->getState('list.filter')))
 		{
 			// Clean filter variable
-			$filter = JString::strtolower($filter);
+			$filter = StringHelper::strtolower($filter);
 			$hitsFilter = (int) $filter;
 			$filter = $db->quote('%' . $db->escape($filter, true) . '%', false);
 

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 // Register dependent classes.
@@ -376,7 +377,7 @@ class FinderModelSearch extends JModelList
 		foreach ($this->includedTerms as $token => $ids)
 		{
 			// Get the mapping table suffix.
-			$suffix = JString::substr(md5(JString::substr($token, 0, 1)), 0, 1);
+			$suffix = StringHelper::substr(md5(StringHelper::substr($token, 0, 1)), 0, 1);
 
 			// Initialize the mapping group.
 			if (!array_key_exists($suffix, $maps))
@@ -523,7 +524,7 @@ class FinderModelSearch extends JModelList
 					do
 					{
 						// Get the map table suffix.
-						$suffix = JString::substr(md5(JString::substr($token, 0, 1)), 0, 1);
+						$suffix = StringHelper::substr(md5(StringHelper::substr($token, 0, 1)), 0, 1);
 
 						// Adjust the query to join on the appropriate mapping table.
 						$query = clone($base);
@@ -654,7 +655,7 @@ class FinderModelSearch extends JModelList
 		foreach ($this->includedTerms as $token => $ids)
 		{
 			// Get the mapping table suffix.
-			$suffix = JString::substr(md5(JString::substr($token, 0, 1)), 0, 1);
+			$suffix = StringHelper::substr(md5(StringHelper::substr($token, 0, 1)), 0, 1);
 
 			// Initialize the mapping group.
 			if (!array_key_exists($suffix, $maps))
@@ -844,7 +845,7 @@ class FinderModelSearch extends JModelList
 					do
 					{
 						// Get the map table suffix.
-						$suffix = JString::substr(md5(JString::substr($token, 0, 1)), 0, 1);
+						$suffix = StringHelper::substr(md5(StringHelper::substr($token, 0, 1)), 0, 1);
 
 						// Adjust the query to join on the appropriate mapping table.
 						$query = clone($base);
@@ -942,7 +943,7 @@ class FinderModelSearch extends JModelList
 		foreach ($this->excludedTerms as $token => $id)
 		{
 			// Get the mapping table suffix.
-			$suffix = JString::substr(md5(JString::substr($token, 0, 1)), 0, 1);
+			$suffix = StringHelper::substr(md5(StringHelper::substr($token, 0, 1)), 0, 1);
 
 			// Initialize the mapping group.
 			if (!array_key_exists($suffix, $maps))
@@ -1125,7 +1126,7 @@ class FinderModelSearch extends JModelList
 		 * Also, we allow this parameter to be passed in either case (lower/upper).
 		 */
 		$order = $input->getWord('filter_order', $params->get('sort_order', 'relevance'));
-		$order = JString::strtolower($order);
+		$order = StringHelper::strtolower($order);
 		switch ($order)
 		{
 			case 'date':
@@ -1156,7 +1157,7 @@ class FinderModelSearch extends JModelList
 		 * Also, we allow this parameter to be passed in either case (lower/upper).
 		 */
 		$dirn = $input->getWord('filter_order_Dir', $params->get('sort_direction', 'desc'));
-		$dirn = JString::strtolower($dirn);
+		$dirn = StringHelper::strtolower($dirn);
 		switch ($dirn)
 		{
 			case 'asc':

--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 // Get the mime type class.
 $mime = !empty($this->result->mime) ? 'mime-' . $this->result->mime : null;
 
@@ -17,21 +19,21 @@ $show_description = $this->params->get('show_description', 1);
 if ($show_description)
 {
 	// Calculate number of characters to display around the result
-	$term_length = JString::strlen($this->query->input);
+	$term_length = StringHelper::strlen($this->query->input);
 	$desc_length = $this->params->get('description_length', 255);
 	$pad_length = $term_length < $desc_length ? (int) floor(($desc_length - $term_length) / 2) : 0;
 
 	// Find the position of the search term
-	$pos = $term_length ? JString::strpos(JString::strtolower($this->result->description), JString::strtolower($this->query->input)) : false;
+	$pos = $term_length ? StringHelper::strpos(StringHelper::strtolower($this->result->description), StringHelper::strtolower($this->query->input)) : false;
 
 	// Find a potential start point
 	$start = ($pos && $pos > $pad_length) ? $pos - $pad_length : 0;
 
 	// Find a space between $start and $pos, start right after it.
-	$space = JString::strpos($this->result->description, ' ', $start > 0 ? $start - 1 : 0);
+	$space = StringHelper::strpos($this->result->description, ' ', $start > 0 ? $start - 1 : 0);
 	$start = ($space && $space < $pos) ? $space + 1 : $start;
 
-	$description = JHtml::_('string.truncate', JString::substr($this->result->description, $start), $desc_length, true);
+	$description = JHtml::_('string.truncate', StringHelper::substr($this->result->description, $start), $desc_length, true);
 }
 
 $route = $this->result->route;

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * HTML View class for the search component
@@ -177,8 +178,8 @@ class SearchViewSearch extends JViewLegacy
 				{
 					// E.g. german umlauts like ä are converted to ae and so
 					// $pos calculated with $srow desn't match for $row
-					$correctPos     = (JString::strlen($srow) > JString::strlen($row));
-					$highlighterLen = JString::strlen($hl1 . $hl2);
+					$correctPos     = (StringHelper::strlen($srow) > StringHelper::strlen($row));
+					$highlighterLen = StringHelper::strlen($hl1 . $hl2);
 				}
 
 				foreach ($searchwords as $hlword)
@@ -209,7 +210,7 @@ class SearchViewSearch extends JViewLegacy
 					}
 					else
 					{
-						if (($pos = JString::strpos($srow, strtolower(SearchHelper::remove_accents($hlword)))) !== false)
+						if (($pos = StringHelper::strpos($srow, strtolower(SearchHelper::remove_accents($hlword)))) !== false)
 						{
 							// Iconv transliterates '€' to 'EUR'
 							// TODO: add other expanding translations?
@@ -219,9 +220,9 @@ class SearchViewSearch extends JViewLegacy
 							if ($correctPos)
 							{
 								// Calculate necessary corrections from 0 to current $pos
-								$ChkRow     = JString::substr($row, 0, $pos);
-								$sChkRowLen = JString::strlen(strtolower(SearchHelper::remove_accents($ChkRow)));
-								$ChkRowLen  = JString::strlen($ChkRow);
+								$ChkRow     = StringHelper::substr($row, 0, $pos);
+								$sChkRowLen = StringHelper::strlen(strtolower(SearchHelper::remove_accents($ChkRow)));
+								$ChkRowLen  = StringHelper::strlen($ChkRow);
 
 								// Correct $pos
 								$pos -= ($sChkRowLen - $ChkRowLen);
@@ -260,9 +261,9 @@ class SearchViewSearch extends JViewLegacy
 							}
 							else
 							{
-								$hlwordLen = JString::strlen($hlword);
-								$row = JString::substr($row, 0, $pos) . $hl1 . JString::substr($row, $pos, JString::strlen($hlword))
-									. $hl2 . JString::substr($row, $pos + JString::strlen($hlword));
+								$hlwordLen = StringHelper::strlen($hlword);
+								$row = StringHelper::substr($row, 0, $pos) . $hl1 . StringHelper::substr($row, $pos, StringHelper::strlen($hlword))
+									. $hl2 . StringHelper::substr($row, $pos + StringHelper::strlen($hlword));
 							}
 
 							$cnt++;

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 $com_path = JPATH_SITE . '/components/com_content/';
 require_once $com_path . 'helpers/route.php';
 
@@ -444,7 +446,7 @@ abstract class ModArticlesCategoryHelper
 			switch ($type)
 			{
 				case 'month_year' :
-					$month_year = JString::substr($item->created, 0, 7);
+					$month_year = StringHelper::substr($item->created, 0, 7);
 
 					if (!isset($grouped[$month_year]))
 					{
@@ -456,7 +458,7 @@ abstract class ModArticlesCategoryHelper
 
 				case 'year' :
 				default:
-					$year = JString::substr($item->created, 0, 4);
+					$year = StringHelper::substr($item->created, 0, 4);
 
 					if (!isset($grouped[$year]))
 					{

--- a/modules/mod_footer/mod_footer.php
+++ b/modules/mod_footer/mod_footer.php
@@ -9,12 +9,14 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 $app        = JFactory::getApplication();
 $date       = JFactory::getDate();
 $cur_year   = JHtml::_('date', $date, 'Y');
 $csite_name = $app->get('sitename');
 
-if (is_int(JString::strpos(JText :: _('MOD_FOOTER_LINE1'), '%date%')))
+if (is_int(StringHelper::strpos(JText :: _('MOD_FOOTER_LINE1'), '%date%')))
 {
 	$line1 = str_replace('%date%', $cur_year, JText :: _('MOD_FOOTER_LINE1'));
 }
@@ -23,7 +25,7 @@ else
 	$line1 = JText :: _('MOD_FOOTER_LINE1');
 }
 
-if (is_int(JString::strpos($line1, '%sitename%')))
+if (is_int(StringHelper::strpos($line1, '%sitename%')))
 {
 	$lineone = str_replace('%sitename%', $csite_name, $line1);
 }

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Helper for mod_random_image
  *
@@ -139,13 +141,13 @@ class ModRandomImageHelper
 		$LiveSite = JUri::base();
 
 		// If folder includes livesite info, remove
-		if (JString::strpos($folder, $LiveSite) === 0)
+		if (StringHelper::strpos($folder, $LiveSite) === 0)
 		{
 			$folder = str_replace($LiveSite, '', $folder);
 		}
 
 		// If folder includes absolute path, remove
-		if (JString::strpos($folder, JPATH_SITE) === 0)
+		if (StringHelper::strpos($folder, JPATH_SITE) === 0)
 		{
 			$folder = str_replace(JPATH_BASE, '', $folder);
 		}

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Email cloack plugin class.
  *
@@ -98,15 +100,15 @@ class PlgContentEmailcloak extends JPlugin
 		 * Check for presence of {emailcloak=off} which is explicits disables this
 		 * bot for the item.
 		 */
-		if (JString::strpos($text, '{emailcloak=off}') !== false)
+		if (StringHelper::strpos($text, '{emailcloak=off}') !== false)
 		{
-			$text = JString::str_ireplace('{emailcloak=off}', '', $text);
+			$text = StringHelper::str_ireplace('{emailcloak=off}', '', $text);
 
 			return true;
 		}
 
 		// Simple performance check to determine whether bot should process further.
-		if (JString::strpos($text, '@') === false)
+		if (StringHelper::strpos($text, '@') === false)
 		{
 			return true;
 		}

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 jimport('joomla.utilities.utility');
 
 /**
@@ -72,7 +74,7 @@ class PlgContentPagebreak extends JPlugin
 		}
 
 		// Simple performance check to determine whether bot should process further.
-		if (JString::strpos($row->text, 'class="system-pagebreak') === false)
+		if (StringHelper::strpos($row->text, 'class="system-pagebreak') === false)
 		{
 			return true;
 		}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 
@@ -721,7 +722,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			// Load component associations.
 			$option = $this->app->input->get('option');
-			$cName = JString::ucfirst(JString::str_ireplace('com_', '', $option)) . 'HelperAssociation';
+			$cName = StringHelper::ucfirst(StringHelper::str_ireplace('com_', '', $option)) . 'HelperAssociation';
 			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
 
 			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Class for Contact Creator
  *
@@ -144,10 +146,10 @@ class PlgUserContactCreator extends JPlugin
 		{
 			if ($name == $table->name)
 			{
-				$name = JString::increment($name);
+				$name = StringHelper::increment($name);
 			}
 
-			$alias = JString::increment($alias, 'dash');
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($name, $alias);


### PR DESCRIPTION
### Summary of Changes

Phase out use of the deprecated `JString` class in the site app and plugins in favor of its parent `Joomla\String\StringHelper`
### Testing Instructions

The frontend and plugins continue to function as normal.
### Documentation Changes Required

N/A
