### PR TITLE
[j4.0] Page Navigation: Show the title by default

### DIFF
--- a/plugins/content/pagenavigation/pagenavigation.xml
+++ b/plugins/content/pagenavigation/pagenavigation.xml
@@ -48,7 +48,7 @@
 					type="list"
 					label="PLG_PAGENAVIGATION_FIELD_DISPLAY_LABEL"
 					description="PLG_PAGENAVIGATION_FIELD_DISPLAY_DESC"
-					default="0"
+					default="1"
 					>
 					<option value="0">PLG_PAGENAVIGATION_FIELD_VALUE_NEXTPREV</option>
 					<option value="1">PLG_PAGENAVIGATION_FIELD_VALUE_TITLE</option>


### PR DESCRIPTION
### Summary of Changes

When enabling the page navigation, by default it shows two buttons labelled "Previous" and "Next".
This patch changes the default behavior so that it instead shows the next/previous article name as label.
### Testing Instructions
1. Enable the "Page navigation" plugin
2. Verify that it shows the page titles instead of "Previous"/"Next" on the buttons.
### Documentation Changes Required

None
