### PR TITLE
Multilingual: adding warning when changing item language.

### DIFF
--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -23,6 +23,11 @@ JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searc
 
 $app = JFactory::getApplication();
 
+if ($app->isSite())
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
 $function  = $app->input->getCmd('function', 'jSelectContact');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/components/com_contact/controller.php
+++ b/components/com_contact/controller.php
@@ -17,6 +17,29 @@ defined('_JEXEC') or die;
 class ContactController extends JControllerLegacy
 {
 	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *                          Recognized key values include 'name', 'default_task', 'model_path', and
+	 *                          'view_path' (this list is not meant to be comprehensive).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($config = array())
+	{
+		$this->input = JFactory::getApplication()->input;
+
+		// Article frontpage Editor contact proxying:
+		if ($this->input->get('view') === 'contacts' && $this->input->get('layout') === 'modal')
+		{
+			JHtml::_('stylesheet', 'system/adminlist.css', array(), true);
+			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+		}
+
+		parent::__construct($config);
+	}
+
+	/**
 	 * Method to display a view.
 	 *
 	 * @param   boolean  $cachable   If true, the view output will be cached

--- a/components/com_contact/models/forms/filter_contacts.xml
+++ b/components/com_contact/models/forms/filter_contacts.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+<fieldset addfieldpath="/administrator/components/com_contacts/models/fields" />
+	<fields name="filter">
+
+		<field
+			name="search"
+			type="text"
+			label="COM_CONTACT_FILTER_SEARCH_LABEL"
+			description="COM_CONTACT_FILTER_SEARCH_DESC"
+			hint="JSEARCH_FILTER"
+		/>
+
+		<field
+			name="published"
+			type="status"
+			label="JOPTION_SELECT_PUBLISHED"
+			description="JOPTION_SELECT_PUBLISHED_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+
+		<field
+			name="category_id"
+			type="category"
+			label="JOPTION_FILTER_CATEGORY"
+			description="JOPTION_FILTER_CATEGORY_DESC"
+			extension="com_contact"
+			published="0,1,2"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_CATEGORY</option>
+		</field>
+
+		<field
+			name="access"
+			type="accesslevel"
+			label="JOPTION_FILTER_ACCESS"
+			description="JOPTION_FILTER_ACCESS_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_ACCESS</option>
+		</field>
+
+		<field
+			name="language"
+			type="contentlanguage"
+			label="JOPTION_FILTER_LANGUAGE"
+			description="JOPTION_FILTER_LANGUAGE_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_LANGUAGE</option>
+			<option value="*">JALL</option>
+		</field>
+
+		<field
+			name="tag"
+			type="tag"
+			label="JOPTION_FILTER_TAG"
+			description="JOPTION_FILTER_TAG_DESC"
+			mode="nested"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_TAG</option>
+		</field>
+
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
+	</fields>
+
+	<fields name="list">
+
+		<field
+			name="fullordering"
+			type="list"
+			label="COM_CONTACT_LIST_FULL_ORDERING"
+			description="COM_CONTACT_LIST_FULL_ORDERING_DESC"
+			default="a.name ASC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.published ASC">JSTATUS_ASC</option>
+			<option value="a.published DESC">JSTATUS_DESC</option>
+			<option value="a.featured ASC">JFEATURED_ASC</option>
+			<option value="a.featured DESC">JFEATURED_DESC</option>
+			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="category_title ASC">JCATEGORY_ASC</option>
+			<option value="category_title DESC">JCATEGORY_DESC</option>
+			<option value="ul.name ASC">COM_CONTACT_FIELD_LINKED_USER_LABEL_ASC</option>
+			<option value="ul.name DESC">COM_CONTACT_FIELD_LINKED_USER_LABEL_DESC</option>
+			<option value="access_level ASC">JGRID_HEADING_ACCESS_ASC</option>
+			<option value="access_level DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option
+				value="association ASC"
+				requires="associations"
+				>
+				JASSOCIATIONS_ASC
+			</option>
+			<option
+				value="association DESC"
+				requires="associations"
+				>
+				JASSOCIATIONS_DESC
+			</option>
+			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
+
+		<field
+			name="limit"
+			type="limitbox"
+			label="COM_CONTACT_LIST_LIMIT"
+			description="COM_CONTACT_LIST_LIMIT_DESC"
+			default="25"
+			class="input-mini"
+			onchange="this.form.submit();"
+		/>
+	</fields>
+</form>

--- a/components/com_menus/controller.php
+++ b/components/com_menus/controller.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_menus
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Menu items manager master display controller.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class MenusController extends JControllerLegacy
+{
+	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *                          Recognized key values include 'name', 'default_task', 'model_path', and
+	 *                          'view_path' (this list is not meant to be comprehensive).
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($config = array())
+	{
+		$this->input = JFactory::getApplication()->input;
+
+		// Menu items frontpage Editor Menus proxying:
+		if ($this->input->get('view') === 'items' && $this->input->get('layout') === 'modal')
+		{
+			JHtml::_('stylesheet', 'system/adminlist.css', array(), true);
+			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+		}
+
+		parent::__construct($config);
+	}
+}

--- a/components/com_menus/menus.php
+++ b/components/com_menus/menus.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Site
- * @subpackage  com_contact
+ * @subpackage  com_menus
  *
  * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -9,19 +9,19 @@
 
 defined('_JEXEC') or die;
 
-JLoader::register('ContactHelperRoute', JPATH_COMPONENT . '/helpers/route.php');
+$app    = JFactory::getApplication();
 $config = array();
 
-$input = JFactory::getApplication()->input;
-
-if ($input->get('view') === 'contacts' && $input->get('layout') === 'modal')
+if ($app->input->get('view') === 'items' && $app->input->get('layout') === 'modal')
 {
 	$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
 	$lang   = JFactory::getLanguage();
 	$lang->load('joomla', JPATH_ADMINISTRATOR);
-	$lang->load('com_contact', JPATH_ADMINISTRATOR);
+	$lang->load('com_menus', JPATH_ADMINISTRATOR);
 }
 
-$controller = JControllerLegacy::getInstance('Contact', $config);
-$controller->execute($input->get('task'));
+// Trigger the controller
+$controller = JControllerLegacy::getInstance('Menus', $config);
+$controller->execute($app->input->get('task'));
 $controller->redirect();
+

--- a/components/com_menus/models/forms/filter_items.xml
+++ b/components/com_menus/models/forms/filter_items.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<field
+		name="menutype"
+		type="menu"
+		label="COM_MENUS_FILTER_CATEGORY"
+		description="JOPTION_FILTER_CATEGORY_DESC"
+		onchange="this.form.submit();"
+		accesstype="manage"
+		>
+		<option value="">COM_MENUS_SELECT_MENU</option>
+	</field>
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
+			description="COM_MENUS_ITEMS_SEARCH_FILTER"
+			hint="JSEARCH_FILTER"
+		/>
+		<field
+			name="published"
+			type="status"
+			label="COM_MENUS_FILTER_PUBLISHED"
+			description="COM_MENUS_FILTER_PUBLISHED_DESC"
+			filter="*,0,1,-2"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+		<field
+			name="access"
+			type="accesslevel"
+			label="JOPTION_FILTER_ACCESS"
+			description="JOPTION_FILTER_ACCESS_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_ACCESS</option>
+		</field>
+		<field
+			name="language"
+			type="contentlanguage"
+			label="JOPTION_FILTER_LANGUAGE"
+			description="JOPTION_FILTER_LANGUAGE_DESC"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_LANGUAGE</option>
+			<option value="*">JALL</option>
+		</field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
+	</fields>
+	<fields name="list">
+		<field
+			name="fullordering"
+			type="list"
+			label="JGLOBAL_SORT_BY"
+			description="JGLOBAL_SORT_BY"
+			statuses="*,0,1,2,-2"
+			onchange="this.form.submit();"
+			default="a.lft ASC"
+			>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.published ASC">JSTATUS_ASC</option>
+			<option value="a.published DESC">JSTATUS_DESC</option>
+			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="menutype_title ASC">COM_MENUS_HEADING_MENU_ASC</option>
+			<option value="menutype_title DESC">COM_MENUS_HEADING_MENU_DESC</option>
+			<option value="a.home ASC">COM_MENUS_HEADING_HOME_ASC</option>
+			<option value="a.home DESC">COM_MENUS_HEADING_HOME_DESC</option>
+			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
+			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
+			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
+			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
+		<field
+			name="limit"
+			type="limitbox"
+			label="COM_MENUS_LIST_LIMIT"
+			description="COM_MENUS_LIST_LIMIT_DESC"
+			class="input-mini"
+			default="25"
+			onchange="this.form.submit();"
+		/>
+	</fields>
+</form>


### PR DESCRIPTION
Create a multingual site.
For example with 3 languages. Here I used en-GB, fr-FR and it-IT
Enable Associations in the language filter.

Create menu items, articles, contacts, newsfeeds, categories, assigning a specific Content Language to each of them. Save them without creating associations yet.

Edit one of these items (test on all kinds) tagged for example to en-GB.
Look at the Associations tab
The possible associations proposed are fr-FR and it-IT => OK
Change the language of the item, for example to fr-FR
DO NOT SAVE
Look again at the associations tab
The available associations are the same as before.

These should change to reflect the new language for the item. 
I.e. we should get en-GB and it-IT
But as the original language value is set in the database, the item has to be saved BEFORE selecting/creating Associations.

Patch and test again.
This PR displays a message to let the user know the item has to be saved again before creating associations.

![screen shot 2016-10-04 at 17 51 39](https://cloud.githubusercontent.com/assets/869724/19082098/0059b18e-8a5d-11e6-8752-0f1c5fa3b7a6.png)

Note: It is normal, once associations are created, to not be able to change the language of the edited item.

@dgt41 @andrepereiradasilva @alikon 

@brianteeman for the new string
