### PR TITLE
[4.0] Fix JPlugin result handling

### DIFF
--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -258,9 +258,6 @@ abstract class JPlugin implements DispatcherAwareInterface
 				// Get the event arguments
 				$arguments = $event->getArguments();
 
-				// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
-				$arguments = array_values($arguments);
-
 				// Extract any old results; they must not be part of the method call.
 				$allResults = [];
 
@@ -270,6 +267,9 @@ abstract class JPlugin implements DispatcherAwareInterface
 
 					unset($arguments['result']);
 				}
+
+				// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
+				$arguments = array_values($arguments);
 
 				/**
 				 * Calling the method directly is faster than using call_user_func_array, hence this argument


### PR DESCRIPTION
### Summary of Changes

Right now when "legacy" event listeners are running, the results are being overwritten instead of appended which results in only the last plugin's result being usable.  This corrects that.
### Testing Instructions

On the extension install page you only have one of the three tabs right now.  With the patch, you'll have all three.
### Documentation Changes Required

N/A
