### PR TITLE
[com_fields] Preventing associations display for Field Groups

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -18,17 +18,18 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app       = JFactory::getApplication();
-$user      = JFactory::getUser();
-$userId    = $user->get('id');
-$extension = $this->escape($this->state->get('filter.extension'));
-$listOrder = $this->escape($this->state->get('list.ordering'));
-$listDirn  = $this->escape($this->state->get('list.direction'));
-$saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$parts     = explode('.', $extension, 2);
-$component = $parts[0];
-$section   = null;
-$columns   = 7;
+$app            = JFactory::getApplication();
+$user           = JFactory::getUser();
+$userId         = $user->get('id');
+$extension      = $this->escape($this->state->get('filter.extension'));
+$listOrder      = $this->escape($this->state->get('list.ordering'));
+$listDirn       = $this->escape($this->state->get('list.direction'));
+$saveOrder      = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$parts          = explode('.', $extension, 2);
+$component      = $parts[0];
+$section        = null;
+$columns        = 7;
+$isCustomFields = false;
 
 if (count($parts) > 1)
 {
@@ -46,6 +47,7 @@ if (count($parts) > 1)
 	{
 		$component = 'com_fields';
 		$section = 'fields&context=' . str_replace('.fields', '', implode('.', $parts));
+		$isCustomFields = true;
 	}
 }
 
@@ -111,7 +113,7 @@ if ($saveOrder)
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
-						<?php if ($this->assoc) :
+						<?php if ($this->assoc && ! $isCustomFields) :
 							$columns++; ?>
 							<th width="5%" class="nowrap hidden-phone hidden-tablet">
 								<?php echo JHtml::_('searchtools.sort', 'COM_CATEGORY_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
@@ -253,7 +255,7 @@ if ($saveOrder)
 							<td class="small hidden-phone">
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
-							<?php if ($this->assoc) : ?>
+							<?php if ($this->assoc && ! $isCustomFields) : ?>
 								<td class="hidden-phone hidden-tablet">
 									<?php if ($item->association): ?>
 										<?php echo JHtml::_('CategoriesAdministrator.association', $item->id, $extension); ?>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -18,18 +18,17 @@ JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$app            = JFactory::getApplication();
-$user           = JFactory::getUser();
-$userId         = $user->get('id');
-$extension      = $this->escape($this->state->get('filter.extension'));
-$listOrder      = $this->escape($this->state->get('list.ordering'));
-$listDirn       = $this->escape($this->state->get('list.direction'));
-$saveOrder      = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$parts          = explode('.', $extension, 2);
-$component      = $parts[0];
-$section        = null;
-$columns        = 7;
-$isCustomFields = false;
+$app       = JFactory::getApplication();
+$user      = JFactory::getUser();
+$userId    = $user->get('id');
+$extension = $this->escape($this->state->get('filter.extension'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
+$parts     = explode('.', $extension, 2);
+$component = $parts[0];
+$section   = null;
+$columns   = 7;
 
 if (count($parts) > 1)
 {
@@ -45,9 +44,12 @@ if (count($parts) > 1)
 	// If the section ends with .fields, then the category belongs to com_fields
 	if (substr($section, -strlen('.fields')) === '.fields')
 	{
-		$component = 'com_fields';
-		$section = 'fields&context=' . str_replace('.fields', '', implode('.', $parts));
-		$isCustomFields = true;
+		$component   = 'com_fields';
+		$section     = 'fields&context=' . str_replace('.fields', '', implode('.', $parts));
+
+		// Custom fields have no associations
+		$this->assoc = false;
+		$columns     = 6;
 	}
 }
 
@@ -113,7 +115,7 @@ if ($saveOrder)
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
-						<?php if ($this->assoc && ! $isCustomFields) :
+						<?php if ($this->assoc) :
 							$columns++; ?>
 							<th width="5%" class="nowrap hidden-phone hidden-tablet">
 								<?php echo JHtml::_('searchtools.sort', 'COM_CATEGORY_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
@@ -255,7 +257,7 @@ if ($saveOrder)
 							<td class="small hidden-phone">
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
-							<?php if ($this->assoc && ! $isCustomFields) : ?>
+							<?php if ($this->assoc) : ?>
 								<td class="hidden-phone hidden-tablet">
 									<?php if ($item->association): ?>
 										<?php echo JHtml::_('CategoriesAdministrator.association', $item->id, $extension); ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -48,6 +48,15 @@ $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 $isModal = $input->get('layout') == 'modal' ? true : false;
 $layout  = $isModal ? 'modal' : 'edit';
 $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+
+// Custom fields have no associations
+$isCustomFields = false;
+$extension = $input->get('extension', '', 'CMD');
+
+if (substr($extension, -strlen('.fields')) === '.fields')
+{
+	$isCustomFields = true;
+}
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_categories&extension=' . $input->getCmd('extension', 'com_content') . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
@@ -82,7 +91,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php if ( ! $isModal && $assoc && $extensionassoc) : ?>
+		<?php if ( ! $isModal && $assoc && $extensionassoc && ! $isCustomFields) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -50,12 +50,11 @@ $layout  = $isModal ? 'modal' : 'edit';
 $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
 
 // Custom fields have no associations
-$isCustomFields = false;
 $extension = $input->get('extension', '', 'CMD');
 
 if (substr($extension, -strlen('.fields')) === '.fields')
 {
-	$isCustomFields = true;
+	$assoc = false;
 }
 ?>
 
@@ -91,7 +90,7 @@ if (substr($extension, -strlen('.fields')) === '.fields')
 		</div>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-		<?php if ( ! $isModal && $assoc && $extensionassoc && ! $isCustomFields) : ?>
+		<?php if ( ! $isModal && $assoc && $extensionassoc) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'associations', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>
 			<?php echo $this->loadTemplate('associations'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12659
Create a multingual site and enable associations in the language filter plugin.

This PR prevents display of the Association column for com_fields Field Groups manager.
It also prevents display of the Association tab when editing a Field Group.

After patch
![screen shot 2016-11-01 at 12 22 09](https://cloud.githubusercontent.com/assets/869724/19888257/ddaf632c-a02d-11e6-97b8-2f8e9a8b08cb.png)
![screen shot 2016-11-01 at 12 21 48](https://cloud.githubusercontent.com/assets/869724/19888258/ddb342d0-a02d-11e6-89b8-c450f100e625.png)

Not sure the language field is necessary for both, except for Ordering on a site with multiple languages

@laoneo
@alikon 
@andrepereiradasilva 
