### PR TITLE
Show a warning / error if the download url comes back as false or the download fails

### DIFF
--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -18,13 +18,17 @@ jimport('joomla.updater.update');
 class InstallerModelLanguages extends JModelList
 {
 	/**
-	 * @var     integer  Extension ID of the en-GB language pack.
+	 * Extension ID of the en-GB language pack.
+	 *
+	 * @var     integer
 	 * @since   3.4
 	 */
 	private $enGbExtensionId = 0;
 
 	/**
-	 * @var     integer  Upate Site ID of the en-GB language pack.
+	 * Upate Site ID of the en-GB language pack.
+	 *
+	 * @var     integer
 	 * @since   3.4
 	 */
 	private $updateSiteId = 0;
@@ -271,7 +275,8 @@ class InstallerModelLanguages extends JModelList
 				// Could not find the url, the information in the update server may be corrupt.
 				$message  = JText::sprintf('COM_INSTALLER_MSG_LANGUAGES_CANT_FIND_REMOTE_MANIFEST', $language->name);
 				$message .= ' ' . JText::_('COM_INSTALLER_MSG_LANGUAGES_TRY_LATER');
-				$app->enqueueMessage($message);
+				$app->enqueueMessage($message, 'warning');
+
 				continue;
 			}
 
@@ -283,7 +288,8 @@ class InstallerModelLanguages extends JModelList
 				// Could not find the url , maybe the url is wrong in the update server, or there is not internet access
 				$message  = JText::sprintf('COM_INSTALLER_MSG_LANGUAGES_CANT_FIND_REMOTE_PACKAGE', $language->name);
 				$message .= ' ' . JText::_('COM_INSTALLER_MSG_LANGUAGES_TRY_LATER');
-				$app->enqueueMessage($message);
+				$app->enqueueMessage($message, 'warning');
+
 				continue;
 			}
 
@@ -296,7 +302,8 @@ class InstallerModelLanguages extends JModelList
 				// There was an error installing the package.
 				$message  = JText::sprintf('COM_INSTALLER_INSTALL_ERROR', $language->name);
 				$message .= ' ' . JText::_('COM_INSTALLER_MSG_LANGUAGES_TRY_LATER');
-				$app->enqueueMessage($message);
+				$app->enqueueMessage($message, 'error');
+
 				continue;
 			}
 
@@ -306,8 +313,7 @@ class InstallerModelLanguages extends JModelList
 			// Cleanup the install files in tmp folder.
 			if (!is_file($package['packagefile']))
 			{
-				$config = JFactory::getConfig();
-				$package['packagefile'] = $config->get('tmp_path') . '/' . $package['packagefile'];
+				$package['packagefile'] = JFactory::getConfig()->get('tmp_path') . '/' . $package['packagefile'];
 			}
 
 			JInstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);


### PR DESCRIPTION
### Summary of Changes

This adds a warning (instead of a gree successful message) or a error if the download url comes back as false or the download fails
### Testing Instructions

Bump the version in the `libraries/cms/version/version.php` file to 3.8 or higher (4.0 etc). Then try and install a language through the Install Language area in the installer component. Note that the message is green (success) apply this patch the message is yellow (warning)

Review.

Please also apply https://github.com/joomla/joomla-cms/issues/12187
### Documentation Changes Required

None
