### PR TITLE
Proxy JFactory::getConfig() to the application classes and deprecate it

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -40,6 +40,7 @@ abstract class JFactory
 	 *
 	 * @var    JConfig
 	 * @since  11.1
+	 * @deprecated  5.0  Use the configuration object within the application.
 	 */
 	public static $config = null;
 
@@ -155,9 +156,25 @@ abstract class JFactory
 	 *
 	 * @see     Registry
 	 * @since   11.1
+	 * @deprecated  5.0  Use the configuration object within the application.
 	 */
 	public static function getConfig($file = null, $type = 'PHP', $namespace = '')
 	{
+		JLog::add(
+			sprintf(
+				'%s() is deprecated. The configuration object should be read from the application.',
+				__METHOD__
+			),
+			JLog::WARNING,
+			'deprecated'
+		);
+
+		// If there is an application object, fetch the configuration from there
+		if (self::$application)
+		{
+			return self::$application->getConfig();
+		}
+
 		if (!self::$config)
 		{
 			if ($file === null)
@@ -542,9 +559,19 @@ abstract class JFactory
 	 *
 	 * @see     Registry
 	 * @since   11.1
+	 * @deprecated  5.0  Use the configuration object within the application.
 	 */
 	protected static function createConfig($file, $type = 'PHP', $namespace = '')
 	{
+		JLog::add(
+			sprintf(
+				'%s() is deprecated. The configuration object should be read from the application.',
+				__METHOD__
+			),
+			JLog::WARNING,
+			'deprecated'
+		);
+
 		if (is_file($file))
 		{
 			include_once $file;

--- a/libraries/src/Cms/Application/Autoconfigurable.php
+++ b/libraries/src/Cms/Application/Autoconfigurable.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Cms\Application;
 
+use Joomla\Registry\Registry;
+
 /**
  * Trait for application classes which can automatically retrieve the global configuration
  *
@@ -59,6 +61,18 @@ trait Autoconfigurable
 	}
 
 	/**
+	 * Retrieve the application configuration object.
+	 *
+	 * @return  Registry
+	 *
+	 * @since   4.0
+	 */
+	public function getConfig()
+	{
+		return $this->config;
+	}
+
+	/**
 	 * Load an object or array into the application configuration object.
 	 *
 	 * @param   mixed  $data  Either an array or object to be loaded into the configuration object.
@@ -72,11 +86,11 @@ trait Autoconfigurable
 		// Load the data into the configuration object.
 		if (is_array($data))
 		{
-			$this->config->loadArray($data);
+			$this->getConfig()->loadArray($data);
 		}
 		elseif (is_object($data))
 		{
-			$this->config->loadObject($data);
+			$this->getConfig()->loadObject($data);
 		}
 
 		return $this;

--- a/tests/unit/suites/libraries/cms/component/router/JComponentRouterBaseTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/JComponentRouterBaseTest.php
@@ -28,7 +28,7 @@ class JComponentRouterBaseTest extends TestCase
 	 */
 	public function testConstruct()
 	{
-		$app_bkp = JFactory::$application;
+		$this->saveFactoryState();
 		$app = $this->getMockCmsApp();
 		JFactory::$application = $app;
 		$menu = TestMockMenu::create($this);
@@ -69,7 +69,7 @@ class JComponentRouterBaseTest extends TestCase
 		$this->assertEquals($app, $object->app);
 		$this->assertEquals($menu, $object->menu);
 
-		JFactory::$language = $app_bkp;
+		$this->restoreFactoryState();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/archive/JArchiveTest.php
+++ b/tests/unit/suites/libraries/joomla/archive/JArchiveTest.php
@@ -63,10 +63,6 @@ class JArchiveTest extends JArchiveTestCase
 			$this->markTestSkipped('Gzip files can not be extracted.');
 		}
 
-		// we need a configuration with a tmp_path set
-		$config = JFactory::$config;
-		$config->set('tmp_path', __DIR__ . '/output');
-
 		JArchive::extract(__DIR__ . '/logo-gz.png.gz', $this->outputPath);
 		$this->assertFileExists($this->outputPath . '/logo-gz.png');
 	}
@@ -82,10 +78,6 @@ class JArchiveTest extends JArchiveTestCase
 		{
 			$this->markTestSkipped('Bzip2 files can not be extracted.');
 		}
-
-		// we need a configuration with a tmp_path set
-		$config = JFactory::$config;
-		$config->set('tmp_path', __DIR__ . '/output');
 
 		JArchive::extract(__DIR__ . '/logo-bz2.png.bz2', $this->outputPath);
 		$this->assertFileExists($this->outputPath . '/logo-bz2.png');

--- a/tests/unit/suites/libraries/joomla/archive/JArchiveTestCase.php
+++ b/tests/unit/suites/libraries/joomla/archive/JArchiveTestCase.php
@@ -7,6 +7,8 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
+use Joomla\Registry\Registry;
+
 /**
  * Abstract test case for archive package tests
  *
@@ -14,7 +16,7 @@
  * @subpackage  Archive
  * @since       3.1
  */
-abstract class JArchiveTestCase extends PHPUnit_Framework_TestCase
+abstract class JArchiveTestCase extends TestCase
 {
 	/**
 	 * Output path
@@ -43,10 +45,15 @@ abstract class JArchiveTestCase extends PHPUnit_Framework_TestCase
 			mkdir($this->outputPath, 0777);
 		}
 
-		if (! is_dir($this->outputPath))
+		if (!is_dir($this->outputPath))
 		{
 			$this->markTestSkipped('We can not create the output dir, so skip all tests');
 		}
+
+		$this->saveFactoryState();
+
+		// We need a configuration with a tmp_path set
+		JFactory::$config = new Registry(['tmp_path' => __DIR__ . '/output']);
 	}
 
 	/**
@@ -68,6 +75,8 @@ abstract class JArchiveTestCase extends PHPUnit_Framework_TestCase
 			}
 			rmdir($this->outputPath);
 		}
+
+		$this->restoreFactoryState();
 
 		unset($this->outputPath);
 		parent::tearDown();

--- a/tests/unit/suites/libraries/joomla/user/JUserTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserTest.php
@@ -42,6 +42,7 @@ class JUserTest extends TestCaseDatabase
 		$mockApp->expects($this->any())
 			->method('getDispatcher')
 			->willReturn($this->getMockDispatcher());
+
 		JFactory::$application = $mockApp;
 
 		$this->object = new JUser('42');
@@ -209,6 +210,7 @@ class JUserTest extends TestCaseDatabase
 				'root.1',
 				true
 			),
+			// TODO - When `assertSame` is used, this case fails because a null value is returned
 			'core.admin Other user' => array(
 				43,
 				'core.admin',
@@ -248,22 +250,9 @@ class JUserTest extends TestCaseDatabase
 	public function testAuthorise($userId, $action, $asset, $expected)
 	{
 		// Set up user 99 to be root_user from configuration
-		$testConfig = $this->getMock('JConfig', array('get'));
-		$testConfig->expects(
-			$this->any()
-		)
-			->method('get')
-			->will($this->returnValue(99));
-		JFactory::$config = $testConfig;
+		JFactory::$application->getConfig()->set('root_user', 99);
 
-		// Run through test cases
-		$user = new JUser($userId);
-		$this->assertThat(
-			$user->authorise($action, $asset),
-			$this->equalTo($expected),
-			'Line: ' . __LINE__ . ' Failed for user ' . $user->id
-		);
-
+		$this->assertEquals($expected, (new JUser($userId))->authorise($action, $asset), 'Failed for user ' . $userId);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
- If there is an application object in the factory, fetch the configuration from it when calling `JFactory::getConfig()`
- Deprecate the configuration object store in the factory for removal at 5.0; fetch the config out of the application class
- Since the application configuration doesn't get overloaded anymore, the top level `execution` and `uri` (for web apps) config keys created during app instantiation are now available globally, as well as any other config values set during instantiation (for web apps that includes a couple of session variables, for CLI there is a `cwd` value)
### Testing Instructions

The damn user editor parameter works
### Documentation Changes Required

Document new method available by way of the `Autoconfigurable` trait, document deprecations
