### PR TITLE
The comment on the $week property help text was wrong

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -27,7 +27,7 @@ defined('JPATH_PLATFORM') or die;
  * @property-read  string   $second        s - Seconds with leading zeros.
  * @property-read  string   $month         m - Numeric representation of a month, with leading zeros.
  * @property-read  string   $ordinal       S - English ordinal suffix for the day of the month, 2 characters.
- * @property-read  string   $week          W - Numeric representation of the day of the week.
+ * @property-read  string   $week          W - ISO-8601 week number of year, weeks starting on Monday.
  * @property-read  string   $year          Y - A full numeric representation of a year, 4 digits.
  *
  * @since  11.1


### PR DESCRIPTION
Pull Request for Issue #12440
### Summary of Changes

Comment on $week property was wrong
### Testing Instructions
### Documentation Changes Required

$week          W - Numeric representation of the day of the week.
should be:
$week          W - ISO-8601 week number of year, weeks starting on Monday
