### PR TITLE
[4.0] B/C Break - Recompose JApplicationCli to extend the Framework

### DIFF
--- a/administrator/includes/helper.php
+++ b/administrator/includes/helper.php
@@ -30,8 +30,14 @@ class JAdministratorHelper
 		$app = JFactory::getApplication();
 		$option = strtolower($app->input->get('option'));
 
-		$app->loadIdentity();
 		$user = $app->getIdentity();
+
+		if (!$user)
+		{
+			$app->loadIdentity(JFactory::getUser());
+
+			$user = $app->getIdentity();
+		}
 
 		if ($user->get('guest') || !$user->authorise('core.login.admin'))
 		{

--- a/cli/deletefiles.php
+++ b/cli/deletefiles.php
@@ -50,7 +50,7 @@ class DeletefilesCli extends JApplicationCli
 	 *
 	 * @since   3.0
 	 */
-	public function doExecute()
+	protected function doExecute()
 	{
 		// Import the dependencies
 		jimport('joomla.filesystem.file');
@@ -60,10 +60,7 @@ class DeletefilesCli extends JApplicationCli
 		JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
 
 		// Instantiate the class
-		$class = new JoomlaInstallerScript;
-
-		// Run the delete method
-		$class->deleteUnexistingFiles();
+		(new JoomlaInstallerScript)->deleteUnexistingFiles();
 	}
 }
 

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -100,7 +100,7 @@ class FinderCli extends JApplicationCli
 	 *
 	 * @since   2.5
 	 */
-	public function doExecute()
+	protected function doExecute()
 	{
 		// Print a blank line.
 		$this->out(JText::_('FINDER_CLI'));

--- a/cli/garbagecron.php
+++ b/cli/garbagecron.php
@@ -38,10 +38,9 @@ class GarbageCron extends JApplicationCli
 	 *
 	 * @since   2.5
 	 */
-	public function doExecute()
+	protected function doExecute()
 	{
-		$cache = JFactory::getCache();
-		$cache->gc();
+		JFactory::getCache()->gc();
 	}
 }
 

--- a/cli/update_cron.php
+++ b/cli/update_cron.php
@@ -51,7 +51,7 @@ class Updatecron extends JApplicationCli
 	 *
 	 * @since   2.5
 	 */
