### PR TITLE
User Groups - removed label: enabled/disabled users

### DIFF
--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -66,13 +66,13 @@ JFactory::getDocument()->addScriptDeclaration('
 						<th class="nowrap">
 							<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_GROUP_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
-						<th width="1%" class="nowrap center">
-							<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></i>
-							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
+						<th width="1%" class="nowrap center hidden-phone hidden-tablet">
+							<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"
+							   data-original-title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></i>
 						</th>
-						<th width="1%" class="nowrap center">
-							<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></i>
-							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
+						<th width="1%" class="nowrap center hidden-phone hidden-tablet">
+							<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"
+							   data-original-title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></i>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>


### PR DESCRIPTION
On the **User Groups** page is the layout of the **columns** **Enabled users** and **Disabled users** and their columns are IMHO not nice. 
### Summary of Changes

This PR removes the text labels **Enabled users** and **Disabled users** so that the layout looks better and **more in consistent** with the similar columns of the **item counters on the Category page** (Content > Categories) 

![article-categories](https://cloud.githubusercontent.com/assets/1217850/18653260/f328fe82-7ed8-11e6-8837-eeddfafb6072.png)
### Testing Instructions
#### Before the PR:

backend: Users > User Groups

![users-groups-enabled-disabled-users-before](https://cloud.githubusercontent.com/assets/1217850/18653261/f3297e52-7ed8-11e6-890b-de09e2dd6095.png)
#### After the PR:

backend: Users > User Groups

![users-groups-enabled-disabled-users-after](https://cloud.githubusercontent.com/assets/1217850/18653262/f32a84e6-7ed8-11e6-9652-e4cb47486462.png)
