### PR TITLE
[3.7] Admin - Simplify instantiation of Registry

### DIFF
--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -46,8 +46,7 @@ function admin_postinstall_eaccelerator_action()
 	$prev = ArrayHelper::fromObject(new JConfig);
 	$data = array_merge($prev, array('cacheHandler' => 'file'));
 
-	$config = new Registry('config');
-	$config->loadArray($data);
+	$config = new Registry($data);
 
 	jimport('joomla.filesystem.path');
 	jimport('joomla.filesystem.file');

--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -129,8 +129,7 @@ class BannersTableBanner extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['params']);
+			$registry = new Registry($array['params']);
 
 			if ((int) $registry->get('width', 0) < 0)
 			{

--- a/administrator/components/com_categories/controllers/category.php
+++ b/administrator/components/com_categories/controllers/category.php
@@ -177,15 +177,13 @@ class CategoriesControllerCategory extends JControllerForm
 
 		if (isset($item->params) && is_array($item->params))
 		{
-			$registry = new Registry;
-			$registry->loadArray($item->params);
+			$registry = new Registry($item->params);
 			$item->params = (string) $registry;
 		}
 
 		if (isset($item->metadata) && is_array($item->metadata))
 		{
-			$registry = new Registry;
-			$registry->loadArray($item->metadata);
+			$registry = new Registry($item->metadata);
 			$item->metadata = (string) $registry;
 		}
 	}

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -179,8 +179,7 @@ class CategoriesModelCategory extends JModelAdmin
 			}
 
 			// Convert the metadata field to an array.
-			$registry = new Registry;
-			$registry->loadString($result->metadata);
+			$registry = new Registry($result->metadata);
 			$result->metadata = $registry->toArray();
 
 			// Convert the created and modified dates to local user time for display in the form.

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -202,8 +202,7 @@ class ConfigModelApplication extends ConfigModelForm
 		// Save the text filters
 		if (isset($data['filters']))
 		{
-			$registry = new Registry;
-			$registry->loadArray(array('filters' => $data['filters']));
+			$registry = new Registry(array('filters' => $data['filters']));
 
 			$extension = JTable::getInstance('extension');
 
@@ -277,8 +276,7 @@ class ConfigModelApplication extends ConfigModelForm
 		}
 
 		// Create the new configuration object.
-		$config = new Registry('config');
-		$config->loadArray($data);
+		$config = new Registry($data);
 
 		// Overwrite the old FTP credentials with the new ones.
 		$temp = JFactory::getConfig();
@@ -314,9 +312,8 @@ class ConfigModelApplication extends ConfigModelForm
 		$prev = ArrayHelper::fromObject($prev);
 
 		// Create the new configuration object, and unset the root_user property
-		$config = new Registry('config');
 		unset($prev['root_user']);
