### PR TITLE
New xtd-editors menu and contact display buttons only if correct permissions

### DIFF
--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -41,35 +41,42 @@ class PlgButtonContact extends JPlugin
 		 * jSelectContact creates the link tag, sends it to the editor,
 		 * and closes the select frame.
 		 */
-		$js = "
-		function jSelectContact(id, title, catid, object, link, lang)
+		$user  = JFactory::getUser();
+
+		if ($user->authorise('core.create', 'com_contact')
+				|| $user->authorise('core.edit', 'com_contact')
+				|| $user->authorise('core.edit.own', 'com_contact'))
 		{
-			var hreflang = '';
-			if (lang !== '')
+			$js = "
+			function jSelectContact(id, title, catid, object, link, lang)
 			{
-				var hreflang = ' hreflang = \"' + lang + '\"';
-			}
-			var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
-			jInsertEditorText(tag, '" . $name . "');
-			jModalClose();
-		}";
+				var hreflang = '';
+				if (lang !== '')
+				{
+					var hreflang = ' hreflang = \"' + lang + '\"';
+				}
+				var tag = '<a' + hreflang + ' href=\"' + link + '\">' + title + '</a>';
+				jInsertEditorText(tag, '" . $name . "');
+				jModalClose();
+			}";
 
-		JFactory::getDocument()->addScriptDeclaration($js);
+			JFactory::getDocument()->addScriptDeclaration($js);
 
-		/*
-		 * Use the built-in element view to select the contact.
-		 * Currently uses blank class.
-		 */
-		$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+			/*
+		 	* Use the built-in element view to select the contact.
+			 * Currently uses blank class.
+			 */
+			$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button = new JObject;
-		$button->modal   = true;
-		$button->class   = 'btn';
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
-		$button->name    = 'address';
-		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+			$button = new JObject;
+			$button->modal   = true;
+			$button->class   = 'btn';
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
+			$button->name    = 'address';
+			$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
-		return $button;
+			return $button;
+		}
 	}
 }

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -44,8 +44,8 @@ class PlgButtonContact extends JPlugin
 		$user  = JFactory::getUser();
 
 		if ($user->authorise('core.create', 'com_contact')
-				|| $user->authorise('core.edit', 'com_contact')
-				|| $user->authorise('core.edit.own', 'com_contact'))
+			|| $user->authorise('core.edit', 'com_contact')
+			|| $user->authorise('core.edit.own', 'com_contact'))
 		{
 			$js = "
 			function jSelectContact(id, title, catid, object, link, lang)

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -43,7 +43,7 @@ class PlgButtonMenu extends JPlugin
 		$user  = JFactory::getUser();
 
 		if ($user->authorise('core.create', 'com_menus')
-				|| $user->authorise('core.edit', 'com_menus'))
+			|| $user->authorise('core.edit', 'com_menus'))
 		{
 			$js = "
 			function jSelectMenuItem(id, title, tree, object, uri, language)

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -40,36 +40,42 @@ class PlgButtonMenu extends JPlugin
 		 * jSelectMenuItem creates the link tag, sends it to the editor,
 		 * and closes the select frame.
 		 */
-		$js = "
-		function jSelectMenuItem(id, title, tree, object, uri, language)
+		$user  = JFactory::getUser();
+
+		if ($user->authorise('core.create', 'com_menus')
+				|| $user->authorise('core.edit', 'com_menus'))
 		{
-			var thislang = '';
-			if (language !== '')
+			$js = "
+			function jSelectMenuItem(id, title, tree, object, uri, language)
 			{
-				var thislang = '&lang=';
-			}
-			var tag = '<a href=\"' + uri + thislang + language + '\">' + title + '</a>';
-			jInsertEditorText(tag, '" . $name . "');
-			jModalClose();
-		}";
+				var thislang = '';
+				if (language !== '')
+				{
+					var thislang = '&lang=';
+				}
+				var tag = '<a href=\"' + uri + thislang + language + '\">' + title + '</a>';
+				jInsertEditorText(tag, '" . $name . "');
+				jModalClose();
+			}";
 
-		$doc = JFactory::getDocument();
-		$doc->addScriptDeclaration($js);
+			$doc = JFactory::getDocument();
+			$doc->addScriptDeclaration($js);
 
-		/*
-		 * Use the built-in element view to select the menu item.
-		 * Currently uses blank class.
-		 */
-		$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
+			/*
+			 * Use the built-in element view to select the menu item.
+			 * Currently uses blank class.
+			 */
+			$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;' . JSession::getFormToken() . '=1';
 
-		$button          = new JObject;
-		$button->modal   = true;
-		$button->class   = 'btn';
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
-		$button->name    = 'share-alt';
-		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+			$button          = new JObject;
+			$button->modal   = true;
+			$button->class   = 'btn';
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
+			$button->name    = 'share-alt';
+			$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
 
-		return $button;
+			return $button;
+		}
 	}
 }


### PR DESCRIPTION
Patch similar to https://github.com/joomla/joomla-cms/pull/12353
Adds specific permissions to let display the new xtd-editors menu and contact buttons in the editor.

Note: It is known that these basic permissions should be improved. As they should be done for all xtd-editors, this should be for another PR, if we find a volunteer to do it.


