### PR TITLE
database table #__extensions - Set enabled to 0 by default

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-04.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-04.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__extensions` MODIFY `enabled` DEFAULT '0';

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-04.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-04.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `#__extensions` MODIFY `enabled` DEFAULT '0';
+ALTER TABLE `#__extensions` CHANGE `enabled` `enabled` TINYINT(3) NOT NULL DEFAULT '0';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-04.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-04.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__extensions" ALTER COLUMN "enabled" SET DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-04.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-04.sql
@@ -1,0 +1,1 @@
+ALTER TABLE [#__extensions] ALTER COLUMN [enabled] DEFAULT 0;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -462,7 +462,7 @@ CREATE TABLE IF NOT EXISTS `#__extensions` (
   `element` varchar(100) NOT NULL,
   `folder` varchar(100) NOT NULL,
   `client_id` tinyint(3) NOT NULL,
-  `enabled` tinyint(3) NOT NULL DEFAULT 1,
+  `enabled` tinyint(3) NOT NULL DEFAULT 0,
   `access` int(10) unsigned NOT NULL DEFAULT 1,
   `protected` tinyint(3) NOT NULL DEFAULT 0,
   `manifest_cache` text NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -452,7 +452,7 @@ CREATE TABLE "#__extensions" (
   "element" varchar(100) NOT NULL,
   "folder" varchar(100) NOT NULL,
   "client_id" smallint NOT NULL,
-  "enabled" smallint DEFAULT 1 NOT NULL,
+  "enabled" smallint DEFAULT 0 NOT NULL,
   "access" bigint DEFAULT 1 NOT NULL,
   "protected" smallint DEFAULT 0 NOT NULL,
   "manifest_cache" text NOT NULL,

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -702,7 +702,7 @@ CREATE TABLE [#__extensions](
 	[element] [nvarchar](100) NOT NULL,
 	[folder] [nvarchar](100) NOT NULL,
 	[client_id] [smallint] NOT NULL,
-	[enabled] [smallint] NOT NULL DEFAULT 1,
+	[enabled] [smallint] NOT NULL DEFAULT 0,
 	[access] [int] NOT NULL DEFAULT 1,
 	[protected] [smallint] NOT NULL DEFAULT 0,
 	[manifest_cache] [nvarchar](max) NOT NULL,

--- a/tests/unit/schema/ddl.sql
+++ b/tests/unit/schema/ddl.sql
@@ -180,7 +180,7 @@ CREATE TABLE `jos_extensions` (
   `element` TEXT NOT NULL DEFAULT '',
   `folder` TEXT NOT NULL DEFAULT '',
   `client_id` INTEGER NOT NULL,
-  `enabled` INTEGER NOT NULL DEFAULT '1',
+  `enabled` INTEGER NOT NULL DEFAULT '0',
   `access` INTEGER NOT NULL DEFAULT '1',
   `protected` INTEGER NOT NULL DEFAULT '0',
   `manifest_cache` TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for Issue #12751

### Summary of Changes
This PR sets the default value for "enabled" in the database table "#__extensions" to 0.

### Testing Instructions

#### Before PR
Create a new front-end template with some example module positions:
/templates/example/templateDetails.xml
```
<?xml version="1.0" encoding="utf-8"?>
<extension version="3.6" type="template" client="site">
	<name>EXamPLe</name>
	<version>1.0</version>
	<creationDate>4 November 2016</creationDate>
	<author>Peter Martin</author>
	<positions>
		<position>aaa</position>
		<position>bbb</position>
		<position>ccc</position>
	</positions>
</extension>
```
In Joomla back-end: Extensions > Manage > Discover
**Do not install the template**. 

![discover](https://cloud.githubusercontent.com/assets/1217850/20007740/fcba2e74-a29d-11e6-87d9-286bc9ad7f12.png)

Go to Extensions > Modules > create /edit a module,
and notice that the Module Positions of the Template that is not installed, are available.

![modulemanager](https://cloud.githubusercontent.com/assets/1217850/20007741/fcbb77c0-a29d-11e6-99d5-9b7155643413.png)

#### After PR
Remove the Discovered but Uninstalled Template from the #__extensions table: 
![discover-database](https://cloud.githubusercontent.com/assets/1217850/20007739/fcb7ddae-a29d-11e6-9bbc-f8fb9a9722b0.png)

Install this PR and 
Extensions > Manage > Discover
**Do not install the template**. 

The **Module Positions** of the **Uninstalled Template** should **not be visible in the Module Manager**.

**Note:** If you **install the template via Discover** it should become enabled. 
Extensions > Manage > Discover > Install the template
and test if it's available in Extensions > Templates and/or 
check in the database in #__extensions if will the enabled field has been changed to 1.