### PR TITLE
[3.7.x] Fix Regression #12277: language selector blocked on edit when there are no associations (multilanguage)

### DIFF
--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -96,8 +96,9 @@ class CategoriesViewCategory extends JViewLegacy
 				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
 			}
 		}
-		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		// If not in associations modal, block the language change if in edit modal, language not All, associations enabled and some association.
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled()
+			&& count($this->item->associations) > 0)
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -75,8 +75,9 @@ class ContactViewContact extends JViewLegacy
 				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
 			}
 		}
-		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		// If not in associations modal, block the language change if in edit modal, language not All, associations enabled and some association.
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled()
+			&& count($this->item->associations) > 0)
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -95,8 +95,9 @@ class ContentViewArticle extends JViewLegacy
 				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
 			}
 		}
-		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		// If not in associations modal, block the language change if in edit modal, language not All, associations enabled and some association.
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled()
+			&& count($this->item->associations) > 0)
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}

--- a/administrator/components/com_menus/views/item/view.html.php
+++ b/administrator/components/com_menus/views/item/view.html.php
@@ -84,8 +84,9 @@ class MenusViewItem extends JViewLegacy
 				$this->form->setFieldAttribute('parent_id', 'language', '*,' . $forcedLanguage);
 			}
 		}
-		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		// If not in associations modal, block the language change if in edit modal, language not All, associations enabled and some association.
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled()
+			&& count($this->item->associations) > 0)
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -79,8 +79,9 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 				$this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
 			}
 		}
-		// If not in associations modal, block the language change if in edit modal, language not All and associations enabled.
-		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled())
+		// If not in associations modal, block the language change if in edit modal, language not All, associations enabled and some association.
+		elseif ($this->item->id && $this->form->getValue('language', null, '*') != '*' && JLanguageAssociations::isEnabled()
+			&& count($this->item->associations) > 0)
 		{
 			$this->form->setFieldAttribute('language', 'readonly', 'true');
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12277.
### Summary of Changes

Fixes the regression on 3.7.x where the language selector blocked on edit when there are no associations (multilanguage)
### Testing Instructions
1. Use latest 3.7.x branch with multilingual
2. Check the issue in https://github.com/joomla/joomla-cms/issues/12277
3. Apply patch
4. Check that now you can edit the language if there are no associations.
5. Test edit on contact, newsfeed, menu item, article and category (the ones that support associations) by adding and removing associations and checking the language field on the edit form.
### Documentation Changes Required

None.
