### PR TITLE
[com_content] - deleted featured articles are not deleted from  #__content_frontpage table

### DIFF
--- a/administrator/components/com_content/controllers/articles.php
+++ b/administrator/components/com_content/controllers/articles.php
@@ -133,5 +133,6 @@ class ContentControllerArticles extends JControllerAdmin
 	 */
 	protected function postDeleteHook(JModelLegacy $model, $ids = null)
 	{
+		return $model->delete_featured($ids);
 	}
 }

--- a/administrator/components/com_content/controllers/articles.php
+++ b/administrator/components/com_content/controllers/articles.php
@@ -119,20 +119,4 @@ class ContentControllerArticles extends JControllerAdmin
 	{
 		return parent::getModel($name, $prefix, $config);
 	}
-
-	/**
-	 * Function that allows child controller access to model data
-	 * after the item has been deleted.
-	 *
-	 * @param   JModelLegacy  $model  The data model object.
-	 * @param   integer       $ids    The array of ids for items being deleted.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.2
-	 */
-	protected function postDeleteHook(JModelLegacy $model, $ids = null)
-	{
-		return $model->delete_featured($ids);
-	}
 }

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -828,23 +828,27 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Delete #__content_frontpage items if the deleted articles was featured
 	 *
-	 * @param   object    $pks   The primary key related to the contents that was deleted.
+	 * @param   object  &$pks  The primary key related to the contents that was deleted.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function delete_featured($pks)
+	public function delete(&$pks)
 	{
+		$return = parent::delete($pks);
 
-		// Now check to see if this articles was featured if so delete it from the #__content_frontpage table
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->delete($db->quoteName('#__content_frontpage'))
-			->where('content_id IN (' . implode(',', $pks) . ')');
-		$db->setQuery($query);
-		$db->execute();
+		if ($return)
+		{
+			// Now check to see if this articles was featured if so delete it from the #__content_frontpage table
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->delete($db->quoteName('#__content_frontpage'))
+				->where('content_id IN (' . implode(',', $pks) . ')');
+			$db->setQuery($query);
+			$db->execute();
+		}
 
-		return true;
+		return $return;
 	}
 }

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -832,7 +832,7 @@ class ContentModelArticle extends JModelAdmin
 	 *
 	 * @return  boolean
 	 *
-	 * @since   1.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function delete_featured($pks)
 	{

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -824,4 +824,27 @@ class ContentModelArticle extends JModelAdmin
 	{
 		return JFactory::getUser()->authorise('core.create', 'com_content');
 	}
+
+	/**
+	 * Delete #__content_frontpage items if the deleted articles was featured
+	 *
+	 * @param   object  $pks      The primary key related to the contents that was deleted.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   1.6
+	 */
+	public function delete_featured($pks)
+	{
+
+		// Now check to see if this articles was featured if so delete it from the #__content_frontpage table
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->delete($db->quoteName('#__content_frontpage'))
+			->where('content_id IN (' . implode(',', $pks) . ')');
+		$db->setQuery($query);
+		$db->execute();
+
+		return true;
+	}
 }

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -828,7 +828,7 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Delete #__content_frontpage items if the deleted articles was featured
 	 *
-	 * @param   object  $pks      The primary key related to the contents that was deleted.
+	 * @param   object  $pks      	The primary key related to the contents that was deleted.
 	 *
 	 * @return  boolean
 	 *

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -828,7 +828,7 @@ class ContentModelArticle extends JModelAdmin
 	/**
 	 * Delete #__content_frontpage items if the deleted articles was featured
 	 *
-	 * @param   object  $pks      	The primary key related to the contents that was deleted.
+	 * @param   object    $pks   The primary key related to the contents that was deleted.
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -321,8 +321,8 @@ class PlgContentJoomla extends JPlugin
 		// Now check to see if this article was featured if so delete it from the #__content_frontpage table
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			    ->delete($db->quoteName('#__content_frontpage'))
-			    ->where('content_id = ' . $data->id);
+			 ->delete($db->quoteName('#__content_frontpage'))
+			 ->where('content_id = ' . $data->id);
 		$db->setQuery($query);
 		$db->execute();
 

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -321,8 +321,8 @@ class PlgContentJoomla extends JPlugin
 		// Now check to see if this article was featured if so delete it from the #__content_frontpage table
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			 ->delete($db->quoteName('#__content_frontpage'))
-			 ->where('content_id = ' . $data->id);
+			->delete($db->quoteName('#__content_frontpage'))
+			->where('content_id = ' . $data->id);
 		$db->setQuery($query);
 		$db->execute();
 

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -299,4 +299,33 @@ class PlgContentJoomla extends JPlugin
 
 		return true;
 	}
+
+	/**
+	 * Delete #__content_frontpage item if the deleted article was featured
+	 *
+	 * @param   string  $context  The context for the content passed to the plugin.
+	 * @param   object  $data     The data relating to the content that was deleted.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onContentAfterDelete($context, $data)
+	{
+		// Skip plugin if we are deleting something other than articles
+		if ($context != 'com_content.article')
+		{
+			return true;
+		}
+
+		// Now check to see if this article was featured if so delete it from the #__content_frontpage table
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			    ->delete($db->quoteName('#__content_frontpage'))
+			    ->where('content_id = ' . $data->id);
+		$db->setQuery($query);
+		$db->execute();
+
+		return true;
+	}
 }

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -300,32 +300,4 @@ class PlgContentJoomla extends JPlugin
 		return true;
 	}
 
-	/**
-	 * Delete #__content_frontpage item if the deleted article was featured
-	 *
-	 * @param   string  $context  The context for the content passed to the plugin.
-	 * @param   object  $data     The data relating to the content that was deleted.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function onContentAfterDelete($context, $data)
-	{
-		// Skip plugin if we are deleting something other than articles
-		if ($context != 'com_content.article')
-		{
-			return true;
-		}
-
-		// Now check to see if this article was featured if so delete it from the #__content_frontpage table
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->delete($db->quoteName('#__content_frontpage'))
-			->where('content_id = ' . $data->id);
-		$db->setQuery($query);
-		$db->execute();
-
-		return true;
-	}
 }

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -299,5 +299,4 @@ class PlgContentJoomla extends JPlugin
 
 		return true;
 	}
-
 }


### PR DESCRIPTION
Pull Request for Issue #12475 .
### Summary of Changes

~~added method to the joomla content plugin~~ 
~~used controller `postDeleteHook`  + new model  method `delete_featured`~~
used method delete override to delete item on `#__content_frontpage` when the deleted article was featured
### Testing Instructions

Delete a featured article and check that the content_id item is deleted from #__content_frontpage table too
