### PR TITLE
Solving 12214 Plugin tooltip

### DIFF
--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -13,6 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::_('bootstrap.tooltip');
 $this->fieldsets = $this->form->getFieldsets('params');
 
 JFactory::getDocument()->addScriptDeclaration("


### PR DESCRIPTION
Pull Request for Issue #12214 
### Summary of Changes

Adding `JHtml::_('bootstrap.tooltip');` to display the tooltips correctly
### Testing Instructions

Edit a plugin and hover the grey buttons under the plugin title

Simple test:
after patch one should get:
![screen shot 2016-09-30 at 08 47 34](https://cloud.githubusercontent.com/assets/869724/18983072/f1516e7c-86ea-11e6-8926-17c82ab3a267.png)
