### PR TITLE
[j3.7] New Feature Contact editor-xtd plugin

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -348,6 +348,7 @@ class JoomlaInstallerScript
 			array('plugin', 'urlinstaller', 'installer', 0),
 			array('plugin', 'phpversioncheck', 'quickicon', 0),
 			array('plugin', 'menu', 'editors-xtd', 0),
+			array('plugin', 'contact', 'editors-xtd', 0),
 
 			// Templates
 			array('template', 'beez3', '', 0),

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-10-01.sql
@@ -1,2 +1,2 @@
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+(460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-10-01.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-01.sql
@@ -1,2 +1,2 @@
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
-(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-01.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-10-01.sql
@@ -1,6 +1,6 @@
 SET IDENTITY_INSERT [#__extensions]  ON;
 
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions]  OFF;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-10-01.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-10-01.sql
@@ -1,0 +1,6 @@
+SET IDENTITY_INSERT [#__extensions]  ON;
+
+INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+SET IDENTITY_INSERT [#__extensions]  OFF;

--- a/administrator/components/com_banners/models/forms/banner.xml
+++ b/administrator/components/com_banners/models/forms/banner.xml
@@ -92,7 +92,7 @@
 			description="COM_BANNERS_FIELD_DESCRIPTION_DESC"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak,module,article"
+			hide="readmore,pagebreak,module,article,contact"
 		/>
 
 		<field

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTACT_BUTTON_CONTACT="Contact"
-PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to contacts in an Article. Displays a popup allowing you to choose the contact."
+PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
 PLG_EDITORS-XTD_CONTACT="Button - Contact"

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
@@ -3,6 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CONTACT_BUTTON_CONTACT="Contact"
-PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
+PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT="Contact"
+PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTACT_BUTTON_CONTACT="Contact"
+PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to contacts in an Article. Displays a popup allowing you to choose the contact."
+PLG_EDITORS-XTD_CONTACT="Button - Contact"

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
@@ -1,0 +1,9 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to contacts in an Article. Displays a popup allowing you to choose the contact."
+PLG_EDITORS-XTD_CONTACT="Button - Contact"
+
+

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to contacts in an Article. Displays a popup allowing you to choose the contact."
+PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
 
 

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
@@ -5,5 +5,3 @@
 
 PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
-
-

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_contact.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."
 PLG_EDITORS-XTD_CONTACT="Button - Contact"
+PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION="Displays a button to make it possible to insert links to Contacts in an article. Displays a popup allowing you to choose the contact."

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -616,6 +616,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 3, 0),
 (458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -616,7 +616,7 @@ INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 3, 0),
 (458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -616,7 +616,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 3, 0),
 (458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -615,7 +615,8 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (456, 'plg_installer_folderinstaller', 'plugin', 'folderinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 2, 0),
 (457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 3, 0),
 (458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+(460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1016,7 +1016,7 @@ SELECT 458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quick
 UNION ALL
 SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'contact', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 -- Templates
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1014,7 +1014,9 @@ SELECT 457, 'plg_installer_urlinstaller', 'plugin', 'urlinstaller', 'installer',
 UNION ALL
 SELECT 458, 'plg_quickicon_phpversioncheck', 'plugin', 'phpversioncheck', 'quickicon', 0, 1, 1, 1, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 459, 'plg_editors-xtd_menu', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
+UNION ALL
+SELECT 460, 'plg_editors-xtd_contact', 'plugin', 'menu', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 -- Templates
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -29,8 +29,9 @@ class PlgButtonContact extends JPlugin
 	 *
 	 * @param   string  $name  The name of the button to add
 	 *
-	 * @return array A four element array of (contact_id, contact_title, category_id, object)
-	 * @since  __DEPLOY_VERSION__
+	 * @return  stdClass  The button options as stdClass
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function onDisplay($name)
 	{
@@ -53,8 +54,7 @@ class PlgButtonContact extends JPlugin
 			jModalClose();
 		}";
 
-		$doc = JFactory::getDocument();
-		$doc->addScriptDeclaration($js);
+		JFactory::getDocument()->addScriptDeclaration($js);
 
 		/*
 		 * Use the built-in element view to select the contact.
@@ -62,12 +62,12 @@ class PlgButtonContact extends JPlugin
 		 */
 		$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button = new JObject;
-		$button->modal = true;
-		$button->class = 'btn';
-		$button->link = $link;
-		$button->text = JText::_('PLG_CONTACT_BUTTON_CONTACT');
-		$button->name = 'address';
+		$button = new stdClass;
+		$button->modal   = true;
+		$button->class   = 'btn';
+		$button->link    = $link;
+		$button->text    = JText::_('PLG_CONTACT_BUTTON_CONTACT');
+		$button->name    = 'address';
 		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
 		return $button;

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -30,6 +30,7 @@ class PlgButtonContact extends JPlugin
 	 * @param   string  $name  The name of the button to add
 	 *
 	 * @return array A four element array of (contact_id, contact_title, category_id, object)
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public function onDisplay($name)
 	{

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -66,7 +66,7 @@ class PlgButtonContact extends JPlugin
 		$button->class = 'btn';
 		$button->link = $link;
 		$button->text = JText::_('PLG_CONTACT_BUTTON_CONTACT');
-		$button->name = 'file-add';
+		$button->name = 'address';
 		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
 		return $button;

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -29,7 +29,7 @@ class PlgButtonContact extends JPlugin
 	 *
 	 * @param   string  $name  The name of the button to add
 	 *
-	 * @return  stdClass  The button options as stdClass
+	 * @return  JObject  The button options as JObject
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -62,7 +62,7 @@ class PlgButtonContact extends JPlugin
 		 */
 		$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button = new stdClass;
+		$button = new JObject;
 		$button->modal   = true;
 		$button->class   = 'btn';
 		$button->link    = $link;

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -66,7 +66,7 @@ class PlgButtonContact extends JPlugin
 		$button->modal   = true;
 		$button->class   = 'btn';
 		$button->link    = $link;
-		$button->text    = JText::_('PLG_CONTACT_BUTTON_CONTACT');
+		$button->text    = JText::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
 		$button->name    = 'address';
 		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Editors-xtd.article
+ * @subpackage  Editors-xtd.contact
  *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 /**
- * Editor Article buton
+ * Editor Contact buton
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -20,7 +20,7 @@ class PlgButtonContact extends JPlugin
 	 * Load the language file on instantiation.
 	 *
 	 * @var    boolean
-	 * @since  3.1
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $autoloadLanguage = true;
 

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Editor Article buton
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgButtonContact extends JPlugin
+{
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  3.1
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Display the button
+	 *
+	 * @param   string  $name  The name of the button to add
+	 *
+	 * @return array A four element array of (contact_id, contact_title, category_id, object)
+	 */
+	public function onDisplay($name)
+	{
+		/*
+		 * Javascript to insert the link
+		 * View element calls jSelectContact when a contact is clicked
+		 * jSelectContact creates the link tag, sends it to the editor,
+		 * and closes the select frame.
+		 */
+		$js = "
+		function jSelectContact(id, title, catid, object, link, lang)
+		{
+			var hreflang = '';
+			if (lang !== '')
+			{
+				var hreflang = ' hreflang = \"' + lang + '\"';
+			}
+			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+			jInsertEditorText(tag, '" . $name . "');
+			jModalClose();
+		}";
+
+		$doc = JFactory::getDocument();
+		$doc->addScriptDeclaration($js);
+
+		/*
+		 * Use the built-in element view to select the contact.
+		 * Currently uses blank class.
+		 */
+		$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+
+		$button = new JObject;
+		$button->modal = true;
+		$button->class = 'btn';
+		$button->link = $link;
+		$button->text = JText::_('PLG_CONTACT_BUTTON_CONTACT');
+		$button->name = 'file-add';
+		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+
+		return $button;
+	}
+}

--- a/plugins/editors-xtd/contact/contact.xml
+++ b/plugins/editors-xtd/contact/contact.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>__DEPLOY_VERSION__</version>
-	<description>PLG_CONTACT_XML_DESCRIPTION</description>
+	<description>PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="contact">contact.php</filename>
 	</files>

--- a/plugins/editors-xtd/contact/contact.xml
+++ b/plugins/editors-xtd/contact/contact.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.7" type="plugin" group="editors-xtd" method="upgrade">
+	<name>plg_editors-xtd_contact</name>
+	<author>Joomla! Project</author>
+	<creationDate>October 2016</creationDate>
+	<copyright>Copyright (C) 2005 - 2016 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>__DEPLOY_VERSION__</version>
+	<description>PLG_CONTACT_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="contact">contact.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_editors-xtd_contact.ini</language>
+		<language tag="en-GB">en-GB.plg_editors-xtd_contact.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
This is a new editor-xtd plugin to allow you to easily insert a link to a contact when using the wysiwyg editor. It works exactly the same way as the insert article editor-xtd plugin
### Testing Instructions

Easy test - install Joomla using https://github.com/brianteeman/joomla-cms/archive/contact-editorxtd.zip

Slightly harder test - Apply the patch using the com_patchtester. discover to find the plugin and then install AND enable it

![editor](https://cloud.githubusercontent.com/assets/1296369/19020522/d19376b6-88a2-11e6-829f-bea604d2b4bf.gif)

[Note] this editor plugin is available for all wysiwyg editor areas except for com_banners where it will not work (and has been disabled) as the editor is only for admin display.
