### PR TITLE
Tab state logic fix

### DIFF
--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -24,7 +24,7 @@ jQuery(function($) {
             activeTabsHrefs.push(href);
 
             // Store the selected tabs hrefs in localStorage
-            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, ''), JSON.stringify(activeTabsHrefs));
+            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -36,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, '')));
+        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -52,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, ''));
+                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''));
 
                     return true;
                 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -24,7 +24,7 @@ jQuery(function($) {
             activeTabsHrefs.push(href);
 
             // Store the selected tabs hrefs in localStorage
-            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, ''), JSON.stringify(activeTabsHrefs));
+            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -36,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, '')));
+        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -52,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, ''));
+                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+$/, ''));
 
                     return true;
                 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -24,7 +24,7 @@ jQuery(function($) {
             activeTabsHrefs.push(href);
 
             // Store the selected tabs hrefs in localStorage
-            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, ''), JSON.stringify(activeTabsHrefs));
+            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -36,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, '')));
+        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -52,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, ''));
+                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, ''));
 
                     return true;
                 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -24,7 +24,7 @@ jQuery(function($) {
             activeTabsHrefs.push(href);
 
             // Store the selected tabs hrefs in localStorage
-            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, ''), JSON.stringify(activeTabsHrefs));
+            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -36,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, '')));
+        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -52,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=\d+$/, ''));
+                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&[a-zA-Z]+=[a-zA-Z0-9%]+$/, ''));
 
                     return true;
                 }

--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -11,15 +11,20 @@
 jQuery(function($) {
     var loadTabs = function() {
         function saveActiveTab(href) {
-            if (activeTabsHrefs === null) {
-                activeTabsHrefs = [];
+            // Remove the old entry if exists, key is always dependant on the url
+            // This should be removed in the future
+            if (localStorage.getItem('active-tab')) {
+                localStorage.removeItem('active-tab');
             }
+
+            // Reset the array
+            activeTabsHrefs = [];
 
             // Save clicked tab href to the array
             activeTabsHrefs.push(href);
 
-            // Store the selected tabs hrefs in localstorage
-            localStorage.setItem('active-tabs', JSON.stringify(activeTabsHrefs));
+            // Store the selected tabs hrefs in localStorage
+            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -31,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem('active-tabs'));
+        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -47,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem('active-tabs');
+                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&id=\w+\Z/, ''));
 
                     return true;
                 }


### PR DESCRIPTION
Pull Request for Issue # .
The problem: Many people stated that they experience odd behaviour with the tabs when a page loads (admin area).
### Summary of Changes

The javascript that controlled this behaviour was way to liberal.
So the old behaviour:
- One key-value pair
- As a user is browsing and clicking on tabs these tabs (as their ID) is stored in an array in the key-value of local storage.
- The problem is that the script will loop all this values and set for each one the relative tab as active.

The new logic:
- many key-value pairs
- regular expression removes the `&id=0000` part (could be improved, help is welcome)
- there is a unique key-value pair per view (not per item, e.g. article->edit but not article[123]->edit) 
- should be faster and glitch free
### Testing Instructions

Apply the patch and try any view with tabs

Before:
![screen shot 2016-10-22 at 03 18 13](https://cloud.githubusercontent.com/assets/3889375/19615321/489a9696-9806-11e6-87d6-817f1dbe24d0.png)

After:
![screen shot 2016-10-22 at 03 17 03](https://cloud.githubusercontent.com/assets/3889375/19615327/5371c5da-9806-11e6-8d06-561e46a47b60.png)
### Documentation Changes Required

None
