### PR TITLE
Remove parent class from menu items with only hidden children

### DIFF
--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -56,7 +56,7 @@ class ModMenuHelper
 				{
 					$item->parent = false;
 
-					if (isset($items[$lastitem]) && $items[$lastitem]->id == $item->parent_id)
+					if (isset($items[$lastitem]) && $items[$lastitem]->id == $item->parent_id && $item->params->get('menu_show', 1) == 1)
 					{
 						$items[$lastitem]->parent = true;
 					}


### PR DESCRIPTION
Pull Request for Issue #12890  .

### Summary of Changes
Removes parent class for menu items with only hidden children.

### Testing Instructions
Create a parent menu item and two or more child items. With the patch applied, check that the parent item does not have the parent class when all children are set to hidden. Check that it does have the parent class when one or more child items are visible.

### Documentation Changes Required
None.