### PR TITLE
Adding the ability to use the global value for character count in newsfeeds

### DIFF
--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -424,8 +424,8 @@
 				type="text"
 				label="COM_NEWSFEEDS_FIELD_CHARACTERS_COUNT_LABEL"
 				description="COM_NEWSFEEDS_FIELD_CHARACTERS_COUNT_DESC"
-				default="0"
 				size="6"
+				useglobal="true"
 			/>
 
 			<field

--- a/components/com_newsfeeds/views/categories/tmpl/default.xml
+++ b/components/com_newsfeeds/views/categories/tmpl/default.xml
@@ -278,10 +278,10 @@
 			</field>
 
 			<field name="feed_character_count" type="text"
-				default="0"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
 				size="6"
+				useglobal="true"
 			/>
 		</fieldset>
 

--- a/components/com_newsfeeds/views/category/tmpl/default.xml
+++ b/components/com_newsfeeds/views/category/tmpl/default.xml
@@ -226,10 +226,10 @@
 			</field>
 
 			<field name="feed_character_count" type="text"
-				default="0"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
 				size="6"
+				useglobal="true"
 			/>
 			
 			<field name="feed_display_order" type="list"

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.xml
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.xml
@@ -69,10 +69,10 @@
 			</field>
 
 			<field name="feed_character_count" type="text"
-				default="0"
 				description="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_DESC"
 				label="COM_NEWSFEEDS_FIELD_CHARACTER_COUNT_LABEL"
 				size="6"
+				useglobal="true"
 			/>
 
 			<field name="feed_display_order" type="list"


### PR DESCRIPTION
### Summary of Changes
Removes the default value from the `feed_character_count` parameter in newsfeed form and menu item.
Adds the "Show Global Value" feature to those two fields
This allows to leave the field empty and thus use the value from the component configuration.

### Testing Instructions
1. Create a newsfeed
2. Create a menu item for that newsfeed
3. Play around with the "Characters Count" parameter and make sure it works as expected. If the field is empty, it should show a hint with the value from the component configuration.

### Documentation Changes Required
None