### PR TITLE
[admin sidebar toggle] Correct HTML error (div doesn't support type=button)

### DIFF
--- a/layouts/joomla/sidebars/toggle.php
+++ b/layouts/joomla/sidebars/toggle.php
@@ -16,7 +16,6 @@ JText::script('JTOGGLE_SHOW_SIDEBAR');
 <div
 	id="j-toggle-sidebar-button"
 	class="j-toggle-sidebar-button hidden-phone hasTooltip"
-	type="button"
 	onclick="toggleSidebar(false); return false;"
 	>
 		<span id="j-toggle-sidebar-icon" class="icon-arrow-left-2"></span>


### PR DESCRIPTION
### Summary of Changes

Simple PR to Correct HTML error in the admin sidebar toggle button. (div element doesn't support type=button)

![image](https://cloud.githubusercontent.com/assets/9630530/18723700/9b09dbea-8031-11e6-8943-73565c6cc511.png)
### Testing Instructions

Code review.
### Documentation Changes Required

None.
