### PR TITLE
[com_fields] Change key to name as for lists

### DIFF
--- a/libraries/joomla/form/parameters/checkboxes.xml
+++ b/libraries/joomla/form/parameters/checkboxes.xml
@@ -11,7 +11,7 @@
 			>
 				<fieldset hidden="true" name="list_templates_modal" repeat="true">
 					<field
-						name="key"
+						name="name"
 						label="JLIB_FORM_FIELD_PARAM_CHECKBOX_MULTIPLE_VALUES_KEY_LABEL"
 						size="30"
 						type="text"

--- a/libraries/joomla/form/parameters/radio.xml
+++ b/libraries/joomla/form/parameters/radio.xml
@@ -11,7 +11,7 @@
 			>
 				<fieldset hidden="true" name="list_templates_modal" repeat="true">
 					<field
-						name="key"
+						name="name"
 						label="JLIB_FORM_FIELD_PARAM_RADIO_MULTIPLE_VALUES_KEY_LABEL"
 						size="30"
 						type="text"


### PR DESCRIPTION
Pull Request for Issue #12673.

### Summary of Changes
Changes the key of the list options to the structure needed by the list.

### Testing Instructions
- Create a radio or checkbox field for Articles with some options.
- Create an article.
- Open the fields tab.

### Expected result
The checkboxes or radio button should be shown.
