### PR TITLE
Fixing changed language strings in com_banners

### DIFF
--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -15,6 +15,14 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
+$purchaseTypes = array(
+		'1' => 'UNLIMITED',
+		'2' => 'YEARLY',
+		'3' => 'MONTHLY',
+		'4' => 'WEEKLY',
+		'5' => 'DAILY',
+);
+
 $user       = JFactory::getUser();
 $userId     = $user->get('id');
 $listOrder  = $this->escape($this->state->get('list.ordering'));
@@ -136,9 +144,9 @@ $params     = (isset($this->state->params)) ? $this->state->params : new JObject
 							</td>
 							<td class="small hidden-phone">
 								<?php if ($item->purchase_type < 0): ?>
-									<?php echo JText::sprintf('COM_BANNERS_DEFAULT', JText::_('COM_BANNERS_FIELD_VALUE_' . $params->get('purchase_type'))); ?>
+									<?php echo JText::sprintf('COM_BANNERS_DEFAULT', JText::_('COM_BANNERS_FIELD_VALUE_' . $purchaseTypes[$params->get('purchase_type')])); ?>
 								<?php else: ?>
-									<?php echo JText::_('COM_BANNERS_FIELD_VALUE_' . $item->purchase_type); ?>
+									<?php echo JText::_('COM_BANNERS_FIELD_VALUE_' . $purchaseTypes[$item->purchase_type]); ?>
 								<?php endif; ?>
 							</td>
 							<td class="hidden-phone">


### PR DESCRIPTION
Pull Request for Issue mentioned at https://github.com/joomla/joomla-cms/pull/12178#issuecomment-250507801

Basically my PR https://github.com/joomla/joomla-cms/pull/8300 was incomplete and missed the values being displayed in the Banners -> Clients manager.
### Summary of Changes

Changes the language strings in com_banners -> clients view to use the new ones.
### Testing Instructions
- Delete the strings marked as deprecated in administrator/language/en-GB/en-GB.com_banners.ini:

```
COM_BANNERS_FIELD_VALUE_1="Unlimited"
COM_BANNERS_FIELD_VALUE_2="Yearly"
COM_BANNERS_FIELD_VALUE_3="Monthly"
COM_BANNERS_FIELD_VALUE_4="Weekly"
COM_BANNERS_FIELD_VALUE_5="Daily"
```
- Check the Clients Manager in the Banners view. You should see an untranslated string there.
- Apply PR and the strings are translated again.
### Documentation Changes Required

None.
