### PR TITLE
Deprecate MooTools based helpers

### DIFF
--- a/libraries/cms/html/sliders.php
+++ b/libraries/cms/html/sliders.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Utility class for Sliders elements
  *
  * @since  1.6
+ * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
  */
 abstract class JHtmlSliders
 {
@@ -25,6 +26,7 @@ abstract class JHtmlSliders
 	 * @return  string
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function start($group = 'sliders', $params = array())
 	{
@@ -39,6 +41,7 @@ abstract class JHtmlSliders
 	 * @return  string  hTML to close the pane
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function end()
 	{
@@ -54,6 +57,7 @@ abstract class JHtmlSliders
 	 * @return  string  HTML to start a panel
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function panel($text, $id)
 	{
@@ -70,6 +74,7 @@ abstract class JHtmlSliders
 	 * @return  void
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	protected static function loadBehavior($group, $params = array())
 	{

--- a/libraries/cms/html/sliders.php
+++ b/libraries/cms/html/sliders.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Utility class for Sliders elements
  *
- * @since  1.6
+ * @since       1.6
  * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
  */
 abstract class JHtmlSliders

--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * Utility class for Tabs elements.
  *
  * @since  1.6
+ * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
  */
 abstract class JHtmlTabs
 {
@@ -25,6 +26,7 @@ abstract class JHtmlTabs
 	 * @return  string
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function start($group = 'tabs', $params = array())
 	{
@@ -39,6 +41,7 @@ abstract class JHtmlTabs
 	 * @return  string  HTML to close the pane
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function end()
 	{
@@ -54,6 +57,7 @@ abstract class JHtmlTabs
 	 * @return  string  HTML to start a new panel
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	public static function panel($text, $id)
 	{
@@ -69,6 +73,7 @@ abstract class JHtmlTabs
 	 * @return  void
 	 *
 	 * @since   1.6
+	 * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
 	 */
 	protected static function loadBehavior($group, $params = array())
 	{

--- a/libraries/cms/html/tabs.php
+++ b/libraries/cms/html/tabs.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Utility class for Tabs elements.
  *
- * @since  1.6
+ * @since       1.6
  * @deprecated  __DEPLOY_VERSION__ These helpers are dependent on the deprecated MooTools support
  */
 abstract class JHtmlTabs


### PR DESCRIPTION
### Summary of Changes

These helpers are dependent on MooTools.  Deprecate them.
### Testing Instructions

N/A
### Documentation Changes Required

N/A
