### PR TITLE
[com_fields] Fix gallery field in windows installations

### DIFF
--- a/plugins/fields/gallery/fields/gallery.php
+++ b/plugins/fields/gallery/fields/gallery.php
@@ -53,7 +53,8 @@ class JFormFieldGallery extends JFormFieldList
 		{
 			foreach ($folders as $folder)
 			{
-				$relativePath = str_replace($path . '/', '', $folder);
+				// Relative path, in order to use str_replace you need same directory separators, so "clean" the paths
+				$relativePath = str_replace(JPath::clean($path . '/'), '', JPath::clean($folder));
 
 				$options[] = JHtml::_('select.option', $relativePath, $relativePath);
 			}

--- a/plugins/fields/gallery/layouts/field/prepare/gallery.php
+++ b/plugins/fields/gallery/layouts/field/prepare/gallery.php
@@ -73,8 +73,8 @@ foreach ($value as $path)
 		// Getting the properties of the image
 		$properties = JImage::getImageFileProperties($file);
 
-		// Relative path
-		$localPath    = str_replace(JPATH_ROOT . '/' . $root . '/', '', $file);
+		// Relative path, in order to use str_replace you need same directory separators, so "clean" the paths
+		$localPath    = str_replace(JPath::clean(JPATH_ROOT . '/' . $root . '/'), '', $file);
 		$webImagePath = $root . '/' . $localPath;
 
 		if (($maxImageWidth && $properties->width > $maxImageWidth) || ($maxImageHeight && $properties->height > $maxImageHeight))


### PR DESCRIPTION
Pull Request for Issue
Custom field "gallery" is bogus both in form and when viewing in windows installations

### Summary of Changes
Fixed path for both form and in viewing

Note this is different than PRs that try
to fix 'folderslist' field, and to (improve) JFolders::foders()
in windows installations

### Testing Instructions
1. Make sure that gallery field is published in plugins manager
2. Then go to "fields" of Articles manager and create a new "gallery" field
3. Then edit the an article and save it
4. Then view the article in frontend

For step "2", as path in its configuration test with:
images/sampledata/
images\sampledata\

### Documentation Changes Required
None
