### PR TITLE
Adds .pht, .php3, .php4 and .php5 to media upload blacklist.

### DIFF
--- a/libraries/cms/helper/media.php
+++ b/libraries/cms/helper/media.php
@@ -92,7 +92,8 @@ class JHelperMedia
 		// Media file names should never have executable extensions buried in them.
 		$executable = array(
 			'php', 'js', 'exe', 'phtml', 'java', 'perl', 'py', 'asp', 'dll', 'go', 'ade', 'adp', 'bat', 'chm', 'cmd', 'com', 'cpl', 'hta', 'ins', 'isp',
-			'jse', 'lib', 'mde', 'msc', 'msp', 'mst', 'pif', 'scr', 'sct', 'shb', 'sys', 'vb', 'vbe', 'vbs', 'vxd', 'wsc', 'wsf', 'wsh',
+			'jse', 'lib', 'mde', 'msc', 'msp', 'mst', 'pif', 'scr', 'sct', 'shb', 'sys', 'vb', 'vbe', 'vbs', 'vxd', 'wsc', 'wsf', 'wsh', 'php3', 'php4',
+			'php5', 'pht',
 		);
 
 		$check = array_intersect($filetypes, $executable);


### PR DESCRIPTION
Because this is security relevant I have moved the content to the private security repo, thanks for finding the issue Robert (@rdeutz)
