### PR TITLE
remove tab on meta charset

### DIFF
--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -72,7 +72,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate charset when using HTML5 (should happen first)
 		if ($document->isHtml5())
 		{
-			$buffer .= $tab . '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
+			$buffer .= '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
 		}
 
 		// Generate base tag (need to happen early)

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -72,7 +72,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		// Generate charset when using HTML5 (should happen first)
 		if ($document->isHtml5())
 		{
-			$buffer .= '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
+			$buffer .= $tab . '<meta charset="' . $document->getCharset() . '" />' . $lnEnd;
 		}
 
 		// Generate base tag (need to happen early)
@@ -353,6 +353,6 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= $tab . $custom . $lnEnd;
 		}
 
-		return $buffer;
+		return ltrim($buffer, $tab);
 	}
 }


### PR DESCRIPTION
On the template source you will see a tab on the meta.

Before:
![before](https://cloud.githubusercontent.com/assets/876623/20291689/427094ce-aae8-11e6-8968-500f4c9a55a5.png)
After:
![after](https://cloud.githubusercontent.com/assets/876623/20291690/477a6b7a-aae8-11e6-94e8-bcc319fd5f69.png)
