### PR TITLE
Allow empty search - uses wrong value

### DIFF
--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -75,7 +75,7 @@ jQuery(function() {";
 			<?php echo JText::_('COM_FINDER_SEARCH_TERMS'); ?>
 		</label>
 		<input type="text" name="q" id="q" size="30" value="<?php echo $this->escape($this->query->input); ?>" class="inputbox" />
-		<?php if ($this->escape($this->query->input) != '' || $this->params->get('allow_empty_search')):?>
+		<?php if ($this->escape($this->query->input) != '' || $this->params->get('allow_empty_query')):?>
 			<button name="Search" type="submit" class="btn btn-primary"><span class="icon-search icon-white"></span> <?php echo JText::_('JSEARCH_FILTER_SUBMIT');?></button>
 		<?php else: ?>
 			<button name="Search" type="submit" class="btn btn-primary disabled"><span class="icon-search icon-white"></span> <?php echo JText::_('JSEARCH_FILTER_SUBMIT');?></button>


### PR DESCRIPTION
Pull Request for Issue #12489

### Steps to reproduce the issue

Create finder component page. Set to allow empty search. Display page mouse over search button. The search button is rendered as disabled (class contains 'disabled')

### Expected result

search button should be rendered enabled, that is, the tag should not have class 'disabled'

### Actual result

The search button is rendered as disabled (class contains 'disabled')

This was because 
The parameter name used in components/com_finder/views/search/tmpl/default_form.php line 78 , allow_empty_search, should be 'allow_empty_query' to match the parameter field defined in administrator/components/com_finder/config.xml line 37.

This PR fixes that

Thanks to @nclifton for this fix