### PR TITLE
[3.7.x] addScript corrections after 11289 merge

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -707,34 +707,31 @@ abstract class JHtml
 		// If only path is required
 		if ($options['pathOnly'])
 		{
-			if (count($includes) == 0)
+			if (count($includes) === 0)
 			{
 				return;
 			}
-			elseif (count($includes) == 1)
+
+			if (count($includes) === 1)
 			{
 				return $includes[0];
 			}
-			else
-			{
-				return $includes;
-			}
+			
+			return $includes;
 		}
+
 		// If inclusion is required
-		else
+		$document = JFactory::getDocument();
+
+		foreach ($includes as $include)
 		{
-			$document = JFactory::getDocument();
-
-			foreach ($includes as $include)
+			// If there is already a version hash in the script reference (by using deprecated MD5SUM).
+			if ($pos = strpos($include, '?') !== false)
 			{
-				// If there is already a version hash in the script reference (by using deprecated MD5SUM).
-				if ($pos = strpos($include, '?') !== false)
-				{
-					$options['version'] = substr($include, $pos + 1);
-				}
-
-				$document->addScript($include, $options, $attribs);
+				$options['version'] = substr($include, $pos + 1);
 			}
+
+			$document->addScript($include, $options, $attribs);
 		}
 	}
 

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -486,6 +486,12 @@ class JDocument
 			}
 		}
 
+		// Default value for type.
+		if (!isset($attribs['type']) && !isset($attribs['mime']))
+		{
+			$attribs['type'] = 'text/javascript';
+		}
+
 		$this->_scripts[$url]            = isset($this->_scripts[$url]) ? array_replace($this->_scripts[$url], $attribs) : $attribs;
 		$this->_scripts[$url]['options'] = isset($this->_scripts[$url]['options']) ? array_replace($this->_scripts[$url]['options'], $options) : $options;
 


### PR DESCRIPTION
Pull Request for corrections to https://github.com/joomla/joomla-cms/pull/11289.
### Summary of Changes

This small PR corrects one thing missing from the https://github.com/joomla/joomla-cms/pull/11289 merge. before the PR the default type was `text/javascript`, after the PR merge there is no deault type.

Also reinstates @mbabker JHtml::script() code review changes (https://github.com/joomla/joomla-cms/pull/10771/files#diff-b01d47e3fbe4a8e5fb4987f4df64b291R679) that was lost in merging conflicts.
### Testing Instructions

Most of all code review.

But you can also test the following:
1. Use latests 3.7.x branch
2. Delete the `$doc->setHtml5(true);` line in /templates/protostar/index.php to set he document as non html5
3. Go to frontend and check code, you will notice the script tags have no `type="text/javascript"`attribute and they should as this document is not rendered as html5
4. Apply patch. check now they have the `type="text/javascript"`attribute as they should
### Documentation Changes Required

None.

@dgt41 @Fedik please test
