### PR TITLE
3.7 Improve Cache Controller

### DIFF
--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -175,7 +175,8 @@ class JCacheControllerCallback extends JCacheController
 		{
 			$data['output'] = JCache::setWorkarounds($output, $coptions);
 		}
-		else {
+		else
+		{
 			$data['output'] = $output;
 		}
 

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -30,6 +30,7 @@ class JCacheControllerCallback extends JCacheController
 	 * @return  mixed  Result of the callback
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0
 	 */
 	public function call()
 	{
@@ -88,86 +89,102 @@ class JCacheControllerCallback extends JCacheController
 
 		$data = $this->cache->get($id);
 
-		$locktest             = new stdClass;
-		$locktest->locked     = null;
-		$locktest->locklooped = null;
+		$locktest = (object) array('locked' => null, 'locklooped' => null);
 
 		if ($data === false)
 		{
 			$locktest = $this->cache->lock($id);
 
-			if ($locktest->locked == true && $locktest->locklooped == true)
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($locktest->locked === true && $locktest->locklooped === true)
 			{
 				$data = $this->cache->get($id);
 			}
 		}
 
-		$coptions = array();
-
 		if ($data !== false)
 		{
-			$cached                = unserialize(trim($data));
-			$coptions['mergehead'] = isset($woptions['mergehead']) ? $woptions['mergehead'] : 0;
-			$output                = ($wrkarounds == false) ? $cached['output'] : JCache::getWorkarounds($cached['output'], $coptions);
-			$result                = $cached['result'];
-
-			if ($locktest->locked == true)
+			if ($locktest->locked === true)
 			{
 				$this->cache->unlock($id);
 			}
+
+			$data = unserialize(trim($data));
+
+			if ($wrkarounds)
+			{
+				echo JCache::getWorkarounds(
+					$data['output'],
+					array('mergehead' => isset($woptions['mergehead']) ? $woptions['mergehead'] : 0)
+				);
+			}
+			else
+			{
+				echo $data['output'];
+			}
+
+			return $data['result'];
+		}
+
+		if (!is_array($args))
+		{
+			$referenceArgs = !empty($args) ? array(&$args) : array();
 		}
 		else
 		{
-			if (!is_array($args))
-			{
-				$referenceArgs = !empty($args) ? array(&$args) : array();
-			}
-			else
-			{
-				$referenceArgs = &$args;
-			}
+			$referenceArgs = &$args;
+		}
 
-			if ($locktest->locked == false)
-			{
-				$locktest = $this->cache->lock($id);
-			}
+		if ($locktest->locked === false && $locktest->locklooped === true)
+		{
+			// We can not store data because another process is in the middle of saving
+			return call_user_func_array($callback, $referenceArgs);
+		}
 
-			if (isset($woptions['modulemode']) && $woptions['modulemode'] == 1)
+		$coptions = array();
+
+		if (isset($woptions['modulemode']) && $woptions['modulemode'] == 1)
+		{
+			$document = JFactory::getDocument();
+
+			if (method_exists($document, 'getHeadData'))
 			{
-				$document = JFactory::getDocument();
-				$coptions['modulemode'] = 1;
-				if (method_exists($document, 'getHeadData'))
-				{
-					$coptions['headerbefore'] = $document->getHeadData();
-				}
-			}
-			else
-			{
-				$coptions['modulemode'] = 0;
+				$coptions['headerbefore'] = $document->getHeadData();
 			}
 
-			ob_start();
-			ob_implicit_flush(false);
+			$coptions['modulemode'] = 1;
+		}
+		else
+		{
+			$coptions['modulemode'] = 0;
+		}
 
-			$result = call_user_func_array($callback, $referenceArgs);
-			$output = ob_get_clean();
+		$coptions['nopathway'] = isset($woptions['nopathway']) ? $woptions['nopathway'] : 1;
+		$coptions['nohead']    = isset($woptions['nohead'])    ? $woptions['nohead'] : 1;
+		$coptions['nomodules'] = isset($woptions['nomodules']) ? $woptions['nomodules'] : 1;
 
-			$coptions['nopathway'] = isset($woptions['nopathway']) ? $woptions['nopathway'] : 1;
-			$coptions['nohead']    = isset($woptions['nohead']) ? $woptions['nohead'] : 1;
-			$coptions['nomodules'] = isset($woptions['nomodules']) ? $woptions['nomodules'] : 1;
+		ob_start();
+		ob_implicit_flush(false);
 
-			$cached = array(
-				'output' => ($wrkarounds == false) ? $output : JCache::setWorkarounds($output, $coptions),
-				'result' => $result,
-			);
+		$result = call_user_func_array($callback, $referenceArgs);
+		$output = ob_get_clean();
 
-			// Store the cache data
-			$this->cache->store(serialize($cached), $id);
+		$data = array('result' => $result);
 
-			if ($locktest->locked == true)
-			{
-				$this->cache->unlock($id);
-			}
+		if ($wrkarounds)
+		{
+			$data['output'] = JCache::setWorkarounds($output, $coptions);
+		}
+		else {
+			$data['output'] = $output;
+		}
+
+		// Store the cache data
+		$this->cache->store(serialize($data), $id);
+
+		if ($locktest->locked === true)
+		{
+			$this->cache->unlock($id);
 		}
 
 		echo $output;

--- a/libraries/joomla/cache/controller/output.php
+++ b/libraries/joomla/cache/controller/output.php
@@ -37,6 +37,7 @@ class JCacheControllerOutput extends JCacheController
 	 *
 	 * @var    stdClass
 	 * @since  11.1
+	 * @deprecated  4.0
 	 */
 	protected $_locktest = null;
 
@@ -49,9 +50,16 @@ class JCacheControllerOutput extends JCacheController
 	 * @return  boolean
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0
 	 */
 	public function start($id, $group = null)
 	{
+		JLog::add(
+			__METHOD__ . '() is deprecated.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		// If we have data in cache use that.
 		$data = $this->cache->get($id, $group);
 
@@ -104,9 +112,16 @@ class JCacheControllerOutput extends JCacheController
 	 * @return  boolean  True if the cache data was stored
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0
 	 */
 	public function end()
 	{
+		JLog::add(
+			__METHOD__ . '() is deprecated.',
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		// Get data from output buffer and echo it
 		$data = ob_get_clean();
 		echo $data;
@@ -126,5 +141,77 @@ class JCacheControllerOutput extends JCacheController
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Get stored cached data by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  mixed  Boolean false on no result, cached object otherwise
+	 *
+	 * @since   11.1
+	 */
+	public function get($id, $group = null)
+	{
+		$data = $this->cache->get($id, $group);
+
+		if ($data === false)
+		{
+			$locktest = $this->cache->lock($id, $group);
+
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($locktest->locked === true && $locktest->locklooped === true)
+			{
+				$data = $this->cache->get($id, $group);
+			}
+
+			if ($locktest->locked === true)
+			{
+				$this->cache->unlock($id, $group);
+			}
+		}
+
+		// Check again because we might get it from second attempt
+		if ($data !== false)
+		{
+			// Trim to fix unserialize errors
+			$data = unserialize(trim($data));
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Store data to cache by ID and group
+	 *
+	 * @param   mixed    $data        The data to store
+	 * @param   string   $id          The cache data ID
+	 * @param   string   $group       The cache data group
+	 * @param   boolean  $wrkarounds  True to use wrkarounds
+	 *
+	 * @return  boolean  True if cache stored
+	 *
+	 * @since   11.1
+	 */
+	public function store($data, $id, $group = null, $wrkarounds = true)
+	{
+		$locktest = $this->cache->lock($id, $group);
+
+		if ($locktest->locked === false && $locktest->locklooped === true)
+		{
+			// We can not store data because another process is in the middle of saving
+			return false;
+		}
+
+		$result = $this->cache->store(serialize($data), $id, $group);
+
+		if ($locktest->locked === true)
+		{
+			$this->cache->unlock($id, $group);
+		}
+
+		return $result;
 	}
 }

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -53,7 +53,7 @@ class JCacheControllerPage extends JCacheController
 	public function get($id = false, $group = 'page')
 	{
 		// If an id is not given, generate it from the request
-		if ($id == false)
+		if (!$id)
 		{
 			$id = $this->_makeId();
 		}
@@ -77,15 +77,14 @@ class JCacheControllerPage extends JCacheController
 		// We got a cache hit... set the etag header and echo the page data
 		$data = $this->cache->get($id, $group);
 
-		$this->_locktest             = new stdClass;
-		$this->_locktest->locked     = null;
-		$this->_locktest->locklooped = null;
+		$this->_locktest = (object) array('locked' => null, 'locklooped' => null);
 
 		if ($data === false)
 		{
 			$this->_locktest = $this->cache->lock($id, $group);
 
-			if ($this->_locktest->locked == true && $this->_locktest->locklooped == true)
+			// If locklooped is true try to get the cached data again; it could exist now.
+			if ($this->_locktest->locked === true && $this->_locktest->locklooped === true)
 			{
 				$data = $this->cache->get($id, $group);
 			}
@@ -93,16 +92,15 @@ class JCacheControllerPage extends JCacheController
 
 		if ($data !== false)
 		{
-			$data = unserialize(trim($data));
-
-			$data = JCache::getWorkarounds($data);
-
-			$this->_setEtag($id);
-
-			if ($this->_locktest->locked == true)
+			if ($this->_locktest->locked === true)
 			{
 				$this->cache->unlock($id, $group);
 			}
+
+			$data = unserialize(trim($data));
+			$data = JCache::getWorkarounds($data);
+
+			$this->_setEtag($id);
 
 			return $data;
 		}
@@ -128,55 +126,56 @@ class JCacheControllerPage extends JCacheController
 	 */
 	public function store($data, $id, $group = null, $wrkarounds = true)
 	{
+		if ($this->_locktest->locked === false && $this->_locktest->locklooped === true)
+		{
+			// We can not store data because another process is in the middle of saving
+			return false;
+		}
+
 		// Get page data from the application object
-		if (empty($data))
+		if (!$data)
 		{
 			$data = JFactory::getApplication()->getBody();
+
+			// Only attempt to store if page data exists.
+			if (!$data)
+			{
+				return false;
+			}
 		}
 
 		// Get id and group and reset the placeholders
-		if (empty($id))
+		if (!$id)
 		{
 			$id = $this->_id;
 		}
 
-		if (empty($group))
+		if (!$group)
 		{
 			$group = $this->_group;
 		}
 
-		// Only attempt to store if page data exists
-		if ($data)
+		if ($wrkarounds)
 		{
-			if ($wrkarounds)
-			{
-				$data = JCache::setWorkarounds(
-					$data,
-					array(
-						'nopathway' => 1,
-						'nohead'    => 1,
-						'nomodules' => 1,
-						'headers'   => true,
-					)
-				);
-			}
-
-			if ($this->_locktest->locked == false)
-			{
-				$this->_locktest = $this->cache->lock($id, $group);
-			}
-
-			$sucess = $this->cache->store(serialize($data), $id, $group);
-
-			if ($this->_locktest->locked == true)
-			{
-				$this->cache->unlock($id, $group);
-			}
-
-			return $sucess;
+			$data = JCache::setWorkarounds(
+				$data,
+				array(
+					'nopathway' => 1,
+					'nohead'    => 1,
+					'nomodules' => 1,
+					'headers'   => true,
+				)
+			);
 		}
 
-		return false;
+		$result = $this->cache->store(serialize($data), $id, $group);
+
+		if ($this->_locktest->locked === true)
+		{
+			$this->cache->unlock($id, $group);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/libraries/joomla/cache/controller/view.php
+++ b/libraries/joomla/cache/controller/view.php
@@ -31,26 +31,24 @@ class JCacheControllerView extends JCacheController
 	public function get($view, $method = 'display', $id = false, $wrkarounds = true)
 	{
 		// If an id is not given generate it from the request
-		if ($id == false)
+		if (!$id)
 		{
 			$id = $this->_makeId($view, $method);
 		}
 
 		$data = $this->cache->get($id);
 
-		$locktest             = new stdClass;
-		$locktest->locked     = null;
-		$locktest->locklooped = null;
+		$locktest = (object) array('locked' => null, 'locklooped' => null);
 
 		if ($data === false)
 		{
-			$locktest = $this->cache->lock($id, null);
+			$locktest = $this->cache->lock($id);
 
 			/*
 			 * If the loop is completed and returned true it means the lock has been set.
 			 * If looped is true try to get the cached data again; it could exist now.
 			 */
-			if ($locktest->locked == true && $locktest->locklooped == true)
+			if ($locktest->locked === true && $locktest->locklooped === true)
 			{
 				$data = $this->cache->get($id);
 			}
@@ -60,56 +58,63 @@ class JCacheControllerView extends JCacheController
 
 		if ($data !== false)
 		{
+			if ($locktest->locked === true)
+			{
+				$this->cache->unlock($id);
+			}
+
 			$data = unserialize(trim($data));
 
-			if ($wrkarounds === true)
+			if ($wrkarounds)
 			{
 				echo JCache::getWorkarounds($data);
 			}
 			else
 			{
 				// No workarounds, so all data is stored in one piece
-				echo isset($data) ? $data : null;
-			}
-
-			if ($locktest->locked == true)
-			{
-				$this->cache->unlock($id);
+				echo $data;
 			}
 
 			return true;
 		}
 
 		// No hit so we have to execute the view
-		if (method_exists($view, $method))
+		if (!method_exists($view, $method))
 		{
-			// If previous lock failed try again
-			if ($locktest->locked == false)
-			{
-				$locktest = $this->cache->lock($id);
-			}
+			return false;
+		}
 
-			// Capture and echo output
-			ob_start();
-			ob_implicit_flush(false);
+		if ($locktest->locked === false && $locktest->locklooped === true)
+		{
+			// We can not store data because another process is in the middle of saving
 			$view->$method();
-			$data = ob_get_clean();
-			echo $data;
 
-			/*
-			 * For a view we have a special case.  We need to cache not only the output from the view, but the state
-			 * of the document head after the view has been rendered.  This will allow us to properly cache any attached
-			 * scripts or stylesheets or links or any other modifications that the view has made to the document object
-			 */
-			$cached = $wrkarounds == true ? JCache::setWorkarounds($data) : $data;
+			return false;
+		}
 
-			// Store the cache data
-			$this->cache->store(serialize($cached), $id);
+		// Capture and echo output
+		ob_start();
+		ob_implicit_flush(false);
+		$view->$method();
+		$data = ob_get_clean();
+		echo $data;
 
-			if ($locktest->locked == true)
-			{
-				$this->cache->unlock($id);
-			}
+		/*
+		 * For a view we have a special case.  We need to cache not only the output from the view, but the state
+		 * of the document head after the view has been rendered.  This will allow us to properly cache any attached
+		 * scripts or stylesheets or links or any other modifications that the view has made to the document object
+		 */
+		if ($wrkarounds)
+		{
+			$data = JCache::setWorkarounds($data);
+		}
+
+		// Store the cache data
+		$this->cache->store(serialize($data), $id);
+
+		if ($locktest->locked === true)
+		{
+			$this->cache->unlock($id);
 		}
 
 		return false;
@@ -118,14 +123,14 @@ class JCacheControllerView extends JCacheController
 	/**
 	 * Generate a view cache ID.
 	 *
-	 * @param   object  &$view   The view object to cache output for
+	 * @param   object  $view    The view object to cache output for
 	 * @param   string  $method  The method name to cache for the view object
 	 *
 	 * @return  string  MD5 Hash
 	 *
 	 * @since   11.1
 	 */
-	protected function _makeId(&$view, $method)
+	protected function _makeId($view, $method)
 	{
 		return md5(serialize(array(JCache::makeId(), get_class($view), $method)));
 	}


### PR DESCRIPTION
Pull Request for Issue #12133 and other optimizations.

### Summary of Changes
- Deprecate `get` and `store` methods in `JCacheController`, subclasses should have own methods.
- Deprecate `start` and `end` methods in `JCacheControllerOutput` - joomla does not use it
- Deprecate `call` method in `JCacheControllerCallback`
- Remove `setLifeTime`, `setCaching` from JCacheController because `__call()` method can call it directly on JCache instance.
- Replace operator == to === for `locked` and `locklooped` variables.
- Do not store if lock can not be locked:

``` php
if ($locktest->locked === false && $locktest->locklooped === true)
```
- Add `get` and `store` method to `JCacheControllerOutput` which is the same as deprecated method `get` and `store` in `JCacheController`. 
- In subclasses of `JCacheController` I did optimization on `get` methods.
  - move `unlock()` method before unserialize(...)
  - Generally unlock cache as fast as we can
- Do not use ternary operator on variables with a lots of data, see http://fabien.potencier.org/the-php-ternary-operator-fast-or-not.html

### Testing Instructions
Joomla should work as before.
Code review.

### Documentation Changes Required
None.
