### PR TITLE
[4.0] [B/C break] Use a MySql more strict sql mode

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -95,8 +95,6 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
 			'STRICT_TRANS_TABLES',
-			'NO_ZERO_IN_DATE',
-			'NO_ZERO_DATE',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -91,8 +91,8 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			throw new JDatabaseExceptionConnecting('Could not connect to MySQL.');
 		}
 
-		// Set sql_mode to non_strict mode
-		mysql_query("SET @@SESSION.sql_mode = '';", $this->connection);
+		// Set sql_mode to MySql 5.7.8+ default strict mode.
+		mysql_query("SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';", $this->connection);
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -92,7 +92,17 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		}
 
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
-		mysql_query("SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';", $this->connection);
+		$sqlModes = array(
+			'ONLY_FULL_GROUP_BY',
+			'STRICT_TRANS_TABLES',
+			'NO_ZERO_IN_DATE',
+			'NO_ZERO_DATE',
+			'ERROR_FOR_DIVISION_BY_ZERO',
+			'NO_AUTO_CREATE_USER',
+			'NO_ENGINE_SUBSTITUTION',
+		);
+
+		mysql_query("SET @@SESSION.sql_mode = '" . implode(',', $sqlModes). "';", $this->connection);
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -102,7 +102,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 			'NO_ENGINE_SUBSTITUTION',
 		);
 
-		mysql_query("SET @@SESSION.sql_mode = '" . implode(',', $sqlModes). "';", $this->connection);
+		mysql_query("SET @@SESSION.sql_mode = '" . implode(',', $sqlModes) . "';", $this->connection);
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -194,7 +194,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			'NO_ENGINE_SUBSTITUTION',
 		);
 
-		mysqli_query($this->connection, "SET @@SESSION.sql_mode = '" . implode(',', $sqlModes). "';");
+		mysqli_query($this->connection, "SET @@SESSION.sql_mode = '" . implode(',', $sqlModes) . "';");
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -184,7 +184,17 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		}
 
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
-		mysqli_query($this->connection, "SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';");
+		$sqlModes = array(
+			'ONLY_FULL_GROUP_BY',
+			'STRICT_TRANS_TABLES',
+			'NO_ZERO_IN_DATE',
+			'NO_ZERO_DATE',
+			'ERROR_FOR_DIVISION_BY_ZERO',
+			'NO_AUTO_CREATE_USER',
+			'NO_ENGINE_SUBSTITUTION',
+		);
+
+		mysqli_query($this->connection, "SET @@SESSION.sql_mode = '" . implode(',', $sqlModes). "';");
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -183,8 +183,8 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 			throw new JDatabaseExceptionConnecting('Could not connect to MySQL.');
 		}
 
-		// Set sql_mode to non_strict mode
-		mysqli_query($this->connection, "SET @@SESSION.sql_mode = '';");
+		// Set sql_mode to MySql 5.7.8+ default strict mode.
+		mysqli_query($this->connection, "SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';");
 
 		// If auto-select is enabled select the given database.
 		if ($this->options['select'] && !empty($this->options['database']))

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -187,8 +187,6 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
 			'STRICT_TRANS_TABLES',
-			'NO_ZERO_IN_DATE',
-			'NO_ZERO_DATE',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -152,7 +152,17 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
-		$this->connection->query("SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';");
+		$sqlModes = array(
+			'ONLY_FULL_GROUP_BY',
+			'STRICT_TRANS_TABLES',
+			'NO_ZERO_IN_DATE',
+			'NO_ZERO_DATE',
+			'ERROR_FOR_DIVISION_BY_ZERO',
+			'NO_AUTO_CREATE_USER',
+			'NO_ENGINE_SUBSTITUTION',
+		);
+
+		$this->connection->query("SET @@SESSION.sql_mode = '" . implode(',', $sqlModes) . "';");
 	}
 
 	/**

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -151,7 +151,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		$this->connection->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 		$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
-		// Set sql_mode to non_strict mode
+		// Set sql_mode to MySql 5.7.8+ default strict mode.
 		$this->connection->query("SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';");
 	}
 

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -155,8 +155,6 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
 			'STRICT_TRANS_TABLES',
-			'NO_ZERO_IN_DATE',
-			'NO_ZERO_DATE',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -152,7 +152,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		$this->connection->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
 
 		// Set sql_mode to non_strict mode
-		$this->connection->query("SET @@SESSION.sql_mode = '';");
+		$this->connection->query("SET @@SESSION.sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';");
 	}
 
 	/**

--- a/tests/unit/schema/mysql.sql
+++ b/tests/unit/schema/mysql.sql
@@ -17,9 +17,9 @@ DROP TABLE IF EXISTS `jos_dbtest`;
 
 CREATE TABLE `jos_dbtest` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(50) NOT NULL,
+  `title` varchar(50) NOT NULL DEFAULT '',
   `start_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `description` text NOT NULL,
+  `description` text NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/tests/unit/schema/mysql.sql
+++ b/tests/unit/schema/mysql.sql
@@ -18,7 +18,7 @@ DROP TABLE IF EXISTS `jos_dbtest`;
 CREATE TABLE `jos_dbtest` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `title` varchar(50) NOT NULL,
-  `start_date` datetime NOT NULL,
+  `start_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `description` text NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
+++ b/tests/unit/suites/database/driver/mysql/JDatabaseDriverMysqlTest.php
@@ -268,7 +268,7 @@ class JDatabaseDriverMysqlTest extends TestCaseDatabaseMysql
 		$title->Comment    = '';
 
 		$start_date = new stdClass;
-		$start_date->Default    = null;
+		$start_date->Default    = '0000-00-00 00:00:00';
 		$start_date->Field      = 'start_date';
 		$start_date->Type       = 'datetime';
 		$start_date->Null       = 'NO';

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -270,7 +270,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$title->Comment    = '';
 
 		$start_date = new stdClass;
-		$start_date->Default    = null;
+		$start_date->Default    = '0000-00-00 00:00:00';
 		$start_date->Field      = 'start_date';
 		$start_date->Type       = 'datetime';
 		$start_date->Null       = 'NO';

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -267,7 +267,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		$title->Comment    = '';
 
 		$start_date             = new stdClass;
-		$start_date->Default    = null;
+		$start_date->Default    = '0000-00-00 00:00:00';
 		$start_date->Field      = 'start_date';
 		$start_date->Type       = 'datetime';
 		$start_date->Null       = 'NO';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12491.
### Summary of Changes

Changes the default sql drivers sql_mode to a more strict mode.

See, for more info about the sql modes (ex: it's default values):
- http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
- http://dev.mysql.com/doc/refman/5.6/en/sql-mode.html

Sor adiditonal info see https://github.com/joomla/joomla-cms/issues/12491
### Testing Instructions

But overall MySql, MySqli and PDO MySql db drivers should continue to work.

Note: This will generate db errors in some parts in the Joomla core that will need to be fixed in future PRs.
### Documentation Changes Required

Warn about this B/C break in 4.0. Reference MySql strict modes.
### Notes

CMS mantainers: maybe a RED :wink:  "4.0 B/C break" label should be added in github to keep track of 4.0 B/C breaks.

> The following table shows the format of the “zero” value for each type. The “zero” values are special, but you can store or refer to them explicitly using the values shown in the table. You can also do this using the values '0' or 0, which are easier to write. For temporal types that include a date part (DATE, DATETIME, and TIMESTAMP), use of these values produces warnings if the NO_ZERO_DATE SQL mode is enabled.

See http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html

So or we remove the `NO_ZERO_DATE` sql mode or we have to change all dates accross joomla db and code.
