### PR TITLE
Remove useless empty rule

### DIFF
--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -375,12 +375,6 @@ fieldset.radio.btn-group {
 }
 /* Input Prepend Chosen Select Boxes */
 /* Common styling for Chosen Select Boxes with Input Prepend/Append */
-.input-prepend .chzn-container-single .chzn-single,
-.input-append .chzn-container-single .chzn-single {
-}
-.input-prepend .chzn-container-single .chzn-drop,
-.input-append .chzn-container-single .chzn-drop {
-}
 .input-prepend > .add-on,
 .input-append > .add-on {
 	vertical-align: top;


### PR DESCRIPTION
Pull Request to remove some useless empty {LESS} rules. They are a leftover from https://github.com/joomla/joomla-cms/pull/12442

### Summary of Changes
Removes the empty rules.

### Testing Instructions
Nothing to test as no CSS is changed (empty rules have no impact). Just review.

### Documentation Changes Required
None.