### PR TITLE
Encoding issue with hepsite.xml

### DIFF
--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -2,6 +2,6 @@
 <joshelp>
 	<sites>
 		<site tag="en-GB" url="https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&amp;lang={langcode}">English (GB) - Joomla help wiki</site>
-		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
+		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Fran&ccedil;ais (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>

--- a/administrator/help/helpsites.xml
+++ b/administrator/help/helpsites.xml
@@ -2,6 +2,6 @@
 <joshelp>
 	<sites>
 		<site tag="en-GB" url="https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&amp;lang={langcode}">English (GB) - Joomla help wiki</site>
-		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Fran&ccedil;ais (FR) - Aide de Joomla!</site>
+		<site tag="fr-FR" url="https://help.joomla.fr/index.php?option=com_help&amp;keyref=Help{major}{minor}:{keyref}">Français (FR) - Aide de Joomla!</site>
 	</sites>
 </joshelp>


### PR DESCRIPTION
When using the helpsites dropdown in Global Configuration (without refresh! as we have the same issue on the server) there is an encoding mismatch as the file is ISO while the word `Français` was copied from utf8.

@rdeutz 

Please merge in 3.6.4 and Use this file to replace directly on the server
