### PR TITLE
Wrong method return type

### DIFF
--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -217,7 +217,7 @@ class UsersControllerUser extends UsersController
 	/**
 	 * Method to logout directly and redirect to page.
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.5
 	 */


### PR DESCRIPTION
The method UsersControllerUser::menulogout() is declared to return "boolean", but actually it returns void. It has two exit points, and on both it does not return any value.
The "boolean" declaration has been clearly copied and pasted by another method.
### Summary of Changes

Changed return type declaration to void.
### Testing Instructions

Just merge on review.
