### PR TITLE
Ajax list limit issue in menu manager edit form

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -530,8 +530,11 @@ class MenusControllerItem extends JControllerForm
 		$menutype = $this->input->get->get('menutype');
 
 		$model = $this->getModel('Items', '', array());
+		$model->getState();
 		$model->setState('filter.menutype', $menutype);
 		$model->setState('list.select', 'a.id, a.title, a.level');
+		$model->setState('list.start', 0);
+		$model->setState('list.limit', 0);
 
 		$results = $model->getItems();
 


### PR DESCRIPTION
### Summary of Changes

When creating/editing a menu item, the list of available choices for parent menu item is populated via ajax whenever the "menu" option is changed.

Currently this list is limited to 20, which should not apply here and all the items in the selected menu must be shown.
### Testing Instructions
1. Create more than 20 menu items under a single menu (let's say **Main Menu**).
2. Go to create another menu item under **User Menu** and before you hit save change the **Menu** selection to **Main Menu**
3. Notice the **Parent Menu** dropdown just below the **Menu** field, it will show only the first 20 menu items from **Main Menu**
4. Apply this patch, and repeat 2 and 3. It should now show all the available menu items.
### Documentation Changes Required

None
