### PR TITLE
[ACL] [com_menus items view] Correct check when "All Menus" is selected

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -262,7 +262,7 @@ class MenusModelItems extends JModelList
 			->join('LEFT', '#__viewlevels AS ag ON ag.id = a.access');
 
 		// Join over the menu types.
-		$query->select($db->quoteName('mt.title', 'menutype_title'))
+		$query->select($db->quoteName(array('mt.id', 'mt.title'), array('menutype_id', 'menutype_title')))
 			->join('LEFT', $db->quoteName('#__menu_types', 'mt') . ' ON ' . $db->qn('mt.menutype') . ' = ' . $db->qn('a.menutype'));
 
 		// Join over the associations.
@@ -273,7 +273,7 @@ class MenusModelItems extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.title');
+				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.id, mt.title');
 		}
 
 		// Join over the extensions

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -24,7 +24,6 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 $ordering   = ($listOrder == 'a.lft');
 $canOrder   = $user->authorise('core.edit.state',	'com_menus');
 $saveOrder  = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
-$menuTypeId = (int) $this->state->get('menutypeid');
 $menuType   = (string) $app->getUserState('com_menus.items.menutype', '', 'string');
 
 if ($saveOrder && $menuType)
@@ -109,12 +108,13 @@ if ($menuType == '')
 
 				<tbody>
 				<?php
+				
 				foreach ($this->items as $i => $item) :
 					$orderkey   = array_search($item->id, $this->ordering[$item->parent_id]);
-					$canCreate  = $user->authorise('core.create',     'com_menus.menu.' . $menuTypeId);
-					$canEdit    = $user->authorise('core.edit',       'com_menus.menu.' . $menuTypeId);
+					$canCreate  = $user->authorise('core.create',     'com_menus.menu.' . $item->menutype_id);
+					$canEdit    = $user->authorise('core.edit',       'com_menus.menu.' . $item->menutype_id);
 					$canCheckin = $user->authorise('core.manage',     'com_checkin') || $item->checked_out == $user->get('id')|| $item->checked_out == 0;
-					$canChange  = $user->authorise('core.edit.state', 'com_menus.menu.' . $menuTypeId) && $canCheckin;
+					$canChange  = $user->authorise('core.edit.state', 'com_menus.menu.' . $item->menutype_id) && $canCheckin;
 
 					// Get the parents of item for sorting
 					if ($item->level > 1)


### PR DESCRIPTION
### Summary of Changes

The ACL check in com_menus items view, when all menus is selected, is wrong. It's getting the menutype id from the state (0 in this case) and not from the real menu type id of each of those menu items.
This PR corrects that.

### Testing Instructions

Mainly code review.
But you can test com_menus items view still works fine and ACL in when all menus is selected is now working fine.

### Documentation Changes Required

none.