### PR TITLE
Ensure query is only run if items are found to avoid database exception

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -229,26 +229,29 @@ class BannersModelBanners extends JModelList
 		$db        = $this->getDbo();
 		$query     = $db->getQuery(true);
 
-		foreach ($items as $item)
+		if (count($items))
 		{
-			$bid[] = (int) $item->id;
-		}
+			foreach ($items as $item)
+			{
+				$bid[] = (int) $item->id;
+			}
 
-		// Increment impression made
-		$query->clear()
-			->update('#__banners')
-			->set('impmade = (impmade + 1)')
-			->where('id IN (' . implode(',', $bid) . ')');
-		$db->setQuery($query);
+			// Increment impression made
+			$query->clear()
+				->update('#__banners')
+				->set('impmade = (impmade + 1)')
+				->where('id IN (' . implode(',', $bid) . ')');
+			$db->setQuery($query);
 
-		try
-		{
-			$db->execute();
-		}
-		catch (JDatabaseExceptionExecuting $e)
-		{
-			JError::raiseError(500, $e->getMessage());
-		}
+			try
+			{
+				$db->execute();
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				JError::raiseError(500, $e->getMessage());
+			}
+		}	
 
 		foreach ($items as $item)
 		{

--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -254,7 +254,7 @@ class BannersModelBanners extends JModelList
 		{
 			JError::raiseError(500, $e->getMessage());
 		}
-			
+
 		foreach ($items as $item)
 		{
 			// Track impressions

--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -229,30 +229,32 @@ class BannersModelBanners extends JModelList
 		$db        = $this->getDbo();
 		$query     = $db->getQuery(true);
 
-		if (count($items))
+		if (!count($items))
 		{
-			foreach ($items as $item)
-			{
-				$bid[] = (int) $item->id;
-			}
+			return;
+		}
+		
+		foreach ($items as $item)
+		{
+			$bid[] = (int) $item->id;
+		}
 
-			// Increment impression made
-			$query->clear()
-				->update('#__banners')
-				->set('impmade = (impmade + 1)')
-				->where('id IN (' . implode(',', $bid) . ')');
-			$db->setQuery($query);
+		// Increment impression made
+		$query->clear()
+			->update('#__banners')
+			->set('impmade = (impmade + 1)')
+			->where('id IN (' . implode(',', $bid) . ')');
+		$db->setQuery($query);
 
-			try
-			{
-				$db->execute();
-			}
-			catch (JDatabaseExceptionExecuting $e)
-			{
-				JError::raiseError(500, $e->getMessage());
-			}
-		}	
-
+		try
+		{
+			$db->execute();
+		}
+		catch (JDatabaseExceptionExecuting $e)
+		{
+			JError::raiseError(500, $e->getMessage());
+		}
+			
 		foreach ($items as $item)
 		{
 			// Track impressions


### PR DESCRIPTION
Pull Request for Issue #11969 and other fringe cases
(Alternative solution to #12508 to retain performance gains recently made)
### Summary of Changes

This PR is the result of debugging on two live sites with deadly fatal exceptions as per #11969

The error this PR resolved is one like:

`"jos-Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 3 SQL=UPDATE #__banners SET impmade = (impmade + 1) WHERE id IN ()"`

On code review it was clear this code was low quality, running a sql query where there were no items to update, but yet we still tried to execute a query when there were no items to increment impmade to.. this causes a deadly JDatabaseException because the sql was invalid (as the result of the implode of empty array $bid), 

returning out of the method when there are no items to update stops this exception firing
### Testing Instructions

Find a site where you get the deadly issue reported - apply patch - see its fixed - check that banners impressions are still logged when other banners are displayed correctly.
