### PR TITLE
Add "show global value" feature to com_contact

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -96,8 +96,8 @@
 			default="1"
 			class="btn-group btn-group-yesno"
 			>
-			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
 
 		<field

--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -432,8 +432,8 @@
 				label="JGLOBAL_SHOW_CATEGORY_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_CATEGORY_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="hide">JHIDE</option>
 				<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
 				<option value="show_with_link">COM_CONTACT_FIELD_VALUE_WITH_LINK</option>
@@ -445,8 +445,8 @@
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -456,8 +456,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
 				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="sliders">COM_CONTACT_FIELD_VALUE_SLIDERS</option>
 				<option value="tabs">COM_CONTACT_FIELD_VALUE_TABS</option>
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
@@ -469,8 +469,8 @@
 				label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_TAGS_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -481,8 +481,8 @@
 				label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_INFO_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -493,8 +493,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_NAME_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -505,8 +505,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -517,8 +517,8 @@
 				label="JGLOBAL_EMAIL"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_E_MAIL_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -529,8 +529,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -541,8 +541,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -553,8 +553,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -565,8 +565,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -577,8 +577,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_COUNTRY_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -589,8 +589,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_TELEPHONE_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -601,8 +601,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_MOBILE_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -613,8 +613,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_FAX_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -625,8 +625,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_WEBPAGE_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -637,8 +637,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_SHOW_IMAGE_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_SHOW_IMAGE_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -649,8 +649,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_MISC_INFO_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -661,8 +661,8 @@
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_VCARD_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -673,8 +673,8 @@
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_SHOW_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -685,8 +685,8 @@
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
 				default=""
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
 				<option value="15">J15</option>
@@ -709,8 +709,8 @@
 				label="COM_CONTACT_FIELD_PROFILE_SHOW_LABEL"
 				description="COM_CONTACT_FIELD_PROFILE_SHOW_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -732,8 +732,8 @@
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -842,8 +842,8 @@
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -854,8 +854,8 @@
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
 				description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -893,8 +893,8 @@
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
 				description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -905,8 +905,8 @@
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
 				description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
 				class="chzn-color"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>

--- a/components/com_contact/views/categories/tmpl/default.xml
+++ b/components/com_contact/views/categories/tmpl/default.xml
@@ -27,8 +27,8 @@
 			<field name="show_base_description" type="list"
 				label="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_LABEL"
 				description="JGLOBAL_FIELD_SHOW_BASE_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -41,8 +41,8 @@
 			<field name="maxLevelcat" type="list"
 				description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
 				label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="-1">JALL</option>
 				<option value="1">J1</option>
 				<option value="2">J2</option>
@@ -54,8 +54,8 @@
 			<field name="show_empty_categories_cat" type="list"
 				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
 				description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -63,8 +63,8 @@
 			<field name="show_subcat_desc_cat" type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 				description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -72,8 +72,8 @@
 			<field name="show_cat_items_cat" type="list"
 				label="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -88,8 +88,8 @@
 			<field name="show_category_title" type="list"
 				label="JGLOBAL_SHOW_CATEGORY_TITLE"
 				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -97,8 +97,8 @@
 			<field name="show_description" type="list"
 				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -106,8 +106,8 @@
 			<field name="show_description_image" type="list"
 				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -115,8 +115,8 @@
 			<field name="maxLevel" type="list"
 				description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
 				label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="-1">JALL</option>
 				<option value="0">JNONE</option>
 				<option value="1">J1</option>
@@ -129,8 +129,8 @@
 			<field name="show_empty_categories" type="list"
 				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
 				description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -139,8 +139,8 @@
 			<field name="show_subcat_desc" type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 				description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -148,8 +148,8 @@
 			<field name="show_cat_items" type="list"
 				label="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -164,20 +164,19 @@
 			<field
 				name="filter_field"
 				type="list"
-				default=""
 				description="JGLOBAL_FILTER_FIELD_DESC"
 				label="JGLOBAL_FILTER_FIELD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="hide">JHIDE</option>
