### PR TITLE
[com_finder] Add useglobal to "Search" menu item type

### DIFF
--- a/components/com_finder/views/search/tmpl/default.xml
+++ b/components/com_finder/views/search/tmpl/default.xml
@@ -11,187 +11,217 @@
 
 	<fields name="request" addfieldpath="/administrator/components/com_finder/models/fields">
 		<fieldset name="request">
-			<field name="q"
+			<field
+				name="q"
 				type="text"
 				label="COM_FINDER_SEARCH_SEARCH_QUERY_LABEL"
 				description="COM_FINDER_SEARCH_SEARCH_QUERY_DESC"
 				size="30"
 			/>
-			<field name="f"
+			<field
+				name="f"
 				type="searchfilter"
-				default=""
 				label="COM_FINDER_SEARCH_FILTER_SEARCH_LABEL"
 				description="COM_FINDER_SEARCH_FILTER_SEARCH_DESC"
+				default=""
 			/>
 		</fieldset>
 	</fields>
 	<fields name="params" addfieldpath="/administrator/components/com_finder/models/fields">
 		<fieldset name="basic">
-			<field name="show_date_filters"
+			<field
+				name="show_date_filters"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_DATE_FILTERS_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_DATE_FILTERS_DESC">
+				description="COM_FINDER_CONFIG_SHOW_DATE_FILTERS_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 			</field>
-			<field name="show_advanced"
+			<field
+				name="show_advanced"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_ADVANCED_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_ADVANCED_DESC">
-				<option value="1">JSHOW</option>
-				<option value="0">JHIDE</option>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
-			</field>
-			<field name="expand_advanced"
-				type="list"
+				description="COM_FINDER_CONFIG_SHOW_ADVANCED_DESC"
 				default=""
-				validate="options"
-				label="COM_FINDER_CONFIG_EXPAND_ADVANCED_LABEL"
-				description="COM_FINDER_CONFIG_EXPAND_ADVANCED_DESC">
+				useglobal="true"
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+			</field>
+			<field
+				name="expand_advanced"
+				type="list"
+				label="COM_FINDER_CONFIG_EXPAND_ADVANCED_LABEL"
+				description="COM_FINDER_CONFIG_EXPAND_ADVANCED_DESC"
+				default=""
+				useglobal="true"
+				>
+				<option value="1">JSHOW</option>
+				<option value="0">JHIDE</option>
 			</field>
 			<field type="spacer" />
-			<field name="show_description"
+			<field
+				name="show_description"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_DESCRIPTION_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_DESCRIPTION_DESC">
+				description="COM_FINDER_CONFIG_SHOW_DESCRIPTION_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 			</field>
-			<field name="description_length"
+			<field
+				name="description_length"
 				type="text"
-				default="255"
-				filter="integer"
 				label="COM_FINDER_CONFIG_DESCRIPTION_LENGTH_LABEL"
 				description="COM_FINDER_CONFIG_DESCRIPTION_LENGTH_DESC"
-				size="5"
-			/>
-			<field name="show_url"
-				type="list"
 				default=""
-				validate="options"
+				filter="integer"
+				size="5"
+				useglobal="true"
+			/>
+			<field
+				name="show_url"
+				type="list"
 				label="COM_FINDER_CONFIG_SHOW_URL_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_URL_DESC">
+				description="COM_FINDER_CONFIG_SHOW_URL_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
 			</field>
 			<field type="spacer" />
 		</fieldset>
 		<fieldset name="advanced">
-			<field name="show_pagination_limit" type="list"
+			<field
+				name="show_pagination_limit"
+				type="list"
 				label="JGLOBAL_DISPLAY_SELECT_LABEL"
+				description="JGLOBAL_DISPLAY_SELECT_DESC"
 				validate="options"
-				description="JGLOBAL_DISPLAY_SELECT_DESC">
+				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field name="show_pagination" type="list"
+			<field
+				name="show_pagination"
+				type="list"
+				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
 				validate="options"
-				label="JGLOBAL_PAGINATION_LABEL" >
+				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
-			<field name="show_pagination_results" type="list"
+			<field
+				name="show_pagination_results"
+				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
+				description="JGLOBAL_PAGINATION_RESULTS_DESC"
 				validate="options"
-				description="JGLOBAL_PAGINATION_RESULTS_DESC" >
+				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-			<field name="allow_empty_query"
-				type="radio"
-				class="btn-group btn-group-yesno"
-				default="0"
-				validate="options"
+			<field
+				name="allow_empty_query"
+				type="list"
 				label="COM_FINDER_ALLOW_EMPTY_QUERY_LABEL"
