### PR TITLE
Use proper field name to show modified user

### DIFF
--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -144,7 +144,7 @@
 		/>
 
 		<field
-			name="modified_user_id"
+			name="modified_by"
 			type="user"
 			label="JGLOBAL_FIELD_MODIFIED_BY_LABEL"
 			class="readonly"


### PR DESCRIPTION
### Summary of Changes
Adjusting the field form xml to properly show the user which modified the field

### Testing Instructions
Change an existing field and check the "modified by" field.
Before PR this will be empty, even after multiple saves.
After PR this will be populated after first change of the field.

### Documentation Changes Required
None
