### PR TITLE
Fix JUri path in language filter plugin

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -338,6 +338,13 @@ class PlgSystemLanguageFilter extends JPlugin
 				if ($found)
 				{
 					array_shift($parts);
+
+					// Empty parts array when "index.php" is the only part left.
+					if (count($parts) == 1 && $parts[0] === 'index.php')
+					{
+						$parts = array();
+					}
+
 					$uri->setPath(implode('/', $parts));
 				}
 			}


### PR DESCRIPTION
Pull Request for Issue #12558.

Components may break in some case if accessed using an URL like `http://localhost/joomla/en/index.php?option=com_contact`. The reason is that due to some faulty routing the request parameters from the default menu item are added. This is likely at least a view parameter (eg "view=article"). Now since the original request didn't specify a view and expected the default view of the component to be executed. But that view parameter from the menu item now becomes active and since that view doesn't exist in the requested component it blows up in an error page.
### Summary of Changes

The language filter plugin removes the language tag from the JUri path during its `parseRule` method. This is needed so further processing of the routing doesn't work from a wrong menu path, for the homepage, this path should be empty.
Now with that specific request, the index.php ends up in the path, making it non-empty. The further routing parsing now wrongly assumes this is part of the SEF URL and comes to wrong conclusions in the end.

This PR empties the $parts array before setting it to the JUri->path if `index.php`  is the only part left in that array.
### Testing Instructions
1. Set up a multilingual site with the language filter plugin active
2. Enable SEF URLs and URL rewriting
3. Set up a default homepage for the active language pointing to a single article
4. Use link `http://localhost/joomla/en/?option=com_contact` (adjust to your testing site). This Link should work and give you the contacts categories view.
5. Use link `http://localhost/joomla/en/index.php?option=com_contact` (note the `index.php` part). This Link should not work and give you a "View not found [name, type, prefix]: article, html, contactView" error page.
6. Appy PR and try this link again, it should work now
7. Try other configurations and links, they all should still work as expected.
### Documentation Changes Required

None
