### PR TITLE
[4.0] Updated Session Package

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -393,16 +393,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/session.git",
-                "reference": "144cd6bc1d268e3777963cef6f5f705ebe22d9c0"
+                "reference": "927573d3208cec451b8a61c2916d97a1ef280a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/session/zipball/144cd6bc1d268e3777963cef6f5f705ebe22d9c0",
-                "reference": "144cd6bc1d268e3777963cef6f5f705ebe22d9c0",
+                "url": "https://api.github.com/repos/joomla-framework/session/zipball/927573d3208cec451b8a61c2916d97a1ef280a32",
+                "reference": "927573d3208cec451b8a61c2916d97a1ef280a32",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4|>=7.0"
+                "php": "^5.5.9|~7.0"
             },
             "require-dev": {
                 "joomla/database": "~2.0@dev",
@@ -415,9 +415,16 @@
                 "squizlabs/php_codesniffer": "1.*"
             },
             "suggest": {
+                "ext-apc": "To use APC cache as a session handler",
+                "ext-apcu": "To use APCu cache as a session handler",
+                "ext-memcache": "To use a Memcache server as a session handler",
+                "ext-memcached": "To use a Memcached server as a session handler",
+                "ext-redis": "To use a Redis server as a session handler",
+                "ext-wincache": "To use WinCache as a session handler",
+                "ext-xcache": "To use XCache as a session handler",
                 "joomla/database": "Install joomla/database if you want to use Database session storage.",
                 "joomla/event": "The joomla/event package is required to use Joomla\\Session\\Session.",
-                "joomla/input": "The joomla/input package is required to use Joomla\\Session\\Session.",
+                "joomla/input": "The joomla/input package is required to use Address and Forwarded session validators.",
                 "paragonie/random_compat": "The paragonie/random_compat package is required to use Joomla\\Session\\Session on PHP 5.x."
             },
             "type": "joomla-package",
@@ -442,7 +449,7 @@
                 "joomla",
                 "session"
             ],
