### PR TITLE
Review en-US install language

### DIFF
--- a/installation/language/en-US/en-US.ini
+++ b/installation/language/en-US/en-US.ini
@@ -95,7 +95,7 @@ INSTL_SAMPLE_LEARN_SET_DESC="Install Joomla with example articles that describe 
 INSTL_SAMPLE_TESTING_SET_DESC="Install Joomla with all possible menu items to help with testing Joomla."
 
 ;Summary view
-INSTL_FINALISATION="Finalisation"
+INSTL_FINALISATION="Finalization"
 INSTL_SUMMARY_INSTALL="Install"
 INSTL_SUMMARY_EMAIL_LABEL="Email Configuration"
 INSTL_SUMMARY_EMAIL_DESC="Send configuration settings to %s by email after installation."
@@ -150,7 +150,7 @@ INSTL_LANGUAGES_WARNING_BACK_BUTTON="Return to last installation step"
 
 ;Default language view
 INSTL_DEFAULTLANGUAGE_ACTIVATE_MULTILANGUAGE="Activate the multilingual feature"
-INSTL_DEFAULTLANGUAGE_ACTIVATE_MULTILANGUAGE_DESC="If active, your Joomla site will have the multilingual feature active with localised menus for each installed language."
+INSTL_DEFAULTLANGUAGE_ACTIVATE_MULTILANGUAGE_DESC="If active, your Joomla site will have the multilingual feature active with localized menus for each installed language."
 INSTL_DEFAULTLANGUAGE_ACTIVATE_LANGUAGE_CODE_PLUGIN="Enable the language code plugin"
 INSTL_DEFAULTLANGUAGE_ACTIVATE_LANGUAGE_CODE_PLUGIN_DESC="If enabled, the language code plugin will add the ability to change the language code in the generated HTML document to improve SEO."
 INSTL_DEFAULTLANGUAGE_ADMINISTRATOR="Default Administrator language"
@@ -165,7 +165,7 @@ INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU="Joomla was unable to automatically 
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM="Joomla was unable to automatically create the %s home menu item."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_MODULE="Joomla was unable to automatically create the %s menu module."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY="Joomla was unable to automatically create the %s content category."
-INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE="Joomla was unable to automatically create the %s localised article."
+INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE="Joomla was unable to automatically create the %s localized article."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_MODULESWHITCHER_LANGUAGECODE="Joomla was unable to automatically publish the language switcher module."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGECODE="Joomla was unable to automatically enable the Language Code Plugin."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGEFILTER="Joomla was unable to automatically enable the Language Filter Plugin."
@@ -177,7 +177,7 @@ INSTL_DEFAULTLANGUAGE_DESC_FRONTEND="Joomla has installed the following language
 INSTL_DEFAULTLANGUAGE_FRONTEND="Default Site language"
 INSTL_DEFAULTLANGUAGE_FRONTEND_COULDNT_SET_DEFAULT="Joomla was unable to set the language as default. English will be used as default language for the Frontend SITE."
 INSTL_DEFAULTLANGUAGE_FRONTEND_SET_DEFAULT="Joomla has set %s as your default SITE language."
-INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT="Install localised content"
+INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT="Install localized content"
 INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT_DESC="If active, Joomla will automatically create one content category per each installed language. Also, one featured article containing dummy content will be created on each category."
 INSTL_DEFAULTLANGUAGE_MULTILANGUAGE_TITLE="Multilingual"
 INSTL_DEFAULTLANGUAGE_MULTILANGUAGE_DESC="This section allows you to automatically activate the Joomla! multilingual feature."


### PR DESCRIPTION
### Summary of Changes

Updated en-US install language, it's just our use of Z over S at this point
### Testing Instructions

Review
### Documentation Changes Required
