### PR TITLE
Routing: Fixing notice for non-existing views

### DIFF
--- a/libraries/cms/component/router/view.php
+++ b/libraries/cms/component/router/view.php
@@ -83,7 +83,7 @@ abstract class JComponentRouterView extends JComponentRouterBase
 		$key    = false;
 
 		// Get the right view object
-		if (isset($query['view']) && $views[$query['view']])
+		if (isset($query['view']) && isset($views[$query['view']]))
 		{
 			$viewobj = $views[$query['view']];
 		}


### PR DESCRIPTION
In #12321 we noticed that a non-registered view throws a notice. This fixes that. Nothing big to test...
