### PR TITLE
Make more use of the autoloader

### DIFF
--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -47,10 +47,10 @@ class CategoriesHelper
 
 		if (file_exists($file))
 		{
-			require_once $file;
-
 			$prefix = ucfirst(str_replace('com_', '', $component));
 			$cName = $prefix . 'Helper';
+
+			JLoader::register($cName, $file);
 
 			if (class_exists($cName))
 			{

--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -385,10 +385,10 @@ class CategoriesModelCategories extends JModelList
 
 		if (file_exists($file))
 		{
-			require_once $file;
-
 			$prefix = ucfirst($eName);
 			$cName = $prefix . 'Helper';
+
+			JLoader::register($cName, $file);
 
 			if (class_exists($cName) && is_callable(array($cName, 'countItems')))
 			{

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -398,8 +398,9 @@ class CategoriesModelCategory extends JModelAdmin
 
 		if (file_exists($path))
 		{
-			require_once $path;
 			$cName = ucfirst($eName) . ucfirst($section) . 'HelperCategory';
+
+			JLoader::register($cName, $path);
 
 			if (class_exists($cName) && is_callable(array($cName, 'onPrepareForm')))
 			{

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -119,7 +119,7 @@ abstract class FinderIndexer
 		if (file_exists($path))
 		{
 			// Instantiate the parser.
-			include_once $path;
+			JLoader::register($class, $path);
 
 			return new $class;
 		}

--- a/administrator/components/com_finder/helpers/indexer/parser.php
+++ b/administrator/components/com_finder/helpers/indexer/parser.php
@@ -55,7 +55,7 @@ abstract class FinderIndexerParser
 		}
 
 		// Instantiate the parser.
-		include_once $path;
+		JLoader::register($class, $path);
 		$instances[$format] = new $class;
 
 		return $instances[$format];

--- a/administrator/components/com_finder/helpers/indexer/stemmer.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer.php
@@ -63,7 +63,7 @@ abstract class FinderIndexerStemmer
 		}
 
 		// Instantiate the stemmer.
-		include_once $path;
+		JLoader::register($class, $path);
 		$instances[$adapter] = new $class;
 
 		return $instances[$adapter];

--- a/administrator/components/com_joomlaupdate/views/upload/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/upload/view.html.php
@@ -38,10 +38,7 @@ class JoomlaupdateViewUpload extends JViewLegacy
 		$language->load('com_installer', JPATH_ADMINISTRATOR, null, true);
 
 		// Import com_login's model
-		if (!class_exists('LoginModelLogin'))
-		{
-			@include_once JPATH_ADMINISTRATOR . '/components/com_login/models/login.php';
-		}
+		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_login/models', 'LoginModel');
 
 		// Render the view.
 		parent::display($tpl);

--- a/administrator/components/com_tags/helpers/tags.php
+++ b/administrator/components/com_tags/helpers/tags.php
@@ -43,9 +43,9 @@ class TagsHelper extends JHelperContent
 
 		if (file_exists($file))
 		{
-			require_once $file;
-
 			$cName = 'TagsHelper';
+
+			JLoader::register($cName, $file);
 
 			if (class_exists($cName))
 			{

--- a/administrator/components/com_tags/models/tags.php
+++ b/administrator/components/com_tags/models/tags.php
@@ -346,7 +346,7 @@ class TagsModelTags extends JModelList
 
 	/**
 	 * Method to load the countItems method from the extensions
-	 * 
+	 *
 	 * @param   stdClass[]  &$items     The category items
 	 * @param   string      $extension  The category extension
 	 *
@@ -373,10 +373,10 @@ class TagsModelTags extends JModelList
 
 		if (file_exists($file))
 		{
-			require_once $file;
-
 			$prefix = ucfirst(str_replace('com_', '', $component));
 			$cName = $prefix . 'Helper';
+
+			JLoader::register($cName, $file);
 
 			if (class_exists($cName) && is_callable(array($cName, 'countTagItems')))
 			{

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -156,7 +156,7 @@ class FinderCli extends JApplicationCli
 	 */
 	private function index()
 	{
-		require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php';
+		JLoader::register('FinderIndexer', JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php');
 
 		// Disable caching.
 		$config = JFactory::getConfig();

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -86,7 +86,7 @@ elseif ($input->get('module'))
 
 		if (is_file($helperFile))
 		{
-			require_once $helperFile;
+			JLoader::register($class, $helperFile);
 
 			if (method_exists($class, $method . 'Ajax'))
 			{

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -20,7 +20,7 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Search Component router constructor
-	 * 
+	 *
 	 * @param   JApplicationCms  $app   The application object
 	 * @param   JMenu            $menu  The menu object to work with
 	 */
@@ -52,14 +52,14 @@ class ContactRouter extends JComponentRouterView
 		}
 		else
 		{
-			require_once JPATH_SITE . '/components/com_contact/helpers/legacyrouter.php';
+			JLoader::register('ContactRouterRulesLegacy', __DIR__ . '/helpers/legacyrouter.php');
 			$this->attachRule(new ContactRouterRulesLegacy($this));
 		}
 	}
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -92,7 +92,7 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -105,7 +105,7 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a contact
-	 * 
+	 *
 	 * @param   string  $id     ID of the contact to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -139,7 +139,7 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the id for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
 	 *
@@ -175,10 +175,10 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getCategoriesId($segment, $query)
@@ -188,10 +188,10 @@ class ContactRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a contact
-	 * 
+	 *
 	 * @param   string  $segment  Segment of the contact to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getContactId($segment, $query)

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -20,7 +20,7 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Content Component router constructor
-	 * 
+	 *
 	 * @param   JApplicationCms  $app   The application object
 	 * @param   JMenu            $menu  The menu object to work with
 	 */
@@ -54,14 +54,14 @@ class ContentRouter extends JComponentRouterView
 		}
 		else
 		{
-			require_once JPATH_SITE . '/components/com_content/helpers/legacyrouter.php';
+			JLoader::register('ContentRouterRulesLegacy', __DIR__ . '/helpers/legacyrouter.php');
 			$this->attachRule(new ContentRouterRulesLegacy($this));
 		}
 	}
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -94,7 +94,7 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -107,7 +107,7 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for an article
-	 * 
+	 *
 	 * @param   string  $id     ID of the article to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -141,7 +141,7 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the id for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
 	 *
@@ -177,10 +177,10 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getCategoriesId($segment, $query)
@@ -190,10 +190,10 @@ class ContentRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for an article
-	 * 
+	 *
 	 * @param   string  $segment  Segment of the article to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getArticleId($segment, $query)

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -20,7 +20,7 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Newsfeeds Component router constructor
-	 * 
+	 *
 	 * @param   JApplicationCms  $app   The application object
 	 * @param   JMenu            $menu  The menu object to work with
 	 */
@@ -51,14 +51,14 @@ class NewsfeedsRouter extends JComponentRouterView
 		}
 		else
 		{
-			require_once JPATH_SITE . '/components/com_newsfeeds/helpers/legacyrouter.php';
+			JLoader::register('NewsfeedsRouterRulesLegacy', __DIR__ . '/helpers/legacyrouter.php');
 			$this->attachRule(new NewsfeedsRouterRulesLegacy($this));
 		}
 	}
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -90,7 +90,7 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $id     ID of the category to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -103,7 +103,7 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a newsfeed
-	 * 
+	 *
 	 * @param   string  $id     ID of the newsfeed to retrieve the segments for
 	 * @param   array   $query  The request that is build right now
 	 *
@@ -137,7 +137,7 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the id for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
 	 *
@@ -173,10 +173,10 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a category
-	 * 
+	 *
 	 * @param   string  $segment  Segment to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getCategoriesId($segment, $query)
@@ -186,10 +186,10 @@ class NewsfeedsRouter extends JComponentRouterView
 
 	/**
 	 * Method to get the segment(s) for a newsfeed
-	 * 
+	 *
 	 * @param   string  $segment  Segment of the newsfeed to retrieve the ID for
 	 * @param   array   $query    The request that is parsed right now
-	 * 
+	 *
 	 * @return  mixed   The id of this item or false
 	 */
 	public function getNewsfeedId($segment, $query)

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -18,7 +18,7 @@ class UsersRouter extends JComponentRouterView
 {
 	/**
 	 * Users Component router constructor
-	 * 
+	 *
 	 * @param   JApplicationCms  $app   The application object
 	 * @param   JMenu            $menu  The menu object to work with
 	 */
@@ -45,7 +45,7 @@ class UsersRouter extends JComponentRouterView
 		}
 		else
 		{
-			require_once JPATH_SITE . '/components/com_users/helpers/legacyrouter.php';
+			JLoader::register('UsersRouterRulesLegacy', __DIR__ . '/helpers/legacyrouter.php');
 			$this->attachRule(new UsersRouterRulesLegacy($this));
 		}
 	}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -116,7 +116,7 @@ abstract class JHtml
 				throw new InvalidArgumentException(sprintf('%s %s not found.', $prefix, $file), 500);
 			}
 
-			require_once $path;
+			JLoader::register($className, $path);
 
 			if (!class_exists($className))
 			{

--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -912,13 +912,9 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		{
 			$manifestScriptFile = $this->parent->getPath('source') . '/' . $manifestScript;
 
-			if (is_file($manifestScriptFile))
-			{
-				// Load the file
-				include_once $manifestScriptFile;
-			}
-
 			$classname = $this->getScriptClassName();
+
+			JLoader::register($classname, $manifestScriptFile);
 
 			if (class_exists($classname))
 			{

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -341,14 +341,10 @@ class JInstallerAdapterFile extends JInstallerAdapter
 			{
 				$manifestScriptFile = $this->parent->getPath('extension_root') . '/' . $manifestScript;
 
-				if (is_file($manifestScriptFile))
-				{
-					// Load the file
-					include_once $manifestScriptFile;
-				}
-
 				// Set the class name
 				$classname = $row->element . 'InstallerScript';
+
+				JLoader::register($classname, $manifestScriptFile);
 
 				if (class_exists($classname))
 				{

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -569,14 +569,10 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		{
 			$manifestScriptFile = $this->parent->getPath('extension_root') . '/' . $manifestScript;
 
-			if (is_file($manifestScriptFile))
-			{
-				// Load the file
-				include_once $manifestScriptFile;
-			}
-
 			// Set the class name
 			$classname = $element . 'InstallerScript';
+
+			JLoader::register($classname, $manifestScriptFile);
 
 			if (class_exists($classname))
 			{

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -523,14 +523,10 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 		{
 			$manifestScriptFile = $this->parent->getPath('extension_root') . '/' . $manifestScript;
 
-			if (is_file($manifestScriptFile))
-			{
-				// Load the file
-				include_once $manifestScriptFile;
-			}
-
 			// Set the class name
 			$classname = $row->element . 'InstallerScript';
+
+			JLoader::register($classname, $manifestScriptFile);
 
 			if (class_exists($classname))
 			{

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -515,16 +515,13 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		{
 			$manifestScriptFile = $this->parent->getPath('source') . '/' . $manifestScript;
 
-			if (is_file($manifestScriptFile))
-			{
-				// Load the file
-				include_once $manifestScriptFile;
-			}
 			// If a dash is present in the folder, remove it
 			$folderClass = str_replace('-', '', $row->folder);
 
 			// Set the class name
 			$classname = 'Plg' . $folderClass . $row->element . 'InstallerScript';
+
+			JLoader::register($classname, $manifestScriptFile);
 
 			if (class_exists($classname))
 			{

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -2289,7 +2289,7 @@ class JInstaller extends JAdapter
 			if (!class_exists($class))
 			{
 				// Try to load the adapter object
-				require_once $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName;
+				JLoader::register($class, $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName);
 
 				if (!class_exists($class))
 				{
@@ -2350,7 +2350,7 @@ class JInstaller extends JAdapter
 			}
 
 			// Try once more to find the class
-			require_once $path;
+			JLoader::register($class, $path);
 
 			if (!class_exists($class))
 			{

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -127,10 +127,11 @@ class JMenu
 				{
 					$path = $info->path . '/includes/menu.php';
 
-					if (file_exists($path))
+					JLoader::register($classname, $path);
+
+					if (class_exists($classname))
 					{
 						JLog::add('Non-autoloadable JMenu subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
 					}
 				}
 			}

--- a/libraries/cms/pathway/pathway.php
+++ b/libraries/cms/pathway/pathway.php
@@ -79,10 +79,11 @@ class JPathway
 				{
 					$path = $info->path . '/includes/pathway.php';
 
-					if (file_exists($path))
+					JLoader::register($classname, $path);
+
+					if (class_exists($classname))
 					{
 						JLog::add('Non-autoloadable JPathway subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
 					}
 				}
 			}

--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -184,10 +184,11 @@ class JRouter
 				{
 					$path = $info->path . '/includes/router.php';
 
-					if (file_exists($path))
+					JLoader::register($classname, $path);
+
+					if (class_exists($classname))
 					{
 						JLog::add('Non-autoloadable JRouter subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
 					}
 				}
 			}

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -731,14 +731,8 @@ class JRouterSite extends JRouter
 
 			if (!class_exists($class))
 			{
-				// Use the component routing handler if it exists
-				$path = JPATH_SITE . '/components/' . $component . '/router.php';
-
-				// Use the custom routing handler if it exists
-				if (file_exists($path))
-				{
-					require_once $path;
-				}
+				// Add the custom routing handler to the autoloader if it exists
+				JLoader::register($class, JPATH_SITE . '/components/' . $component . '/router.php');
 			}
 
 			if (class_exists($class))

--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -138,9 +138,9 @@ class JAdapter extends JObject
 		}
 
 		// Try to load the adapter object
-		require_once $fullpath;
-
 		$class = $this->_classprefix . ucfirst($name);
+
+		JLoader::register($class, $fullpath);
 
 		if (!class_exists($class))
 		{

--- a/libraries/joomla/cache/controller.php
+++ b/libraries/joomla/cache/controller.php
@@ -102,7 +102,7 @@ class JCacheController
 				throw new RuntimeException('Unable to load Cache Controller: ' . $type, 500);
 			}
 
-			include_once $path;
+			JLoader::register($class, $path);
 
 			// The class should now be loaded
 			if (!class_exists($class))

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -158,7 +158,7 @@ class JCacheStorage
 				throw new JCacheExceptionUnsupported(sprintf('Unable to load Cache Storage: %s', $handler));
 			}
 
-			include_once $path;
+			JLoader::register($class, $path);
 
 			// The class should now be loaded
 			if (!class_exists($class))

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -292,10 +292,11 @@ class JDocument
 				// @deprecated 4.0 - JDocument objects should be autoloaded instead
 				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
 
-				if (file_exists($path))
+				JLoader::register($class, $path);
+
+				if (class_exists($class))
 				{
 					JLog::add('Non-autoloadable JDocument subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-					require_once $path;
 				}
 				// Default to the raw format
 				else
@@ -1124,8 +1125,9 @@ class JDocument
 					throw new RuntimeException('Unable to load renderer class', 500);
 				}
 
+				JLoader::register($class, $path);
+
 				JLog::add('Non-autoloadable JDocumentRenderer subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-				require_once $path;
 
 				// If the class still doesn't exist after including the path, we've got issues
 				if (!class_exists($class))

--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -206,12 +206,13 @@ class JFormHelper
 		foreach ($paths as $path)
 		{
 			$file = JPath::find($path, $type);
+
 			if (!$file)
 			{
 				continue;
 			}
 
-			require_once $file;
+			JLoader::register($class, $file);
 
 			if (class_exists($class))
 			{

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -233,10 +233,7 @@ class JLanguage
 
 		while (!class_exists($class) && $path)
 		{
-			if (file_exists($path))
-			{
-				require_once $path;
-			}
+			JLoader::register($class, $path);
 
 			$path = next($paths);
 		}

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -65,7 +65,7 @@ abstract class JSessionStorage
 					throw new JSessionExceptionUnsupported('Unable to load session storage class: ' . $name);
 				}
 
-				require_once $path;
+				JLoader::register($class, $path);
 
 				// The class should now be loaded
 				if (!class_exists($class))

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -286,7 +286,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 				if ($tryThis = JPath::find($paths[$pathIndex++], strtolower($type) . '.php'))
 				{
 					// Import the class file.
-					include_once $tryThis;
+					JLoader::register($tableClass, $tryThis);
 				}
 			}
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -141,11 +141,9 @@ class JCategories
 		{
 			$path = JPATH_SITE . '/components/' . $component . '/helpers/category.php';
 
-			if (is_file($path))
-			{
-				include_once $path;
-			}
-			else
+			JLoader::register($classname, $path);
+
+			if (!class_exists($classname))
 			{
 				return false;
 			}

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -274,18 +274,19 @@ class JControllerLegacy extends JObject
 		// Include the class if not present.
 		if (!class_exists($class))
 		{
-			// If the controller file path exists, include it.
-			if (file_exists($path))
+			JLoader::register($class, $path);
+
+			if (!class_exists($class))
 			{
-				require_once $path;
-			}
-			elseif (isset($backuppath) && file_exists($backuppath))
-			{
-				require_once $backuppath;
-			}
-			else
-			{
-				throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
+				if (isset($backuppath) && file_exists($backuppath))
+				{
+					JLoader::register($class, $backuppath);
+				}
+
+				if (!class_exists($class))
+				{
+					throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
+				}
 			}
 		}
 
@@ -585,7 +586,7 @@ class JControllerLegacy extends JObject
 				return null;
 			}
 
-			require_once $path;
+			JLoader::register($viewClass, $path);
 
 			if (!class_exists($viewClass))
 			{

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -191,7 +191,7 @@ abstract class JModelLegacy extends JObject
 				return false;
 			}
 
-			require_once $path;
+			JLoader::register($modelClass, $path);
 
 			if (!class_exists($modelClass))
 			{

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -12,9 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\String\StringHelper;
 
 $com_path = JPATH_SITE . '/components/com_content/';
-require_once $com_path . 'helpers/route.php';
 
-JModelLegacy::addIncludePath($com_path . '/models', 'ContentModel');
+JLoader::register('ContentHelperRoute', $com_path . 'helpers/route.php');
+JModelLegacy::addIncludePath($com_path . 'models', 'ContentModel');
 
 /**
  * Helper for mod_articles_category

--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -251,14 +251,6 @@ class PlgFinderCategories extends FinderIndexerAdapter
 
 		$item->setLanguage();
 
-		// Need to import component route helpers dynamically, hence the reason it's handled here.
-		$path = JPATH_SITE . '/components/' . $item->extension . '/helpers/route.php';
-
-		if (is_file($path))
-		{
-			include_once $path;
-		}
-
 		$extension = ucfirst(substr($item->extension, 4));
 
 		// Initialize the item parameters.
@@ -290,6 +282,9 @@ class PlgFinderCategories extends FinderIndexerAdapter
 		$item->url = $this->getUrl($item->id, $item->extension, $this->layout);
 
 		$class = $extension . 'HelperRoute';
+
+		// Need to import component route helpers dynamically, hence the reason it's handled here.
+		JLoader::register($class, JPATH_SITE . '/components/' . $item->extension . '/helpers/route.php');
 
 		if (class_exists($class) && method_exists($class, 'getCategoryRoute'))
 		{


### PR DESCRIPTION
### Summary of Changes

Continued from #10881 and #10882 manual imports of files are replaced where practical with making use of the class autoloader.
### Testing Instructions

Areas with changes this time include:
- `com_categories` and it loading classes from other components
- The Smart Search indexer
- `com_ajax` and how it loads the helper files
- Component routers when using legacy structures
- `JHtml` in general
- Extension manifest scripts
- The extension adapters themselves
- The cache API components
- The loader methods in `JDocument`
- `JLanguage` and its loading of a localise class
- Components of the `JForm` API
- MVC Layer

Pre- and post- patch all object should load as expected
### Documentation Changes Required

Make the decision that the preferred best practice is to use the autoloader over include statements like these, since some insist on being able to overload classes this helps with being able to do that and since the CMS doesn't have a service layer this is the next best option.
