### PR TITLE
[RFC] Another way to fast reorder table with single SQL query

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -54,7 +54,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 * @var    string
 	 * @since  12.1
 	 */
-	protected static $dbMinimum = '8.3.18';
+	protected static $dbMinimum = '8.4.2';
 
 	/**
 	 * Operator used for concatenation

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -56,6 +56,57 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	}
 
 	/**
+	 * Connects to the database if needed.
+	 *
+	 * @return  void  Returns void if the database connected successfully.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function connect()
+	{
+		if ($this->connection)
+		{
+			return;
+		}
+
+		parent::connect();
+
+		$this->connection->sqliteCreateFunction(
+			'ROW_NUMBER',
+			function($init = null)
+			{
+				static $rownum, $partition;
+
+				if ($init !== null)
+				{
+					$rownum = $init;
+					$partition = null;
+
+					return $rownum;
+				}
+
+				$args = func_get_args();
+				array_shift($args);
+
+				$partitionBy = $args ? implode(',', $args) : null;
+
+				if ($partitionBy === null || $partitionBy === $partition)
+				{
+					$rownum++;
+				}
+				else
+				{
+					$rownum    = 1;
+					$partition = $partitionBy;
+				}
+
+				return $rownum;
+			}
+		);
+	}
+
+	/**
 	 * Disconnects the database.
 	 *
 	 * @return  void

--- a/libraries/joomla/database/query.php
+++ b/libraries/joomla/database/query.php
@@ -157,6 +157,12 @@ abstract class JDatabaseQuery
 	protected $unionAll = null;
 
 	/**
+	 * @var    array  Details of window function.
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $selectRowNumber = null;
+
+	/**
 	 * Magic method to provide method alias support for quote() and quoteName().
 	 *
 	 * @param   string  $method  The called method.
@@ -241,24 +247,27 @@ abstract class JDatabaseQuery
 					$query .= (string) $this->where;
 				}
 
-				if ($this->group)
+				if ($this->selectRowNumber === null)
 				{
-					$query .= (string) $this->group;
-				}
+					if ($this->group)
+					{
+						$query .= (string) $this->group;
+					}
 
-				if ($this->having)
-				{
-					$query .= (string) $this->having;
-				}
+					if ($this->having)
+					{
+						$query .= (string) $this->having;
+					}
 
-				if ($this->union)
-				{
-					$query .= (string) $this->union;
-				}
+					if ($this->union)
+					{
+						$query .= (string) $this->union;
+					}
 
-				if ($this->unionAll)
-				{
-					$query .= (string) $this->unionAll;
+					if ($this->unionAll)
+					{
+						$query .= (string) $this->unionAll;
+					}
 				}
 
 				if ($this->order)
@@ -468,6 +477,7 @@ abstract class JDatabaseQuery
 			case 'select':
 				$this->select = null;
 				$this->type = null;
+				$this->selectRowNumber = null;
 				break;
 
 			case 'delete':
@@ -552,6 +562,7 @@ abstract class JDatabaseQuery
 			default:
 				$this->type = null;
 				$this->select = null;
+				$this->selectRowNumber = null;
 				$this->delete = null;
 				$this->update = null;
 				$this->insert = null;
@@ -1816,5 +1827,87 @@ abstract class JDatabaseQuery
 	public function findInSet($value, $set)
 	{
 		return "";
+	}
+
+	/**
+	 * Validate arguments which are passed to selectRowNumber method and set up common variables.
+	 *
+	 * @param   string  $orderBy               An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias      An alias for new ordering column.
+	 * @param   string  $partitionBy           An expression of grouping for window function.
+	 * @param   string  $partitionColumnAlias  An alias for calculated grouping column.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	protected function validateRowNumber($orderBy, $orderColumnAlias, $partitionBy = null, $partitionColumnAlias = null)
+	{
+		if ($this->selectRowNumber)
+		{
+			throw new RuntimeException("Method 'selectRowNumber' can be called only once per instance.");
+		}
+
+		// Required by sqlite
+		if ($partitionBy !== null && $partitionColumnAlias !== null)
+		{
+			if (strpos($partitionBy, ',') !== false)
+			{
+				$this->select($this->concatenate(explode(',', $partitionBy), ',') . ' AS ' . $partitionColumnAlias);
+			}
+			else
+			{
+				$this->select($partitionBy . ' AS ' . $partitionColumnAlias);
+			}
+
+		}
+		else
+		{
+			$this->type = 'select';
+		}
+
+		$this->selectRowNumber = array(
+			'orderBy' => $orderBy,
+			'orderColumnAlias' => $orderColumnAlias,
+			'partitionBy' => $partitionBy,
+			'partitionColumnAlias' => $partitionColumnAlias,
+		);
+	}
+
+	/**
+	 * Return the number of the current row, support for partition, starting from 1
+	 *
+	 * Usage:
+	 * $query->select('id');
+	 * $query->selectRowNumber('ordering,publish_up DESC', 'new_ordering');
+	 * $query->from('#__content');
+	 *
+	 * @param   string  $orderBy               An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias      An alias for new ordering column.
+	 * @param   string  $partitionBy           An expression of grouping for window function.
+	 * @param   string  $partitionColumnAlias  An alias for calculated grouping column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function selectRowNumber($orderBy, $orderColumnAlias, $partitionBy = null, $partitionColumnAlias = null)
+	{
+		$this->validateRowNumber($orderBy, $orderColumnAlias, $partitionBy, $partitionColumnAlias);
+
+		$column = "ROW_NUMBER() OVER (";
+
+		if ($partitionBy !== null)
+		{
+			$column .= "PARTITION BY $partitionBy ";
+		}
+
+		$column .= "ORDER BY $orderBy) AS $orderColumnAlias";
+
+		$this->select($column);
+
+		return $this;
 	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -83,6 +83,16 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 					$query .= (string) $this->where;
 				}
 
+				if ($this->selectRowNumber)
+				{
+					if ($this->order)
+					{
+						$query .= (string) $this->order;
+					}
+
+					break;
+				}
+
 				if ($this->group)
 				{
 					$query .= (string) $this->group;
@@ -123,23 +133,36 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 
 				if ($this->join)
 				{
-					$onWord = ' ON ';
+					$tmpFrom     = $this->from;
+					$tmpWhere    = $this->where ? clone $this->where : null;
+					$this->from  = null;
 
 					// Workaround for special case of JOIN with UPDATE
 					foreach ($this->join as $join)
 					{
 						$joinElem = $join->getElements();
 
-						$joinArray = explode($onWord, $joinElem[0]);
+						$joinArray = preg_split('/\sON\s/i', $joinElem[0], 2);
 
 						$this->from($joinArray[0]);
-						$this->where($joinArray[1]);
+
+						if (isset($joinArray[1]))
+						{
+							$this->where($joinArray[1]);
+						}
 					}
 
 					$query .= (string) $this->from;
-				}
 
-				if ($this->where)
+					if ($this->where)
+					{
+						$query .= (string) $this->where;
+					}
+
+					$this->from  = $tmpFrom;
+					$this->where = $tmpWhere;
+				}
+				elseif ($this->where)
 				{
 					$query .= (string) $this->where;
 				}

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -273,4 +273,125 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	{
 		return 'CURRENT_TIMESTAMP';
 	}
+
+	/**
+	 * Magic function to convert the query to a string.
+	 *
+	 * @return  string  The completed query.
+	 *
+	 * @since   11.1
+	 */
+	public function __toString()
+	{
+		switch ($this->type)
+		{
+			case 'select':
+				if ($this->selectRowNumber)
+				{
+					$orderBy              = $this->selectRowNumber['orderBy'];
+					$orderColumnAlias     = $this->selectRowNumber['orderColumnAlias'];
+					$partitionBy          = $this->selectRowNumber['partitionBy'];
+					$partitionColumnAlias = $this->selectRowNumber['partitionColumnAlias'];
+
+					if ($partitionBy !== null && $partitionColumnAlias !== null)
+					{
+						$orderBy = $partitionColumnAlias . ',' . $orderBy;
+						$column  = "ROW_NUMBER(NULL,$partitionColumnAlias) AS $orderColumnAlias";
+					}
+					else
+					{
+						$column = "ROW_NUMBER() AS $orderColumnAlias";
+					}
+
+					if ($this->select === null)
+					{
+						$query = PHP_EOL . "SELECT 1"
+							. PHP_EOL . (string) $this->from . ','
+							. PHP_EOL . "( SELECT ROW_NUMBER(0) ) AS r"
+							. PHP_EOL . (string) $this->where
+							. PHP_EOL . "ORDER BY $orderBy";
+					}
+					else
+					{
+						$tmpOrder    = $this->order;
+						$this->order = null;
+						$query       = parent::__toString() . PHP_EOL . "ORDER BY $orderBy";
+						$column      = "w.*, $column";
+						$this->order = $tmpOrder;
+					}
+
+					// Special sqlite query to count ROW_NUMBER
+					$query = PHP_EOL . "SELECT $column"
+						. PHP_EOL . "FROM ( $query ) AS w,"
+						. PHP_EOL . "( SELECT ROW_NUMBER(0) ) AS r"
+						// Forbid to flatten subqueries.
+						. ((string) $this->order ?: PHP_EOL . 'ORDER BY NULL');
+
+					return $this->processLimit($query, $this->limit, $this->offset);
+				}
+
+				break;
+
+			case 'update':
+				if ($this->join)
+				{
+					$table = $this->update->getElements();
+					$table = $table[0];
+
+					if ($this->columns === null)
+					{
+						$fields = $this->db->getTableColumns($table);
+
+						foreach ($fields as $key => $value)
+						{
+							$fields[$key] = $key;
+						}
+
+						$this->columns = new JDatabaseQueryElement('()', $fields);
+					}
+
+					$fields   = $this->columns->getElements();
+					$elements = $this->set->getElements();
+
+					foreach ($elements as $nameValue)
+					{
+						$setArray = explode(' = ', $nameValue, 2);
+						$fields[$setArray[0]] = $setArray[1];
+					}
+
+					$select = new JDatabaseQuerySqlite($this->db);
+					$select->select(array_values($fields))
+						->from($table);
+
+					$select->join  = $this->join;
+					$select->where = $this->where;
+
+					return 'INSERT OR REPLACE INTO ' . $table
+						. ' (' . implode(',', array_keys($fields)) . ')'
+						. (string) $select;
+				}
+		}
+
+		return parent::__toString();
+	}
+
+	/**
+	 * Return the number of the current row, support for partition, starting from 1
+	 *
+	 * @param   string  $orderBy               An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias      An alias for new ordering column.
+	 * @param   string  $partitionBy           An expression of grouping for window function.
+	 * @param   string  $partitionColumnAlias  An alias for calculated grouping column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function selectRowNumber($orderBy, $orderColumnAlias, $partitionBy = null, $partitionColumnAlias = null)
+	{
+		$this->validateRowNumber($orderBy, $orderColumnAlias, $partitionBy, $partitionColumnAlias);
+
+		return $this;
+	}
 }

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -356,6 +356,13 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 					foreach ($elements as $nameValue)
 					{
 						$setArray = explode(' = ', $nameValue, 2);
+
+						if ($setArray[0][0] === '`')
+						{
+							// Unquote column name
+							$setArray[0] = substr($setArray[0], 1, -1);
+						}
+
 						$fields[$setArray[0]] = $setArray[1];
 					}
 

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -79,19 +79,22 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 					$query .= (string) $this->where;
 				}
 
-				if ($this->group)
+				if ($this->selectRowNumber === null)
 				{
-					$query .= (string) $this->group;
+					if ($this->group)
+					{
+						$query .= (string) $this->group;
+					}
+
+					if ($this->having)
+					{
+						$query .= (string) $this->having;
+					}
 				}
 
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
-				}
-
-				if ($this->having)
-				{
-					$query .= (string) $this->having;
 				}
 
 				if ($this instanceof JDatabaseQueryLimitable && ($this->limit > 0 || $this->offset > 0))
@@ -162,18 +165,38 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				break;
 
 			case 'update':
-				$query .= (string) $this->update;
-
 				if ($this->join)
 				{
+					$tmpUpdate    = $this->update;
+					$tmpFrom      = $this->from;
+					$this->update = null;
+					$this->from   = null;
+
+					$updateElem  = $tmpUpdate->getElements();
+					$updateArray = explode(' ', $updateElem[0]);
+
+					// Use table alias if exists
+					$this->update(end($updateArray));
+					$this->from($updateElem[0]);
+
+					$query .= (string) $this->update;
+					$query .= (string) $this->set;
+					$query .= (string) $this->from;
+
+					$this->update = $tmpUpdate;
+					$this->from   = $tmpFrom;
+
 					// Special case for joins
 					foreach ($this->join as $join)
 					{
 						$query .= (string) $join;
 					}
 				}
-
-				$query .= (string) $this->set;
+				else
+				{
+					$query .= (string) $this->update;
+					$query .= (string) $this->set;
+				}
 
 				if ($this->where)
 				{

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1360,41 +1360,37 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		$quotedOrderingField = $this->_db->quoteName($orderingField);
 
-		// Get the primary keys and ordering values for the selection.
-		$query = $this->_db->getQuery(true)
-			->select(implode(',', $this->_tbl_keys) . ', ' . $quotedOrderingField)
+		$subquery = $this->_db->getQuery(true)
 			->from($this->_tbl)
-			->where($quotedOrderingField . ' >= 0')
-			->order($quotedOrderingField);
+			->selectRowNumber($quotedOrderingField, 'new_ordering');
+
+		$query = $this->_db->getQuery(true)
+			->update($this->_tbl)
+			->set($quotedOrderingField . ' = sq.new_ordering');
+
+		$innerOn = array();
+
+		// Get the primary keys for the selection.
+		foreach ($this->_tbl_keys as $i => $k)
+		{
+			$subquery->select($this->_db->quoteName($k, 'pk__' . $i));
+			$innerOn[] = $this->_db->quoteName($k) . ' = sq.' . $this->_db->quoteName('pk__' . $i);
+		}
 
 		// Setup the extra where and ordering clause data.
 		if ($where)
 		{
+			$subquery->where($where);
 			$query->where($where);
 		}
 
-		$this->_db->setQuery($query);
-		$rows = $this->_db->loadObjectList();
+		$subquery->where($quotedOrderingField . ' >= 0');
+		$query->where($quotedOrderingField . ' >= 0');
 
-		// Compact the ordering values.
-		foreach ($rows as $i => $row)
-		{
-			// Make sure the ordering is a positive integer.
-			if ($row->$orderingField >= 0)
-			{
-				// Only update rows that are necessary.
-				if ($row->$orderingField != $i + 1)
-				{
-					// Update the row ordering field.
-					$query->clear()
-						->update($this->_tbl)
-						->set($quotedOrderingField . ' = ' . ($i + 1));
-					$this->appendPrimaryKeys($query, $row);
-					$this->_db->setQuery($query);
-					$this->_db->execute();
-				}
-			}
-		}
+		$query->innerJoin('(' . (string) $subquery . ') AS sq ON ' . implode(' AND ', $innerOn));
+
+		$this->_db->setQuery($query);
+		$this->_db->execute();
 
 		return true;
 	}

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -182,6 +182,55 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQueryPostgresql::__string method for a 'selectRowNumber' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectRowNumber()
+	{
+		$this->_instance
+			->select('id')
+			->selectRowNumber('ordering', 'new_ordering')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT id,ROW_NUMBER() OVER (ORDER BY ordering) AS new_ordering" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->select('id')
+			->selectRowNumber('ordering', 'row_number', 'catid', 'catid');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT id,catid AS catid,ROW_NUMBER() OVER (PARTITION BY catid ORDER BY ordering) AS row_number" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->select('id')
+			->select('ordering')
+			->order('id');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT id,ordering" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY id",
+			(string) $this->_instance
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void
@@ -190,19 +239,26 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function test__toStringUpdate()
 	{
-		$q = new JDatabaseQueryPostgresql($this->dbo);
-
-		$q->update('#__foo AS a')
+		$this->_instance
+			->update('#__foo AS a')
 			->join('INNER', 'b ON b.id = a.id')
 			->set('a.id = 2')
 			->where('b.id = 1');
+
+		$string = (string) $this->_instance;
 
 		$this->assertEquals(
 			PHP_EOL . "UPDATE #__foo AS a" .
 			PHP_EOL . "SET a.id = 2" .
 			PHP_EOL . "FROM b" .
 			PHP_EOL . "WHERE b.id = 1 AND b.id = a.id",
-			(string) $q
+			$string
+		);
+
+		// Run method __toString() again on the same query
+		$this->assertEquals(
+			$string,
+			(string) $this->_instance
 		);
 	}
 

--- a/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
+++ b/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
@@ -118,4 +118,63 @@ class JDatabaseQuerySqliteTest extends TestCase
 			$this->_instance->currentTimestamp()
 		);
 	}
+
+	/**
+	 * Test for the JDatabaseQuerySqlite::__string method for a 'selectRowNumber' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectRowNumber()
+	{
+		$this->_instance
+			->select('id')
+			->selectRowNumber('ordering', 'new_ordering')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, ROW_NUMBER() AS new_ordering" .
+			PHP_EOL . "FROM ( " .
+			PHP_EOL . "SELECT id" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY ordering ) AS w," .
+			PHP_EOL . "( SELECT ROW_NUMBER(0) ) AS r" .
+			PHP_EOL . "ORDER BY NULL",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->select('id')
+			->selectRowNumber('ordering', 'row_number', 'catid', 'catid');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, ROW_NUMBER(NULL,catid) AS row_number" .
+			PHP_EOL . "FROM ( " .
+			PHP_EOL . "SELECT id,catid AS catid" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY catid,ordering ) AS w," .
+			PHP_EOL . "( SELECT ROW_NUMBER(0) ) AS r" .
+			PHP_EOL . "ORDER BY NULL",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->select('id')
+			->select('ordering')
+			->order('id');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT id,ordering" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY id",
+			(string) $this->_instance
+		);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/10567.

Related PRs #11184 and #8563

### Summary of Changes

* Big **performance improvement** in `JTable` `reorder` method.
* Add a new public method to `JDatabaseQuery` `selectRowNumber()` with support for mysql, postgresql>=8.4, sqlsrv and sqlite3.
* Do not load table rows to php memory. Use multi-table `UPDATE` syntax to reorder table in one sql query.
* PostgreSQL:
   -  Before patch each call for `(string) $query;` returned different result.
* SQLSRV: 
   - Fix multi table update to generate correct query.
   - In SELECT query move HAVING before ORDER BY
* SQLite:
    - add support for multi table update query by `INSERT OR REPLACE INTO`
    - add sqlite function `ROW_NUMBER(init=null, partitionBy=null)` after establish a connection.
* Add unit tests for selectRowNumber and multi table update queries.
* Fix a few other unit test files that generated error after applied my changes.

### Testing Instructions
Just as in a competitive PR #11184.

In short: 
* Create a new featured article in a category with a lots of articles. Patched version should be faster but you may not see it if you have less than 1000 articles in the category.
* Check that your new article is on the top. [Set ordering ascending in list order]

Note:
* Content items start ordering from 0.
* Featured items start ordering from 1.

The test to be more enjoyable, you can add below code after `$query->execute()`
https://github.com/joomla/joomla-cms/pull/12839/files#diff-8254e2c441a41d3fa26f0f83fbbb3043R1390

```php
JFactory::getApplication()->enqueueMessage(
'<b>reorder()</b>:<br/>'.$this->_db->replacePrefix($query).'<br/>Affected:'.$this->_db->getAffectedRows(), 'message');
```

### Documentation Changes Required
Probably.

Introduce a new public method `JDatabaseQuery::selectRowNumber()`.
Main database drivers (mysql, postgresql, sqlsrv and sqlite) can use Update with innerJoin.
SQLite driver has a new sqlite function `ROW_NUMBER(init=null, partitionBy=null)`

