### PR TITLE
Fix fatal error in newsfeeds category view

### DIFF
--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -70,9 +70,8 @@ class NewsfeedsViewCategory extends JViewCategory
 	{
 		parent::prepareDocument();
 
-		$id = (int) @$menu->query['id'];
-
 		$menu = $this->menu;
+		$id = (int) @$menu->query['id'];
 
 		if ($menu && ($menu->query['option'] != 'com_newsfeeds' || $menu->query['view'] == 'newsfeed' || $id != $this->category->id))
 		{


### PR DESCRIPTION
### Summary of Changes

We've had a masked fatal error in newsfeeds for several versions because a variable was used before it was created
### Testing Instructions

Ensure newsfeeds category view continues to work without issues.

Bonus - this is just on code review but I think breadcrumbs will now correctly pull the menu item title for breadcrumbs rather than the newsfeed item (as is consistent with other components).
