### PR TITLE
[com_menus] - wrong group by when multilanguages enabled - postgresql

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -273,7 +273,7 @@ class MenusModelItems extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_menus.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.id, mt.title');
+				->group('a.id, e.enabled, l.title, l.image, u.name, c.element, ag.title, e.name, mt.id, mt.title, l.sef');
 		}
 
 		// Join over the extensions


### PR DESCRIPTION
Pull Request for fix regression from #12051 .  
redo of #12676 for fix conflicts

### Summary of Changes
fixed wrong `group by` when multilanguages enabled

### Testing Instructions
- latest staging  fresh multilanguage install 
- Go to Menu -> All menu items
![menugroupby](https://cloud.githubusercontent.com/assets/181681/20473970/3e3276f8-afc4-11e6-9c94-5f547ad9c7c5.png)


- postgresql - got sql error wrong group by
- mysql  - should work as before 


