### PR TITLE
[4.0] Error Handling Adjustments

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -473,7 +473,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 	 * @param   string  $name     The name of the application/client.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JMenu|null
+	 * @return  JMenu
 	 *
 	 * @since   3.2
 	 */
@@ -490,16 +490,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 			$options['app'] = $this;
 		}
 
-		try
-		{
-			$menu = JMenu::getInstance($name, $options);
-		}
-		catch (Exception $e)
-		{
-			return;
-		}
-
-		return $menu;
+		return JMenu::getInstance($name, $options);
 	}
 
 	/**
@@ -545,7 +536,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JPathway|null
+	 * @return  JPathway
 	 *
 	 * @since   3.2
 	 */
@@ -556,16 +547,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 			$name = $this->getName();
 		}
 
-		try
-		{
-			$pathway = JPathway::getInstance($name, $options);
-		}
-		catch (Exception $e)
-		{
-			return;
-		}
-
-		return $pathway;
+		return JPathway::getInstance($name, $options);
 	}
 
 	/**
@@ -574,7 +556,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 	 * @param   string  $name     The name of the application.
 	 * @param   array   $options  An optional associative array of configuration settings.
 	 *
-	 * @return  JRouter|null
+	 * @return  JRouter
 	 *
 	 * @since   3.2
 	 */
@@ -586,16 +568,7 @@ class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 			$name = $app->getName();
 		}
 
