### PR TITLE
com_users notes category incorrect ACL level in several installation sql

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -60,7 +60,7 @@ INSERT INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`, `titl
 (28, 3, 4, 5, 2, 'com_banners.category.3', 'Uncategorised', '{}'),
 (29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'),
 (30, 19, 74, 75, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'),
-(32, 24, 86, 87, 1, 'com_users.category.7', 'Uncategorised', '{}'),
+(32, 24, 86, 87, 2, 'com_users.category.7', 'Uncategorised', '{}'),
 (33, 1, 91, 92, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (34, 1, 93, 94, 1, 'com_joomlaupdate', 'com_joomlaupdate', '{}'),
 (35, 1, 95, 96, 1, 'com_tags', 'com_tags', '{}'),

--- a/installation/sql/mysql/sample_blog.sql
+++ b/installation/sql/mysql/sample_blog.sql
@@ -42,7 +42,7 @@ INSERT IGNORE INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`
 (28, 3, 4, 5, 2, 'com_banners.category.3', 'Uncategorised', '{}'),
 (29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'),
 (30, 19, 56, 57, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'),
-(32, 24, 68, 69, 1, 'com_users.category.7', 'Uncategorised', '{}'),
+(32, 24, 68, 69, 2, 'com_users.category.7', 'Uncategorised', '{}'),
 (33, 1, 73, 74, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (35, 8, 24, 33, 2, 'com_content.category.9', 'Blog', '{}'),
 (36, 27, 19, 20, 3, 'com_content.article.1', 'About', '{}'),

--- a/installation/sql/mysql/sample_brochure.sql
+++ b/installation/sql/mysql/sample_brochure.sql
@@ -44,7 +44,7 @@ INSERT IGNORE INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`
 (28, 3, 4, 5, 2, 'com_banners.category.3', 'Uncategorised', '{}'),
 (29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'),
 (30, 19, 62, 63, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'),
-(32, 24, 74, 75, 1, 'com_users.category.7', 'Uncategorised', '{}'),
+(32, 24, 74, 75, 2, 'com_users.category.7', 'Uncategorised', '{}'),
 (33, 1, 79, 80, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (35, 27, 19, 20, 3, 'com_content.article.2', 'About Us', '{}'),
 (36, 8, 24, 27, 2, 'com_content.category.8', 'News', '{}'),

--- a/installation/sql/mysql/sample_data.sql
+++ b/installation/sql/mysql/sample_data.sql
@@ -43,7 +43,7 @@ INSERT IGNORE INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`
 (28, 3, 4, 5, 2, 'com_banners.category.3', 'Uncategorised', '{}'),
 (29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'),
 (30, 19, 88, 89, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'),
-(32, 24, 100, 101, 1, 'com_users.category.7', 'Uncategorised', '{}'),
+(32, 24, 100, 101, 2, 'com_users.category.7', 'Uncategorised', '{}'),
 (33, 1, 105, 106, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (34, 1, 107, 108, 1, 'com_joomlaupdate', 'com_joomlaupdate', '{}'),
 (35, 1, 109, 110, 1, 'com_tags', 'com_tags', '{}'),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -58,7 +58,7 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (28, 3, 4, 5, 2, 'com_banners.category.3', 'Uncategorised', '{}'),
 (29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'),
 (30, 19, 74, 75, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'),
-(32, 24, 86, 87, 1, 'com_users.category.7', 'Uncategorised', '{}'),
+(32, 24, 86, 87, 2, 'com_users.category.7', 'Uncategorised', '{}'),
 (33, 1, 91, 92, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (34, 1, 93, 94, 1, 'com_joomlaupdate', 'com_joomlaupdate', '{}'),
 (35, 1, 95, 96, 1, 'com_tags', 'com_tags', '{}'),

--- a/installation/sql/postgresql/sample_blog.sql
+++ b/installation/sql/postgresql/sample_blog.sql
@@ -38,7 +38,7 @@ INSERT INTO "#__assets" VALUES
 (28,3,4,5,2,'com_banners.category.3','Uncategorised','{}'),
 (29,7,14,15,2,'com_contact.category.4','Uncategorised','{}'),
 (30,19,56,57,2,'com_newsfeeds.category.5','Uncategorised','{}'),
-(32,24,68,69,1,'com_users.category.7','Uncategorised','{}'),
+(32,24,68,69,2,'com_users.category.7','Uncategorised','{}'),
 (33,1,79,80,1,'com_finder','com_finder','{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (35,8,24,33,2,'com_content.category.9','Blog','{}'),
 (36,27,19,20,3,'com_content.article.1','About','{}'),

--- a/installation/sql/postgresql/sample_data.sql
+++ b/installation/sql/postgresql/sample_data.sql
@@ -37,7 +37,7 @@ INSERT INTO "#__assets" VALUES
 (28,3,4,5,2,'com_banners.category.3','Uncategorised','{}'),
 (29,7,14,15,2,'com_contact.category.4','Uncategorised','{}'),
 (30,19,44,45,2,'com_newsfeeds.category.5','Uncategorised','{}'),
-(32,24,56,57,1,'com_users.category.7','Uncategorised','{}'),
+(32,24,56,57,2,'com_users.category.7','Uncategorised','{}'),
 (33,1,65,66,1,'com_finder','com_finder','{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (34,1,67,68,1,'com_joomlaupdate','com_joomlaupdate','{}'),
 (35,27,19,20,3,'com_content.article.1','Getting Started','{"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1}}'),

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -92,7 +92,7 @@ SELECT 29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'
 UNION ALL
 SELECT 30, 19, 74, 75, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'
 UNION ALL
-SELECT 32, 24, 86, 87, 1, 'com_users.category.7', 'Uncategorised', '{}'
+SELECT 32, 24, 86, 87, 2, 'com_users.category.7', 'Uncategorised', '{}'
 UNION ALL
 SELECT 33, 1, 91, 92, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'
 UNION ALL

--- a/installation/sql/sqlazure/sample_blog.sql
+++ b/installation/sql/sqlazure/sample_blog.sql
@@ -66,7 +66,7 @@ SELECT 29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'
 UNION ALL
 SELECT 30, 19, 56, 57, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'
 UNION ALL
-SELECT 32, 24, 68, 69, 1, 'com_users.category.7', 'Uncategorised', '{}'
+SELECT 32, 24, 68, 69, 2, 'com_users.category.7', 'Uncategorised', '{}'
 UNION ALL
 SELECT 33, 1, 79, 80, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'
 UNION ALL

--- a/installation/sql/sqlazure/sample_brochure.sql
+++ b/installation/sql/sqlazure/sample_brochure.sql
@@ -63,7 +63,7 @@ SELECT 29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncaterised', '{}'
 UNION ALL
 SELECT 30, 19, 56, 57, 2, 'com_newsfeeds.category.5', 'Uncaterised', '{}'
 UNION ALL
-SELECT 32, 24, 68, 69, 1, 'com_users.notes.category.7', 'Uncaterised', '{}'
+SELECT 32, 24, 68, 69, 2, 'com_users.category.7', 'Uncaterised', '{}'
 UNION ALL
 SELECT 33, 1, 77, 78, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'
 UNION ALL

--- a/installation/sql/sqlazure/sample_data.sql
+++ b/installation/sql/sqlazure/sample_data.sql
@@ -65,7 +65,7 @@ SELECT 29, 7, 14, 15, 2, 'com_contact.category.4', 'Uncategorised', '{}'
 UNION ALL
 SELECT 30, 19, 44, 45, 2, 'com_newsfeeds.category.5', 'Uncategorised', '{}'
 UNION ALL
-SELECT 32, 24, 56, 57, 1, 'com_users.category.7', 'Uncategorised', '{}'
+SELECT 32, 24, 56, 57, 2, 'com_users.category.7', 'Uncategorised', '{}'
 UNION ALL
 SELECT 33, 1, 65, 66, 1, 'com_finder', 'com_finder', '{"core.admin":{"7":1},"core.manage":{"6":1}}'
 UNION ALL


### PR DESCRIPTION
Pull Request for new Issue.

### Summary of Changes

Simple PR to correct a bug in sql installation files.
Com_users notes category as an incorrect ACL `level` `1` in several installation sql files.

Should work like this:
- Level 0: Root asset (root.1)
- Level 1: Component (com_users)
- Level 2: Category (com_users.category.7)

So it should be level 2.

### Testing Instructions

Code review.

### Documentation Changes Required

None.