### PR TITLE
Add onAfterTranslate system event

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -374,6 +374,8 @@ class JLanguage
 			}
 		}
 
+		JEventDispatcher::getInstance()->trigger('onAfterTranslate', array(&$string, $key, $this));
+
 		return $string;
 	}
 


### PR DESCRIPTION
Pull Request to add onAfterTranslate system event

### Summary of Changes

Add new onAfterTranslate event, allow hooking after the key is translated.

An example use case: It'd be great if Joomla allows developers to override the default "**" (for translated key) and "??" (for untranslated key) characters when language debug is enabled.

Another use case (from @ot2sen): in context (in line) translation for Joomla

### Testing Instructions

* Text shows up normally in both language debug ON/OFF

