### PR TITLE
[4.0] com_templates: correct incomplete group by clause

### DIFF
--- a/administrator/components/com_templates/models/styles.php
+++ b/administrator/components/com_templates/models/styles.php
@@ -120,7 +120,7 @@ class TemplatesModelStyles extends JModelList
 		// Join on menus.
 		$query->select('COUNT(m.template_style_id) AS assigned')
 			->join('LEFT', $db->quoteName('#__menu', 'm') . ' ON ' . $db->quoteName('m.template_style_id') . ' = ' . $db->quoteName('a.id'))
-			->group('a.id, a.template, a.title, a.home, a.client_id, l.title, l.image, e.extension_id');
+			->group($db->quoteName(array('a.id', 'a.template', 'a.title', 'a.home', 'a.client_id', 'l.title', 'l.image', 'l.sef', 'e.extension_id')));
 
 		// Join over the language.
 		$query->join('LEFT', $db->quoteName('#__languages', 'l') . ' ON ' . $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.home'));


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

If you enable associations in language filter 4.0 branch is producing an sql error because of the group by clause.

Related to the more strict `ONLY_FULL_GROUP_BY` sql_mode added in 4.0 branch (https://github.com/joomla/joomla-cms/pull/12494)

### Testing Instructions

Mainly code review, but you can also

- Use 4.0 branch
- Enable language filter plugin and associations
- Go to extensions -> tempaltes -> styles you get an sql error
- Apply patch, no error

### Documentation Changes Required

None.