### PR TITLE
JLayoutFile wrong type hint

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -640,7 +640,7 @@ class JLayoutFile extends JLayoutBase
 	/**
 	 * Render a layout with the same include paths & options
 	 *
-	 * @param   object  $layoutId     Object which properties are used inside the layout file to build displayed output
+	 * @param   string  $layoutId    The identifier for the sublayout to be searched in a subfolder with the name of the current layout
 	 * @param   mixed   $displayData  Data to be rendered
 	 *
 	 * @return  string  The necessary HTML to display the layout

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -640,7 +640,7 @@ class JLayoutFile extends JLayoutBase
 	/**
 	 * Render a layout with the same include paths & options
 	 *
-	 * @param   string  $layoutId    The identifier for the sublayout to be searched in a subfolder with the name of the current layout
+	 * @param   string  $layoutId     The identifier for the sublayout to be searched in a subfolder with the name of the current layout
 	 * @param   mixed   $displayData  Data to be rendered
 	 *
 	 * @return  string  The necessary HTML to display the layout


### PR DESCRIPTION
### Summary of Changes

Change type hint to string from object.
### Testing Instructions

None. No code changes.
### Documentation Changes Required

Update argument type for `JLayoutFile::sublayout()` method
