### PR TITLE
[com_tags] - correct tfoot colspan

### DIFF
--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -30,6 +30,7 @@ $parts     = explode('.', $extension);
 $component = $parts[0];
 $section   = null;
 $mode      = false;
+$tfc       = 0;
 
 if (count($parts) > 1)
 {
@@ -94,21 +95,25 @@ if ($saveOrder)
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"></i>
 							</th>
+							<?php $tfc++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"></i>
 							</th>
+							<?php $tfc++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-archive hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"></i>
 							</th>
+							<?php $tfc++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-trash hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"></i>
 							</th>
+							<?php $tfc++; ?>
 						<?php endif;?>
  
 						<th width="10%" class="nowrap hidden-phone">
@@ -124,7 +129,7 @@ if ($saveOrder)
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="7">
+						<td colspan="<?php echo $tfc + 7; ?>">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -30,7 +30,7 @@ $parts     = explode('.', $extension);
 $component = $parts[0];
 $section   = null;
 $mode      = false;
-$tfc       = 0;
+$columns   = 0;
 
 if (count($parts) > 1)
 {
@@ -95,25 +95,25 @@ if ($saveOrder)
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"></i>
 							</th>
-							<?php $tfc++; ?>
+							<?php $columns++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"></i>
 							</th>
-							<?php $tfc++; ?>
+							<?php $columns++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-archive hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"></i>
 							</th>
-							<?php $tfc++; ?>
+							<?php $columns++; ?>
 						<?php endif;?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) :?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-trash hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"></i>
 							</th>
-							<?php $tfc++; ?>
+							<?php $columns++; ?>
 						<?php endif;?>
  
 						<th width="10%" class="nowrap hidden-phone">
@@ -129,7 +129,7 @@ if ($saveOrder)
 				</thead>
 				<tfoot>
 					<tr>
-						<td colspan="<?php echo $tfc + 7; ?>">
+						<td colspan="<?php echo $columns; ?>">
 							<?php echo $this->pagination->getListFooter(); ?>
 						</td>
 					</tr>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -30,7 +30,7 @@ $parts     = explode('.', $extension);
 $component = $parts[0];
 $section   = null;
 $mode      = false;
-$columns   = 0;
+$columns   = 7;
 
 if (count($parts) > 1)
 {


### PR DESCRIPTION
### Summary of Changes
correct tfoot colspan when count items active

### Testing Instructions
in backend -> components -> tags 
from search tools enable the tag type items count
![tfoot](https://cloud.githubusercontent.com/assets/181681/20638794/53d7da34-b3b1-11e6-89cc-b311c91c035e.PNG)

you should notice that the footer colspan is worng

apply the pacth
 the footer colspan is ok 
![tfoot2](https://cloud.githubusercontent.com/assets/181681/20638819/d123ef1e-b3b1-11e6-96af-49861c9628e0.PNG)

