### PR TITLE
Travis is unable to handle node_js tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ matrix:
   allow_failures:
     - php: 7.1
     - php: hhvm
+    - node_js: 6.1
 
 services:
   - memcache


### PR DESCRIPTION
@wilsonge it looks like travis is not able to execute the js tests regulary so we need to disable that again :(
