### PR TITLE
Remove unnecessary code from JDatabaseDriverPostgresqlTest

### DIFF
--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -944,12 +944,6 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testExecute()
 	{
-		/* REPLACE is not present in PostgreSQL */
-		$query = self::$driver->getQuery(true);
-		$query->delete();
-		$query->from('#__dbtest')->where('id=5');
-		self::$driver->setQuery($query)->execute();
-
 		$query = self::$driver->getQuery(true);
 		$query->insert('#__dbtest')
 			->columns('id,title,start_date, description')


### PR DESCRIPTION
Pull Request for Issue Remove unnecessary code from JDatabaseDriverPostgresqlTest.
### Summary of Changes

Remove unnecessary code from JDatabaseDriverPostgresqlTest as there is no need to delete any specific key before running the test
### Testing Instructions

review travis CI tests, JDatabaseDriverPostgresql Tests should still pass
### Documentation Changes Required

none
