### PR TITLE
Errors installing new extensions on already existing packages

### DIFF
--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -125,7 +125,7 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 			}
 
 			$tmpInstaller  = new JInstaller;
-			$installResult = $tmpInstaller->{$this->route}($package['dir']);
+			$installResult = $tmpInstaller->install($package['dir']);
 
 			if (!$installResult)
 			{


### PR DESCRIPTION
## 1. Issue description

When a new extension is added to an existing package the package installer runs the `update` method to install it. That causes issues like:
- Database changes are not added if a new extension requires it.
- Cannot find manifiests warnings when installing the version with new extensions. 
## 2. Summary of Changes

This forces the install method to be `install` because adapters are already smart enough to detect when they should install or update the extensions in the package.
## 3. Testing Instructions

To perform the next tests I'm providing a sample package with three versions:
- [pkg_sample-v1.0.0.zip](https://github.com/joomla/joomla-cms/files/549938/pkg_sample-v1.0.0.zip) - First version that includes:
  - A dummy library (`lib_sample`)
  - A dummy module (`mod_sample`)
  - A dummy content plugin (`plg_content_sample`)
- [pkg_sample-v1.0.1.zip](https://github.com/joomla/joomla-cms/files/549941/pkg_sample-v1.0.1.zip) - New package version that includes previous extensions plus:
  - A dummy component that creates a db table (`com_sample`)
  - A dummy system plugin (`plg_system_sample`)
- [pkg_sample-v1.0.2.zip](https://github.com/joomla/joomla-cms/files/549974/pkg_sample-v1.0.2.zip) - New version that includes SQL updates for the DB table to test that extensions are able to detect install / udpate.
### 3.1. Reproduce the issue (before applying the patch)
1. Use a clean joomla based on latest staging.
2. Install `pkg_sample-v1.0.0.zip`. See that no errors happen.
3. Install `pkg_sample-v1.0.1.zip`. 
4. Confirm that you get a warning like:

![upgrade-error](https://cloud.githubusercontent.com/assets/1119272/19677892/c0fde27c-9a9b-11e6-9c82-f3fd4f991dde.png)

That warning is caused because it tries to run update method on a plugin that is not installed (`plg_system_sample`).
4. Confirm that database table `#__sample_test` hasn't been created. This is caused because the component has been installed through `update()` instead of `install()`
### 3.2. Confirm that the patch works (after applying the patch)
1. Use a clean joomla based on latest staging.
2. Install `pkg_sample-v1.0.0.zip`. Ensure that no errors happen.
3. Install `pkg_sample-v1.0.1.zip`. Ensure that no errors are shown. 
4. Confirm that these extensions are installed:
   - `lib_sample` - Name in extensions manager:  `Sample - Library` - Tipo: Library
   - `mod_sample` - Name in extensions manager: `Sample - Module` - Type: Module
   - `com_sample` - Name in extensions manager: `Sample` - Type: Component
   - `plg_content_sample` - Name in extensions manager: `Sample` - Type: Content Plugin
   - `plg_system_sample` - Name in extensions manager: `Sample` - Type: System Plugin
   - `pkg_sample` - Name in extensions manager: `Sample - All` - Type: Package
5. Confirm that database table exists `#__sample_test` and doesn't have a column `new_column`.
6. Install `pkg_sample-v1.0.2.zip`. Ensure that no errors happen.
7. Confirm that the table `#__sample_test` now has a column `new_column`.
8. Uninstall an extension called `Sample - All`. Ensure that no errors are shown.
9. Ensure that `#__sample_test` database table has been removed.
### 3.3. Confirm that direct installations work (after applying the patch)

Install v1.0.1:
0. Use a clean joomla based on latest staging.
1. Install `pkg_sample-v1.0.1.zip`. Ensure that no errors are shown.
2. Uninstall an extension called `Sample - All`. Ensure that no errors are shown.
3. Ensure that `#__sample_test` database table has been removed.

Install v1.0.1 and upgrade to v1.0.2:
1. Install `pkg_sample-v1.0.1.zip`. Ensure that no errors are shown.
2. Install `pkg_sample-v1.0.2.zip`. Ensure that no errors happen.
3. Confirm that the table `#__sample_test` has a column `new_column`.
4. Uninstall an extension called `Sample - All`. Ensure that no errors are shown.
5. Ensure that `#__sample_test` database table has been removed.

Install v1.0.2:
1. Install `pkg_sample-v1.0.2.zip`. Ensure that no errors happen.
2. Confirm that the table `#__sample_test` has a column `new_column`.
3. Uninstall an extension called `Sample - All`. Ensure that no errors are shown.
4. Ensure that `#__sample_test` database table has been removed.
## 4.Documentation Changes Required

No changes required because this is fixing a bug.
