### PR TITLE
com_fields: allowing custom field Label to be translated by a string

### DIFF
--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -14,7 +14,7 @@ if (!key_exists('field', $displayData))
 }
 
 $field = $displayData['field'];
-$label = $field->label;
+$label = JText::_($field->label);
 $value = $field->value;
 $class = $field->params->get('render_class');
 
@@ -26,6 +26,6 @@ if (!$value)
 ?>
 
 <dd class="field-entry <?php echo $class; ?>" id="field-entry-<?php echo $field->id; ?>">
-	<span class="field-label"><?php echo htmlentities(JText::_($label)); ?>: </span>
+	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, "UTF-8"); ?>: </span>
 	<span class="field-value"><?php echo $value; ?></span>
 </dd>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -26,6 +26,6 @@ if (!$value)
 ?>
 
 <dd class="field-entry <?php echo $class; ?>" id="field-entry-<?php echo $field->id; ?>">
-	<span class="field-label"><?php echo htmlentities($label); ?>: </span>
+	<span class="field-label"><?php echo htmlentities(JText::_($label)); ?>: </span>
 	<span class="field-value"><?php echo $value; ?></span>
 </dd>


### PR DESCRIPTION
This patch allows the custom field label to be translated with a new string.
To test, enter a constant compatible in the Label field when you create your custom field.

`Note: YES, NO, TRUE, FALSE are reserved words in INI format.
; Double quotes in the values have to be formatted as "_QQ_"`

For example: JM_MYFIELD
Then add an override for the language in the Language Manager->Overrides
JM_MYFIELD="A nice demo field"
Display the field