### PR TITLE
Add missing mediaversion to polyfill js files

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -1000,7 +1000,8 @@ abstract class JHtmlBehavior
 			}
 
 			// If include according to browser.
-			$scriptOptions = !is_null($conditionalBrowser) ? array('relative' => true, 'conditional' => $conditionalBrowser) : array('relative' => true);
+			$scriptOptions = array('version' => 'auto', 'relative' => true);
+			$scriptOptions = $conditionalBrowser !== null ? array_replace($scriptOptions, array('conditional' => $conditionalBrowser)) : $scriptOptions;
 
 			JHtml::_('script', 'system/polyfill.' . $polyfillType . '.js', $scriptOptions);
 


### PR DESCRIPTION
### Summary of Changes

This simple PR add media version to polyfll js files.

### Testing Instructions

Simple Test. Code review, or:
- Go to site homepage, view page source and confirm polyfill media version DOES NOT EXISTS in polyfill js files
```html
<!--[if lt IE 9]><script src="/media/system/js/polyfill.event.js"></script><![endif]-->
```
- Apply patch
- Go to site homepage, view page source and confirm media version EXISTS in polyfill js files
```html
<!--[if lt IE 9]><script src="/media/system/js/polyfill.event.js?923058328df38d83cc809d587c7c445a"></script><![endif]-->
```

### Documentation Changes Required

None.
