### PR TITLE
Add big red warning flag that the app classes are very tightly coupled to sessions in JFactory

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -758,7 +758,13 @@ class JApplicationCms extends JApplicationWeb
 
 		$this->registerEvent('onAfterSessionStart', array($this, 'afterSessionStart'));
 
-		// There's an internal coupling to the session object being present in JFactory, need to deal with this at some point
+		/*
+		 * Note: The below code CANNOT change from instantiating a session via JFactory until there is a proper dependency injection container supported
+		 * by the application. The current default behaviours result in this method being called each time an application class is instantiated meaning
+		 * each application will attempt to start a new session. https://github.com/joomla/joomla-cms/issues/12108 explains why things will crash and
+		 * burn if you ever attempt to make this change without a proper dependency injection container.
+		 */
+
 		$session = JFactory::getSession($options);
 		$session->initialise($this->input, $this->dispatcher);
 		$session->start();


### PR DESCRIPTION
### Summary of Changes

Adds a big red warning flag that Joomla has a very tight internal dependency to the global singleton factory and that any attempt to ever change this code results in things crashing and burning catastrophically because of the crappy tight internal dependency to the global singleton factory.
### Testing Instructions

Review
### Documentation Changes Required

N/A
