### PR TITLE
Remove configuration and data integrity checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "joomla/data": "~1.2",
         "joomla/di": "~1.2",
         "joomla/event": "~1.1",
-        "joomla/registry": "~1.4 >=1.4.5",
+        "joomla/registry": "1.5.1",
         "joomla/session": "~1.3",
         "joomla/string": "~1.3",
         "joomla/uri": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15ae8f9ee2aa080639758e0925fa9b45",
-    "content-hash": "ea772882d62aa0ce41eaaa27dcb93653",
+    "hash": "5b47efe033f77287ec494ee290722ee3",
+    "content-hash": "aba2886147d35a687252ead03795777a",
     "packages": [
         {
             "name": "ircmaxell/password-compat",
@@ -386,23 +386,22 @@
         },
         {
             "name": "joomla/registry",
-            "version": "1.5.2",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
-                "reference": "bd3592c6f0554a72811df52aeaea98c7815f6e5a"
+                "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/bd3592c6f0554a72811df52aeaea98c7815f6e5a",
-                "reference": "bd3592c6f0554a72811df52aeaea98c7815f6e5a",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+                "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9",
                 "shasum": ""
             },
             "require": {
                 "joomla/compat": "~1.0",
                 "joomla/utilities": "~1.0",
-                "php": ">=5.3.10|>=7.0",
-                "symfony/polyfill-php55": "~1.0"
+                "php": ">=5.3.10|>=7.0"
             },
             "require-dev": {
                 "joomla/test": "~1.0",
@@ -435,7 +434,7 @@
                 "joomla",
                 "registry"
             ],
-            "time": "2016-05-14 20:42:05"
+            "time": "2016-04-18 23:57:43"
         },
         {
             "name": "joomla/session",

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -167,12 +167,6 @@ class JCacheStorage
 			}
 		}
 
-		// Validate the cache storage is supported on this platform
-		if (!$class::isSupported())
-		{
-			throw new JCacheExceptionUnsupported(sprintf('The %s Cache Storage is not supported on this platform.', $handler));
-		}
-
 		return new $class($options);
 	}
 

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -74,12 +74,6 @@ abstract class JSessionStorage
 				}
 			}
 
-			// Validate the session storage is supported on this platform
-			if (!$class::isSupported())
-			{
-				throw new JSessionExceptionUnsupported(sprintf('The %s Session Storage is not supported on this platform.', $name));
-			}
-
 			self::$instances[$name] = new $class($options);
 		}
 

--- a/libraries/vendor/composer/autoload_files.php
+++ b/libraries/vendor/composer/autoload_files.php
@@ -22,7 +22,7 @@ return array(
     '4292e2fa66516089e6006723267587b4' => $vendorDir . '/joomla/string/src/phputf8/utils/ascii.php',
     '87465e33b7551b401bf051928f220e9a' => $vendorDir . '/joomla/string/src/phputf8/utils/validation.php',
     'e40631d46120a9c38ea139981f8dab26' => $vendorDir . '/ircmaxell/password-compat/lib/password.php',
-    'edc6464955a37aa4d5fbf39d40fb6ee7' => $vendorDir . '/symfony/polyfill-php55/bootstrap.php',
     '5255c38a0faeba867671b61dfda6d864' => $vendorDir . '/paragonie/random_compat/lib/random.php',
+    'edc6464955a37aa4d5fbf39d40fb6ee7' => $vendorDir . '/symfony/polyfill-php55/bootstrap.php',
     'bd9634f2d41831496de0d3dfe4c94881' => $vendorDir . '/symfony/polyfill-php56/bootstrap.php',
 );

--- a/libraries/vendor/composer/autoload_static.php
+++ b/libraries/vendor/composer/autoload_static.php
@@ -23,8 +23,8 @@ class ComposerStaticInit205c915b9c7d3e718e7c95793ee67ffe
         '4292e2fa66516089e6006723267587b4' => __DIR__ . '/..' . '/joomla/string/src/phputf8/utils/ascii.php',
         '87465e33b7551b401bf051928f220e9a' => __DIR__ . '/..' . '/joomla/string/src/phputf8/utils/validation.php',
         'e40631d46120a9c38ea139981f8dab26' => __DIR__ . '/..' . '/ircmaxell/password-compat/lib/password.php',
