### PR TITLE
Correct Feature Articles view footer colspan

### DIFF
--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -21,6 +21,7 @@ $listOrder = str_replace(' ' . $this->state->get('list.direction'), '', $this->s
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $canOrder  = $user->authorise('core.edit.state', 'com_content.article');
 $saveOrder = $listOrder == 'fp.ordering';
+$columns   = 10;
 
 if ($saveOrder)
 {
@@ -78,9 +79,11 @@ if ($saveOrder)
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 						</th>
 						<?php if ($this->vote) : ?>
+							<?php $columns++; ?>
 							<th width="1%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 							</th>
+							<?php $columns++; ?>
 							<th width="1%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 							</th>
@@ -92,7 +95,7 @@ if ($saveOrder)
 					</thead>
 					<tfoot>
 					<tr>
-						<td colspan="10">
+						<td colspan="<?php echo $columns; ?>">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

Feature Articles view footer as a wrong colspan when votes are enabled (default).
![image](https://cloud.githubusercontent.com/assets/9630530/20029729/5f4a169a-a34c-11e6-85a9-2755cbf67214.png)

### Testing Instructions

Very simple test (30 sec):

1. Apply patch
2. Go to Content -> Featured Articles and check the colspan and check is ok now

### Documentation Changes Required

None