### PR TITLE
Config News Feeds - changed title: News Feed: Options

### DIFF
--- a/administrator/language/en-GB/en-GB.com_newsfeeds.ini
+++ b/administrator/language/en-GB/en-GB.com_newsfeeds.ini
@@ -15,7 +15,7 @@ COM_NEWSFEEDS_CATEGORIES_DESC="These settings apply for News Feeds Categories Op
 COM_NEWSFEEDS_CHANGE_FEED="Select or Change News Feed"
 ; COM_NEWSFEEDS_CHANGE_FEED_BUTTON is deprecated, use COM_NEWSFEEDS_CHANGE_FEED instead;
 COM_NEWSFEEDS_CHANGE_FEED_BUTTON="Select Feed"
-COM_NEWSFEEDS_CONFIGURATION="News Feed: Options"
+COM_NEWSFEEDS_CONFIGURATION="News Feeds: Options"
 COM_NEWSFEEDS_EDIT_NEWSFEED="Edit News Feed"
 COM_NEWSFEEDS_ERROR_UNIQUE_ALIAS="Another News feed from this category has the same alias (remember it may be a trashed item)."
 COM_NEWSFEEDS_ERROR_ALL_LANGUAGE_ASSOCIATED="A news feed item set to All languages can't be associated. Associations have not been set."


### PR DESCRIPTION
The **Title** of the configuration view **News Feed: Options** is **different** (singular) from the **News Feeds** title in the list of Components on the Global Configuration page.

![configure-components-plural-single-newsfeeds-both-before](https://cloud.githubusercontent.com/assets/1217850/18664544/4d64a0aa-7f23-11e6-8342-d1ba518b52d9.png)
### Testing Instructions
#### Before the PR:

Backend: System > Global Configuration > under COMPONENT (left menu)
Click on Configure Menu Title: **News Feeds** (= plural).
The Title " **News Feed**: Options" is singular.

![configure-components-plural-single-newsfeeds-before](https://cloud.githubusercontent.com/assets/1217850/18664531/3db3d63a-7f23-11e6-8869-af378cf154fd.png)
#### After the PR:

Backend: System > Global Configuration > under COMPONENT (left menu)
Click on Configure Menu Title: **News Feeds**.
The Title " **News Feeds**: Options" is plural too.

![configure-components-plural-single-newsfeeds-after](https://cloud.githubusercontent.com/assets/1217850/18664532/3db50460-7f23-11e6-942f-ce62ac173cfe.png)
