### PR TITLE
[3.7.x] Admin login language field fix

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -5954,14 +5954,9 @@ fieldset.radio.btn-group {
 .input-prepend .chzn-container-single .chzn-single,
 .input-append .chzn-container-single .chzn-single {
   border-color: #cccccc;
-  height: 26px;
   -moz-box-shadow: none;
   -webkit-box-shadow: none;
   box-shadow: none;
-}
-.input-prepend .chzn-container-single .chzn-drop,
-.input-append .chzn-container-single .chzn-drop {
-  border-color: #cccccc;
 }
 .input-prepend > .add-on,
 .input-append > .add-on {
@@ -7256,14 +7251,6 @@ a:focus {
 }
 .navbar-inverse {
   color: #333333;
-}
-.login .chzn-single {
-  width: 222px !important;
-}
-.login .chzn-container,
-.login .chzn-drop {
-  width: 230px !important;
-  max-width: 230px !important;
 }
 .login .btn-large {
   margin-top: 15px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -5951,13 +5951,6 @@ fieldset.radio.btn-group {
 }
 /* Input Prepend Chosen Select Boxes */
 /* Common styling for Chosen Select Boxes with Input Prepend/Append */
-.input-prepend .chzn-container-single .chzn-single,
-.input-append .chzn-container-single .chzn-single {
-  border-color: #cccccc;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
 .input-prepend > .add-on,
 .input-append > .add-on {
   vertical-align: top;
@@ -7248,6 +7241,16 @@ a:focus {
 }
 .view-login .input-medium {
   width: 176px;
+}
+.view-login #lang_chzn {
+  width: 233px !important;
+}
+.view-login #lang_chzn .chzn-single div {
+  width: 43px;
+}
+.view-login .input-prepend .add-on,
+.view-login .controls .btn-group > .btn {
+  margin-left: 0;
 }
 .navbar-inverse {
   color: #333333;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5954,14 +5954,9 @@ fieldset.radio.btn-group {
 .input-prepend .chzn-container-single .chzn-single,
 .input-append .chzn-container-single .chzn-single {
   border-color: #cccccc;
-  height: 26px;
   -moz-box-shadow: none;
   -webkit-box-shadow: none;
   box-shadow: none;
-}
-.input-prepend .chzn-container-single .chzn-drop,
-.input-append .chzn-container-single .chzn-drop {
-  border-color: #cccccc;
 }
 .input-prepend > .add-on,
 .input-append > .add-on {
@@ -7256,14 +7251,6 @@ a:focus {
 }
 .navbar-inverse {
   color: #333333;
-}
-.login .chzn-single {
-  width: 222px !important;
-}
-.login .chzn-container,
-.login .chzn-drop {
-  width: 230px !important;
-  max-width: 230px !important;
 }
 .login .btn-large {
   margin-top: 15px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -5951,13 +5951,6 @@ fieldset.radio.btn-group {
 }
 /* Input Prepend Chosen Select Boxes */
 /* Common styling for Chosen Select Boxes with Input Prepend/Append */
-.input-prepend .chzn-container-single .chzn-single,
-.input-append .chzn-container-single .chzn-single {
-  border-color: #cccccc;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-}
 .input-prepend > .add-on,
 .input-append > .add-on {
   vertical-align: top;
@@ -7248,6 +7241,16 @@ a:focus {
 }
 .view-login .input-medium {
   width: 176px;
+}
+.view-login #lang_chzn {
+  width: 233px !important;
+}
+.view-login #lang_chzn .chzn-single div {
+  width: 43px;
+}
+.view-login .input-prepend .add-on,
+.view-login .controls .btn-group > .btn {
+  margin-left: 0;
 }
 .navbar-inverse {
   color: #333333;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -143,14 +143,6 @@ a:focus {
 }
 
 .login {
-	.chzn-single {
-		width: 222px !important;
-	}
-	.chzn-container,
-	.chzn-drop {
-		width: 230px !important;
-		max-width: 230px !important;
-	}
 	.btn-large {
 		margin-top: 15px;
 	}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -136,6 +136,15 @@ a:focus {
 	.input-medium {
 		width: 176px;
 	}
+	#lang_chzn {
+		width: 233px !important;
+		.chzn-single div {
+			width:43px;
+		}
+	}
+	.input-prepend .add-on, .controls .btn-group > .btn {
+		margin-left:0;
+	}
 }
 
 .navbar-inverse {

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -377,10 +377,6 @@ fieldset.radio.btn-group {
 /* Common styling for Chosen Select Boxes with Input Prepend/Append */
 .input-prepend .chzn-container-single .chzn-single,
 .input-append .chzn-container-single .chzn-single {
-	border-color: @inputBorder;
-	-moz-box-shadow: none;
-	-webkit-box-shadow: none;
-	box-shadow: none;
 }
 .input-prepend .chzn-container-single .chzn-drop,
 .input-append .chzn-container-single .chzn-drop {

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -378,14 +378,12 @@ fieldset.radio.btn-group {
 .input-prepend .chzn-container-single .chzn-single,
 .input-append .chzn-container-single .chzn-single {
 	border-color: @inputBorder;
-	height: 26px;
 	-moz-box-shadow: none;
 	-webkit-box-shadow: none;
 	box-shadow: none;
 }
 .input-prepend .chzn-container-single .chzn-drop,
 .input-append .chzn-container-single .chzn-drop {
-	border-color: @inputBorder;
 }
 .input-prepend > .add-on,
 .input-append > .add-on {


### PR DESCRIPTION
Pull Request for Issue #12436 .
### Summary of Changes

Removes CSS override on the language field of the admin login. CSS was forcing an incorrect height on field and incorrect width on field dropdown. 
### Testing Instructions

Using Joomla 3.7 install multiple languages. Open login screen. Check field alignment (dropdown opened & closed)

**Before Patch**
![admin-lang1](https://cloud.githubusercontent.com/assets/2803503/19419692/aecc8464-93d4-11e6-9cf1-2429fa64c336.png)

**After Patch**
![admin-lang2](https://cloud.githubusercontent.com/assets/2803503/19419693/b30ac70c-93d4-11e6-8ff5-68eab1709b2e.png)
### Documentation Changes Required

None
