### PR TITLE
Regression 3.7: menu item params loaded incorrectly

### DIFF
--- a/templates/protostar/index.php
+++ b/templates/protostar/index.php
@@ -137,7 +137,7 @@ else
 	echo ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
 	<!-- Body -->
-	<div class="body">
+	<div class="body" id="top">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<!-- Header -->
 			<header class="header" role="banner">
@@ -203,7 +203,7 @@ else
 			<hr />
 			<jdoc:include type="modules" name="footer" style="none" />
 			<p class="pull-right">
-				<a href="#" id="back-top">
+				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_PROTOSTAR_BACKTOTOP'); ?>
 				</a>
 			</p>


### PR DESCRIPTION
Pull Request for Issue #12787

### Summary of Changes
Issue is due to the change at root/libraries/cms/application/site.php line 355 from:
$temp = new Registry; $temp->loadString($menu->params);

to

$temp = new Registry($menu->params);

### Testing Instructions
Test the menu item params override no more taking effect in com_content, etc

### Documentation Changes Required

**Steps to reproduce the issue**

Use JApplicationSite getParams('com_mycomponent') method for a certain component in the frontend, having a valid routed menu item.

**Expected result**

All component params are merged with the specific menu item parameters in the same JRegistry object
If you have a menu item parameter 'myparam' and you call:
$registry = $this->app->getParams('com_mycomponent') ;

You always had:
$myParam = $registry->get('myparam');

**Actual result**

Menu item parameters are not merged as properties of the JRegistry object that can be obtained using the JRegistry 'get' method, but instead menu items parameters are all included in an array property named 'data'.
If you have a menu item parameter 'myparam' and you call:
$registry = $this->app->getParams('com_mycomponent') ;

You have:
$menuParameters = $registry->get('data');
$myParam = $menuParameters['myparam'];

**System information (as much as possible)**

Issue is due to the change at root/libraries/cms/application/site.php line 355 from:
$temp = new Registry; $temp->loadString($menu->params);

to

$temp = new Registry($menu->params);
