### PR TITLE
[com_fields] Use JComponentHelper::getParams() instead of JComponentHelper::getComponent('com_foo')->params

### DIFF
--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -39,7 +39,7 @@ class ContactHelper extends JHelperContent
 			$vName == 'categories'
 		);
 
-		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getComponent('com_contact')->params->get('custom_fields_enable', '1'))
+		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_contact')->get('custom_fields_enable', '1'))
 		{
 			JHtmlSidebar::addEntry(
 				JText::_('JGLOBAL_FIELDS'),

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -40,7 +40,7 @@ class ContentHelper extends JHelperContent
 			$vName == 'categories'
 		);
 
-		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getComponent('com_content')->params->get('custom_fields_enable', '1'))
+		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_content')->get('custom_fields_enable', '1'))
 		{
 			JHtmlSidebar::addEntry(
 					JText::_('JGLOBAL_FIELDS'),

--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -68,7 +68,7 @@ class UsersHelper
 			);
 		}
 
-		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getComponent('com_users')->params->get('custom_fields_enable', '1'))
+		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_users')->get('custom_fields_enable', '1'))
 		{
 			JHtmlSidebar::addEntry(
 				JText::_('JGLOBAL_FIELDS'),

--- a/administrator/modules/mod_menu/tmpl/default_enabled.php
+++ b/administrator/modules/mod_menu/tmpl/default_enabled.php
@@ -112,7 +112,7 @@ if ($user->authorise('core.manage', 'com_users'))
 		$menu->getParent();
 	}
 
-	if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getComponent('com_users')->params->get('custom_fields_enable', '1'))
+	if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_users')->get('custom_fields_enable', '1'))
 	{
 		$menu->addChild(
 				new JMenuNode(
@@ -245,7 +245,7 @@ if ($user->authorise('core.manage', 'com_content'))
 		$menu->getParent();
 	}
 
-	if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getComponent('com_content')->params->get('custom_fields_enable', '1'))
+	if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_content')->get('custom_fields_enable', '1'))
 	{
 		$menu->addChild(
 			new JMenuNode(


### PR DESCRIPTION
### Summary of Changes
This PR simplifies com_fields code a bit by changing the useage of `JComponentHelper::getComponent('com_foo')->params` to `JComponentHelper::getParams('com_foo')`

Just proper use of existing API

### Testing Instructions
Test that the com_fields links in the sidebar appear as expected.
Test that the backend menu items under "Content" for com_fields appear as expected.

### Documentation Changes Required
None
