### PR TITLE
Update french help site url to use https

### DIFF
--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -2,6 +2,6 @@
 <joshelp>
 	<sites>
 		<site tag="en-GB" url="https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}">English (GB) - Joomla help wiki</site>
-		<site tag="fr-FR" url="http://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
+		<site tag="fr-FR" url="https://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">FranÃ§ais (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>

--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 <joshelp>
 	<sites>
-		<site tag="en-GB" url="https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}">English (GB) - Joomla help wiki</site>
+		<site tag="en-GB" url="https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&amp;lang={langcode}">English (GB) - Joomla help wiki</site>
 		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>

--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -2,6 +2,6 @@
 <joshelp>
 	<sites>
 		<site tag="en-GB" url="https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}">English (GB) - Joomla help wiki</site>
-		<site tag="fr-FR" url="https://help.joomla.fr/3/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
+		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>

--- a/tests/unit/suites/libraries/cms/form/field/JFormFieldHelpsiteTest.php
+++ b/tests/unit/suites/libraries/cms/form/field/JFormFieldHelpsiteTest.php
@@ -80,7 +80,7 @@ class JFormFieldHelpsiteTest extends TestCase
 		);
 
 		$this->assertContains(
-			'<option value="https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}">',
+			'<option value="https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&amp;lang={langcode}">',
 			$field->input,
 			'The getInput method should return an option with a link to the help site.'
 		);


### PR DESCRIPTION
Looks like the french help site has been updated (at some point) to use https

Changing it here saves a redirect ;)
