### PR TITLE
Fix folderlist on Windows-based web servers

### DIFF
--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -198,6 +198,9 @@ class JFormFieldFolderList extends JFormAbstractlist
 			$options[] = JHtml::_('select.option', '', JText::alt('JOPTION_USE_DEFAULT', preg_replace('/[^a-zA-Z0-9_\-]/', '_', $this->fieldname)));
 		}
 
+		// Clean the $path contents
+		$path = JPath::clean($path);
+
 		// Get a list of folders in the search path with the given filter.
 		$folders = JFolder::folders($path, $this->filter, $this->recursive, true);
 

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -216,7 +216,7 @@ class JFormFieldFolderList extends JFormAbstractlist
 				}
 
 				// Remove the root part and the leading /
-				$folder = trim(str_replace($path, '', $folder), '/');
+				$folder = trim(str_replace(rtrim($path, '/\\'), '', $folder), '/\\');
 
 				$options[] = JHtml::_('select.option', $folder, $folder);
 			}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
On line 219, the root folder path is trimmed on the end of both back and forward slashes, and the resulting folder is trimmed of both back and forward slashes.

### Testing Instructions
The changes address the issue of folderlist on Windows-based web servers. You can test this on IIS or WAMP, just access any module (or plugin) that uses folderlist, and you will see "C:\wamp\www\/images" or "C:\inetpub\wwwroot\/images", when it should only show as "images".

Since there are no built-in extensions that use folder list, you can add the following field to any module's xml file to test it:

`<field name="test_field" type="folderlist" default="images" label="TEST_LABEL" directory="" description="TEST_DESC" hide_none="true" hide_default="true" exclude="^[Aa]dministrator$|^[Cc]ache$|^[Cc]omponents$|^[Cc]li$|^[Ii]ncludes$|^[Ll]anguage$|^[Ll]ibraries$|^[Ll]ogs$|^[Mm]odules$|^[Pp]lugins$|^[Tt]emplates$|^[Xx]mlrpc$" />`


### Documentation Changes Required

On non-windows-based web servers, the current code works fine, but on windows-based web servers, like IIS or WAMP, the folderlist options will look like "C:\wamp\www\/images" or "C:\inetpub\wwwroot\/images", when it should only show as "images". This messes up any extension that uses folderlist on windows-based web servers. 

I propose to change line 219 from:
`$folder = trim(str_replace($path,  '', $folder), '/');`
to:
`$folder = trim(str_replace(rtrim($path, '/\\'), '', $folder), '/\\');`

This essentially accommodates Windows systems to make the folderlist work as it should.