+				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
 
 			<field name="show_pagination_limit" type="list"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -185,8 +184,8 @@
 			<field name="show_headings" type="list"
 				description="JGLOBAL_SHOW_HEADINGS_DESC"
 				label="JGLOBAL_SHOW_HEADINGS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -194,8 +193,8 @@
 		<field name="show_position_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_POSITION_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_POSITION_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -203,8 +202,8 @@
 		<field name="show_email_headings" type="list"
 			label="JGLOBAL_EMAIL"
 			description="COM_CONTACT_FIELD_CONFIG_EMAIL_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -213,8 +212,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_PHONE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_PHONE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -223,8 +222,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_MOBILE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -233,8 +232,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_FAX_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_FAX_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -242,8 +241,8 @@
 		<field name="show_suburb_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_SUBURB_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SUBURB_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -252,8 +251,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_STATE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_STATE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -262,8 +261,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_COUNTRY_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_COUNTRY_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -271,8 +270,8 @@
 			<field name="show_pagination" type="list"
 				description="JGLOBAL_PAGINATION_DESC"
 				label="JGLOBAL_PAGINATION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
@@ -282,12 +281,11 @@
 				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
-
 			</field>
 
 </fieldset>
@@ -295,11 +293,11 @@
 <fieldset name="contact" label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL">
 
 				<field name="presentation_style"
-				type="list"
-				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
-				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+					type="list"
+					description="COM_CONTACT_FIELD_PRESENTATION_DESC"
+					label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
+					useglobal="true"
+				>
 				<option value="sliders">COM_CONTACT_FIELD_VALUE_SLIDERS</option>
 				<option value="tabs">COM_CONTACT_FIELD_VALUE_TABS</option>
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
@@ -308,8 +306,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="hide">JHIDE</option>
 				<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
 				<option value="show_with_link">COM_CONTACT_FIELD_VALUE_WITH_LINK</option>
@@ -319,8 +317,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -330,8 +328,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_TAGS_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -341,8 +339,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_INFO_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -351,8 +349,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_NAME_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -361,8 +359,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 
@@ -372,8 +370,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_E_MAIL_DESC"
 				label="JGLOBAL_EMAIL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -382,8 +380,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -392,8 +390,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -402,8 +400,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -412,8 +410,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -422,8 +420,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_COUNTRY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -432,8 +430,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TELEPHONE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -442,8 +440,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_MOBILE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -452,8 +450,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_FAX_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -462,8 +460,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_WEBPAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -472,8 +470,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -482,8 +480,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_VCARD_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -492,8 +490,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_MISC_INFO_DESC"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -502,8 +500,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_ARTICLES_SHOW_DESC"
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -511,8 +509,8 @@
 			<field name="articles_display_num" type="list" default=""
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
@@ -534,8 +532,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -582,8 +580,8 @@
 			<field name="show_email_form" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -591,8 +589,8 @@
 			<field name="show_email_copy" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -621,8 +619,8 @@
 			<field name="validate_session" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -630,8 +628,8 @@
 			<field name="custom_reply" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -649,8 +647,8 @@
 			<field name="show_feed_link" type="list"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>

--- a/components/com_contact/views/categories/tmpl/default.xml
+++ b/components/com_contact/views/categories/tmpl/default.xml
@@ -543,6 +543,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkb_name"
@@ -550,6 +551,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkc_name"
@@ -557,6 +559,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkd_name"
@@ -564,6 +567,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linke_name"
@@ -571,6 +575,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 </fieldset>
 		<!-- Form options. -->
@@ -638,6 +643,7 @@
 				description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 		</fieldset>
 

--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -43,8 +43,8 @@
 			<field name="show_category_title" type="list"
 				label="JGLOBAL_SHOW_CATEGORY_TITLE"
 				description="JGLOBAL_SHOW_CATEGORY_TITLE_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -52,8 +52,8 @@
 			<field name="show_description" type="list"
 				description="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_DESCRIPTION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -61,8 +61,8 @@
 			<field name="show_description_image" type="list"
 				description="JGLOBAL_SHOW_CATEGORY_IMAGE_DESC"
 				label="JGLOBAL_SHOW_CATEGORY_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -70,8 +70,8 @@
 			<field name="maxLevel" type="list"
 				description="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_DESC"
 				label="JGLOBAL_MAXIMUM_CATEGORY_LEVELS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="-1">JALL</option>
 				<option value="0">JNONE</option>
 				<option value="1">J1</option>
