### PR TITLE
[4.0] Recompose JApplicationWeb onto the Framework's web application class

### DIFF
--- a/components/com_config/controller/helper.php
+++ b/components/com_config/controller/helper.php
@@ -26,7 +26,7 @@ class ConfigControllerHelper
 	 * not prefixed with Config.
 	 * Additional options maybe added to parameterise the controller.
 	 *
-	 * @param   JApplicationBase  $app  An application object
+	 * @param   \Joomla\Application\AbstractApplication  $app  An application object
 	 *
 	 * @return  JController  A JController object
 	 *

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -22,7 +22,7 @@ use Joomla\Session\SessionEvent;
  *
  * @since  3.2
  */
-class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
+abstract class JApplicationCms extends JApplicationWeb implements ContainerAwareInterface
 {
 	use ContainerAwareTrait;
 

--- a/libraries/cms/ucm/type.php
+++ b/libraries/cms/ucm/type.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractApplication;
+
 /**
  * UCM Class for handling content types
  *
@@ -77,13 +79,13 @@ class JUcmType implements JUcm
 	/**
 	 * Class constructor
 	 *
-	 * @param   string            $alias        The alias for the item
-	 * @param   JDatabaseDriver   $database     The database object
-	 * @param   JApplicationBase  $application  The application object
+	 * @param   string               $alias        The alias for the item
+	 * @param   JDatabaseDriver      $database     The database object
+	 * @param   AbstractApplication  $application  The application object
 	 *
 	 * @since   3.1
 	 */
-	public function __construct($alias = null, JDatabaseDriver $database = null, JApplicationBase $application = null)
+	public function __construct($alias = null, JDatabaseDriver $database = null, AbstractApplication $application = null)
 	{
 		$this->db = $database ? $database : JFactory::getDbo();
 		$app      = $application ? $application : JFactory::getApplication();

--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -21,7 +21,8 @@ use Joomla\Registry\Registry;
  *
  * @property-read  JInput  $input  The application input object
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0  Application classes should be based on \Joomla\Application\AbstractApplication
  */
 abstract class JApplicationBase extends AbstractApplication implements DispatcherAwareInterface
 {
@@ -45,19 +46,5 @@ abstract class JApplicationBase extends AbstractApplication implements Dispatche
 		$this->config = $config instanceof Registry ? $config : new Registry;
 
 		$this->initialise();
-	}
-
-	/**
-	 * Method to run the application routines.  Most likely you will want to instantiate a controller
-	 * and execute it, or perform some sort of task directly.
-	 *
-	 * @return  void
-	 *
-	 * @since   3.4 (CMS)
-	 * @deprecated  4.0  The default concrete implementation of doExecute() will be removed, subclasses will need to provide their own implementation.
-	 */
-	protected function doExecute()
-	{
-		return;
 	}
 }

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -9,7 +9,13 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractWebApplication;
+use Joomla\Application\Web\WebClient;
 use Joomla\Cms\Application\Autoconfigurable;
+use Joomla\Cms\Application\EventAware;
+use Joomla\Cms\Application\IdentityAware;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
@@ -20,60 +26,30 @@ use Joomla\String\StringHelper;
  *
  * @since  11.4
  */
-class JApplicationWeb extends JApplicationBase
+abstract class JApplicationWeb extends AbstractWebApplication implements DispatcherAwareInterface
 {
-	use Autoconfigurable;
+	use Autoconfigurable, DispatcherAwareTrait, EventAware, IdentityAware;
 
 	/**
-	 * @var    string  Character encoding string.
-	 * @since  11.3
-	 */
-	public $charSet = 'utf-8';
-
-	/**
-	 * @var    string  Response mime type.
-	 * @since  11.3
-	 */
-	public $mimeType = 'text/html';
-
-	/**
-	 * @var    JDate  The body modified date for response headers.
-	 * @since  11.3
-	 */
-	public $modifiedDate;
-
-	/**
-	 * @var    JApplicationWebClient  The application client object.
-	 * @since  11.3
-	 */
-	public $client;
-
-	/**
-	 * @var    JDocument  The application document object.
+	 * The application document object.
+	 *
+	 * @var    JDocument
 	 * @since  11.3
 	 */
 	protected $document;
 
 	/**
-	 * @var    JLanguage  The application language object.
+	 * The application language object.
+	 *
+	 * @var    JLanguage
 	 * @since  11.3
 	 */
 	protected $language;
 
 	/**
-	 * @var    SessionInterface  The application session object.
-	 * @since  11.3
-	 */
-	protected $session;
-
-	/**
-	 * @var    object  The application response object.
-	 * @since  11.3
-	 */
-	protected $response;
-
-	/**
-	 * @var    JApplicationWeb  The application instance.
+	 * The application instance.
+	 *
+	 * @var    JApplicationWeb
 	 * @since  11.3
 	 */
 	protected static $instance;
@@ -81,7 +57,7 @@ class JApplicationWeb extends JApplicationBase
 	/**
 	 * A map of integer HTTP 1.1 response codes to the full HTTP Status for the headers.
 	 *
-	 * @var    object
+	 * @var    array
 	 * @since  3.4
 	 * @see    http://tools.ietf.org/pdf/rfc7231.pdf
 	 */
@@ -100,52 +76,23 @@ class JApplicationWeb extends JApplicationBase
 	/**
 	 * Class constructor.
 	 *
-	 * @param   JInput                 $input   An optional argument to provide dependency injection for the application's
-	 *                                          input object.  If the argument is a JInput object that object will become
-	 *                                          the application's input object, otherwise a default input object is created.
-	 * @param   Registry               $config  An optional argument to provide dependency injection for the application's
-	 *                                          config object.  If the argument is a Registry object that object will become
-	 *                                          the application's config object, otherwise a default config object is created.
-	 * @param   JApplicationWebClient  $client  An optional argument to provide dependency injection for the application's
-	 *                                          client object.  If the argument is a JApplicationWebClient object that object will become
-	 *                                          the application's client object, otherwise a default client object is created.
+	 * @param   JInput     $input   An optional argument to provide dependency injection for the application's
+	 *                              input object.  If the argument is a JInput object that object will become
+	 *                              the application's input object, otherwise a default input object is created.
+	 * @param   Registry   $config  An optional argument to provide dependency injection for the application's
+	 *                              config object.  If the argument is a Registry object that object will become
+	 *                              the application's config object, otherwise a default config object is created.
+	 * @param   WebClient  $client  An optional argument to provide dependency injection for the application's
+	 *                              client object.  If the argument is a WebClient object that object will become
+	 *                              the application's client object, otherwise a default client object is created.
 	 *
 	 * @since   11.3
 	 */
-	public function __construct(JInput $input = null, Registry $config = null, JApplicationWebClient $client = null)
+	public function __construct(JInput $input = null, Registry $config = null, WebClient $client = null)
 	{
-		// If an input object is given use it.
-		if ($input instanceof JInput)
-		{
-			$this->input = $input;
-		}
-		// Create the input based on the application logic.
-		else
-		{
-			$this->input = new JInput;
-		}
-
-		// If a config object is given use it.
-		if ($config instanceof Registry)
-		{
-			$this->config = $config;
-		}
-		// Instantiate a new configuration object.
-		else
-		{
-			$this->config = new Registry;
-		}
-
-		// If a client object is given use it.
-		if ($client instanceof JApplicationWebClient)
-		{
-			$this->client = $client;
-		}
-		// Instantiate a new web client object.
-		else
-		{
-			$this->client = new JApplicationWebClient;
-		}
+		$this->input  = $input ?: new JInput;
+		$this->config = $config ?: new Registry;
+		$this->client = $client ?: new WebClient;
 
 		// Load the configuration object.
 		$this->loadConfiguration($this->fetchConfigurationData());
@@ -174,83 +121,22 @@ class JApplicationWeb extends JApplicationBase
 	 * @return  JApplicationWeb
 	 *
 	 * @since   11.3
+	 * @throws  RuntimeException
 	 */
 	public static function getInstance($name = null)
 	{
 		// Only create the object if it doesn't exist.
-		if (empty(self::$instance))
+		if (empty(static::$instance))
 		{
-			if (class_exists($name) && (is_subclass_of($name, 'JApplicationWeb')))
+			if (!class_exists($name))
 			{
-				self::$instance = new $name;
+				throw new RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}
-			else
-			{
-				self::$instance = new JApplicationWeb;
-			}
+
+			static::$instance = new $name;
 		}
 
-		return self::$instance;
-	}
-
-	/**
-	 * Initialise the application.
-	 *
-	 * @param   mixed  $session     An optional argument to provide dependency injection for the application's
-	 *                              session object.  If the argument is a SessionInterface object that object will become
-	 *                              the application's session object, if it is false then there will be no session
-	 *                              object, and if it is null then the default session object will be created based
-	 *                              on the application's loadSession() method.
-	 * @param   mixed  $document    An optional argument to provide dependency injection for the application's
-	 *                              document object.  If the argument is a JDocument object that object will become
-	 *                              the application's document object, if it is false then there will be no document
-	 *                              object, and if it is null then the default document object will be created based
-	 *                              on the application's loadDocument() method.
-	 * @param   mixed  $language    An optional argument to provide dependency injection for the application's
-	 *                              language object.  If the argument is a JLanguage object that object will become
-	 *                              the application's language object, if it is false then there will be no language
-	 *                              object, and if it is null then the default language object will be created based
-	 *                              on the application's loadLanguage() method.
-	 * @param   mixed  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                              event dispatcher.  If the argument is a DispatcherInterface object that object will become
-	 *                              the application's event dispatcher, if it is null then the default event dispatcher
-	 *                              will be created based on the application's loadDispatcher() method.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @deprecated  13.1 (Platform) & 4.0 (CMS)
-	 * @see     JApplicationWeb::loadSession()
-	 * @see     JApplicationWeb::loadDocument()
-	 * @see     JApplicationWeb::loadLanguage()
-	 * @see     JApplicationBase::loadDispatcher()
-	 * @since   11.3
-	 */
-	public function initialise($session = null, $document = null, $language = null, DispatcherInterface $dispatcher = null)
-	{
-		// Create the session based on the application logic.
-		if ($session !== false)
-		{
-			$this->setSession($session);
-		}
-
-		// Create the document based on the application logic.
-		if ($document !== false)
-		{
-			$this->loadDocument($document);
-		}
-
-		// Create the language based on the application logic.
-		if ($language !== false)
-		{
-			$this->loadLanguage($language);
-		}
-
-		if ($dispatcher)
-		{
-			$this->setDispatcher($dispatcher);
-		}
-
-		return $this;
+		return static::$instance;
 	}
 
 	/**
@@ -339,124 +225,6 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
-	 * Checks the accept encoding of the browser and compresses the data before
-	 * sending it to the client if possible.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	protected function compress()
-	{
-		// Supported compression encodings.
-		$supported = array(
-			'x-gzip' => 'gz',
-			'gzip' => 'gz',
-			'deflate' => 'deflate',
-		);
-
-		// Get the supported encoding.
-		$encodings = array_intersect($this->client->encodings, array_keys($supported));
-
-		// If no supported encoding is detected do nothing and return.
-		if (empty($encodings))
-		{
-			return;
-		}
-
-		// Verify that headers have not yet been sent, and that our connection is still alive.
-		if ($this->checkHeadersSent() || !$this->checkConnectionAlive())
-		{
-			return;
-		}
-
-		// Iterate through the encodings and attempt to compress the data using any found supported encodings.
-		foreach ($encodings as $encoding)
-		{
-			if (($supported[$encoding] == 'gz') || ($supported[$encoding] == 'deflate'))
-			{
-				// Verify that the server supports gzip compression before we attempt to gzip encode the data.
-				// @codeCoverageIgnoreStart
-				if (!extension_loaded('zlib') || ini_get('zlib.output_compression'))
-				{
-					continue;
-				}
-				// @codeCoverageIgnoreEnd
-
-				// Attempt to gzip encode the data with an optimal level 4.
-				$data = $this->getBody();
-				$gzdata = gzencode($data, 4, ($supported[$encoding] == 'gz') ? FORCE_GZIP : FORCE_DEFLATE);
-
-				// If there was a problem encoding the data just try the next encoding scheme.
-				// @codeCoverageIgnoreStart
-				if ($gzdata === false)
-				{
-					continue;
-				}
-				// @codeCoverageIgnoreEnd
-
-				// Set the encoding headers.
-				$this->setHeader('Content-Encoding', $encoding);
-
-				// Header will be removed at 4.0
-				if ($this->get('MetaVersion'))
-				{
-					$this->setHeader('X-Content-Encoded-By', 'Joomla');
-				}
-
-				// Replace the output with the encoded data.
-				$this->setBody($gzdata);
-
-				// Compression complete, let's break out of the loop.
-				break;
-			}
-		}
-	}
-
-	/**
-	 * Method to send the application response to the client.  All headers will be sent prior to the main
-	 * application output data.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	protected function respond()
-	{
-		// Send the content-type header.
-		$this->setHeader('Content-Type', $this->mimeType . '; charset=' . $this->charSet);
-
-		// If the response is set to uncachable, we need to set some appropriate headers so browsers don't cache the response.
-		if (!$this->response->cachable)
-		{
-			// Expires in the past.
-			$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
-
-			// Always modified.
-			$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-			$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-
-			// HTTP 1.0
-			$this->setHeader('Pragma', 'no-cache');
-		}
-		else
-		{
-			// Expires.
-			$this->setHeader('Expires', gmdate('D, d M Y H:i:s', time() + 900) . ' GMT');
-
-			// Last modified.
-			if ($this->modifiedDate instanceof JDate)
-			{
-				$this->setHeader('Last-Modified', $this->modifiedDate->format('D, d M Y H:i:s'));
-			}
-		}
-
-		$this->sendHeaders();
-
-		echo $this->getBody();
-	}
-
-	/**
 	 * Redirect to another URL.
 	 *
 	 * If the headers have not been sent the redirect will be accomplished using a "301 Moved Permanently"
@@ -519,7 +287,7 @@ class JApplicationWeb extends JApplicationBase
 		else
 		{
 			// We have to use a JavaScript redirect here because MSIE doesn't play nice with utf-8 URLs.
-			if (($this->client->engine == JApplicationWebClient::TRIDENT) && !StringHelper::is_ascii($url))
+			if (($this->client->engine == WebClient::TRIDENT) && !StringHelper::is_ascii($url))
 			{
 				$html = '<html><head>';
 				$html .= '<meta http-equiv="content-type" content="text/html; charset=' . $this->charSet . '" />';
@@ -556,183 +324,6 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
-	 * Set/get cachable state for the response.  If $allow is set, sets the cachable state of the
-	 * response.  Always returns the current state.
-	 *
-	 * @param   boolean  $allow  True to allow browser caching.
-	 *
-	 * @return  boolean
-	 *
-	 * @since   11.3
-	 */
-	public function allowCache($allow = null)
-	{
-		if ($allow !== null)
-		{
-			$this->response->cachable = (bool) $allow;
-		}
-
-		return $this->response->cachable;
-	}
-
-	/**
-	 * Method to set a response header.  If the replace flag is set then all headers
-	 * with the given name will be replaced by the new one.  The headers are stored
-	 * in an internal array to be sent when the site is sent to the browser.
-	 *
-	 * @param   string   $name     The name of the header to set.
-	 * @param   string   $value    The value of the header to set.
-	 * @param   boolean  $replace  True to replace any headers with the same name.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function setHeader($name, $value, $replace = false)
-	{
-		// Sanitize the input values.
-		$name = (string) $name;
-		$value = (string) $value;
-
-		// If the replace flag is set, unset all known headers with the given name.
-		if ($replace)
-		{
-			foreach ($this->response->headers as $key => $header)
-			{
-				if ($name == $header['name'])
-				{
-					unset($this->response->headers[$key]);
-				}
-			}
-
-			// Clean up the array as unsetting nested arrays leaves some junk.
-			$this->response->headers = array_values($this->response->headers);
-		}
-
-		// Add the header to the internal array.
-		$this->response->headers[] = array('name' => $name, 'value' => $value);
-
-		return $this;
-	}
-
-	/**
-	 * Method to get the array of response headers to be sent when the response is sent
-	 * to the client.
-	 *
-	 * @return  array
-	 *
-	 * @since   11.3
-	 */
-	public function getHeaders()
-	{
-		return $this->response->headers;
-	}
-
-	/**
-	 * Method to clear any set response headers.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function clearHeaders()
-	{
-		$this->response->headers = array();
-
-		return $this;
-	}
-
-	/**
-	 * Send the response headers.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function sendHeaders()
-	{
-		if (!$this->checkHeadersSent())
-		{
-			foreach ($this->response->headers as $header)
-			{
-				if ('status' == strtolower($header['name']))
-				{
-					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header('HTTP/1.1 ' . $header['value'], null, (int) $header['value']);
-				}
-				else
-				{
-					$this->header($header['name'] . ': ' . $header['value']);
-				}
-			}
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Set body content.  If body content already defined, this will replace it.
-	 *
-	 * @param   string  $content  The content to set as the response body.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function setBody($content)
-	{
-		$this->response->body = array((string) $content);
-
-		return $this;
-	}
-
-	/**
-	 * Prepend content to the body content
-	 *
-	 * @param   string  $content  The content to prepend to the response body.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function prependBody($content)
-	{
-		array_unshift($this->response->body, (string) $content);
-
-		return $this;
-	}
-
-	/**
-	 * Append content to the body content
-	 *
-	 * @param   string  $content  The content to append to the response body.
-	 *
-	 * @return  JApplicationWeb  Instance of $this to allow chaining.
-	 *
-	 * @since   11.3
-	 */
-	public function appendBody($content)
-	{
-		array_push($this->response->body, (string) $content);
-
-		return $this;
-	}
-
-	/**
-	 * Return the body content
-	 *
-	 * @param   boolean  $asArray  True to return the body as an array of strings.
-	 *
-	 * @return  mixed  The response body either as an array or concatenated string.
-	 *
-	 * @since   11.3
-	 */
-	public function getBody($asArray = false)
-	{
-		return $asArray ? $this->response->body : implode((array) $this->response->body);
-	}
-
-	/**
 	 * Method to get the application document object.
 	 *
 	 * @return  JDocument  The document object
@@ -757,102 +348,6 @@ class JApplicationWeb extends JApplicationBase
 	}
 
 	/**
-	 * Method to get the application session object.
-	 *
-	 * @return  SessionInterface  The session object
-	 *
-	 * @since   11.3
-	 */
-	public function getSession()
-	{
-		if ($this->session === null)
-		{
-			throw new RuntimeException('A Joomla\Session\SessionInterface object has not been set.');
-		}
-
-		return $this->session;
-	}
-
-	/**
-	 * Method to check the current client connnection status to ensure that it is alive.  We are
-	 * wrapping this to isolate the connection_status() function from our code base for testing reasons.
-	 *
-	 * @return  boolean  True if the connection is valid and normal.
-	 *
-	 * @codeCoverageIgnore
-	 * @see     connection_status()
-	 * @since   11.3
-	 */
-	protected function checkConnectionAlive()
-	{
-		return connection_status() === CONNECTION_NORMAL;
-	}
-
-	/**
-	 * Method to check to see if headers have already been sent.  We are wrapping this to isolate the
-	 * headers_sent() function from our code base for testing reasons.
-	 *
-	 * @return  boolean  True if the headers have already been sent.
-	 *
-	 * @codeCoverageIgnore
-	 * @see     headers_sent()
-	 * @since   11.3
-	 */
-	protected function checkHeadersSent()
-	{
-		return headers_sent();
-	}
-
-	/**
-	 * Method to detect the requested URI from server environment variables.
-	 *
-	 * @return  string  The requested URI
-	 *
-	 * @since   11.3
-	 */
-	protected function detectRequestUri()
-	{
-		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
-		{
-			$scheme = 'https://';
-		}
-		else
-		{
-			$scheme = 'http://';
-		}
-
-		/*
-		 * There are some differences in the way that Apache and IIS populate server environment variables.  To
-		 * properly detect the requested URI we need to adjust our algorithm based on whether or not we are getting
-		 * information from Apache or IIS.
-		 */
-		// Define variable to return
-		$uri = '';
-
-		// If PHP_SELF and REQUEST_URI are both populated then we will assume "Apache Mode".
-		if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI']))
-		{
-			// The URI is built from the HTTP_HOST and REQUEST_URI environment variables in an Apache environment.
-			$uri = $scheme . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
-		}
-		// If not in "Apache Mode" we will assume that we are in an IIS environment and proceed.
-		elseif (isset($_SERVER['HTTP_HOST']))
-		{
-			// IIS uses the SCRIPT_NAME variable instead of a REQUEST_URI variable... thanks, MS
-			$uri = $scheme . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
-
-			// If the QUERY_STRING variable exists append it to the URI string.
-			if (isset($_SERVER['QUERY_STRING']) && !empty($_SERVER['QUERY_STRING']))
-			{
-				$uri .= '?' . $_SERVER['QUERY_STRING'];
-			}
-		}
-
-		return trim($uri);
-	}
-
-	/**
 	 * Flush the media version to refresh versionable assets
 	 *
 	 * @return  void
@@ -863,40 +358,6 @@ class JApplicationWeb extends JApplicationBase
 	{
 		$version = new JVersion;
 		$version->refreshMediaVersion();
-	}
-
-	/**
-	 * Method to send a header to the client.  We are wrapping this to isolate the header() function
-	 * from our code base for testing reasons.
-	 *
-	 * @param   string   $string   The header string.
-	 * @param   boolean  $replace  The optional replace parameter indicates whether the header should
-	 *                             replace a previous similar header, or add a second header of the same type.
-	 * @param   integer  $code     Forces the HTTP response code to the specified value. Note that
-	 *                             this parameter only has an effect if the string is not empty.
-	 *
-	 * @return  void
-	 *
-	 * @codeCoverageIgnore
-	 * @see     header()
-	 * @since   11.3
-	 */
-	protected function header($string, $replace = true, $code = null)
-	{
-		$string = str_replace(chr(0), '', $string);
-		header($string, $replace, $code);
-	}
-
-	/**
-	 * Determine if we are using a secure (SSL) connection.
-	 *
-	 * @return  boolean  True if using SSL, false if not.
-	 *
-	 * @since   12.2
-	 */
-	public function isSSLConnection()
-	{
-		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION');
 	}
 
 	/**
@@ -958,121 +419,5 @@ class JApplicationWeb extends JApplicationBase
 		$this->getLogger()->warning(__METHOD__ . '() is deprecated.  Inject the session as a service instead.', array('category' => 'deprecated'));
 
 		return $this;
-	}
-
-	/**
-	 * Sets the session for the application to use, if required.
-	 *
-	 * @param   SessionInterface  $session  A session object.
-	 *
-	 * @return  JApplicationWeb This method is chainable.
-	 *
-	 * @since   4.0
-	 */
-	public function setSession(SessionInterface $session)
-	{
-		$this->session = $session;
-
-		return $this;
-	}
-
-	/**
-	 * Method to load the system URI strings for the application.
-	 *
-	 * @param   string  $requestUri  An optional request URI to use instead of detecting one from the
-	 *                               server environment variables.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	protected function loadSystemUris($requestUri = null)
-	{
-		// Set the request URI.
-		// @codeCoverageIgnoreStart
-		if (!empty($requestUri))
-		{
-			$this->set('uri.request', $requestUri);
-		}
-		else
-		{
-			$this->set('uri.request', $this->detectRequestUri());
-		}
-		// @codeCoverageIgnoreEnd
-
-		// Check to see if an explicit base URI has been set.
-		$siteUri = trim($this->get('site_uri'));
-
-		if ($siteUri != '')
-		{
-			$uri = JUri::getInstance($siteUri);
-			$path = $uri->toString(array('path'));
-		}
-		// No explicit base URI was set so we need to detect it.
-		else
-		{
-			// Start with the requested URI.
-			$uri = JUri::getInstance($this->get('uri.request'));
-
-			// If we are working from a CGI SAPI with the 'cgi.fix_pathinfo' directive disabled we use PHP_SELF.
-			if (strpos(php_sapi_name(), 'cgi') !== false && !ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI']))
-			{
-				// We aren't expecting PATH_INFO within PHP_SELF so this should work.
-				$path = dirname($_SERVER['PHP_SELF']);
-			}
-			// Pretty much everything else should be handled with SCRIPT_NAME.
-			else
-			{
-				$path = dirname($_SERVER['SCRIPT_NAME']);
-			}
-		}
-
-		$host = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
-
-		// Check if the path includes "index.php".
-		if (strpos($path, 'index.php') !== false)
-		{
-			// Remove the index.php portion of the path.
-			$path = substr_replace($path, '', strpos($path, 'index.php'), 9);
-		}
-
-		$path = rtrim($path, '/\\');
-
-		// Set the base URI both as just a path and as the full URI.
-		$this->set('uri.base.full', $host . $path . '/');
-		$this->set('uri.base.host', $host);
-		$this->set('uri.base.path', $path . '/');
-
-		// Set the extended (non-base) part of the request URI as the route.
-		if (stripos($this->get('uri.request'), $this->get('uri.base.full')) === 0)
-		{
-			$this->set('uri.route', substr_replace($this->get('uri.request'), '', 0, strlen($this->get('uri.base.full'))));
-		}
-
-		// Get an explicitly set media URI is present.
-		$mediaURI = trim($this->get('media_uri'));
-
-		if ($mediaURI)
-		{
-			if (strpos($mediaURI, '://') !== false)
-			{
-				$this->set('uri.media.full', $mediaURI);
-				$this->set('uri.media.path', $mediaURI);
-			}
-			else
-			{
-				// Normalise slashes.
-				$mediaURI = trim($mediaURI, '/\\');
-				$mediaURI = !empty($mediaURI) ? '/' . $mediaURI . '/' : '/';
-				$this->set('uri.media.full', $this->get('uri.base.host') . $mediaURI);
-				$this->set('uri.media.path', $mediaURI);
-			}
-		}
-		// No explicit media URI was set, build it dynamically from the base uri.
-		else
-		{
-			$this->set('uri.media.full', $this->get('uri.base.full') . 'media/');
-			$this->set('uri.media.path', $this->get('uri.base.path') . 'media/');
-		}
 	}
 }

--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractApplication;
+
 /**
  * Joomla Platform Base Controller Class
  *
@@ -19,7 +21,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * The application object.
 	 *
-	 * @var    JApplicationBase
+	 * @var    AbstractApplication
 	 * @since  12.1
 	 */
 	protected $app;
@@ -35,12 +37,12 @@ abstract class JControllerBase implements JController
 	/**
 	 * Instantiate the controller.
 	 *
-	 * @param   JInput            $input  The input object.
-	 * @param   JApplicationBase  $app    The application object.
+	 * @param   JInput               $input  The input object.
+	 * @param   AbstractApplication  $app    The application object.
 	 *
 	 * @since  12.1
 	 */
-	public function __construct(JInput $input = null, JApplicationBase $app = null)
+	public function __construct(JInput $input = null, AbstractApplication $app = null)
 	{
 		// Setup dependencies.
 		$this->app = isset($app) ? $app : $this->loadApplication();
@@ -50,7 +52,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * Get the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */
@@ -112,7 +114,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * Load the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractApplication;
+
 /**
  * Joomla Platform Controller Interface
  *
@@ -32,7 +34,7 @@ interface JController extends Serializable
 	/**
 	 * Get the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */
@@ -41,7 +43,7 @@ interface JController extends Serializable
 	/**
 	 * Get the input object.
 	 *
-	 * @return  \Joomla\Input\Input  The input object.
+	 * @return  JInput  The input object.
 	 *
 	 * @since   12.1
 	 */

--- a/tests/unit/core/mock/application/cli.php
+++ b/tests/unit/core/mock/application/cli.php
@@ -48,23 +48,24 @@ class TestMockApplicationCli extends TestMockApplicationBase
 	 */
 	public static function create($test, $options = array())
 	{
-		// Collect all the relevant methods in JApplicationCli.
-		$methods = self::getMethods();
-
 		// Create the mock.
-		$mockObject = $test->getMock(
+		$mockObject = $test->getMockForAbstractClass(
+			// Original class name.
 			'JApplicationCli',
-			$methods,
 			// Constructor arguments.
-			array(),
+			$constructor,
 			// Mock class name.
 			'',
 			// Call original constructor.
-			true
+			true,
+			// Call original clone.
+			true,
+			// Call autoload.
+			true,
+			// Mocked methods.
+			self::getMethods()
 		);
 
-		$mockObject = self::addBehaviours($test, $mockObject, $options);
-
-		return $mockObject;
+		return self::addBehaviours($test, $mockObject, $options);
 	}
 }

--- a/tests/unit/core/mock/application/cms.php
+++ b/tests/unit/core/mock/application/cms.php
@@ -85,23 +85,24 @@ class TestMockApplicationCms extends TestMockApplicationWeb
 			$_SERVER['HTTP_HOST'] = 'localhost';
 		}
 
-		$methods = self::getMethods();
-
-		if (isset($options))
 		// Create the mock.
-		$mockObject = $test->getMock(
+		$mockObject = $test->getMockForAbstractClass(
+			// Original class name.
 			'JApplicationCms',
-			$methods,
 			// Constructor arguments.
 			$constructor,
 			// Mock class name.
 			'',
 			// Call original constructor.
-			true
+			true,
+			// Call original clone.
+			true,
+			// Call autoload.
+			true,
+			// Mocked methods.
+			self::getMethods()
 		);
 
-		$mockObject = self::addBehaviours($test, $mockObject, $options);
-
-		return $mockObject;
+		return self::addBehaviours($test, $mockObject, $options);
 	}
 }

--- a/tests/unit/core/mock/application/web.php
+++ b/tests/unit/core/mock/application/web.php
@@ -144,14 +144,15 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 *
 	 * If any *Body methods are implemented in the test class, all should be implemented otherwise behaviour will be unreliable.
 	 *
-	 * @param   TestCase  $test     A test object.
-	 * @param   array     $options  A set of options to configure the mock.
+	 * @param   TestCase  $test         A test object.
+	 * @param   array     $options      A set of options to configure the mock.
+	 * @param   array     $constructor  An array containing constructor arguments to inject into the mock.
 	 *
 	 * @return  PHPUnit_Framework_MockObject_MockObject
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test, $options = array())
+	public static function create($test, $options = array(), $constructor = array())
 	{
 		// Set expected server variables.
 		if (!isset($_SERVER['HTTP_HOST']))
@@ -159,24 +160,25 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 			$_SERVER['HTTP_HOST'] = 'localhost';
 		}
 
-		// Collect all the relevant methods in JApplicationWeb (work in progress).
-		$methods = self::getMethods();
-
 		// Create the mock.
-		$mockObject = $test->getMock(
+		$mockObject = $test->getMockForAbstractClass(
+			// Original class name.
 			'JApplicationWeb',
-			$methods,
 			// Constructor arguments.
-			array(),
+			$constructor,
 			// Mock class name.
 			'',
 			// Call original constructor.
-			true
+			true,
+			// Call original clone.
+			true,
+			// Call autoload.
+			true,
+			// Mocked methods.
+			self::getMethods()
 		);
 
-		$mockObject = self::addBehaviours($test, $mockObject, $options);
-
-		return $mockObject;
+		return self::addBehaviours($test, $mockObject, $options);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/plugin/JPluginTest.php
+++ b/tests/unit/suites/libraries/cms/plugin/JPluginTest.php
@@ -11,6 +11,8 @@ require_once __DIR__ . '/stubs/PlgSystemBase.php';
 require_once __DIR__ . '/stubs/PlgSystemJoomla.php';
 require_once __DIR__ . '/stubs/PlgSystemPrivate.php';
 
+use Joomla\Application\AbstractApplication;
+
 /**
  * Test class for JPlugin.
  *
@@ -47,7 +49,7 @@ class JPluginTest extends TestCase
 	protected function tearDown()
 	{
 		$this->restoreFactoryState();
-	
+
 		parent::tearDown();
 	}
 
@@ -64,9 +66,9 @@ class JPluginTest extends TestCase
 		$plugin = new PlgSystemJoomla;
 
 		$this->assertInstanceOf(
-			'JApplicationBase',
+			AbstractApplication::class,
 			TestReflection::getValue($plugin, 'app'),
-			'Assert the $app property is an instance of JApplicationBase'
+			'Assert the $app property is an instance of ' . AbstractApplication::class
 		);
 
 		$this->assertInstanceOf(

--- a/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemJoomla.php
+++ b/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemJoomla.php
@@ -21,7 +21,7 @@ class PlgSystemJoomla extends JPlugin
 	/**
 	 * Application object
 	 *
-	 * @var    JApplicationBase
+	 * @var    \Joomla\Application\AbstractApplication
 	 * @since  3.1
 	 */
 	protected $app;

--- a/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemPrivate.php
+++ b/tests/unit/suites/libraries/cms/plugin/stubs/PlgSystemPrivate.php
@@ -21,7 +21,7 @@ class PlgSystemPrivate extends JPlugin
 	/**
 	 * Application object
 	 *
-	 * @var    JApplicationBase
+	 * @var    \Joomla\Application\AbstractApplication
 	 * @since  3.1
 	 */
 	private $app;

--- a/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
@@ -51,6 +51,8 @@ class JApplicationCliTest extends TestCase
 	 */
 	protected function tearDown()
 	{
+		TestReflection::setValue('JApplicationCli', 'instance', null);
+
 		unset($this->class);
 		parent::tearDown();
 	}
@@ -211,7 +213,7 @@ class JApplicationCliTest extends TestCase
 		$this->assertInstanceOf(
 			'JApplicationCliInspector',
 			JApplicationCli::getInstance('JApplicationCliInspector'),
-			'Tests that getInstance will instantiate a valid child class of JCli.'
+			'Tests that getInstance will instantiate a valid child class of JApplicationCli.'
 		);
 
 		TestReflection::setValue('JApplicationCli', 'instance', 'foo');
@@ -229,8 +231,6 @@ class JApplicationCliTest extends TestCase
 	 */
 	public function testGetInstanceForUnexistingClass()
 	{
-		TestReflection::setValue('JApplicationCli', 'instance', null);
-
 		JApplicationCli::getInstance('Foo');
 	}
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -61,24 +61,6 @@ class JApplicationWebTest extends TestCase
 	protected $backupServer;
 
 	/**
-	 * Data for detectRequestUri method.
-	 *
-	 * @return  array
-	 *
-	 * @since   11.3
-	 */
-	public function getDetectRequestUriData()
-	{
-		return array(
-			// HTTPS, PHP_SELF, REQUEST_URI, HTTP_HOST, SCRIPT_NAME, QUERY_STRING, (resulting uri)
-			array(null, '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php?foo=bar'),
-			array('on', '/j/index.php', '/j/index.php?foo=bar', 'joom.la:3', '/j/index.php', '', 'https://joom.la:3/j/index.php?foo=bar'),
-			array(null, '', '', 'joom.la:3', '/j/index.php', '', 'http://joom.la:3/j/index.php'),
-			array(null, '', '', 'joom.la:3', '/j/index.php', 'foo=bar', 'http://joom.la:3/j/index.php?foo=bar'),
-		);
-	}
-
-	/**
 	 * Data for fetchConfigurationData method.
 	 *
 	 * @return  array
@@ -134,6 +116,8 @@ class JApplicationWebTest extends TestCase
 		// Reset some web inspector static settings.
 		JApplicationWebInspector::$headersSent = false;
 		JApplicationWebInspector::$connectionAlive = true;
+
+		TestReflection::setValue('JApplicationWeb', 'instance', null);
 
 		$_SERVER = $this->backupServer;
 		unset($this->backupServer);
@@ -258,278 +242,6 @@ class JApplicationWebTest extends TestCase
 		$this->class->clearHeaders();
 
 		$this->assertEquals(array(), TestReflection::getValue($this->class, 'response')->headers);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::compress method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testCompressWithGzipEncoding()
-	{
-		// Fill the header body with a value.
-		TestReflection::setValue(
-			$this->class,
-			'response',
-			(object) array(
-				'cachable' => null,
-				'headers' => null,
-				'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.'),
-			)
-		);
-
-		// Load the client encoding with a value.
-		TestReflection::setValue(
-			$this->class,
-			'client',
-			(object) array(
-				'encodings' => array('gzip', 'deflate'),
-			)
-		);
-
-		TestReflection::invoke($this->class, 'compress');
-
-		// Ensure that the compressed body is shorter than the raw body.
-		$this->assertLessThan(471, strlen($this->class->getBody()));
-
-		// Ensure that the compression headers were set.
-		$this->assertEquals(
-			array(
-				0 => array('name' => 'Content-Encoding', 'value' => 'gzip')
-			),
-			TestReflection::getValue($this->class, 'response')->headers
-		);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::compress method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testCompressWithDeflateEncoding()
-	{
-		// Fill the header body with a value.
-		TestReflection::setValue(
-			$this->class,
-			'response',
-			(object) array(
-				'cachable' => null,
-				'headers' => null,
-				'body' => array('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.'),
-			)
-		);
-
-		// Load the client encoding with a value.
-		TestReflection::setValue(
-			$this->class,
-			'client',
-			(object) array(
-				'encodings' => array('deflate', 'gzip'),
-			)
-		);
-
-		TestReflection::invoke($this->class, 'compress');
-
-		// Ensure that the compressed body is shorter than the raw body.
-		$this->assertLessThan(471, strlen($this->class->getBody()));
-
-		// Ensure that the compression headers were set.
-		$this->assertEquals(
-			array(
-				0 => array('name' => 'Content-Encoding', 'value' => 'deflate')
-			),
-			TestReflection::getValue($this->class, 'response')->headers
-		);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::compress method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testCompressWithNoAcceptEncodings()
-	{
-		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.';
-
-		// Replace \r\n -> \n to ensure same length on all platforms
-		// Fill the header body with a value.
-		TestReflection::setValue(
-			$this->class,
-			'response',
-			(object) array(
-				'cachable' => null,
-				'headers' => null,
-				'body' => array(str_replace("\r\n", "\n", $string)),
-			)
-		);
-
-		// Load the client encoding with a value.
-		TestReflection::setValue(
-			$this->class,
-			'client',
-			(object) array(
-				'encodings' => array(),
-			)
-		);
-
-		TestReflection::invoke($this->class, 'compress');
-
-		// Ensure that the compressed body is the same as the raw body since there is no compression.
-		$this->assertSame(471, strlen($this->class->getBody()));
-
-		// Ensure that the compression headers were not set.
-		$this->assertNull(TestReflection::getValue($this->class, 'response')->headers);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::compress method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testCompressWithHeadersSent()
-	{
-		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.';
-
-		// Replace \r\n -> \n to ensure same length on all platforms
-		// Fill the header body with a value.
-		TestReflection::setValue(
-			$this->class,
-			'response',
-			(object) array(
-				'cachable' => null,
-				'headers' => null,
-				'body' => array(str_replace("\r\n", "\n", $string)),
-			)
-		);
-
-		// Load the client encoding with a value.
-		TestReflection::setValue(
-			$this->class,
-			'client',
-			(object) array(
-				'encodings' => array('gzip', 'deflate'),
-			)
-		);
-
-		// Set the headers sent flag to true.
-		JApplicationWebInspector::$headersSent = true;
-
-		TestReflection::invoke($this->class, 'compress');
-
-		// Set the headers sent flag back to false.
-		JApplicationWebInspector::$headersSent = false;
-
-		// Ensure that the compressed body is the same as the raw body since there is no compression.
-		$this->assertSame(471, strlen($this->class->getBody()));
-
-		// Ensure that the compression headers were not set.
-		$this->assertNull(TestReflection::getValue($this->class, 'response')->headers);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::compress method.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testCompressWithUnsupportedEncodings()
-	{
-		$string = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-					eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-					veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-					consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
-					dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
-					sunt in culpa qui officia deserunt mollit anim id est laborum.';
-
-		// Replace \r\n -> \n to ensure same length on all platforms
-		// Fill the header body with a value.
-		TestReflection::setValue(
-			$this->class,
-			'response',
-			(object) array(
-				'cachable' => null,
-				'headers' => null,
-				'body' => array(str_replace("\r\n", "\n", $string)),
-			)
-		);
-
-		// Load the client encoding with a value.
-		TestReflection::getValue(
-			$this->class,
-			'client',
-			(object) array(
-				'encodings' => array('foo', 'bar'),
-			)
-		);
-
-		TestReflection::invoke($this->class, 'compress');
-
-		// Ensure that the compressed body is the same as the raw body since there is no supported compression.
-		$this->assertSame(471, strlen($this->class->getBody()));
-
-		// Ensure that the compression headers were not set.
-		$this->assertNull(TestReflection::getValue($this->class, 'response')->headers);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::detectRequestUri method.
-	 *
-	 * @param   string  $https        @todo
-	 * @param   string  $phpSelf      @todo
-	 * @param   string  $requestUri   @todo
-	 * @param   string  $httpHost     @todo
-	 * @param   string  $scriptName   @todo
-	 * @param   string  $queryString  @todo
-	 * @param   string  $expects      @todo
-	 *
-	 * @return  void
-	 *
-	 * @dataProvider getDetectRequestUriData
-	 * @since   11.3
-	 */
-	public function testDetectRequestUri($https, $phpSelf, $requestUri, $httpHost, $scriptName, $queryString, $expects)
-	{
-		if ($https !== null)
-		{
-			$_SERVER['HTTPS'] = $https;
-		}
-
-		$_SERVER['PHP_SELF'] = $phpSelf;
-		$_SERVER['REQUEST_URI'] = $requestUri;
-		$_SERVER['HTTP_HOST'] = $httpHost;
-		$_SERVER['SCRIPT_NAME'] = $scriptName;
-		$_SERVER['QUERY_STRING'] = $queryString;
-
-		$this->assertEquals($expects, TestReflection::invoke($this->class, 'detectRequestUri'));
 	}
 
 	/**
@@ -693,90 +405,23 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testGetInstance()
 	{
-		$this->assertInstanceOf('JApplicationWebInspector', JApplicationWeb::getInstance('JApplicationWebInspector'));
+		$app = JApplicationWeb::getInstance('JApplicationWebInspector');
 
-		TestReflection::setValue('JApplicationWeb', 'instance', 'foo');
-
-		$this->assertEquals('foo', JApplicationWeb::getInstance('JApplicationWebInspector'));
-
-		TestReflection::setValue('JApplicationWeb', 'instance', null);
-
-		$this->assertInstanceOf('JApplicationWeb', JApplicationWeb::getInstance('Foo'));
+		$this->assertInstanceOf('JApplicationWebInspector', $app);
+		$this->assertSame($app, JApplicationWeb::getInstance('JApplicationWebInspector'), 'The same application object was not returned.');
 	}
 
 	/**
-	 * Tests the JApplicationWeb::initialise method with default settings.
+	 * Tests the JApplicationWeb::getInstance method for an unexisting class.
 	 *
 	 * @return  void
 	 *
 	 * @since   11.3
+	 * @expectedException  RuntimeException
 	 */
-	public function testInitialiseWithDefaults()
+	public function testGetInstanceForUnexistingClass()
 	{
-		// TODO JSession default is not tested properly.
-
-		$this->class->initialise(false);
-
-		$this->assertAttributeInstanceOf('JDocument', 'document', $this->class);
-		$this->assertAttributeInstanceOf('JLanguage', 'language', $this->class);
-		$this->assertAttributeEmpty('dispatcher', $this->class);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::initialise method with false injection.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testInitialiseWithFalse()
-	{
-		$this->class->initialise(false, false, false);
-
-		$this->assertAttributeEmpty('session', $this->class);
-		$this->assertAttributeEmpty('document', $this->class);
-		$this->assertAttributeEmpty('language', $this->class);
-	}
-
-	/**
-	 * Tests the JApplicationWeb::initialise method with dependancy injection.
-	 *
-	 * @return  void
-	 *
-	 * @since   11.3
-	 */
-	public function testInitialiseWithInjection()
-	{
-		$mockSession = $this->getMock('JSession', array('test'), array(), '', false);
-		$mockSession
-			->expects($this->any())
-			->method('test')
-			->willReturnSelf();
-
-		$mockDocument = $this->getMock('JDocument', array('test'), array(), '', false);
-		$mockDocument
-			->expects($this->any())
-			->method('test')
-			->willReturnSelf();
-
-		$mockLanguage = $this->getMock('JLanguage', array('test'), array(), '', false);
-		$mockLanguage
-			->expects($this->any())
-			->method('test')
-			->willReturnSelf();
-
-		$mockDispatcher = $this->getMock('\\Joomla\\Event\\DispatcherInterface', array('addListener', 'dispatch', 'removeListener'), array(), '', false);
-		$mockDispatcher
-			->expects($this->any())
-			->method('dispatch')
-			->willReturnSelf();
-
-		$this->class->initialise($mockSession, $mockDocument, $mockLanguage, $mockDispatcher);
-
-		$this->assertSame($mockSession, $this->class->getSession()->test());
-		$this->assertSame($mockDocument, $this->class->getDocument()->test());
-		$this->assertSame($mockLanguage, $this->class->getLanguage()->test());
-		$this->assertSame($mockDispatcher, $this->class->getDispatcher()->dispatch('foo'));
+		JApplicationWeb::getInstance('Foo');
 	}
 
 	/**
@@ -1207,23 +852,5 @@ class JApplicationWebTest extends TestCase
 			),
 			TestReflection::getValue($this->class, 'response')->headers
 		);
-	}
-
-	/**
-	 * Tests the isSSLConnection method
-	 *
-	 * @return  void
-	 *
-	 * @since   12.2
-	 */
-	public function testIsSSLConnection()
-	{
-		unset($_SERVER['HTTPS']);
-
-		$this->assertFalse($this->class->isSSLConnection());
-
-		$_SERVER['HTTPS'] = 'on';
-
-		$this->assertTrue($this->class->isSSLConnection());
 	}
 }


### PR DESCRIPTION
### Summary of Changes

Recomposes `JApplicationWeb` to extend `Joomla\Application\AbstractWebApplication` with some other miscellaneous changes:
- Remove tests that are now covered by the parent class
- Restructures the mock class builders for `JApplicationCli`,  `JApplicationCms`, and `JApplicationWeb` for the revised application structure
- Changes typehints for the base application class
- Deprecates `JApplicationBase` as it's now unused, to be removed in 5.0 (build custom apps inheriting from one of the existing subclasses or `Joomla\Application\AbstractApplication`)
- Makes `JApplicationWeb` and `JApplicationCms` abstract
- Removes some deprecated code
### Testing Instructions

CMS web apps continue to function as expected
### Documentation Changes Required

Derive it from above 😉 
