### PR TITLE
[plg_recaptcha] Check if can show captcha error messages

### DIFF
--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -202,9 +202,12 @@ class PlgCaptchaRecaptcha extends JPlugin
 				if ( !isset($response->success) || !$response->success)
 				{
 					// @todo use exceptions here
-					foreach ($response->errorCodes as $error)
+					if (is_array($response->errorCodes))
 					{
-						$this->_subject->setError($error);
+						foreach ($response->errorCodes as $error)
+						{
+							$this->_subject->setError($error);
+						}
 					}
 
 					return false;


### PR DESCRIPTION
Pull Request for Issue -.

This is updated PR of #9305.

Captcha API may not return any error codes for failed check.
In this case the `JRecaptcha::verifyResponse` doesn't return an array of error codes but an empty string (see https://github.com/joomla/joomla-cms/blob/3.6.2/plugins/captcha/recaptcha/recaptchalib.php#L142) and we get a PHP warning:

```
Warning: Invalid argument supplied for foreach() in [joomla]/plugins/captcha/recaptcha/recaptcha.php on line 205
```
### Summary of Changes

Checking if response error codes format is an array.
### Testing Instructions

I'm not sure how to trigger a recaptcha error without an error code, if I find out I'll update the testing intructions.

For now please do code review
### Documentation Changes Required

none
