### PR TITLE
cache not cleared after extension uninstall in com_installer

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -220,6 +220,10 @@ class InstallerModelInstall extends JModelLegacy
 
 		JInstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);
 
+		// Clean the frontend and admin cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+
 		return $result;
 	}
 

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -270,6 +270,15 @@ class InstallerModelManage extends InstallerModel
 		$app->setUserState('com_installer.message', $installer->message);
 		$app->setUserState('com_installer.extension_message', $installer->get('extension_message'));
 
+		//Clear admin cache
+		$options = array(
+			'defaultgroup' => '_system',
+			'cachebase'    => JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache'
+		);
+
+		$cache = JCache::getInstance('callback', $options);
+		$cache->clean();
+
 		return $result;
 	}
 

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -145,6 +145,10 @@ class InstallerModelManage extends InstallerModel
 			}
 		}
 
+		// Clean the frontend and admin cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+
 		return $result;
 	}
 
@@ -270,14 +274,9 @@ class InstallerModelManage extends InstallerModel
 		$app->setUserState('com_installer.message', $installer->message);
 		$app->setUserState('com_installer.extension_message', $installer->get('extension_message'));
 
-		//Clear admin cache
-		$options = array(
-			'defaultgroup' => '_system',
-			'cachebase'    => JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache'
-		);
-
-		$cache = JCache::getInstance('callback', $options);
-		$cache->clean();
+		// Clean the frontend and admin cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
 
 		return $result;
 	}

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -369,6 +369,10 @@ class InstallerModelUpdate extends JModelList
 			$result = $res & $result;
 		}
 
+		// Clean the frontend and admin cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+
 		// Set the final state
 		$this->setState('result', $result);
 	}


### PR DESCRIPTION
After uninstalling an extension the system cache is not cleared
As the component helper class uses the cache system for database queries (https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/component/helper.php#L446) the usage of the method getComponent in this class after uninstalling an extension may not be relevant as it will use outdated cache datas.

### Steps to reproduce the issue
On a fresh install
* Download the test component attached
* In global configuration page, activate progressive or conservative cache
* Install the given test component (com_test), result from component helper is the same than database
* Uninstall the installed component (com_test)
* Install the given component again, result from component helper differs from what's actually in database


### Expected result
Result from component helper and database should be the same


### Actual result
After the second install the result from component helper differs from what's actually in database


### Test PR
* Apply pull request 
* Uninstall and reinstall the com_test extension
* The result from component helper and database should now be the same

### System information (as much as possible)
* Joomla latest version
* Conservative or progressive cache enabled


### Additional comments
com_test will print echo in the install script the result of component helper and database queries to get com_test id in #__extensions table
There is also a component menu entry where the issue can also be verified

[com_test.zip](https://github.com/joomla/joomla-cms/files/604026/com_test.zip)
