### PR TITLE
add support for user.js to beez and protostar

### DIFF
--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -88,7 +88,7 @@ $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript
 // Check for a custom js file
 $userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
 
-if (file_exists($userJs && filesize($userJs) > 0)
+if (file_exists($userJs) && filesize($userJs) > 0)
 {
 	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
 }

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -85,6 +85,14 @@ $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/respond.src.js');
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js');
 
+// Check for a custom js file
+$userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
+
+if (file_exists($userJs && filesize($userJs) > 0)
+{
+	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
+}
+
 require __DIR__ . '/jsstrings.php';
 ?>
 <!DOCTYPE html>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -86,12 +86,7 @@ $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js');
 
 // Check for a custom js file
-$userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
-
-if (file_exists($userJs) && filesize($userJs) > 0)
-{
-	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
-}
+JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
 
 require __DIR__ . '/jsstrings.php';
 ?>

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -86,7 +86,7 @@ $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js');
 
 // Check for a custom js file
-JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'templates/' . $this->template . '/javascript/user.js', array('version' => 'auto'));
 
 require __DIR__ . '/jsstrings.php';
 ?>

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -89,7 +89,7 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 // Check for a custom js file
 $userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
 
-if (file_exists($userJs && filesize($userJs) > 0)
+if (file_exists($userJs) && filesize($userJs) > 0)
 {
 	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
 }

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -86,6 +86,14 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/user.css');
 }
 
+// Check for a custom js file
+$userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
+
+if (file_exists($userJs && filesize($userJs) > 0)
+{
+	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
+}
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -87,12 +87,7 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 }
 
 // Check for a custom js file
-$userJs = JPATH_SITE . '/templates/' . $this->template . '/js/user.js';
-
-if (file_exists($userJs) && filesize($userJs) > 0)
-{
-	$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/user.js');
-}
+JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -69,6 +69,9 @@ if (file_exists($userCss) && filesize($userCss) > 0)
 	$this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/user.css');
 }
 
+// Check for a custom js file
+JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 


### PR DESCRIPTION
Pull Request for Issue #12683 .

### Summary of Changes
We have support for user.css - this adds support or an equivalent js file

### Testing Instructions
Create a user.js file with some content in /templates/beez3/js
Create a user.js file with some content in /templates/protostar/js
and check that they are loaded

Remove the user.js files and check that the template is not trying to load them
