### PR TITLE
[Smart Search] Fix for tags issue #10122

### DIFF
--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -257,6 +257,9 @@ class PlgFinderTags extends FinderIndexerAdapter
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);
 
+		// Get content extras.
+		FinderIndexerHelper::getContentExtras($item);
+
 		// Index the item.
 		$this->indexer->index($item);
 	}
@@ -295,7 +298,6 @@ class PlgFinderTags extends FinderIndexerAdapter
 			->select('a.created_time AS start_date, a.created_user_id AS created_by')
 			->select('a.metakey, a.metadesc, a.metadata, a.language, a.access')
 			->select('a.modified_time AS modified, a.modified_user_id AS modified_by')
-			->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date')
 			->select('a.published AS state, a.access, a.created_time AS start_date, a.params');
 
 		// Handle the alias CASE WHEN portion of the query


### PR DESCRIPTION
Pull Request for Issue #10122 .

### Summary of Changes
Smart Search was not retrieving com_tags items in search results.  This turned out to be due to the publish_down date being set to the current date whenever a tag is saved.  Hence, Smart Search would not retrieve any com_tags items because it saw them as no longer published.

As far as I can tell, the publish_up and publish_down fields are not actually used in the com_tags component.  At least, they don't appear anywhere in the UI so there's no way to change them.  Not sure whether they should simply be removed from com_tags or implemented properly.  Anyway, this PR fixes the issue by simply ignoring those fields when constructing the search index.

I have also taken the opportunity of adding a call to FinderIndexerHelper::getContextExtras which will be required if anyone ever needs to extend the index for com_tags items.  I think the new com_fields makes use of it, for example.

### Testing Instructions
See #10122 which describes the problem with screenshots.

### Documentation Changes Required
None.
