### PR TITLE
[com_fields] Fix notices in contact view

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $label = $field->label;
 $value = $field->value;
-$class = $field->render_class;
+$class = $field->params->get('render_class');
 
 if (!$value)
 {

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -49,6 +49,9 @@ if (!$fields)
 	return;
 }
 
+// Check if we have mail context in first element
+$isMail = (reset($fields)->context == 'com_contact.mail');
+
 // Load some output definitions
 $container = 'dl';
 
@@ -64,7 +67,7 @@ if (key_exists('container-class', $displayData) && $displayData['container-class
 	$class = $displayData['container-class'];
 }
 
-if ($fields[0]->context != 'com_contact.mail')
+if (!$isMail)
 {
 	// Print the container tag
 	echo '<' . $container . ' class="fields-container ' . $class . '">';
@@ -82,7 +85,7 @@ foreach ($fields as $field)
 	echo FieldsHelper::render($context, 'field.render', array('field' => $field));
 }
 
-if ($fields[0]->context != 'com_contact.mail')
+if (!$isMail)
 {
 	// Close the container
 	echo '</' . $container . '>';


### PR DESCRIPTION
Pull Request for Issue #12728 

### Summary of Changes
* `render_class` is a param, not an object property.
* The `$fields` array doesn't always start with  the key `0`. This PR uses `reset` to get the first item.

### Testing Instructions
* Create multiple custom fields for contacts and set the "edit value" permissions so it is allowed by public. Set the fields to different positions (unter tab options -> automatic display)
* Edit a contact to add some value to those fields.
* View that contact in frontend.

Before PR you get multiple notices after PR they are gone.

### Documentation Changes Required
None