### PR TITLE
[com_fields] Allow zero as value in fields

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -133,7 +133,7 @@ class FieldsHelper
 					$field->value = self::$fieldCache->getFieldValue($field->id, $field->context, $item->id);
 				}
 
-				if (! $field->value)
+				if ($field->value == '')
 				{
 					$field->value = $field->default_value;
 				}

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -191,7 +191,7 @@ class FieldsHelper
 	 */
 	public static function render($context, $layoutFile, $displayData)
 	{
-		$value = null;
+		$value = '';
 
 		/*
 		 * Because the layout refreshes the paths before the render function is
@@ -206,13 +206,13 @@ class FieldsHelper
 			$value = JLayoutHelper::render($layoutFile, $displayData, null, array('component' => $parts[0], 'client' => 0));
 		}
 
-		if (!$value)
+		if ($value == '')
 		{
 			// Trying to render the layout on Fields itself
 			$value = JLayoutHelper::render($layoutFile, $displayData, null, array('component' => 'com_fields','client' => 0));
 		}
 
-		if (!$value)
+		if ($value == '')
 		{
 			// Trying to render the layout of the plugins
 			foreach (JFolder::listFolderTree(JPATH_PLUGINS . '/fields', '.', 1) as $folder)

--- a/components/com_fields/layouts/field/prepare/base.php
+++ b/components/com_fields/layouts/field/prepare/base.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/checkboxes.php
+++ b/components/com_fields/layouts/field/prepare/checkboxes.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }
@@ -27,7 +27,7 @@ $options = JFormAbstractlist::getOptionsFromField($field);
 
 foreach ($options as $optionValue => $optionText)
 {
-	if (in_array($optionValue, $value))
+	if (in_array((string) $optionValue, $value))
 	{
 		$texts[] = JText::_($optionText);
 	}

--- a/components/com_fields/layouts/field/prepare/editor.php
+++ b/components/com_fields/layouts/field/prepare/editor.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/imagelist.php
+++ b/components/com_fields/layouts/field/prepare/imagelist.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/list.php
+++ b/components/com_fields/layouts/field/prepare/list.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }
@@ -27,7 +27,7 @@ $options = JFormAbstractlist::getOptionsFromField($field);
 
 foreach ($options as $optionValue => $optionText)
 {
-	if (in_array($optionValue, $value))
+	if (in_array((string) $optionValue, $value))
 	{
 		$texts[] = JText::_($optionText);
 	}

--- a/components/com_fields/layouts/field/prepare/media.php
+++ b/components/com_fields/layouts/field/prepare/media.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/radio.php
+++ b/components/com_fields/layouts/field/prepare/radio.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }
@@ -27,7 +27,7 @@ $options = JFormAbstractlist::getOptionsFromField($field);
 
 foreach ($options as $optionValue => $optionText)
 {
-	if (in_array($optionValue, $value))
+	if (in_array((string) $optionValue, $value))
 	{
 		$texts[] = JText::_($optionText);
 	}

--- a/components/com_fields/layouts/field/prepare/sql.php
+++ b/components/com_fields/layouts/field/prepare/sql.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/textarea.php
+++ b/components/com_fields/layouts/field/prepare/textarea.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/url.php
+++ b/components/com_fields/layouts/field/prepare/url.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/user.php
+++ b/components/com_fields/layouts/field/prepare/user.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/prepare/usergrouplist.php
+++ b/components/com_fields/layouts/field/prepare/usergrouplist.php
@@ -16,7 +16,7 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $value = $field->value;
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -18,7 +18,7 @@ $label = $field->label;
 $value = $field->value;
 $class = $field->params->get('render_class');
 
-if (!$value)
+if ($value == '')
 {
 	return;
 }

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -70,8 +70,8 @@ echo '<' . $container . ' class="fields-container ' . $class . '">';
 // Loop through the fields and print them
 foreach ($fields as $field)
 {
-	// If the value is empty dp nothing
-	if (!isset($field->value) || !$field->value)
+	// If the value is empty do nothing
+	if (!isset($field->value) || $field->value == '')
 	{
 		continue;
 	}


### PR DESCRIPTION
Pull Request for allowing `0` as value in com_fields fields.

### Summary of Changes
Changing the value checks from a generic boolean check to one that triggers on an empty string (or null).

### Testing Instructions
1. Create a custom field. If it's a list type with at least one option containing a 0 as value. Eg 
![yesno](https://cloud.githubusercontent.com/assets/1018684/20056175/2db18998-a4e5-11e6-90d7-d035f59757a8.PNG)
2. Select the 0 value (eg "No") in the item and save.
3. Check the item in frontend. Before PR the field will not be shown, after the PR the field will show with proper option.

Further testing:
Check with different options (eg no value entered), enable the "multiple" feature, set a default value.
Check with other formfields like text and enter a 0.

### Documentation Changes Required
None
