### PR TITLE
Solve php notices in usergroups edit view

### DIFF
--- a/administrator/components/com_users/models/fields/groupparent.php
+++ b/administrator/components/com_users/models/fields/groupparent.php
@@ -35,21 +35,20 @@ class JFormFieldGroupParent extends JFormAbstractlist
 	{
 		$options = JHelperUsergroups::getInstance()->getAll();
 
-		$user = JFactory::getUser();
-
 		// Prevent parenting to children of this item.
 		if ($id = $this->form->getValue('id'))
 		{
 			unset($options[$id]);
 		}
 
-		$options = array_values($options);
+		$options      = array_values($options);
+		$isSuperAdmin = JFactory::getUser()->authorise('core.admin');
 
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
 			// Show groups only if user is super admin or group is not super admin
-			if ($user->authorise('core.admin') || (!JAccess::checkGroup($options[$i]->value, 'core.admin')))
+			if ($isSuperAdmin || !JAccess::checkGroup($options[$i]->id, 'core.admin'))
 			{
 				$options[$i]->value = $options[$i]->id;
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->title;
@@ -61,8 +60,6 @@ class JFormFieldGroupParent extends JFormAbstractlist
 		}
 
 		// Merge any additional options in the XML definition.
-		$options = array_merge(parent::getOptions(), $options);
-
-		return $options;
+		return array_merge(parent::getOptions(), $options);
 	}
 }


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

There are several notices in com_users usergroup edit view.
```
Notice: Undefined property: stdClass::$value in /path/to/joomla-staging/administrator/components/com_users/models/fields/groupparent.php on line 52
```

This PR solves them

### Testing Instructions

1. Latest staging
2. Create a user with Administrator group
3. Login with that user
4. Go to Usergroups and edit Manager Group
5. You will get several php notices
6. Apply path
7. Repeat steps and check all is fine now

### Documentation Changes Required

None.