### PR TITLE
Using a neutral colour for multilingual buttons at installation time

### DIFF
--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -214,3 +214,51 @@ fieldset {
 textarea, input[type="text"], input[type="password"], input[type="datetime"], input[type="datetime-local"], input[type="date"], input[type="month"], input[type="time"], input[type="week"], input[type="number"], input[type="email"], input[type="url"], input[type="search"], input[type="tel"], input[type="color"], .uneditable-input {
 	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
 }
+
+#jform_activateMultilanguage .btn-danger:hover,
+#jform_activateMultilanguage .btn-danger:focus,
+#jform_activateMultilanguage .btn-danger:active,
+#jform_activateMultilanguage .btn-danger.active,
+#jform_activateMultilanguage .btn-danger.disabled,
+#jform_activateMultilanguage .btn-danger[disabled],
+#jform_activateMultilanguage .btn-success:hover,
+#jform_activateMultilanguage .btn-success:focus,
+#jform_activateMultilanguage .btn-success:active,
+#jform_activateMultilanguage .btn-success.active,
+#jform_activateMultilanguage .btn-success.disabled,
+#jform_activateMultilanguage .btn-success[disabled] {
+	background-color: #72afef;
+	color: #fff;
+}
+
+#jform_installLocalisedContent .btn-danger:hover,
+#jform_installLocalisedContent .btn-danger:focus,
+#jform_installLocalisedContent .btn-danger:active,
+#jform_installLocalisedContent .btn-danger.active,
+#jform_installLocalisedContent .btn-danger.disabled,
+#jform_installLocalisedContent .btn-danger[disabled],
+#jform_installLocalisedContent .btn-success:hover,
+#jform_installLocalisedContent .btn-success:focus,
+#jform_installLocalisedContent .btn-success:active,
+#jform_installLocalisedContent .btn-success.active,
+#jform_installLocalisedContent .btn-success.disabled,
+#jform_installLocalisedContent .btn-success[disabled] {
+	background-color: #72afef;
+	color: #fff;
+}
+
+#jform_activatePluginLanguageCode .btn-danger:hover,
+#jform_activatePluginLanguageCode .btn-danger:focus,
+#jform_activatePluginLanguageCode .btn-danger:active,
+#jform_activatePluginLanguageCode .btn-danger.active,
+#jform_activatePluginLanguageCode .btn-danger.disabled,
+#jform_activatePluginLanguageCode .btn-danger[disabled],
+#jform_activatePluginLanguageCode .btn-success:hover,
+#jform_activatePluginLanguageCode .btn-success:focus,
+#jform_activatePluginLanguageCode .btn-success:active,
+#jform_activatePluginLanguageCode .btn-success.active,
+#jform_activatePluginLanguageCode .btn-success.disabled,
+#jform_activatePluginLanguageCode .btn-success[disabled] {
+	background-color: #72afef;
+	color: #fff;
+}

--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -227,7 +227,7 @@ textarea, input[type="text"], input[type="password"], input[type="datetime"], in
 #jform_activateMultilanguage .btn-success.active,
 #jform_activateMultilanguage .btn-success.disabled,
 #jform_activateMultilanguage .btn-success[disabled] {
-	background-color: #72afef;
+	background-color: #5a97d7;
 	color: #fff;
 }
 
@@ -243,7 +243,7 @@ textarea, input[type="text"], input[type="password"], input[type="datetime"], in
 #jform_installLocalisedContent .btn-success.active,
 #jform_installLocalisedContent .btn-success.disabled,
 #jform_installLocalisedContent .btn-success[disabled] {
-	background-color: #72afef;
+	background-color: #5a97d7;
 	color: #fff;
 }
 
@@ -259,6 +259,6 @@ textarea, input[type="text"], input[type="password"], input[type="datetime"], in
 #jform_activatePluginLanguageCode .btn-success.active,
 #jform_activatePluginLanguageCode .btn-success.disabled,
 #jform_activatePluginLanguageCode .btn-success[disabled] {
-	background-color: #72afef;
+	background-color: #5a97d7;
 	color: #fff;
 }

--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -215,50 +215,11 @@ textarea, input[type="text"], input[type="password"], input[type="datetime"], in
 	box-shadow: 0 1px 0 rgba(255, 255, 255, 0.2) inset, 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
-#jform_activateMultilanguage .btn-danger:hover,
-#jform_activateMultilanguage .btn-danger:focus,
-#jform_activateMultilanguage .btn-danger:active,
-#jform_activateMultilanguage .btn-danger.active,
-#jform_activateMultilanguage .btn-danger.disabled,
-#jform_activateMultilanguage .btn-danger[disabled],
-#jform_activateMultilanguage .btn-success:hover,
-#jform_activateMultilanguage .btn-success:focus,
-#jform_activateMultilanguage .btn-success:active,
-#jform_activateMultilanguage .btn-success.active,
-#jform_activateMultilanguage .btn-success.disabled,
-#jform_activateMultilanguage .btn-success[disabled] {
-	background-color: #5a97d7;
-	color: #fff;
-}
-
-#jform_installLocalisedContent .btn-danger:hover,
-#jform_installLocalisedContent .btn-danger:focus,
-#jform_installLocalisedContent .btn-danger:active,
-#jform_installLocalisedContent .btn-danger.active,
-#jform_installLocalisedContent .btn-danger.disabled,
-#jform_installLocalisedContent .btn-danger[disabled],
-#jform_installLocalisedContent .btn-success:hover,
-#jform_installLocalisedContent .btn-success:focus,
-#jform_installLocalisedContent .btn-success:active,
-#jform_installLocalisedContent .btn-success.active,
-#jform_installLocalisedContent .btn-success.disabled,
-#jform_installLocalisedContent .btn-success[disabled] {
-	background-color: #5a97d7;
-	color: #fff;
-}
-
-#jform_activatePluginLanguageCode .btn-danger:hover,
-#jform_activatePluginLanguageCode .btn-danger:focus,
-#jform_activatePluginLanguageCode .btn-danger:active,
-#jform_activatePluginLanguageCode .btn-danger.active,
-#jform_activatePluginLanguageCode .btn-danger.disabled,
-#jform_activatePluginLanguageCode .btn-danger[disabled],
-#jform_activatePluginLanguageCode .btn-success:hover,
-#jform_activatePluginLanguageCode .btn-success:focus,
-#jform_activatePluginLanguageCode .btn-success:active,
-#jform_activatePluginLanguageCode .btn-success.active,
-#jform_activatePluginLanguageCode .btn-success.disabled,
-#jform_activatePluginLanguageCode .btn-success[disabled] {
-	background-color: #5a97d7;
-	color: #fff;
+#jform_activateMultilanguage [class*="btn-"]:active,
+#jform_activateMultilanguage [class*="btn-"].active,
+#jform_installLocalisedContent [class*="btn-"]:active,
+#jform_installLocalisedContent [class*="btn-"].active,
+#jform_activatePluginLanguageCode [class*="btn-"]:active,
+#jform_activatePluginLanguageCode [class*="btn-"].active {
+    background-color: #294f7e;
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12715

### Summary of Changes
Added overrides to boostrap css in the installation template.css in order to use only a highlight color when a button has been selected.

### Testing Instructions
Install a clean Joomla as default Multilingual site.
In the specific page to set Multilingual you now should get:
![screen shot 2016-11-13 at 15 17 32](https://cloud.githubusercontent.com/assets/869724/20246408/90cb3652-a9b6-11e6-8479-bef42f6b6464.png)


@brianteeman
@andrepereiradasilva 
@C-Lodder 