### PR TITLE
Minor change in doc block: the type is string, not array

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -971,7 +971,7 @@ abstract class JHtmlBehavior
 	 * Add javascript polyfills.
 	 *
 	 * @param   string|array  $polyfillTypes       The polyfill type(s). Examples: event, array('event', 'classlist').
-	 * @param   array         $conditionalBrowser  A IE conditional expression. Example: lt IE 9 (lower than IE 9).
+	 * @param   string        $conditionalBrowser  A IE conditional expression. Example: lt IE 9 (lower than IE 9).
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
### Summary of Changes

Just a minor correction in the new polyfill doc block (should be string, not array)
### Testing Instructions

Merged on code review.
### Documentation Changes Required

None.
