### PR TITLE
[3.6.3] Regression installer Add the ID to remove it

### DIFF
--- a/installation/view/complete/tmpl/default.php
+++ b/installation/view/complete/tmpl/default.php
@@ -19,10 +19,10 @@ defined('_JEXEC') or die;
 	<div class="alert alert-success">
 		<h3><?php echo JText::_('INSTL_COMPLETE_TITLE'); ?></h3>
 	</div>
-	<div class="row-fluid">	
+	<div id="languages" class="row-fluid">
 		<h3><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_1'); ?></h3>
 		<hr class="hr-condensed" />
-		<div class="row-fluid">	
+		<div class="row-fluid">
 			<div class="span6">
 				<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC'); ?></p>
 				<p><a href="#" class="btn btn-primary" id="instLangs" onclick="return Install.goToPage('languages');"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('INSTL_COMPLETE_INSTALL_LANGUAGES'); ?></a></p>


### PR DESCRIPTION
### Summary of Changes

This adds the id back after https://github.com/joomla/joomla-cms/pull/11389 we need this so the JS that removes the folder also remove this div as befor the change.
### Testing Instructions
- Install staging or 3.6.3-rc1
- Hit the "remove install folder" button
- confirm that the div about "extra steps for language" did not get removed
- install https://github.com/zero-24/joomla-cms/archive/fix_installer.zip
- confirm that the div is removed on hit that button.
### Documentation Changes Required

None
