### PR TITLE
Updating Hathor to use new Live and Upload for joomlaupdate

### DIFF
--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -1667,7 +1667,7 @@ p.tab-description {
 	float: left;
 }
 #form-login {
-	float: right;
+	float: left;
 	padding: 1.1em;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;

--- a/administrator/templates/hathor/css/template.css
+++ b/administrator/templates/hathor/css/template.css
@@ -3593,6 +3593,7 @@ div#database-sliders {
 fieldset.uploadform {
 	margin-top: 10px;
 	margin-bottom: 10px;
+	min-height: 200px;
 }
 #installer-database,
 #installer-discover,

--- a/administrator/templates/hathor/css/template_rtl.css
+++ b/administrator/templates/hathor/css/template_rtl.css
@@ -1320,3 +1320,6 @@ div.toggle-editor {
 .modal-footer button {
 	float: left;
 }
+#form-login  {
+	float: right;
+}

--- a/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
+++ b/administrator/templates/hathor/html/com_joomlaupdate/default/default.php
@@ -9,180 +9,71 @@
 
 defined('_JEXEC') or die;
 
-$ftpFieldsDisplay = $this->ftp['enabled'] ? '' : 'style = "display: none"';
-$params           = JComponentHelper::getParams('com_joomlaupdate');
+/** @var JoomlaupdateViewDefault $this */
 
-switch ($params->get('updatesource', 'default'))
-{
-	// "Minor & Patch Release for Current version AND Next Major Release".
-	case 'sts':
-	case 'next':
-		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_NEXT';
-		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_NEXT');
-		break;
-
-	// "Testing"
-	case 'testing':
-		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_TESTING';
-		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_TESTING');
-		break;
-
-	// "Custom"
-	case 'custom':
-		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_CUSTOM';
-		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_CUSTOM');
-		break;
-
-	// "Minor & Patch Release for Current version (recommended and default)".
-	// The commented "case" below are for documenting where 'default' and legacy options falls
-	// case 'default':
-	// case 'lts':
-	// case 'nochange':
-	default:
-		$langKey          = 'COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATES_INFO_DEFAULT';
-		$updateSourceKey  = JText::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_DEFAULT');
-}
-
+JHtml::_('jquery.framework');
+JHtml::_('bootstrap.tooltip');
 JHtml::_('formbehavior.chosen', 'select');
+JHtml::script('com_joomlaupdate/default.js', false, true, false);
 
