### PR TITLE
Can't logout with the menu item Users > Logout

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -519,6 +519,7 @@ class JApplicationWeb extends JApplicationBase
 				$this->header($this->responseMap[$status]);
 				$this->setHeader('Location', $url);
 				$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
+
 				// Set cache related headers
 				$this->setCacheHeaders();
 				$this->sendHeaders();
@@ -577,6 +578,8 @@ class JApplicationWeb extends JApplicationBase
 	/**
 	 * Set all the necessary cache-related headers, based on the current value of $this->response->cachable,
 	 * which in turn can be set by the components controllers, in case of need, with JApplicationWeb::allowCache()
+	 *
+	 * @return  void
 	 *
 	 * @since 3.6.4
 	 */

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -581,7 +581,7 @@ class JApplicationWeb extends JApplicationBase
 	 *
 	 * @return  void
 	 *
-	 * @since 3.6.4
+	 * @since __DEPLOY_VERSION__
 	 */
 	protected function setCacheHeaders()
 	{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -419,30 +419,8 @@ class JApplicationWeb extends JApplicationBase
 		// Send the content-type header.
 		$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
 
-		// If the response is set to uncachable, we need to set some appropriate headers so browsers don't cache the response.
-		if (!$this->response->cachable)
-		{
-			// Expires in the past.
-			$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
-
-			// Always modified.
-			$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-			$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-
-			// HTTP 1.0
-			$this->setHeader('Pragma', 'no-cache');
-		}
-		else
-		{
-			// Expires.
-			$this->setHeader('Expires', gmdate('D, d M Y H:i:s', time() + 900) . ' GMT');
-
-			// Last modified.
-			if ($this->modifiedDate instanceof JDate)
-			{
-				$this->setHeader('Last-Modified', $this->modifiedDate->format('D, d M Y H:i:s'));
-			}
-		}
+		// Set cache related headers
+		$this->setCacheHeaders();
 
 		$this->sendHeaders();
 
@@ -539,8 +517,11 @@ class JApplicationWeb extends JApplicationBase
 
 				// All other cases use the more efficient HTTP header for redirection.
 				$this->header($this->responseMap[$status]);
-				$this->header('Location: ' . $url);
-				$this->header('Content-Type: text/html; charset=' . $this->charSet);
+				$this->setHeader('Location', $url);
+				$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
+				// Set cache related headers
+				$this->setCacheHeaders();
+				$this->sendHeaders();
 			}
 		}
 
@@ -590,6 +571,41 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		return $this->response->cachable;
+	}
+
+
+	/**
+	 * Set all the necessary cache-related headers, based on the current value of $this->response->cachable,
+	 * which in turn can be set by the components controllers, in case of need, with JApplicationWeb::allowCache()
+	 *
+	 * @since 3.6.4
+	 */
+	protected function setCacheHeaders()
+	{
+		// If the response is set to uncachable, we need to set some appropriate headers so browsers don't cache the response.
+		if (!$this->response->cachable)
+		{
+			// Expires in the past.
+			$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
+
+			// Always modified.
+			$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
+			$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+
+			// HTTP 1.0
+			$this->setHeader('Pragma', 'no-cache');
+		}
+		else
+		{
+			// Expires.
+			$this->setHeader('Expires', gmdate('D, d M Y H:i:s', time() + 900) . ' GMT');
+
+			// Last modified.
+			if ($this->modifiedDate instanceof JDate)
+			{
+				$this->setHeader('Last-Modified', $this->modifiedDate->format('D, d M Y H:i:s'));
+			}
+		}
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -403,10 +403,12 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				/*
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
 				array('Pragma: no-cache', true, null)
+				*/
 			),
 			$this->class->headers
 		);
@@ -613,10 +615,12 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 301 Moved Permanently', true, null),
 				array('Location: ' . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				/*
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
 				array('Pragma: no-cache', true, null)
+				*/
 			),
 			$this->class->headers
 		);

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -393,6 +393,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		TestReflection::setValue($this->class, 'config', $config);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
@@ -400,6 +403,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null),
 			),
 			$this->class->headers
 		);
@@ -432,6 +439,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		TestReflection::setValue($this->class, 'config', $config);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, 'Test Message', 'message', false);
 
 		$this->assertEquals(
@@ -449,6 +459,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null),
 			),
 			$this->class->headers
 		);
@@ -481,6 +495,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		TestReflection::setValue($this->class, 'config', $config);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, '', 'message');
 
 		// The message isn't enqueued as it's an empty string
@@ -494,6 +511,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null),
 			),
 			$this->class->headers
 		);
@@ -582,6 +603,9 @@ class JApplicationCmsTest extends TestCaseDatabase
 			)
 		);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
@@ -589,6 +613,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 301 Moved Permanently', true, null),
 				array('Location: ' . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null),
 			),
 			$this->class->headers
 		);

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -406,7 +406,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-				array('Pragma: no-cache', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);
@@ -462,7 +462,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-				array('Pragma: no-cache', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);
@@ -514,7 +514,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-				array('Pragma: no-cache', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);
@@ -616,7 +616,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-				array('Pragma: no-cache', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -403,12 +403,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
-				/*
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
 				array('Pragma: no-cache', true, null)
-				*/
 			),
 			$this->class->headers
 		);
