### PR TITLE
Fixing Contact urls for linked authors

### DIFF
--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -62,7 +62,7 @@ class PlgContentContact extends JPlugin
 
 		if ($contact)
 		{
-			require_once JPATH_ROOT . '/components/com_contact/helpers/route.php';
+			JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 			$row->contact_link = JRoute::_(ContactHelperRoute::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));
 		}
 		else

--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -57,15 +57,13 @@ class PlgContentContact extends JPlugin
 			return true;
 		}
 
-		$row->contactid = $this->getContactId($row->created_by);
+		$contact = $this->getContactId($row->created_by);
+		$row->contactid = $contact->contactid;
 
-		if ($row->contactid)
+		if ($contact)
 		{
-			$needle = 'index.php?option=com_contact&view=contact&id=' . $row->contactid;
-			$menu = JFactory::getApplication()->getMenu();
-			$item = $menu->getItems('link', $needle, true);
-			$link = $item ? $needle . '&Itemid=' . $item->id : $needle;
-			$row->contact_link = JRoute::_($link);
+			require_once JPATH_ROOT . '/components/com_contact/helpers/route.php';
+			$row->contact_link = JRoute::_(ContactHelperRoute::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));
 		}
 		else
 		{
@@ -93,7 +91,7 @@ class PlgContentContact extends JPlugin
 
 		$query = $this->db->getQuery(true);
 
-		$query->select('MAX(contact.id) AS contactid');
+		$query->select('MAX(contact.id) AS contactid, contact.alias, contact.catid');
 		$query->from($this->db->quoteName('#__contact_details', 'contact'));
 		$query->where('contact.published = 1');
 		$query->where('contact.user_id = ' . (int) $created_by);
@@ -107,7 +105,7 @@ class PlgContentContact extends JPlugin
 
 		$this->db->setQuery($query);
 
-		$contacts[$created_by] = $this->db->loadResult();
+		$contacts[$created_by] = $this->db->loadObject();
 
 		return $contacts[$created_by];
 	}

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -137,7 +137,7 @@ else
 	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
-	<div class="body">
+	<div class="body" id="top">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<!-- Header -->
 			<header class="header" role="banner">
@@ -203,7 +203,7 @@ else
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right">
-				<a href="#" id="back-top">
+				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
 				</a>
 			</p>


### PR DESCRIPTION
Pull Request for Issue #12603.
### Summary of Changes

Used the right method to generate that URL.
### Testing Instructions

Create a contact for the super user
Create some articles
Create a menu item to display one or multiple articles, do NOT make it the home page.
Create a menu item displaying the Contact category to which belongs the super user contact: alias is english-contacts in this case.
Do NOT create a menu item displaying the single contact.
Display the article in frontend.
Click on the Super User link in the article intro
See that the link is not correct.
Apply patch and see that the link is correct.
### Documentation Changes Required

none
