### PR TITLE
[ACL] Backend ordering columns in list views review

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -19,7 +19,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_banners.category');
 $saveOrder = $listOrder == 'a.ordering';
 
 if ($saveOrder)

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -19,7 +19,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = str_replace(' ' . $this->state->get('list.direction'), '', $this->state->get('list.fullordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_content.article');
 $saveOrder = $listOrder == 'fp.ordering';
 $columns   = 10;
 

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -22,7 +22,6 @@ $userId     = $user->get('id');
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 $ordering   = ($listOrder == 'a.lft');
-$canOrder   = $user->authorise('core.edit.state',	'com_menus');
 $saveOrder  = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 $menuTypeId = (int) $this->state->get('menutypeid');
 $menuType   = (string) $app->getUserState('com_menus.items.menutype', '', 'string');

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -19,7 +19,6 @@ JHtml::_('formbehavior.chosen', 'select');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -19,7 +19,6 @@ JHtml::_('formbehavior.chosen', 'select');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_plugins');
 $saveOrder = $listOrder == 'ordering';
 
 if ($saveOrder)

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -23,7 +23,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_tags');
 $saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 $extension = $this->escape($this->state->get('filter.extension'));
 $parts     = explode('.', $extension);

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -19,7 +19,6 @@ JHtml::_('formbehavior.chosen', 'select');
 $user       = JFactory::getUser();
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
-$canOrder   = $user->authorise('core.edit.state', 'com_users');
 $saveOrder  = $listOrder == 'a.ordering';
 
 if ($saveOrder)

--- a/administrator/templates/hathor/html/com_banners/banners/default.php
+++ b/administrator/templates/hathor/html/com_banners/banners/default.php
@@ -17,7 +17,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_banners.category');
+$canOrder  = $user->authorise('core.edit.state', 'com_banners');
 $saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/templates/hathor/html/com_banners/banners/default.php
+++ b/administrator/templates/hathor/html/com_banners/banners/default.php
@@ -17,6 +17,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_banners');
 $saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">
@@ -99,7 +100,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) : ?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'banners.saveorder'); ?>
 					<?php endif;?>
 				</th>

--- a/administrator/templates/hathor/html/com_banners/banners/default.php
+++ b/administrator/templates/hathor/html/com_banners/banners/default.php
@@ -17,7 +17,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_banners');
 $saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_banners&view=banners'); ?>" method="post" name="adminForm" id="adminForm">
@@ -100,7 +99,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) : ?>
+					<?php if ($saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'banners.saveorder'); ?>
 					<?php endif;?>
 				</th>

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -21,6 +21,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state', $extension);
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $jinput    = JFactory::getApplication()->input;
 $component = $jinput->get('extension');
@@ -95,7 +96,7 @@ $component = $jinput->get('extension');
 						</th>
 						<th class="nowrap ordering-col">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.lft', $listDirn, $listOrder); ?>
-							<?php if ($saveOrder) : ?>
+							<?php if ($canOrder && $saveOrder) : ?>
 								<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'categories.saveorder'); ?>
 							<?php endif; ?>
 						</th>
@@ -146,9 +147,9 @@ $component = $jinput->get('extension');
 						$canChange = $user->authorise('core.edit.state', $extension . '.category.' . $item->id) && $canCheckin;
 						?>
 						<tr class="row<?php echo $i % 2; ?>">
-							<th class="center">
+							<td class="center">
 								<?php echo JHtml::_('grid.id', $i, $item->id); ?>
-							</th>
+							</td>
 							<td>
 								<?php echo str_repeat('<span class="gi">|&mdash;</span>', $item->level - 1) ?>
 								<?php if ($item->checked_out) : ?>

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -21,7 +21,6 @@ $extension = $this->escape($this->state->get('filter.extension'));
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.lft');
-$canOrder  = $user->authorise('core.edit.state', $extension);
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $jinput    = JFactory::getApplication()->input;
 $component = $jinput->get('extension');
@@ -96,7 +95,7 @@ $component = $jinput->get('extension');
 						</th>
 						<th class="nowrap ordering-col">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.lft', $listDirn, $listOrder); ?>
-							<?php if ($canOrder && $saveOrder) : ?>
+							<?php if ($saveOrder) : ?>
 								<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'categories.saveorder'); ?>
 							<?php endif; ?>
 						</th>

