### PR TITLE
RTL: correcting image popup display

### DIFF
--- a/administrator/components/com_media/views/imageslist/tmpl/default.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default.php
@@ -19,16 +19,33 @@ if ($lang->isRtl())
 }
 
 JFactory::getDocument()->addScriptDeclaration("var ImageManager = window.parent.ImageManager;");
-JFactory::getDocument()->addStyleDeclaration(
-	"
-		@media (max-width: 767px) {
-			li.imgOutline.thumbnail.height-80.width-80.center {
-				float: left;
-				margin-left: 15px;
+
+if ($lang->isRtl())
+{
+	JFactory::getDocument()->addStyleDeclaration(
+		"
+			@media (max-width: 767px) {
+				li.imgOutline.thumbnail.height-80.width-80.center {
+					float: right;
+					margin-right: 15px;
+				}
 			}
-		}
-	"
-);
+		"
+	);
+}
+else
+{
+	JFactory::getDocument()->addStyleDeclaration(
+		"
+			@media (max-width: 767px) {
+				li.imgOutline.thumbnail.height-80.width-80.center {
+					float: left;
+					margin-left: 15px;
+				}
+			}
+		"
+	);
+}
 ?>
 <?php if (count($this->images) > 0 || count($this->folders) > 0) : ?>
 	<ul class="manager thumbnails">


### PR DESCRIPTION
### Testing Instructions
Set en-GB.xml to rtl
In frontend as in backend, click to select an image in a form.
The popup has to be less than 767px wide.
The popup displays only as LTR (folders at left, margin too).

Before patch:

![screen shot 2016-11-30 at 11 47 24](https://cloud.githubusercontent.com/assets/869724/20749867/62a88f86-b6f4-11e6-844b-a57ea97b4bc9.png)

After patch

![screen shot 2016-11-30 at 11 51 29](https://cloud.githubusercontent.com/assets/869724/20749874/6c3e571a-b6f4-11e6-9e2b-3c805fcde9be.png)


