### PR TITLE
[com_banners banner edit] Move jQuery to template

### DIFF
--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -10,6 +10,8 @@
 defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
+JHtml::_('jquery.framework');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
 

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -62,7 +62,6 @@ class BannersViewBanner extends JViewLegacy
 		}
 
 		$this->addToolbar();
-		JHtml::_('jquery.framework');
 
 		return parent::display($tpl);
 	}

--- a/administrator/templates/hathor/html/com_banners/banner/edit.php
+++ b/administrator/templates/hathor/html/com_banners/banner/edit.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
+JHtml::_('jquery.framework');
 JHtml::_('behavior.formvalidator');
 
 JFactory::getDocument()->addScriptDeclaration("


### PR DESCRIPTION
### Summary of Changes

Very simple PR, just moves the jquery to the template (instead of the view) in com_banners banner edit view.
### Testing Instructions

Mainly code review, but if you want to test: Apply patch 3.7.x branch, create a banner, view html source and confirm jQuery is still loaded in com_banners banner edit view.
### Documentation Changes Required

None.
