### PR TITLE
Make CodeMirror work in repeatable subforms

### DIFF
--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -20,17 +20,17 @@ $content = $displayData->content;
 $buttons = $displayData->buttons;
 $modifier = $params->get('fullScreenMod', '') !== '' ? implode($params->get('fullScreenMod', ''), ' + ') . ' + ' : '';
 
-JFactory::getDocument()->addScriptDeclaration('
-	jQuery(function () {
-		var id = ' . json_encode($id) . ', options = ' . json_encode($options) . ';
-		/** Register Editor */
-		Joomla.editors.instances[id] = CodeMirror.fromTextArea(document.getElementById(id), options);
-	});
-');
 ?>
-<p class="label">
-    <?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $modifier, $params->get('fullScreen', 'F10')); ?>
-</p>
-<?php echo '<textarea name="', $name, '" id="', $id, '" cols="', $cols, '" rows="', $rows, '">', $content, '</textarea>'; ?>
 
-<?php echo $displayData->buttons; ?>
+<p class="label"><?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $params->get('fullScreen', 'F10')); ?></p>
+
+<?php
+	echo '<textarea class="codemirror-source" name="', $name,
+		'" id="', $id,
+		'" cols="', $cols,
+		'" rows="', $rows,
+		'" data-options="', htmlspecialchars(json_encode($options)),
+		'">', $content, '</textarea>';
+?>
+
+<?php echo $buttons; ?>

--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -22,7 +22,9 @@ $modifier = $params->get('fullScreenMod', '') !== '' ? implode($params->get('ful
 
 ?>
 
-<p class="label"><?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $params->get('fullScreen', 'F10')); ?></p>
+<p class="label">
+    <?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $modifier, $params->get('fullScreen', 'F10')); ?>
+</p>
 
 <?php
 	echo '<textarea class="codemirror-source" name="', $name,

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -83,13 +83,14 @@ JFactory::getDocument()->addScriptDeclaration(
 
 			// Initialize any CodeMirrors on page load and when a subform is added
 			$(function ($) {
-				initCodeMirror(null, $('body'));
+				initCodeMirror();
 				$('body').on('subform-row-add', initCodeMirror);
 			});
 
 			function initCodeMirror(event, container)
 			{
-				$('textarea.codemirror-source', container).each(function () {
+				container = container || document;
+				$(container).find('textarea.codemirror-source').each(function () {
 					var input = $(this).removeClass('codemirror-source');
 					var id = input.prop('id');
 

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -61,7 +61,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				// jQuery's ready function.
 				$(function () {
 					// Some browsers do something weird with the fieldset which doesn't work well with CodeMirror. Fix it.
-					$(editor.getTextArea()).parent('fieldset').css('min-width', 0);
+					$(editor.getWrapperElement()).parent('fieldset').css('min-width', 0);
 					// Listen for Bootstrap's 'shown' event. If this editor was in a hidden element when created, it may need to be refreshed.
 					$(document.body).on("shown shown.bs.tab shown.bs.modal", function () { editor.refresh(); });
 				});
@@ -80,6 +80,23 @@ JFactory::getDocument()->addScriptDeclaration(
 				marker.className = "CodeMirror-markergutter-mark";
 				return marker;
 			}
+
+			// Initialize any CodeMirrors on page load and when a subform is added
+			$(function ($) {
+				initCodeMirror(null, $('body'));
+				$('body').on('subform-row-add', initCodeMirror);
+			});
+
+			function initCodeMirror(event, container)
+			{
+				$('textarea.codemirror-source', container).each(function () {
+					var input = $(this).removeClass('codemirror-source');
+					var id = input.prop('id');
+
+					Joomla.editors.instances[id] = cm.fromTextArea(this, input.data('options'));
+				});
+			}
+
 		}(CodeMirror, jQuery));
 JS
 );


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes
#### Before:

Each instance of CodeMirror has an initialization function specific to its id which runs on page load. This doesn't work for CodeMirror instances that should appear within subforms since they may not exist when the page loads and their ids are added dynamically.
#### After:

One function to initialize any and all instances of CodeMirror. Runs once on page load and again on `subform-row-add` so that CodeMirror will work when placed in a subform. 
### Testing Instructions

Use CodeMirror without subform and expect it to work as usual.
Create a form with an `editor` field in a repeatable subform. Before this change, you should get only a plain `textarea`. After, you should get a fully functional CodeMirror for each row you add. 
### Documentation Changes Required

Nope
