### PR TITLE
[fix] undefined group path when ordering items by title. Fixes #12903

### DIFF
--- a/libraries/cms/helper/usergroups.php
+++ b/libraries/cms/helper/usergroups.php
@@ -308,6 +308,11 @@ final class JHelperUsergroups
 
 		$parentGroup = $this->has($parentId) ? $this->get($parentId) : $this->load($parentId);
 
+		if (!property_exists($parentGroup, 'path'))
+		{
+			$parentGroup = $this->populateGroupData($parentGroup);
+		}
+
 		$group->path = array_merge($parentGroup->path, array($group->id));
 		$group->level = count($group->path) - 1;
 


### PR DESCRIPTION
Pull Request for Issue #12903 .

### Summary of Changes

When usergroups are populated from an array of objects `path` may not be defined. This ensures that if not path is found it will be generated.

### Testing Instructions

Ensure that you have error reporting enabled in your station. Then:

* Go to backend groups view and order groups by id. Ensure that no warnings are shown.
* Go to backend groups view and order groups by title. Ensure that no warnings are shown.
* Go to backend users view and ensure that batch works.
* Go to backend users view and check that group searchtools filter works properly.
* Go to backend users view and create an user. Confirm that groups selection is correctly saved.
* Go to backend groups view and ensure that groups are shown.
* Go to backend groups view and ensure that pagination works.
* Go to backend groups view and try to create a new group
* Go to backend groups view and edit a group. Ensure that the group is not shown in the parent field.
* Go to backend groups view and edit a group to change the parent group. Confirm data is saved.
* Go to backend articles view and edit an article to change its permissions. Confirm data is saved.

### Documentation Changes Required

No changes required.