### PR TITLE
[modules db table] Add default to content db field in mysql (already like that is postgresql and sqlsrv)

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-27.sql
@@ -1,0 +1,2 @@
+-- Normalize modules contend field with other db systems. Add default value.
+ALTER TABLE `#__modules` MODIFY `content` text NOT NULL DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-27.sql
@@ -1,2 +1,2 @@
--- Normalize modules contend field with other db systems. Add default value.
+-- Normalize modules content field with other db systems. Add default value.
 ALTER TABLE `#__modules` MODIFY `content` text NOT NULL DEFAULT '';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1414,7 +1414,7 @@ CREATE TABLE IF NOT EXISTS `#__modules` (
   `asset_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to the #__assets table.',
   `title` varchar(100) NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
-  `content` text NOT NULL,
+  `content` text NOT NULL DEFAULT '',
   `ordering` int(11) NOT NULL DEFAULT 0,
   `position` varchar(50) NOT NULL DEFAULT '',
   `checked_out` int(10) unsigned NOT NULL DEFAULT 0,


### PR DESCRIPTION
### Summary of Changes

Add empty default value to #__modules content db field in mysql (already like that is postgresql and sqlsrv).

### Testing Instructions

Mainly code review. But you can also:

- On update
  - Run the update query for your db system manually and check the db field now as a default value.

- On install
  - Use latest staging, apply patch
  - Delete configuration.php file and install as usual. Check all fine and the db field are correctly created.

### Documentation Changes Required

None.

### Notes

Although the issue was found on 4.0 because of a more strict sql_mode, this also applies in 3.x since this db field should always have a default value.