### PR TITLE
Add Publish down to content sorting options

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -910,6 +910,8 @@
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
+				<option value="unpublished">JUNPUBLISHED</option>
+
 			</field>
 
 		<field name="show_pagination"

--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -173,6 +173,11 @@ class ContentHelperQuery
 				$queryDate = ' CASE WHEN a.publish_up = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_up END ';
 				break;
 
+			// Use created if publish_down is not set
+			case 'published' :
+				$queryDate = ' CASE WHEN a.publish_down = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_down END ';
+				break;
+
 			case 'created' :
 			default :
 				$queryDate = ' a.created ';

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -279,6 +279,7 @@
 					<option value="created">JGLOBAL_CREATED</option>
 					<option value="modified">JGLOBAL_MODIFIED</option>
 					<option value="published">JPUBLISHED</option>
+					<option value="published">JUNPUBLISHED</option>					
 				</field>
 
 				<field

--- a/components/com_content/views/category/tmpl/default.xml
+++ b/components/com_content/views/category/tmpl/default.xml
@@ -271,6 +271,7 @@
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
+				<option value="unpublished">JUNPUBLISHED</option>
 			</field>
 
 			<field name="show_pagination" type="list"

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -105,6 +105,7 @@
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
 				<option value="published">JPUBLISHED</option>
+				<option value="unpublished">JUNPUBLISHED</option>
 			</field>
 
 			<field name="show_pagination" type="list"

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -137,7 +137,7 @@ else
 	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
-	<div class="body">
+	<div class="body" id="top">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<!-- Header -->
 			<header class="header" role="banner">
@@ -203,7 +203,7 @@ else
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right">
-				<a href="#" id="back-top">
+				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
 				</a>
 			</p>


### PR DESCRIPTION
Pull Request for Issue #12483 .

### Summary of Changes
In the front end we can sort by date and chose to use either the created, modified or published dates. This PR add the unpublished date to that list.

This is for the category blog, category list and featured views and there is a new global option as well

### Testing Instructions
#### Part 1
Create a category with 3 featured articles - each with a different Stop Publishing date
Create a category blog, category list and featured menu item to display those articles
In the options for the menu item select
Article Order - Oldest First or Most recent first
Date for Ordering - Unpublished

You will see that the articles are now displayed in the order that they will be unpublished

#### Part 2
Go to the component options for the articles and in the Shared tab set the Date for Ordering to Unpublished
Go back to your three menu items and change the Date for Ordering to Use Global

You will see that the articles are still displayed in the order that they will be unpublished

