### PR TITLE
[com_fields] Remove coupling between com_fields and com_categories

### DIFF
--- a/administrator/components/com_categories/models/categories.php
+++ b/administrator/components/com_categories/models/categories.php
@@ -377,12 +377,6 @@ class CategoriesModelCategories extends JModelList
 		if (count($parts) > 1)
 		{
 			$section = $parts[1];
-
-			// If the section ends with .fields, then the category belongs to com_fields
-			if (substr($section, -strlen('.fields')) === '.fields')
-			{
-				$component = 'com_fields';
-			}
 		}
 
 		// Try to find the component helper.

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -40,13 +40,6 @@ if (count($parts) > 1)
 	{
 		$section = $inflector->toPlural($section);
 	}
-
-	// If the section ends with .fields, then the category belongs to com_fields
-	if (substr($section, -strlen('.fields')) === '.fields')
-	{
-		$component = 'com_fields';
-		$section = 'fields&context=' . str_replace('.fields', '', implode('.', $parts));
-	}
 }
 
 if ($saveOrder)
@@ -166,6 +159,9 @@ if ($saveOrder)
 						{
 							$parentsStr = "";
 						}
+
+						$itemCountComponent = isset($item->count_component) ? $item->count_component : $component;
+						$itemCountSection   = isset($item->count_section) ? $item->count_section : $section;
 						?>
 						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id ?>" parents="<?php echo $parentsStr ?>" level="<?php echo $item->level ?>">
 							<td class="order nowrap center hidden-phone">
@@ -227,25 +223,25 @@ if ($saveOrder)
 							</td>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $itemCountComponent . ($itemCountSection ? '&view=' . $itemCountSection : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1&filter[level]=' . (int) $item->level);?>">
 										<?php echo $item->count_published; ?></a>
 								</td>
 							<?php endif;?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $itemCountComponent . ($itemCountSection ? '&view=' . $itemCountSection : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0&filter[level]=' . (int) $item->level);?>">
 										<?php echo $item->count_unpublished; ?></a>
 								</td>
 							<?php endif;?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $itemCountComponent . ($itemCountSection ? '&view=' . $itemCountSection : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2&filter[level]=' . (int) $item->level);?>">
 										<?php echo $item->count_archived; ?></a>
 								</td>
 							<?php endif;?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $itemCountComponent . ($itemCountSection ? '&view=' . $itemCountSection : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2&filter[level]=' . (int) $item->level);?>">
 										<?php echo $item->count_trashed; ?></a>
 								</td>
 							<?php endif;?>

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -57,14 +57,21 @@ class ContactHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The contact category objects
+	 * @param   stdClass[]  &$items   The category objects
+	 * @param   string      $section  The section
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $section)
 	{
+		// If the section ends with .fields, then the category belongs to com_fields
+		if (substr($section, -strlen('.fields')) === '.fields')
+		{
+			return FieldsHelper::countItems($items, $section, 'com_contact');
+		}
+
 		$db = JFactory::getDbo();
 
 		foreach ($items as $item)

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -80,14 +80,21 @@ class ContentHelper extends JHelperContent
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The banner category objects
+	 * @param   stdClass[]  &$items   The category objects
+	 * @param   string      $section  The section
 	 *
 	 * @return  stdClass[]
 	 *
 	 * @since   3.5
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $section)
 	{
+		// If the section ends with .fields, then the category belongs to com_fields
+		if (substr($section, -strlen('.fields')) === '.fields')
+		{
+			return FieldsHelper::countItems($items, $section, 'com_content');
+		}
+
 		$db = JFactory::getDbo();
 
 		foreach ($items as $item)

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -508,7 +508,7 @@ class FieldsHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function countItems(&$items)
+	public static function countItems(&$items, $section, $component)
 	{
 		$db = JFactory::getDbo();
 
@@ -518,6 +518,8 @@ class FieldsHelper
 			$item->count_archived    = 0;
 			$item->count_unpublished = 0;
 			$item->count_published   = 0;
+			$item->count_component   = 'com_fields';
+			$item->count_section     = 'fields&context=' . $component . '.' . str_replace('.fields', '', $section);
 
 			$query = $db->getQuery(true);
 			$query->select('state, count(*) AS count')
@@ -528,26 +530,26 @@ class FieldsHelper
 
 			$fields = $db->loadObjectList();
 
-			foreach ($fields as $article)
+			foreach ($fields as $field)
 			{
-				if ($article->state == 1)
+				if ($field->state == 1)
 				{
-					$item->count_published = $article->count;
+					$item->count_published = $field->count;
 				}
 
-				if ($article->state == 0)
+				if ($field->state == 0)
 				{
-					$item->count_unpublished = $article->count;
+					$item->count_unpublished = $field->count;
 				}
 
-				if ($article->state == 2)
+				if ($field->state == 2)
 				{
-					$item->count_archived = $article->count;
+					$item->count_archived = $field->count;
 				}
 
-				if ($article->state == -2)
+				if ($field->state == -2)
 				{
-					$item->count_trashed = $article->count;
+					$item->count_trashed = $field->count;
 				}
 			}
 		}

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -502,7 +502,9 @@ class FieldsHelper
 	/**
 	 * Adds Count Items for Category Manager.
 	 *
-	 * @param   stdClass[]  &$items  The field category objects
+	 * @param   stdClass[]  &$items     The field category objects
+	 * @param   string      $section    The section
+	 * @param   string      $component  The component
 	 *
 	 * @return  stdClass[]
 	 *


### PR DESCRIPTION
Pull Request to decouple com_fields and com_categories as discussed in #12681.

### Summary of Changes
com_categories does have a hard dependency to com_fields for the count item functionality
![image](https://cloud.githubusercontent.com/assets/251072/20264914/2b3bebca-aa6e-11e6-9178-2fdda986a2cd.png). This PR removes this dependency and com_categories will become unaware of com_fields again.

### Testing Instructions
The count item functionality should work as before.