### PR TITLE
[JAccess] Calculate if user is super user using JAccess preloading (3.7.x)

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -149,6 +149,12 @@ class JAccess
 		$action = strtolower(preg_replace('#[\s\-]+#', '.', trim($action)));
 		$asset  = strtolower(preg_replace('#[\s\-]+#', '.', trim($asset)));
 
+		// If guest user, checking core.admin in root asset (aka super user) no need to check, just return false.
+		if ($userId === 0 && $action === 'core.admin' && in_array($asset, array(null, 1, 'root.1')))
+		{
+			return false;
+		}
+
 		// Default to the root asset node.
 		if (empty($asset))
 		{

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -375,7 +375,7 @@ class JUser extends JObject
 			{
 				$this->isRoot = true;
 			}
-			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin', 'root.1'))
+			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin'))
 			{
 				$this->isRoot = true;
 			}

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -350,13 +350,13 @@ class JUser extends JObject
 	 * object and optionally an access extension object
 	 *
 	 * @param   string  $action     The name of the action to check for permission.
-	 * @param   string  $assetname  The name of the asset on which to perform the action.
+	 * @param   string  $assetName  The name of the asset on which to perform the action.
 	 *
 	 * @return  boolean  True if authorised
 	 *
 	 * @since   11.1
 	 */
-	public function authorise($action, $assetname = null)
+	public function authorise($action, $assetName = null)
 	{
 		// Make sure we only check for core.admin once during the run.
 		if ($this->isRoot === null)
@@ -375,22 +375,13 @@ class JUser extends JObject
 			{
 				$this->isRoot = true;
 			}
-			elseif ($this->id > 0)
+			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin', 'root.1'))
 			{
-				// Get all groups against which the user is mapped.
-				$identities = $this->getAuthorisedGroups();
-				array_unshift($identities, $this->id * -1);
-
-				if (JAccess::getAssetRules(1)->allow('core.admin', $identities))
-				{
-					$this->isRoot = true;
-
-					return true;
-				}
+				$this->isRoot = true;
 			}
 		}
 
-		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetname);
+		return $this->isRoot ? true : JAccess::check($this->id, $action, $assetName);
 	}
 
 	/**

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -375,7 +375,7 @@ class JUser extends JObject
 			{
 				$this->isRoot = true;
 			}
-			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin'))
+			elseif ($this->id > 0 && JAccess::check($this->id, 'core.admin', 'root.1'))
 			{
 				$this->isRoot = true;
 			}


### PR DESCRIPTION
### Summary of Changes

This PR aims to improve performance in super user calculation by taking advantage of asset access preloading.

The following tests were made with a super user logged in frontend homepage in sample multilingual site.
### Before

![image](https://cloud.githubusercontent.com/assets/9630530/18617462/7ade987c-7dc7-11e6-87bb-9210e4d82903.png)
### After

![image](https://cloud.githubusercontent.com/assets/9630530/18617473/c312d4be-7dc7-11e6-96c8-2e6ef73137a4.png)
### Testing Instructions
1. Code review.
2. Apply patch on 3.7.x branch.
3. Login and logout with a super user and without a superuser.
4. Check if super user permissions are ALWAYS correctly identified in all circunstances.

Note: Please test this careful as this is the super user permissions ...
### Documentation Changes Required

None.

mantainers please confirm the root asset is always called `root.1` and id is always `1`
