### PR TITLE
Move the checkboxes to the leftmost column in detail view

### DIFF
--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -97,6 +97,11 @@ $doc->addScriptDeclaration(
 		<table class="table table-striped table-condensed">
 		<thead>
 			<tr>
+				<?php if ($this->canDelete) : ?>
+					<th width="1%">
+						<?php echo JHtml::_('grid.checkall'); ?>
+					</th>
+				<?php endif;?>
 				<th width="1%"><?php echo JText::_('JGLOBAL_PREVIEW'); ?></th>
 				<th><?php echo JText::_('COM_MEDIA_NAME'); ?></th>
 				<th width="15%"><?php echo JText::_('COM_MEDIA_PIXEL_DIMENSIONS'); ?></th>
@@ -105,7 +110,6 @@ $doc->addScriptDeclaration(
 				<?php if ($this->canDelete) : ?>
 					<th width="8%">
 						<?php echo JText::_('JACTION_DELETE'); ?>
-						<?php echo JHtml::_('grid.checkall'); ?>
 					</th>
 				<?php endif;?>
 			</tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_docs.php
@@ -19,6 +19,12 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->documents as $i => $doc) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
 	<tr>
+		<?php if ($this->canDelete):?>
+			<td>
+				<?php echo JHtml::_('grid.id', $i, $doc->name, false, 'rm', 'cb-document'); ?>
+			</td>
+		<?php endif;?>
+
 		<td>
 			<a title="<?php echo $doc->name; ?>">
 				<?php echo JHtml::_('image', $doc->icon_16, $doc->title, null, true, true) ? JHtml::_('image', $doc->icon_16, $doc->title, array('width' => 16, 'height' => 16), true) : JHtml::_('image', 'media/con_info.png', $doc->title, array('width' => 16, 'height' => 16), true); ?>
@@ -40,7 +46,6 @@ $dispatcher = JEventDispatcher::getInstance();
 				<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $doc->name; ?>" rel="<?php echo $doc->name; ?>">
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
-				<?php echo JHtml::_('grid.id', $i, $doc->name, false, 'rm', 'cb-document'); ?>
 			</td>
 		<?php endif;?>
 

--- a/administrator/components/com_media/views/medialist/tmpl/details_folders.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_folders.php
@@ -14,6 +14,11 @@ JHtml::_('bootstrap.tooltip');
 <?php foreach ($this->folders as $i => $folder) : ?>
 	<?php $link = 'index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=' . $folder->path_relative; ?>
 	<tr>
+		<?php if ($this->canDelete):?>
+			<td>
+				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>
+			</td>
+		<?php endif;?>
 		<td class="imgTotal">
 			<a href="<?php echo $link; ?>" target="folderframe"><span class="icon-folder-2"></span></a>
 		</td>
@@ -31,7 +36,6 @@ JHtml::_('bootstrap.tooltip');
 				<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=folder.delete&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>&amp;<?php echo JSession::getFormToken(); ?>=1&amp;rm[]=<?php echo $folder->name; ?>" rel="<?php echo $folder->name; ?> :: <?php echo $folder->files + $folder->folders; ?>">
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
-				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>
 			</td>
 		<?php endif;?>
 	</tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
@@ -21,6 +21,12 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->images as $i => $image) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$image, &$params)); ?>
 	<tr>
+		<?php if ($this->canDelete):?>
+			<td>
+				<?php echo JHtml::_('grid.id', $i, $image->name, false, 'rm', 'cb-image'); ?>
+			</td>
+		<?php endif;?>
+
 		<td>
 			<a class="img-preview" href="<?php echo COM_MEDIA_BASEURL, '/', $image->path_relative; ?>" title="<?php echo $image->name; ?>">
 				<?php echo JHtml::_('image', COM_MEDIA_BASEURL . '/' . $image->path_relative, JText::sprintf('COM_MEDIA_IMAGE_TITLE', $image->title, JHtml::_('number.bytes', $image->size)), array('width' => $image->width_16, 'height' => $image->height_16)); ?>
@@ -46,7 +52,6 @@ $dispatcher = JEventDispatcher::getInstance();
 				<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $image->name; ?>" rel="<?php echo $image->name; ?>">
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE');?>"></span>
 				</a>
-				<?php echo JHtml::_('grid.id', $i, $image->name, false, 'rm', 'cb-image'); ?>
 			</td>
 		<?php endif;?>
 	</tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_up.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_up.php
@@ -13,6 +13,9 @@ $user = JFactory::getUser();
 ?>
 <?php if ($this->state->folder != '') : ?>
 <tr>
+	<?php if ($this->canDelete):?>
+		<td>&#160;</td>
+	<?php endif;?>
 	<td class="imgTotal">
 		<a href="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $this->state->parent; ?>" target="folderframe">
 			<span class="icon-arrow-up"></span></a>

--- a/administrator/components/com_media/views/medialist/tmpl/details_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_videos.php
@@ -28,6 +28,12 @@ jQuery(document).ready(function($){
 <?php foreach ($this->videos as $i => $video) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
 	<tr>
+		<?php if ($this->canDelete):?>
+			<td>
+				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>
+			</td>
+		<?php endif;?>
+
 		<td>
 			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', $video->name; ?>" title="<?php echo $video->title; ?>">
 				<?php JHtml::_('image', $video->icon_16, $video->title, null, true); ?>
@@ -53,7 +59,6 @@ jQuery(document).ready(function($){
 				<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $video->name; ?>" rel="<?php echo $video->name; ?>">
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
-				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>
 			</td>
 		<?php endif;?>
 	</tr>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Moved media manager's checkboxes to the leftmost column so they are not right next to the delete buttons.

### Testing Instructions
Expect the checkboxes to still work in exactly the same way (they are really only used for batch deletions anyway). 

### Documentation Changes Required
Probably not.
