### PR TITLE
[4.0] com_content: correct incomplete group by clause

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -201,14 +201,39 @@ class ContentModelArticles extends JModelList
 			->join('LEFT', '#__users AS ua ON ua.id = a.created_by');
 
 		// Join on voting table
-		$assogroup = 'a.id, l.title, l.image, uc.name, ag.title, c.title, ua.name';
+		$associationsGroupBy = array(
+			'a.id',
+			'a.title',
+			'a.alias',
+			'a.checked_out',
+			'a.checked_out_time',
+			'a.state',
+			'a.access',
+			'a.created',
+			'a.created_by',
+			'a.created_by_alias',
+			'a.ordering',
+			'a.featured',
+			'a.language',
+			'a.hits',
+			'a.publish_up',
+			'a.publish_down',
+			'a.catid',
+			'l.title',
+			'l.image',
+			'uc.name',
+			'ag.title',
+			'c.title',
+			'ua.name',
+		);
 
 		if (JPluginHelper::isEnabled('content', 'vote'))
 		{
-			$assogroup .= ', v.rating_sum, v.rating_count';
 			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
 					COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
+
+			array_push($associationsGroupBy, 'v.rating_sum', 'v.rating_count');
 		}
 
 		// Join over the associations.
@@ -217,7 +242,7 @@ class ContentModelArticles extends JModelList
 			$query->select('COUNT(asso2.id)>1 as association')
 				->join('LEFT', '#__associations AS asso ON asso.id = a.id AND asso.context=' . $db->quote('com_content.item'))
 				->join('LEFT', '#__associations AS asso2 ON asso2.key = asso.key')
-				->group($assogroup);
+				->group($db->quoteName($associationsGroupBy));
 		}
 
 		// Filter by access level.


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

If you enable associations in language filter 4.0 bracnh is producing an sql error because of the group by clause.

Related to the more strict `ONLY_FULL_GROUP_BY` sql_mode added in 4.0 branch (https://github.com/joomla/joomla-cms/pull/12494)

### Testing Instructions

Mainly code review, but you can also

- Use 4.0 branch
- Enable language filter plugin and associations
- Go to content -> articles you get an sql error
- Apply patch, no error

### Documentation Changes Required

None.