### PR TITLE
[com_fields] If the label is empty set it from the title automatically

### DIFF
--- a/administrator/components/com_fields/views/field/tmpl/edit.php
+++ b/administrator/components/com_fields/views/field/tmpl/edit.php
@@ -30,8 +30,8 @@ JFactory::getDocument()->addScriptDeclaration('
 	jQuery(document).ready(function() {
 		jQuery("#jform_title").data("dp-old-value", jQuery("#jform_title").val());
 		jQuery("#jform_title").change(function(data, handler) {
-			if(jQuery("#jform_title").data("dp-old-value") == jQuery("#jform_params_label").val()) {
-				jQuery("#jform_params_label").val(jQuery("#jform_title").val());
+			if(jQuery("#jform_title").data("dp-old-value") == jQuery("#jform_label").val()) {
+				jQuery("#jform_label").val(jQuery("#jform_title").val());
 			}
 
 			jQuery("#jform_title").data("dp-old-value", jQuery("#jform_title").val());


### PR DESCRIPTION
### Summary of Changes
The label should be populated automatically from the title when it is empty. This was the old behavior but got broken by PR #12740.

### Testing Instructions
- Click on Articles -> Fields -> New
- Define a title

### Expected result
The label will be populated with the title content.

### Actual result
The label stays empty.
