### PR TITLE
Regression J3.7: menu item params loaded incorrectly

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -351,7 +351,9 @@ final class JApplicationSite extends JApplicationCms
 				// Get show_page_heading from com_menu global settings
 				$params[$hash]->def('show_page_heading', $temp->get('show_page_heading'));
 
-				$params[$hash]->merge($menu->params);
+				$temp = new Registry;
+				$temp->loadString($menu->params);
+				$params[$hash]->merge($temp);
 				$title = $menu->title;
 			}
 			else


### PR DESCRIPTION
**Pull Request for Issue #12787**

**Summary of Changes**

Issue is due to the change at root/libraries/cms/application/site.php line 355 from:
$temp = new Registry; $temp->loadString($menu->params);

to

$temp = new Registry($menu->params);

**Testing Instructions**

Test the menu item params override no more taking effect in com_content, etc

**Documentation Changes Required**

**Steps to reproduce the issue**

Use JApplicationSite getParams('com_mycomponent') method for a certain component in the frontend, having a valid routed menu item.

**Expected result**

All component params are merged with the specific menu item parameters in the same JRegistry object
If you have a menu item parameter 'myparam' and you call:
$registry = $this->app->getParams('com_mycomponent') ;

You always had:
$myParam = $registry->get('myparam');

**Actual result**

Menu item parameters are not merged as properties of the JRegistry object that can be obtained using the JRegistry 'get' method, but instead menu items parameters are all included in an array property named 'data'.
If you have a menu item parameter 'myparam' and you call:
$registry = $this->app->getParams('com_mycomponent') ;

You have:
$menuParameters = $registry->get('data');
$myParam = $menuParameters['myparam'];

**System information (as much as possible)**

Issue is due to the change at root/libraries/cms/application/site.php line 355 from:
$temp = new Registry; $temp->loadString($menu->params);

to

$temp = new Registry($menu->params);

Currently menu item params are not applied in J3.7 at all. Just test creating for example a menu item for a single article view.