### PR TITLE
JFormAbstractlist ignores 0 as option text

### DIFF
--- a/libraries/joomla/form/abstractlist.php
+++ b/libraries/joomla/form/abstractlist.php
@@ -118,7 +118,7 @@ abstract class JFormAbstractlist extends JFormField
 			}
 
 			$value = (string) $option['value'];
-			$text  = trim((string) $option) ? trim((string) $option) : $value;
+			$text  = trim((string) $option) != '' ? trim((string) $option) : $value;
 
 			$disabled = (string) $option['disabled'];
 			$disabled = ($disabled == 'true' || $disabled == 'disabled' || $disabled == '1');


### PR DESCRIPTION
Currently JFormAbstractlist (which means all list type formfields) ignores an option text set to 0. It will use the option value instead.

### Summary of Changes
Changing the boolean check to a check against an empty string

### Testing Instructions
Create or adjust an existing list formfield definition and add an option with any value but 0 as text to it. For example adjust the state field in the article.xml (https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/forms/article.xml#L31-L43) and add
````
<option value="text-0">0</option>
<option value="text-empty"></option>
````
to the options list. It should look like this then:
````
<field name="state" type="list" label="JSTATUS"
	description="JFIELD_PUBLISHED_DESC" class="chzn-color-state"
	filter="intval" size="1" default="1"
>
	<option value="1">
		JPUBLISHED</option>
	<option value="0">
		JUNPUBLISHED</option>
	<option value="2">
		JARCHIVED</option>
	<option value="-2">
		JTRASHED</option>
	<option value="text-0">0</option>
	<option value="text-empty"></option>
</field>
````
Check the field in the item form (in our example the article state).
Before PR you get two additional entries `text-0` and `text-empty`.
After PR you get two additional entries `0` and `text-empty`.

### Documentation Changes Required
None
