### PR TITLE
Correcting strings in TFA Google plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.ini
+++ b/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.ini
@@ -22,7 +22,7 @@ PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK="https://support.google.com/accounts/bin
 PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2="Compatible clients for other devices and operating system (listed in Wikipedia)."
 ; Change and check this link if there is a translation in your language available. (current: German, Spanish, French, Japanese, Polish)
 PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK="https://en.wikipedia.org/wiki/Google_Authenticator#Implementation"
-PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT="Download and install Google Authenticator, or a compatible application such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_"> FreeOTP</a>, on your smartphone or desktop. Use one of the following:"
+PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT="Download and install Google Authenticator, or a compatible application such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_">FreeOTP</a>, on your smartphone or desktop. Use one of the following:"
 PLG_TWOFACTORAUTH_TOTP_STEP1_WARN="Please remember to sync your device's clock with a time-server. Time drift in your device may cause an inability to log in to your site."
 PLG_TWOFACTORAUTH_TOTP_STEP2_ACCOUNT="Account"
 PLG_TWOFACTORAUTH_TOTP_STEP2_ALTTEXT="Alternatively, you can scan the following QR code in Google Authenticator."
@@ -33,4 +33,4 @@ PLG_TWOFACTORAUTH_TOTP_STEP2_TEXT="You will need to enter the following informat
 PLG_TWOFACTORAUTH_TOTP_STEP3_HEAD="Step 3 - Activate Two Factor Authentication"
 PLG_TWOFACTORAUTH_TOTP_STEP3_SECURITYCODE="Security Code"
 PLG_TWOFACTORAUTH_TOTP_STEP3_TEXT="In order to verify that everything is set up properly, please enter the security code displayed in Google Authenticator in the field below and select the button. If the code is correct, the Two Factor Authentication feature will be enabled."
-PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href="_QQ_"https://en.wikipedia.org/wiki/Google_Authenticator"_QQ_" target="_QQ_"_blank"_QQ_">Google Authenticator</a> Google Authenticator or other compatible time-based One Time Password generators such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_"> FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."
+PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href="_QQ_"https://en.wikipedia.org/wiki/Google_Authenticator"_QQ_" target="_QQ_"_blank"_QQ_">Google Authenticator</a> or other compatible time-based One Time Password generators such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_">FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."

--- a/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.ini
+++ b/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.ini
@@ -22,7 +22,7 @@ PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK="https://support.google.com/accounts/bin
 PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2="Compatible clients for other devices and operating system (listed in Wikipedia)."
 ; Change and check this link if there is a translation in your language available. (current: German, Spanish, French, Japanese, Polish)
 PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK="https://en.wikipedia.org/wiki/Google_Authenticator#Implementation"
-PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT="Download and install Google Authenticator, or a compatible application such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_">FreeOTP</a>, on your smartphone or desktop. Use one of the following:"
+PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT="Download and install <a href="_QQ_"https://en.wikipedia.org/wiki/Google_Authenticator"_QQ_" target="_QQ_"_blank"_QQ_">Google Authenticator</a>, or a compatible application such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_">FreeOTP</a>, on your smartphone or desktop. Use one of the following:"
 PLG_TWOFACTORAUTH_TOTP_STEP1_WARN="Please remember to sync your device's clock with a time-server. Time drift in your device may cause an inability to log in to your site."
 PLG_TWOFACTORAUTH_TOTP_STEP2_ACCOUNT="Account"
 PLG_TWOFACTORAUTH_TOTP_STEP2_ALTTEXT="Alternatively, you can scan the following QR code in Google Authenticator."

--- a/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_twofactorauth_totp.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_TWOFACTORAUTH_TOTP="Two Factor Authentication - Google Authenticator"
-PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href="_QQ_"https://en.wikipedia.org/wiki/Google_Authenticator"_QQ_" target="_QQ_"_blank"_QQ_">Google Authenticator</a> Google Authenticator or other compatible time-based One Time Password generators such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_"> FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."
+PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href="_QQ_"https://en.wikipedia.org/wiki/Google_Authenticator"_QQ_" target="_QQ_"_blank"_QQ_">Google Authenticator</a> or other compatible time-based One Time Password generators such as <a href="_QQ_"https://freeotp.github.io/"_QQ_" target="_QQ_"_blank"_QQ_">FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."


### PR DESCRIPTION
One of our translators raised an issue on Crowdin regarding the source strings in the Google Authenticator Two Factor Authentication plugin.

### Summary of Changes
* Removes a duplicated "Google Authenticator"
* Removes a space in an anchor tag before "FreeOTP"
![googletotp](https://cloud.githubusercontent.com/assets/1018684/20538739/bc7ff56a-b0f2-11e6-8eab-a080d95abf12.PNG)

### Testing Instructions
Check the plugin description and see that it is correct now.

### Documentation Changes Required
None