### PR TITLE
[4.0] Fix parameter order on storage object

### DIFF
--- a/installation/service/provider/session.php
+++ b/installation/service/provider/session.php
@@ -59,7 +59,7 @@ class InstallationServiceProviderSession implements ServiceProviderInterface
 
 					$input = $app->input;
 
-					$storage = new JoomlaStorage($handler, array(), $input);
+					$storage = new JoomlaStorage($input, $handler);
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
 					$dispatcher->addListener('onAfterSessionStart', array($app, 'afterSessionStart'));

--- a/libraries/src/Cms/Service/Provider/Session.php
+++ b/libraries/src/Cms/Service/Provider/Session.php
@@ -208,7 +208,7 @@ class Session implements ServiceProviderInterface
 
 					$input = JFactory::getApplication()->input;
 
-					$storage = new JoomlaStorage($handler, array('cookie_lifetime' => $lifetime), $input);
+					$storage = new JoomlaStorage($input, $handler, array('cookie_lifetime' => $lifetime));
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
 					$dispatcher->addListener('onAfterSessionStart', array(JFactory::getApplication(), 'afterSessionStart'));

--- a/libraries/src/Cms/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Cms/Session/Storage/JoomlaStorage.php
@@ -47,13 +47,13 @@ class JoomlaStorage extends NativeStorage
 	/**
 	 * Constructor
 	 *
+	 * @param   \JInput                   $input    Input object
 	 * @param   \SessionHandlerInterface  $handler  Session save handler
 	 * @param   array                     $options  Session options
-	 * @param   \JInput                   $input    Input object
 	 *
 	 * @since   4.0
 	 */
-	public function __construct(\SessionHandlerInterface $handler = null, array $options = array(), \JInput $input)
+	public function __construct(\JInput $input, \SessionHandlerInterface $handler = null, array $options = array())
 	{
 		// Disable transparent sid support
 		ini_set('session.use_trans_sid', '0');


### PR DESCRIPTION
### Summary of Changes

The store requires a `JInput` object but it is defined after two optional parameters.  Reorder the constructor.
### Testing Instructions

Sessions still work
### Documentation Changes Required

N/A
