### PR TITLE
green for recommended setting

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -856,7 +856,7 @@
 		<field
 			name="offline"
 			type="radio"
-			class="btn-group btn-group-yesno"
+			class="btn-group btn-group-yesno btn-group-reversed"
 			default="0"
 			label="COM_CONFIG_FIELD_SITE_OFFLINE_LABEL"
 			description="COM_CONFIG_FIELD_SITE_OFFLINE_DESC"


### PR DESCRIPTION
Pull Request for Issue #12704 .

### Summary of Changes
This cosmetic PR reverses the colours for the Site offline option
Green should be for the recommended setting etc

The same could be applied to ALL other options but its beyond the scope of this PR and personally I would not consider until J4 which will have a new admin template and who knows maybe even a different approach to displaying options


###  After 

![image](https://cloud.githubusercontent.com/assets/1296369/19938022/5d24c53c-a11b-11e6-9197-06297ee7b049.png)