### PR TITLE
Native language (adjustments after 12036 merge)

### DIFF
--- a/installation/form/field/language.php
+++ b/installation/form/field/language.php
@@ -62,7 +62,7 @@ class InstallationFormFieldLanguage extends JFormFieldList
 		}
 
 		// Get the list of available languages.
-		$options = JLanguageHelper::createLanguageList($native);
+		$options = JLanguageHelper::createLanguageList($native, JPATH_BASE, false, false, 'nativeName');
 
 		// Fix wrongly set parentheses in RTL languages
 		if (JFactory::getLanguage()->isRtl())

--- a/installation/form/field/language.php
+++ b/installation/form/field/language.php
@@ -62,7 +62,7 @@ class InstallationFormFieldLanguage extends JFormFieldList
 		}
 
 		// Get the list of available languages.
-		$options = JLanguageHelper::createLanguageList($native, JPATH_BASE, false, false, 'nativeName');
+		$options = JLanguageHelper::createLanguageList($native);
 
 		// Fix wrongly set parentheses in RTL languages
 		if (JFactory::getLanguage()->isRtl())

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -53,11 +53,17 @@ class JLanguageHelper
 		{
 			if (!$installed || array_key_exists($lang, $installed_languages))
 			{
-				$list[] = array(
-					'text'     => isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'],
-					'value'    => $lang,
-					'selected' => $lang === $actualLanguage ? 'selected="selected"' : null,
+				$option = array(
+					'text'  => isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'],
+					'value' => $lang,
 				);
+
+				if ($lang === $actualLanguage)
+				{
+					$option['selected'] = 'selected="selected"';
+				}
+
+				$list[] = $option;
 			}
 		}
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -23,13 +23,12 @@ class JLanguageHelper
 	 * @param   string   $basePath        Base path to use
 	 * @param   boolean  $caching         True if caching is used
 	 * @param   boolean  $installed       Get only installed languages
-	 * @param   string   $field           The metadata field name
 	 *
 	 * @return  array  List of system languages
 	 *
 	 * @since   11.1
 	 */
-	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false, $field ='nativeName')
+	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false)
 	{
 		$list = array();
 
@@ -56,7 +55,7 @@ class JLanguageHelper
 			{
 				$option = array();
 
-				$option['text'] = isset($metadata[$field]) ? $metadata[$field] : $metadata['name'];
+				$option['text'] = isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'];
 				$option['value'] = $lang;
 
 				if ($lang == $actualLanguage)

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -23,12 +23,13 @@ class JLanguageHelper
 	 * @param   string   $basePath        Base path to use
 	 * @param   boolean  $caching         True if caching is used
 	 * @param   boolean  $installed       Get only installed languages
+	 * @param   string   $field           The metadata field name
 	 *
 	 * @return  array  List of system languages
 	 *
 	 * @since   11.1
 	 */
-	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false)
+	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false, $field ='name')
 	{
 		$list = array();
 
@@ -55,7 +56,7 @@ class JLanguageHelper
 			{
 				$option = array();
 
-				$option['text'] = $metadata['name'];
+				$option['text'] = isset($metadata[$field]) ? $metadata[$field] : $metadata['name'];
 				$option['value'] = $lang;
 
 				if ($lang == $actualLanguage)
@@ -145,6 +146,7 @@ class JLanguageHelper
 					$obj = new stdClass;
 					$obj->lang_code = $metadata['tag'];
 					$languages[$key][] = $obj;
+					
 				}
 			}
 			else

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -29,7 +29,7 @@ class JLanguageHelper
 	 *
 	 * @since   11.1
 	 */
-	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false, $field ='name')
+	public static function createLanguageList($actualLanguage, $basePath = JPATH_BASE, $caching = false, $installed = false, $field ='nativeName')
 	{
 		$list = array();
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -146,7 +146,6 @@ class JLanguageHelper
 					$obj = new stdClass;
 					$obj->lang_code = $metadata['tag'];
 					$languages[$key][] = $obj;
-					
 				}
 			}
 			else

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -53,17 +53,11 @@ class JLanguageHelper
 		{
 			if (!$installed || array_key_exists($lang, $installed_languages))
 			{
-				$option = array();
-
-				$option['text'] = isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'];
-				$option['value'] = $lang;
-
-				if ($lang == $actualLanguage)
-				{
-					$option['selected'] = 'selected="selected"';
-				}
-
-				$list[] = $option;
+				$list[] = array(
+					'text'     => isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'],
+					'value'    => $lang,
+					'selected' => $lang === $actualLanguage ? 'selected="selected"' : null,
+				);
 			}
 		}
 

--- a/tests/unit/suites/libraries/joomla/language/JLanguageHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageHelperTest.php
@@ -23,7 +23,7 @@ class JLanguageHelperTest extends PHPUnit_Framework_TestCase
 	public function testCreateLanguageList()
 	{
 		$option = array(
-			'text'     => 'English (en-GB)',
+			'text'     => 'English (United Kingdom)',
 			'value'    => 'en-GB',
 			'selected' => 'selected="selected"'
 		);


### PR DESCRIPTION
Pull Request for New Issue.
### Summary of Changes

One side effect of https://github.com/joomla/joomla-cms/pull/12036 merge was that en-GB native language title `English (United Kingdom)` was replace is several language select fields (installation, admin login and user profile admin language) by `English (en-GB)`

This PR restaures the previous text by checking if the new `nativeName` metadata exists for the language, if so, will use it, if not, will fallback to `name` metadata.
### Testing Instructions
- Use 3.7.x branch
- Go to `/installation/index.php?view=site` and confirm the title of en-GB language is `English (en-GB)`

![image](https://cloud.githubusercontent.com/assets/9630530/19291877/e958da7e-900f-11e6-8b90-db0aecfa1290.png)
- Apply patch
- Repeat step and confirm the title of en-GB language title is `English (United Kingdom)`

![image](https://cloud.githubusercontent.com/assets/9630530/19291831/912cf9d4-900f-11e6-9619-b0d663042dc2.png)
- Also confirm the same result in the admin login and user profile admin language select fields, ie, whenever joomla is using the xml files metadada to generate this select fields.
### Documentation Changes Required

None.
