### PR TITLE
Remove JFilter mock from JInstaller Adapter tests

### DIFF
--- a/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerAdapterTest.php
@@ -43,11 +43,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	public function setUp()
 	{
 		parent::setUp();
-
-		// Mock JFilter
-		$filterMock = $this->getMock('JFilterInput', array('filter'));
-		$filterSig = md5(serialize(array(array(), array(), 0, 0, 1)));
-		TestReflection::setValue('JFilterInput', 'instances', array($filterSig => $filterMock));
 	}
 
 	/**
@@ -59,9 +54,6 @@ class JInstallerAdapterTest extends TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		// Reset the filter instances.
-		TestReflection::setValue('JFilterInput', 'instances', array());
-
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
Pull Request for Issue unnecessary code in Unit test .
### Summary of Changes

Remove JFilter from JInstaller test setup

We don't need JFilter just hanging out in the JInstaller Adapter tests
### Testing Instructions

Review Travis Tests for passing
### Documentation Changes Required

None
