### PR TITLE
First Level Menu item alias: preventing saving forbidden aliases

### DIFF
--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -122,25 +122,7 @@ class JTableMenu extends JTableNested
 		// Cast the home property to an int for checking.
 		$this->home = (int) $this->home;
 
-		// Verify that a first level menu item alias is not 'component'.
-		if ($this->parent_id == 1 && $this->alias == 'component')
-		{
-			$this->setError(JText::_('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_COMPONENT'));
-
-			return false;
-		}
-
-		// Verify that a first level menu item alias is not the name of a folder.
-		jimport('joomla.filesystem.folder');
-
-		if ($this->parent_id == 1 && in_array($this->alias, JFolder::folders(JPATH_ROOT)))
-		{
-			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_FOLDER', $this->alias, $this->alias));
-
-			return false;
-		}
-
-		// Verify that the home item a component.
+		// Verify that the home item is a component.
 		if ($this->home && $this->type != 'component')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_MENU_HOME_NOT_COMPONENT'));
@@ -171,6 +153,24 @@ class JTableMenu extends JTableNested
 		$originalAlias = trim($this->alias);
 		$this->alias   = !$originalAlias ? $this->title : $originalAlias;
 		$this->alias   = JApplicationHelper::stringURLSafe(trim($this->alias), $this->language);
+
+		// Verify that a first level menu item alias is not 'component'.
+		if ($this->parent_id == 1 && $this->alias == 'component')
+		{
+			$this->setError(JText::_('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_COMPONENT'));
+
+			return false;
+		}
+
+		// Verify that a first level menu item alias is not the name of a folder.
+		jimport('joomla.filesystem.folder');
+
+		if ($this->parent_id == 1 && in_array($this->alias, JFolder::folders(JPATH_ROOT)))
+		{
+			$this->setError(JText::sprintf('JLIB_DATABASE_ERROR_MENU_ROOT_ALIAS_FOLDER', $this->alias, $this->alias));
+
+			return false;
+		}
 
 		// If alias still empty (for instance, new menu item with chinese characters with no unicode alias setting).
 		if (empty($this->alias))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12862

In joomla, a first level menu item alias should not be the name of a folder.
Also, it should not be `component`

When creating a new menu item at the ROOT of the Menu and NOT filling the alias field, that one is automatically created (same when the menu item is not at the ROOT, but in this case we do not have the issue).
This is done in the store() method and therefore the forbidden aliases are not yet checked by the check() method.

### Summary of Changes
Moving the checks for forbidden aliases from the check() method to the store() method
### Testing Instructions
Create a new menu item (for example a single article one) at the ROOT of the Menu.
Give it the Title of a folder in the root of the site, for example `tmp`.
Do NOT fill the alias field.
The menu item is saved with `tmp` as alias.
Do the same, but use `component` as title.
The menu item is saved with `component` as alias.

Trash and delete these menu items.

Patch and redo. Now you will rightfully get the message:
`Save failed with the following error: A first level menu item alias can't be 'tmp' because 'tmp' is a sub-folder of your joomla installation folder.`
and similar message when using `component`
`Save failed with the following error: A first level menu item alias can't be 'component'.`
and the menu item is not saved.

Editing a ROOT existing menu item and changing its alias to a folder name or `component` will still be prevented from save.


