### PR TITLE
[Smart Search] Log peak memory usage in web indexer

### DIFF
--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -186,6 +186,9 @@ class FinderControllerIndexer extends JControllerLegacy
 			// Swap the applications back.
 			$app = $admin;
 
+			// Log batch completion and memory high-water mark.
+			JLog::add('Batch completed, peak memory usage: ' . number_format(memory_get_peak_usage(true)) . ' bytes', JLog::INFO);
+
 			// Send the response.
 			$this->sendResponse($state);
 		}


### PR DESCRIPTION
Tried to add this to https://github.com/joomla/joomla-cms/pull/12679 but git doesn't like me today. :-(

### Summary of Changes
Merely adds a log entry at the end of each indexer batch which includes the peak memory usage.

### Testing Instructions
* Enable logging in Smart Search (it's in the Options, under the Index tab).
* Run the indexer
* Look at the log file (/administrator/logs/indexer.php) and note the additional entry.

Here's an example:

```
2016-11-01T09:53:29+00:00	INFO 127.0.0.1	-	Starting the indexer
2016-11-01T09:53:29+00:00	INFO 127.0.0.1	-	Starting the indexer batch process
2016-11-01T09:53:29+00:00	INFO 127.0.0.1	-	Batch completed, peak memory usage: 4,194,304 bytes
```

### Documentation Changes Required
None.

