### PR TITLE
Add full_image layout

### DIFF
--- a/components/com_content/views/article/tmpl/default.php
+++ b/components/com_content/views/article/tmpl/default.php
@@ -97,14 +97,7 @@ JHtml::_('behavior.caption');
 	<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 	<?php if ($params->get('access-view')):?>
-	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
-	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
-	<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
-	<?php if ($images->image_fulltext_caption):
-		echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
-	endif; ?>
-	src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
-	<?php endif; ?>
+	<?php echo JLayoutHelper::render('joomla.content.full_image', $this->item); ?>
 	<?php
 	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative):
 		echo $this->item->pagination;

--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+$params = $displayData->params;
+?>
+<?php $images = json_decode($displayData->images); ?>
+	<?php if (isset($images->image_fulltext) && !empty($images->image_fulltext)) : ?>
+		<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
+		<div class="pull-<?php echo htmlspecialchars($imgfloat); ?> item-image"> <img
+		<?php if ($images->image_fulltext_caption):
+			echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_fulltext_caption) . '"';
+		endif; ?>
+		src="<?php echo htmlspecialchars($images->image_fulltext); ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>" itemprop="image"/> </div>
+	<?php endif; ?>


### PR DESCRIPTION
I am not sure why but we have a layout for intro_image but not for full_image. This pr addresses that.

### Testing Instructions
Create an article with an intro and a full image (from the images and links tab) and make sure that article can be accessed from the front end from a single article, featured articles, category list and category blog view
Check that the images display as expected
Apply the PR and recheck - there should be no visible change at all

This is fully B/C as the code itself has not changed its just been moved and if you have an override in your template for com_content then the override will still work
