### PR TITLE
Trying to fix some of the HHVM unittests

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -137,7 +137,11 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			throw new JDatabaseExceptionConnecting('Error connecting to PGSQL database.');
 		}
 
-		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
+		if (function_exists('pg_set_error_verbosity'))
+		{
+			pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
+		}
+
 		pg_query($this->connection, 'SET standard_conforming_strings=off');
 		pg_query($this->connection, 'SET escape_string_warning=off');
 	}

--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -133,12 +133,12 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 
 		if (!empty(self::$_options['host']))
 		{
-		        $dsn .= 'host=' . self::$_options['host'] . ' ';
+		        $dsn .= 'host=' . self::$_options['host'] . ';';
 		}
 
 		if (!empty(self::$_options['port']))
 		{
-		        $dsn .= 'port=' . self::$_options['port'] . ' ';
+		        $dsn .= 'port=' . self::$_options['port'] . ';';
 		}
 
 		$dsn .= 'dbname=' . self::$_options['database'];


### PR DESCRIPTION
According to the documentation, a DSN connection string should use semicolons as delimiter and not spaces. It should also not make any difference for the normal PHP implementation. Since we have currently ~80 errors in the test suite when running on HHVM and most of these are related to this DSN string, I'm trying to fix this. Funnily, I don't have access to HHVM, so I'm going to try to fix this by running this through the unittests again and again... :speak_no_evil: :smile: 