--- a/administrator/templates/hathor/html/com_categories/categories/default.php
+++ b/administrator/templates/hathor/html/com_categories/categories/default.php
@@ -21,6 +21,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state', $extension);
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $jinput    = JFactory::getApplication()->input;
 $component = $jinput->get('extension');
@@ -95,7 +96,7 @@ $component = $jinput->get('extension');
 						</th>
 						<th class="nowrap ordering-col">
 							<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.lft', $listDirn, $listOrder); ?>
-							<?php if ($saveOrder) : ?>
+							<?php if ($canOrder && $saveOrder) : ?>
 								<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'categories.saveorder'); ?>
 							<?php endif; ?>
 						</th>

--- a/administrator/templates/hathor/html/com_contact/contacts/default.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/default.php
@@ -18,7 +18,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_contact');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 ?>
@@ -110,7 +109,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'contacts.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_contact/contacts/default.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/default.php
@@ -18,7 +18,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_contact.category');
+$canOrder  = $user->authorise('core.edit.state', 'com_contact');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 ?>

--- a/administrator/templates/hathor/html/com_contact/contacts/default.php
+++ b/administrator/templates/hathor/html/com_contact/contacts/default.php
@@ -18,6 +18,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_contact');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 ?>
@@ -109,7 +110,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'contacts.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_content/featured/default.php
+++ b/administrator/templates/hathor/html/com_content/featured/default.php
@@ -17,6 +17,7 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_content');
 $saveOrder = $listOrder == 'fp.ordering';
 $n         = count($this->items);
 ?>
@@ -93,7 +94,7 @@ $n         = count($this->items);
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'fp.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'featured.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_content/featured/default.php
+++ b/administrator/templates/hathor/html/com_content/featured/default.php
@@ -17,7 +17,6 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_content.article');
 $saveOrder = $listOrder == 'fp.ordering';
 $n         = count($this->items);
 ?>
@@ -94,7 +93,7 @@ $n         = count($this->items);
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'fp.ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'featured.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -80,7 +80,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th width="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'languages.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -79,7 +79,7 @@ $saveOrder = $listOrder == 'a.ordering';
 					<?php echo JHtml::_('grid.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
 				</th>
 				<th width="nowrap ordering-col">
-					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
+					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
 					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'languages.saveorder'); ?>
 					<?php endif; ?>

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -19,6 +19,7 @@ $userId    = $user->get('id');
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_languages');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
@@ -80,7 +81,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th width="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'languages.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_languages/languages/default.php
+++ b/administrator/templates/hathor/html/com_languages/languages/default.php
@@ -19,7 +19,6 @@ $userId    = $user->get('id');
 $n         = count($this->items);
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_languages');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -20,7 +20,6 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.lft');
-$canOrder  = $user->authorise('core.edit.state',	'com_menus');
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $menutypeid	= (int) $this->state->get('menutypeid');
 $assoc     = JLanguageAssociations::isEnabled();
@@ -60,7 +59,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				<?php echo JHtml::_('select.options', $this->f_levels, 'value', 'text', $this->state->get('filter.level'));?>
 			</select>
 
-            <label class="selectlabel" for="filter_published">
+            		<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
 			<select name="filter_published" id="filter_published">
@@ -68,7 +67,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
 
-            <label class="selectlabel" for="filter_access">
+            		<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
@@ -104,7 +103,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.lft', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'items.saveorder'); ?>
 					<?php endif; ?>
 				</th>
@@ -117,9 +116,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				<th class="home-col">
 					<?php echo JHtml::_('grid.sort', 'COM_MENUS_HEADING_HOME', 'a.home', $listDirn, $listOrder); ?>
 				</th>
-				<?php
-				if ($assoc):
-				?>
+				<?php if ($assoc) : ?>
 				<th class="width-5">
 					<?php echo JHtml::_('grid.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 				</th>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -20,6 +20,7 @@ $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.lft');
+$canOrder  = $user->authorise('core.edit.state', 'com_menus');
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $menutypeid	= (int) $this->state->get('menutypeid');
 $assoc     = JLanguageAssociations::isEnabled();
@@ -103,7 +104,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.lft', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'items.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -19,7 +19,6 @@ $client    = $this->state->get('client_id') ? 'administrator' : 'site';
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_modules');
 $saveOrder = $listOrder == 'ordering';
 ?>
 
