### PR TITLE
[com_users] - fix user note subject escaped twice

### DIFF
--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -91,7 +91,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 						<?php if ($item->checked_out) : ?>
 							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'notes.', $canCheckin); ?>
 						<?php endif; ?>
-						<?php $subject = $item->subject ? $this->escape($item->subject) : JText::_('COM_USERS_EMPTY_SUBJECT'); ?>
+						<?php $subject = $item->subject ? $item->subject : JText::_('COM_USERS_EMPTY_SUBJECT'); ?>
 						<?php if ($canEdit) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_users&task=note.edit&id=' . $item->id); ?>"><?php echo $this->escape($subject); ?></a>
 						<?php else : ?>


### PR DESCRIPTION
Pull Request for Issue #12159 .
### Summary of Changes

fix user note subject escaped twice
### Testing Instructions

enter a Subject that contains a double quote such as:  user priv "approval" history

see #12159

![pr12159](https://cloud.githubusercontent.com/assets/181681/18807636/a0fcbee2-824c-11e6-86f1-3024dd77b701.PNG)
