### PR TITLE
Remove deprecated function

### DIFF
--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -185,15 +185,15 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		// Escape strings for HTML output
 		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
 
-		$this->assignRef('params', $params);
-		$this->assignRef('newsfeed', $newsfeed);
-		$this->assignRef('state', $state);
-		$this->assignRef('item', $item);
-		$this->assignRef('user', $user);
+		$this->params = $params;
+		$this->newsfeed = $newsfeed;
+		$this->state = $state;
+		$this->item = $item;
+		$this->user = $user;
 
 		if (!empty($msg))
 		{
-			$this->assignRef('msg', $msg);
+			$this->msg = $msg;
 		}
 
 		$this->print = $print;


### PR DESCRIPTION
### Summary of Changes

`JViewLegacy::assignRef` has been deprecated for a long long time. This is the last usage of it in the CMS. This paves the way for it's removal in J4 with #12263
### Testing Instructions

Ensure the newsfeed view continues to work as before
### Documentation Changes Required

n/a
