### PR TITLE
[4.0] com_newsfeeds: correct incomplete group by clause

### DIFF
--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -185,7 +185,32 @@ class NewsfeedsModelNewsfeeds extends JModelList
 			$query->select('COUNT(asso2.id)>1 AS association')
 				->join('LEFT', $db->quoteName('#__associations', 'asso') . ' ON asso.id = a.id AND asso.context = ' . $db->quote('com_newsfeeds.item'))
 				->join('LEFT', $db->quoteName('#__associations', 'asso2') . ' ON asso2.key = asso.key')
-				->group('a.id, l.title, l.image, uc.name, ag.title, c.title');
+				->group(
+					$db->quoteName(
+						array(
+							'a.id',
+							'a.name',
+							'a.alias',
+							'a.checked_out',
+							'a.checked_out_time',
+							'a.catid',
+							'a.numarticles',
+							'a.cache_time',
+							'a.created_by',
+							'a.published',
+							'a.access',
+							'a.ordering',
+							'a.language',
+							'a.publish_up',
+							'a.publish_down',
+							'l.title',
+							'l.image',
+							'uc.name',
+							'ag.title',
+							'c.title',
+						)
+					)
+				);
 		}
 
 		// Filter by access level.


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

If you enable associations in language filter 4.0 bracnh is producing an sql error because of the groupby clause.

Related to the more strict `ONLY_FULL_GROUP_BY` sql_mode added in 4.0 branch (https://github.com/joomla/joomla-cms/pull/12494)

### Testing Instructions

Mainly code review, but you can also

- Use 4.0 branch
- Enable language filter plugin and associations
- Go to components -> newsfeeds you get an sql error
- Apply patch, no error

### Documentation Changes Required

None.