### PR TITLE
[3.7.x]regression in index view of com_finder

### DIFF
--- a/administrator/components/com_finder/views/index/view.html.php
+++ b/administrator/components/com_finder/views/index/view.html.php
@@ -84,12 +84,6 @@ class FinderViewIndex extends JViewLegacy
 
 		FinderHelper::addSubmenu('index');
 
-		// Check for plugin state
-		if (!$this->pluginState['plg_content_finder']->enabled)
-		{
-			JFactory::getApplication()->enqueueMessage(JText::_('COM_FINDER_INDEX_PLUGIN_CONTENT_NOT_ENABLED'), 'warning');
-		}
-
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{


### PR DESCRIPTION
Pull Request for Issue #12218  .
### Summary of Changes

Removes the dublicate message
### Testing Instructions

Make sure the Smartsearch Content plugin is disabled
Then go to
`/administrator/index.php?option=com_finder&view=index`

The message is repeated twice, and the first one is not a correct link.
![screen shot 2016-09-30 at 11 21 15](https://cloud.githubusercontent.com/assets/869724/18987074/33272b9c-8700-11e6-8fa3-e243534ffd06.png)

It is `/administrator/%s` instead of `/administrator/index.php?option=com_plugins&task=plugin.edit&extension_id=441`

apply the patch

the wrong get removed
### Documentation Changes Required

none
