### PR TITLE
[com_fields] Don't show associations and permissions tab for field groups

### DIFF
--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -90,7 +90,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<div class="hidden"><?php echo $this->loadTemplate('associations'); ?></div>
 		<?php endif; ?>
 
-		<?php if ($this->canDo->get('core.admin')) : ?>
+		<?php if ($this->canDo->get('core.admin') && $this->form->getField('rules')) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'rules', JText::_('COM_CATEGORIES_FIELDSET_RULES')); ?>
 			<?php echo $this->form->getInput('rules'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -302,6 +302,8 @@ class PlgSystemFields extends JPlugin
 			// Tags are not working on custom field groups because there is no entry
 			// in the content_types table
 			$form->removeField('tags');
+			$form->removeField('rules');
+			$form->removeGroup('associations');
 			return true;
 		}
 


### PR DESCRIPTION
Pull Request for Pull Request #12681.

### Summary of Changes
This PR removes the association and permission tab for field groups. All relevant code belongs to com_fields and com_categories is unaware about com_fields.

### Testing Instructions
- Setup Joomla in multilingual mode with additional languages.
- Create a field group.

### Expected result
Associations and permission tab is not shown.

