### PR TITLE
Wrong color on active menu item in mobile view - Protostar

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -5656,6 +5656,12 @@ a.badge:focus {
 		-moz-border-radius: 3px;
 		border-radius: 3px;
 	}
+	.nav-collapse .nav > li.active > a {
+		color: #fff;
+	}
+	.nav-collapse .nav > li.active > a:hover {
+		color: #555;
+	}
 	.nav-collapse .btn {
 		padding: 4px 10px 4px;
 		font-weight: normal;


### PR DESCRIPTION
Pull Request for Issue #12223  .
### Steps to reproduce the issue
1. View the screen on a mobile device
2. Click the nav menu icon (hamburger icon) 
3. The active menu icon has a blue background and a dark font color which makes it hard to read.
### Expected result

The font color on active menu item should be #fff
### Actual result

The font color on active menu is #555
### System information (as much as possible)

Joomla 3.6.3 rc 1
### Additional comments

![protostar-mobile](https://cloud.githubusercontent.com/assets/1540099/18990570/8aeb414a-871b-11e6-80eb-c9c717424208.png)
