### PR TITLE
Add "show global value" feature to com_tags

### DIFF
--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -15,14 +15,14 @@
 
 			<field 
 				name="id" 
-				type="tag" 				
+				type="tag"
 				label="COM_TAGS_FIELD_TAG_LABEL"
 				description="COM_TAGS_FIELD_SELECT_TAG_DESC"
 				custom="deny"
 				required="true"
 				multiple="true"
 			/>
-			
+
 			<field 
 				name="types" 
 				type="contenttype"
@@ -30,19 +30,19 @@
 				description="COM_TAGS_FIELD_TYPE_DESC"
 				multiple="true"
 			/>
-			
+
 			<field 
 				name="tag_list_language_filter"
 				type="contentlanguage"
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
 				description="COM_TAGS_FIELD_LANGUAGE_FILTER_DESC"
 				default=""
-				>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="all">JALL</option>
-					<option value="current_language">JCURRENT</option>
+				useglobal="true"
+			>
+				<option value="all">JALL</option>
+				<option value="current_language">JCURRENT</option>
 			</field>
-			
+
 		</fieldset>
 	</fields>
 
@@ -55,8 +55,8 @@
 				type="list"
 				label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
 				description="COM_TAGS_SHOW_TAG_TITLE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -65,9 +65,9 @@
 				name="tag_list_show_tag_image" 
 				type="list"
 				label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
-				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"			
+				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -77,25 +77,25 @@
 				type="list"
 				label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
 				description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
+
 			<field 
 				name="tag_list_image" 
 				type="media"
 				label="COM_TAGS_TAG_LIST_MEDIA_LABEL"
 				description="COM_TAGS_TAG_LIST_MEDIA_DESC"
 			/>
-			
+
 			<field 
 				name="tag_list_description" 
 				type="textarea"
 				class="inputbox"
 				label="COM_TAGS_SHOW_TAG_LIST_DESCRIPTION_LABEL"
-				description="COM_TAGS_TAG_LIST_DESCRIPTION_DESC"		
+				description="COM_TAGS_TAG_LIST_DESCRIPTION_DESC"
 				rows="3" 
 				cols="30" 
 				filter="safehtml"
@@ -106,8 +106,8 @@
 				type="list"
 				label="COM_TAGS_NUMBER_TAG_ITEMS_LABEL"
 				description="COM_TAGS_NUMBER_TAG_ITEMS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -118,13 +118,13 @@
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
 				description="JGLOBAL_FIELD_FIELD_ORDERING_DESC"
 				default=""
+				useglobal="true"
 			>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="c.core_title">JGLOBAL_TITLE</option>
-					<option value="match_count">COM_TAGS_MATCH_COUNT</option>
-					<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
-					<option value="c.core_modified_time">JGLOBAL_MODIFIED_DATE</option>
-					<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
+				<option value="c.core_title">JGLOBAL_TITLE</option>
+				<option value="match_count">COM_TAGS_MATCH_COUNT</option>
+				<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
+				<option value="c.core_modified_time">JGLOBAL_MODIFIED_DATE</option>
+				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
 			<field 
@@ -132,8 +132,8 @@
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="ASC">JGLOBAL_ORDER_ASCENDING</option>
 				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 			</field>
@@ -141,21 +141,21 @@
 		</fieldset>
 
 		<fieldset name="advanced" label="COM_TAGS_ITEM_OPTIONS">
-			
+
 			<field 
 				name="spacer2" 
 				type="spacer" 
 				class="text"
 				label="COM_TAGS_SUBSLIDER_DRILL_TAG_LIST_LABEL"
 			/>
-			
+
 			<field 
 				name="tag_list_show_item_image" 
 				type="list"
-				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"				
+				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -165,12 +165,12 @@
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			
+
 			<field
 				name="tag_list_item_maximum_characters"
 				type="text"
@@ -185,8 +185,8 @@
 				default=""
 				label="JGLOBAL_FILTER_FIELD_LABEL"
 				description="JGLOBAL_FILTER_FIELD_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -194,13 +194,13 @@
 
 		<fieldset name="pagination" label="COM_TAGS_PAGINATION_OPTIONS">
 
-			<field	
+			<field
 				name="show_pagination_limit" 
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -210,8 +210,8 @@
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
@@ -221,50 +221,51 @@
 				name="show_pagination_results" 
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
+			>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
 			</field>
-			
+
 		</fieldset>
-		
+
 		<fieldset name="selection" label="COM_TAGS_LIST_SELECTION_OPTIONS">
