### PR TITLE
[4.0] Remove manual include behaviors

### DIFF
--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -121,24 +121,6 @@ class JMenu
 
 			if (!class_exists($classname))
 			{
-				// @deprecated 4.0 Everything in this block is deprecated but the warning is only logged after the file_exists
-				// Load the menu object
-				$info = JApplicationHelper::getClientInfo($client, true);
-
-				if (is_object($info))
-				{
-					$path = $info->path . '/includes/menu.php';
-
-					if (file_exists($path))
-					{
-						JLog::add('Non-autoloadable JMenu subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
-					}
-				}
-			}
-
-			if (!class_exists($classname))
-			{
 				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_MENU_LOAD', $client), 500);
 			}
 

--- a/libraries/cms/pathway/pathway.php
+++ b/libraries/cms/pathway/pathway.php
@@ -71,24 +71,6 @@ class JPathway
 
 			if (!class_exists($classname))
 			{
-				// @deprecated 4.0 Everything in this block is deprecated but the warning is only logged after the file_exists
-				// Load the pathway object
-				$info = JApplicationHelper::getClientInfo($client, true);
-
-				if (is_object($info))
-				{
-					$path = $info->path . '/includes/pathway.php';
-
-					if (file_exists($path))
-					{
-						JLog::add('Non-autoloadable JPathway subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
-					}
-				}
-			}
-
-			if (!class_exists($classname))
-			{
 				throw new RuntimeException(JText::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $client), 500);
 			}
 

--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -175,24 +175,6 @@ class JRouter
 
 			if (!class_exists($classname))
 			{
-				// @deprecated 4.0 Everything in this block is deprecated but the warning is only logged after the file_exists
-				// Load the router object
-				$info = JApplicationHelper::getClientInfo($client, true);
-
-				if (is_object($info))
-				{
-					$path = $info->path . '/includes/router.php';
-
-					if (file_exists($path))
-					{
-						JLog::add('Non-autoloadable JRouter subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-						include_once $path;
-					}
-				}
-			}
-
-			if (!class_exists($classname))
-			{
 				throw new RuntimeException(JText::sprintf('JLIB_APPLICATION_ERROR_ROUTER_LOAD', $client), 500);
 			}
 


### PR DESCRIPTION
### Summary of Changes

Remove manual include behaviors of factory methods of `JMenu`, `JPathway`, and `JRouter`
### Testing Instructions

Code still loads correctly; all of core is autoloaded and not using these paths anyway.
### Documentation Changes Required

Document removed behavior.
