### PR TITLE
HTML5 allows block elements inside anchors, modify TinyMCE default behaviour for this

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -874,7 +874,8 @@ class PlgEditorTinymce extends JPlugin
 			default: /* Advanced mode*/
 				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
 					. "| outdent indent | undo redo | link unlink anchor code | hr table | subscript superscript | charmap";
-
+					
+				$scriptOptions['valid_children'] = '+a[div|p|h1|h2|h3|h4|h5|h6]';
 				$scriptOptions['valid_elements'] = $valid_elements;
 				$scriptOptions['extended_valid_elements'] = $elements;
 				$scriptOptions['invalid_elements'] = $invalid_elements;
@@ -889,6 +890,7 @@ class PlgEditorTinymce extends JPlugin
 				break;
 
 			case 2: /* Extended mode*/
+				$scriptOptions['valid_children'] = '+a[div|p|h1|h2|h3|h4|h5|h6]';
 				$scriptOptions['valid_elements'] = $valid_elements;
 				$scriptOptions['extended_valid_elements'] = $elements;
 				$scriptOptions['invalid_elements'] = $invalid_elements;


### PR DESCRIPTION
Pull Request for Issue #12784 

### Summary of Changes
Add a new script option for TinyMCE:
```php
$scriptOptions['valid_children'] = '+a[div|p|h1|h2|h3|h4|h5|h6]';
```

### Testing Instructions
TinyMCE try adding block elements: div or p or h1 inside a link
No code cleanup should happen

### Documentation Changes Required
None