@@ -615,12 +613,10 @@ class JApplicationCmsTest extends TestCaseDatabase
 				array('HTTP/1.1 301 Moved Permanently', true, null),
 				array('Location: ' . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
-				/*
 				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
 				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
 				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
 				array('Pragma: no-cache', true, null)
-				*/
 			),
 			$this->class->headers
 		);

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1047,6 +1047,9 @@ class JApplicationWebTest extends TestCase
 
 		TestReflection::setValue($this->class, 'config', $config);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
@@ -1054,6 +1057,10 @@ class JApplicationWebTest extends TestCase
 				array('HTTP/1.1 303 See other', true, null),
 				array('Location: ' . $base . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);
@@ -1139,6 +1146,9 @@ class JApplicationWebTest extends TestCase
 			)
 		);
 
+		// Ensure that the response is not cachable. A cachable one would have different headers.
+		$this->class->allowCache(false);
+		// Run the redirect
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
@@ -1146,6 +1156,10 @@ class JApplicationWebTest extends TestCase
 				array('HTTP/1.1 301 Moved Permanently', true, null),
 				array('Location: ' . $url, true, null),
 				array('Content-Type: text/html; charset=utf-8', true, null),
+				array('Expires: Wed, 17 Aug 2005 00:00:00 GMT', true, null),
+				array('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT', true, null),
+				array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+				array('Pragma: no-cache', true, null)
 			),
 			$this->class->headers
 		);


### PR DESCRIPTION
The menu item Users > Logout recently introduced highlights an old time latent problem related to the cache.
Basically, while JApplicationWeb::respond() respects the fact that the page can be cachable or not, JApplicationWeb::redirect() totally ignores that fact.
As a result, redirections can be cached causing weird bugs.
One of them, is the inability to execute the log-out a second time. That is, you can login, then logout, login again, but from here to the cache expiration you won't be able to logout furthermore.
We didn't noticed this up to now, because the "Logout button" submits a form, and a POST request is never cached. The new "Logout menu item" is a GET request instead, which on the contrary can be cached.

Cache problem are tricky to reproduce and debug, due to the different way the various cache layers work and react to different inputs, (such as a simple URL request vs a page refresh). For that reason I'll explain how to reproduce the problem step by step.

I've verified this problem with Google Chrome. In my tests, Mozilla Firefox is **not** affected. I haven't tested further browsers.

Since the logout button is not affected, the problem can be observed through the Logout menu item, so prepare it. New menu item > Type = Users - Logout. Save and close.

To test this, you need to activate a cache layer between the web server and the client.
While a proxy should be fine for this purpose, I've used Apache module mod_expires instead, which is a common environment in many hosting providers. It's easy con configure and from the browser's point of view, it has a predictable behaviour.
mod_expires configuration follows:
1- Ensure that Apache mod_expires is enabled.

```
a2enmod expires
service apache2 restart
```

2- Set up the cache in the .htaccess.

```
ExpiresActive On
ExpiresDefault "now plus 1 hour"
```

This sets a one hour cache to all resources, such as images, js, css. php would be affected as well, but note that Joomla, while generating its HTML output, overrides this general settings by turning off any cache through appropriate HTTP response headers (see JApplicationWeb::respond()).

Open the "Network" console in Google Chrome, and browse any page of the Joomla website.
It's headers contains all the necessary anti-cache elements:

```
Cache-Control: no-cache
Pragma: no-cache
Expires: (a date in the far past)
```

See screenshot n.1.
So far, so good.

![screenshot1](https://cloud.githubusercontent.com/assets/1609992/19615966/228012e8-9800-11e6-90be-16d5b69ef06a.png)

Now, login and logout using the "Logout menu item". The logout is successful, but note the absence of the necessary anti-cache elements. Also note the "Expires" date in the future.
See screenshot n.2.
The page can now be cached. We will have big problems soon.

![screenshot2](https://cloud.githubusercontent.com/assets/1609992/19615967/2cdfcf44-9800-11e6-98e1-20405f6a53a5.png)

Login again. Now there is no way to Logout by the "Logout menu item". By pressing the Logout menu item we get the page from the cache, and no PHP code is executed server-side.
See screenshot n.3.

![screenshot3](https://cloud.githubusercontent.com/assets/1609992/19615969/32fd5450-9800-11e6-871c-096cd742bbc8.png)

The PR proposed simply uniforms the way that JApplicationWeb::respond() and JApplicationWeb::redirect() handle the cache-related headers.
See screenshot n.4.
After applying the PR, the redirect contains all the necessary anti-cache elements.

![screenshot4](https://cloud.githubusercontent.com/assets/1609992/19615971/3b6d1bde-9800-11e6-934e-ec8d38428a31.png)
