### PR TITLE
[com_fields]remove captcha from field types

### DIFF
--- a/administrator/components/com_fields/models/fields/type.php
+++ b/administrator/components/com_fields/models/fields/type.php
@@ -20,7 +20,7 @@ class JFormFieldType extends JFormAbstractlist
 {
 	public $type = 'Type';
 
-	public static $BLACKLIST = array('moduleposition', 'captcha');
+	public static $BLACKLIST = array('moduleposition');
 
 	/**
 	 * Method to attach a JForm object to the field.

--- a/administrator/components/com_fields/models/fields/type.php
+++ b/administrator/components/com_fields/models/fields/type.php
@@ -20,7 +20,7 @@ class JFormFieldType extends JFormAbstractlist
 {
 	public $type = 'Type';
 
-	public static $BLACKLIST = array('moduleposition');
+	public static $BLACKLIST = array('moduleposition', 'captcha');
 
 	/**
 	 * Method to attach a JForm object to the field.

--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  2.5
  */
-class JFormFieldCaptcha extends JFormField implements JFormDomfieldinterface
+class JFormFieldCaptcha extends JFormField
 {
 	/**
 	 * The field type.


### PR DESCRIPTION
As discussed here #12703 there is no point at all in having captcha as a custom field type. And even if you have it the way fields is coded it doesnt work as th display in admin and required fields do not work

this PR removes the captcha field type from the list of custom field types that can be created