### PR TITLE
fixed issue #12761. function total throws SQL exception in SQL Server

### DIFF
--- a/libraries/cms/helper/usergroups.php
+++ b/libraries/cms/helper/usergroups.php
@@ -197,7 +197,7 @@ final class JHelperUsergroups
 				->select('count(id)')
 				->from('#__usergroups');
 
-			$db->setQuery($query, 0, 1);
+			$db->setQuery($query);
 
 			$this->total = (int) $db->loadResult();
 		}


### PR DESCRIPTION
Pull Request for Issue #12761  .

### Summary of Changes
removed parameter values for "limit" and "offset" passed in "setQuery" in function "total"

### Testing Instructions
1. Go to "Menu->Mange"
2. Select a menu
3. Click "Edit" button

The editing interface should appear without SQL exception.
### Documentation Changes Required
N/A
