### PR TITLE
Add deprecated message that in 4.0 the html5 property will be default true

### DIFF
--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -97,6 +97,8 @@ class JDocumentHtml extends JDocument
 	 *
 	 * @var    boolean
 	 * @since  12.1
+	 *
+	 * @deprecated  4.0  Will be replaced by $html5 and the default value will be true.
 	 */
 	private $_html5 = null;
 

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -98,7 +98,7 @@ class JDocumentHtml extends JDocument
 	 * @var    boolean
 	 * @since  12.1
 	 *
-	 * @deprecated  4.0  Will be replaced by $html5 and the default value will be true.
+	 * @note  4.0  Will be replaced by $html5 and the default value will be true.
 	 */
 	private $_html5 = null;
 


### PR DESCRIPTION
### Summary of Changes

Not much else to say: Add deprecated message that in 4.0 the html5 property  in JDocumentHtml will be default as true.
### Testing Instructions

Code review.
### Documentation Changes Required

None.
