### PR TITLE
php7 fix: sqlsrv_fetch_object

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -971,7 +971,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
-		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
+		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes
### Testing Instructions
### Documentation Changes Required

Return "Fatal error: Class 'stdclass' not found" with php7
