### PR TITLE
Phase out JString calls in libraries

### DIFF
--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Utility class for creating different select lists
  *
@@ -105,9 +107,9 @@ abstract class JHtmlList
 		{
 			$items[$i]->text = JText::_($items[$i]->text);
 
-			if (JString::strlen($items[$i]->text) > $chop)
+			if (StringHelper::strlen($items[$i]->text) > $chop)
 			{
-				$text = JString::substr($items[$i]->text, 0, $chop) . "...";
+				$text = StringHelper::substr($items[$i]->text, 0, $chop) . "...";
 			}
 			else
 			{

--- a/libraries/cms/html/string.php
+++ b/libraries/cms/html/string.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * HTML helper class for rendering manipulated strings.
  *
@@ -45,7 +47,7 @@ abstract class JHtmlString
 			// Deal with spacing issues in the input.
 			$text = str_replace('>', '> ', $text);
 			$text = str_replace(array('&nbsp;', '&#160;'), ' ', $text);
-			$text = JString::trim(preg_replace('#\s+#mui', ' ', $text));
+			$text = StringHelper::trim(preg_replace('#\s+#mui', ' ', $text));
 
 			// Strip the tags from the input and decode entities.
 			$text = strip_tags($text);
@@ -53,13 +55,13 @@ abstract class JHtmlString
 
 			// Remove remaining extra spaces.
 			$text = str_replace('&nbsp;', ' ', $text);
-			$text = JString::trim(preg_replace('#\s+#mui', ' ', $text));
+			$text = StringHelper::trim(preg_replace('#\s+#mui', ' ', $text));
 		}
 
 		// Whether or not allowing HTML, truncate the item text if it is too long.
-		if ($length > 0 && JString::strlen($text) > $length)
+		if ($length > 0 && StringHelper::strlen($text) > $length)
 		{
-			$tmp = trim(JString::substr($text, 0, $length));
+			$tmp = trim(StringHelper::substr($text, 0, $length));
 
 			if (substr($tmp, 0, 1) == '<' && strpos($tmp, '>') === false)
 			{
@@ -70,8 +72,8 @@ abstract class JHtmlString
 			if ($noSplit)
 			{
 				// Find the position of the last space within the allowed length.
-				$offset = JString::strrpos($tmp, ' ');
-				$tmp = JString::substr($tmp, 0, $offset + 1);
+				$offset = StringHelper::strrpos($tmp, ' ');
+				$tmp = StringHelper::substr($tmp, 0, $offset + 1);
 
 				// If there are no spaces and the string is longer than the maximum
 				// we need to just use the ellipsis. In that case we are done.
@@ -80,9 +82,9 @@ abstract class JHtmlString
 					return '...';
 				}
 
-				if (JString::strlen($tmp) > $length - 3)
+				if (StringHelper::strlen($tmp) > $length - 3)
 				{
-					$tmp = trim(JString::substr($tmp, 0, JString::strrpos($tmp, ' ')));
+					$tmp = trim(StringHelper::substr($tmp, 0, StringHelper::strrpos($tmp, ' ')));
 				}
 			}
 
@@ -276,14 +278,14 @@ abstract class JHtmlString
 	public static function abridge($text, $length = 50, $intro = 30)
 	{
 		// Abridge the item text if it is too long.
-		if (JString::strlen($text) > $length)
+		if (StringHelper::strlen($text) > $length)
 		{
 			// Determine the remaining text length.
 			$remainder = $length - ($intro + 3);
 
 			// Extract the beginning and ending text sections.
-			$beg = JString::substr($text, 0, $intro);
-			$end = JString::substr($text, JString::strlen($text) - $remainder);
+			$beg = StringHelper::substr($text, 0, $intro);
+			$end = StringHelper::substr($text, StringHelper::strlen($text) - $remainder);
 
 			// Build the resulting string.
 			$text = $beg . '...' . $end;

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Class to create and parse routes for the site application
  *
@@ -311,13 +313,13 @@ class JRouterSite extends JRouter
 			$items = $this->menu->getMenu();
 
 			$found           = false;
-			$route_lowercase = JString::strtolower($route);
+			$route_lowercase = StringHelper::strtolower($route);
 			$lang_tag        = $this->app->getLanguage()->getTag();
 
 			// Iterate through all items and check route matches.
 			foreach ($items as $item)
 			{
-				if ($item->route && JString::strpos($route_lowercase . '/', $item->route . '/') === 0 && $item->type != 'menulink')
+				if ($item->route && StringHelper::strpos($route_lowercase . '/', $item->route . '/') === 0 && $item->type != 'menulink')
 				{
 					// Usual method for non-multilingual site.
 					if (!$this->app->getLanguageFilter())

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -139,7 +140,7 @@ class JTableCorecontent extends JTable
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->core_metakey);
+			$after_clean = StringHelper::str_ireplace($bad_characters, "", $this->core_metakey);
 
 			// Create array using commas as delimiter
 			$keys = explode(',', $after_clean);

--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Filter\OutputFilter;
+use Joomla\String\StringHelper;
 
 /**
  * JFilterOutput
@@ -72,7 +73,7 @@ class JFilterOutput extends OutputFilter
 		$str = $lang->transliterate($str);
 
 		// Trim white spaces at beginning and end of alias and make lowercase
-		$str = trim(JString::strtolower($str));
+		$str = trim(StringHelper::strtolower($str));
 
 		// Remove any duplicate whitespace, and ensure all characters are alphanumeric
 		$str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -9,6 +9,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\Normalise;
+use Joomla\String\StringHelper;
+
 /**
  * Abstract Form Field class for the Joomla Platform.
  *
@@ -343,15 +346,15 @@ abstract class JFormField
 		// Detect the field type if not set
 		if (!isset($this->type))
 		{
-			$parts = JStringNormalise::fromCamelCase(get_called_class(), true);
+			$parts = Normalise::fromCamelCase(get_called_class(), true);
 
 			if ($parts[0] == 'J')
 			{
-				$this->type = JString::ucfirst($parts[count($parts) - 1], '_');
+				$this->type = StringHelper::ucfirst($parts[count($parts) - 1], '_');
 			}
 			else
 			{
-				$this->type = JString::ucfirst($parts[0], '_') . JString::ucfirst($parts[count($parts) - 1], '_');
+				$this->type = StringHelper::ucfirst($parts[0], '_') . StringHelper::ucfirst($parts[count($parts) - 1], '_');
 			}
 		}
 	}

--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 jimport('joomla.filesystem.path');
 
 /**
@@ -169,7 +171,7 @@ class JFormHelper
 			list($prefix, $type) = explode('.', $type);
 		}
 
-		$class = JString::ucfirst($prefix, '_') . 'Form' . JString::ucfirst($entity, '_') . JString::ucfirst($type, '_');
+		$class = StringHelper::ucfirst($prefix, '_') . 'Form' . StringHelper::ucfirst($entity, '_') . StringHelper::ucfirst($type, '_');
 
 		if (class_exists($class))
 		{

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -10,6 +10,8 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
+use Joomla\Uri\UriHelper;
 
 /**
  * Form Rule class for the Joomla Platform.
@@ -45,7 +47,7 @@ class JFormRuleUrl extends JFormRule
 			return true;
 		}
 
-		$urlParts = JString::parse_url($value);
+		$urlParts = UriHelper::parse_url($value);
 
 		// See http://www.w3.org/Addressing/URL/url-spec.txt
 		// Use the full list or optionally specify a list of permitted schemes.
@@ -76,7 +78,7 @@ class JFormRuleUrl extends JFormRule
 				return false;
 			}
 			// The best we can do for the rest is make sure that the path exists and is valid UTF-8.
-			if (!array_key_exists('path', $urlParts) || !JString::valid((string) $urlParts['path']))
+			if (!array_key_exists('path', $urlParts) || !StringHelper::valid((string) $urlParts['path']))
 			{
 				return false;
 			}
@@ -103,7 +105,7 @@ class JFormRuleUrl extends JFormRule
 
 		// The best we can do for the rest is make sure that the strings are valid UTF-8
 		// and the port is an integer.
-		if (array_key_exists('host', $urlParts) && !JString::valid((string) $urlParts['host']))
+		if (array_key_exists('host', $urlParts) && !StringHelper::valid((string) $urlParts['host']))
 		{
 			return false;
 		}
@@ -113,7 +115,7 @@ class JFormRuleUrl extends JFormRule
 			return false;
 		}
 
-		if (array_key_exists('path', $urlParts) && !JString::valid((string) $urlParts['path']))
+		if (array_key_exists('path', $urlParts) && !StringHelper::valid((string) $urlParts['path']))
 		{
 			return false;
 		}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
+
 /**
  * Allows for quoting in language .ini files.
  */
@@ -398,7 +400,7 @@ class JLanguage
 		}
 
 		$string = JLanguageTransliterate::utf8_latin_to_ascii($string);
-		$string = JString::strtolower($string);
+		$string = StringHelper::strtolower($string);
 
 		return $string;
 	}

--- a/libraries/joomla/string/punycode.php
+++ b/libraries/joomla/string/punycode.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Uri\UriHelper;
+
 JLoader::register('idna_convert', JPATH_LIBRARIES . '/idna_convert/idna_convert.class.php');
 
 /**
@@ -65,7 +67,7 @@ abstract class JStringPunycode
 	 */
 	public static function urlToPunycode($uri)
 	{
-		$parsed = JString::parse_url($uri);
+		$parsed = UriHelper::parse_url($uri);
 
 		if (!isset($parsed['host']) || $parsed['host'] == '')
 		{
@@ -136,7 +138,7 @@ abstract class JStringPunycode
 			return;
 		}
 
-		$parsed = JString::parse_url($uri);
+		$parsed = UriHelper::parse_url($uri);
 
 		if (!isset($parsed['host']) || $parsed['host'] == '')
 		{

--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -9,6 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -395,11 +396,11 @@ abstract class JArrayHelper
 			}
 			elseif ($caseSensitive)
 			{
-				$cmp = JString::strcmp($va, $vb, $locale);
+				$cmp = StringHelper::strcmp($va, $vb, $locale);
 			}
 			else
 			{
-				$cmp = JString::strcasecmp($va, $vb, $locale);
+				$cmp = StringHelper::strcasecmp($va, $vb, $locale);
 			}
 
 			if ($cmp > 0)

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Prototype admin model.
@@ -864,8 +865,8 @@ abstract class JModelAdmin extends JModelForm
 
 		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
 		{
-			$title = JString::increment($title);
-			$alias = JString::increment($alias, 'dash');
+			$title = StringHelper::increment($title);
+			$alias = StringHelper::increment($alias, 'dash');
 		}
 
 		return array($title, $alias);

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Content table
@@ -254,7 +255,7 @@ class JTableContent extends JTable
 			$bad_characters = array("\n", "\r", "\"", "<", ">");
 
 			// Remove bad characters
-			$after_clean = JString::str_ireplace($bad_characters, "", $this->metakey);
+			$after_clean = StringHelper::str_ireplace($bad_characters, "", $this->metakey);
 
 			// Create array using commas as delimiter
 			$keys = explode(',', $after_clean);


### PR DESCRIPTION
### Summary of Changes

Phase out use of the deprecated `JString` class in the libraries in favor of its parent `Joomla\String\StringHelper` or other replacements as appropriate
### Testing Instructions

The libraries continue to function as normal.
### Documentation Changes Required

N/A