@@ -113,7 +112,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'modules.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -19,6 +19,7 @@ $client    = $this->state->get('client_id') ? 'administrator' : 'site';
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_modules');
 $saveOrder = $listOrder == 'ordering';
 ?>
 
@@ -112,7 +113,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'modules.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -19,7 +19,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds.category');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 ?>
@@ -106,7 +105,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'newsfeeds.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeeds/default.php
@@ -19,6 +19,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_newsfeeds');
 $saveOrder = $listOrder == 'a.ordering';
 $assoc     = JLanguageAssociations::isEnabled();
 ?>
@@ -105,7 +106,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'newsfeeds.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -17,7 +17,6 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_plugins');
 $saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">
@@ -54,7 +53,7 @@ $saveOrder = $listOrder == 'ordering';
 				<option value=""><?php echo JText::_('COM_PLUGINS_OPTION_FOLDER');?></option>
 				<?php echo JHtml::_('select.options', PluginsHelper::folderOptions(), 'value', 'text', $this->state->get('filter.folder'));?>
 			</select>
-            <label class="selectlabel" for="filter_access">
+            		<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
@@ -82,7 +81,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'plugins.saveorder'); ?>
 					<?php endif; ?>
 				</th>
@@ -93,7 +92,7 @@ $saveOrder = $listOrder == 'ordering';
 				<th class="nowrap width-10">
 					<?php echo JHtml::_('grid.sort', 'COM_PLUGINS_ELEMENT_HEADING', 'element', $listDirn, $listOrder); ?>
 				</th>
-                <th class="title access-col">
+                		<th class="title access-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ACCESS', 'access', $listDirn, $listOrder); ?>
 				</th>
 				<th class="nowrap id-col">

--- a/administrator/templates/hathor/html/com_plugins/plugins/default.php
+++ b/administrator/templates/hathor/html/com_plugins/plugins/default.php
@@ -17,6 +17,7 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_plugins');
 $saveOrder = $listOrder == 'ordering';
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugins'); ?>" method="post" name="adminForm" id="adminForm">
@@ -81,7 +82,7 @@ $saveOrder = $listOrder == 'ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'plugins.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_users/levels/default.php
+++ b/administrator/templates/hathor/html/com_users/levels/default.php
@@ -17,7 +17,6 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_users');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
@@ -52,7 +51,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'levels.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_users/levels/default.php
+++ b/administrator/templates/hathor/html/com_users/levels/default.php
@@ -17,6 +17,7 @@ JHtml::_('behavior.multiselect');
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_users');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
@@ -51,7 +52,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'levels.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -18,7 +18,6 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$canOrder  = $user->authorise('core.edit.state', 'com_weblinks.category');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
@@ -57,7 +56,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				<?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_weblinks'), 'value', 'text', $this->state->get('filter.category_id'));?>
 			</select>
 
-            <label class="selectlabel" for="filter_access">
+            		<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
 			<select name="filter_access" id="filter_access">
@@ -104,7 +103,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($canOrder && $saveOrder) :?>
+					<?php if ($saveOrder) :?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'weblinks.saveorder'); ?>
 					<?php endif; ?>
 				</th>

--- a/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
+++ b/administrator/templates/hathor/html/com_weblinks/weblinks/default.php
@@ -18,6 +18,7 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+$canOrder  = $user->authorise('core.edit.state', 'com_weblinks');
 $saveOrder = $listOrder == 'a.ordering';
 ?>
 
@@ -103,7 +104,7 @@ $saveOrder = $listOrder == 'a.ordering';
 				</th>
 				<th class="nowrap ordering-col">
 					<?php echo JHtml::_('grid.sort', 'JGRID_HEADING_ORDERING', 'a.ordering', $listDirn, $listOrder); ?>
-					<?php if ($saveOrder) :?>
+					<?php if ($canOrder && $saveOrder) : ?>
 						<?php echo JHtml::_('grid.order', $this->items, 'filesave.png', 'weblinks.saveorder'); ?>
 					<?php endif; ?>
 				</th>


### PR DESCRIPTION
### Summary of Changes

As discussed in https://github.com/joomla/joomla-cms/pull/12799 this PR makes a review of the ordering columns ACL across all backend views (isis and hathor).

### Testing Instructions

Mainly code review, but you can test if featured view continues to work.

- Apply patch
- Without `core.edit.state` permission you can't change ordering columns in list views in isis and hathor.

### Documentation Changes Required

None.