### PR TITLE
Break up the head renderer into smaller, specialized functions.

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -63,16 +63,86 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		$app->triggerEvent('onBeforeCompileHead');
 
 		// Get line endings
-		$lnEnd        = $document->_getLineEnd();
-		$tab          = $document->_getTab();
-		$tagEnd       = ' />';
-		$buffer       = '';
-		$mediaVersion = $document->getMediaVersion();
+		$lnEnd  = $document->_getLineEnd();
+
+		// Get the meta tags (also base, title, etc.)
+		$buffer = $this->fetchMetaTags($document);
+
+		// Get (non-stylesheet) link tags if any
+		if (!empty($document->_links))
+		{
+			$buffer = array_merge($buffer, $this->fetchLinkTags($document));
+		}
+
+		// Get the stylesheets
+		if (!empty($document->_styleSheets))
+		{
+			$buffer = array_merge($buffer, $this->fetchStyleSheets($document));
+		}
+
+		// Get the style declarations
+		if (!empty($document->_style))
+		{
+			$buffer = array_merge($buffer, $this->fetchStyleDeclarations($document));
+		}
+
+		// Get scripts (loaded as external files)
+		if (!empty($document->_scripts))
+		{
+			$buffer = array_merge($buffer, $this->fetchScripts($document));
+		}
+
+		// Get script options
+		$scriptOptions = $document->getScriptOptions();
+
+		if (!empty($scriptOptions))
+		{
+			$buffer = array_merge($buffer, $this->fetchScriptOptions($document));
+		}
+
+		// Get script declarations
+		if (!empty($document->_script))
+		{
+			$buffer = array_merge($buffer, $this->fetchScriptDeclarations($document));
+		}
+
+		// Get translation strings for javascript
+		$script = JText::script();
+
+		if (!empty($script))
+		{
+			$buffer = array_merge($buffer, $this->fetchScriptLanguageDeclarations($document));
+		}
+
+		// Get custom tags
+		if (!empty($document->_custom))
+		{
+			$buffer = array_merge($buffer, $this->fetchCustomTags($document));
+		}
+
+		return implode($lnEnd, $buffer);
+	}
+
+	/**
+	 * Gets the meta, title, and base tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchMetaTags($document)
+	{
+		$tab     = $document->_getTab();
+		$isHtml5 = $document->isHtml5();
+		$tagEnd  = $isHtml5 ? ' >' : ' />';
+		$buffer  = array();
 
 		// Generate charset when using HTML5 (should happen first)
-		if ($document->isHtml5())
+		if ($isHtml5)
 		{
-			$buffer .= $tab . '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
+			$buffer[] = $tab . '<meta charset="' . $document->getCharset() . '"' . $tagEnd;
 		}
 
 		// Generate base tag (need to happen early)
@@ -80,7 +150,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if (!empty($base))
 		{
-			$buffer .= $tab . '<base href="' . $base . '" />' . $lnEnd;
+			$buffer[] = $tab . '<base href="' . $base . '"' . $tagEnd;
 		}
 
 		// Generate META tags (needs to happen as early as possible in the head)
@@ -88,14 +158,13 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			foreach ($tag as $name => $content)
 			{
-				if ($type == 'http-equiv' && !($document->isHtml5() && $name == 'content-type'))
+				// Html5 doesn't need content-type
+				if ($isHtml5 && $type == 'http-equiv' && $name == 'content-type')
 				{
-					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+					continue;
 				}
-				elseif ($type != 'http-equiv' && !empty($content))
-				{
-					$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
-				}
+
+				$buffer[] = $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '"' . $tagEnd;
 			}
 		}
 
@@ -104,7 +173,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if ($documentDescription)
 		{
-			$buffer .= $tab . '<meta name="description" content="' . htmlspecialchars($documentDescription, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+			$buffer[] = $tab . '<meta name="description" content="' . htmlspecialchars($documentDescription, ENT_COMPAT, 'UTF-8') . '"' . $tagEnd;
 		}
 
 		// Don't add empty generators
@@ -112,146 +181,185 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 		if ($generator)
 		{
-			$buffer .= $tab . '<meta name="generator" content="' . htmlspecialchars($generator, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+			$buffer[] = $tab . '<meta name="generator" content="' . htmlspecialchars($generator, ENT_COMPAT, 'UTF-8') . '"' . $tagEnd;
 		}
 
-		$buffer .= $tab . '<title>' . htmlspecialchars($document->getTitle(), ENT_COMPAT, 'UTF-8') . '</title>' . $lnEnd;
+		$buffer[] = $tab . '<title>' . htmlspecialchars($document->getTitle(), ENT_COMPAT, 'UTF-8') . '</title>';
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets the (non-stylesheet) link tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchLinkTags($document)
+	{
+		$tab     = $document->_getTab();
+		$isHtml5 = $document->isHtml5();
+		$tagEnd  = $isHtml5 ? ' >' : ' />';
+		$buffer  = array();
 
 		// Generate link declarations
 		foreach ($document->_links as $link => $linkAtrr)
 		{
-			$buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
+			$attr = array(
+				'href="' . $link . '"',
+				$linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"'
+			);
 
 			if (is_array($linkAtrr['attribs']))
 			{
-				if ($temp = ArrayHelper::toString($linkAtrr['attribs']))
-				{
-					$buffer .= ' ' . $temp;
-				}
+				$attr[] = ArrayHelper::toString($linkAtrr['attribs']);
 			}
 
-			$buffer .= ' />' . $lnEnd;
+			$buffer[] = $tab . '<link ' . implode(' ', $attr) . $tagEnd;
 		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets the (stylesheet) link tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchStyleSheets($document)
+	{
+		$tab          = $document->_getTab();
+		$isHtml5      = $document->isHtml5();
+		$mediaVersion = $document->getMediaVersion();
+		$tagEnd       = $isHtml5 ? ' >' : ' />';
+		$buffer       = array();
 
 		$defaultCssMimes = array('text/css');
 
 		// Generate stylesheet links
 		foreach ($document->_styleSheets as $src => $attribs)
 		{
-			// Check if stylesheet uses IE conditional statements.
-			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
+			$conditional = null;
+			$attr = array('rel="stylesheet"');
 
-			// Check if script uses media version.
-			if (isset($attribs['options']['version']) && $attribs['options']['version'] && strpos($src, '?') === false
-				&& ($mediaVersion || $attribs['options']['version'] !== 'auto'))
+			if (!is_null($attribs['mime']) && (!$isHtml5 || !in_array($attribs['mime'], $defaultCssMimes)))
 			{
-				$src .= '?' . ($attribs['options']['version'] === 'auto' ? $mediaVersion : $attribs['options']['version']);
+				$attr[] = 'type="' . $attribs['mime'] . '"';
 			}
 
-			$buffer .= $tab;
+			if (isset($attribs['options']) && is_array($attribs['options']))
+			{
+				$options = $attribs['options'];
+
+ 				$conditional = isset($options['conditional']) ? $options['conditional'] : null;
+
+				if (isset($options['version']) && $options['version'] && strpos($src, '?') === false
+					&& ($mediaVersion || $options['version'] !== 'auto'))
+  				{
+  					$src .= '?' . ($options['version'] === 'auto' ? $mediaVersion : $options['version']);
+				}
+			}
+
+			$attr[] = 'href="' . $src . '"';
+
+			$buffer[] = $tab;
 
 			// This is for IE conditional statements support.
 			if (!is_null($conditional))
 			{
-				$buffer .= '<!--[if ' . $conditional . ']>';
+				$attr[] = 'media="' . $attribs['media'] . '"';
 			}
 
-			$buffer .= '<link href="' . $src . '" rel="stylesheet"';
-
-			// Add script tag attributes.
-			foreach ($attribs as $attrib => $value)
+			if (is_array($attribs['attribs']) && !empty($attribs['attribs']))
 			{
-				// Don't add the 'options' attribute. This attribute is for internal use (version, conditional, etc).
-				if ($attrib === 'options')
-				{
-					continue;
-				}
-
-				// Don't add type attribute if document is HTML5 and it's a default mime type. 'mime' is for B/C.
-				if (in_array($attrib, array('type', 'mime')) && $document->isHtml5() && in_array($value, $defaultCssMimes))
-				{
-					continue;
-				}
-
-				// Don't add type attribute if document is HTML5 and it's a default mime type. 'mime' is for B/C.
-				if ($attrib === 'mime')
-				{
-					$attrib = 'type';
-				}
-
-				// Add attribute to script tag output.
-				$buffer .= ' ' . htmlspecialchars($attrib, ENT_COMPAT, 'UTF-8');
-
-				// Json encode value if it's an array.
-				$value = !is_scalar($value) ? json_encode($value) : $value;
-
-				$buffer .= '="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
+				$attr[] = ArrayHelper::toString($attribs['attribs']);
 			}
 
-			$buffer .= $tagEnd;
-
-			// This is for IE conditional statements support.
-			if (!is_null($conditional))
-			{
-				$buffer .= '<![endif]-->';
-			}
-
-			$buffer .= $lnEnd;
+			$buffer[] = $tab . '<link ' . implode(' ', $attr) . $tagEnd;
 		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets the style tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchStyleDeclarations($document)
+	{
+		$tab    = $document->_getTab();
+		$buffer = array();
+
+		$defaultCssMimes = array('text/css');
 
 		// Generate stylesheet declarations
 		foreach ($document->_style as $type => $content)
 		{
-			$buffer .= $tab . '<style';
+			$openTag = $tab . '<style';
 
 			if (!is_null($type) && (!$document->isHtml5() || !in_array($type, $defaultCssMimes)))
 			{
-				$buffer .= ' type="' . $type . '"';
+				$openTag .= ' type="' . $type . '"';
 			}
 
-			$buffer .= '>' . $lnEnd;
+			$openTag .= '>';
+
+			$buffer[] = $openTag;
 
 			// This is for full XHTML support.
 			if ($document->_mime != 'text/html')
 			{
-				$buffer .= $tab . $tab . '/*<![CDATA[*/' . $lnEnd;
+				$buffer[] = $tab . $tab . '/*<![CDATA[*/';
 			}
 