-        'edc6464955a37aa4d5fbf39d40fb6ee7' => __DIR__ . '/..' . '/symfony/polyfill-php55/bootstrap.php',
         '5255c38a0faeba867671b61dfda6d864' => __DIR__ . '/..' . '/paragonie/random_compat/lib/random.php',
+        'edc6464955a37aa4d5fbf39d40fb6ee7' => __DIR__ . '/..' . '/symfony/polyfill-php55/bootstrap.php',
         'bd9634f2d41831496de0d3dfe4c94881' => __DIR__ . '/..' . '/symfony/polyfill-php56/bootstrap.php',
     );
 

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -856,61 +856,6 @@
         "description": "PHPMailer is a full-featured email creation and transfer class for PHP"
     },
     {
-        "name": "joomla/registry",
-        "version": "1.5.2",
-        "version_normalized": "1.5.2.0",
-        "source": {
-            "type": "git",
-            "url": "https://github.com/joomla-framework/registry.git",
-            "reference": "bd3592c6f0554a72811df52aeaea98c7815f6e5a"
-        },
-        "dist": {
-            "type": "zip",
-            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/bd3592c6f0554a72811df52aeaea98c7815f6e5a",
-            "reference": "bd3592c6f0554a72811df52aeaea98c7815f6e5a",
-            "shasum": ""
-        },
-        "require": {
-            "joomla/compat": "~1.0",
-            "joomla/utilities": "~1.0",
-            "php": ">=5.3.10|>=7.0",
-            "symfony/polyfill-php55": "~1.0"
-        },
-        "require-dev": {
-            "joomla/test": "~1.0",
-            "phpunit/phpunit": "~4.8|~5.0",
-            "squizlabs/php_codesniffer": "1.*",
-            "symfony/yaml": "~2.0|~3.0"
-        },
-        "suggest": {
-            "symfony/yaml": "Install symfony/yaml if you require YAML support."
-        },
-        "time": "2016-05-14 20:42:05",
-        "type": "joomla-package",
-        "extra": {
-            "branch-alias": {
-                "dev-master": "1.x-dev"
-            }
-        },
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "Joomla\\Registry\\": "src/"
-            }
-        },
-        "notification-url": "https://packagist.org/downloads/",
-        "license": [
-            "GPL-2.0+"
-        ],
-        "description": "Joomla Registry Package",
-        "homepage": "https://github.com/joomla-framework/registry",
-        "keywords": [
-            "framework",
-            "joomla",
-            "registry"
-        ]
-    },
-    {
         "name": "symfony/polyfill-php56",
         "version": "v1.2.0",
         "version_normalized": "1.2.0.0",
@@ -1122,6 +1067,60 @@
             "data",
             "framework",
             "joomla"
+        ]
+    },
+    {
+        "name": "joomla/registry",
+        "version": "1.5.1",
+        "version_normalized": "1.5.1.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/registry.git",
+            "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/registry/zipball/b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+            "reference": "b9fd1812e19619bb4722a0711b691dbfefff8ee9",
+            "shasum": ""
+        },
+        "require": {
+            "joomla/compat": "~1.0",
+            "joomla/utilities": "~1.0",
+            "php": ">=5.3.10|>=7.0"
+        },
+        "require-dev": {
+            "joomla/test": "~1.0",
+            "phpunit/phpunit": "~4.8|~5.0",
+            "squizlabs/php_codesniffer": "1.*",
+            "symfony/yaml": "~2.0|~3.0"
+        },
+        "suggest": {
+            "symfony/yaml": "Install symfony/yaml if you require YAML support."
+        },
+        "time": "2016-04-18 23:57:43",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Registry\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Registry Package",
+        "homepage": "https://github.com/joomla-framework/registry",
+        "keywords": [
+            "framework",
+            "joomla",
+            "registry"
         ]
     }
 ]

