### PR TITLE
Shared session without another new parameter in config

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -254,26 +254,6 @@ class ConfigModelApplication extends ConfigModelForm
 			$table->purge(-1);
 		}
 
-		// Set the shared session configuration
-		if (isset($data['shared_session']))
-		{
-			$currentShared = isset($prev['shared_session']) ? $prev['shared_session'] : '0';
-
-			// Has the user enabled shared sessions?
-			if ($data['shared_session'] == 1 && $currentShared == 0)
-			{
-				// Generate a random shared session name
-				$data['session_name'] = JUserHelper::genRandomPassword(16);
-			}
-
-			// Has the user disabled shared sessions?
-			if ($data['shared_session'] == 0 && $currentShared == 1)
-			{
-				// Remove the session name value
-				unset($data['session_name']);
-			}
-		}
-
 		if (empty($data['cache_handler']))
 		{
 			$data['caching'] = 0;

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -780,15 +780,15 @@
 			size="6" />
 
 		<field
-			name="shared_session"
+			name="session_name"
 			type="radio"
 			class="btn-group btn-group-yesno"
-			default="0"
+			default=""
 			label="COM_CONFIG_FIELD_SHARED_SESSION_LABEL"
 			description="COM_CONFIG_FIELD_SHARED_SESSION_DESC"
-			filter="integer">
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
+			filter="cmd">
+			<option value="shared">JYES</option>
+			<option value="">JNO</option>
 		</field>
 
 		<field

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -31,11 +31,11 @@ JHtml::_('bootstrap.tooltip');
 				</strong>
 
 				<small class="small hasTooltip" title="<?php echo JHtml::tooltipText('JCLIENT'); ?>">
-					<?php if ($user->client_id === null) : ?>
-						<?php // Don't display a client ?>
-					<?php elseif ($user->client_id) : ?>
+					<?php if (JFactory::getApplication()->get('session_name')) : ?>
+						<?php // Don't display a client if we have a shared session ?>
+					<?php elseif ($user->client_id == 1) : ?>
 						<?php echo JText::_('JADMINISTRATION'); ?>
-					<?php else : ?>
+					<?php elseif ($user->client_id == 0) : ?>
 						<?php echo JText::_('JSITE'); ?>
 					<?php endif; ?>
 				</small>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -31,7 +31,7 @@ JHtml::_('bootstrap.tooltip');
 				</strong>
 
 				<small class="small hasTooltip" title="<?php echo JHtml::tooltipText('JCLIENT'); ?>">
-					<?php if (JFactory::getApplication()->get('session_name')) : ?>
+					<?php if (JFactory::getConfig()->get('session_name', '')) : ?>
 						<?php // Don't display a client if we have a shared session ?>
 					<?php elseif ($user->client_id == 1) : ?>
 						<?php echo JText::_('JADMINISTRATION'); ?>

--- a/administrator/modules/mod_status/mod_status.php
+++ b/administrator/modules/mod_status/mod_status.php
@@ -27,7 +27,7 @@ $unread = (int) $db->loadResult();
 $count = 0;
 
 // Get the number of backend logged in users if shared sessions is not enabled.
-if (!$config->get('shared_session', '0'))
+if ($config->get('session_name', '') == '')
 {
 	$query->clear()
 		->select('COUNT(session_id)')
@@ -61,7 +61,7 @@ else
 $online_num = 0;
 
 // Get the number of frontend logged in users if shared sessions is not enabled.
-if (!$config->get('shared_session', '0'))
+if ($config->get('session_name', '') == '')
 {
 	$query->clear()
 		->select('COUNT(session_id)')
@@ -75,7 +75,7 @@ if (!$config->get('shared_session', '0'))
 $total_users = 0;
 
 // Get the number of logged in users if shared sessions is enabled.
-if ($config->get('shared_session', '0'))
+if ($config->get('session_name', '') != '')
 {
 	$query->clear()
 		->select('COUNT(session_id)')

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -40,7 +40,7 @@ if ($params->get('show_viewadmin', 0))
 }
 
 // Print logged in user count based on the shared session state
-if (JFactory::getConfig()->get('shared_session', '0'))
+if (JFactory::getConfig()->get('session_name', '') != '')
 {
 	// Print the frontend logged in  users.
 	if ($params->get('show_loggedin_users', 1))

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -144,7 +144,7 @@ class InstallationModelConfiguration extends JModelBase
 		// Session setting.
 		$registry->set('lifetime', 15);
 		$registry->set('session_handler', 'database');
-		$registry->set('shared_session', 0);
+		$registry->set('session_name', '');
 
 		// Generate the configuration class string buffer.
 		$buffer = $registry->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -198,7 +198,7 @@ class JApplicationCms extends JApplicationWeb
 				$db->quote($user->username),
 			);
 
-			if ($this->get('session_name', '') == '')
+			if (JFactory::getConfig()->get('session_name', '') == '')
 			{
 				$columns[] = $db->quoteName('client_id');
 				$values[] = (int) $this->getClientId();

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -198,7 +198,7 @@ class JApplicationCms extends JApplicationWeb
 				$db->quote($user->username),
 			);
 
-			if (!$this->get('shared_session', '0'))
+			if ($this->get('session_name', '') == '')
 			{
 				$columns[] = $db->quoteName('client_id');
 				$values[] = (int) $this->getClientId();

--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -32,12 +32,16 @@ class ModWhosonlineHelper
 		$user_array  = 0;
 		$guest_array = 0;
 
-		$whereCondition = JFactory::getConfig()->get('shared_session', '0') ? 'IS NULL' : '= 0';
-
 		$query = $db->getQuery(true)
 			->select('guest, client_id')
-			->from('#__session')
-			->where('client_id ' . $whereCondition);
+			->from('#__session');
+
+		// Filter by client id only if shared session not enabled
+		if (JFactory::getConfig()->get('session_name', '') == '')
+		{
+			$query->where('client_id = 0');
+		}
+
 		$db->setQuery($query);
 
 		try
@@ -85,15 +89,19 @@ class ModWhosonlineHelper
 	 **/
 	public static function getOnlineUserNames($params)
 	{
-		$whereCondition = JFactory::getConfig()->get('shared_session', '0') ? 'IS NULL' : '= 0';
-
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName(array('a.username', 'a.userid', 'a.client_id')))
 			->from('#__session AS a')
 			->where($db->quoteName('a.userid') . ' != 0')
-			->where($db->quoteName('a.client_id') . ' ' . $whereCondition)
-			->group($db->quoteName(array('a.username', 'a.userid', 'a.client_id')));
+			->group($db->quoteName(array('a.username', 'a.userid')));
+
+		// Filter by client id only if shared session not enabled
+		if (JFactory::getConfig()->get('session_name', '') == '')
+		{
+			$query->where($db->quoteName('a.client_id') . ' = 0');
+			$query->group($db->quoteName('a.client_id'));
+		}
 
 		$user = JFactory::getUser();
 

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -271,7 +271,7 @@ class PlgUserJoomla extends JPlugin
 			return true;
 		}
 
-		$sharedSessions = $this->app->get('shared_session', '0');
+		$sharedSessions = $this->app->get('session_name', '') != '';
 
 		// Check to see if we're deleting the current session
 		if ($my->id == $user['id'] && (!$sharedSessions && $options['clientid'] == $this->app->getClientId()))

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -271,7 +271,7 @@ class PlgUserJoomla extends JPlugin
 			return true;
 		}
 
-		$sharedSessions = $this->app->get('session_name', '') != '';
+		$sharedSessions = JFactory::getConfig()->get('session_name', '') != '';
 
 		// Check to see if we're deleting the current session
 		if ($my->id == $user['id'] && (!$sharedSessions && $options['clientid'] == $this->app->getClientId()))


### PR DESCRIPTION
### Summary of Changes

This is in continuation with @mbabker's #12068. For more details see that PR. 

The addition of this in the global configuration page is a nice improvement. The same effect can be achieved without introducing an new parameter `shared_session`. **Having two parameters for the same purpose is not a great idea**. However we cannot get rid of existing `session_name` parameter due to our B/C promise. Hence this PR, and **this is valid only before the first public release of J3.7**.

With or without this patch:

``` php
// Not shared session, empty 'session_name' in configuration.php
JFactory::getConfig()->get('session_name');       // ''
JFactory::getApplication()->get('session_name');  // 'site' or 'administrator'

// Shared session, pre-defined 'session_name' in configuration.php, e.g. 'abcde'
JFactory::getConfig()->get('session_name');       // 'abcde'
JFactory::getApplication()->get('session_name');  // 'abcde'
```

Database changes in the other PR can also be avoided but it doesn't harm in any way, so I have skipped them. I can do that if advised so.
### Testing Instructions
1. This should behave exactly as described in #12068.
2. Add `public $session_name = 'something';` to your `configuration.php` and login to backend. You should be automatically logged in to front-end as well. The reverse is also true, provided you have enough access rights.
3. Without this patch if you open and save global configuration your setting will be lost, as  mbabker said.
4. Apply this patch, open and save global configuration. Everything should be same as in _2_ above, the value in the configuration may change to 'shared' but the behaviour will be same.
### Documentation Changes Required

None, however any references to the new parameter `shared_session` should be removed if already added.
## 

**PS:** It is also possible to avoid logout when changing this setting from backend by using 'administrator' as the shared session_name, however I am not sure if this is a good idea.
