### PR TITLE
Restore edition for com_templates

### DIFF
--- a/administrator/components/com_templates/views/template/view.html.php
+++ b/administrator/components/com_templates/views/template/view.html.php
@@ -151,7 +151,7 @@ class TemplatesViewTemplate extends JViewLegacy
 
 		$this->addToolbar();
 
-		if (!JFactory::getUser()->authorise('core.admin'))
+		if (!JFactory::getUser()->authorise('core.edit', 'com_templates'))
 		{
 			$this->setLayout('readonly');
 		}
@@ -172,8 +172,8 @@ class TemplatesViewTemplate extends JViewLegacy
 		$user  = JFactory::getUser();
 		$app->input->set('hidemainmenu', true);
 
-		// User is global SuperUser
-		$isSuperUser = $user->authorise('core.admin');
+		// User have rights to edit the template
+		$isTemplateEditor = $user->authorise('core.edit', 'com_templates');
 
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
@@ -182,8 +182,8 @@ class TemplatesViewTemplate extends JViewLegacy
 
 		JToolbarHelper::title(JText::sprintf('COM_TEMPLATES_MANAGER_VIEW_TEMPLATE', ucfirst($this->template->name)), 'eye thememanager');
 
-		// Only show file edit buttons for global SuperUser
-		if ($isSuperUser)
+		// Only show file edit buttons for users with right to edit the template
+		if ($isTemplateEditor)
 		{
 			// Add an Apply and save button
 			if ($this->type == 'file')
@@ -216,8 +216,8 @@ class TemplatesViewTemplate extends JViewLegacy
 			$bar->appendButton('Popup', 'picture', 'COM_TEMPLATES_BUTTON_PREVIEW', JUri::root() . 'index.php?tp=1&templateStyle=' . $this->preview->id, 800, 520);
 		}
 
-		// Only show file manage buttons for global SuperUser
-		if ($isSuperUser)
+		// Only show file manage buttons for users with rights to edit the template
+		if ($isTemplateEditor)
 		{
 			// Add Manage folders button
 			JToolbarHelper::modal('folderModal', 'icon-folder icon white', 'COM_TEMPLATES_BUTTON_FOLDERS');


### PR DESCRIPTION
### Summary of Changes

In the view, the buttons were just display to the super users ; but in the controller the checks where still made according to the access level and the "core.edit" on "com_templates".
To keep a cohesion between the view, the controller and the Joomla ACL system ; the button should be displayed in the view.
### Testing Instructions

As a non super user account but with "admin" and "edit" ACL on "com_templates", go in the template manager.
The list of files won't be visible, the account will only see the "readonly" view.
### Going further

In order to make a difference between the right to edit the template settings and the right to edit the template files ; it could be interesting to add a new entry in the access.xml file.
Thanks to that, in the controller, it would be possible to make the according checks and not authorize user to modify the files (or perform action like compiling the less).
Because even if the user cannot see the file content via the editor, he can still submit data to modify them.
### Documentation Changes Required

None
