### PR TITLE
delete old files from Joomla 3.2.3 version

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1176,6 +1176,11 @@ class JoomlaInstallerScript
 			'/libraries/joomla/registry/format/json.php',
 			'/libraries/joomla/registry/format/php.php',
 			'/libraries/joomla/registry/format/xml.php',
+			'/libraries/joomla/github/users.php',
+			'/media/system/js/validate-jquery-uncompressed.js',
+			'/templates/beez3/html/message.php',
+			'/libraries/fof/platform/joomla.php',
+			'/libraries/fof/readme.txt',
 			// Joomla 3.3.1
 			'/administrator/templates/isis/html/message.php',
 			// Joomla 3.3.6


### PR DESCRIPTION
Pull Request for Issue #12304 .

### Summary of Changes
delete old files in the update procedure

### Testing Instructions
install a new 3.2.3 version, update to 3.7.0 and some old files still here:
libraries/joomla/github/users.php
media/system/js/validate-jquery-uncompressed.js
templates/beez3/html/message.php
libraries/fof/platform/joomla.php
libraries/fof/readme.txt

### Documentation Changes Required
from an 3.2.3 installation, these file no longer exist in Joomla 3.7.0