### PR TITLE
[4.0] B/C Break - Typehint the database driver in JTable

### DIFF
--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -22,11 +22,11 @@ class BannersTableBanner extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_banners.banner';
 		parent::__construct('#__banners', 'id', $db);

--- a/administrator/components/com_banners/tables/client.php
+++ b/administrator/components/com_banners/tables/client.php
@@ -21,11 +21,11 @@ class BannersTableClient extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias        = 'com_banners.client';
 		$this->checked_out_time = $db->getNullDate();

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -29,11 +29,11 @@ class ContactTableContact extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_contact.contact';
 		parent::__construct('#__contact_details', 'id', $db);

--- a/administrator/components/com_content/tables/featured.php
+++ b/administrator/components/com_content/tables/featured.php
@@ -19,11 +19,11 @@ class ContentTableFeatured extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.6
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__content_frontpage', 'content_id', $db);
 	}

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -22,11 +22,11 @@ class FinderTableFilter extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__finder_filters', 'filter_id', $db);
 	}

--- a/administrator/components/com_finder/tables/link.php
+++ b/administrator/components/com_finder/tables/link.php
@@ -19,11 +19,11 @@ class FinderTableLink extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__finder_links', 'link_id', $db);
 	}

--- a/administrator/components/com_finder/tables/map.php
+++ b/administrator/components/com_finder/tables/map.php
@@ -21,11 +21,11 @@ class FinderTableMap extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  JDatabaseDriver connector object.
+	 * @param   JDatabaseDriver  $db  JDatabaseDriver connector object.
 	 *
 	 * @since   2.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__finder_taxonomy', 'id', $db);
 	}

--- a/administrator/components/com_messages/tables/message.php
+++ b/administrator/components/com_messages/tables/message.php
@@ -19,11 +19,11 @@ class MessagesTableMessage extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database connector object
+	 * @param   JDatabaseDriver  $db  Database connector object
 	 *
 	 * @since   1.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__messages', 'message_id', $db);
 	}

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -27,9 +27,9 @@ class NewsfeedsTableNewsfeed extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  A database connector object
+	 * @param   JDatabaseDriver  $db  A database connector object
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_newsfeeds.newsfeed';
 		parent::__construct('#__newsfeeds', 'id', $db);

--- a/administrator/components/com_redirect/tables/link.php
+++ b/administrator/components/com_redirect/tables/link.php
@@ -23,7 +23,7 @@ class RedirectTableLink extends JTable
 	 *
 	 * @since   1.6
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__redirect_links', 'id', $db);
 	}

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -23,7 +23,7 @@ class TagsTableTag extends JTableNested
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_tags.tag';
 		parent::__construct('#__tags', 'id', $db);

--- a/administrator/components/com_templates/tables/style.php
+++ b/administrator/components/com_templates/tables/style.php
@@ -21,11 +21,11 @@ class TemplatesTableStyle extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  A database connector object
+	 * @param   JDatabaseDriver  $db  A database connector object
 	 *
 	 * @since   1.6
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__template_styles', 'id', $db);
 	}

--- a/administrator/components/com_users/tables/note.php
+++ b/administrator/components/com_users/tables/note.php
@@ -19,11 +19,11 @@ class UsersTableNote extends JTable
 	/**
 	 * Constructor
 	 *
-	 * @param   JDatabaseDriver  &$db  Database object
+	 * @param   JDatabaseDriver  $db  Database object
 	 *
 	 * @since  2.5
 	 */
-	public function __construct(&$db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		$this->typeAlias = 'com_users.note';
 		parent::__construct('#__user_notes', 'id', $db);

--- a/libraries/cms/table/contenthistory.php
+++ b/libraries/cms/table/contenthistory.php
@@ -42,7 +42,7 @@ class JTableContenthistory extends JTable
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__ucm_history', 'version_id', $db);
 		$this->ignoreChanges = array(

--- a/libraries/cms/table/contenttype.php
+++ b/libraries/cms/table/contenttype.php
@@ -23,7 +23,7 @@ class JTableContenttype extends JTable
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__content_types', 'type_id', $db);
 	}

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -26,7 +26,7 @@ class JTableCorecontent extends JTable
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__ucm_content', 'core_content_id', $db);
 	}

