### PR TITLE
Smart search menu item doesn't allow to set some options to Use Global

### DIFF
--- a/components/com_finder/views/search/tmpl/default.xml
+++ b/components/com_finder/views/search/tmpl/default.xml
@@ -126,7 +126,7 @@
 			</field>
 			<field name="show_suggested_query"
 				type="list"
-				default="1"
+				default=""
 				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_DESC">
@@ -136,7 +136,7 @@
 			</field>
 			<field name="show_explained_query"
 				type="list"
-				default="1"
+				default=""
 				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_LABEL"
 				description="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_DESC">


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Fix for a bug when it's not possible to change some options to _Use Global_ in Smart search menu item.
Besides default options are set to _Yes_ instead of _Use Global_.

Bug has been introduced in #3285.
### Testing Instructions
1. Create new menu item: _Smart Search > Search_, fill in menu tile
2. Navigate to tab _Advanced_
3. You should see _Did you mean_ and _Query Explanation_ set to _Use Global_ (without patch it's set to 'Yes')
4. Change options to _Use Global_
5. Save and check if options in _Advanced_ tab have been saved.
### Documentation Changes Required

not required
