### PR TITLE
Config Menus - blue bar with Fieldset Description

### DIFF
--- a/administrator/components/com_menus/config.xml
+++ b/administrator/components/com_menus/config.xml
@@ -3,7 +3,7 @@
 	<fieldset
 		name="page-options"
 		label="COM_MENUS_PAGE_OPTIONS_LABEL"
-		>
+		description="COM_MENUS_PAGE_OPTIONS_FIELDSET_DESC">
 
 		<field
 			name="page_title"

--- a/administrator/language/en-GB/en-GB.com_menus.ini
+++ b/administrator/language/en-GB/en-GB.com_menus.ini
@@ -148,6 +148,7 @@ COM_MENUS_MENU_TYPE_NOT_ALLOWED="This is a reserved menutype."
 COM_MENUS_MENUS_FILTER_SEARCH_DESC="Search in title and menu type."
 COM_MENUS_MENUS_FILTER_SEARCH_LABEL="Search Menus"
 COM_MENUS_PAGE_OPTIONS_LABEL="Page Display"
+COM_MENUS_PAGE_OPTIONS_FIELDSET_DESC="Configure default page display settings."
 ; in the following string
 ; %1$s is for module title, %2$s is for access-title, %3$s is for position
 COM_MENUS_MODULE_ACCESS_POSITION="%1$s <small>(%2$s in %3$s)</small>"


### PR DESCRIPTION
Most **Component Configuration Options** have under the option tab **a blue bar with a description**

### Summary of Changes

This PR **adds a blue bar** with description **to Menus: Options**.

### Testing Instructions
#### Before the PR:
backend: System > Global Configuration > (in Left menu) Menus > [**Page display**]

![info-label-options-menus-pagedisplay-before](https://cloud.githubusercontent.com/assets/1217850/18654453/7b65fc66-7ee1-11e6-8d61-6aa56a5e1441.png)

#### After the PR:
backend: System > Global Configuration > (in Left menu) Menus > [**Page display**]

![info-label-options-menus-pagedisplay-after](https://cloud.githubusercontent.com/assets/1217850/18654452/7b63b942-7ee1-11e6-82a9-e33f5465bbea.png)