+JFactory::getDocument()->addScriptDeclaration("
+jQuery(document).ready(function($) {
+	$('#extraction_method').change(function(e){
+		extractionMethodHandler('#extraction_method', 'row_ftp');
+	});
+	$('#upload_method').change(function(e){
+		extractionMethodHandler('#upload_method', 'upload_ftp');
+	});
+
+	$('button.submit').on('click', function() {
+		$('div.download_message').show();
+	});
+});");
 ?>
 
-<form action="index.php" method="post" id="adminForm">
+<div id="joomlaupdate-wrapper">
+	<form enctype="multipart/form-data" action="index.php" method="post" id="adminForm" class="form-horizontal">
+		<?php echo  JHtml::_('sliders.start', 'joomlaupdate-slider'); ?>
+		<?php if ($this->showUploadAndUpdate) : ?>
+			<?php echo JHtml::_('sliders.panel', JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_ONLINE'), 'online-update'); ?>
+		<?php endif; ?>
 
-<?php if (is_null($this->updateInfo['object'])) : ?>
+		<?php if ($this->selfUpdate) : ?>
+			<?php // If we have a self update notice to install it first! ?>
+			<?php JFactory::getApplication()->enqueueMessage(JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALL_SELF_UPDATE_FIRST'), 'error'); ?>
+			<?php echo $this->loadTemplate('updatemefirst'); ?>
+		<?php else : ?>
+			<?php if (!isset($this->updateInfo['object']->downloadurl->_data) && $this->updateInfo['installed'] < $this->updateInfo['latest']) : ?>
+				<?php // If we have no download URL we can't reinstall or update ?>
+				<?php echo $this->loadTemplate('nodownload'); ?>
+			<?php elseif (!$this->updateInfo['hasUpdate']) : ?>
+				<?php // If we have no update we can reinstall the core ?>
+				<?php echo $this->loadTemplate('reinstall'); ?>
+			<?php else : ?>
+				<?php // Ok let's show the update template ?>
+				<?php echo $this->loadTemplate('update'); ?>
+			<?php endif; ?>
+		<?php endif; ?>
 
-<fieldset>
-	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATES'); ?>
-	</legend>
-	<p>
-		<?php echo JText::sprintf($langKey, $updateSourceKey); ?>
-	</p>
-	<p>
-		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_NOUPDATESNOTICE', JVERSION); ?>
-	</p>
-</fieldset>
+		<input type="hidden" name="task" value="update.download" />
+		<input type="hidden" name="option" value="com_joomlaupdate" />
 
-<?php else: ?>
+		<?php echo JHtml::_('form.token'); ?>
+	</form>
 
-<fieldset>
-	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPDATEFOUND'); ?>
-	</legend>
+	<?php // Only Super Users have access to the Update & Install for obvious security reasons ?>
+	<?php if ($this->showUploadAndUpdate) : ?>
+		<?php echo JHtml::_('sliders.panel', JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_UPLOAD'), 'upload-update'); ?>
+		<?php echo $this->loadTemplate('upload'); ?>
+		<?php echo JHtml::_('sliders.end'); ?>
+	<?php endif; ?>
 
-	<table class="adminlist">
-		<tbody>
-			<tr class="row0">
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLED'); ?>
-				</td>
-				<td>
-					<?php echo $this->updateInfo['installed']; ?>
-				</td>
-			</tr>
-			<tr class="row1">
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_LATEST'); ?>
-				</td>
-				<td>
-					<?php echo $this->updateInfo['latest']; ?>
-				</td>
-			</tr>
-			<tr class="row0">
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_PACKAGE'); ?>
-				</td>
-				<td>
-					<a href="<?php echo $this->updateInfo['object']->downloadurl->_data; ?>">
-						<?php echo $this->updateInfo['object']->downloadurl->_data; ?>
-					</a>
-				</td>
-			</tr>
-			<tr class="row1">
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INFOURL'); ?>
-				</td>
-				<td>
-					<a href="<?php echo $this->updateInfo['object']->get('infourl')->_data; ?>">
-						<?php echo $this->updateInfo['object']->get('infourl')->title; ?>
-					</a>
-				</td>
-			</tr>
-			<tr class="row0">
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_METHOD'); ?>
-				</td>
-				<td>
-					<?php echo $this->methodSelect; ?>
-				</td>
-			</tr>
-			<tr class="row1" id="row_ftp_hostname" <?php echo $ftpFieldsDisplay; ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME'); ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>" />
-				</td>
-			</tr>
-			<tr class="row0" id="row_ftp_port" <?php echo $ftpFieldsDisplay; ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT'); ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>" />
-				</td>
-			</tr>
-			<tr class="row1" id="row_ftp_username" <?php echo $ftpFieldsDisplay; ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME'); ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>" />
-				</td>
-			</tr>
-			<tr class="row0" id="row_ftp_password" <?php echo $ftpFieldsDisplay; ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD'); ?>
-				</td>
-				<td>
-					<input type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>" />
-				</td>
-			</tr>
-			<tr class="row1" id="row_ftp_directory" <?php echo $ftpFieldsDisplay; ?>>
-				<td>
-					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY'); ?>
-				</td>
-				<td>
-					<input type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>" />
-				</td>
-			</tr>
-		</tbody>
-		<tfoot>
-			<tr>
-				<td>
-					&nbsp;
-				</td>
-				<td>
-					<button class="submit" type="submit">
-						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_INSTALLUPDATE'); ?>
-					</button>
-				</td>
-			</tr>
-		</tfoot>
-	</table>
-</fieldset>
-
-<?php endif; ?>
-
-<?php echo JHtml::_('form.token'); ?>
-<input type="hidden" name="task" value="update.download" />
-<input type="hidden" name="option" value="com_joomlaupdate" />
-</form>
-
-<div class="download_message" style="display: none">
-	<p></p>
-	<p class="nowarning">
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS'); ?>
-	</p>
-	<div class="joomlaupdate_spinner"></div>
+	<div class="download_message" style="display: none">
+		<p></p>
+		<p class="nowarning">
+			<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS'); ?>
+		</p>
+		<div class="joomlaupdate_spinner"></div>
+	</div>
+	<div id="loading"></div>
 </div>

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -754,7 +754,7 @@ p.tab-description {
 }
 
 #form-login {
-	float: right;
+	float: left;
 	padding: 1.1em;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;

--- a/administrator/templates/hathor/less/template.less
+++ b/administrator/templates/hathor/less/template.less
@@ -3234,6 +3234,7 @@ div#database-sliders {
 fieldset.uploadform {
 	margin-top: 10px;
 	margin-bottom: 10px;
+	min-height: 200px;
 }
 
 /* Installer Database */


### PR DESCRIPTION
Pull Request for Issue #12406
### Summary of Changes

Updated Hathor joomlaupdate default view to display the new choices
### Testing Instructions

Before patch, they do not show.
After patch,  the new views display correctly in sliders.

![screen shot 2016-10-18 at 11 58 45](https://cloud.githubusercontent.com/assets/869724/19473275/271300e0-952b-11e6-9214-6a603069dd56.png)

![screen shot 2016-10-18 at 11 58 58](https://cloud.githubusercontent.com/assets/869724/19473280/2ea48310-952b-11e6-8b16-af3c6d7de575.png)
### Documentation Changes Required

None
