### PR TITLE
[4.0] Remove exception catching in JMail

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -8,11 +8,10 @@
 
 namespace Joomla\CMS\Mail;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Log\Log;
-
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -95,10 +94,11 @@ class Mail extends PHPMailer
 	/**
 	 * Send the mail
 	 *
-	 * @return  boolean  Boolean true if successful.
+	 * @return  boolean  Boolean true if successful, false if exception throwing is disabled.
 	 *
 	 * @since   11.1
-	 * @throws  \RuntimeException
+	 * @throws  \RuntimeException  if the mail function is disabled
+	 * @throws  phpmailerException if sending failed and exception throwing is enabled
 	 */
 	public function Send()
 	{
@@ -111,36 +111,25 @@ class Mail extends PHPMailer
 
 			try
 			{
-				// Try sending with default settings
 				$result = parent::send();
 			}
 			catch (phpmailerException $e)
 			{
-				$result = false;
-
-				if ($this->SMTPAutoTLS)
+				// If auto TLS is disabled just let this bubble up
+				if (!$this->SMTPAutoTLS)
 				{
-					/**
-					 * PHPMailer has an issue with servers with invalid certificates
-					 *
-					 * See: https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls
-					 */
-					$this->SMTPAutoTLS = false;
-
-					try
-					{
-						// Try it again with TLS turned off
-						$result = parent::send();
-					}
-					catch (phpmailerException $e)
-					{
-						// Keep false for B/C compatibility
-						$result = false;
-					}
+					throw $e;
 				}
+
+				$result = false;
 			}
 
-			if ($result == false)
+			/*
+			 * If sending failed and auto TLS is enabled, retry sending with the feature disabled
+			 *
+			 * See https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting#opportunistic-tls for more info
+			 */
+			if (!$result && $this->SMTPAutoTLS)
 			{
 				throw new \RuntimeException(\JText::_($this->ErrorInfo), 500);
 			}
@@ -154,35 +143,6 @@ class Mail extends PHPMailer
 	}
 
 	/**
-	 * Set the From and FromName properties.
-	 *
-	 * @param   string   $address  The sender email address
-	 * @param   string   $name     The sender name
-	 * @param   boolean  $auto     Whether to also set the Sender address, defaults to true
-	 *
-	 * @return  boolean
-	 *
-	 * @since   11.1
-	 */
-	public function setFrom($address, $name = '', $auto = true)
-	{
-		try
-		{
-			if (parent::setFrom($address, $name, $auto) === false)
-			{
-				return false;
-			}
-		}
-		catch (phpmailerException $e)
-		{
-			// The parent method will have already called the logging callback, just log our deprecated error handling message
-			Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
-
-			return false;
-		}
-	}
-
-	/**
 	 * Set the email sender
 	 *
 	 * @param   mixed  $from  email address and Name of sender
@@ -192,50 +152,40 @@ class Mail extends PHPMailer
 	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
-	 * @throws  \UnexpectedValueException
+	 * @throws  \UnexpectedValueException if the sender is not a valid address
+	 * @throws  phpmailerException if setting the sender failed and exception throwing is enabled
 	 */
 	public function setSender($from)
 	{
-		// Wrapped in try/catch if PHPMailer is configured to throw exceptions
-		try
+		if (is_array($from))
 		{
-			if (is_array($from))
+			// If $from is an array we assume it has an address and a name
+			if (isset($from[2]))
 			{
-				// If $from is an array we assume it has an address and a name
-				if (isset($from[2]))
-				{
-					// If it is an array with entries, use them
-					$result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]), (bool) $from[2]);
-				}
-				else
-				{
-					$result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]));
-				}
-			}
-			elseif (is_string($from))
-			{
-				// If it is a string we assume it is just the address
-				$result = $this->setFrom(MailHelper::cleanLine($from));
+				// If it is an array with entries, use them
+				$result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]), (bool) $from[2]);
 			}
 			else
 			{
-				// If it is neither, we log a message and throw an exception
-				Log::add(\JText::sprintf('JLIB_MAIL_INVALID_EMAIL_SENDER', $from), Log::WARNING, 'jerror');
-
-				throw new \UnexpectedValueException(sprintf('Invalid email Sender: %s, Mail::setSender(%s)', $from));
-			}
-
-			// Check for boolean false return if exception handling is disabled
-			if ($result === false)
-			{
-				return false;
+				$result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]));
 			}
 		}
