### PR TITLE
Remove Searchbox from all fields except Category

### DIFF
--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -13,7 +13,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('jquery.framework');
 JHtml::_('behavior.formvalidator');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 $app = JFactory::getApplication();
 $input = $app->input;

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 $this->configFieldsets  = array('editorConfig');
 $this->hiddenFieldsets  = array('basic-limited');

--- a/administrator/components/com_fields/views/field/tmpl/edit.php
+++ b/administrator/components/com_fields/views/field/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.tabstate');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 $app = JFactory::getApplication();
 $input = $app->input;

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.combobox');
 JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0));
+JHtml::_('formbehavior.chosen', '#jform_position', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 $hasContent = empty($this->item->module) ||  isset($this->item->xml->customContent);
 $hasContentFieldName = "content";

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -14,7 +14,8 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('formbehavior.chosen', 'select', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0 ));
+JHtml::_('formbehavior.chosen', 'select');
 
 $app   = JFactory::getApplication();
 $input = $app->input;


### PR DESCRIPTION
Pull Request for Issue #12843 .

### Summary of Changes
The PRs to create a category "on the fly" (#8623, #8635, #8634, #8632, #8433) changed the call to load Chosen so the search field shows always. By default it would only show if there are more than 10 options.
This PR reverts that change and adds a specific Chosen call for the category field only.

### Testing Instructions
Test the following backend edit forms
* Article
* Banner
* Newsfeed
* Contact
* Custom Field
* Module (Position field)

Before PR each list field shows a search field:
![state](https://cloud.githubusercontent.com/assets/1018684/20177406/dc17bd72-a74c-11e6-97c3-7ad3746dc2f9.PNG)

After PR the searchfield is gone except for the category (fields group) field.
![category](https://cloud.githubusercontent.com/assets/1018684/20177439/0b7b9df4-a74d-11e6-9024-5cd7a6b6e2cc.PNG)

### Documentation Changes Required
None