@@ -84,8 +84,8 @@
 			<field name="show_empty_categories" type="list"
 				label="JGLOBAL_SHOW_EMPTY_CATEGORIES_LABEL"
 				description="COM_CONTACT_SHOW_EMPTY_CATEGORIES_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -94,8 +94,8 @@
 			<field name="show_subcat_desc" type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL"
 				description="JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -103,8 +103,8 @@
 			<field name="show_cat_items" type="list"
 				label="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_CAT_ITEMS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -122,8 +122,8 @@
 				default=""
 				description="JGLOBAL_FILTER_FIELD_DESC"
 				label="JGLOBAL_FILTER_FIELD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -131,8 +131,8 @@
 			<field name="show_pagination_limit" type="list"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -140,8 +140,8 @@
 			<field name="show_headings" type="list"
 				description="JGLOBAL_SHOW_HEADINGS_DESC"
 				label="JGLOBAL_SHOW_HEADINGS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -149,8 +149,8 @@
 			<field name="show_image_heading" type="list"
 				label="COM_CONTACT_FIELD_CONFIG_SHOW_IMAGE_LABEL" 
 				description="COM_CONTACT_FIELD_CONFIG_SHOW_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -158,8 +158,8 @@
 		<field name="show_position_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_POSITION_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_POSITION_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -167,8 +167,8 @@
 		<field name="show_email_headings" type="list"
 			label="JGLOBAL_EMAIL"
 			description="COM_CONTACT_FIELD_CONFIG_EMAIL_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -177,8 +177,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_PHONE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_PHONE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -187,8 +187,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_MOBILE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -197,8 +197,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_FAX_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_FAX_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -206,8 +206,8 @@
 		<field name="show_suburb_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_SUBURB_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SUBURB_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -216,8 +216,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_STATE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_STATE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -226,8 +226,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_COUNTRY_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_COUNTRY_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -235,8 +235,8 @@
 			<field name="show_pagination" type="list"
 				description="JGLOBAL_PAGINATION_DESC"
 				label="JGLOBAL_PAGINATION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
@@ -246,9 +246,9 @@
 				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 
@@ -258,8 +258,8 @@
 				description="COM_CONTACT_FIELD_INITIAL_SORT_DESC"
 				label="COM_CONTACT_FIELD_INITIAL_SORT_LABEL"
 				validate="options"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="name">COM_CONTACT_FIELD_VALUE_NAME</option>
 				<option value="sortname">COM_CONTACT_FIELD_VALUE_SORT_NAME</option>
 				<option value="ordering">COM_CONTACT_FIELD_VALUE_ORDERING</option>
@@ -267,12 +267,12 @@
 </fieldset>
 
 <fieldset name="contact" label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL">
-				<field name="presentation_style"
+			<field name="presentation_style"
 				type="list"
 				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
 				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="sliders">COM_CONTACT_FIELD_VALUE_SLIDERS</option>
 				<option value="tabs">COM_CONTACT_FIELD_VALUE_TABS</option>
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
@@ -281,8 +281,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="hide">JHIDE</option>
 				<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
 				<option value="show_with_link">COM_CONTACT_FIELD_VALUE_WITH_LINK</option>
@@ -292,8 +292,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -303,8 +303,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_TAGS_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -314,8 +314,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_INFO_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -324,8 +324,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_NAME_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -334,8 +334,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 
@@ -345,8 +345,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_E_MAIL_DESC"
 				label="JGLOBAL_EMAIL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -355,8 +355,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -365,8 +365,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -375,8 +375,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -385,8 +385,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -395,8 +395,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_COUNTRY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -405,8 +405,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TELEPHONE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -415,8 +415,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_MOBILE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -425,8 +425,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_FAX_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -435,8 +435,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_WEBPAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -445,8 +445,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -455,8 +455,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_VCARD_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -466,8 +466,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_MISC_INFO_DESC"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -476,8 +476,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_ARTICLES_SHOW_DESC"
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -485,8 +485,8 @@
 			<field name="articles_display_num" type="list" default=""
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
@@ -508,8 +508,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -567,8 +567,8 @@
 			<field name="show_email_form" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -576,8 +576,8 @@
 			<field name="show_email_copy" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -606,8 +606,8 @@
 			<field name="validate_session" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -615,8 +615,8 @@
 			<field name="custom_reply" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -634,8 +634,8 @@
 			<field name="show_feed_link" type="list"
 				description="JGLOBAL_Show_Feed_Link_Desc"
 				label="JGLOBAL_Show_Feed_Link_Label"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>

--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -530,6 +530,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkb_name"
@@ -537,6 +538,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkc_name"
@@ -544,6 +546,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkd_name"
@@ -551,6 +554,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linke_name"
@@ -558,6 +562,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 </fieldset>
 		<!-- Form options. -->
@@ -625,6 +630,7 @@
 				description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 		</fieldset>
 

