### PR TITLE
Custom calendar is not applied to version history preview and compare dates

### DIFF
--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -74,7 +74,45 @@ class ContenthistoryModelCompare extends JModelItem
 					$object = new stdClass;
 					$object->data = ContenthistoryHelper::prepareData($table);
 					$object->version_note = $table->version_note;
-					$object->save_date = $table->save_date;
+
+					// Let's use custom calendars when present
+					$object->save_date = JHtml::_('date', $table->save_date, 'Y-m-d H:i:s');
+
+					if (array_key_exists('modified_time', $object->data) && $object->data->modified_time->value != '0000-00-00 00:00:00')
+					{
+						$object->data->modified_time->value = JHtml::_('date', $object->data->modified_time->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('created_time', $object->data) && $object->data->created_time->value != '0000-00-00 00:00:00')
+					{
+						$object->data->created_time->value = JHtml::_('date', $object->data->created_time->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('modified', $object->data) && $object->data->modified->value != '0000-00-00 00:00:00')
+					{
+						$object->data->modified->value = JHtml::_('date', $object->data->modified->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('created', $object->data) && $object->data->created->value != '0000-00-00 00:00:00')
+					{
+						$object->data->created->value = JHtml::_('date', $object->data->created->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('checked_out_time', $object->data) && $object->data->checked_out_time->value != '0000-00-00 00:00:00')
+					{
+						$object->data->checked_out_time->value = JHtml::_('date', $object->data->checked_out_time->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('publish_up', $object->data) && $object->data->publish_up->value != '0000-00-00 00:00:00')
+					{
+						$object->data->publish_up->value = JHtml::_('date', $object->data->publish_up->value, 'Y-m-d H:i:s');
+					}
+
+					if (array_key_exists('publish_down', $object->data) && $object->data->publish_down->value != '0000-00-00 00:00:00')
+					{
+						$object->data->publish_down->value = JHtml::_('date', $object->data->publish_down->value, 'Y-m-d H:i:s');
+					}
+
 					$result[] = $object;
 				}
 

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -88,7 +88,7 @@ class ContenthistoryModelCompare extends JModelItem
 						'publish_down',
 					);
 
-					foreach($dateProperties as $dateProperty)
+					foreach ($dateProperties as $dateProperty)
 					{
 						if (array_key_exists($dateProperty, $object->data) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
 						{

--- a/administrator/components/com_contenthistory/models/compare.php
+++ b/administrator/components/com_contenthistory/models/compare.php
@@ -78,39 +78,22 @@ class ContenthistoryModelCompare extends JModelItem
 					// Let's use custom calendars when present
 					$object->save_date = JHtml::_('date', $table->save_date, 'Y-m-d H:i:s');
 
-					if (array_key_exists('modified_time', $object->data) && $object->data->modified_time->value != '0000-00-00 00:00:00')
-					{
-						$object->data->modified_time->value = JHtml::_('date', $object->data->modified_time->value, 'Y-m-d H:i:s');
-					}
+					$dateProperties = array (
+						'modified_time',
+						'created_time',
+						'modified',
+						'created',
+						'checked_out_time',
+						'publish_up',
+						'publish_down',
+					);
 
-					if (array_key_exists('created_time', $object->data) && $object->data->created_time->value != '0000-00-00 00:00:00')
+					foreach($dateProperties as $dateProperty)
 					{
-						$object->data->created_time->value = JHtml::_('date', $object->data->created_time->value, 'Y-m-d H:i:s');
-					}
-
-					if (array_key_exists('modified', $object->data) && $object->data->modified->value != '0000-00-00 00:00:00')
-					{
-						$object->data->modified->value = JHtml::_('date', $object->data->modified->value, 'Y-m-d H:i:s');
-					}
-
-					if (array_key_exists('created', $object->data) && $object->data->created->value != '0000-00-00 00:00:00')
-					{
-						$object->data->created->value = JHtml::_('date', $object->data->created->value, 'Y-m-d H:i:s');
-					}
-
-					if (array_key_exists('checked_out_time', $object->data) && $object->data->checked_out_time->value != '0000-00-00 00:00:00')
-					{
-						$object->data->checked_out_time->value = JHtml::_('date', $object->data->checked_out_time->value, 'Y-m-d H:i:s');
-					}
-
-					if (array_key_exists('publish_up', $object->data) && $object->data->publish_up->value != '0000-00-00 00:00:00')
-					{
-						$object->data->publish_up->value = JHtml::_('date', $object->data->publish_up->value, 'Y-m-d H:i:s');
-					}
-
-					if (array_key_exists('publish_down', $object->data) && $object->data->publish_down->value != '0000-00-00 00:00:00')
-					{
-						$object->data->publish_down->value = JHtml::_('date', $object->data->publish_down->value, 'Y-m-d H:i:s');
+						if (array_key_exists($dateProperty, $object->data) && $object->data->$dateProperty->value != '0000-00-00 00:00:00')
+						{
+							$object->data->$dateProperty->value = JHtml::_('date', $object->data->$dateProperty->value, 'Y-m-d H:i:s');
+						}
 					}
 
 					$result[] = $object;

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -70,39 +70,22 @@ class ContenthistoryModelPreview extends JModelItem
 			// Let's use custom calendars when present
 			$result->save_date = JHtml::_('date', $table->save_date, 'Y-m-d H:i:s');
 
-			if (array_key_exists('modified_time', $result->data) && $result->data->modified_time->value != '0000-00-00 00:00:00')
-			{
-				$result->data->modified_time->value = JHtml::_('date', $result->data->modified_time->value, 'Y-m-d H:i:s');
-			}
+			$dateProperties = array (
+				'modified_time',
+				'created_time',
+				'modified',
+				'created',
+				'checked_out_time',
+				'publish_up',
+				'publish_down',
+			);
 
-			if (array_key_exists('created_time', $result->data) && $result->data->created_time->value != '0000-00-00 00:00:00')
+			foreach($dateProperties as $dateProperty)
 			{
-				$result->data->created_time->value = JHtml::_('date', $result->data->created_time->value, 'Y-m-d H:i:s');
-			}
-
-			if (array_key_exists('modified', $result->data) && $result->data->modified->value != '0000-00-00 00:00:00')
-			{
-				$result->data->modified->value = JHtml::_('date', $result->data->modified->value, 'Y-m-d H:i:s');
-			}
-
-			if (array_key_exists('created', $result->data) && $result->data->created->value != '0000-00-00 00:00:00')
-			{
-				$result->data->created->value = JHtml::_('date', $result->data->created->value, 'Y-m-d H:i:s');
-			}
-
-			if (array_key_exists('checked_out_time', $result->data) && $result->data->checked_out_time->value != '0000-00-00 00:00:00')
-			{
-				$result->data->checked_out_time->value = JHtml::_('date', $result->data->checked_out_time->value, 'Y-m-d H:i:s');
-			}
-
-			if (array_key_exists('publish_up', $result->data) && $result->data->publish_up->value != '0000-00-00 00:00:00')
-			{
-				$result->data->publish_up->value = JHtml::_('date', $result->data->publish_up->value, 'Y-m-d H:i:s');
-			}
-
-			if (array_key_exists('publish_down', $result->data) && $result->data->publish_down->value != '0000-00-00 00:00:00')
-			{
-				$result->data->publish_down->value = JHtml::_('date', $result->data->publish_down->value, 'Y-m-d H:i:s');
+				if (array_key_exists($dateProperty, $result->data) && $result->data->$dateProperty->value != '0000-00-00 00:00:00')
+				{
+					$result->data->$dateProperty->value = JHtml::_('date', $result->data->$dateProperty->value, 'Y-m-d H:i:s');
+				}
 			}
 
 			return $result;

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -80,7 +80,7 @@ class ContenthistoryModelPreview extends JModelItem
 				'publish_down',
 			);
 
-			foreach($dateProperties as $dateProperty)
+			foreach ($dateProperties as $dateProperty)
 			{
 				if (array_key_exists($dateProperty, $result->data) && $result->data->$dateProperty->value != '0000-00-00 00:00:00')
 				{

--- a/administrator/components/com_contenthistory/models/preview.php
+++ b/administrator/components/com_contenthistory/models/preview.php
@@ -64,9 +64,46 @@ class ContenthistoryModelPreview extends JModelItem
 		if ($return == true)
 		{
 			$result = new stdClass;
-			$result->save_date = $table->save_date;
 			$result->version_note = $table->version_note;
 			$result->data = ContenthistoryHelper::prepareData($table);
+
+			// Let's use custom calendars when present
+			$result->save_date = JHtml::_('date', $table->save_date, 'Y-m-d H:i:s');
+
+			if (array_key_exists('modified_time', $result->data) && $result->data->modified_time->value != '0000-00-00 00:00:00')
+			{
+				$result->data->modified_time->value = JHtml::_('date', $result->data->modified_time->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('created_time', $result->data) && $result->data->created_time->value != '0000-00-00 00:00:00')
+			{
+				$result->data->created_time->value = JHtml::_('date', $result->data->created_time->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('modified', $result->data) && $result->data->modified->value != '0000-00-00 00:00:00')
+			{
+				$result->data->modified->value = JHtml::_('date', $result->data->modified->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('created', $result->data) && $result->data->created->value != '0000-00-00 00:00:00')
+			{
+				$result->data->created->value = JHtml::_('date', $result->data->created->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('checked_out_time', $result->data) && $result->data->checked_out_time->value != '0000-00-00 00:00:00')
+			{
+				$result->data->checked_out_time->value = JHtml::_('date', $result->data->checked_out_time->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('publish_up', $result->data) && $result->data->publish_up->value != '0000-00-00 00:00:00')
+			{
+				$result->data->publish_up->value = JHtml::_('date', $result->data->publish_up->value, 'Y-m-d H:i:s');
+			}
+
+			if (array_key_exists('publish_down', $result->data) && $result->data->publish_down->value != '0000-00-00 00:00:00')
+			{
+				$result->data->publish_down->value = JHtml::_('date', $result->data->publish_down->value, 'Y-m-d H:i:s');
+			}
 
 			return $result;
 		}


### PR DESCRIPTION
Testing instructions:
Install the fa-IR persian language pack.
Edit an article (or a category, or a newsfeed, etc.
Click on the Versions toolbar button.

Before patch:
![screen shot 2016-09-22 at 11 14 25](https://cloud.githubusercontent.com/assets/869724/18742698/f5fc4f40-80b5-11e6-9b02-663677648ec0.png)

After patch
![screen shot 2016-09-22 at 11 01 55](https://cloud.githubusercontent.com/assets/869724/18742428/7b64d140-80b4-11e6-84bb-a849e254e1dd.png)

**Note:** the order of the date in the title, although now correctly set to Jalali is not in the same order as the other date fields below. These last ones are the same as in the Manager and in the Publishing tab date fields. This is independant from this PR
This could be solved by checkingif the language is RTL and change the order of Ymd in the models.
Instead of
`$object->save_date = JHtml::_('date', $table->save_date, 'Y-m-d H:i:s');`
we could use
`$object->save_date = JHtml::_('date', $table->save_date, 'd-m-Y H:i:s');`

As I am not sure this would fit for all RTL languages, I did not do it.
Therefore, this is already much better imho as we do get the Jalali date.
