### PR TITLE
Don't add media version if media version is empty (now for css)

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -142,7 +142,8 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$conditional = isset($attribs['options']) && isset($attribs['options']['conditional']) ? $attribs['options']['conditional'] : null;
 
 			// Check if script uses media version.
-			if (strpos($src, '?') === false && isset($attribs['options']) && isset($attribs['options']['version']) && $attribs['options']['version'])
+			if (isset($attribs['options']['version']) && $attribs['options']['version'] && strpos($src, '?') === false
+				&& ($mediaVersion || $attribs['options']['version'] !== 'auto'))
 			{
 				$src .= '?' . ($attribs['options']['version'] === 'auto' ? $mediaVersion : $attribs['options']['version']);
 			}


### PR DESCRIPTION
### Summary of Changes

Don't add media version to stylesheets (css) if media version is empty.

This is exactly equal to https://github.com/joomla/joomla-cms/pull/12716 (already merged), but now for stylesheets.

### Testing Instructions

Simple test. Code review or:

- Add this to isis index.php
```php
$this->SetMediaVersion(null);
```
- Load any admin page and check page source, you will notice the resulting html is, for instance, `<link href="/administrator/templates/isis/css/template.css?" rel="stylesheet" />` (note the question mark in the end)
- Apply patch
- Refresh the page and notice there is no question mark now.

### Documentation Changes Required

None.