### PR TITLE
Fix for Undefined offset in Content History preview popup

### DIFF
--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -120,7 +120,11 @@ class ContenthistoryHelper
 					if (isset($expandedObjectArray[$name]))
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
-						$valueText = trim((string) $optionFieldArray[0]);
+                        if (is_array($optionFieldArray) && count($optionFieldArray)) {
+                            $valueText = trim((string)$optionFieldArray[0]);
+                        } else {
+                            $valueText = NULL;
+                        }
 						$values[(string) $field->attributes()->name] = JText::_($valueText);
 					}
 				}

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -121,14 +121,13 @@ class ContenthistoryHelper
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
 						
+						$valueText = null;
+						
 						if (is_array($optionFieldArray) && count($optionFieldArray))
-						{
+						{							
 							$valueText = trim((string) $optionFieldArray[0]);
 						}
-						else
-						{
-							$valueText = null;
-						}
+
 						$values[(string) $field->attributes()->name] = JText::_($valueText);
 					}
 				}

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -120,14 +120,15 @@ class ContenthistoryHelper
 					if (isset($expandedObjectArray[$name]))
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
-                        			if (is_array($optionFieldArray) && count($optionFieldArray))
+						
+						if (is_array($optionFieldArray) && count($optionFieldArray))
 						{
-                            				$valueText = trim((string) $optionFieldArray[0]);
-                        			} 
-						else 
+							$valueText = trim((string) $optionFieldArray[0]);
+						}
+						else
 						{
-                           				$valueText = null;
-                        			}
+							$valueText = null;
+						}
 						$values[(string) $field->attributes()->name] = JText::_($valueText);
 					}
 				}

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -120,11 +120,11 @@ class ContenthistoryHelper
 					if (isset($expandedObjectArray[$name]))
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
-                        if (is_array($optionFieldArray) && count($optionFieldArray)) {
-                            $valueText = trim((string)$optionFieldArray[0]);
-                        } else {
-                            $valueText = NULL;
-                        }
+                        			if (is_array($optionFieldArray) && count($optionFieldArray)) {
+                            				$valueText = trim((string)$optionFieldArray[0]);
+                        			} else {
+                           				$valueText = NULL;
+                        			}
 						$values[(string) $field->attributes()->name] = JText::_($valueText);
 					}
 				}

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -123,7 +123,9 @@ class ContenthistoryHelper
                         			if (is_array($optionFieldArray) && count($optionFieldArray))
 						{
                             				$valueText = trim((string) $optionFieldArray[0]);
-                        			} else {
+                        			} 
+						else 
+						{
                            				$valueText = null;
                         			}
 						$values[(string) $field->attributes()->name] = JText::_($valueText);

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -120,10 +120,11 @@ class ContenthistoryHelper
 					if (isset($expandedObjectArray[$name]))
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
-                        			if (is_array($optionFieldArray) && count($optionFieldArray)) {
-                            				$valueText = trim((string)$optionFieldArray[0]);
+                        			if (is_array($optionFieldArray) && count($optionFieldArray))
+						{
+                            				$valueText = trim((string) $optionFieldArray[0]);
                         			} else {
-                           				$valueText = NULL;
+                           				$valueText = null;
                         			}
 						$values[(string) $field->attributes()->name] = JText::_($valueText);
 					}

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -36,13 +36,13 @@ class ContenthistoryViewPreview extends JViewLegacy
 		
 		if (false === $this->item) 
 		{
-            		$language = JFactory::getLanguage();
-            		$language->load('com_content', JPATH_SITE, null, true);
-			
-            		JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
+			$language = JFactory::getLanguage();
+			$language->load('com_content', JPATH_SITE, null, true);
 
-            		return false;
-        	}
+			JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
+
+			return false;
+		}
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -33,6 +33,15 @@ class ContenthistoryViewPreview extends JViewLegacy
 	{
 		$this->state = $this->get('State');
 		$this->item = $this->get('Item');
+		
+		if (FALSE === $this->item) {
+            		$language = JFactory::getLanguage();
+            		$language->load('com_content', JPATH_SITE, NULL, TRUE);
+			
+            		JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
+
+            		return FALSE;
+        	}
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -34,13 +34,14 @@ class ContenthistoryViewPreview extends JViewLegacy
 		$this->state = $this->get('State');
 		$this->item = $this->get('Item');
 		
-		if (FALSE === $this->item) {
+		if (false === $this->item) 
+		{
             		$language = JFactory::getLanguage();
-            		$language->load('com_content', JPATH_SITE, NULL, TRUE);
+            		$language->load('com_content', JPATH_SITE, null, true);
 			
             		JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
 
-            		return FALSE;
+            		return false;
         	}
 
 		// Check for errors.

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -32,12 +32,11 @@ class ContenthistoryViewPreview extends JViewLegacy
 	public function display($tpl = null)
 	{
 		$this->state = $this->get('State');
-		$this->item = $this->get('Item');
+		$this->item  = $this->get('Item');
 		
 		if (false === $this->item) 
 		{
-			$language = JFactory::getLanguage();
-			$language->load('com_content', JPATH_SITE, null, true);
+			JFactory::getLanguage()->load('com_content', JPATH_SITE, null, true);
 
 			JError::raiseError(404, JText::_('COM_CONTENT_ERROR_ARTICLE_NOT_FOUND'));
 


### PR DESCRIPTION
Set error reporting to E_ALL (Like it should be for development)

Article Manager -> Edit Getting Started -> Versions -> Select a version -> popup url is like:

http://example.com/administrator/index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&b05a6963679e395c78f4b883e2c00b56=1&version_id=2 

repeated errors on page of 

`Notice: Undefined offset: 0 in example.com/administrator/components/com_contenthistory/helpers/contenthistory.php on line 123`

### Summary of Changes

Better checking of the array before attempting to access its members

### Testing Instructions

Do above - replicate Notices, apply patch, see they disappear... 

### Documentation Changes Required

None

### EDIT

So like a prat I committed my next fix to this branch too... so this PR now contains that too.

The problem that solves is that if you fake a non-existing version ID in the popup with a url like:

`http://127.0.0.1:8000/administrator/index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&b05a6963679e395c78f4b883e2c00b56=1&version_id=212312`

Then you get 
<img width="1076" alt="screen shot 2016-11-06 at 17 04 17" src="https://cloud.githubusercontent.com/assets/400092/20039826/157e56f0-a443-11e6-96d1-b8f6bd3b46c1.png">

This PR also fixes that now... 



