### PR TITLE
[Smart Search] Add peak memory usage to CLI indexer

### DIFF
--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -142,6 +142,7 @@ class FinderCli extends JApplicationCli
 
 		// Total reporting.
 		$this->out(JText::sprintf('FINDER_CLI_PROCESS_COMPLETE', round(microtime(true) - $this->time, 3)), true);
+		$this->out(JText::sprintf('FINDER_CLI_PEAK_MEMORY_USAGE', number_format(memory_get_peak_usage(true))));
 
 		// Print a blank line at the end.
 		$this->out();

--- a/language/en-GB/en-GB.finder_cli.ini
+++ b/language/en-GB/en-GB.finder_cli.ini
@@ -9,6 +9,7 @@ FINDER_CLI_FILTER_RESTORE_WARNING="Warning: Did not find taxonomy %s/%s in filte
 FINDER_CLI_INDEX_PURGE="Clear index"
 FINDER_CLI_INDEX_PURGE_FAILED="- index clear failed."
 FINDER_CLI_INDEX_PURGE_SUCCESS="- index clear successful"
+FINDER_CLI_PEAK_MEMORY_USAGE="Peak memory usage: %s bytes"
 FINDER_CLI_PROCESS_COMPLETE="Total Processing Time: %s seconds."
 FINDER_CLI_RESTORE_FILTER_COMPLETED="- number of filters restored: %s"
 FINDER_CLI_RESTORE_FILTERS="Restoring filters"


### PR DESCRIPTION
### Summary of Changes
Merely adds the peak memory usage to the output of the Smart Search CLI indexer.

### Testing Instructions
Run the CLI indexer and look for the new line in the output.  Here's an example:

```
Starting Indexer
Setting up Smart Search plugins
Setup 8 items in 0.154 seconds.
 * Processed batch 1 in 0.052 seconds.
Total Processing Time: 0.207 seconds.
Peak memory usage: 6,291,456 bytes
```

### Documentation Changes Required
None.
