### PR TITLE
[ACL] [new field] Correct invalid core.edit.state check when creating a new field

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -409,7 +409,11 @@ class FieldsModelField extends JModelAdmin
 			$this->loadTypeForms($form, $data['type'], $component);
 		}
 
-		if (!JFactory::getUser()->authorise('core.edit.state', $context . '.field.' . $jinput->get('id')))
+		$fieldId    = $jinput->get('id');
+		$parts      = explode('.', $context);
+		$assetKey   = $fieldId ? $context . '.field.' . $fieldId : $parts[0];
+
+		if (!JFactory::getUser()->authorise('core.edit.state', $assetKey))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('ordering', 'disabled', 'true');


### PR DESCRIPTION
### Summary of Changes

This is basicly the same issue as https://github.com/joomla/joomla-cms/pull/12820 but for field.

When creating a new field there is a check being made for ex: com_content.article.field.id, but since this is a new field, the id doesn't yet exist, so we should fallback to the field component asset in this case.

### Testing Instructions

- Code review
- Apply patch
- Check the published field when creating a new field, with or without `core.edit.state` permission in the component.

### Documentation Changes Required

None.
