### PR TITLE
Add logger callback to catch our deprecated methods in PHPUnit run

### DIFF
--- a/libraries/vendor/composer/ClassLoader.php
+++ b/libraries/vendor/composer/ClassLoader.php
@@ -53,8 +53,8 @@ class ClassLoader
 
     private $useIncludePath = false;
     private $classMap = array();
-
     private $classMapAuthoritative = false;
+    private $missingClasses = array();
 
     public function getPrefixes()
     {
@@ -322,20 +322,20 @@ class ClassLoader
         if (isset($this->classMap[$class])) {
             return $this->classMap[$class];
         }
-        if ($this->classMapAuthoritative) {
+        if ($this->classMapAuthoritative || isset($this->missingClasses[$class])) {
             return false;
         }
 
         $file = $this->findFileWithExtension($class, '.php');
 
         // Search for Hack files if we are running on HHVM
-        if ($file === null && defined('HHVM_VERSION')) {
+        if (false === $file && defined('HHVM_VERSION')) {
             $file = $this->findFileWithExtension($class, '.hh');
         }
 
-        if ($file === null) {
+        if (false === $file) {
             // Remember that this class does not exist.
-            return $this->classMap[$class] = false;
+            $this->missingClasses[$class] = true;
         }
 
         return $file;
@@ -399,6 +399,8 @@ class ClassLoader
         if ($this->useIncludePath && $file = stream_resolve_include_path($logicalPathPsr0)) {
             return $file;
         }
+
+        return false;
     }
 }
 

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -118,5 +118,8 @@ JLoader::registerPrefix('Test', __DIR__ . '/core');
 // Register the deprecation handler
 TestHelper::registerDeprecationHandler();
 
+// Register the deprecation logger
+TestHelper::registerDeprecationLogger();
+
 // Register the logger if enabled
 TestHelper::registerLogger();

--- a/tests/unit/core/helper/helper.php
+++ b/tests/unit/core/helper/helper.php
@@ -164,6 +164,28 @@ class TestHelper
 	}
 
 	/**
+	 * Adds a logger to include Joomla deprecations in the unit test results
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function registerDeprecationLogger()
+	{
+		JLog::addLogger(
+			array(
+				'logger'   => 'callback',
+				'callback' => function (JLogEntry $entry)
+				{
+					@trigger_error($entry->message, E_USER_DEPRECATED);
+				},
+			),
+			JLog::ALL,
+			array('deprecated')
+		);
+	}
+
+	/**
 	 * Adds optional logging support for the unit test run
 	 *
 	 * @return  void


### PR DESCRIPTION
### Summary of Changes

Add to the result output of the PHPUnit run the deprecated functions that are called by way of the unit test suite.  This is a helpful metric to gauge where in our code (either the tests themselves or something triggered by them) deprecated functions are called and can be helpful when refactoring code to stop using them or when removing them.
### Testing Instructions

Review https://travis-ci.org/mbabker/joomla-cms/jobs/167952648 for an example of the output with this change.
### Documentation Changes Required

N/A
