### PR TITLE
[a11y] Protostar back to top

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -202,7 +202,7 @@ else
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right">
-				<a href="#" id="back-top">
+				<a href="#back-top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
 				</a>
 			</p>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -202,7 +202,7 @@ else
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right">
-				<a href="#back-top" id="back-top">
+				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
 				</a>
 			</p>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -137,7 +137,7 @@ else
 	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
-	<div class="body">
+	<div class="body" id="top">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<!-- Header -->
 			<header class="header" role="banner">


### PR DESCRIPTION
For accessibility purposes all links should be meaningful and the current back to top link in the protostar template is just a # which is not meaningful.
Web Content Accessibility Guidelines (WCAG) 2.0, Level A: 4.1.2 Name, Role, Value

Also added an anchor at the top so that this "back to top" functionality will work on a non-js enabled browser
### Summary of Changes

This simple PR turns the link to #top and adds an ID to the body
### Testing Instructions
1. Apply the PR and ensure that the back to top link in protostar still works
2. Apply the PR, disable JS in your browser and ensure hat the back to top link in protostar will work
### Documentation Changes Required

none
