### PR TITLE
Deprecating modes in JRouter

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -59,6 +59,7 @@ class JRouter
 	 *
 	 * @var    integer
 	 * @since  1.5
+	 * @deprecated  4.0
 	 */
 	protected $mode = null;
 
@@ -67,7 +68,7 @@ class JRouter
 	 *
 	 * @var    integer
 	 * @since  1.5
-	 * @deprecated  4.0 Will convert to $mode
+	 * @deprecated  4.0
 	 */
 	protected $_mode = null;
 
@@ -294,6 +295,7 @@ class JRouter
 	 * @return  integer
 	 *
 	 * @since   1.5
+	 * @deprecated  4.0
 	 */
 	public function getMode()
 	{
@@ -308,6 +310,7 @@ class JRouter
 	 * @return  void
 	 *
 	 * @since   1.5
+	 * @deprecated  4.0
 	 */
 	public function setMode($mode)
 	{


### PR DESCRIPTION
This deprecates modes in JRouter. This simply marks the methods and members as deprecated for 4.0. We will not need modes in Joomla 4.0 anymore, The idea is to have this behavior replicated with specific rules and adding or removing those rules based on configuration.
