### PR TITLE
Fix error notice on front-end search

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -112,6 +112,7 @@ class PlgSearchContent extends JPlugin
 					$wheres2[] = 'LOWER(a.metakey) LIKE LOWER(' . $word . ')';
 					$wheres2[] = 'LOWER(a.metadesc) LIKE LOWER(' . $word . ')';
 					$wheres2[] = 'LOWER(fv.value) LIKE LOWER(' . $word . ')';
+					$wheres[]  = implode(' OR ', $wheres2);
 				}
 
 				$where = '(' . implode(($phrase == 'all' ? ') AND (' : ') OR ('), $wheres) . ')';


### PR DESCRIPTION
### Summary of Changes
With the merge of #11833 the search filter broke. See here:
https://github.com/joomla/joomla-cms/pull/11833/files#diff-b32bbae639a4113309650b03c2b09ba1L113

The line ```$wheres[]  = implode(' OR ', $wheres2);``` got removed by accident it looks. This PR adds this line back.

### Testing Instructions
1. Install Joomla with sample data
2. Go to the front-end and search for any word with the search box in the top right corner
3. You will see an error notice "An error has occured"
4. Apply patch
5. Re-run the search query and the error is gone.

### Documentation Changes Required
None
