### PR TITLE
Install adapters return extension ID on success

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -564,7 +564,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	/**
 	 * Generic install method for extensions
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean|integer  The extension ID on success, boolean false on failure
 	 *
 	 * @since   3.4
 	 */
@@ -1028,7 +1028,7 @@ abstract class JInstallerAdapter extends JAdapterInstance
 	/**
 	 * Generic update method for extensions
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean|integer  The extension ID on success, boolean false on failure
 	 *
 	 * @since   3.4
 	 */

--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -73,7 +73,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	 * the ability to install multiple distinct packs in one install. The
 	 * preferred method is to use a package to install multiple language packs.
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean|integer  The extension ID on success, boolean false on failure
 	 *
 	 * @since   3.1
 	 */
@@ -131,9 +131,9 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 	 * @param   integer  $clientId  The client id.
 	 * @param   object   &$element  The XML element.
 	 *
-	 * @return  boolean
+	 * @return  boolean|integer  The extension ID on success, boolean false on failure
 	 *
-	 * @since  3.1
+	 * @since   3.1
 	 */
 	protected function _install($cname, $basePath, $clientId, &$element)
 	{

--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -290,7 +290,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 	/**
 	 * Custom update method
 	 *
-	 * @return  boolean  True on success
+	 * @return  boolean|integer  The extension ID on success, boolean false on failure
 	 *
 	 * @since   3.1
 	 */


### PR DESCRIPTION
### Summary of Changes

`JInstallerAdapter::install()` and `JInstallerAdapter::update()` return the extension ID of the installed/updated extension on success, these methods do not only return boolean values.  Fixed the docs.

### Testing Instructions

Review

### Documentation Changes Required

Already done 😉 