### PR TITLE
Check to ensure user is not disabled before sending the email update notification

### DIFF
--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -360,6 +360,7 @@ class PlgSystemUpdatenotification extends JPlugin
 							)
 						)->from($db->qn('#__users'))
 						->where($db->qn('id') . ' IN(' . implode(',', $userIDs) . ')')
+						->where($db->qn('block') . ' = ' . (int) 0)
 						->where($db->qn('sendEmail') . ' = ' . $db->q('1'));
 
 			if (!empty($emails))

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -360,7 +360,7 @@ class PlgSystemUpdatenotification extends JPlugin
 							)
 						)->from($db->qn('#__users'))
 						->where($db->qn('id') . ' IN(' . implode(',', $userIDs) . ')')
-						->where($db->qn('block') . ' = ' . (int) 0)
+						->where($db->qn('block') . ' = 0')
 						->where($db->qn('sendEmail') . ' = ' . $db->q('1'));
 
 			if (!empty($emails))


### PR DESCRIPTION
The Joomla plugin that checks for updates and sends emails to SuperUsers informing them that an update is available only checked to see if the superuser has sendEmail set to Yes. It did not check to ensure that the user was not blocked (disabled).

This PR adds a check to ensure that the user is not blocked and so it only sends the email notification to users who are 

1. User Group = SuperUsers
2. User Status = Enabled 
3. Receive System Emails = yes

