### PR TITLE
[ACL] [com_categories categories view] Correct when display batch button

### DIFF
--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -146,7 +146,6 @@ class CategoriesViewCategories extends JViewLegacy
 		$section    = $this->state->get('filter.section');
 		$canDo      = JHelperContent::getActions($component, 'category', $categoryId);
 		$user       = JFactory::getUser();
-		$extension  = JFactory::getApplication()->input->get('extension', '', 'word');
 
 		// Get the toolbar object instance
 		$bar = JToolbar::getInstance('toolbar');
@@ -210,9 +209,9 @@ class CategoriesViewCategories extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', $extension)
-			&& $user->authorise('core.edit', $extension)
-			&& $user->authorise('core.edit.state', $extension))
+		if ($canDo->get('core.create')
+			&& $canDo->get('core.edit')
+			&& $canDo->get('core.edit.state'))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 


### PR DESCRIPTION
### Summary of Changes

The categories ACL for displaying the batch button is not correct. It's based on a extension var that is not correct, for instance in com_fields groups the asset name is `com_contentarticlefields` when it should be `com_content`.

### Testing Instructions

1. Code review.
2. Test if "Batch" button appears on com_content field groups when a user is not able to `core.create`.
3. Apply patch
4. Repeat step 2, no button now

### Documentation Changes Required

None.