--- a/libraries/vendor/joomla/registry/src/Factory.php
+++ b/libraries/vendor/joomla/registry/src/Factory.php
@@ -25,7 +25,7 @@ class Factory
 	protected static $formatInstances = array();
 
 	/**
-	 * Returns an AbstractRegistryFormat object, only creating it if it doesn't already exist.
+	 * Returns a AbstractRegistryFormat object, only creating it if it doesn't already exist.
 	 *
 	 * @param   string  $type     The format to load
 	 * @param   array   $options  Additional options to configure the object

--- a/libraries/vendor/joomla/registry/src/Format/Json.php
+++ b/libraries/vendor/joomla/registry/src/Format/Json.php
@@ -53,7 +53,6 @@ class Json extends AbstractRegistryFormat
 	 * @return  object   Data object.
 	 *
 	 * @since   1.0
-	 * @throws  \RuntimeException
 	 */
 	public function stringToObject($data, array $options = array('processSections' => false))
 	{
@@ -64,14 +63,6 @@ class Json extends AbstractRegistryFormat
 			return AbstractRegistryFormat::getInstance('Ini')->stringToObject($data, $options);
 		}
 
-		$decoded = json_decode($data);
-
-		// Check for an error decoding the data
-		if ($decoded === null)
-		{
-			throw new \RuntimeException(sprintf('Error decoding JSON data: %s', json_last_error_msg()));
-		}
-
-		return $decoded;
+		return json_decode($data);
 	}
 }

--- a/libraries/vendor/joomla/registry/src/Registry.php
+++ b/libraries/vendor/joomla/registry/src/Registry.php
@@ -26,14 +26,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	protected $data;
 
 	/**
-	 * Flag if the Registry data object has been initialized
-	 *
-	 * @var    boolean
-	 * @since  1.5.2
-	 */
-	protected $initialized = false;
-
-	/**
 	 * Registry instances container.
 	 *
 	 * @var    array
@@ -286,7 +278,7 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	}
 
 	/**
-	 * Load an associative array of values into the default namespace
+	 * Load a associative array of values into the default namespace
 	 *
 	 * @param   array    $array      Associative array of value to load
 	 * @param   boolean  $flattened  Load from a one-dimensional array
@@ -364,16 +356,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 		$handler = AbstractRegistryFormat::getInstance($format, $options);
 
 		$obj = $handler->stringToObject($data, $options);
-
-		// If the data object has not yet been initialized, direct assign the object
-		if (!$this->initialized)
-		{
-			$this->data        = $obj;
-			$this->initialized = true;
-
-			return $this;
-		}
-
 		$this->loadObject($obj);
 
 		return $this;
@@ -680,9 +662,6 @@ class Registry implements \JsonSerializable, \ArrayAccess, \IteratorAggregate, \
 	 */
 	protected function bindData($parent, $data, $recursive = true, $allowNull = true)
 	{
-		// The data object is now initialized
-		$this->initialized = true;
-
 		// Ensure the input data is an array.
 		$data = is_object($data)
 			? get_object_vars($data)


### PR DESCRIPTION
### Summary of Changes

Joomla community members have indicated they have issues with the core code having added integrity checks to high level APIs which could cause a site to render an error page (if rendered at all) due to the additional checks raising an error condition.  Therefore this reverts three high level checks I have personally added to the core API:
- Checks for invalid data structure when adding data to a `Registry`
- Checks for an invalid configuration when instantiating a cache handler
- Checks for an invalid configuration when instantiating a session handler
### Testing Instructions
- With invalid JSON data, the error should now be silently absorbed and the site blissfully function as expected.  You can fill your database full of records containing `{""}` to validate this for fields holding JSON data.
- Invalidly configured cache and session handlers will probably result in a fatal error now.
