### PR TITLE
Multilingual Managers: htmlspecialchars needed

### DIFF
--- a/administrator/components/com_categories/helpers/html/categoriesadministrator.php
+++ b/administrator/components/com_categories/helpers/html/categoriesadministrator.php
@@ -72,7 +72,7 @@ abstract class JHtmlCategoriesAdministrator
 					$classes = 'hasPopover label label-association label-' . $item->lang_sef;
 
 					$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes
-						. '" data-content="' . $item->title . '" data-placement="top">'
+						. '" data-content="' . htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '" data-placement="top">'
 						. $text . '</a>';
 				}
 			}

--- a/administrator/components/com_contact/helpers/html/contact.php
+++ b/administrator/components/com_contact/helpers/html/contact.php
@@ -72,7 +72,7 @@ abstract class JHtmlContact
 					$text = strtoupper($item->lang_sef);
 					$url = JRoute::_('index.php?option=com_contact&task=contact.edit&id=' . (int) $item->id);
 
-					$tooltip = $item->title . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
+					$tooltip = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 					$classes = 'hasPopover label label-association label-' . $item->lang_sef;
 
 					$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -73,7 +73,7 @@ abstract class JHtmlContentAdministrator
 					$text    = $item->lang_sef ? strtoupper($item->lang_sef) : 'XX';
 					$url     = JRoute::_('index.php?option=com_content&task=article.edit&id=' . (int) $item->id);
 
-					$tooltip = $item->title . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
+					$tooltip = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 					$classes = 'hasPopover label label-association label-' . $item->lang_sef;
 
 					$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -72,7 +72,7 @@ abstract class MenusHtmlMenus
 					$text = strtoupper($item->lang_sef);
 					$url = JRoute::_('index.php?option=com_menus&task=item.edit&id=' . (int) $item->id);
 
-					$tooltip = $item->title . '<br />' . JText::sprintf('COM_MENUS_MENU_SPRINTF', $item->menu_title);
+					$tooltip = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br />' . JText::sprintf('COM_MENUS_MENU_SPRINTF', $item->menu_title);
 					$classes = 'hasPopover label label-association label-' . $item->lang_sef;
 
 					$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes

--- a/administrator/components/com_newsfeeds/helpers/html/newsfeed.php
+++ b/administrator/components/com_newsfeeds/helpers/html/newsfeed.php
@@ -69,7 +69,7 @@ class JHtmlNewsfeed
 				{
 					$text = strtoupper($item->lang_sef);
 					$url = JRoute::_('index.php?option=com_newsfeeds&task=newsfeed.edit&id=' . (int) $item->id);
-					$tooltip = $item->title . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
+					$tooltip = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8') . '<br />' . JText::sprintf('JCATEGORY_SPRINTF', $item->category_title);
 					$classes = 'hasPopover label label-association label-' . $item->lang_sef;
 
 					$item->link = '<a href="' . $url . '" title="' . $item->language_title . '" class="' . $classes


### PR DESCRIPTION
### Summary of Changes
Passing `$item->title` through `htmlspecialchars()`
### Testing Instructions
Create a multilingual site (2 languages are enough).
Associate 2 articles.
Associate 2 categories.
Associate 2 menu items.
Associate 2 contacts.
Associate 2 newsfeeds.

For each of these **add double quotes** in the title of one of the items.
Example: `mymenu "Useful"`, etc.

Display the managers for each kind of item
You will get stuff like this in the associations column (here the title is `Poètes "français"`)

![screen shot 2016-11-28 at 10 38 11](https://cloud.githubusercontent.com/assets/869724/20663669/a4f8a986-b558-11e6-8bb3-418493f702a6.png)
or for `contact "en"`

![screen shot 2016-11-28 at 10 33 53](https://cloud.githubusercontent.com/assets/869724/20663731/d2e7fb80-b558-11e6-8c46-0eed6b05de1b.png)


Patch, now you will correctly get:
![screen shot 2016-11-28 at 10 56 06](https://cloud.githubusercontent.com/assets/869724/20663878/5a7d9f1e-b559-11e6-89bd-39b535b2834d.png)

 and

![screen shot 2016-11-28 at 10 35 50](https://cloud.githubusercontent.com/assets/869724/20663988/b9920418-b559-11e6-874f-60f8371075a1.png)

same for the other components.