### PR TITLE
Fixing typo in the comment

### DIFF
--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 /**
- * Editor Readmore buton
+ * Editor Readmore button
  *
  * @since  1.5
  */


### PR DESCRIPTION
### Summary of Changes

Fixed a small typo in the comment.
`Buton` > `Button`
### Testing Instructions

Code review
### Documentation Changes Required

None
