### PR TITLE
[4.0] Break inheritance from JAdapterInstance

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -9,18 +9,12 @@
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.base.adapterinstance');
-
 /**
  * Abstract adapter for the installer.
  *
- * @method         JInstaller  getParent()  Retrieves the parent object.
- * @property-read  JInstaller  $parent      Parent object
- *
  * @since  3.4
- * @note   As of 4.0, this class will no longer extend from JAdapterInstance
  */
-abstract class JInstallerAdapter extends JAdapterInstance
+abstract class JInstallerAdapter
 {
 	/**
 	 * ID for the currently installed extension if present
@@ -59,7 +53,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 *
 	 * Making this object public allows extensions to customize the manifest in custom scripts.
 	 *
-	 * @var    string
+	 * @var    SimpleXMLElement
 	 * @since  3.4
 	 */
 	public $manifest = null;
@@ -79,6 +73,14 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 * @since  3.4
 	 */
 	protected $name = null;
+
+	/**
+	 * Installer used with this adapter
+	 *
+	 * @var    JInstaller
+	 * @since  4.0
+	 */
+	protected $parent = null;
 
 	/**
 	 * Install function routing
@@ -117,7 +119,16 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	 */
 	public function __construct(JInstaller $parent, JDatabaseDriver $db, array $options = array())
 	{
-		parent::__construct($parent, $db, $options);
+		$this->parent = $parent;
+		$this->db     = $db;
+
+		foreach ($options as $key => $value)
+		{
+			if (property_exists($this, $key))
+			{
+				$this->$key = $value;
+			}
+		}
 
 		// Get a generic JTableExtension instance for use if not already loaded
 		if (!($this->extension instanceof JTableInterface))
@@ -529,6 +540,18 @@ abstract class JInstallerAdapter extends JAdapterInstance
 		$name = JFilterInput::getInstance()->clean($name, 'string');
 
 		return $name;
+	}
+
+	/**
+	 * Retrieves the parent installer
+	 *
+	 * @return  JInstaller
+	 *
+	 * @since   4.0
+	 */
+	public function getParent()
+	{
+		return $this->parent;
 	}
 
 	/**

--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -726,8 +726,8 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 		}
 
 		// Set the extensions name
-		$this->set('name', $this->getName());
-		$this->set('element', $this->getElement());
+		$this->name = $this->getName();
+		$this->element = $this->getElement();
 
 		// Attempt to load the admin language file; might have uninstall strings
 		$this->loadLanguage(JPATH_ADMINISTRATOR . '/components/' . $this->element);
@@ -874,7 +874,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	{
 		$db     = $this->parent->getDbo();
 
-		$option = $this->get('element');
+		$option = $this->element;
 
 		// If a component exists with this option in the table then we don't need to add menus
 		$query = $db->getQuery(true)
@@ -1108,7 +1108,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			{
 				if (!$table->delete((int) $menuid))
 				{
-					$this->setError($table->getError());
+					JError::raiseWarning(1, $table->getError());
 
 					$result = false;
 				}
@@ -1133,7 +1133,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	protected function _updateSiteMenus($component_id = null)
 	{
 		$db     = $this->parent->getDbo();
-		$option = $this->get('element');
+		$option = $this->element;
 
 		// Update all menu items which contain 'index.php?option=com_extension' or 'index.php?option=com_extension&...'
 		// to use the new component id.

--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -356,7 +356,7 @@ class JInstallerAdapterFile extends JInstallerAdapter
 					$this->parent->manifestClass = new $classname($this);
 
 					// And set this so we can copy it later
-					$this->set('manifest_script', $manifestScript);
+					$this->manifest_script = $manifestScript;
 				}
 			}
 

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -29,6 +29,14 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	protected $core = false;
 
 	/**
+	 * The language tag for the package
+	 *
+	 * @var    string
+	 * @since  4.0
+	 */
+	protected $tag;
+
+	/**
 	 * Method to copy the extension's base files from the `<files>` tag(s) and the manifest file
 	 *
 	 * @return  void
@@ -141,8 +149,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Get the language name
 		// Set the extensions name
-		$name = JFilterInput::getInstance()->clean((string) $this->getManifest()->name, 'cmd');
-		$this->set('name', $name);
+		$this->name = JFilterInput::getInstance()->clean((string) $this->getManifest()->name, 'cmd');
 
 		// Get the Language tag [ISO tag, eg. en-GB]
 		$tag = (string) $this->getManifest()->tag;
@@ -155,7 +162,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			return false;
 		}
 
-		$this->set('tag', $tag);
+		$this->tag = $tag;
 
 		// Set the language installation path
 		$this->parent->setPath('extension_site', $basePath . '/language/' . $tag);
@@ -279,9 +286,9 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Add an entry to the extension table with a whole heap of defaults
 		$row = JTable::getInstance('extension');
-		$row->set('name', $this->get('name'));
+		$row->set('name', $this->name);
 		$row->set('type', 'language');
-		$row->set('element', $this->get('tag'));
+		$row->set('element', $this->tag);
 
 		// There is no folder for languages
 		$row->set('folder', '');
@@ -302,7 +309,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
-		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'folder' => ''));
+		$uid = $update->find(array('element' => $this->tag, 'type' => 'language', 'folder' => ''));
 
 		if ($uid)
 		{
@@ -412,7 +419,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
-		$uid = $update->find(array('element' => $this->get('tag'), 'type' => 'language', 'client_id' => $clientId));
+		$uid = $update->find(array('element' => $this->tag, 'type' => 'language', 'client_id' => $clientId));
 
 		if ($uid)
 		{
@@ -421,7 +428,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 
 		// Update an entry to the extension table
 		$row = JTable::getInstance('extension');
-		$eid = $row->find(array('element' => strtolower($this->get('tag')), 'type' => 'language', 'client_id' => $clientId));
+		$eid = $row->find(array('element' => strtolower($this->tag), 'type' => 'language', 'client_id' => $clientId));
 
 		if ($eid)
 		{
@@ -440,9 +447,9 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			$row->set('params', $this->parent->getParams());
 		}
 
-		$row->set('name', $this->get('name'));
+		$row->set('name', $this->name);
 		$row->set('type', 'language');
-		$row->set('element', $this->get('tag'));
+		$row->set('element', $this->tag);
 		$row->set('manifest_cache', $this->parent->generateManifestCache());
 
 		if (!$row->store())

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -317,8 +317,9 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		$name = (string) $this->getManifest()->name;
 		$name = JFilterInput::getInstance()->clean($name, 'string');
 		$element = str_replace('.xml', '', basename($this->parent->getPath('manifest')));
-		$this->set('name', $name);
-		$this->set('element', $element);
+
+		$this->name    = $name;
+		$this->element = $element;
 
 		// We don't want to compromise this instance!
 		$installer = new JInstaller;

--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -538,7 +538,7 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 				$this->parent->manifestClass = new $classname($this);
 
 				// And set this so we can copy it later
-				$this->set('manifest_script', $manifestScript);
+				$this->manifest_script = $manifestScript;
 			}
 		}
 

--- a/libraries/cms/installer/adapter/plugin.php
+++ b/libraries/cms/installer/adapter/plugin.php
@@ -523,7 +523,7 @@ class JInstallerAdapterPlugin extends JInstallerAdapter
 				$this->parent->manifestClass = new $classname($this);
 
 				// And set this so we can copy it later
-				$this->set('manifest_script', $manifestScript);
+				$this->manifest_script = $manifestScript;
 			}
 		}
 

--- a/libraries/cms/installer/script.php
+++ b/libraries/cms/installer/script.php
@@ -118,7 +118,7 @@ class JInstallerScript
 		}
 
 		// Extension manifest file version
-		$this->release = $parent->get("manifest")->version;
+		$this->release = $parent->getManifest()->version;
 		$extensionType = substr($this->extension, 0, 3);
 
 		// Modules parameters are located in the module table - else in the extension table

--- a/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
@@ -80,17 +80,18 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	{
 		$mockInstaller = $this->getMock('JInstaller');
 		$mockDatabase = $this->getMockDatabase();
-		$object = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase, array('foo' => 'bar')));
+		$object = $this->getMockForAbstractClass('JInstallerAdapter', array($mockInstaller, $mockDatabase, array('type' => 'component')));
 
 		$this->assertAttributeInstanceOf('JTableExtension', 'extension', $object);
 
 		$this->assertAttributeSame($mockDatabase, 'db', $object);
 		$this->assertAttributeSame($mockInstaller, 'parent', $object);
 
-		$this->assertEquals(
-			'bar',
-			$object->foo,
-			'Tests any options are set as class variables by JObject'
+		$this->assertAttributeSame(
+			'component',
+			'type',
+			$object,
+			'Options which are valid class variables should be set'
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes

Break the inheritance from `JAdapterInstance` (and inherently `JObject`) for `JInstallerAdapter` and its subclasses.
### Testing Instructions

Extension management still works correctly.
### Documentation Changes Required

Document changes in the API (mainly the loss of the `JObject` API methods).
