### PR TITLE
Handle PHP error if download url comes back as false

### DIFF
--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -343,11 +343,18 @@ class InstallerModelLanguages extends JModelList
 	 *
 	 * @since   2.5.7
 	 */
-	protected function _getPackageUrl( $remote_manifest )
+	protected function _getPackageUrl($remote_manifest)
 	{
 		$update = new JUpdate;
 		$update->loadFromXml($remote_manifest);
-		$package_url = trim($update->get('downloadurl', false)->_data);
+		$downloadUrlElement = $update->get('downloadurl', false);
+
+		if ($downloadUrlElement === false)
+		{
+			return false;
+		}
+
+		$package_url = trim($downloadUrlElement->_data);
 
 		return $package_url;
 	}

--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -354,9 +354,7 @@ class InstallerModelLanguages extends JModelList
 			return false;
 		}
 
-		$package_url = trim($downloadUrlElement->_data);
-
-		return $package_url;
+		return trim($downloadUrlElement->_data);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Fix edge case when you are on a Joomla site of a version higher than allowed by a language pack that no download url is available causing a Joomla error
### Testing Instructions

Bump the version in the `libraries/cms/version/version.php` file to 3.8 or higher (4.0 etc). Then try and install a language through the Install Language area in the installer component. Note that a PHP notice will flash up on your screen. Apply patch and no more errors
### Documentation Changes Required

None
