### PR TITLE
[ACL] [com_contact contacts view] Correct invalid check

### DIFF
--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -156,9 +156,9 @@ class ContactViewContacts extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', 'com_contacts')
-			&& $user->authorise('core.edit', 'com_contacts')
-			&& $user->authorise('core.edit.state', 'com_contacts'))
+		if ($user->authorise('core.create', 'com_contact')
+			&& $user->authorise('core.edit', 'com_contact')
+			&& $user->authorise('core.edit.state', 'com_contact'))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 


### PR DESCRIPTION
### Summary of Changes

In com_contact contacts view there is invalid ACL checks, checking for `com_contacts` component which des not exist. The name is `com_contact`, this PR corrects that.

### Testing Instructions

Mainly code review, but you can test if contacts view continues to work.

1. Apply patch
2. Contacts view still work.

### Documentation Changes Required

None.