### PR TITLE
[4.0] Tweak default htaccess for better default use

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -8,11 +8,11 @@
 # READ THIS COMPLETELY IF YOU CHOOSE TO USE THIS FILE!
 #
 # The line 'Options +FollowSymLinks' may cause problems with some server configurations.
-# It is required for the use of mod_rewrite, but it may have already been set by your 
+# It is required for the use of mod_rewrite, but it may have already been set by your
 # server administrator in a way that disallows changing it in this .htaccess file.
-# If using it causes your site to produce an error, comment it out (add # to the 
-# beginning of the line), reload your site in your browser and test your sef urls. If 
-# they work, then it has been set by your server administrator and you do not need to 
+# If using it causes your site to produce an error, comment it out (add # to the
+# beginning of the line), reload your site in your browser and test your sef urls. If
+# they work, then it has been set by your server administrator and you do not need to
 # set it here.
 ##
 
@@ -23,56 +23,68 @@ IndexIgnore *
 Options +FollowSymlinks
 Options -Indexes
 
-## Mod_rewrite in use.
+## These directives are only enabled if the mod_rewrite module is enabled
+<IfModule mod_rewrite.c>
+	RewriteEngine On
 
-RewriteEngine On
+	## Begin - Rewrite rules to block out some common exploits.
+	# If you experience problems on your site then comment out the operations listed
+	# below by adding a # to the beginning of the line.
+	# This attempts to block the most common type of exploit `attempts` on Joomla!
+	#
+	# Block any script trying to base64_encode data within the URL.
+	RewriteCond %{QUERY_STRING} base64_encode[^(]*\([^)]*\) [OR]
+	# Block any script that includes a <script> tag in URL.
+	RewriteCond %{QUERY_STRING} (<|%3C)([^s]*s)+cript.*(>|%3E) [NC,OR]
+	# Block any script trying to set a PHP GLOBALS variable via URL.
+	RewriteCond %{QUERY_STRING} GLOBALS(=|\[|\%[0-9A-Z]{0,2}) [OR]
+	# Block any script trying to modify a _REQUEST variable via URL.
+	RewriteCond %{QUERY_STRING} _REQUEST(=|\[|\%[0-9A-Z]{0,2})
+	# Return 403 Forbidden header and show the content of the root home page
+	RewriteRule .* index.php [F]
+	#
+	## End - Rewrite rules to block out some common exploits.
 
-## Begin - Rewrite rules to block out some common exploits.
-# If you experience problems on your site then comment out the operations listed 
-# below by adding a # to the beginning of the line.
-# This attempts to block the most common type of exploit `attempts` on Joomla!
-#
-# Block any script trying to base64_encode data within the URL.
-RewriteCond %{QUERY_STRING} base64_encode[^(]*\([^)]*\) [OR]
-# Block any script that includes a <script> tag in URL.
-RewriteCond %{QUERY_STRING} (<|%3C)([^s]*s)+cript.*(>|%3E) [NC,OR]
-# Block any script trying to set a PHP GLOBALS variable via URL.
-RewriteCond %{QUERY_STRING} GLOBALS(=|\[|\%[0-9A-Z]{0,2}) [OR]
-# Block any script trying to modify a _REQUEST variable via URL.
-RewriteCond %{QUERY_STRING} _REQUEST(=|\[|\%[0-9A-Z]{0,2})
-# Return 403 Forbidden header and show the content of the root home page
-RewriteRule .* index.php [F]
-#
-## End - Rewrite rules to block out some common exploits.
+	## Begin - Custom redirects
+	#
+	# If you need to redirect some pages, or set a canonical non-www to
+	# www redirect (or vice versa), place that code here. Ensure those
+	# redirects use the correct RewriteRule syntax and the [R=301,L] flags.
+	#
+	## End - Custom redirects
 
-## Begin - Custom redirects
-#
-# If you need to redirect some pages, or set a canonical non-www to
-# www redirect (or vice versa), place that code here. Ensure those
-# redirects use the correct RewriteRule syntax and the [R=301,L] flags.
-#
-## End - Custom redirects
+	##
+	# Uncomment the following line if your webserver's URL
+	# is not directly related to physical file paths.
+	# Update Your Joomla! Directory (just / for root).
+	##
 
-##
-# Uncomment the following line if your webserver's URL
-# is not directly related to physical file paths.
-# Update Your Joomla! Directory (just / for root).
-##
+	# RewriteBase /
 
-# RewriteBase /
+	## Begin - Joomla! core SEF Section.
+	#
+	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+	#
+	# If the requested path and file is not /index.php and the request
+	# has not already been internally rewritten to the index.php script
+	RewriteCond %{REQUEST_URI} !^/index\.php
+	# and the requested path and file doesn't directly match a physical file
+	RewriteCond %{REQUEST_FILENAME} !-f
+	# and the requested path and file doesn't directly match a physical folder
+	RewriteCond %{REQUEST_FILENAME} !-d
+	# internally rewrite the request to the index.php script
+	RewriteRule .* index.php [L]
+	#
+	## End - Joomla! core SEF Section.
+</IfModule>
 
-## Begin - Joomla! core SEF Section.
-#
-RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-#
-# If the requested path and file is not /index.php and the request
-# has not already been internally rewritten to the index.php script
-RewriteCond %{REQUEST_URI} !^/index\.php
-# and the requested path and file doesn't directly match a physical file
-RewriteCond %{REQUEST_FILENAME} !-f
-# and the requested path and file doesn't directly match a physical folder
-RewriteCond %{REQUEST_FILENAME} !-d
-# internally rewrite the request to the index.php script
-RewriteRule .* index.php [L]
-#
-## End - Joomla! core SEF Section.
+## These directives are only enabled if the mod_rewrite module is disabled
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a temporary redirect of
+        # the start page to the front controller explicitly so that the website
+        # and the generated links can still be used.
+        RedirectMatch 302 ^/$ /index.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
+</IfModule>


### PR DESCRIPTION
### Summary of Changes

For 4.0, we should try to ship a "better" default `.htaccess` file (possibly to the point we could try to enable it by default coming out of our installer).  This tries to make a couple of improvements:

1) Enable the rewrite rules only if mod_rewrite is actually enabled
2) Try to handle cases where mod_rewrite isn't enabled, the site has SEF URLs, and a link is shared without the `index.php/` segment (this part comes out of the Symfony Standard default `.htaccess` file)

### Testing Instructions

This is mostly review.  But if you can get a server without mod_rewrite set up, you can try to test this.

### Documentation Changes Required

N/A