### PR TITLE
Use new features of JHtml::script and etc...

### DIFF
--- a/administrator/templates/hathor/component.php
+++ b/administrator/templates/hathor/component.php
@@ -28,6 +28,9 @@ JHtml::_('jquery.framework');
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Load system style CSS
 $this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
@@ -76,7 +79,7 @@ if ($this->params->get('boldText'))
 }
 
 // Load template javascript
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -93,7 +96,6 @@ else
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/administrator/templates/hathor/cpanel.php
+++ b/administrator/templates/hathor/cpanel.php
@@ -17,6 +17,9 @@ $lang  = JFactory::getLanguage();
 // Output as HTML5
 $this->setHtml5(true);
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
@@ -68,7 +71,7 @@ if ($this->params->get('boldText'))
 }
 
 // Load template javascript
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -87,7 +90,6 @@ else
 	<jdoc:include type="head" />
 	<!--[if IE 8]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie8.css" rel="stylesheet" /><![endif]-->
 	<!--[if IE 7]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7.css" rel="stylesheet" /><![endif]-->
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body id="minwidth" class="cpanel-page">
 <div id="containerwrap">

--- a/administrator/templates/hathor/index.php
+++ b/administrator/templates/hathor/index.php
@@ -23,6 +23,9 @@ JHtml::_('jquery.framework');
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Load system style CSS
 $this->addStyleSheetVersion($this->baseurl . '/templates/system/css/system.css');
 
@@ -71,7 +74,7 @@ if (file_exists($customCss) && filesize($customCss) > 0)
 }
 
 // Load template javascript
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -103,7 +106,6 @@ $this->addScriptDeclaration("
 	<jdoc:include type="head" />
 	<!--[if IE 8]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie8.css" rel="stylesheet" /><![endif]-->
 	<!--[if IE 7]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" /><![endif]-->
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body id="minwidth-body">
 <div id="containerwrap" data-basepath="<?php echo JURI::root(true); ?>">

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -27,6 +27,9 @@ JHtml::_('jquery.framework');
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Load system style CSS
 $this->addStyleSheet($this->baseurl . '/templates/system/css/system.css');
 
@@ -75,7 +78,7 @@ if ($this->params->get('boldText'))
 }
 
 // Load template javascript
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Logo file
 if ($this->params->get('logoFile'))
@@ -92,7 +95,6 @@ else
 <head>
 	<jdoc:include type="head" />
 	<!--[if IE 7]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo  $this->template; ?>/css/ie7.css" rel="stylesheet" /><![endif]-->
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body id="login-page">
 	<div id="containerwrap">

--- a/administrator/templates/isis/component.php
+++ b/administrator/templates/isis/component.php
@@ -20,7 +20,11 @@ $this->setHtml5(true);
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
+// Load template script
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
@@ -54,7 +58,6 @@ if ($this->params->get('linkColor'))
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane component">
 	<jdoc:include type="message" />

--- a/administrator/templates/isis/index.php
+++ b/administrator/templates/isis/index.php
@@ -27,7 +27,11 @@ $mainPageUri = $frontEndUri->toString();
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
+// Load template script
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
 
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
@@ -167,14 +171,14 @@ if ($this->params->get('linkColor'))
 		color: " . $this->params->get('linkColor') . ";
 	}");
 }
+
+$this->setMetaData('X-UA-Compatible', 'IE=edge', 'http-equiv')
+	->setMetaData('viewport', 'width=device-width, initial-scale=1.0');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ' task-' . $task . ' itemid-' . $itemid; ?>" data-basepath="<?php echo JURI::root(true); ?>">
 <!-- Top Navigation -->

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -29,6 +29,9 @@ $color_is_light = ($background_color && colorIsLight($background_color));
 JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template' . ($this->direction == 'rtl' ? '-rtl' : '') . '.css');
 
@@ -104,14 +107,15 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		display: none;
 	}");
 }
+
+$this->setMetaData('X-UA-Compatible', 'IE=edge', 'http-equiv')
+	->setMetaData('viewport', 'width=device-width, initial-scale=1.0');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="site <?php echo $option . " view-" . $view . " layout-" . $layout . " task-" . $task . " itemid-" . $itemid . " "; ?>">
 	<!-- Container -->

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -13,12 +13,15 @@ defined('_JEXEC') or die;
 
 // Output as HTML5
 $this->setHtml5(true);
