### PR TITLE
Fix count of home pages inside same menu Type, and decrease SQL sort buffer memory needed by mod_menu

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -35,7 +35,7 @@ abstract class ModMenuHelper
 			->select('b.language')
 			->where('(b.client_id = 0 OR b.client_id IS NULL)');
 
-		// Explicit Group-By needed by non-Mysql DBs (in MySql it is implied)
+		// Explicit Group-By needed by non-Mysql DBs (in MySql, if skipped, it will be implied)
 		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language');
 
 		$db->setQuery($query);

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -57,7 +57,7 @@ abstract class ModMenuHelper
 		$db->setQuery($query);
 		$langs = $db->loadObjectList('lang_code');
 
-		foreach($result as $m)
+		foreach ($result as $m)
 		{
 			if (isset($langs[$m->language]))
 			{

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -35,7 +35,7 @@ abstract class ModMenuHelper
 			->select('b.language')
 			->where('(b.client_id = 0 OR b.client_id IS NULL)');
 
-		// Explicit Group-By needed by non-Mysql DBs (in MySql, if skipped, it will be implied)
+		// Explicit Group-By needed by non-Mysql DBs and in Mysql with ONLY_FULL_GROUP_BY ON
 		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language');
 
 		$db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #12983 

This is also an example of how GROUP BY in other queries should be revised

### Summary of Changes
**[EDITED]**
1. Fix the counting of multiple home page menu items inside the same **MENU** (Type) (see here: https://github.com/joomla/joomla-cms/pull/12991#issuecomment-262836905)
2. Greatly reduces the length of GROUP-BY (and execute it only once) in the getMenus of mod_menu HELPER class, thus reducing (by a lot) the memory needed by the sort buffer of the DB servers

### Testing Instructions
Open backend menu "Menus",
- no duplicate entries appear
- the per language home-page menu items appear correctly (see the attached picture)

Edit with e.g. phpmyadmin and set 2 home pages menu inside the same MENY Type (e.g. Australian Parks MENU), and set homes e.g. an English and a French
- The MENU (Type) should show the misconfiguration via showing a Globe icon instead of a language flag (see comment here: https://github.com/joomla/joomla-cms/pull/12991#issuecomment-262836905)

(previous behaviour makes the MENU appear twice with 2 language flags, like if there are 2 MENUs with same name)

### Documentation Changes Required
none
![mod_menu](https://cloud.githubusercontent.com/assets/5092940/20573900/b1f30b00-b1ba-11e6-8c5b-70e8fd52b3e2.png)