-			
-			<field 
+
+			<field
 				name="return_any_or_all" 
 				type="list"
 				label="COM_TAGS_SEARCH_TYPE_LABEL"
 				description="COM_TAGS_SEARCH_TYPE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">COM_TAGS_ALL</option>
 				<option value="1">COM_TAGS_ANY</option>
 			</field>
-			
+
 			<field 
 				name="include_children" 
 				type="list"
 				label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
 				description="COM_TAGS_INCLUDE_CHILDREN_DESC"
 				default=""
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">COM_TAGS_EXCLUDE</option>
 				<option value="1">COM_TAGS_INCLUDE</option>
-			</field>		
-				
+			</field>
+
 		</fieldset>
-		
+
 		<fieldset name="integration">
-			
-			<field 
+
+			<field
 				name="show_feed_link" 
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>

--- a/components/com_tags/views/tag/tmpl/default.xml
+++ b/components/com_tags/views/tag/tmpl/default.xml
@@ -177,6 +177,7 @@
 				filter="integer"
 				label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
 				description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
+				useglobal="true"
 			/>
 
 			<field

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -37,10 +37,10 @@
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
 				description="COM_TAGS_FIELD_LANGUAGE_FILTER_DESC"
 				default=""
+				useglobal="true"
 			>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="all">JALL</option>
-					<option value="current_language">JCURRENT</option>
+				<option value="all">JALL</option>
+				<option value="current_language">JCURRENT</option>
 			</field>
 
 		</fieldset>
@@ -54,8 +54,8 @@
 				type="list"
 				label="COM_TAGS_SHOW_TAG_TITLE_LABEL"
 				description="COM_TAGS_SHOW_TAG_TITLE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -65,8 +65,8 @@
 				type="list"
 				label="COM_TAGS_SHOW_TAG_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_TAG_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -76,8 +76,8 @@
 				type="list"
 				label="COM_TAGS_SHOW_TAG_DESCRIPTION_LABEL"
 				description="COM_TAGS_SHOW_TAG_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -105,8 +105,8 @@
 				type="list"
 				label="COM_TAGS_NUMBER_TAG_ITEMS_LABEL"
 				description="COM_TAGS_NUMBER_TAG_ITEMS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -117,8 +117,8 @@
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
 				description="JGLOBAL_FIELD_FIELD_ORDERING_DESC"
 				default=""
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="c.core_title">JGLOBAL_TITLE</option>
 				<option value="match_count">COM_TAGS_MATCH_COUNT</option>
 				<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
@@ -131,8 +131,8 @@
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="ASC">JGLOBAL_ORDER_ASCENDING</option>
 				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 			</field>
@@ -153,8 +153,8 @@
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -164,8 +164,8 @@
 				type="list"
 				label="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_LABEL"
 				description="COM_TAGS_TAG_LIST_SHOW_ITEM_DESCRIPTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -184,8 +184,8 @@
 				default=""
 				label="JGLOBAL_FILTER_FIELD_LABEL"
 				description="JGLOBAL_FILTER_FIELD_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -195,8 +195,8 @@
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -222,8 +222,8 @@
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
@@ -233,10 +233,11 @@
 				name="show_pagination_results" 
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC">
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
+			>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
 			</field>
 
 			<field 
@@ -244,8 +245,8 @@
 				type="list"
 				label="JGLOBAL_SHOW_DATE_LABEL"
 				description="JGLOBAL_SHOW_DATE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="created">JGLOBAL_CREATED</option>
 				<option value="modified">JGLOBAL_MODIFIED</option>
@@ -269,8 +270,8 @@
 				type="list"
 				label="COM_TAGS_SEARCH_TYPE_LABEL"
 				description="COM_TAGS_SEARCH_TYPE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">COM_TAGS_ALL</option>
 				<option value="1">COM_TAGS_ANY</option>
 			</field>
@@ -281,8 +282,8 @@
 				label="COM_TAGS_INCLUDE_CHILDREN_LABEL"
 				description="COM_TAGS_INCLUDE_CHILDREN_DESC"
 				default=""
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">COM_TAGS_EXCLUDE</option>
 				<option value="1">COM_TAGS_INCLUDE</option>
 			</field>
@@ -296,8 +297,8 @@
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>

--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -176,6 +176,7 @@
 				filter="integer"
 				label="COM_TAGS_LIST_MAX_CHARACTERS_LABEL"
 				description="COM_TAGS_LIST_MAX_CHARACTERS_DESC"
+				useglobal="true"
 			/>
 
 			<field

