### PR TITLE
[4.0] Fix the JLanguage tests

### DIFF
--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -230,7 +230,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetTransliterator()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		// Note: set -> $funtion1: set returns NULL and get returns $function1
@@ -320,7 +320,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetPluralSuffixesCallback()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		$this->assertTrue(
@@ -409,7 +409,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetIgnoredSearchWordsCallback()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		$this->assertTrue(
@@ -499,7 +499,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetLowerLimitSearchWordCallback()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		$this->assertTrue(
@@ -589,7 +589,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetUpperLimitSearchWordCallback()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		$this->assertTrue(
@@ -679,7 +679,7 @@ class JLanguageTest extends PHPUnit_Framework_TestCase
 	public function testSetSearchDisplayedCharactersNumberCallback()
 	{
 		$function1 = 'phpinfo';
-		$function2 = 'print';
+		$function2 = function () { return; };
 		$lang = new JLanguage('');
 
 		$this->assertTrue(


### PR DESCRIPTION
### Summary of Changes

Fix the tests that are injecting a string to inject something callable, in this case an empty lambda function.
### Testing Instructions

Fixes the JLanguage failures
### Documentation Changes Required

N/A
