### PR TITLE
[3.7.x] Fixes the missing string in com_newsfeeds Options

### DIFF
--- a/administrator/language/en-GB/en-GB.com_newsfeeds.ini
+++ b/administrator/language/en-GB/en-GB.com_newsfeeds.ini
@@ -15,6 +15,7 @@ COM_NEWSFEEDS_CATEGORIES_DESC="These settings apply for News Feeds Categories Op
 COM_NEWSFEEDS_CHANGE_FEED="Select or Change News Feed"
 ; COM_NEWSFEEDS_CHANGE_FEED_BUTTON is deprecated, use COM_NEWSFEEDS_CHANGE_FEED instead;
 COM_NEWSFEEDS_CHANGE_FEED_BUTTON="Select Feed"
+COM_NEWSFEEDS_CONFIG_INTEGRATION_SETTINGS_DESC="These settings determine how the Newsfeeds Component will integrate with other extensions."
 COM_NEWSFEEDS_CONFIGURATION="News Feed: Options"
 COM_NEWSFEEDS_EDIT_NEWSFEED="Edit News Feed"
 COM_NEWSFEEDS_ERROR_UNIQUE_ALIAS="Another News feed from this category has the same alias (remember it may be a trashed item)."


### PR DESCRIPTION
### Summary of Changes

This just adds the missing string like the other stings
### Testing Instructions

Go to backend -> System -> Global Configuration -> Newsfeeds ->Integration
### Documentation Changes Required

None