--- a/components/com_tags/views/tags/tmpl/default.xml
+++ b/components/com_tags/views/tags/tmpl/default.xml
@@ -29,10 +29,10 @@
 				default=""
 				label="COM_TAGS_FIELD_LANGUAGE_FILTER_LABEL"
 				description="COM_TAGS_FIELD_LANGUAGE_FILTER_DESC"
+				useglobal="true"
 			>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="all">JALL</option>
-					<option value="current_language">JCURRENT</option>
+				<option value="all">JALL</option>
+				<option value="current_language">JCURRENT</option>
 			</field>
 			
 		</fieldset>
@@ -54,7 +54,7 @@
 				name="all_tags_description" 
 				type="textarea"
 				label="COM_TAGS_SHOW_ALL_TAGS_DESCRIPTION_LABEL"
-				description="COM_TAGS_ALL_TAGS_DESCRIPTION_DESC"				
+				description="COM_TAGS_ALL_TAGS_DESCRIPTION_DESC"
 				class="inputbox"
 				rows="3" 
 				cols="30" 
@@ -65,7 +65,7 @@
 				name="all_tags_show_description_image" 
 				type="list"
 				label="COM_TAGS_SHOW_ALL_TAGS_IMAGE_LABEL"
-				description="COM_TAGS_SHOW_ALL_TAGS_IMAGE_DESC"				
+				description="COM_TAGS_SHOW_ALL_TAGS_IMAGE_DESC"
 			>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
@@ -84,13 +84,13 @@
 				type="list"
 				label="JGLOBAL_FIELD_FIELD_ORDERING_LABEL"
 				description="JGLOBAL_FIELD_FIELD_ORDERING_DESC"
+				useglobal="true"
 			>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="title">JGLOBAL_TITLE</option>
-					<option value="hits">JGLOBAL_HITS</option>
-					<option value="created_time">JGLOBAL_CREATED_DATE</option>
-					<option value="modified_time">JGLOBAL_MODIFIED_DATE</option>
-					<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
+				<option value="title">JGLOBAL_TITLE</option>
+				<option value="hits">JGLOBAL_HITS</option>
+				<option value="created_time">JGLOBAL_CREATED_DATE</option>
+				<option value="modified_time">JGLOBAL_MODIFIED_DATE</option>
+				<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
 			<field 
@@ -98,8 +98,8 @@
 				type="list"
 				label="JGLOBAL_ORDER_DIRECTION_LABEL"
 				description="JGLOBAL_ORDER_DIRECTION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="ASC">JGLOBAL_ORDER_ASCENDING</option>
 				<option value="DESC">JGLOBAL_ORDER_DESCENDING</option>
 			</field>
@@ -109,8 +109,8 @@
 				type="list"
 				label="COM_TAGS_SHOW_ITEM_IMAGE_LABEL"
 				description="COM_TAGS_SHOW_ITEM_IMAGE_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -139,8 +139,8 @@
 				type="list"
 				label="JGLOBAL_HITS"
 				description="COM_TAGS_FIELD_CONFIG_HITS_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -164,8 +164,8 @@
 				default=""
 				label="JGLOBAL_FILTER_FIELD_LABEL"
 				description="JGLOBAL_FILTER_FIELD_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -176,8 +176,8 @@
 				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
 				description="JGLOBAL_DISPLAY_SELECT_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
@@ -186,9 +186,9 @@
 				name="show_pagination" 
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
-				description="JGLOBAL_PAGINATION_DESC"				
+				description="JGLOBAL_PAGINATION_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
@@ -199,22 +199,21 @@
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
+				useglobal="true"
 			>
-					<option value="">JGLOBAL_USE_GLOBAL</option>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
 			</field>
 			
 		</fieldset>
 		<fieldset name="integration">
-			
-			<field 
+			<field
 				name="show_feed_link" 
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
+				useglobal="true"
 			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>


### PR DESCRIPTION
This PR expands the already merged #11911 to com_tags

### Summary of Changes
Enables the new "Show Global Value" feature for all tag menu item types.

### Testing Instructions
Test the tag menu items. All list elements with a "Use Global" entry should show the global value like this:
![tagoption](https://cloud.githubusercontent.com/assets/1018684/20217983/c28a9be6-a822-11e6-9179-5af5cdfc815d.PNG)

Exception: The robots field will not show the global value.

Note: If you get a message that some global values can't be found, try saving the component options.

Another note: The parameters `Show Heading Image` and `Tag Descriptions` currently have a "Use Global" option, but that one is useless since the component settings don't have that field. So there is no global value to be used. I left it like this as it is out of scope of this PR and I don't know if we should remove the option or add the field to the component options.

### Documentation Changes Required
None
