### PR TITLE
[ACL] [com_templates style view] Correct invalid check

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -91,7 +91,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		echo JLayoutHelper::render('joomla.edit.params', $this);
 		?>
 
-		<?php if ($user->authorise('core.edit', 'com_menu') && $this->item->client_id == 0 && $this->canDo->get('core.edit.state')) : ?>
+		<?php if ($user->authorise('core.edit', 'com_menus') && $this->item->client_id == 0 && $this->canDo->get('core.edit.state')) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'assignment', JText::_('COM_TEMPLATES_MENUS_ASSIGNMENT')); ?>
 			<?php echo $this->loadTemplate('assignment'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>


### PR DESCRIPTION
### Summary of Changes

In com_templates style view there is invalid ACL checks, checking for `com_menu` component which does not exist. The name is `com_menus`, this PR corrects that.

### Testing Instructions

Mainly code review, but you can test if edit a template style view continues to work and com_menus ACL is now respected.

### Documentation Changes Required

None.