### PR TITLE
Global 'Help Server' refresh button height fix

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8086,6 +8086,7 @@ th .tooltip-inner {
 	max-height: 100%;
 }
 #helpsite-refresh {
+	padding: 4px 12px;
 	vertical-align: top;
 }
 .alert-no-items {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8086,6 +8086,7 @@ th .tooltip-inner {
 	max-height: 100%;
 }
 #helpsite-refresh {
+	padding: 4px 12px;
 	vertical-align: top;
 }
 .alert-no-items {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1229,6 +1229,7 @@ th .tooltip-inner {
 }
 /* Help site refresh button*/
 #helpsite-refresh {
+	padding: 4px 12px;
 	vertical-align: top;
 }
 .alert-no-items {


### PR DESCRIPTION
Pull Request for Issue #12705 .

### Summary of Changes
Give 'refresh' button an equal height to the appending dropdown.

### Testing Instructions
Apply patch and navigate to Global Config -> System tab

![global-help](https://cloud.githubusercontent.com/assets/2803503/19960168/03634b9e-a1a3-11e6-9ebb-ffdea7bcc43b.jpg)

### Documentation Changes Required
None
