### PR TITLE
Fix typo in cache memcached storage

### DIFF
--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -69,11 +69,11 @@ class JCacheStorageMemcached extends JCacheStorage
 
 		$config = JFactory::getConfig();
 
-		$host = $config->get('memcache_server_host', 'localhost');
-		$port = $config->get('memcache_server_port', 11211);
+		$host = $config->get('memcached_server_host', 'localhost');
+		$port = $config->get('memcached_server_port', 11211);
 
 
-		// Create the memcache connection
+		// Create the memcached connection
 		if ($config->get('memcached_persist', true))
 		{
 			static::$_db = new Memcached($this->_hash);


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Dedicated to 3.6.3.
Memcached storage should get host and port from memcached not memcache settings. 
### Testing Instructions

Code review.
### Documentation Changes Required

None.
