### PR TITLE
$menu->params is already a Registry object.

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -351,8 +351,7 @@ final class JApplicationSite extends JApplicationCms
 				// Get show_page_heading from com_menu global settings
 				$params[$hash]->def('show_page_heading', $temp->get('show_page_heading'));
 
-				$temp = new Registry($menu->params);
-				$params[$hash]->merge($temp);
+				$params[$hash]->merge($menu->params);
 				$title = $menu->title;
 			}
 			else


### PR DESCRIPTION
Pull Request for Issue #12519 .
### Summary of Changes

`JApplicationSite::getParams()` tried to instantiate a new registry object from $menu->params, but that is already a registry object.
This PR removes that step and directly merges the component and menu params.
### Testing Instructions

Set up a menu item for a component of your choice and set some parameters different from the global counterpart
Check that the menu parameter overrides the component ones.
### Documentation Changes Required

None
