### PR TITLE
[ACL] [new category] Correct invalid core.edit.state check when creating a new category

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -271,9 +271,9 @@ class CategoriesModelCategory extends JModelAdmin
 			$data['extension'] = $extension;
 		}
 
-		$user = JFactory::getUser();
+		$categoryId = $jinput->get('id');
 
-		if (!$user->authorise('core.edit.state', $extension . '.category.' . $jinput->get('id')))
+		if ($categoryId && !JFactory::getUser()->authorise('core.edit.state', $extension . '.category.' . $categoryId))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('ordering', 'disabled', 'true');

--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -272,8 +272,10 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		$categoryId = $jinput->get('id');
+		$parts      = explode('.', $extension);
+		$assetKey   = $categoryId ? $extension . '.category.' . $categoryId : $parts[0];
 
-		if ($categoryId && !JFactory::getUser()->authorise('core.edit.state', $extension . '.category.' . $categoryId))
+		if (!JFactory::getUser()->authorise('core.edit.state', $assetKey))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('ordering', 'disabled', 'true');


### PR DESCRIPTION
### Summary of Changes

When creating a new category there is a check being made for ex: com_content.category.id, but since this is a new category, the id doesn't yet exist, so we should fallback to the category component asset in this case.

### Testing Instructions

- Code review
- Apply patch
- Check the published field when creating a new category, with or without `core.edit.state` permission in the component.

### Documentation Changes Required

None.
