### PR TITLE
[3.7.x] Lets use the correct API to get this string translated (com_postinstall)

### DIFF
--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -194,7 +194,7 @@ class PostinstallModelMessages extends FOFModel
 		$options = array();
 
 		JFactory::getLanguage()->load('files_joomla.sys', JPATH_SITE, null, false, false);
-		
+
 		foreach ($extension_ids as $eid)
 		{
 			$options[] = JHtml::_('select.option', $eid, $this->getExtensionName($eid));

--- a/administrator/components/com_postinstall/models/messages.php
+++ b/administrator/components/com_postinstall/models/messages.php
@@ -82,7 +82,7 @@ class PostinstallModelMessages extends FOFModel
 		$lang->load($extension->element, $basePath);
 
 		// Return the localised name
-		return JText::_($extension->name);
+		return JText::_(strtoupper($extension->name));
 	}
 
 	/**
@@ -193,16 +193,11 @@ class PostinstallModelMessages extends FOFModel
 
 		$options = array();
 
+		JFactory::getLanguage()->load('files_joomla.sys', JPATH_SITE, null, false, false);
+		
 		foreach ($extension_ids as $eid)
 		{
-			$extension_name = $this->getExtensionName($eid);
-
-			if ($extension_name == 'files_joomla')
-			{
-				$extension_name = JText::_('COM_POSTINSTALL_TITLE_JOOMLA');
-			}
-
-			$options[] = JHtml::_('select.option', $eid, $extension_name);
+			$options[] = JHtml::_('select.option', $eid, $this->getExtensionName($eid));
 		}
 
 		return $options;
@@ -230,8 +225,8 @@ class PostinstallModelMessages extends FOFModel
 	 * description_key     The JText language key for the main body (description) of this PIM
 	 *                     Example: COM_FOOBAR_POSTINSTALL_MESSAGEONE_DESCRIPTION
 	 *
-	 * action_key		   The JText language key for the action button. Ignored and not required when type=message
-	 * 					   Example: COM_FOOBAR_POSTINSTALL_MESSAGEONE_ACTION
+	 * action_key          The JText language key for the action button. Ignored and not required when type=message
+	 *                     Example: COM_FOOBAR_POSTINSTALL_MESSAGEONE_ACTION
 	 *
 	 * language_extension  The extension name which holds the language keys used above.
 	 *                     For example, com_foobar, mod_something, plg_system_whatever, tpl_mytemplate

--- a/administrator/components/com_postinstall/views/messages/view.html.php
+++ b/administrator/components/com_postinstall/views/messages/view.html.php
@@ -40,14 +40,7 @@ class PostinstallViewMessages extends FOFViewHtml
 		$this->token = JFactory::getSession()->getFormToken();
 		$this->extension_options = $model->getComponentOptions();
 
-		$extension_name = JText::_('COM_POSTINSTALL_TITLE_JOOMLA');
-
-		if ($this->eid != 700)
-		{
-			$extension_name = $model->getExtensionName($this->eid);
-		}
-
-		JToolBarHelper::title(JText::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $extension_name));
+		JToolBarHelper::title(JText::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $model->getExtensionName($this->eid)));
 
 		return parent::onBrowse($tpl);
 	}

--- a/administrator/language/en-GB/en-GB.com_postinstall.ini
+++ b/administrator/language/en-GB/en-GB.com_postinstall.ini
@@ -14,5 +14,4 @@ COM_POSTINSTALL_LBL_RELEASENEWS="Release news <a href="_QQ_"https://www.joomla.o
 COM_POSTINSTALL_LBL_SINCEVERSION="Since version %s"
 COM_POSTINSTALL_MESSAGES_FOR="Showing messages for"
 COM_POSTINSTALL_MESSAGES_TITLE="Post-installation Messages for %s"
-COM_POSTINSTALL_TITLE_JOOMLA="Joomla"
 COM_POSTINSTALL_XML_DESCRIPTION="Displays post-installation and post-upgrade messages for Joomla and its extensions."

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -912,9 +912,6 @@ JWARNING_TRASH_MUST_SELECT="You must select at least one item to remove."
 JWARNING_DELETE_MUST_SELECT="You must select at least one item to permanently delete."
 JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
 
-; Extensionname
-FILES_JOOMLA="Joomla!"
-
 ; Date format
 
 DATE_FORMAT_LC="l, d F Y"

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -912,6 +912,9 @@ JWARNING_TRASH_MUST_SELECT="You must select at least one item to remove."
 JWARNING_DELETE_MUST_SELECT="You must select at least one item to permanently delete."
 JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
 
+; Extensionname
+FILES_JOOMLA="Joomla!"
+
 ; Date format
 
 DATE_FORMAT_LC="l, d F Y"


### PR DESCRIPTION
### Summary of Changes

Now we use the correct string also in com_postinstall for `files_joomla`
### Testing Instructions

Enable language debug
Go to com_postinstall
see the warning about `files_joomla`
apply this patch
see the warning is gone.
### Documentation Changes Required

None
