### PR TITLE
Remove hardcoded published column from JTableNested

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -972,7 +972,7 @@ class JTableNested extends JTable
 					->where('n.lft < ' . (int) $node->lft)
 					->where('n.rgt > ' . (int) $node->rgt)
 					->where('n.parent_id > 0')
-					->where('n.published < ' . (int) $compareState);
+					->where($this->_db->qn('n.' . $this->getColumnAlias('published')) . ' < ' . (int) $compareState);
 
 				// Just fetch one row (one is one too many).
 				$this->_db->setQuery($query, 0, 1);
@@ -993,7 +993,7 @@ class JTableNested extends JTable
 			// Update and cascade the publishing state.
 			$query->clear()
 				->update($this->_db->quoteName($this->_tbl))
-				->set('published = ' . (int) $state)
+				->set($this->_db->qn($this->getColumnAlias('published')) . ' = ' . (int) $state)
 				->where('(lft > ' . (int) $node->lft . ' AND rgt < ' . (int) $node->rgt . ') OR ' . $k . ' = ' . (int) $pk);
 			$this->_db->setQuery($query)->execute();
 


### PR DESCRIPTION
## 1. Issue description

Joomla allows flexible columns for columns like `published`, `checked_out`, etc. You just have to define in your table a property like:

``` php
    /**
     * Array with alias for "special" columns such as ordering, hits etc etc
     *
     * @var    array
     */
    protected $_columnAlias = array(
        'published' => 'state'
    );
```

And Joomla will be able to publish & unpublish items using the `state` column. That works perfectly for tables that extend `JTable` but does not for tables that extend `JTableNested`.
## 2. Summary of Changes

This replaces the hardcoded `published` column with `$this->getColumnAlias('published')` which defaults to `published` if alias is not defined. So it should be 100% compatible.
## 3. Testing Instructions.
1. Apply the patch.
2. Go to `Content` > `Categories` and try to publish & unpublish some categories.
3. Ensure that no errors are shown.
4. Ensure that unpublishing a category with children also unpublishes child categories. 
5. Ensure that publishing a category with children also publishes child categories.
## 4. Documentation Changes Required

This is an improvement to make tables more flexible and has no implications on documentation.
