### PR TITLE
[REGRESSION 3.6.3] Revert 11736

### DIFF
--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -17,6 +17,14 @@ defined('_JEXEC') or die;
 class PlgSystemLogout extends JPlugin
 {
 	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  3.1
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe -- event dispatcher.
@@ -72,13 +80,13 @@ class PlgSystemLogout extends JPlugin
 	/**
 	 * Method to handle an error condition.
 	 *
-	 * @param   Exception  $error  The Exception object to be handled.
+	 * @param   Exception  &$error  The Exception object to be handled.
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public static function handleError($error)
+	public static function handleError(&$error)
 	{
 		// Get the application object.
 		$app = JFactory::getApplication();
@@ -86,12 +94,9 @@ class PlgSystemLogout extends JPlugin
 		// Make sure the error is a 403 and we are in the frontend.
 		if ($error->getCode() == 403 && $app->isSite())
 		{
-			// Load language file.
-			parent::loadLanguage();
-
 			// Redirect to the home page.
-			$app->enqueueMessage(JText::_('PLG_SYSTEM_LOGOUT_REDIRECT'), 'message');
-			$app->redirect(JRoute::_('index.php'));
+			$app->enqueueMessage(JText::_('PLG_SYSTEM_LOGOUT_REDIRECT'));
+			$app->redirect('index.php');
 		}
 		else
 		{


### PR DESCRIPTION
Pull request for issue https://github.com/joomla/joomla-cms/issues/12322
### Summary of Changes

https://github.com/joomla/joomla-cms/pull/11736 causes fatal errors on user logout.
![regression](https://cloud.githubusercontent.com/assets/9630530/19152566/7826bf04-8bca-11e6-91e1-b72adbc86ae6.gif)

This is a regression and revering 11736 solves it.
### Testing Instructions
1. Use latests staging
2. Login in the frontend, edit an article and logout while editing: ERROR
3. Apply path
4. Repeat step 2. No error.
### Documentation Changes Required

None.

@zero-24 @wilsonge since 3.6.3 release is close (i think) please put a release blocker here for 3.6.3 and don't release 3.6.3 without checking this.
