### PR TITLE
Set a proper default value for getParams always

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -1521,12 +1521,12 @@ class JInstaller extends JAdapter
 	}
 
 	/**
-	 * Method to parse the parameters of an extension, build the INI
-	 * string for its default parameters, and return the INI string.
+	 * Method to parse the parameters of an extension, build the JSON string for its default parameters, and return the JSON string.
 	 *
-	 * @return  string   INI string of parameter values
+	 * @return  string  JSON string of parameter values
 	 *
 	 * @since   3.1
+	 * @note    This method must always return a JSON compliant string
 	 */
 	public function getParams()
 	{
@@ -1535,6 +1535,7 @@ class JInstaller extends JAdapter
 		{
 			return '{}';
 		}
+
 		// Getting the fieldset tags
 		$fieldsets = $this->manifest->config->fields->fieldset;
 
@@ -1547,7 +1548,7 @@ class JInstaller extends JAdapter
 			if (!count($fieldset->children()))
 			{
 				// Either the tag does not exist or has no children therefore we return zero files processed.
-				return;
+				return '{}';
 			}
 
 			// Iterating through the fields and collecting the name/default values:


### PR DESCRIPTION
### Summary of Changes

`JInstaller::getParams()` has a code path that results in a null value being returned.  This value ultimately gets stored to the extensions table's params column, which can lead to a JSON decoding error.
### Testing Instructions

I don't know a way to reproduce this off hand, however, if you look at where this method is used in the install adapters, you can make sense of how this can be an issue.  Sorry, moving quickly that's the best I can give.
### Documentation Changes Required

None explicitly required however the method still documents itself as returning INI strings (used during 1.5) so I've corrected that and added an inline note indicating the need for a JSON compliant return value.
