### PR TITLE
[com_finder] - cast to char before use LIKE operator  on datetime/tim…

### DIFF
--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -215,7 +215,7 @@ class FinderModelIndex extends JModelList
 			// Filter by indexdate only if $search doesn't contains non-ascii characters
 			if (!preg_match('/[^\x00-\x7F]/', $search))
 			{
-				$orSearchSql .= ' OR CAST((' . $db->quoteName('l.indexdate') . ') AS CHAR(19)) LIKE  ' . $search;
+				$orSearchSql .= ' OR ' . $query->castAsChar($db->quoteName('l.indexdate')) . ' LIKE ' . $search;
 			}
 
 			$query->where('(' . $orSearchSql . ')');

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -215,7 +215,7 @@ class FinderModelIndex extends JModelList
 			// Filter by indexdate only if $search doesn't contains non-ascii characters
 			if (!preg_match('/[^\x00-\x7F]/', $search))
 			{
-				$orSearchSql .= ' OR ' . $db->quoteName('l.indexdate') . ' LIKE  ' . $search;
+				$orSearchSql .= ' OR CAST((' . $db->quoteName('l.indexdate') . ') AS CHAR(19)) LIKE  ' . $search;
 			}
 
 			$query->where('(' . $orSearchSql . ')');


### PR DESCRIPTION
fix for standard SQL
### Summary of Changes

A timestamp/datetime field CANNOT be used with LIKE operator we need to cast to char before in standard SQL
### Testing Instructions

Smart Search: Indexed Content search field   with a date work as before
