### PR TITLE
[JHtmlNumber::bytes] Format number according to language

### DIFF
--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -105,6 +105,7 @@ abstract class JHtmlNumber
 			$suffix = $stdSuffixes[$i];
 		}
 
-		return round($oBytes / pow($base, $i), (int) $precision) . ' ' . $suffix;
+		return number_format(round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('THOUSANDS_SEPARATOR'),
+			JText::_('DECIMALS_SEPARATOR'))  . ' ' . $suffix;
 	}
 }

--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -105,7 +105,8 @@ abstract class JHtmlNumber
 			$suffix = $stdSuffixes[$i];
 		}
 
-		return number_format(round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('DECIMALS_SEPARATOR'),
-			JText::_('THOUSANDS_SEPARATOR'))  . ' ' . $suffix;
+		return number_format(
+			round($oBytes / pow($base, $i), (int) $precision),(int) $precision, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')
+		) . ' ' . $suffix;
 	}
 }

--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -105,7 +105,7 @@ abstract class JHtmlNumber
 			$suffix = $stdSuffixes[$i];
 		}
 
-		return number_format(round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('THOUSANDS_SEPARATOR'),
-			JText::_('DECIMALS_SEPARATOR'))  . ' ' . $suffix;
+		return number_format(round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('DECIMALS_SEPARATOR'),
+			JText::_('THOUSANDS_SEPARATOR'))  . ' ' . $suffix;
 	}
 }

--- a/libraries/cms/html/number.php
+++ b/libraries/cms/html/number.php
@@ -106,7 +106,7 @@ abstract class JHtmlNumber
 		}
 
 		return number_format(
-			round($oBytes / pow($base, $i), (int) $precision),(int) $precision, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')
+			round($oBytes / pow($base, $i), (int) $precision), (int) $precision, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')
 		) . ' ' . $suffix;
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
@@ -28,27 +28,27 @@ class JHtmlNumberTest extends TestCase
 		return array(
 			// Element order: result, bytes, unit, precision
 			array(
-				'1 b',
+				'1.00 b',
 				1,
 			),
 			array(
-				'1 kB',
+				'1.00 kB',
 				1024,
 			),
 			array(
-				'1 MB',
+				'1.00 MB',
 				1024 * 1024,
 			),
 			array(
-				'1 GB',
+				'1.00 GB',
 				1024 * 1024 * 1024,
 			),
 			array(
-				'1 TB',
+				'1.00 TB',
 				1024 * 1024 * 1024 * 1024,
 			),
 			array(
-				'1 PB',
+				'1.00 PB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 			),
 			array(
@@ -58,57 +58,57 @@ class JHtmlNumberTest extends TestCase
 
 			// Test units.
 			array(
-				'1 YB',
+				'1.00 YB',
 				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
 				'auto',
 			),
 			array(
-				'1 YB',
+				'1.00 YB',
 				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
 				'YB',
 			),
 			array(
-				'1024 ZB',
+				'1,024.00 ZB',
 				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
 				'ZB',
 			),
 			array(
-				'1048576 EB',
+				'1,048,576.00 EB',
 				1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
 				'EB',
 			),
 			array(
-				'1 PB',
+				'1.00 PB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'PB',
 			),
 			array(
-				'1024 TB',
+				'1,024.00 TB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'TB',
 			),
 			array(
-				'1048576 GB',
+				'1,048,576.00 GB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'GB',
 			),
 			array(
-				'1073741824 MB',
+				'1,073,741,824.00 MB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'MB',
 			),
 			array(
-				'1099511627776 kB',
+				'1,099,511,627,776 kB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'kB',
 			),
 			array(
-				'1.1258999068426E+15 b',
+				'1,125,899,906,842,624.00 b',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'b',
 			),
 			array(
-				'1.1258999068426E+15',
+				'1,125,899,906,842,624.00',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'',
 			),
@@ -145,16 +145,16 @@ class JHtmlNumberTest extends TestCase
 
 			// Test unit suffixed inputs
 			array(
-				'1 MB',
+				'1.00 MB',
 				'1024K',
 			),
 			array(
-				'1024 MB',
+				'1,024.00 MB',
 				'1 GB',
 				'MB'
 			),
 			array(
-				'10.5 GB',
+				'10.50 GB',
 				'1.0752E+4 MB',
 				'GB'
 			),
@@ -177,7 +177,7 @@ class JHtmlNumberTest extends TestCase
 
 			// Test IEC aware output with automatic unit
 			array(
-				'1 MB',
+				'1.00 MB',
 				1000 * 1000,
 				'auto',
 				2,
@@ -186,14 +186,14 @@ class JHtmlNumberTest extends TestCase
 
 			// Test automatic binary units output
 			array(
-				'1 MiB',
+				'1.00 MiB',
 				1024 * 1024,
 				'binary',
 				2,
 				true
 			),
 			array(
-				'1 MiB',
+				'1.00 MiB',
 				1024 * 1024,
 				'binary',
 				2,
@@ -202,14 +202,14 @@ class JHtmlNumberTest extends TestCase
 
 			// Test IEC aware specific unit output
 			array(
-				'1000 KiB',
+				'1,000.00 KiB',
 				'1024 KB',
 				'KiB',
 				2,
 				true
 			),
 			array(
-				'1048.58 kB',
+				'1,048.58 kB',
 				'1024 KiB',
 				'kB',
 				2,

--- a/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlNumberTest.php
@@ -98,7 +98,7 @@ class JHtmlNumberTest extends TestCase
 				'MB',
 			),
 			array(
-				'1,099,511,627,776 kB',
+				'1,099,511,627,776.00 kB',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'kB',
 			),
@@ -108,7 +108,7 @@ class JHtmlNumberTest extends TestCase
 				'b',
 			),
 			array(
-				'1,125,899,906,842,624.00',
+				'1.1258999068426E+15',
 				1024 * 1024 * 1024 * 1024 * 1024,
 				'',
 			),


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

As discussed in https://github.com/joomla/joomla-websites/issues/765 `JHtmlNumber::bytes()` is returning the number format always in english format.

This PR makes it return the format in the current language, using the languages packs `DECIMALS_SEPARATOR` and `THOUSANDS_SEPARATOR` variables for formatting the number.

### Testing Instructions

- Use a multilingual site with some languages (example: pt-PT) and apply patch
- Add to protostar index.php the following code
```php
echo JHtmlNumber::bytes(1).'<br/>';
echo JHtmlNumber::bytes(1024).'<br/>';
echo JHtmlNumber::bytes(1024*1024).'<br/>';
echo JHtmlNumber::bytes(1024*1024*1024).'<br/>';
echo JHtmlNumber::bytes(1024*1024*1024*1024).'<br/>';
```
- Go to site and check if the number format is correct in all the languages you installed (you can check if respect the language variables in `/language/xx-XX/xx-XX.ini` file).

### Documentation Changes Required

None.