### PR TITLE
Publish URLs when batch changing their destination URL

### DIFF
--- a/administrator/components/com_redirect/models/link.php
+++ b/administrator/components/com_redirect/models/link.php
@@ -199,7 +199,7 @@ class RedirectModelLink extends JModelAdmin
 	}
 
 	/**
-	 * Method to duplicate URL links.
+	 * Method to batch update URLs to have new redirect urls and comments. Note will publish any unpublished URLs.
 	 *
 	 * @param   array   &$pks     An array of link ids.
 	 * @param   string  $url      The new URL to set for the redirect.
@@ -236,6 +236,7 @@ class RedirectModelLink extends JModelAdmin
 				->update($db->quoteName('#__redirect_links'))
 				->set($db->quoteName('new_url') . ' = ' . $db->quote($url))
 				->set($db->quoteName('modified_date') . ' = ' . $db->quote($date))
+				->set($db->quoteName('published') . ' = ' . 1)
 				->where($db->quoteName('id') . ' IN (' . implode(',', $pks) . ')');
 
 			if (!empty($comment))


### PR DESCRIPTION
### Summary of Changes

In previous versions of Joomla when you changed the destination url of multiple items it would automatically publish them. Some time around 3.5/3.6 we lost this behaviour as part of a larger refactor. This adds it back
### Testing Instructions

Trigger some 404's in the redirect component. Now select all of them and assign a new url using the form at the bottom of the list view. Before patch the url will be assigned but they will stay unpublished. After patch they will be automatically published as part of the process.
### Documentation Changes Required

None
