### PR TITLE
Fix DSN seperator for postgresql

### DIFF
--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -133,12 +133,12 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 
 		if (!empty(self::$_options['host']))
 		{
-		        $dsn .= 'host=' . self::$_options['host'] . ' ';
+		        $dsn .= 'host=' . self::$_options['host'] . ';';
 		}
 
 		if (!empty(self::$_options['port']))
 		{
-		        $dsn .= 'port=' . self::$_options['port'] . ' ';
+		        $dsn .= 'port=' . self::$_options['port'] . ';';
 		}
 
 		$dsn .= 'dbname=' . self::$_options['database'];


### PR DESCRIPTION
Pull Request for Issue #12336 on staging.
Replaces closed issue #12341

### Summary of Changes
We use semicolons `;` everywhere else in database DSN test setups, we should here as well to be consistent.

Note: Although this change won't be needed whenever HHVM 3.16.0 (and hopefully 3.15.3 LTS) gets released in the next few weeks; We should be consistent in our use of DSN separators in all test setups unless there is a specific need to use a different syntax.

### Testing Instructions
Fixes the "PDOException: [112]: could not translate host name" issue in the HHVM postgresql tests, 

### Documentation Changes Required
none
