### PR TITLE
Set correct component id for system links

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -482,6 +482,11 @@ class MenusControllerItem extends JControllerForm
 		{
 			$title = 'component';
 		}
+		else
+		{
+			// Set correct component id to ensure proper 404 messages with system links
+			$data['component_id'] = 0;
+		}
 
 		$app->setUserState('com_menus.edit.item.type', $title);
 

--- a/libraries/legacy/table/menu.php
+++ b/libraries/legacy/table/menu.php
@@ -97,12 +97,6 @@ class JTableMenu extends JTableNested
 			return false;
 		}
 
-		// Set correct component id to ensure proper 404 messages with separator items
-		if ($this->type == "separator")
-		{
-			$this->component_id = 0;
-		}
-
 		// Check for a path.
 		if (trim($this->path) == '')
 		{


### PR DESCRIPTION
### Summary of Changes

Set correct component id to ensure proper 404 messages with system links

### Testing Instructions

1. Create a new menu item for articles with type category blog.
2. Save.
3. Check the database entry in the #__menu table and column component_id.
4. Result is 22.
5. Change the menu item type to system link heading.
6. Save.
7. Check the database entry in the #__menu table and column component_id.
8. Result is 22. This is incorrect.

Apply the patch.

Repeat step 1 - 7.

Final result is as expected component_id = 0 in the #__menu table.

### Documentation Changes Required

none