### PR TITLE
[ACL] [com_menus item edit view] Correct check on new with "All Menu Items" selected

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -123,16 +123,10 @@ class MenusModelItem extends JModelAdmin
 	 */
 	protected function canEditState($record)
 	{
-		$user = JFactory::getUser();
+		$menuTypeId = !empty($record->menutype) ? $this->getMenuTypeId($record->menutype) : 0;
+		$assetKey   = $menuTypeId ? 'com_menus.menu.' . (int) $menuTypeId : 'com_menus';
 
-		$menuTypeId = 0;
-
-		if (!empty($record->menutype))
-		{
-			$menuTypeId = $this->getMenuTypeId($record->menutype);
-		}
-
-		return $user->authorise('core.edit.state', 'com_menus.menu.' . (int) $menuTypeId);
+		return JFactory::getUser()->authorise('core.edit.state', $assetKey);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

When we create a menu item without selecting a menu first, ie, we are in "All Menus Item" view and press New to create a new menu item, the core.edit.state ACL check is not correct because we don't have a menutype id.

So this PR makes it use com_menus asset in this case.

### Testing Instructions

Mainly code review. But you can also:

1. Use latest staging and apply patch
2. Create a user in Administrator group
3. Go to com_menus permissions and disable core.edit.state for Administrator 
4. Login with Administrator user
5. Go to "All Menu items" view
6. Click New for creating a new menu item and check the published field is disabled

### Documentation Changes Required

None.