### PR TITLE
Solve warning in with JHtml::includeRelativeFiles (#12777)

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -370,7 +370,7 @@ abstract class JHtml
 					 * Detect if we received a file in the format name.min.ext
 					 * If so, strip the .min part out, otherwise append -uncompressed
 					 */
-					if (preg_match('#\.min$#', $strip))
+					if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
 					{
 						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
 					}
@@ -515,7 +515,7 @@ abstract class JHtml
 					 * Detect if we received a file in the format name.min.ext
 					 * If so, strip the .min part out, otherwise append -uncompressed
 					 */
-					if (preg_match('#\.min$#', $strip))
+					if (strlen($strip) > 4 && preg_match('#\.min$#', $strip))
 					{
 						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
 					}

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -370,11 +370,9 @@ abstract class JHtml
 					 * Detect if we received a file in the format name.min.ext
 					 * If so, strip the .min part out, otherwise append -uncompressed
 					 */
-					if (strrpos($strip, '.min', '-4'))
+					if (preg_match('#\.min$#', $strip))
 					{
-						$position = strrpos($strip, '.min', '-4');
-						$filename = str_replace('.min', '.', $strip, $position);
-						$files[]  = $filename . $ext;
+						$files[] = preg_replace('#\.min$#', '', $strip) . $ext;
 					}
 					else
 					{
@@ -517,11 +515,9 @@ abstract class JHtml
 					 * Detect if we received a file in the format name.min.ext
 					 * If so, strip the .min part out, otherwise append -uncompressed
 					 */
-					if (strrpos($strip, '.min', '-4'))
+					if (preg_match('#\.min$#', $strip))
 					{
-						$position = strrpos($strip, '.min', '-4');
-						$filename = str_replace('.min', '.', $strip, $position);
-						$files[]  = $filename . $ext;
+						$files[] = preg_replace('#\.min$#', '', $strip) . $ext;
 					}
 					else
 					{

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -372,7 +372,7 @@ abstract class JHtml
 					 */
 					if (preg_match('#\.min$#', $strip))
 					{
-						$files[] = preg_replace('#\.min$#', '', $strip) . $ext;
+						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
 					}
 					else
 					{
@@ -517,7 +517,7 @@ abstract class JHtml
 					 */
 					if (preg_match('#\.min$#', $strip))
 					{
-						$files[] = preg_replace('#\.min$#', '', $strip) . $ext;
+						$files[] = preg_replace('#\.min$#', '.', $strip) . $ext;
 					}
 					else
 					{


### PR DESCRIPTION
Pull Request for Issue #12777.

### Summary of Changes

Solves a warning that appear when you try to include a js/css file with less that 4 characters.

### Testing Instructions

- Enable debug and debug plugin
- Apply patch
- Add a simple css file in `/administrator/templates/isis/css/a.css`
- Add to isis index.php
```php
JHtml::_('stylesheet', 'a.css', array('relative' => true));
```
- Check no warning on isis
- Check also there is no warning in hathor cpanel (see https://github.com/joomla/joomla-cms/issues/12777)

### Documentation Changes Required

None
