### PR TITLE
readme download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When ready, it can be moved to an online hosting account of your choice.
 
 Updates are free!
 ---------------------
-* Always use the [latest version](https://www.joomla.org/download.html).
+* Always use the [latest version](https://downloads.joomla.org).
 
 Where can you get support and help?
 ---------------------

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When ready, it can be moved to an online hosting account of your choice.
 
 Updates are free!
 ---------------------
-* Always use the [latest version](https://downloads.joomla.org).
+* Always use the [latest version](https://www.joomla.org/download.html).
 
 Where can you get support and help?
 ---------------------

--- a/README.txt
+++ b/README.txt
@@ -42,7 +42,7 @@
 	See the tutorial: https://docs.joomla.org/Installing_Joomla_locally
 
 9- Updates are free!
-	* Always use the latest version: https://www.joomla.org/download.html
+	* Always use the latest version: https://downloads.joomla.org
 
 10- Where can you get support and help?
 	* The Joomla! Documentation: https://docs.joomla.org/Main_Page

--- a/README.txt
+++ b/README.txt
@@ -1,13 +1,13 @@
 1- What is this?
 	* This is a Joomla! installation/upgrade package to version 3.x
 	* Joomla! Official site: https://www.joomla.org
-	* Joomla! 3.6 version history - https://docs.joomla.org/Joomla_3.6_version_history
+	* Joomla! 3.7 version history - https://docs.joomla.org/Joomla_3.7_version_history
 	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/master
 
 2- What is Joomla?
 	* Joomla! is a Content Management System (CMS) which enables you to build Web sites and powerful online applications.
-	* It's a free and OpenSource software, distributed under the GNU General Public License version 2 or later.
-	* This is a simple and powerful web server application and it requires a server with PHP and either MySQL, PostgreSQL, or SQL Server to run.
+	* It's a free and Open Source software, distributed under the GNU General Public License version 2 or later.
+	* This is a simple and powerful web server application and it requires a server with PHP and either MySQL, PostgreSQL or SQL Server to run.
 	You can find full technical requirements here: https://www.joomla.org/about-joomla/technical-requirements.html.
 
 3- Is Joomla! for you?
@@ -36,20 +36,20 @@
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://www.joomla.org/about-joomla/technical-requirements.html
-	* How do you install Joomla - hhttps://docs.joomla.org/J3.x:Installing_Joomla
+	* How do you install Joomla - https://docs.joomla.org/J3.x:Installing_Joomla
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Installing_Joomla_locally
 
 9- Updates are free!
-	* Always use the latest version: https://downloads.joomla.org
+	* Always use the latest version: https://www.joomla.org/download.html
 
 10- Where can you get support and help?
 	* The Joomla! Documentation: https://docs.joomla.org/Main_Page
 	* FAQ Frequently Asked Questions: https://docs.joomla.org/Category:FAQ
 	* Find the information you need: https://docs.joomla.org/Start_here
 	* Find help and other users: https://www.joomla.org/about-joomla/create-and-share.html
-	* Post questions at our forums: http://forum.joomla.org
+	* Post questions at our forums: https://forum.joomla.org
 	* Joomla! Resources Directory (JRD): http://resources.joomla.org/
 
 11- Do you already have a Joomla! site that's not built with Joomla! 3.x ?

--- a/README.txt
+++ b/README.txt
@@ -1,13 +1,13 @@
 1- What is this?
 	* This is a Joomla! installation/upgrade package to version 3.x
 	* Joomla! Official site: https://www.joomla.org
-	* Joomla! 3.7 version history - https://docs.joomla.org/Joomla_3.7_version_history
+	* Joomla! 3.6 version history - https://docs.joomla.org/Joomla_3.6_version_history
 	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/master
 
 2- What is Joomla?
 	* Joomla! is a Content Management System (CMS) which enables you to build Web sites and powerful online applications.
-	* It's a free and Open Source software, distributed under the GNU General Public License version 2 or later.
-	* This is a simple and powerful web server application and it requires a server with PHP and either MySQL, PostgreSQL or SQL Server to run.
+	* It's a free and OpenSource software, distributed under the GNU General Public License version 2 or later.
+	* This is a simple and powerful web server application and it requires a server with PHP and either MySQL, PostgreSQL, or SQL Server to run.
 	You can find full technical requirements here: https://www.joomla.org/about-joomla/technical-requirements.html.
 
 3- Is Joomla! for you?
@@ -36,20 +36,20 @@
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://www.joomla.org/about-joomla/technical-requirements.html
-	* How do you install Joomla - https://docs.joomla.org/J3.x:Installing_Joomla
+	* How do you install Joomla - hhttps://docs.joomla.org/J3.x:Installing_Joomla
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Installing_Joomla_locally
 
 9- Updates are free!
-	* Always use the latest version: https://www.joomla.org/download.html
+	* Always use the latest version: https://downloads.joomla.org
 
 10- Where can you get support and help?
 	* The Joomla! Documentation: https://docs.joomla.org/Main_Page
 	* FAQ Frequently Asked Questions: https://docs.joomla.org/Category:FAQ
 	* Find the information you need: https://docs.joomla.org/Start_here
 	* Find help and other users: https://www.joomla.org/about-joomla/create-and-share.html
-	* Post questions at our forums: https://forum.joomla.org
+	* Post questions at our forums: http://forum.joomla.org
 	* Joomla! Resources Directory (JRD): http://resources.joomla.org/
 
 11- Do you already have a Joomla! site that's not built with Joomla! 3.x ?


### PR DESCRIPTION
Now that downloads.joomla.org is live this corrects the link in the readme file to avoid a redirect