### PR TITLE
Add PHP 7.1 support dates to notification plugin

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -125,6 +125,10 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 				'security' => '2017-12-03',
 				'eos'      => '2018-12-03'
 			),
+			'7.1' => array(
+				'security' => '2018-12-01',
+				'eos'      => '2019-12-01'
+			),
 		);
 
 		// Fill our return array with default values


### PR DESCRIPTION
### Summary of Changes

PHP 7.1 released today, add its support timeframe per https://secure.php.net/supported-versions.php to our notification plugin.

### Testing Instructions

Review only, unless you mangle the code in this patch there's nothing to test 😉 

### Documentation Changes Required

N/A