### PR TITLE
Joomla 4.0: Fixing double columns in session query

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -250,16 +250,6 @@ abstract class JApplicationCms extends JApplicationWeb implements ContainerAware
 				$values[] = (int) $this->getClientId();
 			}
 
-			$query->insert($db->quoteName('#__session'))
-				->columns($columns)
-				->values(implode(', ', $values));
-
-			if (!$this->get('shared_session', '0'))
-			{
-				$columns[] = $db->quoteName('client_id');
-				$values[] = (int) $this->getClientId();
-			}
-
 			// If the insert failed, exit the application.
 			try
 			{


### PR DESCRIPTION
The current 4.0-dev branch throws a fatal error when executing the front- and backend. This is due to this duplicate code. With this removed, the application works again.