### PR TITLE
[ACL] [com_fields fields view] Correct when display batch button

### DIFF
--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -196,9 +196,9 @@ if ($saveOrder)
 				</tbody>
 			</table>
 			<?php //Load the batch processing form. ?>
-			<?php if ($user->authorise('core.create', $context)
-				&& $user->authorise('core.edit', $context)
-				&& $user->authorise('core.edit.state', $context)) : ?>
+			<?php if ($user->authorise('core.create', $this->component)
+				&& $user->authorise('core.edit', $this->component)
+				&& $user->authorise('core.edit.state', $this->component)) : ?>
 				<?php echo JHtml::_(
 						'bootstrap.renderModal',
 						'collapseModal',

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -152,8 +152,7 @@ class FieldsViewFields extends JViewLegacy
 		}
 
 		// Add a batch button
-		if ($user->authorise('core.create', $this->context) && $user->authorise('core.edit', $this->context)
-			&& $user->authorise('core.edit.state', $this->context))
+		if ($canDo->get('core.create') && $canDo->get('core.edit') && $canDo->get('core.edit.state'))
 		{
 			$title = JText::_('JTOOLBAR_BATCH');
 


### PR DESCRIPTION
### Summary of Changes

This is basicly the same problem as https://github.com/joomla/joomla-cms/pull/12800.

The fields ACL for displaying the batch button is not correct. It's based on a context var. 
As it is, it's trying to check ACL for an asset with the name of `com_content.article` (or `com_users.user` or `com_contact.contact`) when it should be checking the ACL of the component `com_content` (or `com_users` or `com_contact`).

This PR aims to correct that.

### Testing Instructions

1. Code review.
2. Test if "Batch" button appears on com_fields fields (ex: Content -> Fields) when a user is not able to `core.create` in the component.
3. Apply patch
4. Repeat step 2, no button now

### Documentation Changes Required

None.