+
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -22,6 +22,9 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
 JHtml::_('script', 'installation/template/js/installation.js');
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Add Stylesheets
 JHtml::_('bootstrap.loadCss', true, $this->direction);
 JHtml::_('stylesheet', 'installation/template/css/template.css');
@@ -50,7 +53,6 @@ $this->addScriptOptions('system.installation', array('url' => JRoute::_('index.p
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 	<head>
 		<jdoc:include type="head" />
-		<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	</head>
 	<body data-basepath="<?php echo JUri::root(true); ?>">
 		<!-- Header -->

--- a/templates/beez3/component.php
+++ b/templates/beez3/component.php
@@ -48,13 +48,16 @@ if ($this->direction == 'rtl')
 		$this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/' . htmlspecialchars($color, ENT_COMPAT, 'UTF-8') . '_rtl.css');
 	}
 }
+
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
 	<!--[if lte IE 6]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ieonly.css" rel="stylesheet" /><![endif]-->
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<div id="all">

--- a/templates/beez3/index.php
+++ b/templates/beez3/index.php
@@ -85,17 +85,20 @@ $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/respond.src.js');
 $this->addScript($this->baseurl . '/templates/' . $this->template . '/javascript/template.js');
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes')
+	->setMetaData('HandheldFriendly', 'true')
+	->setMetaData('apple-mobile-web-app-capable', 'YES');
+
 require __DIR__ . '/jsstrings.php';
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 	<head>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes"/>
-		<meta name="HandheldFriendly" content="true" />
-		<meta name="apple-mobile-web-app-capable" content="YES" />
 		<jdoc:include type="head" />
 		<!--[if IE 7]><link href="<?php echo $this->baseurl; ?>/templates/<?php echo $this->template; ?>/css/ie7only.css" rel="stylesheet" /><![endif]-->
-		<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 	</head>
 	<body id="shadow">
 		<div id="all">

--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -19,18 +19,21 @@ $this->setHtml5(true);
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 JHtmlBootstrap::loadCss($includeMaincss = false, $this->direction);
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1, maximum-scale=1');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane modal">
 	<jdoc:include type="message" />

--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -40,7 +40,10 @@ else
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
+
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
 
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
@@ -120,13 +123,13 @@ else
 {
 	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
 }
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1.0');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="site <?php echo $option
 	. ' view-' . $view

--- a/templates/protostar/offline.php
+++ b/templates/protostar/offline.php
@@ -22,7 +22,10 @@ $fullWidth = 1;
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
-$this->addScriptVersion($this->baseurl . '/templates/' . $this->template . '/js/template.js');
+JHtml::_('script', 'template.js', array('relative' => true, 'version' => 'auto'));
+
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
 
 // Add Stylesheets
 $this->addStyleSheetVersion($this->baseurl . '/templates/' . $this->template . '/css/template.css');
@@ -87,13 +90,13 @@ else
 {
 	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
 }
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1.0');
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="site">
 	<div class="outer">

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -14,6 +14,9 @@ defined('_JEXEC') or die;
 // Output as HTML5
 $this->setHtml5(true);
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
 // Styles
 $this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/general.css');
 ?>
@@ -21,7 +24,6 @@ $this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/ge
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body class="contentpane">
 	<jdoc:include type="message" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -29,14 +29,17 @@ $this->addStyleSheet($this->baseurl . '/templates/' . $this->template . '/css/ge
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
+// Load the polyfills for IE
+JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1.0');
+
 $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<jdoc:include type="head" />
-	<!--[if lt IE 9]><script src="<?php echo JUri::root(true); ?>/media/jui/js/html5.js"></script><![endif]-->
 </head>
 <body>
 	<jdoc:include type="message" />


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Use the new features of `JHtml::script` to set IE conditional scripts and versioned scripts. 
Also, set meta data on the document object rather than writing it directly in the template.
Basically this PR removes direct writing of some tags to the document head and lets the the head renderer take care of those things instead. 
This does not fix any known bug or make anything noticeably better to the end user but Joomla's included templates should serve as examples to template developers so I think it's a good idea for them to make use of features like this as much as possible.

### Testing Instructions
Compare the output html source in the head tag before and after applying this patch. A few tags may have moved around in some inconsequential manner and the uncompressed versions of some scripts may be used which weren't before (applies to debug mode only) but everything should still be there and continue to work exactly as before. 

### Documentation Changes Required
Nope
