### PR TITLE
[Joomla 4] Make JControllerLegacy no longer extend JObject

### DIFF
--- a/administrator/components/com_banners/controller.php
+++ b/administrator/components/com_banners/controller.php
@@ -40,8 +40,7 @@ class BannersController extends JControllerLegacy
 		if ($view == 'banner' && $layout == 'edit' && !$this->checkEditId('com_banners.edit.banner', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_banners&view=banners', false));
 
 			return false;
@@ -49,8 +48,7 @@ class BannersController extends JControllerLegacy
 		elseif ($view == 'client' && $layout == 'edit' && !$this->checkEditId('com_banners.edit.client', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_banners&view=clients', false));
 
 			return false;

--- a/administrator/components/com_categories/controller.php
+++ b/administrator/components/com_categories/controller.php
@@ -68,8 +68,7 @@ class CategoriesController extends JControllerLegacy
 		if ($vName == 'category' && $lName == 'edit' && !$this->checkEditId('com_categories.edit.category', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_categories&view=categories&extension=' . $this->extension, false));
 
 			return false;

--- a/administrator/components/com_contact/controller.php
+++ b/administrator/components/com_contact/controller.php
@@ -46,8 +46,7 @@ class ContactController extends JControllerLegacy
 		if ($view == 'contact' && $layout == 'edit' && !$this->checkEditId('com_contact.edit.contact', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contacts', false));
 
 			return false;

--- a/administrator/components/com_content/controller.php
+++ b/administrator/components/com_content/controller.php
@@ -42,8 +42,7 @@ class ContentController extends JControllerLegacy
 		if ($view == 'article' && $layout == 'edit' && !$this->checkEditId('com_content.edit.article', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_content&view=articles', false));
 
 			return false;

--- a/administrator/components/com_finder/controller.php
+++ b/administrator/components/com_finder/controller.php
@@ -46,8 +46,7 @@ class FinderController extends JControllerLegacy
 		if ($view == 'filter' && $layout == 'edit' && !$this->checkEditId('com_finder.edit.filter', $f_id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $f_id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $f_id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_finder&view=filters', false));
 
 			return false;

--- a/administrator/components/com_finder/controllers/filter.php
+++ b/administrator/components/com_finder/controllers/filter.php
@@ -59,8 +59,7 @@ class FinderControllerFilter extends JControllerForm
 		if (!$this->checkEditId($context, $recordId))
 		{
 			// Somehow the person just went to the form and tried to save it. We don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $recordId));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $recordId), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false));
 
 			return false;
@@ -76,8 +75,7 @@ class FinderControllerFilter extends JControllerForm
 			if ($checkin && $model->checkin($data[$key]) === false)
 			{
 				// Check-in failed. Go back to the item and display a notice.
-				$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()));
-				$this->setMessage($this->getError(), 'error');
+				$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 				$this->setRedirect('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $urlVar));
 
 				return false;
@@ -91,8 +89,7 @@ class FinderControllerFilter extends JControllerForm
 		// Access check.
 		if (!$this->allowSave($data, $key))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false));
 
 			return false;
@@ -160,8 +157,7 @@ class FinderControllerFilter extends JControllerForm
 			$app->setUserState($context . '.data', $validData);
 
 			// Redirect back to the edit screen.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 			$this->setRedirect(
 				JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $key), false)
 			);
@@ -176,8 +172,7 @@ class FinderControllerFilter extends JControllerForm
 			$app->setUserState($context . '.data', $validData);
 
 			// Check-in failed, so go back to the record and display a notice.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 			$this->setRedirect('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $key));
 
 			return false;

--- a/administrator/components/com_installer/controllers/languages.php
+++ b/administrator/components/com_installer/controllers/languages.php
@@ -42,8 +42,7 @@ class InstallerControllerLanguages extends JControllerLegacy
 
 		if (!$model->findLanguages($cache_timeout))
 		{
-			$this->setError($model->getError());
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage($model->getError(), 'error');
 		}
 
 		$this->setRedirect(JRoute::_('index.php?option=com_installer&view=languages', false));

--- a/administrator/components/com_languages/controller.php
+++ b/administrator/components/com_languages/controller.php
@@ -44,8 +44,7 @@ class LanguagesController extends JControllerLegacy
 		if ($view == 'language' && $layout == 'edit' && !$this->checkEditId('com_languages.edit.language', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_languages&view=languages', false));
 
 			return false;

--- a/administrator/components/com_languages/controllers/installed.php
+++ b/administrator/components/com_languages/controllers/installed.php
@@ -46,12 +46,12 @@ class LanguagesControllerInstalled extends JControllerLegacy
 		}
 		else
 		{
-			$msg = $this->getError();
+			$msg = $model->getError();
 			$type = 'error';
 		}
 
 		$clientId = $model->getState('client_id');
-		$this->setredirect('index.php?option=com_languages&view=installed&client=' . $clientId, $msg, $type);
+		$this->setRedirect('index.php?option=com_languages&view=installed&client=' . $clientId, $msg, $type);
 	}
 
 	/**
@@ -86,10 +86,10 @@ class LanguagesControllerInstalled extends JControllerLegacy
 		}
 		else
 		{
-			$msg = $this->getError();
+			$msg = $model->getError();
 			$type = 'error';
 		}
 
-		$this->setredirect('index.php?option=com_languages&view=installed', $msg, $type);
+		$this->setRedirect('index.php?option=com_languages&view=installed', $msg, $type);
 	}
 }

--- a/administrator/components/com_languages/controllers/override.php
+++ b/administrator/components/com_languages/controllers/override.php
@@ -38,8 +38,7 @@ class LanguagesControllerOverride extends JControllerForm
 		// Access check.
 		if (!$this->allowEdit())
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false));
 
 			return;
@@ -76,8 +75,7 @@ class LanguagesControllerOverride extends JControllerForm
 		// Access check.
 		if (!$this->allowSave($data, 'id'))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false));
 
 			return;
@@ -136,8 +134,7 @@ class LanguagesControllerOverride extends JControllerForm
 			$app->setUserState($context . '.data', $validData);
 
 			// Redirect back to the edit screen.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 			$this->setRedirect(
 				JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, 'id'), false)
 			);

--- a/administrator/components/com_media/controller.php
+++ b/administrator/components/com_media/controller.php
@@ -22,7 +22,7 @@ class MediaController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  JControllerLegacy		This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_menus/controller.php
+++ b/administrator/components/com_menus/controller.php
@@ -22,7 +22,7 @@ class MenusController extends JControllerLegacy
 	 * @param   boolean        $cachable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController    This object to support chaining.
+	 * @return  JControllerLegacy    This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -264,8 +264,7 @@ class MenusControllerItem extends JControllerForm
 		// Access check.
 		if (!$this->allowSave($data, $key))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
 				JRoute::_(

--- a/administrator/components/com_messages/controller.php
+++ b/administrator/components/com_messages/controller.php
@@ -22,7 +22,7 @@ class MessagesController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached.
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  JControllerLegacy		This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
@@ -38,8 +38,7 @@ class MessagesController extends JControllerLegacy
 		if ($view == 'message' && $layout == 'edit' && !$this->checkEditId('com_messages.edit.message', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_messages&view=messages', false));
 
 			return false;

--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -22,7 +22,7 @@ class ModulesController extends JControllerLegacy
 	 * @param   boolean        $cachable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}
 	 *
-	 * @return  JController    This object to support chaining.
+	 * @return  JControllerLegacy    This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/administrator/components/com_newsfeeds/controller.php
+++ b/administrator/components/com_newsfeeds/controller.php
@@ -38,8 +38,7 @@ class NewsfeedsController extends JControllerLegacy
 		if ($view == 'newsfeed' && $layout == 'edit' && !$this->checkEditId('com_newsfeeds.edit.newsfeed', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_newsfeeds&view=newsfeeds', false));
 
 			return false;

--- a/administrator/components/com_plugins/controller.php
+++ b/administrator/components/com_plugins/controller.php
@@ -22,7 +22,7 @@ class PluginsController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  JControllerLegacy		This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
@@ -41,8 +41,7 @@ class PluginsController extends JControllerLegacy
 		if ($view == 'plugin' && $layout == 'edit' && !$this->checkEditId('com_plugins.edit.plugin', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_plugins&view=plugins', false));
 
 			return false;

--- a/administrator/components/com_redirect/controller.php
+++ b/administrator/components/com_redirect/controller.php
@@ -28,7 +28,7 @@ class RedirectController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached.
 	 * @param   mixed    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController		This object to support chaining.
+	 * @return  JControllerLegacy		This object to support chaining.
 	 *
 	 * @since   1.5
 	 */
@@ -47,8 +47,7 @@ class RedirectController extends JControllerLegacy
 		if ($view == 'link' && $layout == 'edit' && !$this->checkEditId('com_redirect.edit.link', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_redirect&view=links', false));
 
 			return false;

--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -105,7 +105,7 @@ class RedirectControllerLinks extends JControllerAdmin
 	 * @param   string  $prefix  The prefix of the model.
 	 * @param   array   $config  An array of settings.
 	 *
-	 * @return  JModel instance
+	 * @return  JModelLegacy instance
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_tags/controller.php
+++ b/administrator/components/com_tags/controller.php
@@ -36,8 +36,7 @@ class TagsController extends JControllerLegacy
 		if ($view == 'tag' && $layout == 'edit' && !$this->checkEditId('com_tags.edit.tag', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_tags&view=tags', false));
 
 			return false;

--- a/administrator/components/com_templates/controller.php
+++ b/administrator/components/com_templates/controller.php
@@ -63,8 +63,7 @@ class TemplatesController extends JControllerLegacy
 		if ($view == 'style' && $layout == 'edit' && !$this->checkEditId('com_templates.edit.style', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_templates&view=styles', false));
 
 			return false;

--- a/administrator/components/com_users/controller.php
+++ b/administrator/components/com_users/controller.php
@@ -72,8 +72,7 @@ class UsersController extends JControllerLegacy
 		if ($view == 'user' && $layout == 'edit' && !$this->checkEditId('com_users.edit.user', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=users', false));
 
 			return false;
@@ -81,8 +80,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'group' && $layout == 'edit' && !$this->checkEditId('com_users.edit.group', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=groups', false));
 
 			return false;
@@ -90,8 +88,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'level' && $layout == 'edit' && !$this->checkEditId('com_users.edit.level', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=levels', false));
 
 			return false;
@@ -99,8 +96,7 @@ class UsersController extends JControllerLegacy
 		elseif ($view == 'note' && $layout == 'edit' && !$this->checkEditId('com_users.edit.note', $id))
 		{
 			// Somehow the person just went to the form - we don't allow that.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_UNHELD_ID', $id), 'error');
 			$this->setRedirect(JRoute::_('index.php?option=com_users&view=notes', false));
 
 			return false;

--- a/administrator/components/com_users/controllers/mail.php
+++ b/administrator/components/com_users/controllers/mail.php
@@ -46,7 +46,7 @@ class UsersControllerMail extends JControllerLegacy
 		}
 
 		$msg = $model->getError();
-		$this->setredirect('index.php?option=com_users&view=mail', $msg, $type);
+		$this->setRedirect('index.php?option=com_users&view=mail', $msg, $type);
 	}
 
 	/**

--- a/components/com_content/controller.php
+++ b/components/com_content/controller.php
@@ -50,7 +50,7 @@ class ContentController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached.
 	 * @param   boolean  $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  This object to support chaining.
+	 * @return  JControllerLegacy  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/components/com_tags/controller.php
+++ b/components/com_tags/controller.php
@@ -22,7 +22,7 @@ class TagsController extends JControllerLegacy
 	 * @param   boolean        $cachable   If true, the view output will be cached
 	 * @param   mixed|boolean  $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  This object to support chaining.
+	 * @return  JControllerLegacy  This object to support chaining.
 	 *
 	 * @since   3.1
 	 */

--- a/components/com_users/controller.php
+++ b/components/com_users/controller.php
@@ -22,7 +22,7 @@ class UsersController extends JControllerLegacy
 	 * @param   boolean  $cachable   If true, the view output will be cached
 	 * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
 	 *
-	 * @return  JController  This object to support chaining.
+	 * @return  JControllerLegacy  This object to support chaining.
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/controller/form.php
+++ b/libraries/cms/controller/form.php
@@ -150,8 +150,7 @@ class JControllerForm extends JControllerLegacy
 		if (!$this->allowAdd())
 		{
 			// Set the internal error and also the redirect error.
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -317,8 +316,7 @@ class JControllerForm extends JControllerLegacy
 				if ($model->checkin($recordId) === false)
 				{
 					// Check-in failed, go back to the record and display a notice.
-					$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()));
-					$this->setMessage($this->getError(), 'error');
+					$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 					$this->setRedirect(
 						JRoute::_(
@@ -383,8 +381,7 @@ class JControllerForm extends JControllerLegacy
 		// Access check.
 		if (!$this->allowEdit(array($key => $recordId), $key))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -400,8 +397,7 @@ class JControllerForm extends JControllerLegacy
 		if ($checkin && !$model->checkout($recordId))
 		{
 			// Check-out failed, display a notice but allow the user to see the record.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -562,8 +558,7 @@ class JControllerForm extends JControllerLegacy
 		// Access check.
 		if (!$this->allowEdit(array($key => $recordId), $key))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -644,8 +639,7 @@ class JControllerForm extends JControllerLegacy
 			if ($checkin && $model->checkin($data[$key]) === false)
 			{
 				// Check-in failed. Go back to the item and display a notice.
-				$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()));
-				$this->setMessage($this->getError(), 'error');
+				$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 				$this->setRedirect(
 					JRoute::_(
@@ -666,8 +660,7 @@ class JControllerForm extends JControllerLegacy
 		// Access check.
 		if (!$this->allowSave($data, $key))
 		{
-			$this->setError(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -738,8 +731,7 @@ class JControllerForm extends JControllerLegacy
 			$app->setUserState($context . '.data', $validData);
 
 			// Redirect back to the edit screen.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
 				JRoute::_(
@@ -758,8 +750,7 @@ class JControllerForm extends JControllerLegacy
 			$app->setUserState($context . '.data', $validData);
 
 			// Check-in failed, so go back to the record and display a notice.
-			$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()));
-			$this->setMessage($this->getError(), 'error');
+			$this->setMessage(JText::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
 			$this->setRedirect(
 				JRoute::_(

--- a/libraries/cms/controller/legacy.php
+++ b/libraries/cms/controller/legacy.php
@@ -17,7 +17,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  12.2
  */
-class JControllerLegacy extends JObject
+class JControllerLegacy
 {
 	/**
 	 * The base path of the controller


### PR DESCRIPTION
This removes the dependency of JControllerLegacy on JObject. 

Various extensions needed tweaks so that error messages are set directly with `setMessage` rather than proxying with `setError('foo')` then calling `$this->setMessage($this->getError())`
