### PR TITLE
Deprecate web router classes

### DIFF
--- a/libraries/joomla/application/web/router.php
+++ b/libraries/joomla/application/web/router.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Class to define an abstract Web application router.
  *
- * @since  12.2
+ * @since       12.2
+ * @deprecated  __DEPLOY_VERSION__  Use the `joomla/router` package via Composer instead
  */
 abstract class JApplicationWebRouter
 {

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Basic Web application router class for the Joomla Platform.
  *
- * @since  12.2
+ * @since       12.2
+ * @deprecated  __DEPLOY_VERSION__  Use the `joomla/router` package via Composer instead
  */
 class JApplicationWebRouterBase extends JApplicationWebRouter
 {

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * RESTful Web application router class for the Joomla Platform.
  *
- * @since  12.2
+ * @since       12.2
+ * @deprecated  __DEPLOY_VERSION__  Use the `joomla/router` package via Composer instead
  */
 class JApplicationWebRouterRest extends JApplicationWebRouterBase
 {


### PR DESCRIPTION
### Summary of Changes

These web router classes are pretty much unuseful to the CMS environment and duplicate code to the Framework.  Deprecate them, if you want to build something that uses them pull in the Framework dependency instead.
### Testing Instructions

Review
### Documentation Changes Required

N/A