--- a/components/com_contact/views/contact/tmpl/default.xml
+++ b/components/com_contact/views/contact/tmpl/default.xml
@@ -38,8 +38,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
 				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="sliders">COM_CONTACT_FIELD_VALUE_SLIDERS</option>
 				<option value="tabs">COM_CONTACT_FIELD_VALUE_TABS</option>
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
@@ -48,8 +48,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_CATEGORY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="hide">JHIDE</option>
 				<option value="show_no_link">COM_CONTACT_FIELD_VALUE_NO_LINK</option>
 				<option value="show_with_link">COM_CONTACT_FIELD_VALUE_WITH_LINK</option>
@@ -59,8 +59,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_DESC"
 				label="COM_CONTACT_FIELD_CONTACT_SHOW_LIST_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -70,8 +70,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_TAGS_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -81,8 +81,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_INFO_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -91,8 +91,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_NAME_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -101,8 +101,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 
@@ -112,8 +112,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_E_MAIL_DESC"
 				label="JGLOBAL_EMAIL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -122,8 +122,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -132,8 +132,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -142,8 +142,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -152,8 +152,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -162,8 +162,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_COUNTRY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -172,8 +172,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TELEPHONE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -182,8 +182,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_MOBILE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -192,8 +192,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_FAX_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -202,8 +202,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_WEBPAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -212,8 +212,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -222,8 +222,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_VCARD_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -233,8 +233,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
 				description="COM_CONTACT_FIELD_PARAMS_MISC_INFO_DESC"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -243,8 +243,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_ARTICLES_SHOW_DESC"
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -252,8 +252,8 @@
 			<field name="articles_display_num" type="list" default=""
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
@@ -286,8 +286,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -336,8 +336,8 @@
 			<field name="show_email_form" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -346,8 +346,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -380,8 +380,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -390,8 +390,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>

--- a/components/com_contact/views/contact/tmpl/default.xml
+++ b/components/com_contact/views/contact/tmpl/default.xml
@@ -297,6 +297,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkb_name"
@@ -304,6 +305,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKB_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkc_name"
@@ -311,6 +313,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkd_name"
@@ -318,6 +321,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linke_name"
@@ -325,6 +329,7 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 		</fieldset>
 
@@ -401,6 +406,7 @@
 				description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 		</fieldset>
 	</fields>

--- a/components/com_contact/views/featured/tmpl/default.xml
+++ b/components/com_contact/views/featured/tmpl/default.xml
@@ -355,30 +355,35 @@
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKA_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkb_name" type="text"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKB_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkc_name" type="text"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKC_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linkd_name" type="text"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKD_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 
 			<field name="linke_name" type="text"
 				description="COM_CONTACT_FIELD_LINK_NAME_DESC"
 				label="COM_CONTACT_FIELD_LINKE_NAME_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 	</fieldset>
 
@@ -445,6 +450,7 @@
 				description="COM_CONTACT_FIELD_CONFIG_REDIRECT_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_REDIRECT_LABEL"
 				size="30"
+				useglobal="true"
 			/>
 	</fieldset>
 

--- a/components/com_contact/views/featured/tmpl/default.xml
+++ b/components/com_contact/views/featured/tmpl/default.xml
@@ -24,8 +24,8 @@
 			<field name="show_pagination_limit" type="list"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -33,8 +33,8 @@
 			<field name="show_headings" type="list"
 				description="JGLOBAL_SHOW_HEADINGS_DESC"
 				label="JGLOBAL_SHOW_HEADINGS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -42,8 +42,8 @@
 		<field name="show_position_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_POSITION_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_POSITION_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -51,8 +51,8 @@
 		<field name="show_email_headings" type="list"
 			label="JGLOBAL_EMAIL"
 			description="COM_CONTACT_FIELD_CONFIG_EMAIL_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -61,8 +61,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_PHONE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_PHONE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -71,8 +71,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_MOBILE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_MOBILE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -81,8 +81,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_FAX_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_FAX_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -90,8 +90,8 @@
 		<field name="show_suburb_headings" type="list"
 			label="COM_CONTACT_FIELD_CONFIG_SUBURB_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_SUBURB_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -100,8 +100,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_STATE_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_STATE_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -110,8 +110,8 @@
 			type="list"
 			label="COM_CONTACT_FIELD_CONFIG_COUNTRY_LABEL"
 			description="COM_CONTACT_FIELD_CONFIG_COUNTRY_DESC"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 		</field>
@@ -119,23 +119,22 @@
 		<field name="show_pagination" type="list"
 			description="JGLOBAL_PAGINATION_DESC"
 			label="JGLOBAL_PAGINATION_LABEL"
+			useglobal="true"
 		>
-			<option value="">JGLOBAL_USE_GLOBAL</option>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>
 			<option value="2">JGLOBAL_AUTO</option>
 		</field>
 
 		<field
