### PR TITLE
3.6.3: Allow author to use xtd-editors

### DIFF
--- a/components/com_content/content.php
+++ b/components/com_content/content.php
@@ -12,28 +12,6 @@ defined('_JEXEC') or die;
 JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
 JLoader::register('ContentHelperQuery', JPATH_SITE . '/components/com_content/helpers/query.php');
 
-$input = JFactory::getApplication()->input;
-$user  = JFactory::getUser();
-
-if ($input->get('view') === 'article' && $input->get('layout') === 'pagebreak')
-{
-	if (!$user->authorise('core.edit', 'com_content'))
-	{
-		JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
-
-		return;
-	}
-}
-elseif ($input->get('view') === 'articles' && $input->get('layout') === 'modal')
-{
-	if (!$user->authorise('core.edit', 'com_content'))
-	{
-		JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'warning');
-
-		return;
-	}
-}
-
 $controller = JControllerLegacy::getInstance('Content');
-$controller->execute($input->get('task'));
+$controller->execute(JFactory::getApplication()->input->get('task'));
 $controller->redirect();

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -39,36 +39,43 @@ class PlgButtonArticle extends JPlugin
 		 * jSelectArticle creates the link tag, sends it to the editor,
 		 * and closes the select frame.
 		 */
-		$js = "
-		function jSelectArticle(id, title, catid, object, link, lang)
+		$user  = JFactory::getUser();
+
+		if ($user->authorise('core.create', 'com_content')
+			|| $user->authorise('core.edit', 'com_content')
+			|| $user->authorise('core.edit.own', 'com_content'))
 		{
-			var hreflang = '';
-			if (lang !== '')
+			$js = "
+			function jSelectArticle(id, title, catid, object, link, lang)
 			{
-				var hreflang = ' hreflang = \"' + lang + '\"';
-			}
-			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
-			jInsertEditorText(tag, '" . $name . "');
-			jModalClose();
-		}";
+				var hreflang = '';
+				if (lang !== '')
+				{
+					var hreflang = ' hreflang = \"' + lang + '\"';
+				}
+				var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+				jInsertEditorText(tag, '" . $name . "');
+				jModalClose();
+			}";
 
-		$doc = JFactory::getDocument();
-		$doc->addScriptDeclaration($js);
+			$doc = JFactory::getDocument();
+			$doc->addScriptDeclaration($js);
 
-		/*
-		 * Use the built-in element view to select the article.
-		 * Currently uses blank class.
-		 */
-		$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+			/*
+			 * Use the built-in element view to select the article.
+			 * Currently uses blank class.
+			 */
+			$link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button = new JObject;
-		$button->modal = true;
-		$button->class = 'btn';
-		$button->link = $link;
-		$button->text = JText::_('PLG_ARTICLE_BUTTON_ARTICLE');
-		$button->name = 'file-add';
-		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+			$button = new JObject;
+			$button->modal = true;
+			$button->class = 'btn';
+			$button->link = $link;
+			$button->text = JText::_('PLG_ARTICLE_BUTTON_ARTICLE');
+			$button->name = 'file-add';
+			$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
-		return $button;
+			return $button;
+		}
 	}
 }

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -38,17 +38,24 @@ class PlgButtonModule extends JPlugin
 		 * Use the built-in element view to select the module.
 		 * Currently uses blank class.
 		 */
-		$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
-				. $name . '&amp;' . JSession::getFormToken() . '=1';
+		$user  = JFactory::getUser();
 
-		$button          = new JObject;
-		$button->modal   = true;
-		$button->class   = 'btn';
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_MODULE_BUTTON_MODULE');
-		$button->name    = 'file-add';
-		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+		if ($user->authorise('core.create', 'com_content')
+			|| $user->authorise('core.edit', 'com_content')
+			|| $user->authorise('core.edit.own', 'com_content'))
+		{
+			$link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
+					. $name . '&amp;' . JSession::getFormToken() . '=1';
 
-		return $button;
+			$button          = new JObject;
+			$button->modal   = true;
+			$button->class   = 'btn';
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_MODULE_BUTTON_MODULE');
+			$button->name    = 'file-add';
+			$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+
+			return $button;
+		}
 	}
 }

--- a/plugins/editors-xtd/pagebreak/pagebreak.php
+++ b/plugins/editors-xtd/pagebreak/pagebreak.php
@@ -33,16 +33,23 @@ class PlgButtonPagebreak extends JPlugin
 	 */
 	public function onDisplay($name)
 	{
-		$link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
+		$user  = JFactory::getUser();
 
-		$button          = new JObject;
-		$button->modal   = true;
-		$button->class   = 'btn';
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_EDITORSXTD_PAGEBREAK_BUTTON_PAGEBREAK');
-		$button->name    = 'copy';
-		$button->options = "{handler: 'iframe', size: {x: 500, y: 300}}";
+		if ($user->authorise('core.create', 'com_content')
+			|| $user->authorise('core.edit', 'com_content')
+			|| $user->authorise('core.edit.own', 'com_content'))
+		{
+			$link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
 
-		return $button;
+			$button          = new JObject;
+			$button->modal   = true;
+			$button->class   = 'btn';
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_EDITORSXTD_PAGEBREAK_BUTTON_PAGEBREAK');
+			$button->name    = 'copy';
+			$button->options = "{handler: 'iframe', size: {x: 500, y: 300}}";
+
+			return $button;
+		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/pull/10653#issuecomment-241283338 and https://github.com/joomla/joomla-cms/issues/12338

Moving the access to the xtd-editors buttons to the plugins themselves.
Allow authors to use xtd-articles and pagebreak.

Main reason: displaying the list of articles to an author or to an Editor does not change the kind of articles displayed in the lists, therefore it is useless to prevent authors from using these lists.
Concerning issues with modals in frontend, this now makes sure all xtd-editors modals are only used by logged in users (Image was already taken care of).

To test:
Make sure you have a menu item to Submit Article in frontend, log as a Author, then submit article and use the buttons Articles, Pagebreak, Module.
