### PR TITLE
[fix] feed factory: 0 Error String could not be parsed as XML

### DIFF
--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -82,7 +82,13 @@ class JFeedFactory
 		// Setup the appopriate feed parser for the feed.
 		$parser = $this->_fetchFeedParser($reader->name, $reader);
 
-		return $parser->parse();
+		try {
+			return $parser->parse();
+		}
+		catch (Exception $e)
+		{
+			throw new RuntimeException('Error reading feed.', $e->getCode(), $e);
+		}
 	}
 
 	/**

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -82,7 +82,8 @@ class JFeedFactory
 		// Setup the appopriate feed parser for the feed.
 		$parser = $this->_fetchFeedParser($reader->name, $reader);
 
-		try {
+		try 
+		{
 			return $parser->parse();
 		}
 		catch (Exception $e)


### PR DESCRIPTION
Pull Request for Issue #11106 .
https://github.com/joomla/joomla-cms/issues/11106
This issue is closed, but the problem still exists in 3.6.2: it happened yesterday, http://feeds.joomla.org/JoomlaSecurityNews was not responding fast enough.
### Summary of Changes

Uncatch error in feed factory
Error String could not be parsed as XML : this problem happens randomly
### Testing Instructions

Create an incomplete feed and call it in a newsfeed module
