### PR TITLE
user profile rename folder value

### DIFF
--- a/plugins/user/profile/profile.xml
+++ b/plugins/user/profile/profile.xml
@@ -12,7 +12,7 @@
 	<files>
 		<filename plugin="profile">profile.php</filename>
 		<folder>profiles</folder>
-		<folder>fields</folder>
+		<folder>field</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">en-GB.plg_user_profile.ini</language>


### PR DESCRIPTION
The user profile plugin (which was intended as an example) refers to a folder called field in the xml but the actual folder name is fields

This causes a problem if you intend to clone the profile to create your own

Technically as there are more than one field in the folder i guess the folder should be renames to fields but its easier to just change the name in the xml to match the physical folder.

As this value in the xml is only used if you were installing the plugin (ie when you have cloned it) there are no B/C issues. It will just make it easier for people using this plugin as an example to not miss this incorrect value. (like me for the last hour)
