### PR TITLE
Fix error in JFile::getExt

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -28,10 +28,12 @@ class JFile
 	public static function getExt($file)
 	{
 		$dot = strrpos($file, '.');
+
 		if ($dot === false)
 		{
 			return false;
 		}
+
 		return (string) substr($file, $dot + 1);
 	}
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -21,14 +21,15 @@ class JFile
 	 *
 	 * @param   string  $file  The file name
 	 *
-	 * @return  string  The file extension
+	 * @return  string | boolean  The file extension or false if file does not have extension
 	 *
 	 * @since   11.1
 	 */
 	public static function getExt($file)
 	{
 		$dot = strrpos($file, '.');
-		if ($dot === false) {
+		if ($dot === false)
+		{
 			return false;
 		}
 		return (string) substr($file, $dot + 1);

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -27,9 +27,9 @@ class JFile
 	 */
 	public static function getExt($file)
 	{
-		$dot = strrpos($file, '.') + 1;
-
-		return substr($file, $dot);
+		$dot = strrpos($file, '.');
+		if ($dot === false) { return ''; }
+		return substr($file, $dot + 1);
 	}
 
 	/**

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -28,7 +28,9 @@ class JFile
 	public static function getExt($file)
 	{
 		$dot = strrpos($file, '.');
-		if ($dot === false) { return false; }
+		if ($dot === false) {
+			return false;
+		}
 		return (string) substr($file, $dot + 1);
 	}
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -21,7 +21,7 @@ class JFile
 	 *
 	 * @param   string  $file  The file name
 	 *
-	 * @return  string | boolean  The file extension or false if file does not have extension
+	 * @return  string  The file extension
 	 *
 	 * @since   11.1
 	 */
@@ -31,7 +31,7 @@ class JFile
 
 		if ($dot === false)
 		{
-			return false;
+			return '';
 		}
 
 		return (string) substr($file, $dot + 1);

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -28,8 +28,8 @@ class JFile
 	public static function getExt($file)
 	{
 		$dot = strrpos($file, '.');
-		if ($dot === false) { return ''; }
-		return substr($file, $dot + 1);
+		if ($dot === false) { return false; }
+		return (string) substr($file, $dot + 1);
 	}
 
 	/**


### PR DESCRIPTION
JFile::getExt works incorrect if file does not have extension.
