### PR TITLE
[com_fields] add aliastag to the blacklist

### DIFF
--- a/administrator/components/com_fields/models/fields/type.php
+++ b/administrator/components/com_fields/models/fields/type.php
@@ -20,7 +20,7 @@ class JFormFieldType extends JFormAbstractlist
 {
 	public $type = 'Type';
 
-	public static $BLACKLIST = array('moduleposition');
+	public static $BLACKLIST = array('moduleposition','aliastag');
 
 	/**
 	 * Method to attach a JForm object to the field.

--- a/administrator/components/com_fields/models/fields/type.php
+++ b/administrator/components/com_fields/models/fields/type.php
@@ -20,7 +20,7 @@ class JFormFieldType extends JFormAbstractlist
 {
 	public $type = 'Type';
 
-	public static $BLACKLIST = array('moduleposition','aliastag');
+	public static $BLACKLIST = array('moduleposition', 'aliastag');
 
 	/**
 	 * Method to attach a JForm object to the field.


### PR DESCRIPTION
Pull Request for Issue #12778 .

The fieldtype aliastag should not be in the list of available fieldtypes in com_fields

To test create a new field and you will see the first fieldtype available is aliastag
Apply the PR
the fieldtype aliastag is not offered any more
also doublecheck that the other blacklisted fieldtype "moduleposition" is not presented