### PR TITLE
TOS incorrect to check for an article

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -282,8 +282,8 @@ class PlgUserProfile extends JPlugin
 		$tosarticle = $this->params->get('register_tos_article');
 		$tosenabled = $this->params->get('register-require_tos', 0);
 
-		// We need to be in the registration form and field needs to be enabled 
-		if ($name != 'com_users.registration' || !$tosenabled )
+		// We need to be in the registration form and field needs to be enabled
+		if ($name != 'com_users.registration' || !$tosenabled)
 		{
 			// We only want the TOS in the registration form
 			$form->removeField('tos', 'profile');

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -282,8 +282,8 @@ class PlgUserProfile extends JPlugin
 		$tosarticle = $this->params->get('register_tos_article');
 		$tosenabled = $this->params->get('register-require_tos', 0);
 
-		// We need to be in the registration form, field needs to be enabled and we need an article ID
-		if ($name != 'com_users.registration' || !$tosenabled || !$tosarticle)
+		// We need to be in the registration form and field needs to be enabled 
+		if ($name != 'com_users.registration' || !$tosenabled )
 		{
 			// We only want the TOS in the registration form
 			$form->removeField('tos', 'profile');


### PR DESCRIPTION
Pull Request for Issue #12573 .

### Summary of Changes
The User Profile plugin has an option to add a required field for Terms of Service (TOS) - However it is only working if you also select a TOS article

This PR should enable it to work even if you do NOT select an article


### Testing Instructions
Make sure you enable frontend registration
Enable the user profile plugin

#### Expected result
TOS field is displayed

#### Actual result
TOS field is not displayed

### Apply this PR 
TOS Field is displayed
Also check to ensure that if you select an TOS Article in the profile then the Label for the TOS is still a link


