### PR TITLE
Folder icons in front end

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7673,3 +7673,9 @@ body.modal-open {
 li {
 	word-wrap: break-word;
 }
+ul.manager .height-50 .icon-folder-2 {
+	height: 35px;
+	width: 35px;
+	line-height: 35px;
+	font-size: 30px;
+}

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -674,3 +674,10 @@ body.modal-open {
 li {
 	word-wrap: break-word;
 }
+
+ul.manager .height-50 .icon-folder-2 {
+    height: 35px;
+    width: 35px;
+    line-height: 35px;
+    font-size: 30px;
+}


### PR DESCRIPTION
### Summary of Changes

The folder icons in image manager are tiny when viewed with protostar
This PR resizes them (with the same css) to the larger size seen in the admin
### Testing Instructions

Front end edit article and use any image link - eg image xtd-editor button or image and link tab
### Before PR

![jovb 1](https://cloud.githubusercontent.com/assets/1296369/19682851/6c958472-9aa7-11e6-97ac-09216e31448e.png)
### After PR

![opqw 1](https://cloud.githubusercontent.com/assets/1296369/19682866/778c5de2-9aa7-11e6-9470-550a2f92c4f7.png)
