### PR TITLE
[libraries] Undesired Notices when publishing child category

### DIFF
--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -919,7 +919,7 @@ class JTableNested extends JTable
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', get_class($this), $pks, $state, $userId));
+				$e = new UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', get_class($this), $pks[0], $state, $userId));
 				$this->setError($e);
 
 				return false;
@@ -954,7 +954,7 @@ class JTableNested extends JTable
 				if ($this->_db->loadResult())
 				{
 					// TODO Convert to a conflict exception when available.
-					$e = new RuntimeException(sprintf('%s::publish(%s, %d, %d) checked-out conflict.', get_class($this), $pks, $state, $userId));
+					$e = new RuntimeException(sprintf('%s::publish(%s, %d, %d) checked-out conflict.', get_class($this), $pks[0], $state, $userId));
 
 					$this->setError($e);
 
@@ -982,7 +982,7 @@ class JTableNested extends JTable
 				if (!empty($rows))
 				{
 					$e = new UnexpectedValueException(
-						sprintf('%s::publish(%s, %d, %d) ancestors have lower state.', get_class($this), $pks, $state, $userId)
+						sprintf('%s::publish(%s, %d, %d) ancestors have lower state.', get_class($this), $pks[0], $state, $userId)
 					);
 					$this->setError($e);
 

--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -208,6 +208,7 @@ class JControllerAdmin extends JControllerLegacy
 			{
 				$model->publish($cid, $value);
 				$errors = $model->getErrors();
+				$ntext = null;
 
 				if ($value == 1)
 				{
@@ -234,7 +235,10 @@ class JControllerAdmin extends JControllerLegacy
 					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
 				}
 
-				$this->setMessage(JText::plural($ntext, count($cid)));
+				if ($ntext !== null)
+				{
+					$this->setMessage(JText::plural($ntext, count($cid)));
+				}
 			}
 			catch (Exception $e)
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12726

### Summary of Changes
Making sure not to include in a sprintf an array ($pks is an array, we need the id #)
Making sure the variable is defined

### Testing Instructions
Create a Category (for example in articles)
Create a sub category of the former one

Unpublish the parent category.
This will also unpublish the child.

Now try to publish the child category
You will, rightfully get an error:
```
Error
Failed publishing 1 category as at least one of its parents is unpublished or one of its children is checked out.
```
But, we also a get 2 Notices in the php logs
```
[02-Nov-2016 16:24:32 UTC] PHP Notice:  Array to string conversion in ROOT/libraries/joomla/table/nested.php on line 985
[02-Nov-2016 16:24:32 UTC] PHP Notice:  Undefined variable: ntext in ROOT/libraries/legacy/controller/admin.php on line 237
```
Patch and test again.


