### PR TITLE
[4.0] Set html5 as default Doctype for JDocumentHtml

### DIFF
--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -15,9 +15,6 @@ $lang            = JFactory::getLanguage();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/administrator/templates/isis/error.php
+++ b/administrator/templates/isis/error.php
@@ -22,12 +22,6 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
-// Output document as HTML5.
-if (is_callable(array($doc, 'setHtml5')))
-{
-	$doc->setHtml5(true);
-}
-
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
 $frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -17,9 +17,6 @@ $this->direction = $doc->direction;
 $input           = $app->input;
 $user            = JFactory::getUser();
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
 $frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -13,9 +13,6 @@ $app  = JFactory::getApplication();
 $doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 // Gets the FrontEnd Main page Uri
 $frontEndUri = JUri::getInstance(JUri::root());
 $frontEndUri->setScheme(((int) $app->get('force_ssl', 0) === 2) ? 'https' : 'http');

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -96,9 +96,9 @@ class JDocumentHtml extends JDocument
 	 * Set to true when the document should be output as HTML5
 	 *
 	 * @var    boolean
-	 * @since  12.1
+	 * @since  4.0
 	 */
-	private $_html5 = null;
+	private $html5 = true;
 
 	/**
 	 * Class constructor
@@ -331,7 +331,7 @@ class JDocumentHtml extends JDocument
 	 */
 	public function isHtml5()
 	{
-		return $this->_html5;
+		return $this->html5;
 	}
 
 	/**
@@ -347,7 +347,7 @@ class JDocumentHtml extends JDocument
 	{
 		if (is_bool($state))
 		{
-			$this->_html5 = $state;
+			$this->html5 = $state;
 		}
 	}
 

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -11,9 +11,6 @@ defined('_JEXEC') or die;
 
 $color = $this->params->get('templatecolor');
 
-// Output as HTML5
-$this->setHtml5(true);
-
 $this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 $this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/template.css', 'text/css', 'screen');
 $this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/position.css', 'text/css', 'screen');

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -33,9 +33,6 @@ $config         = JFactory::getConfig();
 $bootstrap      = explode(',', $this->params->get('bootstrap'));
 $option         = JFactory::getApplication()->input->getCmd('option', '');
 
-// Output as HTML5
-$this->setHtml5(true);
-
 if (in_array($option, $bootstrap))
 {
 	// Load optional rtl Bootstrap css and Bootstrap bugfixes

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -14,9 +14,6 @@ $doc             = JFactory::getDocument();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -15,12 +15,6 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output document as HTML5.
-if (is_callable(array($doc, 'setHtml5')))
-{
-	$doc->setHtml5(true);
-}
-
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -15,9 +15,6 @@ $user            = JFactory::getUser();
 $this->language  = $doc->language;
 $this->direction = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 // Getting params from template
 $params = $app->getTemplate(true)->params;
 

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -15,9 +15,6 @@ $doc              = JFactory::getDocument();
 $this->language   = $doc->language;
 $this->direction  = $doc->direction;
 
-// Output as HTML5
-$doc->setHtml5(true);
-
 $fullWidth = 1;
 
 // Add JavaScript Frameworks


### PR DESCRIPTION
### Summary of Changes

Set html5 as default Doctype and do remove the setHtml5 from the tempaltes since is not needed now.
### Testing Instructions

Code review.
### Documentation Changes Required

None.
