### PR TITLE
Fix double parameters creation for parameters of home template and of template override

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -482,13 +482,20 @@ final class JApplicationSite extends JApplicationCms
 
 			foreach ($templates as &$template)
 			{
-				$template->params = new Registry($template->params);
-
 				// Create home element
-				if ($template->home == 1 && !isset($templates[0]) || $this->_language_filter && $template->home == $tag)
+				if ($template->home == 1 && !isset($template_home) || $this->_language_filter && $template->home == $tag)
 				{
-					$templates[0] = clone $template;
+					$template_home = clone $template;
 				}
+
+				$template->params = new Registry($template->params);
+			}
+
+			// Add home element, after loop to avoid double execution
+			if (isset($template_home))
+			{
+				$template_home->params = new Registry($template_home->params);
+				$templates[0] = $template_home;
 			}
 
 			$cache->store($templates, 'templates0' . $tag);

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -523,9 +523,6 @@ final class JApplicationSite extends JApplicationCms
 					if ($tmpl->template == $template_override)
 					{
 						$template = $tmpl;
-
-						$template->params = new Registry($template->params);
-
 						break;
 					}
 				}


### PR DESCRIPTION
Pull Request for Issue #12651  

### Summary of Changes
The home template styles are cloned, inside the foreach loop (see the modified code) **and then added to the same array**: $templates

as $templates[0]

thus parameters creation for template home:  $templates[0]
will happen twice

### Testing Instructions
Styles are applied as configured

### Documentation Changes Required
none
