### PR TITLE
Adding a "Use Global" option to tag list menu item

### DIFF
--- a/components/com_tags/views/tag/tmpl/list.xml
+++ b/components/com_tags/views/tag/tmpl/list.xml
@@ -202,10 +202,10 @@
 			</field>
 
 			<field name="display_num" type="list"
-				default="20"
 				description="COM_TAGS_FIELD_NUMBER_ITEMS_LIST_DESC"
 				label="COM_TAGS_FIELD_NUMBER_ITEMS_LIST_LABEL"
 			>
+				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="5">J5</option>
 				<option value="10">J10</option>
 				<option value="15">J15</option>


### PR DESCRIPTION
### Summary of Changes
Currently, the "Compact List of tagged items" menu item type has a parameter called "# Items to List". It specifies the list limit.
In the tag model, the code is there to fall back to the list_limit value from the global configuration (see https://github.com/joomla/joomla-cms/blob/staging/components/com_tags/models/tag.php#L213), however there is no option in the menu item which would allow that fallback.

This PR adds this option and removes the default value (otherwise you can't use the "Use Global" option).

Note: It's not possible to show the value from the global configuration since the parameter is named differently. In com_tags it is named `display_num` and the global one `list_limit`. We would have to renamed the parameter in com_tags to make it work, but that isn't B/C. Thus it's not possible.

### Testing Instructions
Create a menu item of that type and make sure that parameter works as expected together with the List Limit parameter from the global configuration.

### Documentation Changes Required
None