### PR TITLE
delete old files and folders

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1172,6 +1172,15 @@ class JoomlaInstallerScript
 			'/libraries/joomla/registry/format/xml.php',
 			// Joomla 3.3.1
 			'/administrator/templates/isis/html/message.php',
+			// Joomla 3.3.6
+			'/media/editors/tinymce/plugins/compat3x/editable_selects.js',
+			'/media/editors/tinymce/plugins/compat3x/form_utils.js',
+			'/media/editors/tinymce/plugins/compat3x/mctabs.js',
+			'/media/editors/tinymce/plugins/compat3x/tiny_mce_popup.js',
+			'/media/editors/tinymce/plugins/compat3x/validate.js',
+			'/plugins/user/profile/fields/index.html',
+			'/plugins/user/profile/fields/tos.php',
+			'/administrator/components/com_media/models/forms/index.html',
 			// Joomla! 3.4
 			'/administrator/components/com_tags/helpers/html/index.html',
 			'/administrator/components/com_tags/models/fields/index.html',
@@ -1484,6 +1493,10 @@ class JoomlaInstallerScript
 			'/plugins/user/joomla/postinstall',
 			'/libraries/joomla/registry/format',
 			'/libraries/joomla/registry',
+			// Joomla! 3.3
+			'/administrator/components/com_media/models/forms',
+			'/plugins/user/profile/fields',
+			'/media/editors/tinymce/plugins/compat3x',
 			// Joomla! 3.4
 			'/administrator/components/com_tags/helpers/html',
 			'/administrator/components/com_tags/models/fields',

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1178,7 +1178,6 @@ class JoomlaInstallerScript
 			'/media/editors/tinymce/plugins/compat3x/mctabs.js',
 			'/media/editors/tinymce/plugins/compat3x/tiny_mce_popup.js',
 			'/media/editors/tinymce/plugins/compat3x/validate.js',
-			'/plugins/user/profile/fields/index.html',
 			// Joomla! 3.4
 			'/administrator/components/com_tags/helpers/html/index.html',
 			'/administrator/components/com_tags/models/fields/index.html',
@@ -1493,7 +1492,6 @@ class JoomlaInstallerScript
 			'/libraries/joomla/registry/format',
 			'/libraries/joomla/registry',
 			// Joomla! 3.3
-			'/administrator/components/com_media/models/forms',
 			'/plugins/user/profile/fields',
 			'/media/editors/tinymce/plugins/compat3x',
 			// Joomla! 3.4

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1179,7 +1179,6 @@ class JoomlaInstallerScript
 			'/media/editors/tinymce/plugins/compat3x/tiny_mce_popup.js',
 			'/media/editors/tinymce/plugins/compat3x/validate.js',
 			'/plugins/user/profile/fields/index.html',
-			'/plugins/user/profile/fields/tos.php',
 			// Joomla! 3.4
 			'/administrator/components/com_tags/helpers/html/index.html',
 			'/administrator/components/com_tags/models/fields/index.html',
@@ -1435,6 +1434,7 @@ class JoomlaInstallerScript
 			'/administrator/templates/isis/js/bootstrap.min.js',
 			'/media/system/js/permissions.min.js',
 			'/libraries/platform.php',
+			'/plugins/user/profile/fields/tos.php',
 			// Joomla! 3.6.3
 			'/media/editors/codemirror/mode/jade/jade.js',
 			'/media/editors/codemirror/mode/jade/jade.min.js',

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1180,7 +1180,6 @@ class JoomlaInstallerScript
 			'/media/editors/tinymce/plugins/compat3x/validate.js',
 			'/plugins/user/profile/fields/index.html',
 			'/plugins/user/profile/fields/tos.php',
-			'/administrator/components/com_media/models/forms/index.html',
 			// Joomla! 3.4
 			'/administrator/components/com_tags/helpers/html/index.html',
 			'/administrator/components/com_tags/models/fields/index.html',


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

delete old files and folders in the update procedure
### Testing Instructions

install a new 3.3.6 version, update to 3.6.3 and some old files still here:
media/editors/tinymce/plugins/compat3x/editable_selects.js
media/editors/tinymce/plugins/compat3x/form_utils.js
media/editors/tinymce/plugins/compat3x/mctabs.js
media/editors/tinymce/plugins/compat3x/tiny_mce_popup.js
media/editors/tinymce/plugins/compat3x/validate.js
plugins/user/profile/fields/tos.php
### Documentation Changes Required

from an 3.3.6 installation, these file no longer exist in Joomla 3.6.3
