### PR TITLE
Remove deprecated function use from com_languages

### DIFF
--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -220,7 +220,8 @@ class LanguagesModelInstalled extends JModelList
 				$clientPath   = (int) $lang->client_id === 0 ? JPATH_SITE : JPATH_ADMINISTRATOR;
 				$metafilePath = $clientPath . '/language/' . $lang->element . '/' . $lang->element . '.xml';
 
-				$info = JApplicationHelper::parseXMLLangMetaFile($metafilePath);
+				$info = JInstaller::parseXMLInstallFile($metafilePath);
+
 				if (!is_array($info))
 				{
 					$app = JFactory::getApplication();


### PR DESCRIPTION
### Summary of Changes

`JApplicationHelper::parseXMLLangMetaFile` has been deprecated in favour of `JInstaller::parseXMLInstallFile` for a long time now - so let's use the new method (they are exactly the same function)
### Testing Instructions

Check the main backend page for the Language Component is unchanged
### Note

This function has been removed in the Joomla 4.0 branch - so exta onus to get this done :P (Note we have now patched this exact thing in the 4.0 branch with #12644 - still worth doing for 3.7)
