### PR TITLE
Multilingual: Correcting login redirect

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -620,7 +620,7 @@ class PlgSystemLanguageFilter extends JPlugin
 				   This will override the automatic change to the user preferred site language.
 				   In that case we use the redirect as defined in the menu item.
 				   Otherwise we redirect, when available, to the user preferred site language.
-				 */
+				*/
 				if ($active && !$active->params['login_redirect_url'])
 				{
 					if ($assoc)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -615,12 +615,13 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				$foundAssociation = false;
 
-				/* Looking for associations.
-				   If the login menu item form contains an internal URL redirection,
-				   This will override the automatic change to the user preferred site language.
-				   In that case we use the redirect as defined in the menu item.
-				   Otherwise we redirect, when available, to the user preferred site language.
-				*/
+				/**
+				 * Looking for associations.
+				 * If the login menu item form contains an internal URL redirection,
+				 * This will override the automatic change to the user preferred site language.
+				 * In that case we use the redirect as defined in the menu item.
+				 *  Otherwise we redirect, when available, to the user preferred site language.
+				 */
 				if ($active && !$active->params['login_redirect_url'])
 				{
 					if ($assoc)
@@ -649,10 +650,11 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
-						/* The login form does not contain a menu item redirection.
-						   The active menu item has associations.
-						   We redirect to the user preferred site language associated page.
-						*/
+						/**
+						 * The login form does not contain a menu item redirection.
+						 * The active menu item has associations.
+						 * We redirect to the user preferred site language associated page.
+						 */
 						$associationItemid = $associations[$lang_code];
 						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
 						$foundAssociation = true;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -650,9 +650,10 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
-						// The login form does not contain a menu item redirection.
-						// The active menu item has associations.
-						// We redirect to the user preferred site language associated page.
+						/* The login form does not contain a menu item redirection.
+						   The active menu item has associations.
+						   We redirect to the user preferred site language associated page.
+						*/
 						$associationItemid = $associations[$lang_code];
 						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
 						$foundAssociation = true;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -615,7 +615,13 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				$foundAssociation = false;
 
-				if ($active)
+				/* Looking for associations.
+				   If the login menu item form contains an internal URL redirection,
+				   This will override the automatic change to the user preferred site language.
+				   In that case we use the redirect as defined in the menu item.
+				   Otherwise we redirect, when available, to the user preferred site language.
+				 */
+				if ($active && !$active->params['login_redirect_url'])
 				{
 					if ($assoc)
 					{
@@ -625,14 +631,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Retrieves the Itemid from a login form.
 					$uri = new JUri($this->app->getUserState('users.login.form.return'));
 
-					if ($active->params['login_redirect_url'])
-					{
-						/* The login menu item form contains an internal URL redirection.
-						   This will override the automatic change to the user preferred site language.
-						   We use the redirect as defined in the menu item.
-						*/
-					}
-					elseif ($uri->getVar('Itemid'))
+					if ($uri->getVar('Itemid'))
 					{
 						// The login form contains a menu item redirection. Try to get associations from that menu item.
 						// If any association set to the user preferred site language, redirect to that page.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -623,16 +623,16 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 
 					// Retrieves the Itemid from a login form.
-					$uri    = new JUri($this->app->getUserState('users.login.form.return'));
-					$itemid = $uri->getVar('Itemid');
+					$uri = new JUri($this->app->getUserState('users.login.form.return'));
 
 					if ($active->params['login_redirect_url'])
 					{
-						// The login menu item form contains an internal URL redirection.
-						// This will override the automatic change to the user preferred site language.
-						$this->app->setUserState('users.login.form.return', JRoute::_($this->app->getUserState('users.login.form.return'), false));
+						/* The login menu item form contains an internal URL redirection.
+						   This will override the automatic change to the user preferred site language.
+						   We use the redirect as defined in the menu item.
+						*/
 					}
-					elseif ($itemid)
+					elseif ($uri->getVar('Itemid'))
 					{
 						// The login form contains a menu item redirection. Try to get associations from that menu item.
 						// If any association set to the user preferred site language, redirect to that page.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -622,17 +622,20 @@ class PlgSystemLanguageFilter extends JPlugin
 						$associations = MenusHelper::getAssociations($active->id);
 					}
 
-					// The login menu item contains a redirection.
-					// This will override the automatic change to the user preferred language
+					// Retrieves the Itemid from a login form.
+					$uri    = new JUri($this->app->getUserState('users.login.form.return'));
+					$itemid = $uri->getVar('Itemid');
+
 					if ($active->params['login_redirect_url'])
 					{
+						// The login menu item form contains an internal URL redirection.
+						// This will override the automatic change to the user preferred site language.
 						$this->app->setUserState('users.login.form.return', JRoute::_($this->app->getUserState('users.login.form.return'), false));
 					}
-					elseif ($this->app->getUserState('users.login.form.return'))
+					elseif ($itemid)
 					{
-						// The login module contains a menu item redirection. Try to get association from that menu item.
-						$itemid = preg_replace('/\D+/', '', $this->app->getUserState('users.login.form.return'));
-
+						// The login form contains a menu item redirection. Try to get associations from that menu item.
+						// If any association set to the user preferred site language, redirect to that page.
 						if ($assoc)
 						{
 							$associations = MenusHelper::getAssociations($itemid);
@@ -647,13 +650,16 @@ class PlgSystemLanguageFilter extends JPlugin
 					}
 					elseif (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))
 					{
+						// The login form does not contain a menu item redirection.
+						// The active menu item has associations.
+						// We redirect to the user preferred site language associated page.
 						$associationItemid = $associations[$lang_code];
 						$this->app->setUserState('users.login.form.return', 'index.php?Itemid=' . $associationItemid);
 						$foundAssociation = true;
 					}
 					elseif ($active->home)
 					{
-						// We are on a Home page, we redirect to the user site language home page
+						// We are on a Home page, we redirect to the user preferred site language Home page.
 						$item = $menu->getDefault($lang_code);
 
 						if ($item && $item->language != $active->language && $item->language != '*')


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12920

When login in a multilingual site, the user should be redirected, if possible, to the associated menu item of the page containing the login module.
If redirections are set (in the login module as well as in a login menu item) they should use the possible associations for the redirect.

### Summary of Changes
Using API to get the possible Itemid in order to redirect properly when `Automatic Change` is set to Yes in the language filter plugin.
Added detailed comments explaining what each situation may obtain.

### Testing Instructions
Create a multilingual site from a clean staging. Patch.
Add one more article per language and associate them.
Set the user login preferred site language to another language than the default site language.
Set the language filter plugin to use "Automatic Change"

NOTE: if the user preferred site language is not set, the default site language will be used. Testing does not change. Just replace in the instructions below `user preferred site language` by `site default language`.

The following should work when testing, I added the code comments to clarify.

**--------------**
If login through a login menu item using the Internal URL redirection (on a multilingual site, that url should contain `&lang=xx-XX`):
`// The login menu item form contains an internal URL redirection.`
`// This will override the automatic change to the user preferred site language.`
=> The user will be redirected to that Internal URL, whatever it is.

**-------------**
If login from a login menu item or a login module and a Menu Item redirection is set
`// The login form contains a menu item redirection. Try to get associations from that menu item.`
`// If any association set to the user preferred site language, redirect to that page.`

**-------------**
`// The login form does not contain a Menu Item redirection.`
`// The active menu item has associations.`
`// We redirect to the user preferred site language associated page.`

**-------------**
`// We are on a Home page, we redirect to the user preferred site language Home page.`
I.e. no need to associate the Home pages. They are automatically.

**-------------**
If Associations are **not** implemented, Automatic Change set to Yes, no redirection set to a Menu Item and login from another page than the Home page, the user should be redirected to the same page. 
If login from a Home page, redirection will be set to the preferred site language Home page of the user.

**-------------**
If automatic change is set to No, behaviour will be the same as on a monolanguage site.
I.e. redirect to the same page or, if a redirection is set in the login module or login menu item, redirection to that url or menu item.

### Documentation Changes Required
None. This broke with the new router because the code was not using the proper API.
