### PR TITLE
[com_finder] Allow loading plugin language strings from extension folder

### DIFF
--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -137,7 +137,7 @@ class FinderHelperLanguage
 		foreach ($plugins as $plugin)
 		{
 			$lang->load($plugin->name, JPATH_ADMINISTRATOR)
-				|| $lang->load($plugin->name, JPATH_SITE . '/plugins/finder/' . $plugin->element);
+				|| $lang->load($plugin->name, JPATH_PLUGINS . '/finder/' . $plugin->element);
 		}
 	}
 }

--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -116,7 +116,7 @@ class FinderHelperLanguage
 		// Get array of all the enabled Smart Search plugin names.
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('name')
+			->select(array($db->qn('name'), $db->qn('element')))
 			->from($db->quoteName('#__extensions'))
 			->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
 			->where($db->quoteName('folder') . ' = ' . $db->quote('finder'))
@@ -136,7 +136,8 @@ class FinderHelperLanguage
 		// Load language file for each plugin.
 		foreach ($plugins as $plugin)
 		{
-			$lang->load($plugin->name, JPATH_ADMINISTRATOR);
+			$lang->load($plugin->name, JPATH_ADMINISTRATOR)
+				|| $lang->load($plugin->name, JPATH_SITE . '/plugins/finder/' . $plugin->element);
 		}
 	}
 }


### PR DESCRIPTION
### Summary of Changes

This adds functionality to load finder plugin language strings from the extension folder (just like it's happening in other places).
### Testing Instructions
1. Move _finder - categories_ plugin language files `en-GB.plg_finder_content.ini` and `en-GB.plg_finder_content.sys.ini` from `administrator/language/en-GB` folder to `plugins/finder/content/language/en-GB`
2. Go to _Components > Smart Search_
3. Index content (on toolbar click on _Index_)
4. Add new Search filter (on sidebar click on _Search Filters_, then on toolbar click _New_)
5. First accordion title should say _Search by Author - n_ instead of _Search by PLG_FINDER_QUERY_FILTER_BRANCH_S_AUTHOR - n_ 
### Documentation Changes Required

none
