### PR TITLE
Removing duplicated AS in sql query

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/sqlsrv.php
@@ -466,7 +466,7 @@ class FinderIndexerDriverSqlsrv extends FinderIndexer
 		{
 			// Update the link counts for the terms.
 			$query->update('t')
-				->set('t.links = t.links - 1 from #__finder_terms AS t INNER JOIN #__finder_links_terms' . dechex($i) . ' AS AS m ON m.term_id = t.term_id')
+				->set('t.links = t.links - 1 from #__finder_terms AS t INNER JOIN #__finder_links_terms' . dechex($i) . ' AS m ON m.term_id = t.term_id')
 				->where('m.link_id = ' . $db->quote((int) $linkId));
 			$db->setQuery($query);
 			$db->execute();


### PR DESCRIPTION
Pull Request for Issue #13005.

### Summary of Changes
Removing duplicated AS in sql query resolving query problem

### Testing Instructions
Setup Joomla against SQL Server
Go to "smart search"
Reindex
Select any link in the list and click Delete

### Documentation Changes Required
none
