### PR TITLE
[4.0] Add onBeforeExecute event

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -230,6 +230,35 @@ final class InstallationApplicationWeb extends JApplicationCms
 	}
 
 	/**
+	 * Execute the application.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function execute()
+	{
+		// Perform application routines.
+		$this->doExecute();
+
+		// If we have an application document object, render it.
+		if ($this->document instanceof JDocument)
+		{
+			// Render the application output.
+			$this->render();
+		}
+
+		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
+		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
+		{
+			$this->compress();
+		}
+
+		// Send the application response.
+		$this->respond();
+	}
+
+	/**
 	 * Method to load a PHP configuration class file based on convention and return the instantiated data object.  You
 	 * will extend this method in child classes to provide configuration data from whatever data source is relevant
 	 * for your specific application.

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Cms\Event\AbstractEvent;
+use Joomla\Cms\Event\BeforeExecuteEvent;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
@@ -300,6 +302,20 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 	 */
 	public function execute()
 	{
+		JPluginHelper::importPlugin('system');
+
+		// Trigger the onBeforeExecute event.
+		$this->triggerEvent(
+			'onBeforeExecute',
+			AbstractEvent::create(
+				'onBeforeExecute',
+				[
+					'subject'    => $this,
+					'eventClass' => BeforeExecuteEvent::class,
+				]
+			)
+		);
+
 		// Perform application routines.
 		$this->doExecute();
 

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -316,6 +316,9 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 			)
 		);
 
+		// Mark beforeExecute in the profiler.
+		JDEBUG ? $this->profiler->mark('beforeExecute event dispatched') : null;
+
 		// Perform application routines.
 		$this->doExecute();
 

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -575,22 +575,6 @@ final class JApplicationSite extends JApplicationCms
 			$user->groups = array($guestUsergroup);
 		}
 
-		/*
-		 * If a language was specified it has priority, otherwise use user or default language settings
-		 * Check this only if the languagefilter plugin is enabled
-		 *
-		 * @TODO - Remove the hardcoded dependency to the languagefilter plugin
-		 */
-		if (JPluginHelper::isEnabled('system', 'languagefilter'))
-		{
-			$plugin = JPluginHelper::getPlugin('system', 'languagefilter');
-
-			$pluginParams = new Registry($plugin->params);
-
-			$this->setLanguageFilter(true);
-			$this->setDetectBrowser($pluginParams->get('detect_browser', '1') == '1');
-		}
-
 		if (empty($options['language']))
 		{
 			// Detect the specified language

--- a/libraries/src/Cms/Event/BeforeExecuteEvent.php
+++ b/libraries/src/Cms/Event/BeforeExecuteEvent.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Event;
+
+use Joomla\Application\AbstractApplication;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Event class for representing the application's `onBeforeExecute` event
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BeforeExecuteEvent extends AbstractImmutableEvent
+{
+	/**
+	 * Get the event's application object
+	 *
+	 * @return  AbstractApplication
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getApplication()
+	{
+		return $this->getArgument('subject');
+	}
+}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Cms\Event\BeforeExecuteEvent;
 use Joomla\Registry\Registry;
 
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
@@ -161,6 +162,30 @@ class PlgSystemLanguageFilter extends JPlugin
 		{
 			$this->app->set('sitename', $this->lang_codes[$this->current_lang]->sitename);
 		}
+	}
+
+	/**
+	 * Listener for the onBeforeExecute event
+	 *
+	 * @param   BeforeExecuteEvent  $event
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function onBeforeExecute(BeforeExecuteEvent $event)
+	{
+		/** @var JApplicationCms $app */
+		$app = $event->getApplication();
+
+		if (!$app->isSite())
+		{
+			return;
+		}
+
+		// If a language was specified it has priority, otherwise use user or default language settings
+		$app->setLanguageFilter(true);
+		$app->setDetectBrowser($this->params->get('detect_browser', '1') == '1');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

The parent application classes support the notion of a `onBeforeExecute` event but we don't use it.  Now we will.

The site application has a hardcoded dependency to the parameters of the languagefilter plugin for proper language detection when enabled.  This is because the parameters are set before the first event in the system currently, `onAfterInitialise`.  Triggering an event before these parameters are read lets things work as expected.

This also demonstrates the new plugin system and the use of event objects, as well as demonstrating how a plugin can listen for both styles of events.
### Testing Instructions

Multilanguage features still work.
### Documentation Changes Required

Document the new `onBeforeExecute` event.
