### PR TITLE
Joomla 4.0: Removing JFactory::getAcl()

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -326,28 +326,6 @@ abstract class JFactory
 	}
 
 	/**
-	 * Get an authorization object
-	 *
-	 * Returns the global {@link JAccess} object, only creating it
-	 * if it doesn't already exist.
-	 *
-	 * @return  JAccess object
-	 *
-	 * @deprecated  13.3 (Platform) & 4.0 (CMS) - Use JAccess directly.
-	 */
-	public static function getAcl()
-	{
-		JLog::add(__METHOD__ . ' is deprecated. Use JAccess directly.', JLog::WARNING, 'deprecated');
-
-		if (!self::$acl)
-		{
-			self::$acl = new JAccess;
-		}
-
-		return self::$acl;
-	}
-
-	/**
 	 * Get a database object.
 	 *
 	 * Returns the global {@link JDatabaseDriver} object, only creating it if it doesn't already exist.

--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -140,22 +140,6 @@ class JFactoryTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Tests the JFactory::getACL method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function testGetAcl()
-	{
-		$this->assertInstanceOf(
-			'JAccess',
-			JFactory::getAcl(),
-			'Line: ' . __LINE__
-		);
-	}
-
-	/**
 	 * Tests the JFactory::getURI method.
 	 *
 	 * @return  void


### PR DESCRIPTION
JFactory::getAcl() is deprecated and we are not using it in our codebase. You are already supposed to use JAccess directly.
