### PR TITLE
[com_fields] Remove an unused line.

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -567,7 +567,6 @@ class FieldsModelField extends JModelAdmin
 		if (!key_exists($key, $this->valueCache))
 		{
 			$this->valueCache[$key] = null;
-			$db = $this->_db;
 
 			$query = $this->getDbo()->getQuery(true);
 


### PR DESCRIPTION
Pull Request for removing an unused line in the code

### Summary of Changes
Removes `$db = $this->_db;`.
Since `$db` isn't used afterwards (actually nowhere in whole file) it can be safely deleted.

### Testing Instructions
Code review. Or make sure fields display with proper values in frontend.

### Documentation Changes Required
None
