### PR TITLE
Check for a 'default' element as well as 'default' attribute

### DIFF
--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -203,10 +203,10 @@ class JFormFieldSubform extends JFormField
 			$this->value = json_decode($this->value, true);
 		}
 
-		if (!$this->formsource)
+		if (!$this->formsource && $element->form)
 		{
 			// Set the formsource parameter from the content of the node
-			$this->formsource = $element->children()->saveXML();
+			$this->formsource = $element->form->saveXML();
 		}
 
 		return true;

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1890,7 +1890,7 @@ class JForm
 		 */
 		if ($value === null)
 		{
-			$default = (string) $element['default'];
+			$default = (string) ($element->default ? $element->default : $element['default']);
 
 			if (($translate = $element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
 			{

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1890,7 +1890,7 @@ class JForm
 		 */
 		if ($value === null)
 		{
-			$default = (string) ($element->default ? $element->default : $element['default']);
+			$default = (string) ($element['default'] ? $element['default'] : $element->default);
 
 			if (($translate = $element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
 			{


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes

When getting the default value for a form element, first check if the `<field>` node has a child `<default>`. Use the value of the `<default>` node if it exists, otherwise use the the `default` attribute.

The main value of this will be in conjunction with field types such as `subform` which take their default values as json. Writing correct json into an xml attribute kind of sucks as you must use a lot of `&quot;` and the whole thing gets very long and illegible. By using a dedicated node, you can simply wrap the json inside of `<![CDATA[]]>` and write it normally. So, instead of:

``` xml
<field type="subform" name="myfield" default="{&quot;myfield0&quot;:{&quot;key1&quot;:&quot;value1",&quot;key2&quot;:&quot;value2&quot;},&quot;myfield1&quot;:{&quot;key1&quot;:&quot;value3",&quot;key2&quot;:&quot;value4&quot;},&quot;myfield2&quot;:{&quot;key1&quot;:&quot;value5",&quot;key2&quot;:&quot;value6&quot;}}" /> 
```

You could have:

``` xml
<field type="subform" name="myfield">
    <default><![CDATA[
    {
        "myfield0": {"key1": "value1", "key2": value2},
        "myfield1": {"key1": "value3", "key2": value4},
        "myfield2": {"key1": "value5", "key2": value6}
    }
    ]]></default>
</field>
```
### Testing Instructions

Create a field and give it a `<default>` element as a child. Load the form and notice that the value of the `<default>` node is used for your field. 
### Documentation Changes Required

Probably.