-	public function doExecute()
+	protected function doExecute()
 	{
 		// Get the update cache time
 		$component = JComponentHelper::getComponent('com_installer');

--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -10,10 +10,10 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\AbstractApplication;
+use Joomla\Cms\Application\EventAware;
+use Joomla\Cms\Application\IdentityAware;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
-use Joomla\Event\DispatcherInterface;
-use Joomla\Event\Event;
 use Joomla\Registry\Registry;
 
 /**
@@ -25,15 +25,7 @@ use Joomla\Registry\Registry;
  */
 abstract class JApplicationBase extends AbstractApplication implements DispatcherAwareInterface
 {
-	use DispatcherAwareTrait;
-
-	/**
-	 * The application identity object.
-	 *
-	 * @var    JUser
-	 * @since  12.1
-	 */
-	protected $identity;
+	use DispatcherAwareTrait, EventAware, IdentityAware;
 
 	/**
 	 * Class constructor.
@@ -56,108 +48,6 @@ abstract class JApplicationBase extends AbstractApplication implements Dispatche
 	}
 
 	/**
-	 * Get the application identity.
-	 *
-	 * @return  mixed  A JUser object or null.
-	 *
-	 * @since   12.1
-	 */
-	public function getIdentity()
-	{
-		return $this->identity;
-	}
-
-	/**
-	 * Registers a handler to a particular event group.
-	 *
-	 * @param   string    $event    The event name.
-	 * @param   callable  $handler  The handler, a function or an instance of an event object.
-	 *
-	 * @return  JApplicationBase  The application to allow chaining.
-	 *
-	 * @since   12.1
-	 */
-	public function registerEvent($event, $handler)
-	{
-		try
-		{
-			$this->getDispatcher()->addListener($event, $handler);
-		}
-		catch (UnexpectedValueException $e)
-  		{
-			// No dispatcher is registered, don't throw an error (mimics old behavior)
-  		}
-
-		return $this;
-	}
-
-	/**
-	 * Calls all handlers associated with an event group.
-	 *
-	 * This is a legacy method, implementing old-style (Joomla! 3.x) plugin calls. It's best to go directly through the
-	 * Dispatcher and handle the returned EventInterface object instead of going through this method. This method is
-	 * deprecated and will be removed in Joomla! 5.x.
-	 *
-	 * This method will only return the 'result' argument of the event
-	 *
-	 * @param   string        $eventName  The event name.
-	 * @param   array|Event   $args       An array of arguments or an Event object (optional).
-	 *
-	 * @return  array   An array of results from each function call, or null if no dispatcher is defined.
-	 *
-	 * @since       12.1
-	 * @throws      InvalidArgumentException
-	 * @deprecated  5.0
-	 */
-	public function triggerEvent($eventName, $args = array())
-	{
-		$dispatcher = $this->getDispatcher();
-
-		if ($this->dispatcher instanceof DispatcherInterface)
-		{
-			if ($args instanceof Event)
-			{
-				$event = $args;
-			}
-			elseif (is_array($args))
-			{
-				$event = new Event($eventName, $args);
-			}
-			else
-			{
-				throw new InvalidArgumentException('The arguments must either be an event or an array');
-			}
-
-			$result = $dispatcher->dispatch($eventName, $event);
-
-			// TODO - There are still test cases where the result isn't defined, temporarily leave the isset check in place
-			return !isset($result['result']) || is_null($result['result']) ? [] : $result['result'];
-		}
-
-		return;
-	}
-
-	/**
-	 * Allows the application to load a custom or default identity.
-	 *
-	 * The logic and options for creating this object are adequately generic for default cases
-	 * but for many applications it will make sense to override this method and create an identity,
-	 * if required, based on more specific needs.
-	 *
-	 * @param   JUser  $identity  An optional identity object. If omitted, the factory user is created.
-	 *
-	 * @return  JApplicationBase This method is chainable.
-	 *
-	 * @since   12.1
-	 */
-	public function loadIdentity(JUser $identity = null)
-	{
-		$this->identity = ($identity === null) ? JFactory::getUser() : $identity;
-
-		return $this;
-	}
-
-	/**
 	 * Method to run the application routines.  Most likely you will want to instantiate a controller
 	 * and execute it, or perform some sort of task directly.
 	 *
@@ -170,5 +60,4 @@ abstract class JApplicationBase extends AbstractApplication implements Dispatche
 	{
 		return;
 	}
-
 }

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Cli\CliOutput;
+use Joomla\Cms\Application\Autoconfigurable;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 
@@ -21,6 +22,8 @@ use Joomla\Registry\Registry;
  */
 class JApplicationCli extends JApplicationBase
 {
+	use Autoconfigurable;
+
 	/**
 	 * @var    CliOutput  The output type.
 	 * @since  3.3
@@ -85,7 +88,10 @@ class JApplicationCli extends JApplicationBase
 			$this->config = new Registry;
 		}
 
-		$this->setDispatcher($dispatcher);
+		if ($dispatcher)
+		{
+			$this->setDispatcher($dispatcher);
+		}
 
 		// Load the configuration object.
 		$this->loadConfiguration($this->fetchConfigurationData());
@@ -144,30 +150,6 @@ class JApplicationCli extends JApplicationBase
 
 		// Trigger the onAfterExecute event.
 		$this->triggerEvent('onAfterExecute');
-	}
-
-	/**
-	 * Load an object or array into the application configuration object.
-	 *
-	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
-	 *
-	 * @return  JApplicationCli  Instance of $this to allow chaining.
-	 *
-	 * @since   11.1
-	 */
-	public function loadConfiguration($data)
-	{
-		// Load the data into the configuration object.
-		if (is_array($data))
-		{
-			$this->config->loadArray($data);
-		}
-		elseif (is_object($data))
-		{
-			$this->config->loadObject($data);
-		}
-
-		return $this;
 	}
 
 	/**
@@ -236,51 +218,5 @@ class JApplicationCli extends JApplicationBase
 	public function in()
 	{
 		return rtrim(fread(STDIN, 8192), "\n");
-	}
-
-	/**
-	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
-	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
-	 * for your specific application.
-	 *
-	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
-	 *                          in JPATH_CONFIGURATION will be used.
-	 * @param   string  $class  The class name to instantiate.
-	 *
-	 * @return  mixed   Either an array or object to be loaded into the configuration object.
-	 *
-	 * @since   11.1
-	 */
-	protected function fetchConfigurationData($file = '', $class = 'JConfig')
-	{
-		// Instantiate variables.
-		$config = array();
-
-		if (empty($file))
-		{
-			$file = JPATH_CONFIGURATION . '/configuration.php';
-
-			// Applications can choose not to have any configuration data by not implementing this method and not having a config file.
-			if (!file_exists($file))
-			{
-				$file = '';
-			}
-		}
-
-		if (!empty($file))
-		{
-			JLoader::register($class, $file);
-
-			if (class_exists($class))
-			{
-				$config = new $class;
-			}
-			else
-			{
-				throw new RuntimeException('Configuration class does not exist.');
-			}
-		}
-
-		return $config;
 	}
 }

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -97,6 +97,7 @@ abstract class JApplicationCli extends AbstractCliApplication implements Dispatc
 	 * @return  JApplicationCli
 	 *
 	 * @since   11.1
+	 * @throws  RuntimeException
 	 */
 	public static function getInstance($name = null)
 	{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -9,6 +9,7 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Cms\Application\Autoconfigurable;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
 use Joomla\String\StringHelper;
@@ -21,6 +22,8 @@ use Joomla\String\StringHelper;
  */
 class JApplicationWeb extends JApplicationBase
 {
+	use Autoconfigurable;
+
 	/**
 	 * @var    string  Character encoding string.
 	 * @since  11.3
@@ -550,30 +553,6 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
-	 * Load an object or array into the application configuration object.
-	 *
-	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function loadConfiguration($data)
-	{
-		// Load the data into the configuration object.
-		if (is_array($data))
-		{
-			$this->config->loadArray($data);
-		}
-		elseif (is_object($data))
-		{
-			$this->config->loadObject($data);
-		}
-
-		return $this;
-	}
-
-	/**
 	 * Set/get cachable state for the response.  If $allow is set, sets the cachable state of the
 	 * response.  Always returns the current state.
 	 *
@@ -868,54 +847,6 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		return trim($uri);
-	}
-
-	/**
-	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
-	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
-	 * for your specific application.
-	 *
-	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
-	 *                          in JPATH_CONFIGURATION will be used.
-	 * @param   string  $class  The class name to instantiate.
-	 *
-	 * @return  mixed   Either an array or object to be loaded into the configuration object.
-	 *
-	 * @since   11.3
-	 * @throws  RuntimeException
-	 */
-	protected function fetchConfigurationData($file = '', $class = 'JConfig')
-	{
-		// Instantiate variables.
-		$config = array();
-
-		if (empty($file))
-		{
-			$file = JPATH_CONFIGURATION . '/configuration.php';
-
-			// Applications can choose not to have any configuration data
-			// by not implementing this method and not having a config file.
-			if (!file_exists($file))
-			{
-				$file = '';
-			}
-		}
-
-		if (!empty($file))
-		{
-			JLoader::register($class, $file);
-
-			if (class_exists($class))
-			{
-				$config = new $class;
-			}
-			else
-			{
-				throw new RuntimeException('Configuration class does not exist.');
-			}
-		}
-
-		return $config;
 	}
 
 	/**

--- a/libraries/src/Cms/Application/Autoconfigurable.php
+++ b/libraries/src/Cms/Application/Autoconfigurable.php
@@ -35,6 +35,7 @@ trait Autoconfigurable
 	 * @return  mixed   Either an array or object to be loaded into the configuration object.
 	 *
 	 * @since   4.0
+	 * @throws  \RuntimeException
 	 */
 	protected function fetchConfigurationData($file = '', $class = 'JConfig')
 	{
@@ -58,7 +59,7 @@ trait Autoconfigurable
 
 			if (!class_exists($class))
 			{
-				throw new RuntimeException('Configuration class does not exist.');
+				throw new \RuntimeException('Configuration class does not exist.');
 			}
 
 			$config = new $class;

--- a/libraries/src/Cms/Application/Autoconfigurable.php
+++ b/libraries/src/Cms/Application/Autoconfigurable.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Application;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Trait for application classes which can automatically retrieve the global configuration
+ *
+ * @since  4.0
+ */
+trait Autoconfigurable
+{
+	/**
+	 * The application configuration object.
+	 *
+	 * @var    Registry
+	 * @since  4.0
+	 */
+	protected $config;
+
+	/**
+	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.
+	 *
+	 * @param   string  $file   The path and filename of the configuration file. If not provided, configuration.php
+	 *                          in JPATH_CONFIGURATION will be used.
+	 * @param   string  $class  The class name to instantiate.
+	 *
+	 * @return  mixed   Either an array or object to be loaded into the configuration object.
+	 *
+	 * @since   4.0
+	 */
+	protected function fetchConfigurationData($file = '', $class = 'JConfig')
+	{
+		// Instantiate variables.
+		$config = [];
+
+		if (empty($file))
+		{
+			$file = JPATH_CONFIGURATION . '/configuration.php';
+
+			// Applications can choose not to have any configuration data by not implementing this method and not having a config file.
+			if (!file_exists($file))
+			{
+				$file = '';
+			}
+		}
+
+		if (!empty($file))
+		{
+			\JLoader::register($class, $file);
+
+			if (!class_exists($class))
+			{
+				throw new RuntimeException('Configuration class does not exist.');
+			}
+
+			$config = new $class;
+		}
+
+		return $config;
+	}
+
+	/**
+	 * Load an object or array into the application configuration object.
+	 *
+	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
+	 *
+	 * @return  $this
+	 *
+	 * @since   4.0
+	 */
+	public function loadConfiguration($data)
+	{
+		// Load the data into the configuration object.
+		if (is_array($data))
+		{
+			$this->config->loadArray($data);
+		}
+		elseif (is_object($data))
+		{
+			$this->config->loadObject($data);
+		}
+
+		return $this;
+	}
+}

--- a/libraries/src/Cms/Application/EventAware.php
+++ b/libraries/src/Cms/Application/EventAware.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Application;
+
+use Joomla\Event\DispatcherInterface;
+use Joomla\Event\Event;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Trait for application classes which dispatch events
+ *
+ * @since  4.0
+ */
+trait EventAware
+{
+	/**
+	 * Get the event dispatcher.
+	 *
+	 * @return  DispatcherInterface
+	 *
+	 * @since   4.0
+	 * @throws  \UnexpectedValueException May be thrown if the dispatcher has not been set.
+	 */
+	abstract public function getDispatcher();
+
+	/**
+	 * Get the logger.
+	 *
+	 * @return  LoggerInterface
+	 *
+	 * @since   4.0
+	 */
+	abstract public function getLogger();
+
+	/**
+	 * Registers a handler to a particular event group.
+	 *
+	 * @param   string    $event    The event name.
+	 * @param   callable  $handler  The handler, a function or an instance of an event object.
+	 *
+	 * @return  $this
+	 *
+	 * @since   4.0
+	 */
+	public function registerEvent($event, $handler)
+	{
+		try
+		{
+			$this->getDispatcher()->addListener($event, $handler);
+		}
+		catch (\UnexpectedValueException $e)
+  		{
+			// No dispatcher is registered, don't throw an error (mimics old behavior)
+  		}
+
+		return $this;
+	}
+
+	/**
+	 * Calls all handlers associated with an event group.
+	 *
+	 * This is a legacy method, implementing old-style (Joomla! 3.x) plugin calls. It's best to go directly through the
+	 * Dispatcher and handle the returned EventInterface object instead of going through this method. This method is
+	 * deprecated and will be removed in Joomla! 5.x.
+	 *
+	 * This method will only return the 'result' argument of the event
+	 *
+	 * @param   string        $eventName  The event name.
+	 * @param   array|Event   $args       An array of arguments or an Event object (optional).
+	 *
+	 * @return  array   An array of results from each function call, or null if no dispatcher is defined.
+	 *
+	 * @since       4.0
+	 * @throws      \InvalidArgumentException
+	 * @deprecated  5.0
+	 */
+	public function triggerEvent($eventName, $args = [])
+	{
+		try
+		{
+			$dispatcher = $this->getDispatcher();
+		}
+		catch (\UnexpectedValueException $exception)
+		{
+			$this->getLogger()->error(sprintf('Dispatcher not set in %s, cannot trigger events.', get_class($this)));
+
+			return [];
+		}
+
+		if ($args instanceof Event)
+		{
+			$event = $args;
+		}
+		elseif (is_array($args))
+		{
+			$event = new Event($eventName, $args);
+		}
+		else
+		{
+			throw new \InvalidArgumentException('The arguments must either be an event or an array');
+		}
+
+		$result = $dispatcher->dispatch($eventName, $event);
+
+		// TODO - There are still test cases where the result isn't defined, temporarily leave the isset check in place
+		return !isset($result['result']) || is_null($result['result']) ? [] : $result['result'];
+	}
+}

--- a/libraries/src/Cms/Application/IdentityAware.php
+++ b/libraries/src/Cms/Application/IdentityAware.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Application;
+
+/**
+ * Trait for application classes which are identity (user) aware
+ *
+ * @since  4.0
+ */
+trait IdentityAware
+{
+	/**
+	 * The application identity object.
+	 *
+	 * @var    \JUser
+	 * @since  4.0
+	 */
+	protected $identity;
+
+	/**
+	 * Get the application identity.
+	 *
+	 * @return  \JUser
+	 *
+	 * @since   4.0
+	 */
+	public function getIdentity()
+	{
+		return $this->identity;
+	}
+
+	/**
+	 * Allows the application to load a custom or default identity.
+	 *
+	 * @param   \JUser  $identity  An optional identity object. If omitted, a null user object is created.
+	 *
+	 * @return  $this
+	 *
+	 * @since   4.0
+	 */
+	public function loadIdentity(\JUser $identity = null)
+	{
+		$this->identity = $identity ?: \JUser::getInstance();
+
+		return $this;
+	}
+}

--- a/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
@@ -106,7 +106,7 @@ class JApplicationCliTest extends TestCase
 			->method('test')
 			->willReturn('ok');
 
-		$class = $this->getMock('JApplicationCli', array(), array($mockInput, $mockConfig, $mockDispatcher));
+		$class = $this->getMockForAbstractClass('JApplicationCli', array($mockInput, $mockConfig, null, null, $mockDispatcher));
 
 		$this->assertEquals('ok', $class->input->test(), 'Tests input injection.');
 		$this->assertEquals('ok', TestReflection::getValue($class, 'config')->test(), 'Tests config injection.');
@@ -232,10 +232,6 @@ class JApplicationCliTest extends TestCase
 	 */
 	public function testGet()
 	{
-		$config = new Registry(array('foo' => 'bar'));
-
-		TestReflection::getValue($this->class, 'config', $config);
-
 		$this->assertEquals('bar', $this->class->get('foo', 'bar'), 'Checks a known configuration setting is returned.');
 		$this->assertEquals('car', $this->class->get('goo', 'car'), 'Checks an unknown configuration setting returns the default.');
 	}
@@ -258,14 +254,21 @@ class JApplicationCliTest extends TestCase
 		TestReflection::setValue('JApplicationCli', 'instance', 'foo');
 
 		$this->assertEquals('foo', JApplicationCli::getInstance('JApplicationCliInspector'), 'Tests that singleton value is returned.');
+	}
 
+	/**
+	 * Tests the JApplicationCli::getInstance method for an unexisting class.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 * @expectedException  RuntimeException
+	 */
+	public function testGetInstanceForUnexistingClass()
+	{
 		TestReflection::setValue('JApplicationCli', 'instance', null);
 
-		$this->assertInstanceOf(
-			'JApplicationCli',
-			JApplicationCli::getInstance('Foo'),
-			'Tests that getInstance will instantiate a valid child class of JApplicationCli given a non-existent type.'
-		);
+		JApplicationCli::getInstance('Foo');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

`JApplicationCli` is recomposed to inherit from the Framework's `Joomla\Application\AbstractCliApplication` class now.  This allows the CMS app class to use all features from the Framework.

To do so without losing features, several behaviors from the CMS app class chain are moved into traits and those are now used as appropriate.

This also follows through with the noted change to `JApplicationCli` to make it abstract.
### Testing Instructions

For CLI applications, they should continue to function as is with no changes.  The changes I did make to the `doExecute` method signatures just causes the visibility to match the parent definition.

Web applications should work too.  Because of the trait implementations their code is reshuffled a bit but nothing changes from a practical standpoint.
### Documentation Changes Required

The class inheritance for `JApplicationCli` has changed, this will break `instanceof` checks.

3.x:
- `JApplicationCli`
- `JApplicationBase`
- `Joomla\Application\AbstractApplication`

4.0:
- `JApplicationCli`
- `Joomla\Application\AbstractCliApplication`
- `Joomla\Application\AbstractApplication`

Also, as documented, `JApplicationCli` is now abstract.
