### PR TITLE
[com_finder] - remove reference to panthom table #__finder_links_terms

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -538,11 +538,27 @@ class FinderIndexerDriverMysql extends FinderIndexer
 			$db->execute();
 		}
 
+		// Optimize the filters table.
+		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_filters'));
+		$db->execute();
+
+		// Optimize the terms common table.
+		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_terms_common'));
+		$db->execute();
+
+		// Optimize the types table.
+		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_types'));
+		$db->execute();
+
 		// Remove the orphaned taxonomy nodes.
 		FinderIndexerTaxonomy::removeOrphanNodes();
 
 		// Optimize the taxonomy mapping table.
 		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_taxonomy_map'));
+		$db->execute();
+
+		// Optimize the taxonomy table.
+		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_taxonomy'));
 		$db->execute();
 
 		return true;

--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -538,10 +538,6 @@ class FinderIndexerDriverMysql extends FinderIndexer
 			$db->execute();
 		}
 
-		// Optimize the terms mapping table.
-		$db->setQuery('OPTIMIZE TABLE ' . $db->quoteName('#__finder_links_terms'));
-		$db->execute();
-
 		// Remove the orphaned taxonomy nodes.
 		FinderIndexerTaxonomy::removeOrphanNodes();
 

--- a/components/com_finder/models/search.php
+++ b/components/com_finder/models/search.php
@@ -990,29 +990,6 @@ class FinderModelSearch extends JModelList
 	}
 
 	/**
-	 * Method to get a subquery for filtering link ids mapped to specific
-	 * terms ids.
-	 *
-	 * @param   array  $terms  An array of search term ids.
-	 *
-	 * @return  JDatabaseQuery  A database object.
-	 *
-	 * @since   2.5
-	 */
-	protected function getTermsQuery($terms)
-	{
-		// Create the SQL query to get the matching link ids.
-		// TODO: Impact of removing SQL_NO_CACHE?
-		$db = $this->getDbo();
-		$query = $db->getQuery(true)
-			->select('SQL_NO_CACHE link_id')
-			->from('#__finder_links_terms')
-			->where('term_id IN (' . implode(',', $terms) . ')');
-
-		return $query;
-	}
-
-	/**
 	 * Method to get a store id based on model the configuration state.
 	 *
 	 * This is necessary because the model is used by the component and


### PR DESCRIPTION
If i'm not wrong the `#__finder_links_terms` table don't exists
### Summary of Changes
- remove panthom table #__finder_links_terms optimization
- remove the unused method getTermsQuery() wich refer on panthom table
### Testing Instructions

smart search work as before