-            "time": "2016-05-24 11:57:24"
+            "time": "2016-09-21 10:28:18"
         },
         {
             "name": "joomla/string",

--- a/installation/service/provider/session.php
+++ b/installation/service/provider/session.php
@@ -8,6 +8,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Cms\Session\Storage\JoomlaStorage;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Input\Input;
@@ -55,7 +56,7 @@ class InstallationServiceProviderSession implements ServiceProviderInterface
 					// Set up the storage handler
 					$handler = new FilesystemHandler(JPATH_INSTALLATION . '/sessions');
 
-					$storage = new JSessionStorageJoomla($handler, array(), JFactory::getApplication()->input);
+					$storage = new JoomlaStorage($handler, array(), JFactory::getApplication()->input);
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
 					$dispatcher->addListener('onAfterSessionStart', array($app, 'afterSessionStart'));

--- a/libraries/src/Cms/Service/Provider/Session.php
+++ b/libraries/src/Cms/Service/Provider/Session.php
@@ -14,13 +14,13 @@ defined('JPATH_PLATFORM') or die;
 use InvalidArgumentException;
 use JApplicationHelper;
 use JFactory;
+use Joomla\Cms\Session\Storage\JoomlaStorage;
 use Joomla\Cms\Session\Validator\AddressValidator;
 use Joomla\Cms\Session\Validator\ForwardedValidator;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Session\Handler;
 use JSession;
-use JSessionStorageJoomla;
 use Memcache;
 use Memcached;
 use Redis;
@@ -208,7 +208,7 @@ class Session implements ServiceProviderInterface
 
 					$input = JFactory::getApplication()->input;
 
-					$storage = new JSessionStorageJoomla($handler, array('cookie_lifetime' => $lifetime), $input);
+					$storage = new JoomlaStorage($handler, array('cookie_lifetime' => $lifetime), $input);
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
 					$dispatcher->addListener('onAfterSessionStart', array(JFactory::getApplication(), 'afterSessionStart'));

--- a/libraries/src/Cms/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Cms/Session/Storage/JoomlaStorage.php
@@ -47,13 +47,13 @@ class JoomlaStorage extends NativeStorage
 	/**
 	 * Constructor
 	 *
-	 * @param   SessionHandlerInterface  $handler  Session save handler
-	 * @param   array                    $options  Session options
-	 * @param   \JInput                  $input    Input object
+	 * @param   \SessionHandlerInterface  $handler  Session save handler
+	 * @param   array                     $options  Session options
+	 * @param   \JInput                   $input    Input object
 	 *
 	 * @since   4.0
 	 */
-	public function __construct(SessionHandlerInterface $handler = null, array $options = array(), \JInput $input)
+	public function __construct(\SessionHandlerInterface $handler = null, array $options = array(), \JInput $input)
 	{
 		// Disable transparent sid support
 		ini_set('session.use_trans_sid', '0');

--- a/libraries/src/Cms/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Cms/Session/Storage/JoomlaStorage.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * @package     Joomla.Libraries
- * @subpackage  Session
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
+
+namespace Joomla\Cms\Session\Storage;
 
 defined('JPATH_PLATFORM') or die;
 
@@ -17,7 +18,7 @@ use Joomla\Session\Storage\NativeStorage;
  *
  * @since  4.0
  */
-class JSessionStorageJoomla extends NativeStorage
+class JoomlaStorage extends NativeStorage
 {
 	/**
 	 * Internal data store for the session data
@@ -38,7 +39,7 @@ class JSessionStorageJoomla extends NativeStorage
 	/**
 	 * Input object
 	 *
-	 * @var    JInput
+	 * @var    \JInput
 	 * @since  4.0
 	 */
 	private $input;
@@ -48,11 +49,11 @@ class JSessionStorageJoomla extends NativeStorage
 	 *
 	 * @param   SessionHandlerInterface  $handler  Session save handler
 	 * @param   array                    $options  Session options
-	 * @param   JInput                   $input    Input object
+	 * @param   \JInput                  $input    Input object
 	 *
 	 * @since   4.0
 	 */
-	public function __construct(SessionHandlerInterface $handler = null, array $options = array(), JInput $input)
+	public function __construct(SessionHandlerInterface $handler = null, array $options = array(), \JInput $input)
 	{
 		// Disable transparent sid support
 		ini_set('session.use_trans_sid', '0');
@@ -101,7 +102,7 @@ class JSessionStorageJoomla extends NativeStorage
 		 */
 		if (isset($_COOKIE[$session_name]))
 		{
-			$config        = JFactory::getConfig();
+			$config        = \JFactory::getConfig();
 			$cookie_domain = $config->get('cookie_domain', '');
 			$cookie_path   = $config->get('cookie_path', '/');
 			setcookie($session_name, '', time() - 42000, $cookie_path, $cookie_domain);
@@ -228,7 +229,7 @@ class JSessionStorageJoomla extends NativeStorage
 			$cookie['secure'] = true;
 		}
 
-		$config = JFactory::getConfig();
+		$config = \JFactory::getConfig();
 
 		if ($config->get('cookie_domain', '') != '')
 		{

--- a/libraries/src/Cms/Session/Validator/AddressValidator.php
+++ b/libraries/src/Cms/Session/Validator/AddressValidator.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Session\Validator;
+
+use Joomla\Session\Exception\InvalidSessionException;
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AddressValidator implements ValidatorInterface
+{
+	/**
+	 * The input object.
+	 *
+	 * @var    \JInput
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   \JInput           $input    The input object
+	 * @param   SessionInterface  $session  The session object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(\JInput $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidSessionException
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.address', null);
+		}
+
+		$remoteAddr = $this->input->server->getString('REMOTE_ADDR', '');
+
+		// Check for client address
+		if (!empty($remoteAddr) && filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false)
+		{
+			$ip = $this->session->get('session.client.address');
+
+			if ($ip === null)
+			{
+				$this->session->set('session.client.address', $remoteAddr);
+			}
+			elseif ($remoteAddr !== $ip)
+			{
+				throw new InvalidSessionException('Invalid client IP');
+			}
+		}
+	}
+}

--- a/libraries/src/Cms/Session/Validator/ForwardedValidator.php
+++ b/libraries/src/Cms/Session/Validator/ForwardedValidator.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\Session\Validator;
+
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ForwardedValidator implements ValidatorInterface
+{
+	/**
+	 * The input object.
+	 *
+	 * @var    \JInput
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   \JInput           $input    The input object
+	 * @param   SessionInterface  $session  The session object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(\JInput $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.forwarded', null);
+		}
+
+		$xForwardedFor = $this->input->server->getString('HTTP_X_FORWARDED_FOR', '');
+
+		// Record proxy forwarded for in the session in case we need it later
+		if (!empty($xForwardedFor) && filter_var($xForwardedFor, FILTER_VALIDATE_IP) !== false)
+		{
+			$this->session->set('session.client.forwarded', $xForwardedFor);
+		}
+	}
+}

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -1028,16 +1028,16 @@
         "source": {
             "type": "git",
             "url": "https://github.com/joomla-framework/session.git",
-            "reference": "144cd6bc1d268e3777963cef6f5f705ebe22d9c0"
+            "reference": "927573d3208cec451b8a61c2916d97a1ef280a32"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/session/zipball/144cd6bc1d268e3777963cef6f5f705ebe22d9c0",
-            "reference": "144cd6bc1d268e3777963cef6f5f705ebe22d9c0",
+            "url": "https://api.github.com/repos/joomla-framework/session/zipball/927573d3208cec451b8a61c2916d97a1ef280a32",
+            "reference": "927573d3208cec451b8a61c2916d97a1ef280a32",
             "shasum": ""
         },
         "require": {
-            "php": ">=5.4|>=7.0"
+            "php": "^5.5.9|~7.0"
         },
         "require-dev": {
             "joomla/database": "~2.0@dev",
@@ -1050,12 +1050,19 @@
             "squizlabs/php_codesniffer": "1.*"
         },
         "suggest": {
+            "ext-apc": "To use APC cache as a session handler",
+            "ext-apcu": "To use APCu cache as a session handler",
+            "ext-memcache": "To use a Memcache server as a session handler",
+            "ext-memcached": "To use a Memcached server as a session handler",
+            "ext-redis": "To use a Redis server as a session handler",
+            "ext-wincache": "To use WinCache as a session handler",
+            "ext-xcache": "To use XCache as a session handler",
             "joomla/database": "Install joomla/database if you want to use Database session storage.",
             "joomla/event": "The joomla/event package is required to use Joomla\\Session\\Session.",
-            "joomla/input": "The joomla/input package is required to use Joomla\\Session\\Session.",
+            "joomla/input": "The joomla/input package is required to use Address and Forwarded session validators.",
             "paragonie/random_compat": "The paragonie/random_compat package is required to use Joomla\\Session\\Session on PHP 5.x."
         },
-        "time": "2016-05-24 11:57:24",
+        "time": "2016-09-21 10:28:18",
         "type": "joomla-package",
         "extra": {
             "branch-alias": {

--- a/libraries/vendor/joomla/session/src/Exception/InvalidSessionException.php
+++ b/libraries/vendor/joomla/session/src/Exception/InvalidSessionException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Exception;
+
+/**
+ * Exception thrown when a session validator fails
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class InvalidSessionException extends \RuntimeException
+{
+}

--- a/libraries/vendor/joomla/session/src/Validator/AddressValidator.php
+++ b/libraries/vendor/joomla/session/src/Validator/AddressValidator.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Validator;
+
+use Joomla\Input\Input;
+use Joomla\Session\Exception\InvalidSessionException;
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AddressValidator implements ValidatorInterface
+{
+	/**
+	 * The Input object.
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   Input             $input    The input object
+	 * @param   SessionInterface  $session  DispatcherInterface for the session to use.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Input $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidSessionException
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.address', null);
+		}
+
+		$remoteAddr = $this->input->server->getString('REMOTE_ADDR', '');
+
+		// Check for client address
+		if (!empty($remoteAddr) && filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false)
+		{
+			$ip = $this->session->get('session.client.address');
+
+			if ($ip === null)
+			{
+				$this->session->set('session.client.address', $remoteAddr);
+			}
+			elseif ($remoteAddr !== $ip)
+			{
+				throw new InvalidSessionException('Invalid client IP');
+			}
+		}
+	}
+}

--- a/libraries/vendor/joomla/session/src/Validator/ForwardedValidator.php
+++ b/libraries/vendor/joomla/session/src/Validator/ForwardedValidator.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Validator;
+
+use Joomla\Input\Input;
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ForwardedValidator implements ValidatorInterface
+{
+	/**
+	 * The Input object.
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   Input             $input    The input object
+	 * @param   SessionInterface  $session  DispatcherInterface for the session to use.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Input $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.forwarded', null);
+		}
+
+		$xForwardedFor = $this->input->server->getString('HTTP_X_FORWARDED_FOR', '');
+
+		// Record proxy forwarded for in the session in case we need it later
+		if (!empty($xForwardedFor) && filter_var($xForwardedFor, FILTER_VALIDATE_IP) !== false)
+		{
+			$this->session->set('session.client.forwarded', $xForwardedFor);
+		}
+	}
+}

--- a/libraries/vendor/joomla/session/src/ValidatorInterface.php
+++ b/libraries/vendor/joomla/session/src/ValidatorInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session;
+
+use Joomla\Session\Exception\InvalidSessionException;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ValidatorInterface
+{
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidSessionException
+	 */
+	public function validate($restart = false);
+}


### PR DESCRIPTION
### Summary of Changes

Updates the session package to the latest development head and makes use of the new validators API.  Since `JInput` does not currently extend `Joomla\Input\Input` the validators are copied from the Framework and updated to use the CMS' class for now.

This also namespaces `JSessionStorageJoomla`.
### Testing Instructions

Sessions continue working.
### Documentation Changes Required

N/A; the new API's documented in the Framework repo's docs and is a transparent change to the CMS' user base.
