### PR TITLE
Stop allowing failures on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ matrix:
         - redis-server
       env: INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" # Disabled items that currently do not work in travis-ci hhvm
   allow_failures:
-    - php: 7.1
     - php: hhvm
     - node_js: 6.1
 


### PR DESCRIPTION
### Summary of Changes

PHP 7.1 RC 5 released today, there is one last planned RC after this before stable.  Our tests are green and 7.1 will probably release before we have 3.7 out.  Let's enforce PHP 7.1 compatibility in the test suite.
### Testing Instructions

Review Travis
### Documentation Changes Required

N/A
