### PR TITLE
Add useglobal to com_menus Page Display text fields options

### DIFF
--- a/administrator/components/com_menus/models/forms/item_component.xml
+++ b/administrator/components/com_menus/models/forms/item_component.xml
@@ -41,34 +41,44 @@
 			</field>
 		</fieldset>
 
-		<fieldset name="page-options"
-			label="COM_MENUS_PAGE_OPTIONS_LABEL"
-		>
+		<fieldset name="page-options" label="COM_MENUS_PAGE_OPTIONS_LABEL">
 
-
-			<field name="page_title" type="text"
+			<field
+				name="page_title"
+				type="text"
 				label="COM_MENUS_ITEM_FIELD_PAGE_TITLE_LABEL"
-				description="COM_MENUS_ITEM_FIELD_PAGE_TITLE_DESC" />
+				description="COM_MENUS_ITEM_FIELD_PAGE_TITLE_DESC"
+				useglobal="true"
+			/>
 
-			<field name="show_page_heading" type="list"
-				class="chzn-color"
+			<field
+				name="show_page_heading"
+				type="list"
 				label="COM_MENUS_ITEM_FIELD_SHOW_PAGE_HEADING_LABEL"
 				description="COM_MENUS_ITEM_FIELD_SHOW_PAGE_HEADING_DESC"
+				class="chzn-color"
 				default=""
 				useglobal="true"
 				>
-				<option value="1" class="yes">JYES</option>
-				<option value="0" class="no">JNO</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
 			</field>
 
-			<field name="page_heading" type="text"
+			<field
+				name="page_heading"
+				type="text"
 				label="COM_MENUS_ITEM_FIELD_PAGE_HEADING_LABEL"
-				description="COM_MENUS_ITEM_FIELD_PAGE_HEADING_DESC" />
+				description="COM_MENUS_ITEM_FIELD_PAGE_HEADING_DESC"
+				useglobal="true"
+			/>
 
-			<field name="pageclass_sfx" type="text"
+			<field
+				name="pageclass_sfx"
+				type="text"
 				label="COM_MENUS_ITEM_FIELD_PAGE_CLASS_LABEL"
-				description="COM_MENUS_ITEM_FIELD_PAGE_CLASS_DESC" />
-
+				description="COM_MENUS_ITEM_FIELD_PAGE_CLASS_DESC"
+				useglobal="true"
+			/>
 
 		</fieldset>
 


### PR DESCRIPTION
### Summary of Changes

For the sake of consistency this adds the new Use Global text to com_menus "Page Display" options.

### Testing Instructions

Very simple test:

- Configure com_menus options like this and save the options
![image](https://cloud.githubusercontent.com/assets/9630530/20350793/238012b2-ac08-11e6-975f-fe12b4a11c20.png)

- Now create a new menu item and go directly to "Page Display" tab
You will see the only one showing the global value is the select list

- Apply patch and repeat last step you will get something like this:
![image](https://cloud.githubusercontent.com/assets/9630530/20350860/60bf084a-ac08-11e6-8ca0-88232e00a51d.png)


### Documentation Changes Required

None.

@Bakual please check if ok.