### PR TITLE
Check if batchSelector is defined.

### DIFF
--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			if ($("#batch-category-id").length){var batchSelector = $("#batch-category-id");}
 			if ($("#batch-menu-id").length){var batchSelector = $("#batch-menu-id");}
 			if ($("#batch-position-id").length){var batchSelector = $("#batch-position-id");}
-			if ($("#batch-copy-move").length) {
+			if ($("#batch-copy-move").length && batchSelector) {
 				$("#batch-copy-move").hide();
 				batchSelector.on("change", function(){
 					if (batchSelector.val() != 0 || batchSelector.val() != "") {


### PR DESCRIPTION
In PR https://github.com/joomla/joomla-cms/pull/13019#issuecomment-264247678 an issue was detected which is technically not related to that PR, thus I do an own one.

If you have a batch modal without a category/position/menu selector but have the copy/move radios, you will get a JavaScript error in the console.
That is because someone introduced that code in a lazy way and added it to the JLayout for the language field, and not for the one rendering the category/position/menu selects with the copy/move radios.
Now if you have your own select with those radios like in the mentioned PR, the JavaScript tries to run with an undefined `batchSelector` variable.

### Summary of Changes
This PR just adds a simple check if the variable has some content, otherwise the code will not do anything.
Another approach would be to move the code to the correct JLayouts, but that can be seen as not B/C.

### Testing Instructions
Simplest test would be to apply PR #13019, check the console output in the fields view. You'll see the error. Apply this PR here as well and the error will be gone. Not sure if that is possible with the Patchtester.

Another test is to make sure any batch modals (eg the articles one) still show/hide the copy/move radios when selecting/unselecting a category in the batch modal.

### Documentation Changes Required
None.