-				name="show_pagination_results"
-				type="list"
-				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-
+			name="show_pagination_results"
+			type="list"
+			label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+			description="JGLOBAL_PAGINATION_RESULTS_DESC"
+			useglobal="true"
+		>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
 		</field>
 
 	</fieldset>
@@ -145,8 +144,8 @@
 			<field name="presentation_style" type="list"
 				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
 				label="COM_CONTACT_FIELD_PRESENTATION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="sliders">COM_CONTACT_FIELD_VALUE_SLIDERS</option>
 				<option value="tabs">COM_CONTACT_FIELD_VALUE_TABS</option>
 				<option value="plain">COM_CONTACT_FIELD_VALUE_PLAIN</option>
@@ -157,8 +156,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_TAGS_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_TAGS_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -168,8 +167,8 @@
 				type="list"
 				label="COM_CONTACT_FIELD_SHOW_INFO_LABEL"
 				description="COM_CONTACT_FIELD_SHOW_INFO_DESC"
+				useglobal="true"
 				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -177,8 +176,8 @@
 			<field name="show_name" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_NAME_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_NAME_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -186,8 +185,8 @@
 			<field name="show_position" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_CONTACT_POSITION_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 
@@ -196,8 +195,8 @@
 			<field name="show_email" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_CONTACT_E_MAIL_DESC"
 				label="JGLOBAL_EMAIL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -205,8 +204,8 @@
 			<field name="show_street_address" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STREET_ADDRESS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -214,8 +213,8 @@
 			<field name="show_suburb" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TOWN-SUBURB_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -223,8 +222,8 @@
 			<field name="show_state" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_STATE-COUNTY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -232,8 +231,8 @@
 			<field name="show_postcode" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_POST-ZIP_CODE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -241,8 +240,8 @@
 			<field name="show_country" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_COUNTRY_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_COUNTRY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -250,8 +249,8 @@
 			<field name="show_telephone" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_TELEPHONE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_TELEPHONE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -259,8 +258,8 @@
 			<field name="show_mobile" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_MOBILE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_MOBILE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -268,8 +267,8 @@
 			<field name="show_fax" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_FAX_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_FAX_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -277,8 +276,8 @@
 			<field name="show_webpage" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_WEBPAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_WEBPAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -286,8 +285,8 @@
 			<field name="show_image" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -295,8 +294,8 @@
 			<field name="allow_vcard" type="list"
 				description="COM_CONTACT_FIELD_PARAMS_VCARD_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_VCARD_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -306,8 +305,8 @@
 				type="list"
 				description="COM_CONTACT_FIELD_PARAMS_MISC_INFO_DESC"
 				label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
-				>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				useglobal="true"
+			>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -315,8 +314,8 @@
 			<field name="show_articles" type="list"
 				description="COM_CONTACT_FIELD_ARTICLES_SHOW_DESC"
 				label="COM_CONTACT_FIELD_ARTICLES_SHOW_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -324,8 +323,8 @@
 			<field name="articles_display_num" type="list" default=""
 				label="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_LABEL"
 				description="COM_CONTACT_FIELD_ARTICLES_DISPLAY_NUM_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="use_contact">COM_CONTACT_FIELD_VALUE_USE_CONTACT_SETTINGS</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
@@ -346,8 +345,8 @@
 			<field name="show_links" type="list"
 				description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 				label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -388,8 +387,8 @@
 			<field name="show_email_form" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -397,8 +396,8 @@
 			<field name="show_email_copy" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_DESC"
 				label="COM_CONTACT_FIELD_EMAIL_EMAIL_COPY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -427,8 +426,8 @@
 			<field name="validate_session" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_SESSION_CHECK_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
@@ -436,8 +435,8 @@
 			<field name="custom_reply" type="list"
 				description="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_DESC"
 				label="COM_CONTACT_FIELD_CONFIG_CUSTOM_REPLY_LABEL"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>


### PR DESCRIPTION
This PR expands the already merged #11911 to com_contact

### Summary of Changes
Enables the new "Show Global Value" feature for all contact forms.

### Testing Instructions
Test the contact form and the related menu item forms. All list elements with a "Use Global" entry should show the global value like this:
![showglobal](https://cloud.githubusercontent.com/assets/1018684/20215118/a752ef28-a812-11e6-9e90-22da53946e0c.PNG)

Exception: The robots field will not show the global value.

Note: If you get a message that some global values can't be found, try saving the component options.

### Documentation Changes Required
None
