### PR TITLE
Fix updatenotificaltion plugin

### DIFF
--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -292,10 +292,9 @@ class PlgSystemUpdatenotification extends JPlugin
 
 		try
 		{
-			$assets = JTable::getInstance('Asset', 'JTable');
-			$rootId = $assets->getRootId();
-			$rules = JAccess::getAssetRules($rootId)->getData();
-			$rawGroups = $rules['core.admin'];
+			$rootId    = JTable::getInstance('Asset', 'JTable')->getRootId();
+			$rules     = JAccess::getAssetRules($rootId)->getData();
+			$rawGroups = $rules['core.admin']->getData();
 			$groups    = array();
 
 			if (empty($rawGroups))


### PR DESCRIPTION
Pull Request for Issue #12614 

### Summary of Changes

The method to get the super users have a problem in getting the super user groups

### Testing Instructions

place this code

```
$rootId = JTable::getInstance('Asset', 'JTable')->getRootId();
$rules = JAccess::getAssetRules($rootId)->getData();
$rawGroups = $rules['core.admin'];
$rawGroups_new = $rules['core.admin']->getData();
$rawGroups_old = $rules['core.admin'];

echo 'Old Result:<br>';
print_r($rawGroups_old);
echo '<br>New result:<br>';
print_r($rawGroups_new);
```

In the index.php of your template (you can use the template manager for that)

Result:
![image](https://cloud.githubusercontent.com/assets/2596554/20028832/3f60e184-a33c-11e6-98f1-033cf4c240f9.png)


### Documentation Changes Required

None it is a PHP Problem