--- a/libraries/cms/table/ucm.php
+++ b/libraries/cms/table/ucm.php
@@ -23,7 +23,7 @@ class JTableUcm extends JTable
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__ucm_base', 'ucm_id', $db);
 	}

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -55,7 +55,7 @@ class JTableAsset extends JTableNested
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__assets', 'id', $db);
 	}

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -26,7 +26,7 @@ class JTableExtension extends JTable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__extensions', 'extension_id', $db);
 	}

--- a/libraries/joomla/table/language.php
+++ b/libraries/joomla/table/language.php
@@ -23,7 +23,7 @@ class JTableLanguage extends JTable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__languages', 'lang_id', $db);
 	}

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -135,7 +135,7 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($table, $key, $db, DispatcherInterface $dispatcher = null)
+	public function __construct($table, $key, JDatabaseDriver $db, DispatcherInterface $dispatcher = null)
 	{
 		parent::__construct();
 
@@ -520,7 +520,7 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 	 *
 	 * @since   11.1
 	 */
-	public function setDbo($db)
+	public function setDbo(JDatabaseDriver $db)
 	{
 		$this->_db = $db;
 

--- a/libraries/joomla/table/update.php
+++ b/libraries/joomla/table/update.php
@@ -26,7 +26,7 @@ class JTableUpdate extends JTable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__updates', 'update_id', $db);
 	}

--- a/libraries/joomla/table/updatesite.php
+++ b/libraries/joomla/table/updatesite.php
@@ -26,7 +26,7 @@ class JTableUpdatesite extends JTable
 	 *
 	 * @since   3.4
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__update_sites', 'update_site_id', $db);
 	}

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -34,7 +34,7 @@ class JTableUser extends JTable
 	 *
 	 * @since  11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__users', 'id', $db);
 

--- a/libraries/joomla/table/usergroup.php
+++ b/libraries/joomla/table/usergroup.php
@@ -23,7 +23,7 @@ class JTableUsergroup extends JTable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__usergroups', 'id', $db);
 	}

--- a/libraries/joomla/table/viewlevel.php
+++ b/libraries/joomla/table/viewlevel.php
@@ -23,7 +23,7 @@ class JTableViewlevel extends JTable
 	 *
 	 * @since   11.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__viewlevels', 'id', $db);
 	}

--- a/tests/unit/suites/libraries/joomla/table/stubs/dbtestcomposite.php
+++ b/tests/unit/suites/libraries/joomla/table/stubs/dbtestcomposite.php
@@ -23,7 +23,7 @@ class TableDbTestComposite extends JTable
 	 *
 	 * @since   12.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__dbtest_composite', array('id1', 'id2'), $db);
 	}

--- a/tests/unit/suites/libraries/joomla/table/stubs/nested.php
+++ b/tests/unit/suites/libraries/joomla/table/stubs/nested.php
@@ -25,7 +25,7 @@ class NestedTable extends JTableNested
 	 *
 	 * @since   12.1
 	 */
-	public function __construct($db)
+	public function __construct(JDatabaseDriver $db)
 	{
 		parent::__construct('#__categories', 'id', $db);
 	}
@@ -39,7 +39,7 @@ class NestedTable extends JTableNested
 	{
 		self::$unlocked = true;
 	}
-	
+
 	/**
 	 * Method to reset the root_id
 	 *


### PR DESCRIPTION
### Summary of Changes

`JTable` and its subclasses require the use of a `JDatabaseDriver` object to be passed in either the constructors or the `setDbo()` method however this is not enforced in the code except for a handful of subclasses which are already typehinting.  This adds typehints for all of the classes to ensure the correct object is used.  This also removes all of the referenced parameters, there's not a need for those anymore.
### Testing Instructions

The CMS will continue to function as normal.  There aren't any existing cases in normal operation where another object gets passed in.
### Documentation Changes Required
- Subclasses of `JTable` will need to ensure they are passing a `JDatabaseDriver` object to the parent constructor
- Subclasses of `JTable` will need to change the method signature of `setDbo()` if they have an extended version of that method to include the typehint
