### PR TITLE
Add missing break in switch statement

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -89,6 +89,7 @@ class JFormFieldCalendar extends JFormField
 		{
 			case 'maxlength':
 				$value = (int) $value;
+				break;
 			case 'format':
 			case 'filter':
 				$this->$name = (string) $value;

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -90,6 +90,7 @@ class JFormFieldCalendar extends JFormField
 			case 'maxlength':
 				$value = (int) $value;
 				break;
+				
 			case 'format':
 			case 'filter':
 				$this->$name = (string) $value;


### PR DESCRIPTION
### Summary of Changes

This PR adds a missing `break;` to a switch statement in the calendar field. Very small change 
### Testing Instructions

I see no good way to test this, just verify that the calendar field is still working :)
