### PR TITLE
JFormfield calendar output moved to JLayout 

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  string   $div_class A div CSS class
+ * @var  string   $inputvalue The date value
+ * @var  string   $fdate Formatted date
+ * @var  string   $name The field name
+ * @var  string   $id The field id
+ * @var  string   $attribs Attributes of the input HTML tag
+ * @var  string   $btn_style Button inline style
+ */
+extract($displayData);
+
+?>
+<div <?php echo $div_class; ?>>
+	<input type="text" title="<?php echo $fdate; ?>"
+		name="<?php echo $name; ?>" id="<?php echo $id; ?>"
+		value="<?php echo htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attribs; ?>/>
+	 <button type="button" class="btn" id="<?php echo $id; ?>_img" <?php echo $btn_style; ?>>
+		<span class="icon-calendar"></span>
+	</button>'
+</div>

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1041,11 +1041,18 @@ abstract class JHtml
 		$btn_style = ($readonly || $disabled) ? ' style="display:none;"' : '';
 		$div_class = (!$readonly && !$disabled) ? ' class="input-append"' : '';
 
-		return '<div' . $div_class . '>'
-				. '<input type="text" title="' . ($inputvalue ? static::_('date', $value, null, null) : '')
-				. '" name="' . $name . '" id="' . $id . '" value="' . htmlspecialchars($inputvalue, ENT_COMPAT, 'UTF-8') . '" ' . $attribs . ' />'
-				. '<button type="button" class="btn" id="' . $id . '_img"' . $btn_style . '><span class="icon-calendar"></span></button>'
-			. '</div>';
+		//Format the date
+		$fdate = $inputvalue ? static::_('date', $value, null, null) : '';
+
+		return JLayoutHelper::render('joomla.form.field.calendar',
+				array('div_class' => $div_class,
+				'inputvalue' => $inputvalue,
+				'fdate' => $fdate,
+				'name' => $name,
+				'id' => $id,
+				'attribs' => $attribs,
+				'btn_style' => $btn_style));
+
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Use of JLayout to enable output overrides.
The rest of the code probably has to  stay in JHtml_('calendar') of B/C reasons and wait for J4.

### Testing Instructions
1. Edit/create an item with calendar fields (e.g. article). Check the behaviour of those fields, tooltips and pop-up. (backend and frontend)
2. Install the patch.
3. Repeat 1. Nothing should have changed!
Advanced test - overrides.
1. Add a modified calendar.php file to the possible override folders. 
e.g. your_template/html/layouts/joomla/form/field
2. Check that the calendar fields are overridden.
