### PR TITLE
[com_search] Add useglobal to "Search Form or Search Results" menu item type

### DIFF
--- a/components/com_search/views/search/tmpl/default.xml
+++ b/components/com_search/views/search/tmpl/default.xml
@@ -13,9 +13,11 @@
 	<fields name="request">
 		<fieldset name="request" label="COM_SEARCH_FIELDSET_OPTIONAL_LABEL">
 
-			<field name="searchword" type="text"
-				description="COM_SEARCH_FIELD_DESC"
+			<field
+				name="searchword"
+				type="text"
 				label="COM_SEARCH_FIELD_LABEL"
+				description="COM_SEARCH_FIELD_DESC"
 			/>
 		</fieldset>
 	</fields>
@@ -25,56 +27,67 @@
 		<!-- Basic options. -->
 		<fieldset name="basic" label="COM_MENUS_BASIC_FIELDSET_LABEL">
 
-			<field name="search_phrases" type="list"
-
-				description="COM_SEARCH_FIELD_SEARCH_PHRASES_DESC"
+			<field
+				name="search_phrases"
+				type="list"
 				label="COM_SEARCH_FIELD_SEARCH_PHRASES_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_SEARCH_FIELD_SEARCH_PHRASES_DESC"
+				useglobal="true"
+				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="search_areas" type="list"
-
-				description="COM_SEARCH_FIELD_SEARCH_AREAS_DESC"
+			<field
+				name="search_areas"
+				type="list"
 				label="COM_SEARCH_FIELD_SEARCH_AREAS_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_SEARCH_FIELD_SEARCH_AREAS_DESC"
+				useglobal="true"
+				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
 			</field>
 
-			<field name="show_date" type="list"
-
-				description="COM_SEARCH_CONFIG_FIELD_CREATED_DATE_DESC"
+			<field
+				name="show_date"
+				type="list"
 				label="COM_SEARCH_CONFIG_FIELD_CREATED_DATE_LABEL"
-			>
-				<option value="">JGLOBAL_USE_GLOBAL</option>
+				description="COM_SEARCH_CONFIG_FIELD_CREATED_DATE_DESC"
+				useglobal="true"
+				>
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field name="spacer1" type="spacer" class="text"
-			label="COM_SEARCH_SAVED_SEARCH_OPTIONS"
+			<field
+				name="spacer1"
+				type="spacer"
+				label="COM_SEARCH_SAVED_SEARCH_OPTIONS"
+				class="text"
 			/>
 
 			<!-- Add fields to define saved search. -->
 
-			<field name="searchphrase" type="list"
-				default="0"
-				description="COM_SEARCH_FOR_DESC"
+			<field
+				name="searchphrase"
+				type="list"
 				label="COM_SEARCH_FOR_LABEL"
-			>
+				description="COM_SEARCH_FOR_DESC"
+				default="0"
+				>
 				<option value="0">COM_SEARCH_ALL_WORDS</option>
 				<option value="1">COM_SEARCH_ANY_WORDS</option>
 				<option value="2">COM_SEARCH_EXACT_PHRASE</option>
 			</field>
-			<field name="ordering" type="list"
-				default="0"
-				description="COM_SEARCH_ORDERING_DESC"
+
+			<field
+				name="ordering"
+				type="list"
 				label="COM_SEARCH_ORDERING_LABEL"
-			>
+				description="COM_SEARCH_ORDERING_DESC"
+				default="newest"
+				>
 				<option value="newest">COM_SEARCH_NEWEST_FIRST</option>
 				<option value="oldest">COM_SEARCH_OLDEST_FIRST</option>
 				<option value="popular">COM_SEARCH_MOST_POPULAR</option>


### PR DESCRIPTION
### Summary of Changes

This adds useglobal to com_search also.

Notes:
- Changed a default value from "0" to "newest" (there is no option "0" in that select...)

### Testing Instructions

1. Apply patch
2. Go to com_search options and save them
3. Create a menu item of "Search" > "Search Form or Search Results" type and check if the use global are correctly populated.

![image](https://cloud.githubusercontent.com/assets/9630530/20364766/44ba2010-ac3c-11e6-811a-817e311acc7d.png)

### Documentation Changes Required

None.