### PR TITLE
[3.x] Deprecate keychain for 4.0

### DIFF
--- a/bin/keychain.php
+++ b/bin/keychain.php
@@ -5,6 +5,8 @@
  *
  * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
+ *
+ * @deprecated  4.0  Deprecated without replacement
  */
 
 // Make sure we're being called from the command line, not a web interface

--- a/libraries/joomla/keychain/keychain.php
+++ b/libraries/joomla/keychain/keychain.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Keychain Class
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Deprecated without replacement
  */
 class JKeychain extends \Joomla\Registry\Registry
 {


### PR DESCRIPTION
Pull Request for 3.6.3
### Summary of Changes

Deprecate the not used lib keychain for 4.0
### Testing Instructions

Code review
### Documentation Changes Required

None in 3.x as it still works
