### PR TITLE
Only attempt to banner increment impression when needed

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -235,14 +235,14 @@ class BannersModelBanners extends JModelList
 			$query->clear()
 				->update('#__banners')
 				->set('impmade = (impmade + 1)')
-				->where('id = ' . $db->quote((int)$item->id));
+				->where('id = ' . $db->quote((int) $item->id));
 			$db->setQuery($query);
 			
 			try
 			{
 				$db->execute();
 			}
-				catch (JDatabaseExceptionExecuting $e)
+			catch (JDatabaseExceptionExecuting $e)
 			{
 				JError::raiseError(500, $e->getMessage());
 			}

--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -231,27 +231,22 @@ class BannersModelBanners extends JModelList
 
 		foreach ($items as $item)
 		{
-			$bid[] = (int) $item->id;
-		}
+			// Increment impression made
+			$query->clear()
+				->update('#__banners')
+				->set('impmade = (impmade + 1)')
+				->where('id = ' . $db->quote((int)$item->id));
+			$db->setQuery($query);
+			
+			try
+			{
+				$db->execute();
+			}
+				catch (JDatabaseExceptionExecuting $e)
+			{
+				JError::raiseError(500, $e->getMessage());
+			}
 
-		// Increment impression made
-		$query->clear()
-			->update('#__banners')
-			->set('impmade = (impmade + 1)')
-			->where('id IN (' . implode(',', $bid) . ')');
-		$db->setQuery($query);
-
-		try
-		{
-			$db->execute();
-		}
-		catch (JDatabaseExceptionExecuting $e)
-		{
-			JError::raiseError(500, $e->getMessage());
-		}
-
-		foreach ($items as $item)
-		{
 			// Track impressions
 			$trackImpressions = $item->track_impressions;
 


### PR DESCRIPTION
Pull Request for Issue #11969 and other fringe cases
### Summary of Changes

This PR is the result of debugging on two live sites with deadly fatal exceptions as per #11969

On code review it was clear this code was low quality, running two loops when one would have done, and also causes issues where there were no items to update, but yet we still tried to execute a query when there were no items to increment impmade to.. this causes a deadly JDatabaseExceptionExecuting, rearranging the code block to only run if needed fixes the exception issue.
### Testing Instructions

Find a site where you get the deadly issue reported - apply patch - see its fixed - check that banners impressions are still logged
