### PR TITLE
[4.0] Fix unit test: Now is assertTrue not assertNull

### DIFF
--- a/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
+++ b/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
@@ -163,7 +163,7 @@ class JDocumentHtmlTest extends TestCase
 	 */
 	public function testTheDefaultReturnForIsHtml5()
 	{
-		$this->assertNull($this->object->isHtml5());
+		$this->assertTrue($this->object->isHtml5());
 	}
 
 	/**
@@ -171,7 +171,7 @@ class JDocumentHtmlTest extends TestCase
 	 */
 	public function testTheDefaultReturnForSetHtml5()
 	{
-		$this->assertTrue($this->object->setHtml5(true));
+		$this->assertNull($this->object->setHtml5(true));
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
+++ b/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
@@ -171,7 +171,7 @@ class JDocumentHtmlTest extends TestCase
 	 */
 	public function testTheDefaultReturnForSetHtml5()
 	{
-		$this->assertNull($this->object->setHtml5(true));
+		$this->assertTrue($this->object->setHtml5(true));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Correct unit test in 4.0 after https://github.com/joomla/joomla-cms/pull/12432 merge
### Testing Instructions

Unit test pass.
### Documentation Changes Required

None.
