### PR TITLE
Allow 'default' in path list to allow fallback for overrides.

### DIFF
--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -291,6 +291,12 @@ class JLayoutFile extends JLayoutBase
 			$this->includePaths = $this->getDefaultIncludePaths();
 		}
 
+		$includeDefault = array_search('default', array_values($this->includePaths));
+		if ($includeDefault)
+		{
+			array_splice($this->includePaths, $includeDefault, 1, $this->getDefaultIncludePaths());
+		}
+
 		return $this->includePaths;
 	}
 

--- a/libraries/cms/layout/file.php
+++ b/libraries/cms/layout/file.php
@@ -247,17 +247,6 @@ class JLayoutFile extends JLayoutBase
 			return $this;
 		}
 
-		$includePaths = $this->getIncludePaths();
-
-		if (is_array($paths))
-		{
-			$includePaths = array_unique(array_merge($paths, $includePaths));
-		}
-		else
-		{
-			array_unshift($includePaths, $paths);
-		}
-
 		$this->setIncludePaths($includePaths);
 
 		return $this;

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -1022,8 +1022,12 @@ abstract class JFormField
 	 *
 	 * @since   3.5
 	 */
-	protected function getLayoutPaths()
+	protected function getLayoutPaths(JLayoutFile $renderer = null)
 	{
+		if ($renderer)
+		{
+			return $renderer->getDefaultIncludePaths();
+		}
 		return array();
 	}
 
@@ -1042,7 +1046,7 @@ abstract class JFormField
 
 		$renderer->setDebug($this->isDebugEnabled());
 
-		$layoutPaths = $this->getLayoutPaths();
+		$layoutPaths = $this->getLayoutPaths($renderer);
 
 		if ($layoutPaths)
 		{

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -1018,6 +1018,8 @@ abstract class JFormField
 	/**
 	 * Allow to override renderer include paths in child fields
 	 *
+	 * @param   JLayoutFile  $renderer  Instance of JLayoutFile that can be used to load the default paths.
+	 *
 	 * @return  array
 	 *
 	 * @since   3.5


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Consider the following custom form field class:

```
class JFormFieldMytype extends JFormFieldSubform
{
    protected $type = 'Mytype';
    protected $renderLayout = 'mytypefields';

    protected function getLayoutPaths()
    {
        return array(JPATH_ROOT . '/modules/mod_mymodule/layout/');
    }

    public function getInput()
    {
        // load a bunch of field definitions as XML, and set them into $this->formsource.
        return parent::getInput();
    }
}

```

This class extends the Subform field type to allow me to dynamically generate a group of fields in my module config and render the subform using a custom layout.

However, an unwanted side-effect is that the fields within the subform also inherit the custom layout path. I don't have custom layouts for all the standard field types, so they fail to render, because when you override the layout, JLayoutFile does not retain the defaults as a fall-back.

An interim solution would be to force the defaults back into the path list. The code above would be changed to look like this:

    protected function getLayoutPaths()
    {
        $dummyRenderer = new JLayoutFile('default');
        $defaultPaths = $dummyRenderer->getDefaultIncludePaths();
        $layoutPaths = array(JPATH_ROOT.'/modules/mod_mymodule/layout/');
        return array_merge($layoutPaths, $defaultPaths);
    }

This is not ideal because (1) it's ugly code, (2) it would need to be repeated if you create multiple classes, and (3) it creates a dummy instance of JLayoutFile just for the purposes of getting the default paths, which are then promptly passed back into an existing instance of the same class. However, it is the solution I've gone with in my module code for now, as I need to use my module now, ahead of this PR being accepted and released.

The longer term solution is submitted here. In this PR, I have modified JLayoutFile such that you may include `'default'` in your layout paths array. This will be treated as a special case and replaced with the default paths, thus allowing a fall-back.

We can now write our getLayoutPaths() method like this:

    protected function getLayoutPaths()
    {
        return array(JPATH_ROOT . '/modules/mod_mymodule/layout/', 'default');
    }

This will be particularly useful in field types that extend subform, as noted above, but will be available to any field type, or indeed anything that uses JLayoutFile. But because 'default' has to be added explicitly to the paths array it will not affect any existing code, nor are any APIs or method signatures changed.

### Testing Instructions

- Create a custom field type overriding subform as detailed above. Have it load some standard fields types in the subform.
- Create a custom layout file for the custom subform field type, but not for any of the standard types within it.
- Without this PR, the fields within the subform will not be rendered.
- After the PR, the fields will be rendered correctly.

### Documentation Changes Required

Documentation for creating custom field types and custom layouts is currently very weak.

The [Custom field types](https://docs.joomla.org/Creating_a_custom_form_field_type) page doesn't even mention being able to use custom layouts. I know this is a niche feature, but it would be good to at least mention it, and include the fact that you can use 'default' as a fallback.
