### PR TITLE
[categories] - respect  user level access for categories

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -140,6 +140,9 @@ class JFormFieldCategoryEdit extends JFormAbstractlist
 		}
 
 		$db = JFactory::getDbo();
+		$user = JFactory::getUser();
+		$groups = implode(',', $user->getAuthorisedViewLevels());
+
 		$query = $db->getQuery(true)
 			->select('DISTINCT a.id AS value, a.title AS text, a.level, a.published, a.lft');
 		$subQuery = $db->getQuery(true)
@@ -179,6 +182,9 @@ class JFormFieldCategoryEdit extends JFormAbstractlist
 		{
 			$subQuery->where('published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
 		}
+
+		// Filter categories on User Access Level
+		$subQuery->where('access IN (' . $groups . ')');
 
 		$query->from('(' . (string) $subQuery . ') AS a')
 			->join('LEFT', $db->quoteName('#__categories') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -226,11 +226,12 @@ class ContentModelArticles extends JModelList
 			$query->where('a.access = ' . (int) $access);
 		}
 
-		// Implement View Level Access
+		// Filter by access level on categories.
 		if (!$user->authorise('core.admin'))
 		{
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ')');
+			$query->where('c.access IN (' . $groups . ')');
 		}
 
 		// Filter by published state

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -74,6 +74,7 @@ class ContentModelFeatured extends ContentModelArticles
 		// Create a new query object.
 		$db = $this->getDbo();
 		$query = $db->getQuery(true);
+		$user = JFactory::getUser();
 
 		// Select the required fields from the table.
 		$query->select(
@@ -121,6 +122,13 @@ class ContentModelFeatured extends ContentModelArticles
 		if ($access = $this->getState('filter.access'))
 		{
 			$query->where('a.access = ' . (int) $access);
+		}
+
+		// Filter by access level on categories.
+		if (!$user->authorise('core.admin'))
+		{
+			$groups = implode(',', $user->getAuthorisedViewLevels());
+			$query->where('c.access IN (' . $groups . ')');
 		}
 
 		// Filter by published state

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -44,7 +44,10 @@ abstract class JHtmlCategory
 		if (!isset(static::$items[$hash]))
 		{
 			$config = (array) $config;
-			$db = JFactory::getDbo();
+			$db     = JFactory::getDbo();
+			$user   = JFactory::getUser();
+			$groups = implode(',', $user->getAuthorisedViewLevels());
+
 			$query = $db->getQuery(true)
 				->select('a.id, a.title, a.level')
 				->from('#__categories AS a')
@@ -52,6 +55,9 @@ abstract class JHtmlCategory
 
 			// Filter on extension.
 			$query->where('extension = ' . $db->quote($extension));
+			
+			// Filter on user access level
+			$query->where('a.access IN (' . $groups . ')');
 
 			// Filter on the published state
 			if (isset($config['filter.published']))

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -139,6 +139,7 @@ abstract class JHtmlCategory
 		if (!isset(static::$items[$hash]))
 		{
 			$config = (array) $config;
+			$user = JFactory::getUser();
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select('a.id, a.title, a.level, a.parent_id')
@@ -147,6 +148,10 @@ abstract class JHtmlCategory
 
 			// Filter on extension.
 			$query->where('extension = ' . $db->quote($extension));
+			
+			// Filter on user level.
+			$groups = implode(',', $user->getAuthorisedViewLevels());
+			$query->where('a.access IN (' . $groups . ')');
 
 			// Filter on the published state
 			if (isset($config['filter.published']))


### PR DESCRIPTION
Pull Request for Issue 

-  Article Manager don't respect category user level access.
-  search box category field don't respect category user level access.
-  possible to create a new article in an unaccessbile category


### Summary of Changes
modfified queries to take care of category access level

### Testing Instructions
Create/edit  a category and set "super user" as Access Level
![categories access level](https://cloud.githubusercontent.com/assets/181681/20407473/db83482a-ad11-11e6-90da-a3d832ad57f9.PNG)

Create/edit an user with acess level different than "super suer"  lets call "tester"
![user level](https://cloud.githubusercontent.com/assets/181681/20407619/69a4f16c-ad12-11e6-850a-dff23719ccc4.PNG)

Create a new article in the category that should be unacessible for the test user

### Expected result
if you are logged on backend like "tester" user for your  access level you can't see the articles in the categories  categoria (it-IT)  cause should be inacessible for your level, neither can create a new article in that category

### Actual result
you can see the articles from the category you cannot
![error1](https://cloud.githubusercontent.com/assets/181681/20407930/adb148fa-ad13-11e6-8be1-17216423266c.PNG)

you can see the article from the category you cannot
![erro2](https://cloud.githubusercontent.com/assets/181681/20407933/b3cc64fe-ad13-11e6-9027-a61b2033980b.PNG)

you can see the category tha you cannot
![error3](https://cloud.githubusercontent.com/assets/181681/20407936/b7ff96d6-ad13-11e6-8034-4fc81d102545.png)


### After patch
 you cannot see the articles from the category that you lack of permission

