### PR TITLE
Removing 3.6 from Contributing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,6 @@ There are other branches available which serve specific purposes.
 
 | Branch | Purpose |
 | ------ | ------- |
-| staging | Current codebase. |
+| staging | Current codebase. Branch for the next minor Joomla version. New backward compatible features go into this branch. |
 | master | Each commit made to staging gets tested if it passes unit tests and codestyle rules. It is then merged into master. This is done automatically. |
-| 3.6.x | Branch for the next minor Joomla version. New backward compatible features go into this branch. Commits to staging will be applied to this branch as well. |
 | 4.0-dev | Branch for the next major Joomla version. New backward incompatible features go into this branch. Commits to staging will be applied to this branch as well. |


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removed:
`| 3.6.x | Branch for the next minor Joomla version. New backward compatible features go into this branch. Commits to staging will be applied to this branch as well. |`

Removed the above note from the branches table since as specified in #12775 the 3.7 branch will be removed asap and the staging branch now is used for the 3.7 minor.
### Testing Instructions
None 
### Documentation Changes Required
None
