### PR TITLE
Add "show global value" feature to com_content frontend edit

### DIFF
--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -283,8 +283,9 @@
 				type="list"
 				class="chzn-color"
 				label="JGLOBAL_SHOW_ASSOCIATIONS_LABEL"
-				description="JGLOBAL_SHOW_ASSOCIATIONS_DESC">
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="JGLOBAL_SHOW_ASSOCIATIONS_DESC"
+				useglobal="true"
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
 			</field>

--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -236,11 +236,12 @@
 				name="float_intro"
 				type="list"
 				label="COM_CONTENT_FLOAT_INTRO_LABEL"
-				description="COM_CONTENT_FLOAT_DESC">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="right">COM_CONTENT_RIGHT</option>
-					<option value="left">COM_CONTENT_LEFT</option>
-					<option value="none">COM_CONTENT_NONE</option>
+				description="COM_CONTENT_FLOAT_DESC"
+				useglobal="true"
+				>
+				<option value="right">COM_CONTENT_RIGHT</option>
+				<option value="left">COM_CONTENT_LEFT</option>
+				<option value="none">COM_CONTENT_NONE</option>
 			</field>
 			</fieldset>
 			<fieldset name="image-full">
@@ -265,11 +266,12 @@
 				name="float_fulltext"
 				type="list"
 				label="COM_CONTENT_FLOAT_FULLTEXT_LABEL"
-				description="COM_CONTENT_FLOAT_DESC">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="right">COM_CONTENT_RIGHT</option>
-					<option value="left">COM_CONTENT_LEFT</option>
-					<option value="none">COM_CONTENT_NONE</option>
+				description="COM_CONTENT_FLOAT_DESC"
+				useglobal="true"
+				>
+				<option value="right">COM_CONTENT_RIGHT</option>
+				<option value="left">COM_CONTENT_LEFT</option>
+				<option value="none">COM_CONTENT_NONE</option>
 			</field>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
This PR expands the already merged #11911 to com_content frontend editing

### Summary of Changes
Enables the new "Show Global Value" feature for article frontend form.

### Testing Instructions
Test the article edit form in frontend. The "image float" parameters should show the global value like this:
![imagefloat](https://cloud.githubusercontent.com/assets/1018684/20216052/9c7ca02a-a818-11e6-86da-5753769f791b.PNG)

Note: If you get a message that some global values can't be found, try saving the component options.

### Documentation Changes Required
None