-		catch (phpmailerException $e)
+		elseif (is_string($from))
 		{
-			// The parent method will have already called the logging callback, just log our deprecated error handling message
-			Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
+			// If it is a string we assume it is just the address
+			$result = $this->setFrom(MailHelper::cleanLine($from));
+		}
+		else
+		{
+			// If it is neither, we log a message and throw an exception
+			Log::add(\JText::sprintf('JLIB_MAIL_INVALID_EMAIL_SENDER', $from), Log::WARNING, 'jerror');
 
+			throw new \UnexpectedValueException(sprintf('Invalid email Sender: %s, Mail::setSender(%s)', $from));
+		}
+
+		// Check for boolean false return if exception handling is disabled
+		if ($result === false)
+		{
 			return false;
 		}
 
@@ -288,7 +238,8 @@ class Mail extends PHPMailer
 	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
 	 *
 	 * @since   11.1
-	 * @throws  \InvalidArgumentException
+	 * @throws  \InvalidArgumentException if the argument array counts do not match
+	 * @throws  phpmailerException if setting the address failed and exception throwing is enabled
 	 */
 	protected function add($recipient, $name = '', $method = 'addAddress')
 	{
@@ -311,20 +262,9 @@ class Mail extends PHPMailer
 					$recipientEmail = MailHelper::cleanLine($recipientEmail);
 					$recipientName = MailHelper::cleanLine($recipientName);
 
-					// Wrapped in try/catch if PHPMailer is configured to throw exceptions
-					try
+					// Check for boolean false return if exception handling is disabled
+					if (call_user_func('parent::' . $method, $recipientEmail, $recipientName) === false)
 					{
-						// Check for boolean false return if exception handling is disabled
-						if (call_user_func('parent::' . $method, $recipientEmail, $recipientName) === false)
-						{
-							return false;
-						}
-					}
-					catch (phpmailerException $e)
-					{
-						// The parent method will have already called the logging callback, just log our deprecated error handling message
-						Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
-
 						return false;
 					}
 				}
@@ -337,20 +277,9 @@ class Mail extends PHPMailer
 				{
 					$to = MailHelper::cleanLine($to);
 
-					// Wrapped in try/catch if PHPMailer is configured to throw exceptions
-					try
+					// Check for boolean false return if exception handling is disabled
+					if (call_user_func('parent::' . $method, $to, $name) === false)
 					{
-						// Check for boolean false return if exception handling is disabled
-						if (call_user_func('parent::' . $method, $to, $name) === false)
-						{
-							return false;
-						}
-					}
-					catch (phpmailerException $e)
-					{
-						// The parent method will have already called the logging callback, just log our deprecated error handling message
-						Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
-
 						return false;
 					}
 				}
@@ -360,20 +289,9 @@ class Mail extends PHPMailer
 		{
 			$recipient = MailHelper::cleanLine($recipient);
 
-			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
-			try
+			// Check for boolean false return if exception handling is disabled
+			if (call_user_func('parent::' . $method, $recipient, $name) === false)
 			{
-				// Check for boolean false return if exception handling is disabled
-				if (call_user_func('parent::' . $method, $recipient, $name) === false)
-				{
-					return false;
-				}
-			}
-			catch (phpmailerException $e)
-			{
-				// The parent method will have already called the logging callback, just log our deprecated error handling message
-				Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
-
 				return false;
 			}
 		}
@@ -387,9 +305,10 @@ class Mail extends PHPMailer
 	 * @param   mixed  $recipient  Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name       Either a string or array of strings [name(s)]
 	 *
-	 * @return  Mail|boolean  Returns this object for chaining.
+	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure when exception throwing is disabled.
 	 *
 	 * @since   11.1
