### PR TITLE
Export of Banners Tracks Does Not Export the Banner Name

### DIFF
--- a/administrator/components/com_banners/models/tracks.php
+++ b/administrator/components/com_banners/models/tracks.php
@@ -479,7 +479,7 @@ class BannersModelTracks extends JModelList
 
 			foreach ($this->getItems() as $item)
 			{
-				$this->content .= '"' . str_replace('"', '""', $item->name) . '","'
+				$this->content .= '"' . str_replace('"', '""', $item->banner_name) . '","'
 					. str_replace('"', '""', $item->client_name) . '","'
 					. str_replace('"', '""', $item->category_title) . '","'
 					. str_replace('"', '""', ($item->track_type == 1 ? JText::_('COM_BANNERS_IMPRESSION') : JText::_('COM_BANNERS_CLICK'))) . '","'


### PR DESCRIPTION
Pull Request for Issue #12948

### Steps to reproduce the issue
(a) Install Joomla! 3.6.4 with the Sample Data (Learning)

(b) Log into the back-end

(c) Go to the screen "Banners" (Components => Banners -> Banners)
(d) Click on the button Options
(e) In the resultant screen "Banners: Options", in the tab Client, for the options "Track Impressions" and "Track Clicks" choose value Yes and save the options by clicking on the button "Save & Close"

(f) In the screen "Banners", open each of the banners (Shop 1, Shop 2, and Support Joomla!) for Edit and in the tab "Banner Details", for the options "Track Impressions" and "Track Clicks" choose the value Yes and save the options by clicking on the button "Save & Close"

(g) Go to the screen "Banners: Clients" (Components => Banners -> Clients)
(h) In the screen "Banners: Clients", open each of the clients (Bookstore, Joomla!, and Shop) for Edit and in the tab "Details", for the options "Track Impressions" and "Track Clicks" choose the value Yes and save the options by clicking on the button "Save & Close"

(i) Go to the screen "Templates: Styles (Site)" (Extensions => Templates -> Styles)
(j) Make the style "Beez3 - Default" as the Default template style

(k) View the site in a separate tab/browser
(l) Click several time on each of the banners (Contribute!, Books!, and Shop!)

(m) In the back-end, go to the screen "Banners: Tracks" (Components => Banners -> Tracks)
(n) You would notice the list of clicks and impressions
(o) Click on the button Export
(n) In the resultant pop-up window "Download Tracks", for the option Compressed choose the value No, and Press the button Export

(o) Analyze the exported file


### Expected result
The content of the exported file should look something like as follows:
"Name","Client","Category","Type","Count","Date"
"Shop 1","Bookstore","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"Shop 1","Bookstore","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"Shop 1","Bookstore","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"
"Shop 2","Shop","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"Shop 2","Shop","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"Shop 2","Shop","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"
"Support Joomla!","Joomla!","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"Support Joomla!","Joomla!","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"Support Joomla!","Joomla!","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"


### Actual result
The actual file exported will look something as shown below:
"Name","Client","Category","Type","Count","Date"
"","Bookstore","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"","Bookstore","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"","Bookstore","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"
"","Shop","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"","Shop","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"","Shop","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"
"","Joomla!","Sample Data-Banners","Impression","1","2016-11-19 15:00:00"
"","Joomla!","Sample Data-Banners","Click","1","2016-11-19 15:00:00"
"","Joomla!","Sample Data-Banners","Impression","1","2016-11-19 16:00:00"

Note: Notice the name of the banner is missing in each row.


### System information (as much as possible)
Joomla! - 3.6.4 Stable Version
Windows 10
Apache - 2.4.9
PHP - 5.5.12
MySQL - 5.6.17


### Additional comments

Exporting the banner tracks, results in the following error (stack trace):
<output>[21-Nov-2016 00:36:40 Asia/Kolkata] PHP Notice:  Undefined property: stdClass::$name in C:\wamp\www\joomla_36_4\administrator\components\com_banners\models\tracks.php on line 482
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP Stack trace:
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   1. {main}() C:\wamp\www\joomla_36_4\administrator\index.php:0
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   2. JApplicationCms->execute() C:\wamp\www\joomla_36_4\administrator\index.php:51
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   3. JApplicationAdministrator->doExecute() C:\wamp\www\joomla_36_4\libraries\cms\application\cms.php:261
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   4. JApplicationAdministrator->dispatch() C:\wamp\www\joomla_36_4\libraries\cms\application\administrator.php:152
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   5. JComponentHelper::renderComponent() C:\wamp\www\joomla_36_4\libraries\cms\application\administrator.php:98
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   6. JComponentHelper::executeComponent() C:\wamp\www\joomla_36_4\libraries\cms\component\helper.php:380
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   7. require_once() C:\wamp\www\joomla_36_4\libraries\cms\component\helper.php:405
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   8. JControllerLegacy->execute() C:\wamp\www\joomla_36_4\administrator\components\com_banners\banners.php:20
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP   9. BannersControllerTracks->display() C:\wamp\www\joomla_36_4\libraries\legacy\controller\legacy.php:702
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP  10. BannersViewTracks->display() C:\wamp\www\joomla_36_4\administrator\components\com_banners\controllers\tracks.raw.php:95
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP  11. JViewLegacy->get() C:\wamp\www\joomla_36_4\administrator\components\com_banners\views\tracks\view.raw.php:31
[21-Nov-2016 00:36:40 Asia/Kolkata] PHP  12. BannersModelTracks->getContent() C:\wamp\www\joomla_36_4\libraries\legacy\view\legacy.php:408</output>


### Solution:
As per the error message, tracked down the following line (line no. 482) of code in the file tracks.php located in the directory \administrator\components\com_banners\models.
<code>				$this->content .= '"' . str_replace('"', '""', $item->name) . '","'</code>

Modifying this like of code as shown below, rectifies the issue.
<code>				$this->content .= '"' . str_replace('"', '""', $item->banner_name) . '","'</code>

Note: 
(i) In the SQL, the revised/modified column name banner_name has been used.
(ii) I am planning to make a PR

Please review https://issues.joomla.org/tracker/joomla-cms/12948 for details