### PR TITLE
Set session object's _state to 'inactive' when session is closed

### DIFF
--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -800,6 +800,7 @@ class JSession implements IteratorAggregate
 	public function close()
 	{
 		$this->_handler->save();
+		$this->_state = 'inactive';
 	}
 
 	/**


### PR DESCRIPTION
Currently, if a session is closed (not destroyed) the session object's `_state` property remains set as 'active'. Consequently, using the session object's `start()` method will result in it returning before it can do anything. 

As a session has been ended by the server once the `close()` method has been called the object's `_state` property should possibly be set to 'inactive'. 

### Summary of Changes
Amended `JSession` class' `close()` method to set session object's `_state` property to 'inactive' after a session is ended by the server.

### Testing Instructions
- Apply patch.
- Wait for a session to start.
- Close it using `close();`
- The session object's `_state` property will be set to 'inactive' once the handler's `save()` method has been executed and the server has ended the session.

### Documentation Changes Required
None

### Note
In my testing before implementing this I couldn't see any good reason for a session object's state to remain 'active' once the actual session's been ended by the server; I accept there may well be one I overlooked.