-		$config->loadArray($prev);
+		$config = new Registry($prev);
 
 		// Write the configuration file.
 		return $this->writeConfigFile($config);

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -46,8 +46,7 @@ JFactory::getDocument()->addScriptDeclaration('
 				foreach ($this->submenumodules as $submenumodule)
 				{
 					$output = JModuleHelper::renderModule($submenumodule);
-					$params = new Registry;
-					$params->loadString($submenumodule->params);
+					$params = new Registry($submenumodule->params);
 					echo $output;
 				}
 				?>

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -309,8 +309,7 @@ class ContactModelContact extends JModelAdmin
 		if ($item = parent::getItem($pk))
 		{
 			// Convert the metadata field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->metadata);
+			$registry = new Registry($item->metadata);
 			$item->metadata = $registry->toArray();
 		}
 

--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -56,8 +56,7 @@ class ContactTableContact extends JTable
 		// Transform the params field
 		if (is_array($this->params))
 		{
-			$registry = new Registry;
-			$registry->loadArray($this->params);
+			$registry = new Registry($this->params);
 			$this->params = (string) $registry;
 		}
 

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -269,23 +269,19 @@ class ContentModelArticle extends JModelAdmin
 		if ($item = parent::getItem($pk))
 		{
 			// Convert the params field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->attribs);
+			$registry = new Registry($item->attribs);
 			$item->attribs = $registry->toArray();
 
 			// Convert the metadata field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->metadata);
+			$registry = new Registry($item->metadata);
 			$item->metadata = $registry->toArray();
 
 			// Convert the images field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->images);
+			$registry = new Registry($item->images);
 			$item->images = $registry->toArray();
 
 			// Convert the urls field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->urls);
+			$registry = new Registry($item->urls);
 			$item->urls = $registry->toArray();
 
 			$item->articletext = trim($item->fulltext) != '' ? $item->introtext . "<hr id=\"system-readmore\" />" . $item->fulltext : $item->introtext;
@@ -481,8 +477,7 @@ class ContentModelArticle extends JModelAdmin
 
 		if (isset($data['images']) && is_array($data['images']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($data['images']);
+			$registry = new Registry($data['images']);
 
 			$data['images'] = (string) $registry;
 		}
@@ -533,8 +528,7 @@ class ContentModelArticle extends JModelAdmin
 
 			unset($check);
 
-			$registry = new Registry;
-			$registry->loadArray($data['urls']);
+			$registry = new Registry($data['urls']);
 
 			$data['urls'] = (string) $registry;
 		}

--- a/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
+++ b/administrator/components/com_cpanel/views/cpanel/tmpl/default.php
@@ -56,8 +56,7 @@ $user = JFactory::getUser();
 			foreach ($this->modules as $module)
 			{
 				// Get module parameters
-				$params = new Registry;
-				$params->loadString($module->params);
+				$params = new Registry($module->params);
 				$bootstrapSize = $params->get('bootstrap_size');
 				if (!$bootstrapSize)
 				{

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -471,8 +471,7 @@ class FinderIndexerHelper
 		// Instantiate the parameter object if necessary.
 		if (!($params instanceof Registry))
 		{
-			$registry = new Registry;
-			$registry->loadString($params);
+			$registry = new Registry($params);
 			$params = $registry;
 		}
 

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -507,8 +507,7 @@ class FinderIndexerQuery
 		$this->filter = (int) $filterId;
 
 		// Get a parameter object for the filter date options.
-		$registry = new Registry;
-		$registry->loadString($return->params);
+		$registry = new Registry($return->params);
 		$params = $registry;
 
 		// Set the dates if not already set.

--- a/administrator/components/com_finder/tables/filter.php
+++ b/administrator/components/com_finder/tables/filter.php
@@ -48,8 +48,7 @@ class FinderTableFilter extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['params']);
+			$registry = new Registry($array['params']);
 			$array['params'] = (string) $registry;
 		}
 

--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -180,8 +180,7 @@ class LanguagesModelOverride extends JModelAdmin
 		}
 
 		// Write override.ini file with the strings.
-		$registry = new Registry;
-		$registry->loadObject($strings);
+		$registry = new Registry($strings);
 		$reg = $registry->toString('INI');
 
 		if (!JFile::write($filename, $reg))

--- a/administrator/components/com_languages/models/overrides.php
+++ b/administrator/components/com_languages/models/overrides.php
@@ -271,8 +271,7 @@ class LanguagesModelOverrides extends JModelList
 		}
 
 		// Write override.ini file with the left strings.
-		$registry = new Registry;
-		$registry->loadObject($strings);
+		$registry = new Registry($strings);
 		$reg = $registry->toString('INI');
 
 		$filename = constant('JPATH_' . $client) . '/language/overrides/' . $this->getState('filter.language') . '.override.ini';

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -730,8 +730,7 @@ class MenusModelItem extends JModelAdmin
 		$result = ArrayHelper::toObject($properties);
 
 		// Convert the params field to an array.
-		$registry = new Registry;
-		$registry->loadString($table->params);
+		$registry = new Registry($table->params);
 		$result->params = $registry->toArray();
 
 		// Merge the request arguments in to the params for a component.
