### PR TITLE
[3.6.3] Regression. The wrong editor is loaded

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -628,6 +628,9 @@ class JApplicationCms extends JApplicationWeb
 	 */
 	protected function initialiseApp($options = array())
 	{
+		// Set the configuration in the API.
+		$this->config = JFactory::getConfig();
+
 		// Check that we were given a language in the array (since by default may be blank).
 		if (isset($options['language']))
 		{


### PR DESCRIPTION
### Summary of Changes

Init the config value to load the correct editor. 
### Testing Instructions
- Install 3.6.3-rc2
- set up your default editor (global config) to tinyMCE
- go to your user config
- set the editor to "codemirror"
- try to create or edit an article.
- you notice that the tinymce is loaded
- apply this patch
- the codemirror is loaded (as per user setting)
### Documentation Changes Required

None
### Other things

@mbabker this reversts part of: #11838 can you take a look here maybe there is a better fix?
