### PR TITLE
Make mod_article_news plugin events have a unique context. Fixes #8610

### DIFF
--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -99,13 +99,13 @@ abstract class ModArticlesNewsHelper
 				$item->introtext = preg_replace('/<img[^>]*>/', '', $item->introtext);
 			}
 
-			$results                 = $app->triggerEvent('onContentAfterTitle', array('com_content.article', &$item, &$params, 1));
+			$results                 = $app->triggerEvent('onContentAfterTitle', array('mod_articles_news.content', &$item, &$params, 1));
 			$item->afterDisplayTitle = trim(implode("\n", $results));
 
-			$results                    = $app->triggerEvent('onContentBeforeDisplay', array('com_content.article', &$item, &$params, 1));
+			$results                    = $app->triggerEvent('onContentBeforeDisplay', array('mod_articles_news.content', &$item, &$params, 1));
 			$item->beforeDisplayContent = trim(implode("\n", $results));
 
-			$results                 = $app->triggerEvent('onContentAfterDisplay', array('com_content.article', &$item, &$params, 1));
+			$results                 = $app->triggerEvent('onContentAfterDisplay', array('mod_articles_news.content', &$item, &$params, 1));
 			$item->afterDisplayContent = trim(implode("\n", $results));
 		}
 


### PR DESCRIPTION
Pull Request for Issue #8610 .
### Summary of Changes

Mod article news events now have their own context which allows content plugins to listen to the events
### Documentation Changes Required

The new context for the plugins which means extensions wishing to trigger on this context MUST update the array of possible values
### TODO
1. Check our content modules to see if they also need their own unique plugin names
2. Check our content plugins so that they are still executed in the new context
