### PR TITLE
Remove completed @todo tag

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -46,7 +46,6 @@ class JoomlaupdateModelDefault extends JModelLegacy
 				break;
 
 			// "Custom"
-			// TODO: check if the customurl is valid and not just "not empty".
 			case 'custom':
 				if (trim($params->get('customurl', '')) != '')
 				{


### PR DESCRIPTION
### Summary of Changes

Remove completed TODO comment in source code

It appears that someone has already implemented the feature that the TODO states needs to be "to done" - so removing the todo item to stop it showing up in sensible IDEs
### Testing Instructions

none
### Documentation Changes Required

none
