### PR TITLE
Media Version on installation (solves #12711)

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -465,15 +465,16 @@ final class InstallationApplicationWeb extends JApplicationCms
 		if ($document === null)
 		{
 			$lang = JFactory::getLanguage();
-
 			$type = $this->input->get('format', 'html', 'word');
+			$date = new JDate('now');
 
 			$attributes = array(
-				'charset' => 'utf-8',
-				'lineend' => 'unix',
-				'tab' => '  ',
-				'language' => $lang->getTag(),
-				'direction' => $lang->isRtl() ? 'rtl' : 'ltr',
+				'charset'      => 'utf-8',
+				'lineend'      => 'unix',
+				'tab'          => "\t",
+				'language'     => $lang->getTag(),
+				'direction'    => $lang->isRtl() ? 'rtl' : 'ltr',
+				'mediaversion' => md5($date->format('YmdHi')),
 			);
 
 			$document = JDocument::getInstance($type, $attributes);

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -25,7 +25,7 @@ JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
 JHtml::_('script', 'installation/template/js/installation.js', array('version' => 'auto'));
 
 // Add html5 shiv
-JHtml::_('script', 'jui/html5.js', array('relative' => true, 'conditional' => 'lt IE 9'));
+JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
 
 // Add Stylesheets
 JHtml::_('bootstrap.loadCss', true, $this->direction);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12711.

### Summary of Changes

Following @brianteeman idea this adds the current date (up to minute) as media version for installation.

### Testing Instructions

1. Code review
2. Go to `/installation/index.php?view=languages`, view page source and confirm media version DOES NOT EXISTS in js files
3. Apply patch
4. Go to `/installation/index.php?view=languages`, view page source and confirm media version EXISTS js files

### Documentation Changes Required

None