### PR TITLE
Added optional suffix text to Mass Mail Form page

### DIFF
--- a/administrator/components/com_users/views/mail/tmpl/default.php
+++ b/administrator/components/com_users/views/mail/tmpl/default.php
@@ -39,11 +39,13 @@ JFactory::getDocument()->addScriptDeclaration($script);
 			<fieldset class="adminform">
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('subject'); ?></div>
-					<div class="controls"><?php echo $this->form->getInput('subject'); ?></div>
+					<div class="controls"><?php echo JComponentHelper::getParams('com_users')->get('mailSubjectPrefix'); ?>
+						<?php echo $this->form->getInput('subject'); ?></div>
 				</div>
 				<div class="control-group">
 					<div class="control-label"><?php echo $this->form->getLabel('message'); ?></div>
-					<div class="controls"><?php echo $this->form->getInput('message'); ?></div>
+					<div class="controls"><?php echo $this->form->getInput('message'); ?><br>
+						<?php echo JComponentHelper::getParams('com_users')->get('mailBodySuffix'); ?></div>
 				</div>
 			</fieldset>
 			<input type="hidden" name="task" value="" />


### PR DESCRIPTION
The "**Mass Mail Users**" functionality has an option to **add a Suffix before the Subject**, and some **Mailbody Suffix** to the end of the mail. You can configure that via Users > Mass Mail > [Options] > [Mass Mail].
### Summary of Changes

This PR adds the optional default **Subject Prefix** and **Mailbody Suffix** to the view of the Mass Mail form so that it is clear if, and what, Joomla will add to the mass mail.
### Testing Instructions
#### Before the PR:

backend: Users > Mass Mail (Users) > [Options]
Configure some Subject + Mailbody suffix.

![mass-mail-config](https://cloud.githubusercontent.com/assets/1217850/18632221/96f0e524-7e76-11e6-8ecd-71ced7d7fac6.png)

Go to the Mass Mail form:
Users > Mass Mail (Users) 

![mass-mail-form-before](https://cloud.githubusercontent.com/assets/1217850/18632220/96edb520-7e76-11e6-8771-5005e46e9ef3.png)
#### After the PR:

Go to the Mass Mail form: Users > Mass Mail (Users) 
It should show the configured Subject Suffix before the Subject field,
and the configured Mailbody Suffix below the Mail Text field.

![mass-mail-form-after](https://cloud.githubusercontent.com/assets/1217850/18632219/96ed527e-7e76-11e6-84da-22925efd6cca.png)
