### PR TITLE
Mark _autoload function as public and not private.

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -584,7 +584,7 @@ abstract class JLoader
 	 *
 	 * @since   11.3
 	 */
-	private static function _autoload($class)
+	public static function _autoload($class)
 	{
 		foreach (self::$prefixes as $prefix => $lookup)
 		{
@@ -600,7 +600,7 @@ abstract class JLoader
 	}
 
 	/**
-	 * Load a class based on name and lookup array.
+	 * Load a class based on name and lookup array. 
 	 *
 	 * @param   string  $class   The class to be loaded (wihtout prefix).
 	 * @param   array   $lookup  The array of base paths to use for finding the class file.
@@ -609,7 +609,7 @@ abstract class JLoader
 	 *
 	 * @since   12.1
 	 */
-	private static function _load($class, $lookup)
+	public static function _load($class, $lookup)
 	{
 		// Split the class name into parts separated by camelCase.
 		$parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -609,7 +609,7 @@ abstract class JLoader
 	 *
 	 * @since   12.1
 	 */
-	public static function _load($class, $lookup)
+	private static function _load($class, $lookup)
 	{
 		// Split the class name into parts separated by camelCase.
 		$parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -600,7 +600,7 @@ abstract class JLoader
 	}
 
 	/**
-	 * Load a class based on name and lookup array. 
+	 * Load a class based on name and lookup array.
 	 *
 	 * @param   string  $class   The class to be loaded (wihtout prefix).
 	 * @param   array   $lookup  The array of base paths to use for finding the class file.


### PR DESCRIPTION
Pull Request for Issue `_autoload` was marked private.

Why `_autoload` was ever marked private is highly questionable. Ever since the autoloader has been there, people have been filing issues because it is incompatible with third-party code that uses public functions.

My only assumption is `_autoload` got marked `private` by habit since in PHP 4 there was a preference to indicate methods `private` or `protected` with leading underscores and that resulted in any PHP 5 methods prefixed with underscores being explicitly marked `private` or `protected`.

In this instance, it seems like marking `_autoload` as `private` is the completely wrong thing to do. (it's also questionable why it even works in PHP facebook/hhvm#959 (comment) )
### Summary of Changes

Explicitly mark `_autoload` ~~and `_load`~~ as public.
### Testing Instructions
- Everything should still work in Joomla
- Review Travis CI HHVM tests, the `JLoaderTest::testSetupWithoutPrefixes` failure is no longer listed. 
- Optional extended testing
  - Previously incompatible third-party code that uses public functions should now autoload without issue.
### Documentation Changes Required

Unsure about documentation changes
(possibly should add a note in the docblocks to explicitly state these methods need to be `public`.)