-		try
-		{
-			$router = JRouter::getInstance($name, $options);
-		}
-		catch (Exception $e)
-		{
-			return;
-		}
-
-		return $router;
+		return JRouter::getInstance($name, $options);
 	}
 
 	/**

--- a/libraries/joomla/archive/bzip2.php
+++ b/libraries/joomla/archive/bzip2.php
@@ -43,9 +43,9 @@ class JArchiveBzip2 implements JArchiveExtractable
 	{
 		$this->_data = null;
 
-		if (!extension_loaded('bz2'))
+		if (!static::isSupported())
 		{
-			$this->raiseWarning(100, 'The bz2 extension is not available.');
+			throw new RuntimeException('The bz2 extension is not available.');
 		}
 
 		if (isset($options['use_streams']) && $options['use_streams'] != false)
@@ -58,7 +58,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (!$this->_data)
 		{
-			return $this->raiseWarning(100, 'Unable to read archive');
+			throw new RuntimeException('Unable to read archive');
 		}
 
 		$buffer = bzdecompress($this->_data);
@@ -66,12 +66,12 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (empty($buffer))
 		{
-			return $this->raiseWarning(100, 'Unable to decompress data');
+			throw new RuntimeException('Unable to decompress data');
 		}
 
 		if (JFile::write($destination, $buffer) === false)
 		{
-			return $this->raiseWarning(100, 'Unable to write archive');
+			throw new RuntimeException('Unable to write archive');
 		}
 
 		return true;
@@ -96,7 +96,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 
 		if (!$input->open($archive))
 		{
-			return $this->raiseWarning(100, 'Unable to read archive (bz2)');
+			throw new RuntimeException('Unable to read archive (bz2)');
 
 		}
 
@@ -106,8 +106,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 		{
 			$input->close();
 
-			return $this->raiseWarning(100, 'Unable to write archive (bz2)');
-
+			throw new RuntimeException('Unable to write archive (bz2)');
 		}
 
 		do
@@ -118,7 +117,7 @@ class JArchiveBzip2 implements JArchiveExtractable
 			{
 				$input->close();
 
-				return $this->raiseWarning(100, 'Unable to write archive (bz2)');
+				throw new RuntimeException('Unable to write archive (bz2)');
 			}
 		}
 
@@ -128,27 +127,6 @@ class JArchiveBzip2 implements JArchiveExtractable
 		$input->close();
 
 		return true;
-	}
-
-	/**
-	 * Temporary private method to isolate JError from the extract method
-	 * This code should be removed when JError is removed.
-	 *
-	 * @param   int     $code  The application-internal error code for this error
-	 * @param   string  $msg   The error message, which may also be shown the user if need be.
-	 *
-	 * @return  JException  JException instance if JError class exists
-	 *
-	 * @throws  RuntimeException if JError class does not exist
-	 */
-	private function raiseWarning($code, $msg)
-	{
-		if (class_exists('JError'))
-		{
-			return JError::raiseWarning($code, $msg);
-		}
-
-		throw new RuntimeException($msg);
 	}
 
 	/**

--- a/libraries/joomla/archive/gzip.php
+++ b/libraries/joomla/archive/gzip.php
@@ -58,7 +58,7 @@ class JArchiveGzip implements JArchiveExtractable
 
 		if (!extension_loaded('zlib'))
 		{
-			return $this->raiseWarning(100, 'The zlib extension is not available.');
+			throw new RuntimeException('The zlib extension is not available.');
 		}
 
 		if (isset($options['use_streams']) && $options['use_streams'] != false)
@@ -70,7 +70,7 @@ class JArchiveGzip implements JArchiveExtractable
 
 		if (!$this->_data)
 		{
-			return $this->raiseWarning(100, 'Unable to read archive');
+			throw new RuntimeException('Unable to read archive');
 		}
 
 		$position = $this->_getFilePosition();
@@ -78,12 +78,12 @@ class JArchiveGzip implements JArchiveExtractable
 
 		if (empty($buffer))
 		{
-			return $this->raiseWarning(100, 'Unable to decompress data');
+			throw new RuntimeException('Unable to decompress data');
 		}
 
 		if (JFile::write($destination, $buffer) === false)
 		{
-			return $this->raiseWarning(100, 'Unable to write archive');
+			throw new RuntimeException('Unable to write archive');
 		}
 
 		return true;
@@ -108,7 +108,7 @@ class JArchiveGzip implements JArchiveExtractable
 
 		if (!$input->open($archive))
 		{
-			return $this->raiseWarning(100, 'Unable to read archive (gz)');
+			throw new RuntimeException('Unable to read archive (gz)');
 		}
 
 		$output = JFactory::getStream();
@@ -117,7 +117,7 @@ class JArchiveGzip implements JArchiveExtractable
 		{
 			$input->close();
 
-			return $this->raiseWarning(100, 'Unable to write archive (gz)');
+			throw new RuntimeException('Unable to write archive (gz)');
 		}
 
 		do
@@ -128,7 +128,7 @@ class JArchiveGzip implements JArchiveExtractable
 			{
 				$input->close();
 
-				return $this->raiseWarning(100, 'Unable to write file (gz)');
+				throw new RuntimeException('Unable to write file (gz)');
 			}
 		}
 
@@ -138,27 +138,6 @@ class JArchiveGzip implements JArchiveExtractable
 		$input->close();
 
 		return true;
-	}
-
-	/**
-	 * Temporary private method to isolate JError from the extract method
-	 * This code should be removed when JError is removed.
-	 *
-	 * @param   int     $code  The application-internal error code for this error
-	 * @param   string  $msg   The error message, which may also be shown the user if need be.
-	 *
-	 * @return  JException  JException instance if JError class exists
-	 *
-	 * @throws  RuntimeException if JError class does not exist
-	 */
-	private function raiseWarning($code, $msg)
-	{
-		if (class_exists('JError'))
-		{
-			return JError::raiseWarning($code, $msg);
-		}
-
-		throw new RuntimeException($msg);
 	}
 
 	/**
@@ -189,7 +168,7 @@ class JArchiveGzip implements JArchiveExtractable
 
 		if (!$info)
 		{
-			return $this->raiseWarning(100, 'Unable to decompress data.');
+			throw new RuntimeException('Unable to decompress data.');
 		}
 
 		$position += 10;

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -81,14 +81,7 @@ class JArchiveTar implements JArchiveExtractable
 
 		if (!$this->_data)
 		{
-			if (class_exists('JError'))
-			{
-				return JError::raiseWarning(100, 'Unable to read archive');
-			}
-			else
-			{
-				throw new RuntimeException('Unable to read archive');
-			}
+			throw new RuntimeException('Unable to read archive');
 		}
 
 		$this->_getTarInfo($this->_data);
@@ -105,26 +98,12 @@ class JArchiveTar implements JArchiveExtractable
 				// Make sure the destination folder exists
 				if (!JFolder::create(dirname($path)))
 				{
-					if (class_exists('JError'))
-					{
-						return JError::raiseWarning(100, 'Unable to create destination');
-					}
-					else
-					{
-						throw new RuntimeException('Unable to create destination');
-					}
+					throw new RuntimeException('Unable to create destination');
 				}
 
 				if (JFile::write($path, $buffer) === false)
 				{
-					if (class_exists('JError'))
-					{
-						return JError::raiseWarning(100, 'Unable to write entry');
-					}
-					else
-					{
-						throw new RuntimeException('Unable to write entry');
-					}
+					throw new RuntimeException('Unable to write entry');
 				}
 			}
 		}
@@ -179,14 +158,7 @@ class JArchiveTar implements JArchiveExtractable
 
 			if (!$info)
 			{
-				if (class_exists('JError'))
-				{
-					return JError::raiseWarning(100, 'Unable to decompress data');
-				}
-				else
-				{
-					throw new RuntimeException('Unable to decompress data');
-				}
+				throw new RuntimeException('Unable to decompress data');
 			}
 
 			$position += 512;

--- a/libraries/joomla/archive/zip.php
+++ b/libraries/joomla/archive/zip.php
@@ -134,7 +134,7 @@ class JArchiveZip implements JArchiveExtractable
 	{
 		if (!is_file($archive))
 		{
-			return $this->raiseWarning(100, 'Archive does not exist');
+			throw new RuntimeException('Archive does not exist');
 		}
 
 		if ($this->hasNativeSupport())
@@ -143,27 +143,6 @@ class JArchiveZip implements JArchiveExtractable
 		}
 
 		return $this->extractCustom($archive, $destination);
-	}
-
-	/**
-	 * Temporary private method to isolate JError from the extract method
-	 * This code should be removed when JError is removed.
-	 *
-	 * @param   int     $code  The application-internal error code for this error
-	 * @param   string  $msg   The error message, which may also be shown the user if need be.
-	 *
-	 * @return  JException  JException instance if JError class exists
-	 *
-	 * @throws  RuntimeException if JError class does not exist
-	 */
-	private function raiseWarning($code, $msg)
-	{
-		if (class_exists('JError'))
-		{
-			return JError::raiseWarning($code, $msg);
-		}
-
-		throw new RuntimeException($msg);
 	}
 
 	/**
@@ -227,19 +206,19 @@ class JArchiveZip implements JArchiveExtractable
 
 		if (!extension_loaded('zlib'))
 		{
-			return $this->raiseWarning(100, 'Zlib not supported');
+			throw new RuntimeException('Zlib not supported');
 		}
 
 		$this->_data = file_get_contents($archive);
 
 		if (!$this->_data)
 		{
-			return $this->raiseWarning(100, 'Unable to read archive (zip)');
+			throw new RuntimeException('Unable to read archive (zip)');
 		}
 
 		if (!$this->_readZipInfo($this->_data))
 		{
-			return $this->raiseWarning(100, 'Get ZIP Information failed');
+			throw new RuntimeException('Get ZIP Information failed');
 		}
 
 		for ($i = 0, $n = count($this->_metadata); $i < $n; $i++)
@@ -254,12 +233,12 @@ class JArchiveZip implements JArchiveExtractable
 				// Make sure the destination folder exists
 				if (!JFolder::create(dirname($path)))
 				{
-					return $this->raiseWarning(100, 'Unable to create destination');
+					throw new RuntimeException('Unable to create destination');
 				}
 
 				if (JFile::write($path, $buffer) === false)
 				{
-					return $this->raiseWarning(100, 'Unable to write entry');
+					throw new RuntimeException('Unable to write entry');
 				}
 			}
 		}
@@ -284,13 +263,13 @@ class JArchiveZip implements JArchiveExtractable
 
 		if (!is_resource($zip))
 		{
-			return $this->raiseWarning(100, 'Unable to open archive');
+			throw new RuntimeException('Unable to open archive');
 		}
 
 		// Make sure the destination folder exists
 		if (!JFolder::create($destination))
 		{
-			return $this->raiseWarning(100, 'Unable to create destination');
+			throw new RuntimeException('Unable to create destination');
 		}
 
 		// Read files in the archive
@@ -298,7 +277,7 @@ class JArchiveZip implements JArchiveExtractable
 		{
 			if (!zip_entry_open($zip, $file, "r"))
 			{
-				return $this->raiseWarning(100, 'Unable to read entry');
+				throw new RuntimeException('Unable to read entry');
 			}
 
 			if (substr(zip_entry_name($file), strlen(zip_entry_name($file)) - 1) != "/")
@@ -307,7 +286,7 @@ class JArchiveZip implements JArchiveExtractable
 
 				if (JFile::write($destination . '/' . zip_entry_name($file), $buffer) === false)
 				{
-					return $this->raiseWarning(100, 'Unable to write entry');
+					throw new RuntimeException('Unable to write entry');
 				}
 
 				zip_entry_close($file);
@@ -376,7 +355,7 @@ class JArchiveZip implements JArchiveExtractable
 		{
 			if ($dataLength < $fhStart + 31)
 			{
-				return $this->raiseWarning(100, 'Invalid Zip Data');
+				throw new RuntimeException('Invalid Zip Data');
 			}
 
 			$info = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength', substr($data, $fhStart + 10, 20));
@@ -406,7 +385,7 @@ class JArchiveZip implements JArchiveExtractable
 
 			if ($dataLength < $fhStart + 43)
 			{
-				return $this->raiseWarning(100, 'Invalid ZIP data');
+				throw new RuntimeException('Invalid ZIP data');
 			}
 
 			$info = unpack('vInternal/VExternal/VOffset', substr($data, $fhStart + 36, 10));
@@ -421,7 +400,7 @@ class JArchiveZip implements JArchiveExtractable
 
 			if ($dataLength < $lfhStart + 34)
 			{
-				return $this->raiseWarning(100, 'Invalid Zip Data');
+				throw new RuntimeException('Invalid Zip Data');
 			}
 
 			$info = unpack('vMethod/VTime/VCRC32/VCompressed/VUncompressed/vLength/vExtraLength', substr($data, $lfhStart + 8, 25));

--- a/libraries/joomla/cache/storage/redis.php
+++ b/libraries/joomla/cache/storage/redis.php
@@ -107,22 +107,14 @@ class JCacheStorageRedis extends JCacheStorage
 		{
 			static::$_redis = null;
 
-			if ($app->isAdmin())
-			{
-				JError::raiseWarning(500, 'Redis connection failed');
-			}
-
-			return false;
+			throw new JCacheExceptionConnecting('Redis connection failed', 500);
 		}
 
 		if ($auth == false)
 		{
-			if ($app->isAdmin())
-			{
-				JError::raiseWarning(500, 'Redis authentication failed');
-			}
+			static::$_redis = null;
 
-			return false;
+			throw new JCacheExceptionConnecting('Redis authentication failed', 500);
 		}
 
 		$select = static::$_redis->select($server['db']);
@@ -131,12 +123,7 @@ class JCacheStorageRedis extends JCacheStorage
 		{
 			static::$_redis = null;
 
-			if ($app->isAdmin())
-			{
-				JError::raiseWarning(500, 'Redis failed to select database');
-			}
-
-			return false;
+			throw new JCacheExceptionConnecting('Redis failed to select database', 500);
 		}
 
 		try
@@ -147,12 +134,7 @@ class JCacheStorageRedis extends JCacheStorage
 		{
 			static::$_redis = null;
 
-			if ($app->isAdmin())
-			{
-				JError::raiseWarning(500, 'Redis ping failed');
-			}
-
-			return false;
+			throw new JCacheExceptionConnecting('Redis ping failed', 500);
 		}
 
 		return static::$_redis;

--- a/libraries/joomla/client/helper.php
+++ b/libraries/joomla/client/helper.php
@@ -198,7 +198,7 @@ class JClientHelper
 	 *
 	 * @param   string  $client  The name of the client.
 	 *
-	 * @return  mixed  True, if FTP settings; JError if using legacy tree.
+	 * @return  boolean  True if credentials are present
 	 *
 	 * @since   11.1
 	 * @throws  InvalidArgumentException if credentials invalid
@@ -213,21 +213,12 @@ class JClientHelper
 		if ($user != '' && $pass != '')
 		{
 			// Add credentials to the session
-			if (self::setCredentials($client, $user, $pass))
+			if (!self::setCredentials($client, $user, $pass))
 			{
-				$return = false;
+				throw new InvalidArgumentException('Invalid user credentials');
 			}
-			else
-			{
-				if (class_exists('JError'))
-				{
-					$return = JError::raiseWarning('SOME_ERROR_CODE', JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
-				}
-				else
-				{
-					throw new InvalidArgumentException('Invalid user credentials');
-				}
-			}
+
+			$return = false;
 		}
 		else
 		{

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -88,8 +88,7 @@ class JMail extends PHPMailer
 	/**
 	 * Send the mail
 	 *
-	 * @return  boolean|JException  Boolean true if successful, boolean false if the `mailonline` configuration is set to 0,
-	 *                              or a JException object if the mail function does not exist or sending the message fails.
+	 * @return  boolean  Boolean true if successful.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException
@@ -100,7 +99,7 @@ class JMail extends PHPMailer
 		{
 			if (($this->Mailer == 'mail') && !function_exists('mail'))
 			{
-				return JError::raiseNotice(500, JText::_('JLIB_MAIL_FUNCTION_DISABLED'));
+				throw new RuntimeException(JText::_('JLIB_MAIL_FUNCTION_DISABLED'), 500);
 			}
 
 			try
@@ -136,7 +135,7 @@ class JMail extends PHPMailer
 
 			if ($result == false)
 			{
-				$result = JError::raiseNotice(500, JText::_($this->ErrorInfo));
+				throw new RuntimeException(JText::_($this->ErrorInfo), 500);
 			}
 
 			return $result;

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -115,14 +115,15 @@ class JViewCategory extends JViewLegacy
 		$category   = $this->get('Category');
 		$children   = $this->get('Children');
 		$parent     = $this->get('Parent');
+
 		if ($category == false)
 		{
-			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+			throw new InvalidArgumentException(JText::_('JGLOBAL_CATEGORY_NOT_FOUND'), 404);
 		}
 
 		if ($parent == false)
 		{
-			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+			throw new InvalidArgumentException(JText::_('JGLOBAL_CATEGORY_NOT_FOUND'), 404);
 		}
 
 		$items      = $this->get('Items');
@@ -141,7 +142,7 @@ class JViewCategory extends JViewLegacy
 
 		if (!in_array($category->access, $groups))
 		{
-			return JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new RuntimeException(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		// Setup the category parameters.


### PR DESCRIPTION
### Summary of Changes
- Remove conditionals for returning `JError::raise*` response or throwing exceptions in favor of throwing exceptions for many library functions
- Remove returning `JError::raise*` response in favor of throwing exceptions in other library functions
- Remove silent discarding of errors when retrieving the menu, pathway, and router objects via the application classes
- Have Redis cache throw exceptions as noted in code
### Testing Instructions

Review
### Documentation Changes Required

Error handling expectations are changed from handling legacy `JError` behaviors to catching exceptions in noted places.
