### PR TITLE
[4.0] Installer deprecations

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1334,14 +1334,3 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		return $table->id;
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterComponent instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerComponent extends JInstallerAdapterComponent
-{
-}

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -637,14 +637,3 @@ class JInstallerAdapterFile extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterFile instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerFile extends JInstallerAdapterFile
-{
-}

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -703,14 +703,3 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterLanguage instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerLanguage extends JInstallerAdapterLanguage
-{
-}

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -504,14 +504,3 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterLibrary instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerLibrary extends JInstallerAdapterLibrary
-{
-}

--- a/libraries/cms/installer/adapter/module.php
+++ b/libraries/cms/installer/adapter/module.php
@@ -775,14 +775,3 @@ class JInstallerAdapterModule extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterModule instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerModule extends JInstallerAdapterModule
-{
-}

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -689,14 +689,3 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterPackage instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerPackage extends JInstallerAdapterPackage
-{
-}

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -723,14 +723,3 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterPlugin instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerPlugin extends JInstallerAdapterPlugin
-{
-}

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -305,18 +305,9 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 	 */
 	public function prepareDiscoverInstall()
 	{
-		$client   = JApplicationHelper::getClientInfo($this->extension->client_id);
-		$basePath = $client->path . '/plugins/' . $this->extension->folder;
-
-		if (is_dir($basePath . '/' . $this->extension->element))
-		{
-			$manifestPath = $basePath . '/' . $this->extension->element . '/' . $this->extension->element . '.xml';
-		}
-		else
-		{
-			// @deprecated 4.0 - This path supports Joomla! 1.5 plugin folder layouts
-			$manifestPath = $basePath . '/' . $this->extension->element . '.xml';
-		}
+		$client       = JApplicationHelper::getClientInfo($this->extension->client_id);
+		$basePath     = $client->path . '/plugins/' . $this->extension->folder;
+		$manifestPath = $basePath . '/' . $this->extension->element . '/' . $this->extension->element . '.xml';
 
 		$this->parent->manifest = $this->parent->isManifest($manifestPath);
 		$this->parent->setPath('manifest', $manifestPath);

--- a/libraries/cms/installer/adapter/template.php
+++ b/libraries/cms/installer/adapter/template.php
@@ -611,14 +611,3 @@ class JInstallerAdapterTemplate extends JInstallerAdapter
 		}
 	}
 }
-
-/**
- * Deprecated class placeholder. You should use JInstallerAdapterTemplate instead.
- *
- * @since       3.1
- * @deprecated  4.0
- * @codeCoverageIgnore
- */
-class JInstallerTemplate extends JInstallerAdapterTemplate
-{
-}

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -685,15 +685,14 @@ class JInstaller extends JAdapter
 	/**
 	 * Package uninstallation method
 	 *
-	 * @param   string   $type        Package type
-	 * @param   mixed    $identifier  Package identifier for adapter
-	 * @param   integer  $cid         Application ID; deprecated in 1.6
+	 * @param   string  $type        Package type
+	 * @param   mixed   $identifier  Package identifier for adapter
 	 *
 	 * @return  boolean  True if successful
 	 *
 	 * @since   3.1
 	 */
-	public function uninstall($type, $identifier, $cid = 0)
+	public function uninstall($type, $identifier)
 	{
 		$params = array('extension' => $this->extension, 'route' => 'uninstall');
 


### PR DESCRIPTION
### Summary of Changes

Handles deprecations in the `JInstaller` API:
- Removes the stub classes
- Removes the last remnant of 1.5 style plugin path handling
- Removes a deprecated method parameter
- Removes the adapter caching within `JInstaller`
### Testing Instructions

Extensions are still managed correctly through this API (discover, install/uninstall, update, etc.)
### Documentation Changes Required

Changed behaviors and removed APIs documented
