### PR TITLE
Add article preview button to toolbar

### DIFF
--- a/administrator/components/com_content/helpers/preview.php
+++ b/administrator/components/com_content/helpers/preview.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Preview Link Helper
+ *
+ * @since  3.0
+ */
+class Preview
+{
+	/**
+	 * Get the article URL
+	 *
+	 * @param   object  $article  The article object
+	 *
+	 * @return  string  The article URL
+	 */
+	public static function url($article)
+	{
+		$lang = '';
+		$sef  = '';
+
+		// Get the home Itemid for the language
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		$query->select('id')
+			->from($db->qn('#__menu'))
+			->where($db->qn('home') . '= 1')
+			->where($db->qn('published') . '= 1')
+			->where($db->qn('client_id') . '= 0');
+
+		if (JLanguageMultilang::isEnabled())
+		{
+			$query->where($db->qn('language') . ' = ' . $db->q($article->language));
+		}
+		else
+		{
+			$query->where($db->qn('language') . ' = ' . $db->q('*'));
+		}
+		$db->setQuery($query);
+
+		$Itemid = '&amp;Itemid=' . (int) $db->loadResult();
+
+		if ($article->language && JLanguageMultilang::isEnabled())
+		{
+			// Get the sef prefix for the language
+			$query->clear()
+				->select('sef')
+				->from($db->qn('#__languages'))
+				->where($db->qn('published') . '= 1')
+				->where($db->qn('lang_code') . ' = ' . $db->q($article->language));
+			$db->setQuery($query);
+
+			$sef = $db->loadResult();
+
+			if ($article->language != '*')
+			{
+				$lang = '&amp;lang=' . $sef;
+			}
+			else
+			{
+				$lang = '';
+			}
+		}
+
+		$url = JUri::root() . 'index.php?option=com_content&amp;view=article&amp;id=' . (int) $article->id
+		. '&amp;catid=' . (int) $article->catid . $lang . $Itemid;
+
+		return $url;
+	}
+}

--- a/administrator/components/com_content/helpers/preview.php
+++ b/administrator/components/com_content/helpers/preview.php
@@ -14,12 +14,12 @@ defined('_JEXEC') or die;
  *
  * @since  3.0
  */
-class Preview
+class ContentHelperPreview
 {
 	/**
 	 * Get the article URL
 	 *
-	 * @param   object  $article  The article object
+	 * @param   object  $article  The article item object
 	 *
 	 * @return  string  The article URL
 	 */

--- a/administrator/components/com_content/helpers/preview.php
+++ b/administrator/components/com_content/helpers/preview.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Preview Link Helper
  *
- * @since  3.0
+ * @since  __DEPLOY_VERSION__
  */
 class ContentHelperPreview
 {

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -132,8 +132,8 @@ class ContentViewArticle extends JViewLegacy
 
 			if (!$isNew)
 			{
-				JLoader::register('Preview', JPATH_ADMINISTRATOR . '/components/com_content/helpers/preview.php');
-				$url = Preview::url($this->item);
+				JLoader::register('ContentHelperPreview', JPATH_ADMINISTRATOR . '/components/com_content/helpers/preview.php');
+				$url = ContentHelperPreview::url($this->item);
 
 				JToolbarHelper::preview($url, JText::_('JGLOBAL_PREVIEW'), 'eye');
 			}

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -135,7 +135,7 @@ class ContentViewArticle extends JViewLegacy
 				JLoader::register('Preview', JPATH_ADMINISTRATOR . '/components/com_content/helpers/preview.php');
 				$url = Preview::url($this->item);
 
-				JToolbarHelper::preview($url, 'Preview', 'eye');
+				JToolbarHelper::preview($url, JText::_('JGLOBAL_PREVIEW'), 'eye');
 			}
 
 			JToolbarHelper::cancel('article.cancel', 'JTOOLBAR_CLOSE');

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -130,6 +130,14 @@ class ContentViewArticle extends JViewLegacy
 				JToolbarHelper::versions('com_content.article', $this->item->id);
 			}
 
+			if (!$isNew)
+			{
+				JLoader::register('Preview', JPATH_ADMINISTRATOR . '/components/com_content/helpers/preview.php');
+				$url = Preview::url($this->item);
+
+				JToolbarHelper::preview($url, 'Preview', 'eye');
+			}
+
 			JToolbarHelper::cancel('article.cancel', 'JTOOLBAR_CLOSE');
 		}
 

--- a/administrator/includes/toolbar.php
+++ b/administrator/includes/toolbar.php
@@ -106,12 +106,12 @@ abstract class JToolbarHelper
 	 *
 	 * @since   1.5
 	 */
-	public static function preview($url = '', $updateEditors = false)
+	public static function preview($url = '', $updateEditors = false, $icon = 'preview')
 	{
 		$bar = JToolbar::getInstance('toolbar');
 
 		// Add a preview button.
-		$bar->appendButton('Popup', 'preview', 'Preview', $url . '&task=preview');
+		$bar->appendButton('Popup', $icon, 'Preview', $url . '&task=preview');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request in favour of #10932 
### Summary of Changes

This PR adds a preview button to the toolbar, which upon clicking, reveals a modal, showing the user a preview of the article in the frontend.

![screeny1](https://cloud.githubusercontent.com/assets/2019801/19221079/e725e054-8e33-11e6-9958-177183740a57.png)
### Testing Instructions
1. Apply PR
2. Open an existing article (or create and **save** a new one)
3. Click preview button
4. Ensure the modal displays your site with a preview of the article
### Documentation Changes Required

None
### Note

I've put the function to get the URL in a new helper file rather than the `view.html.php`. Is this the correct approach?