-			$buffer .= $content . $lnEnd;
+			$buffer[] = $content;
 
 			// See above note
 			if ($document->_mime != 'text/html')
 			{
-				$buffer .= $tab . $tab . '/*]]>*/' . $lnEnd;
+				$buffer[] = $tab . $tab . '/*]]>*/';
 			}
 
-			$buffer .= $tab . '</style>' . $lnEnd;
+			$buffer[] = $tab . '</style>';
 		}
 
-		// Generate scripts options
-		$scriptOptions = $document->getScriptOptions();
+		return $buffer;
+	}
 
-		if (!empty($scriptOptions))
-		{
-			$buffer .= $tab . '<script type="application/json" class="joomla-script-options new">';
-
-			$prettyPrint = (JDEBUG && defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : false);
-			$jsonOptions = json_encode($scriptOptions, $prettyPrint);
-			$jsonOptions = $jsonOptions ? $jsonOptions : '{}';
-
-			$buffer .= $jsonOptions;
-			$buffer .= '</script>' . $lnEnd;
-		}
+	/**
+	 * Gets the external file loading script tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchScripts($document)
+	{
+		$tab     = $document->_getTab();
+		$isHtml5 = $document->isHtml5();
+		$buffer  = array();
 
 		$defaultJsMimes         = array('text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript');
 		$html5NoValueAttributes = array('defer', 'async');
+		$mediaVersion           = $document->getMediaVersion();
 
 		// Generate script file links
 		foreach ($document->_scripts as $src => $attribs)
 		{
-			// Check if script uses IE conditional statements.
-			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
-
 			// Check if script uses media version.
 			if (isset($attribs['options']['version']) && $attribs['options']['version'] && strpos($src, '?') === false
 				&& ($mediaVersion || $attribs['options']['version'] !== 'auto'))
@@ -259,15 +367,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				$src .= '?' . ($attribs['options']['version'] === 'auto' ? $mediaVersion : $attribs['options']['version']);
 			}
 
-			$buffer .= $tab;
-
-			// This is for IE conditional statements support.
-			if (!is_null($conditional))
-			{
-				$buffer .= '<!--[if ' . $conditional . ']>';
-			}
-
-			$buffer .= '<script src="' . $src . '"';
+			$attr = array('src="' . $src . '"');
 
 			// Add script tag attributes.
 			foreach ($attribs as $attrib => $value)
@@ -302,61 +402,187 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				}
 
 				// Add attribute to script tag output.
-				$buffer .= ' ' . htmlspecialchars($attrib, ENT_COMPAT, 'UTF-8');
+				$attribValue = htmlspecialchars($attrib, ENT_COMPAT, 'UTF-8');
 
 				if (!($document->isHtml5() && in_array($attrib, $html5NoValueAttributes)))
 				{
 					// Json encode value if it's an array.
 					$value = !is_scalar($value) ? json_encode($value) : $value;
 
-					$buffer .= '="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
+					$attribValue .= '="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"';
 				}
+
+				$attr[] = $attribValue;
 			}
 
-			$buffer .= '></script>';
+			// Check if script uses IE conditional statements.
+			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
 
-			// This is for IE conditional statements support.
-			if (!is_null($conditional))
-			{
-				$buffer .= '<![endif]-->';
-			}
-
-			$buffer .= $lnEnd;
+			$buffer[] = $tab .
+				(is_null($conditional) ? '' : '<!--[if ' . $conditional . ']>') .
+				'<script ' . implode(' ', $attr) . '></script>' .
+				(is_null($conditional) ? '' : '<![endif]-->');
 		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets a script tag containing the Joomla options storage.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchScriptOptions($document)
+	{
+		// Generate scripts options
+		$scriptOptions = $document->getScriptOptions();
+
+		if (empty($scriptOptions))
+		{
+			return array();
+		}
+
+		$tab     = $document->_getTab();
+
+		$prettyPrint  = (JDEBUG && defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : false);
+		$jsonOptions = json_encode($scriptOptions, $prettyPrint);
+		$jsonOptions = $jsonOptions ? $jsonOptions : '{}';
+
+		$buffer = $tab .
+			'<script type="application/json" class="joomla-script-options new">' .
+			$jsonOptions .
+			'</script>';
+
+		return array($buffer);
+	}
+
+	/**
+	 * Gets a script tag containing javascript declarations as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchScriptDeclarations($document)
+	{
+		$tab     = $document->_getTab();
+		$isHtml5 = $document->isHtml5();
+		$buffer  = array();
+
+		$defaultJsMimes = array('text/javascript', 'application/javascript', 'text/x-javascript', 'application/x-javascript');
 
 		// Generate script declarations
 		foreach ($document->_script as $type => $content)
 		{
-			$buffer .= $tab . '<script';
+			$openTag = $tab . '<script';
 
-			if (!is_null($type) && (!$document->isHtml5() || !in_array($type, $defaultJsMimes)))
+			if (!is_null($type) && (!$isHtml5 || !in_array($type, $defaultJsMimes)))
 			{
-				$buffer .= ' type="' . $type . '"';
+				$openTag .= ' type="' . $type . '"';
 			}
 
-			$buffer .= '>' . $lnEnd;
+			$openTag .= '>';
+
+			$buffer[] = $openTag;
 
 			// This is for full XHTML support.
 			if ($document->_mime != 'text/html')
 			{
-				$buffer .= $tab . $tab . '//<![CDATA[' . $lnEnd;
+				$buffer[] = $tab . $tab . '//<![CDATA[';
 			}
 
-			$buffer .= $content . $lnEnd;
+			$buffer[] = $content;
 
 			// See above note
 			if ($document->_mime != 'text/html')
 			{
-				$buffer .= $tab . $tab . '//]]>' . $lnEnd;
+				$buffer[] = $tab . $tab . '//]]>';
 			}
 
-			$buffer .= $tab . '</script>' . $lnEnd;
+			$buffer[] = $tab . '</script>';
 		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets a script tag that loads translation strings.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchScriptLanguageDeclarations($document)
+	{
+		$script = JText::script();
+
+		if (empty($script))
+		{
+			return array();
+		}
+
+		$tab     = $document->_getTab();
+		$isHtml5 = $document->isHtml5();
+		$buffer  = array();
+
+		// Generate script language declarations.
+		$openTag = $tab . '<script';
+
+		if (!$document->isHtml5())
+		{
+			$openTag .= ' type="text/javascript"';
+		}
+
+		$openTag .= '>';
+
+		$buffer[] = $openTag;
+
+		if ($document->_mime != 'text/html')
+		{
+			$buffer[] = $tab . $tab . '//<![CDATA[';
+		}
+
+		// Why is this inside of a closure?
+		$buffer[] = $tab . $tab . '(function() {';
+		$buffer[] = $tab . $tab . $tab . 'Joomla.JText.load(' . json_encode($script) . ');';
+		$buffer[] = $tab . $tab . '})();';
+
+		if ($document->_mime != 'text/html')
+		{
+			$buffer[] = $tab . $tab . '//]]>';
+		}
+
+		$buffer[] = $tab . '</script>';
+
+		return $buffer;
+	}
+
+	/**
+	 * Gets the custom tags as an array.
+	 *
+	 * @param   JDocumentHtml  $document  The document for which the head will be created
+	 *
+	 * @return  array  The tags
+	 *
+	 * @since   3.7
+	 */
+	protected function fetchCustomTags($document)
+	{
+		$tab     = $document->_getTab();
+		$buffer = array();
 
 		// Output the custom tags - array_unique makes sure that we don't output the same tags twice
 		foreach (array_unique($document->_custom) as $custom)
 		{
-			$buffer .= $tab . $custom . $lnEnd;
+			$buffer[] = $tab . $custom;
 		}
 
 		return ltrim($buffer, $tab);

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -86,12 +86,6 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer = array_merge($buffer, $this->fetchStyleDeclarations($document));
 		}
 
