### PR TITLE
Allow two or more content language without images (PR for #12907)

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
@@ -1,0 +1,3 @@
+-- Replace language image UNIQUE index for a normal INDEX.
+ALTER TABLE `#__languages` DROP INDEX `idx_image`;
+ALTER TABLE `#__languages` ADD INDEX `idx_image` (`image`);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
@@ -1,0 +1,3 @@
+-- Replace language image UNIQUE index for a normal INDEX.
+ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image";
+CREATE INDEX "#__idx_image" ON "#__languages" ("image");

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
@@ -1,0 +1,6 @@
+-- Replace language image UNIQUE index for a normal INDEX.
+ALTER TABLE [#__languages] DROP CONSTRAINT [#__languages$idx_image];
+CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
+	[image] ASC
+) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
@@ -3,4 +3,3 @@ ALTER TABLE [#__languages] DROP CONSTRAINT [#__languages$idx_image];
 CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
 	[image] ASC
 ) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
-

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1266,8 +1266,8 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   `ordering` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`lang_id`),
   UNIQUE KEY `idx_sef` (`sef`),
-  UNIQUE KEY `idx_image` (`image`),
   UNIQUE KEY `idx_langcode` (`lang_code`),
+  KEY `idx_image` (`image`),
   KEY `idx_access` (`access`),
   KEY `idx_ordering` (`ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1197,9 +1197,9 @@ CREATE TABLE "#__languages" (
   "ordering" bigint DEFAULT 0 NOT NULL,
   PRIMARY KEY ("lang_id"),
   CONSTRAINT "#__languages_idx_sef" UNIQUE ("sef"),
-  CONSTRAINT "#__languages_idx_image" UNIQUE ("image"),
   CONSTRAINT "#__languages_idx_langcode" UNIQUE ("lang_code")
 );
+CREATE INDEX "#__languages_idx_image" ON "#__languages" ("image");
 CREATE INDEX "#__languages_idx_ordering" ON "#__languages" ("ordering");
 CREATE INDEX "#__languages_idx_access" ON "#__languages" ("access");
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2013,6 +2013,10 @@ CREATE UNIQUE INDEX [idx_access] ON [#__languages]
 	[access] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
+CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
+	[image] ASC
+) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
 SET IDENTITY_INSERT [#__languages] ON;
 
 INSERT INTO [#__languages] ([lang_id], [lang_code], [title], [title_native], [sef], [image], [description], [metakey], [metadesc], [sitename], [published], [access], [ordering])


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12907.

### Summary of Changes

This PR makes the SQL changes to allow two or more languages with no images.

### Testing Instructions

1. Apply patch
2. Delete configuration.php
3. Install joomla with multilanguage
4. After install try to remove all content languages images.

Test the same on update process.

### Documentation Changes Required

None.