### PR TITLE
Add more semantic html5 elements to module tag options

### DIFF
--- a/libraries/cms/form/field/moduletag.php
+++ b/libraries/cms/form/field/moduletag.php
@@ -37,6 +37,7 @@ class JFormFieldModuletag extends JFormFieldList
 	{
 		$options = array();
 		$tags    = array('address', 'article', 'aside', 'details', 'div', 'footer', 'header', 'main', 'nav', 'section', 'summary');
+
 		// Create one new option object for each tag
 		foreach ($tags as $tag)
 		{

--- a/libraries/cms/form/field/moduletag.php
+++ b/libraries/cms/form/field/moduletag.php
@@ -36,8 +36,7 @@ class JFormFieldModuletag extends JFormFieldList
 	protected function getOptions()
 	{
 		$options = array();
-		$tags    = array('article', 'aside', 'details', 'div', 'figcaption',
-			'figure', 'footer', 'header', 'main', 'mark', 'nav', 'section', 'summary', 'time');
+		$tags    = array('address', 'article', 'aside', 'details', 'div', 'footer', 'header', 'main', 'nav', 'section', 'summary');
 		// Create one new option object for each tag
 		foreach ($tags as $tag)
 		{

--- a/libraries/cms/form/field/moduletag.php
+++ b/libraries/cms/form/field/moduletag.php
@@ -36,8 +36,8 @@ class JFormFieldModuletag extends JFormFieldList
 	protected function getOptions()
 	{
 		$options = array();
-		$tags = array('div', 'section', 'aside', 'nav', 'address', 'article');
-
+		$tags    = array('article', 'aside', 'details', 'div', 'figcaption',
+			'figure', 'footer', 'header', 'main', 'mark', 'nav', 'section', 'summary', 'time');
 		// Create one new option object for each tag
 		foreach ($tags as $tag)
 		{


### PR DESCRIPTION
### Summary of Changes

Add more semantic tags to module tag options and sort it alphabetically
`
<addres>
<article>
<aside>
<details>
<div>
<footer>
<header>
<main>
<nav>
<section>
<summary>
`
![image](https://cloud.githubusercontent.com/assets/828371/19477525/de36fcd2-953e-11e6-8fd9-958136e3bf1b.png)
### Testing Instructions

Select another module tag in Modules » Any Module » Advanced
Check if the output works
### Documentation Changes Required
