### PR TITLE
Improve sef plugin tooltip

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_sef.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_sef.ini
@@ -6,4 +6,4 @@
 PLG_SEF_XML_DESCRIPTION="Adds SEF support to links in the document. It operates directly on the HTML and does not require a special tag."
 PLG_SYSTEM_SEF="System - SEF"
 PLG_SEF_DOMAIN_LABEL="Site Domain"
-PLG_SEF_DOMAIN_DESCRIPTION="If your site can be accessed through more than one domain enter the canonical one here."
+PLG_SEF_DOMAIN_DESCRIPTION="If your site can be accessed through more than one domain enter the preferred (sometimes referred to as canonical) domain here. <br /><strong>Note:</strong> https://example.com and https://www.example.com are different domains."


### PR DESCRIPTION
I see lots of confusion about the "preferred domain" setting in the system sef plugin. I hope this PR will help to reduce that. Please note that one "improvement" in this tooltip is the explanation that https://example.com and https://www.example.com are different domains

I used this as a reference https://support.google.com/webmasters/answer/44231?hl=en I hope I haven't misunderstood anything about this param 

![2ta2 1](https://cloud.githubusercontent.com/assets/1296369/19518918/796a8a6c-9601-11e6-83e3-96864b5a4c15.png)
