### PR TITLE
Move fields label to first page of edit form

### DIFF
--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -86,11 +86,10 @@
 
 		<field
 			name="default_value"
-			type="textarea"
+			type="text"
 			filter="raw"
 			label="COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL"
 			description="COM_FIELDS_FIELD_DEFAULT_VALUE_DESC"
-			size="40"
 		/>
 	
 		<field
@@ -180,6 +179,15 @@
 		/>
 
 		<field
+			name="label"
+			type="text"
+			label="COM_FIELDS_FIELD_LABEL_LABEL"
+			description="COM_FIELDS_FIELD_LABEL_DESC"
+			size="40"
+			required="true"
+		/>
+
+		<field
 			name="description"
 			type="textarea"
 			label="JGLOBAL_DESCRIPTION"
@@ -217,16 +225,6 @@
 	</fieldset>
 	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
 		<fieldset name="basic">
-			<field
-				name="label"
-				type="text"
-				label="COM_FIELDS_FIELD_LABEL_LABEL"
-				description="COM_FIELDS_FIELD_LABEL_DESC"
-				class="input-xxlarge"
-				size="40"
-				required="true"
-			/>
-
 			<field
 				name="hint"
 				type="text"

--- a/administrator/components/com_fields/views/field/tmpl/edit.php
+++ b/administrator/components/com_fields/views/field/tmpl/edit.php
@@ -49,6 +49,8 @@ JFactory::getDocument()->addScriptDeclaration('
 		<div class="row-fluid">
 			<div class="span9">
 				<?php echo $this->form->renderField('type'); ?>
+				<?php echo $this->form->renderField('label'); ?>
+				<?php echo $this->form->renderField('description'); ?>
 				<?php echo $this->form->renderField('required'); ?>
 				<?php echo $this->form->renderField('default_value'); ?>
 
@@ -58,7 +60,6 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php endforeach; ?>
 				<?php endforeach; ?>
 
-				<?php echo $this->form->renderField('description'); ?>
 			</div>
 			<div class="span3">
 				<?php $this->set('fields',


### PR DESCRIPTION
Currently, when editing a field the description (tooltip) of the field is on the first tab and the label is on the third one. Imho they should be together and since the label is a required field it should be on the first tab.

### Summary of Changes
* Moving the label field to first tab right below the type field. This way the required fields are the first ones.
* Moving the description right below the label one so they are together.
* Changed the type of the default value field from `textarea` to `text`. I can't think of a usecase where the default value would span multiple rows and thus `text` should be sufficient always. Sidenote here: Does the `default_value` field really need a `raw` filter? That could potentially open a security issue if the input isn't filtered in another place.

This has the good sideeffect that the fieldparameters (those depending on the selected field type) aren't loaded between the common parameters `default_value` and `description`, they now appear at below all other parameters.

### Testing Instructions
Edit a custom field and check the moved parameters and that they still work as expected.

### Documentation Changes Required
None
