### PR TITLE
Fix: JToolbarButtonPopup doesn't respect passed width and height

### DIFF
--- a/libraries/cms/toolbar/button/popup.php
+++ b/libraries/cms/toolbar/button/popup.php
@@ -70,10 +70,10 @@ class JToolbarButtonPopup extends JToolbarButton
 
 		// Build the options array for the modal
 		$params = array();
-		$params['title']  = $options['title'];
-		$params['url']    = $options['doTask'];
-		$params['height'] = $height;
-		$params['width']  = $width;
+		$params['title']      = $options['title'];
+		$params['url']        = $options['doTask'];
+		$params['bodyHeight'] = $height;
+		$params['modalWidth'] = $width;
 
 		if (isset($footer))
 		{


### PR DESCRIPTION
Pull Request for Issue #12747 

### Summary of Changes

The passed parameters should now be respected by the joomla.modal.main layout.

### Testing Instructions

```php
$bar = JToolbar::getInstance('toolbar');
$bar->appendButton('Popup', 'search', \JText::_('JGLOBAL_PREVIEW'), \JRoute::_($previewUrl), 800, 600);
```

### Documentation Changes Required

None.