### PR TITLE
Change base (URL) for JDocument to meet specifications

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -158,7 +158,7 @@ final class JApplicationSite extends JApplicationCms
 
 				if ($router->getMode() == JROUTER_MODE_SEF)
 				{
-					$document->setBase(htmlspecialchars(JUri::current()));
+					$document->setBase(htmlspecialchars(JUri::base()));
 				}
 
 				// Get the template
@@ -171,7 +171,7 @@ final class JApplicationSite extends JApplicationCms
 				break;
 
 			case 'feed':
-				$document->setBase(htmlspecialchars(JUri::current()));
+				$document->setBase(htmlspecialchars(JUri::base()));
 				break;
 		}
 


### PR DESCRIPTION
### Summary of Changes

Currently, if SEF was enabled, the base tag that gets rendered in the head of HTML and Feed documents shows the current address. According to the [specification](https://www.w3.org/TR/html5/document-metadata#the-base-element), it should be the base path of the installation only.
### Testing Instructions

Open a source view (window or tab) for your site and look for the <base> tag within the head section. Where for an installation on localhost (no vhost, installed in a sub-folder) the base address for the frontpage should be something similar to this: `<base href="http://localhost/myjoomla/" />`.

For an online installation this could be: `http[s]://[subdomain].domain.tld/" />`, which would be fine either way.

Now, if you create an article called **Test** and a menu item to that article, the base tag without the patch looks like this: `http[s]://[subdomain].domain.tld/test"[.suffix] />` or, if you linked the article via a category: `http[s]://[subdomain].domain.tld/test/1-test[.suffix]" />`.

After applying the patch the base tag should only include the base or "root" path / address of the site. This, thanks to @zero-24 who did some tests, also works for Joomla! sites that have been installed into a (nested) subfolder.