-				description="COM_FINDER_ALLOW_EMPTY_QUERY_DESC">
+				description="COM_FINDER_ALLOW_EMPTY_QUERY_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
-			<field name="show_suggested_query"
+			<field
+				name="show_suggested_query"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_DESC">
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_FINDER_CONFIG_SHOW_SUGGESTED_QUERY_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
-			<field name="show_explained_query"
+			<field
+				name="show_explained_query"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_DESC">
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_FINDER_CONFIG_SHOW_EXPLAINED_QUERY_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
-			<field name="sort_order"
+			<field
+				name="sort_order"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SORT_ORDER_LABEL"
-				description="COM_FINDER_CONFIG_SORT_ORDER_DESC">
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_FINDER_CONFIG_SORT_ORDER_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="relevance">COM_FINDER_CONFIG_SORT_OPTION_RELEVANCE</option>
 				<option value="date">COM_FINDER_CONFIG_SORT_OPTION_START_DATE</option>
 				<option value="price">COM_FINDER_CONFIG_SORT_OPTION_LIST_PRICE</option>
 			</field>
-			<field name="sort_direction"
+			<field
+				name="sort_direction"
 				type="list"
-				default=""
-				validate="options"
 				label="COM_FINDER_CONFIG_SORT_DIRECTION_LABEL"
-				description="COM_FINDER_CONFIG_SORT_DIRECTION_DESC">
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_FINDER_CONFIG_SORT_DIRECTION_DESC"
+				default=""
+				useglobal="true"
+				>
 				<option value="desc">COM_FINDER_CONFIG_SORT_OPTION_DESCENDING</option>
 				<option value="asc">COM_FINDER_CONFIG_SORT_OPTION_ASCENDING</option>
 			</field>
 			<field type="spacer" />
-			<field name="show_feed"
+			<field
+				name="show_feed"
 				type="radio"
+				label="COM_FINDER_CONFIG_SHOW_FEED_LABEL"
+				description="COM_FINDER_CONFIG_SHOW_FEED_DESC"
 				class="btn-group btn-group-yesno"
 				default="0"
 				validate="options"
-				label="COM_FINDER_CONFIG_SHOW_FEED_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_FEED_DESC">
+				>
 				<option value="1">JSHOW</option>
 				<option value="0">JHIDE</option>
 			</field>
-			<field name="show_feed_text"
+			<field
+				name="show_feed_text"
 				type="radio"
+				label="COM_FINDER_CONFIG_SHOW_FEED_TEXT_LABEL"
+				description="COM_FINDER_CONFIG_SHOW_FEED_TEXT_DESC"
 				class="btn-group btn-group-yesno"
 				default="0"
 				validate="options"
-				label="COM_FINDER_CONFIG_SHOW_FEED_TEXT_LABEL"
-				description="COM_FINDER_CONFIG_SHOW_FEED_TEXT_DESC">
+				>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>
 		</fieldset>
 		<fieldset name="integration">
-			<field name="show_feed_link" type="list"
+			<field
+				name="show_feed_link"
+				type="list"
+				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
 				validate="options"
-				label="JGLOBAL_SHOW_FEED_LINK_LABEL" >
+				>
 				<option value="">JGLOBAL_USE_GLOBAL</option>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>

--- a/components/com_finder/views/search/tmpl/default.xml
+++ b/components/com_finder/views/search/tmpl/default.xml
@@ -80,7 +80,6 @@
 				label="COM_FINDER_CONFIG_DESCRIPTION_LENGTH_LABEL"
 				description="COM_FINDER_CONFIG_DESCRIPTION_LENGTH_DESC"
 				default=""
-				filter="integer"
 				size="5"
 				useglobal="true"
 			/>


### PR DESCRIPTION
### Summary of Changes

This adds useglobal to com_finder also.

Notes:
- There are some fields with use global that i don't know where use global is really fetched from (if from somewhere at all ...). Those i didn't touch, because i couldn't get the value.
- Also removed all hardcoded default values in the ones that useglobal and also removed the options validation
- Add to removed the integer filter on a field or it would always save with 0

### Testing Instructions

1. Apply patch
2. Go to com_finder options and save them
3. Create a menu item of "Smart Search" > "Search" type and check if the use global are correctly populated.

![image](https://cloud.githubusercontent.com/assets/9630530/20364292/71cafa90-ac3a-11e6-8616-110ceea044da.png)

![image](https://cloud.githubusercontent.com/assets/9630530/20364302/7d15765a-ac3a-11e6-9af4-6a5cb35abe64.png)

### Documentation Changes Required

None.
