### PR TITLE
Coding style. PHP constants true, false, and null MUST be in lower case.

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -300,7 +300,7 @@ if(!class_exists('Akeeba_Services_JSON'))
 	        if(function_exists('mb_convert_encoding')) {
 	            return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
 	        }
-
+	        
 	        // Fall back to a custom PHP implementation
 	        $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
 
@@ -6046,7 +6046,7 @@ class AKUtilsLister extends AKAbstractObject
 
 		$handle = @opendir($folder);
 		// If directory is not accessible, just return FALSE
-		if ($handle === false) {
+		if ($handle === FALSE) {
 			$this->setWarning( 'Unreadable directory '.$folder);
 			return $false;
 		}
@@ -6080,7 +6080,7 @@ class AKUtilsLister extends AKAbstractObject
 
 		$handle = @opendir($folder);
 		// If directory is not accessible, just return FALSE
-		if ($handle === false) {
+		if ($handle === FALSE) {
 			$this->setWarning( 'Unreadable directory '.$folder);
 			return $false;
 		}
@@ -7606,19 +7606,19 @@ function recursive_remove_directory($directory)
 	if(!file_exists($directory) || !is_dir($directory))
 	{
 		// ... we return false and exit the function
-		return false;
+		return FALSE;
 	// ... if the path is not readable
 	}elseif(!is_readable($directory))
 	{
 		// ... we return false and exit the function
-		return false;
+		return FALSE;
 	// ... else if the path is readable
 	}else{
 		// we open the directory
 		$handle = opendir($directory);
 		$postproc = AKFactory::getPostProc();
 		// and scan through the items inside
-		while (false !== ($item = readdir($handle)))
+		while (FALSE !== ($item = readdir($handle)))
 		{
 			// if the filepointer is not the current directory
 			// or the parent directory
@@ -7644,9 +7644,9 @@ function recursive_remove_directory($directory)
 		if(!$postproc->rmdir($directory))
 		{
 			// return false if not possible
-			return false;
+			return FALSE;
 		}
 		// return success
-		return true;
+		return TRUE;
 	}
 }

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -300,7 +300,7 @@ if(!class_exists('Akeeba_Services_JSON'))
 	        if(function_exists('mb_convert_encoding')) {
 	            return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
 	        }
-	        
+
 	        // Fall back to a custom PHP implementation
 	        $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
 
@@ -6046,7 +6046,7 @@ class AKUtilsLister extends AKAbstractObject
 
 		$handle = @opendir($folder);
 		// If directory is not accessible, just return FALSE
-		if ($handle === FALSE) {
+		if ($handle === false) {
 			$this->setWarning( 'Unreadable directory '.$folder);
 			return $false;
 		}
@@ -6080,7 +6080,7 @@ class AKUtilsLister extends AKAbstractObject
 
 		$handle = @opendir($folder);
 		// If directory is not accessible, just return FALSE
-		if ($handle === FALSE) {
+		if ($handle === false) {
 			$this->setWarning( 'Unreadable directory '.$folder);
 			return $false;
 		}
@@ -7606,19 +7606,19 @@ function recursive_remove_directory($directory)
 	if(!file_exists($directory) || !is_dir($directory))
 	{
 		// ... we return false and exit the function
-		return FALSE;
+		return false;
 	// ... if the path is not readable
 	}elseif(!is_readable($directory))
 	{
 		// ... we return false and exit the function
-		return FALSE;
+		return false;
 	// ... else if the path is readable
 	}else{
 		// we open the directory
 		$handle = opendir($directory);
 		$postproc = AKFactory::getPostProc();
 		// and scan through the items inside
-		while (FALSE !== ($item = readdir($handle)))
+		while (false !== ($item = readdir($handle)))
 		{
 			// if the filepointer is not the current directory
 			// or the parent directory
@@ -7644,9 +7644,9 @@ function recursive_remove_directory($directory)
 		if(!$postproc->rmdir($directory))
 		{
 			// return false if not possible
-			return FALSE;
+			return false;
 		}
 		// return success
-		return TRUE;
+		return true;
 	}
 }

--- a/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
+++ b/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
@@ -159,7 +159,7 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 				var path = 'hr' + 'ef' + '=';
 				var addy__HASH__ = 'joe' + '@';
 				addy__HASH__ = addy__HASH__ + 'nowhere13' + '.' + 'com?subject= A text';
-				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'?subject= A text>'+addy_text__HASH__+'<\/a>';				
+				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'?subject= A text>'+addy_text__HASH__+'<\/a>';
 		</script></p>
                 "
             ),
@@ -261,7 +261,7 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
                 // assert the render is as the expected render with injected hash
                 $this->assertEquals(trim(str_replace('__HASH__', $hash, $expected)), $result);
 
-                if (NULL !== $expectedHTML) {
+                if (null !== $expectedHTML) {
                     $html = $this->convertJStoHTML($result, $hash);
                     $this->assertEquals($html, $expectedHTML);
                 }
@@ -287,8 +287,8 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
      */
     private function convertJStoHTML($js, $hash)
     {
-        $resultantHTML = NULL;
-        $debug = FALSE;
+        $resultantHTML = null;
+        $debug = false;
 
         $js = html_entity_decode($js);
         $js = str_replace(sprintf('document.getElementById(\'cloak%s\').innerHTML = \'\';', $hash), '', $js);
@@ -308,7 +308,7 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
             $js);
 
         // because with all those replaces, you and I will need this a lot :)
-        if (TRUE === $debug) {
+        if (true === $debug) {
             echo "\n\n" . trim($js) . "\n\n";
             eval($js);
             echo "\n\n";


### PR DESCRIPTION
### Summary of Changes

The PHP keywords MUST be in lower case. The PHP constants true, false, and null MUST be in lower case.

See Joomla Coding Standards: [https://github.com/joomla/coding-standards/blob/master/manual/php.md](https://github.com/joomla/coding-standards/blob/master/manual/php.md)

### Testing Instructions

Code review

### Documentation Changes Required

None