### PR TITLE
Prioritise using MCrypt over Openssl

### DIFF
--- a/libraries/fof/encrypt/aes.php
+++ b/libraries/fof/encrypt/aes.php
@@ -44,11 +44,11 @@ class FOFEncryptAes
 	 */
 	public function __construct($key, $strength = 128, $mode = 'cbc', FOFUtilsPhpfunc $phpfunc = null)
 	{
-		$this->adapter = new FOFEncryptAesOpenssl();
+		$this->adapter = new FOFEncryptAesMcrypt();
 
 		if (!$this->adapter->isSupported($phpfunc))
 		{
-			$this->adapter = new FOFEncryptAesMcrypt();
+			$this->adapter = new FOFEncryptAesOpenssl();
 		}
 
 		$this->adapter->setEncryptionMode($mode, $strength);


### PR DESCRIPTION
This will fix google auth by going back to MCrypt instead of openssl
# This is a worst case scenario patch. Decrypting mcrypt with openssl should always be preferred over this
## Things to note
1. Old users from 3.6.2 will work (yay)
2. Users in 3.6.3 will now be unable to log in (boo)
3. Users running PHP 7.1 will still be unable to login as the mcrypt check will fail and Open SSL will still be used
4. Users registering in PHP 7.1 will still continue to work