+	 * @throws  phpmailerException when exception throwing is enabled
 	 */
 	public function addRecipient($recipient, $name = '')
 	{
@@ -402,9 +321,10 @@ class Mail extends PHPMailer
 	 * @param   mixed  $cc    Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name  Either a string or array of strings [name(s)]
 	 *
-	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
+	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure when exception throwing is disabled.
 	 *
 	 * @since   11.1
+	 * @throws  phpmailerException when exception throwing is enabled
 	 */
 	public function addCc($cc, $name = '')
 	{
@@ -423,9 +343,10 @@ class Mail extends PHPMailer
 	 * @param   mixed  $bcc   Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name  Either a string or array of strings [name(s)]
 	 *
-	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
+	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure when exception throwing is disabled.
 	 *
 	 * @since   11.1
+	 * @throws  phpmailerException when exception throwing is enabled
 	 */
 	public function addBcc($bcc, $name = '')
 	{
@@ -447,29 +368,33 @@ class Mail extends PHPMailer
 	 * @param   mixed   $type         The mime type
 	 * @param   string  $disposition  The disposition of the attachment
 	 *
-	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
+	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure when exception throwing is disabled.
 	 *
 	 * @since   12.2
-	 * @throws  \InvalidArgumentException
+	 * @throws  \InvalidArgumentException if the argument array counts do not match
+	 * @throws  phpmailerException if setting the attachment failed and exception throwing is enabled
 	 */
 	public function addAttachment($path, $name = '', $encoding = 'base64', $type = 'application/octet-stream', $disposition = 'attachment')
 	{
 		// If the file attachments is an array, add each file... otherwise just add the one
 		if (isset($path))
 		{
-			// Wrapped in try/catch if PHPMailer is configured to throw exceptions
-			try
+			$result = true;
+
+			if (is_array($path))
 			{
-				$result = true;
-
-				if (is_array($path))
+				if (!empty($name) && count($path) != count($name))
 				{
-					if (!empty($name) && count($path) != count($name))
-					{
-						throw new \InvalidArgumentException('The number of attachments must be equal with the number of name');
-					}
+					throw new \InvalidArgumentException("The number of attachments must be equal with the number of name");
+				}
 
-					foreach ($path as $key => $file)
+				foreach ($path as $key => $file)
+				{
+					if (!empty($name))
+					{
+						$result = parent::addAttachment($file, $name[$key], $encoding, $type);
+					}
+					else
 					{
 						if (!empty($name))
 						{
@@ -481,10 +406,6 @@ class Mail extends PHPMailer
 						}
 					}
 				}
-				else
-				{
-					$result = parent::addAttachment($path, $name, $encoding, $type, $disposition);
-				}
 
 				// Check for boolean false return if exception handling is disabled
 				if ($result === false)
@@ -492,11 +413,14 @@ class Mail extends PHPMailer
 					return false;
 				}
 			}
-			catch (phpmailerException $e)
+			else
 			{
-				// The parent method will have already called the logging callback, just log our deprecated error handling message
-				Log::add(__METHOD__ . '() will not catch phpmailerException objects as of 4.0.', Log::WARNING, 'deprecated');
+				$result = parent::addAttachment($path, $name, $encoding, $type);
+			}
 
+			// Check for boolean false return if exception handling is disabled
+			if ($result === false)
+			{
 				return false;
 			}
 		}
@@ -543,9 +467,10 @@ class Mail extends PHPMailer
 	 * @param   mixed  $replyto  Either a string or array of strings [email address(es)]
 	 * @param   mixed  $name     Either a string or array of strings [name(s)]
 	 *
-	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure.
+	 * @return  Mail|boolean  Returns this object for chaining on success or boolean false on failure when exception throwing is disabled.
 	 *
 	 * @since   11.1
+	 * @throws  phpmailerException when exception throwing is enabled
 	 */
 	public function addReplyTo($replyto, $name = '')
 	{
@@ -676,9 +601,10 @@ class Mail extends PHPMailer
 	 * @param   mixed    $replyTo      Reply to email address(es)
 	 * @param   mixed    $replyToName  Reply to name(s)
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean  True on success, false on a failure when exception throwing is disabled
 	 *
 	 * @since   11.1
+	 * @throws  phpmailerException when exception throwing is enabled
 	 */
 	public function sendMail($from, $fromName, $recipient, $subject, $body, $mode = false, $cc = null, $bcc = null, $attachment = null,
 		$replyTo = null, $replyToName = null)


### PR DESCRIPTION
### Summary of Changes

Remove the internal handling of exceptions thrown by the PHPMailer API in JMail.  This changes the behavior so that when exception throwing is turned on (default yes) exceptions will be thrown by the API and when disabled boolean values are returned.  This is consistent with the parent API's behavior.
### Testing Instructions

Mail sending still functions as intended.  When exception handling is disabled boolean values are still handled.

Note: We probably need to turn on exception handling in core's mail sending functions otherwise these will bubble to something catching the base `Exception` class or the global handler which triggers the error page.
### Documentation Changes Required

Error handling behavior changed.