@@ -1237,8 +1236,7 @@ class MenusModelItem extends JModelAdmin
 
 		foreach ($items as &$item)
 		{
-			$registry = new Registry;
-			$registry->loadString($item->params);
+			$registry = new Registry($item->params);
 			$params = (string) $registry;
 
 			$query->clear();

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -323,8 +323,7 @@ class MenusModelMenu extends JModelForm
 
 		foreach ($modules as &$module)
 		{
-			$params = new Registry;
-			$params->loadString($module->params);
+			$params = new Registry($module->params);
 
 			$menuType = $params->get('menutype');
 

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -698,8 +698,7 @@ class ModulesModelModule extends JModelAdmin
 			$this->_cache[$pk] = ArrayHelper::toObject($properties, 'JObject');
 
 			// Convert the params field to an array.
-			$registry = new Registry;
-			$registry->loadString($table->params);
+			$registry = new Registry($table->params);
 			$this->_cache[$pk]->params = $registry->toArray();
 
 			// Determine the page assignment mode.

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -367,13 +367,11 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 		if ($item = parent::getItem($pk))
 		{
 			// Convert the params field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->metadata);
+			$registry = new Registry($item->metadata);
 			$item->metadata = $registry->toArray();
 
 			// Convert the images field to an array.
-			$registry = new Registry;
-			$registry->loadString($item->images);
+			$registry = new Registry($item->images);
 			$item->images = $registry->toArray();
 		}
 

--- a/administrator/components/com_plugins/models/plugin.php
+++ b/administrator/components/com_plugins/models/plugin.php
@@ -167,8 +167,7 @@ class PluginsModelPlugin extends JModelAdmin
 			$this->_cache[$pk] = ArrayHelper::toObject($properties, 'JObject');
 
 			// Convert the params field to an array.
-			$registry = new Registry;
-			$registry->loadString($table->params);
+			$registry = new Registry($table->params);
 			$this->_cache[$pk]->params = $registry->toArray();
 
 			// Get the plugin XML.

--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -128,18 +128,15 @@ class TagsModelTag extends JModelAdmin
 			}
 
 			// Convert the metadata field to an array.
-			$registry = new Registry;
-			$registry->loadString($result->metadata);
+			$registry = new Registry($result->metadata);
 			$result->metadata = $registry->toArray();
 
 			// Convert the images field to an array.
-			$registry = new Registry;
-			$registry->loadString($result->images);
+			$registry = new Registry($result->images);
 			$result->images = $registry->toArray();
 
 			// Convert the urls field to an array.
-			$registry = new Registry;
-			$registry->loadString($result->urls);
+			$registry = new Registry($result->urls);
 			$result->urls = $registry->toArray();
 
 			// Convert the created and modified dates to local user time for display in the form.
@@ -287,15 +284,13 @@ class TagsModelTag extends JModelAdmin
 
 		if (isset($data['images']) && is_array($data['images']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($data['images']);
+			$registry = new Registry($data['images']);
 			$data['images'] = (string) $registry;
 		}
 
 		if (isset($data['urls']) && is_array($data['urls']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($data['urls']);
+			$registry = new Registry($data['urls']);
 			$data['urls'] = (string) $registry;
 		}
 

--- a/administrator/components/com_tags/tables/tag.php
+++ b/administrator/components/com_tags/tables/tag.php
@@ -47,29 +47,25 @@ class TagsTableTag extends JTableNested
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['params']);
+			$registry = new Registry($array['params']);
 			$array['params'] = (string) $registry;
 		}
 
 		if (isset($array['metadata']) && is_array($array['metadata']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['metadata']);
+			$registry = new Registry($array['metadata']);
 			$array['metadata'] = (string) $registry;
 		}
 
 		if (isset($array['urls']) && is_array($array['urls']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['urls']);
+			$registry = new Registry($array['urls']);
 			$array['urls'] = (string) $registry;
 		}
 
 		if (isset($array['images']) && is_array($array['images']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['images']);
+			$registry = new Registry($array['images']);
 			$array['images'] = (string) $registry;
 		}
 

--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -354,8 +354,7 @@ class TemplatesModelStyle extends JModelAdmin
 			$this->_cache[$pk] = ArrayHelper::toObject($properties, 'JObject');
 
 			// Convert the params field to an array.
-			$registry = new Registry;
-			$registry->loadString($table->params);
+			$registry = new Registry($table->params);
 			$this->_cache[$pk]->params = $registry->toArray();
 
 			// Get the template XML.

--- a/administrator/components/com_templates/tables/style.php
+++ b/administrator/components/com_templates/tables/style.php
@@ -44,8 +44,7 @@ class TemplatesTableStyle extends JTable
 	{
 		if (isset($array['params']) && is_array($array['params']))
 		{
-			$registry = new Registry;
-			$registry->loadArray($array['params']);
+			$registry = new Registry($array['params']);
 			$array['params'] = (string) $registry;
 		}
 

--- a/administrator/components/com_users/views/notes/view.html.php
+++ b/administrator/components/com_users/views/notes/view.html.php
@@ -83,8 +83,7 @@ class UsersViewNotes extends JViewLegacy
 		// Turn parameters into registry objects
 		foreach ($this->items as $item)
 		{
-			$item->cparams = new Registry;
-			$item->cparams->loadString($item->category_params);
+			$item->cparams = new Registry($item->category_params);
 		}
 
 		$this->addToolbar();

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -148,8 +148,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 					<?php $this->menumodules = JModuleHelper::getModules('menu'); ?>
 					<?php foreach ($this->menumodules as $menumodule) : ?>
 						<?php $output = JModuleHelper::renderModule($menumodule, array('style' => 'none')); ?>
-						<?php $params = new Registry; ?>
-						<?php $params->loadString($menumodule->params); ?>
+						<?php $params = new Registry($menumodule->params); ?>
 						<?php echo $output; ?>
 					<?php endforeach; ?>
 					<ul class="nav nav-user<?php echo ($this->direction == 'rtl') ? ' pull-left' : ' pull-right'; ?>">
@@ -205,8 +204,7 @@ $stickyToolbar = $params->get('stickyToolbar', '1');
 				<?php $this->statusmodules = JModuleHelper::getModules('status'); ?>
 				<?php foreach ($this->statusmodules as $statusmodule) : ?>
 					<?php $output = JModuleHelper::renderModule($statusmodule, array('style' => 'no')); ?>
-					<?php $params = new Registry; ?>
-					<?php $params->loadString($statusmodule->params); ?>
+					<?php $params = new Registry($statusmodule->params); ?>
 					<?php echo $output; ?>
 				<?php endforeach; ?>
 			</div>


### PR DESCRIPTION
### Summary of Changes

The `Registry` object supports constructor injection of data objects (arrays, objects, and strings).  So in places we're creating a registry then loading the data source, we can simplify this to just load it through the constructor.
### Testing Instructions

In the admin app, functions using the `Registry` object continue working as expected.
### Documentation Changes Required

N/A
