### PR TITLE
Overridden strings in both back-end and front-end

### DIFF
--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -107,6 +107,11 @@ class LanguagesModelOverride extends JModelAdmin
 			$result->override = $strings[$pk];
 		}
 
+		$opposite_filename = constant('JPATH_' . strtoupper($this->getState('filter.client') == 'site' ? 'administrator' : 'site')) 
+			. '/language/overrides/' . $this->getState('filter.language', 'en-GB') . '.override.ini';
+		$opposite_strings = LanguagesHelper::parseFile($opposite_filename);
+		$result->both = isset($opposite_strings[$pk]) && ($opposite_strings[$pk] == $strings[$pk]);
+
 		return $result;
 	}
 

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -16,7 +16,13 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 $client    = $this->state->get('filter.client') == '0' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
 $language  = $this->state->get('filter.language');
 $listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction')); ?>
+$listDirn  = $this->escape($this->state->get('list.direction'));
+
+$opposite_client   = $this->state->get('filter.client') == '1' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
+$opposite_filename = constant('JPATH_' . strtoupper(1 - $this->state->get('filter.client')? 'administrator' : 'site')) 
+	. '/language/overrides/' . $this->state->get('filter.language', 'en-GB') . '.override.ini';
+$opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
+?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_languages&view=overrides'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
@@ -94,7 +100,12 @@ $listDirn  = $this->escape($this->state->get('list.direction')); ?>
 							<?php echo $language; ?>
 						</td>
 						<td class="hidden-phone">
-							<?php echo $client; ?>
+							<?php echo $client; ?><?php 
+							if (isset($opposite_strings[$key]) && ($opposite_strings[$key] == $text))
+							{
+								echo '/' . $opposite_client;
+							}
+							?>
 						</td>
 					</tr>
 				<?php $i++; ?>


### PR DESCRIPTION
### Summary of Changes

Set both locations Administrator/Site in the languages overrides view if the string is the same for the front-end and back-end.

Check the checkbox "For Both Locations" in the Languages Override edit form if the string is the same for the front-end and back-end.
### Testing Instructions

Go to Languages / Overrides
Filter on any language - Administrator
Edit/create an override string with checkbox "For Both Locations" checked.
In the overrides view the location is set to Administrator.
Edit the string, the checkbox "For Both Locations" is unchecked.
Apply the patch
Edit/create an override string with checkbox "For Both Locations" checked.
In the overrides view the location is set to Administrator/Site.
Edit the string, the checkbox "For Both Locations" is checked.
