### PR TITLE
Remove unneeded registry creation

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -271,13 +271,11 @@ class ContactModelContact extends JModelForm
 		$groups    = implode(',', $user->getAuthorisedViewLevels());
 		$published = $this->getState('filter.published');
 
-		$contactParams = new Registry($contact->params);
-
 		// If we are showing a contact list, then the contact parameters take priority
 		// So merge the contact parameters with the merged parameters
 		if ($this->getState('params')->get('show_contact_list'))
 		{
-			$this->getState('params')->merge($contactParams);
+			$this->getState('params')->merge($contact->params);
 		}
 
 		// Get the com_content articles by the linked user
@@ -337,7 +335,7 @@ class ContactModelContact extends JModelForm
 			// Use contact setting?
 			if ($articles_display_num === 'use_contact')
 			{
-				$articles_display_num = $contactParams->get('articles_display_num', 10);
+				$articles_display_num = $contact->params->get('articles_display_num', 10);
 
 				// Use global?
 				if ((string) $articles_display_num === '')

--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Registry\Registry;
-
 /**
  * HTML View class for the Contacts component
  *
@@ -60,8 +58,9 @@ class ContactViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$temp       = $item->params;
 			$item->params = clone $this->params;
-			$item->params->merge($item->params);
+			$item->params->merge($temp);
 
 			if ($item->params->get('show_email_headings', 0) == 1)
 			{

--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -60,9 +60,8 @@ class ContactViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$temp       = new Registry($item->params);
 			$item->params = clone $this->params;
-			$item->params->merge($temp);
+			$item->params->merge($item->params);
 
 			if ($item->params->get('show_email_headings', 0) == 1)
 			{

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -96,8 +96,9 @@ class ContactViewFeatured extends JViewLegacy
 		{
 			$item       = &$items[$i];
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$temp       = $item->params;
 			$item->params = clone $params;
-			$item->params->merge($item->params);
+			$item->params->merge($temp);
 
 			if ($item->params->get('show_email', 0) == 1)
 			{

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -96,9 +96,8 @@ class ContactViewFeatured extends JViewLegacy
 		{
 			$item       = &$items[$i];
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$temp       = new Registry($item->params);
 			$item->params = clone $params;
-			$item->params->merge($temp);
+			$item->params->merge($item->params);
 
 			if ($item->params->get('show_email', 0) == 1)
 			{

--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -52,8 +52,9 @@ class NewsfeedsViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
+			$temp       = $item->params;
 			$item->params = clone $this->params;
-			$item->params->merge($item->params);
+			$item->params->merge($temp);
 		}
 
 		return parent::display($tpl);

--- a/components/com_newsfeeds/views/category/view.html.php
+++ b/components/com_newsfeeds/views/category/view.html.php
@@ -52,9 +52,8 @@ class NewsfeedsViewCategory extends JViewCategory
 		foreach ($this->items as $item)
 		{
 			$item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
-			$temp       = new Registry($item->params);
 			$item->params = clone $this->params;
-			$item->params->merge($temp);
+			$item->params->merge($item->params);
 		}
 
 		return parent::display($tpl);

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -153,8 +153,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		// Get the newsfeed
 		$newsfeed = $item;
 
-		$temp = new Registry($item->params);
-		$params->merge($temp);
+		$params->merge($item->params);
 
 		try
 		{

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -49,9 +49,7 @@ class SearchViewSearch extends JViewLegacy
 		// Because the application sets a default page title, we need to get it right from the menu item itself
 		if (is_object($menu))
 		{
-			$menu_params = new Registry($menu->params);
-
-			if (!$menu_params->get('page_title'))
+			if (!$menu->params->get('page_title'))
 			{
 				$params->set('page_title', JText::_('COM_SEARCH_SEARCH'));
 			}


### PR DESCRIPTION
Pull Request for similar Issue #12557.
### Summary of Changes

Referenced PR changes one instance where we tried to create a Registry object from a Registry object.
After scanning the PR which introduced that bug I found several more instances of the same error. This is corrected in this PR.
### Testing Instructions

I did this PR based on code review and debugging (looking at the values of he params during runtime).
To test you can do the same review/debugging: If the params property is already a Registry object it will fail to create one and it doesn't make sense to create one for obvious reasons.

To test in real you need to set some parameters at item level and check that the item params take precedence over menu/component params if needed.
- Contact Item in category, featured and single contact view
- Newsfeed Item in category and single newsfeed view
- In the search view for the traditional search (com_search) you need to check the behavior of the page title parameter in the menu item. If none is specified it should fall back to the default language string, if one is specified it has to take the specified one.
- Last change is in the template override feature, but I'm not 100% sure how to test it. Adding `?template=beez3` to the URL brings you to the code I changed, however I'm not sure which params are used there since no template style is specified. I guess it will just use default values but not sure.
  The code itself is a no brainer since a few lines above the params are already converted to Registry, so this can be reviewed easily.
### Documentation Changes Required

None
