### PR TITLE
[3.7.x] Set new counts too center in the backend article view

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -68,12 +68,12 @@ $assoc = JLanguageAssociations::isEnabled();
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-					<?php if ($assoc) : ?>
-						<?php $columns++; ?>
-						<th width="5%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
-						</th>
-					<?php endif;?>
+						<?php if ($assoc) : ?>
+							<?php $columns++; ?>
+							<th width="5%" class="nowrap hidden-phone">
+								<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif;?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort',  'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 						</th>
@@ -86,16 +86,16 @@ $assoc = JLanguageAssociations::isEnabled();
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 						</th>
-					<?php if ($this->vote) : ?>
-						<?php $columns++; ?>
-						<th width="1%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
-						</th>
-						<?php $columns++; ?>
-						<th width="1%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
-						</th>
-					<?php endif;?>
+						<?php if ($this->vote) : ?>
+							<?php $columns++; ?>
+							<th width="1%" class="nowrap hidden-phone">
+								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
+							</th>
+							<?php $columns++; ?>
+							<th width="1%" class="nowrap hidden-phone">
+								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif;?>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -208,18 +208,18 @@ $assoc = JLanguageAssociations::isEnabled();
 						<td class="nowrap small hidden-phone">
 							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 						</td>
-						<td class="hidden-phone">
+						<td class="hidden-phone center">
 							<span class="badge badge-info">
 								<?php echo (int) $item->hits; ?>
 							</span>
 						</td>
 						<?php if ($this->vote) : ?>
-							<td class="hidden-phone">
+							<td class="hidden-phone center">
 								<span class="badge badge-success" >
 								<?php echo (int) $item->rating_count; ?>
 								</span>
 							</td>
-							<td class="hidden-phone">
+							<td class="hidden-phone center">
 								<span class="badge badge-warning" >
 								<?php echo (int) $item->rating; ?>
 								</span>


### PR DESCRIPTION
### Summary of Changes
- Moves the new colums to center
- minimal cs
### Testing Instructions
- install 3.7.x
- go to the backend artikles view
- see:
  ![image](https://cloud.githubusercontent.com/assets/2596554/18679567/79c952b6-7f60-11e6-941b-e7eb40f10f76.png)
- apply patch
- see that the counts are now center
  ![image](https://cloud.githubusercontent.com/assets/2596554/18679743/2df41fd2-7f61-11e6-86d5-2bf0d2111ea4.png)
### Documentation Changes Required

none
