### PR TITLE
[3.7.x] Regression Hathor modules and users manager (solves #12407)

### DIFF
--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -49,7 +49,7 @@ $saveOrder = $listOrder == 'ordering';
 				<?php echo JHtml::_('select.options', ModulesHelper::getClientOptions(), 'value', 'text', $this->state->get('client_id'));?>
 			</select>
 
-            <label class="selectlabel" for="filter_state">
+			<label class="selectlabel" for="filter_state">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_state" id="filter_state">
@@ -57,7 +57,7 @@ $saveOrder = $listOrder == 'ordering';
 				<?php echo JHtml::_('select.options', ModulesHelper::getStateOptions(), 'value', 'text', $this->state->get('filter.state'));?>
 			</select>
 
-            <label class="selectlabel" for="filter_position">
+			<label class="selectlabel" for="filter_position">
 				<?php echo JText::_('COM_MODULES_OPTION_SELECT_POSITION'); ?>
 			</label>
 			<select name="filter_position" id="filter_position">
@@ -105,13 +105,13 @@ $saveOrder = $listOrder == 'ordering';
 				<th class="title">
 					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'title', $listDirn, $listOrder); ?>
 				</th>
-                <th class="width-5">
+				<th class="width-5">
 					<?php echo JHtml::_('grid.sort', 'JSTATUS', 'published', $listDirn, $listOrder); ?>
 				</th>
 				<th class="width-20">
 					<?php echo JHtml::_('grid.sort', 'COM_MODULES_HEADING_POSITION', 'position', $listDirn, $listOrder); ?>
 				</th>
-                <th class="nowrap ordering-col">
+				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
 					<?php if ($canOrder && $saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'modules.saveorder'); ?>
@@ -120,7 +120,7 @@ $saveOrder = $listOrder == 'ordering';
 				<th class="width-10">
 					<?php echo JHtml::_('grid.sort', 'COM_MODULES_HEADING_MODULE', 'name', $listDirn, $listOrder); ?>
 				</th>
-                	<th class="width-10">
+				<th class="width-10">
 					<?php echo JHtml::_('grid.sort', 'COM_MODULES_HEADING_PAGES', 'pages', $listDirn, $listOrder); ?>
 				</th>
 				<th class="title access-col">
@@ -162,13 +162,13 @@ $saveOrder = $listOrder == 'ordering';
 						<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note));?></p>
 					<?php endif; ?>
 				</td>
-                <td class="center">
+				<td class="center">
 					<?php echo JHtml::_('modules.state', $item->published, $i, $canChange, 'cb'); ?>
 				</td>
 				<td class="center">
 					<?php echo $item->position; ?>
 				</td>
-                <td class="order">
+				<td class="order">
 					<?php if ($canChange) : ?>
 						<?php if ($saveOrder) :?>
 							<?php if ($listDirn == 'asc') : ?>
@@ -185,7 +185,7 @@ $saveOrder = $listOrder == 'ordering';
 						<?php echo $item->ordering; ?>
 					<?php endif; ?>
 				</td>
-                <td class="left">
+				<td class="left">
 					<?php echo $item->name;?>
 				</td>
 				<td class="center">
@@ -212,10 +212,20 @@ $saveOrder = $listOrder == 'ordering';
 		</tbody>
 	</table>
 
-	<?php //Load the batch processing form.is user is allowed ?>
-	<?php if ($user->authorise('core.create', 'com_modules') || $user->authorise('core.edit', 'com_modules')) : ?>
-		<?php echo $this->loadTemplate('batch'); ?>
-	<?php endif;?>
+	<?php // Load the batch processing form. ?>
+	<?php if ($user->authorise('core.create', 'com_modules')
+		&& $user->authorise('core.edit', 'com_modules')
+		&& $user->authorise('core.edit.state', 'com_modules')) : ?>
+		<?php echo JHtml::_(
+			'bootstrap.renderModal',
+			'collapseModal',
+			array(
+				'title' => JText::_('COM_MODULES_BATCH_OPTIONS'),
+				'footer' => $this->loadTemplate('batch_footer')
+			),
+			$this->loadTemplate('batch_body')
+		); ?>
+	<?php endif; ?>
 
 	<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/templates/hathor/html/com_users/users/default.php
+++ b/administrator/templates/hathor/html/com_users/users/default.php
@@ -207,8 +207,20 @@ $loggeduser = JFactory::getUser();
 		</tbody>
 	</table>
 
-	<?php //Load the batch processing form. ?>
-	<?php echo $this->loadTemplate('batch'); ?>
+	<?php // Load the batch processing form if user is allowed ?>
+	<?php if ($loggeduser->authorise('core.create', 'com_users')
+		&& $loggeduser->authorise('core.edit', 'com_users')
+		&& $loggeduser->authorise('core.edit.state', 'com_users')) : ?>
+		<?php echo JHtml::_(
+			'bootstrap.renderModal',
+			'collapseModal',
+			array(
+				'title' => JText::_('COM_USERS_BATCH_OPTIONS'),
+				'footer' => $this->loadTemplate('batch_footer')
+			),
+			$this->loadTemplate('batch_body')
+		); ?>
+	<?php endif;?>
 
 	<?php echo $this->pagination->getListFooter(); ?>
 	<div>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12407

https://github.com/joomla/joomla-cms/pull/11762 has deleted some files which were necessary for Hathor to display the Users Manager as well as the Modules manager.
This PR  corrects the Hathor overrides `default.php` files to use the same code as in other managers using the batch function.

@RonakParmar @brianteeman @wilsonge
