### PR TITLE
JFormFieldUser now shows stored user ID if user is not found

### DIFF
--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -95,7 +95,7 @@ class JFormFieldUser extends JFormField implements JFormDomfieldinterface
 		}
 
 		// User lookup went wrong, we assign the value instead.
-		if ($name === null)
+		if ($name === null && $this->value)
 		{
 			$name = $this->value;
 		}

--- a/libraries/cms/form/field/user.php
+++ b/libraries/cms/form/field/user.php
@@ -94,6 +94,12 @@ class JFormFieldUser extends JFormField implements JFormDomfieldinterface
 			$name = JText::_('JLIB_FORM_SELECT_USER');
 		}
 
+		// User lookup went wrong, we assign the value instead.
+		if ($name === null)
+		{
+			$name = $this->value;
+		}
+
 		$extraData = array(
 				'userName'  => $name,
 				'groups'    => $this->getGroups(),


### PR DESCRIPTION
Pull Request for Issue #12881 .

### Summary of Changes
JFormFieldUser will now show the User ID instead of the User Name when the user wasn't found in the system.

### Testing Instructions
1. Create an article (or any other item) and afterwards delete the user who created the article
2. Open article, you get a warning message that the user wasn't found. The "Created By" field is empty.

After PR the "Created By" field shows the stored User ID.

### Documentation Changes Required
None
