### PR TITLE
Fix elements with tooltip disappearing after mouseover

### DIFF
--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -461,7 +461,7 @@ abstract class JHtmlBootstrap
 			$options = JHtml::getJSObject($opt);
 
 			// Build the script.
-			$script = array('$(' . json_encode($selector) . ').tooltip(' . $options . ')');
+			$script = array('$(' . json_encode($selector) . ').tooltip(' . $options . ').each(function(){this.show = null; this.hide = null;})');
 
 			if ($onShow)
 			{


### PR DESCRIPTION
This happens when Mootools is loaded on the same page, and is caused by a conflict with Mootools' tooltip function.

To test the bug, simply load jQuery and Mootools on the same page, then initialize some elements with jQuery tooltips, then mouseover them. They will disappear on mouseleave.