-		// Get scripts (loaded as external files)
-		if (!empty($document->_scripts))
-		{
-			$buffer = array_merge($buffer, $this->fetchScripts($document));
-		}
-
 		// Get script options
 		$scriptOptions = $document->getScriptOptions();
 
@@ -100,18 +94,16 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer = array_merge($buffer, $this->fetchScriptOptions($document));
 		}
 
+		// Get scripts (loaded as external files)
+		if (!empty($document->_scripts))
+		{
+			$buffer = array_merge($buffer, $this->fetchScripts($document));
+		}
+
 		// Get script declarations
 		if (!empty($document->_script))
 		{
 			$buffer = array_merge($buffer, $this->fetchScriptDeclarations($document));
-		}
-
-		// Get translation strings for javascript
-		$script = JText::script();
-
-		if (!empty($script))
-		{
-			$buffer = array_merge($buffer, $this->fetchScriptLanguageDeclarations($document));
 		}
 
 		// Get custom tags
@@ -507,60 +499,6 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 
 			$buffer[] = $tab . '</script>';
 		}
-
-		return $buffer;
-	}
-
-	/**
-	 * Gets a script tag that loads translation strings.
-	 *
-	 * @param   JDocumentHtml  $document  The document for which the head will be created
-	 *
-	 * @return  array  The tags
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected function fetchScriptLanguageDeclarations($document)
-	{
-		$script = JText::script();
-
-		if (empty($script))
-		{
-			return array();
-		}
-
-		$tab     = $document->_getTab();
-		$isHtml5 = $document->isHtml5();
-		$buffer  = array();
-
-		// Generate script language declarations.
-		$openTag = $tab . '<script';
-
-		if (!$document->isHtml5())
-		{
-			$openTag .= ' type="text/javascript"';
-		}
-
-		$openTag .= '>';
-
-		$buffer[] = $openTag;
-
-		if ($document->_mime != 'text/html')
-		{
-			$buffer[] = $tab . $tab . '//<![CDATA[';
-		}
-
-		// Why is this inside of a closure?
-		$buffer[] = $tab . $tab . '(function() {';
-		$buffer[] = $tab . $tab . $tab . 'Joomla.JText.load(' . json_encode($script) . ');';
-		$buffer[] = $tab . $tab . '})();';
-
-		if ($document->_mime != 'text/html')
-		{
-			$buffer[] = $tab . $tab . '//]]>';
-		}
-
-		$buffer[] = $tab . '</script>';
 
 		return $buffer;
 	}

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -249,7 +249,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$conditional = null;
 			$attr = array('rel="stylesheet"');
 
-			if (!is_null($attribs['mime']) && (!$isHtml5 || !in_array($attribs['mime'], $defaultCssMimes)))
+			if (isset($attribs['mime']) && (!$isHtml5 || !in_array($attribs['mime'], $defaultCssMimes)))
 			{
 				$attr[] = 'type="' . $attribs['mime'] . '"';
 			}
@@ -277,7 +277,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				$attr[] = 'media="' . $attribs['media'] . '"';
 			}
 
-			if (is_array($attribs['attribs']) && !empty($attribs['attribs']))
+			if (isset($attribs['attribs']) && is_array($attribs['attribs']) && !empty($attribs['attribs']))
 			{
 				$attr[] = ArrayHelper::toString($attribs['attribs']);
 			}

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -130,7 +130,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchMetaTags($document)
 	{
@@ -196,7 +196,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchLinkTags($document)
 	{
@@ -231,7 +231,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchStyleSheets($document)
 	{
@@ -295,7 +295,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchStyleDeclarations($document)
 	{
@@ -345,7 +345,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchScripts($document)
 	{
@@ -434,7 +434,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchScriptOptions($document)
 	{
@@ -467,7 +467,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchScriptDeclarations($document)
 	{
@@ -518,7 +518,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchScriptLanguageDeclarations($document)
 	{
@@ -572,7 +572,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	 *
 	 * @return  array  The tags
 	 *
-	 * @since   3.7
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function fetchCustomTags($document)
 	{

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -258,12 +258,12 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			{
 				$options = $attribs['options'];
 
- 				$conditional = isset($options['conditional']) ? $options['conditional'] : null;
+				$conditional = isset($options['conditional']) ? $options['conditional'] : null;
 
 				if (isset($options['version']) && $options['version'] && strpos($src, '?') === false
 					&& ($mediaVersion || $options['version'] !== 'auto'))
-  				{
-  					$src .= '?' . ($options['version'] === 'auto' ? $mediaVersion : $options['version']);
+				{
+					$src .= '?' . ($options['version'] === 'auto' ? $mediaVersion : $options['version']);
 				}
 			}
 

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -136,7 +136,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	{
 		$tab     = $document->_getTab();
 		$isHtml5 = $document->isHtml5();
-		$tagEnd  = $isHtml5 ? ' >' : ' />';
+		$tagEnd  = $isHtml5 ? '>' : '/>';
 		$buffer  = array();
 
 		// Generate charset when using HTML5 (should happen first)
@@ -158,8 +158,8 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			foreach ($tag as $name => $content)
 			{
-				// Html5 doesn't need content-type
-				if ($isHtml5 && $type == 'http-equiv' && $name == 'content-type')
+				// Html5 doesn't need content-type and we don't need empty meta tags
+				if (($isHtml5 && $type == 'http-equiv' && $name == 'content-type') || empty($content))
 				{
 					continue;
 				}
@@ -202,7 +202,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 	{
 		$tab     = $document->_getTab();
 		$isHtml5 = $document->isHtml5();
-		$tagEnd  = $isHtml5 ? ' >' : ' />';
+		$tagEnd  = $isHtml5 ? '>' : '/>';
 		$buffer  = array();
 
 		// Generate link declarations


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

Separated the various parts of a long function into smaller ones. The main purpose being that overriding some small part of this class in a subclass will be a lot simpler. 

Avoiding using string concatenation on long strings by pushing to an array and imploding at the end. This is generally better for performance although, in this case, it may be offset somewhat by the overhead of calling additional functions. 

Avoid the `/>` tag ending for void elements when in html5 mode. Just use `>` instead. Save a whole byte per tag!
### Testing Instructions

Load any page that has a 'head'. All of your tags should appear as expected.
### Documentation Changes Required

Nope
