### PR TITLE
[com_fields] use the new language layout (as all other list views)

### DIFF
--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -182,11 +182,7 @@ if ($saveOrder)
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
 							<td class="small nowrap hidden-phone">
-								<?php if ($item->language == '*') : ?>
-									<?php echo JText::alt('JALL', 'language'); ?>
-								<?php else : ?>
-									<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-								<?php endif; ?>
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 							</td>
 							<td class="center hidden-phone">
 								<span><?php echo (int) $item->id; ?></span>


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

com_fields, fields view is not using the new language layout added in all other views in https://github.com/joomla/joomla-cms/pull/12051

This PR makes it use.

### Testing Instructions

Very simple test.

- Change the image in english content language to "None"
- Now add a field (any) in english language
- Check the fields list view. You will see something like this:
![image](https://cloud.githubusercontent.com/assets/9630530/20466124/d15914c4-af64-11e6-9558-4d26280c7813.png)
- Apply patch
- All fine now.

### Documentation Changes Required

None.
