### PR TITLE
Wrong Return type defined in phpdoc block

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -246,7 +246,7 @@ class JRouter
 	 *
 	 * @param   string  $url  The internal URL or an associative array
 	 *
-	 * @return  string  The absolute search engine friendly URL
+	 * @return  JUri  The absolute search engine friendly URL object
 	 *
 	 * @since   1.5
 	 */


### PR DESCRIPTION
### Changes

Change return type hint from string to JUri
### Testing Instructions

None. No code changed.
### Documentation Changes Required

I guess doc generator will pick it up automatically...
