### PR TITLE
Change typehint for JControllerBase to be more permissive

### DIFF
--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractApplication;
+
 /**
  * Joomla Platform Base Controller Class
  *
@@ -19,7 +21,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * The application object.
 	 *
-	 * @var    JApplicationBase
+	 * @var    AbstractApplication
 	 * @since  12.1
 	 */
 	protected $app;
@@ -35,12 +37,12 @@ abstract class JControllerBase implements JController
 	/**
 	 * Instantiate the controller.
 	 *
-	 * @param   JInput            $input  The input object.
-	 * @param   JApplicationBase  $app    The application object.
+	 * @param   JInput               $input  The input object.
+	 * @param   AbstractApplication  $app    The application object.
 	 *
 	 * @since  12.1
 	 */
-	public function __construct(JInput $input = null, JApplicationBase $app = null)
+	public function __construct(JInput $input = null, AbstractApplication $app = null)
 	{
 		// Setup dependencies.
 		$this->app = isset($app) ? $app : $this->loadApplication();
@@ -50,7 +52,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * Get the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */
@@ -112,7 +114,7 @@ abstract class JControllerBase implements JController
 	/**
 	 * Load the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -32,7 +32,7 @@ interface JController extends Serializable
 	/**
 	 * Get the application object.
 	 *
-	 * @return  JApplicationBase  The application object.
+	 * @return  AbstractApplication  The application object.
 	 *
 	 * @since   12.1
 	 */
@@ -41,7 +41,7 @@ interface JController extends Serializable
 	/**
 	 * Get the input object.
 	 *
-	 * @return  \Joomla\Input\Input  The input object.
+	 * @return  JInput  The input object.
 	 *
 	 * @since   12.1
 	 */


### PR DESCRIPTION
### Summary of Changes

Changes the constructor typehint and doc blocks in `JController` and `JControllerBase` to permit `Joomla\Application\AbstractApplication` objects (from which `JApplicationBase` already extends.  This improves forward compatibility with 4.0.
### Testing Instructions

Code review
### Documentation Changes Required

N/A
