### PR TITLE
[4.0] fix missing $app

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -494,7 +494,8 @@ class JControllerLegacy extends JObject
 	{
 		if ($id)
 		{
-			$values = (array) JFactory::getApplication()->getUserState($context . '.id');
+			$app    = JFactory::getApplication();
+			$values = (array) $app->getUserState($context . '.id');
 
 			$result = in_array((int) $id, $values);
 


### PR DESCRIPTION
Pull Request for Issue #12195 
### Summary of Changes

add missing $app var to that method
### Testing Instructions

code review

Confirm there are no warings like in your error log:

```
[28-Sep-2016 18:37:17 Europe/London] PHP Notice: Undefined variable: app in /Applications/MAMP/htdocs/github-joomla-cms/libraries/legacy/controller/legacy.php on line 503
[28-Sep-2016 18:37:17 Europe/London] PHP Fatal error: Call to a member function getLogger() on null in /Applications/MAMP/htdocs/github-joomla-cms/libraries/legacy/controller/legacy.php on line 503
```
### Documentation Changes Required

none
