### PR TITLE
fix for regression 12326 (3.7.x)

### DIFF
--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -25,17 +25,15 @@
 		<field
 			name="catid"
 			type="modal_category"
-			extension="com_users"
-			required="true"
 			label="COM_USERS_FIELD_CATEGORY_ID_LABEL"
 			description="JFIELD_CATEGORY_DESC"
+			extension="com_users"
 			required="true"
 			select="true"
 			new="true"
 			edit="true"
 			clear="true"
-		>
-		</field>
+		/>
 
 		<field
 			name="subject"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12326.
### Summary of Changes

Fix user notes duplicated required attribute generating a 500 error on user note create.
### Testing Instructions
1. Apply patch
2. Create a user note. all fine
### Documentation Changes Required

None.
