### PR TITLE
JComponent::isEnabled should always return boolean

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -75,9 +75,7 @@ class JComponentHelper
 	 */
 	public static function isEnabled($option)
 	{
-		$result = static::getComponent($option, true);
-
-		return $result->enabled;
+		return (bool) static::getComponent($option, true)->enabled;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/12228.

### Summary of Changes
Before patch the method return "1" or "0" or boolean value.

After patch always return boolean value.

### Testing Instructions
Code review.

### Documentation Changes Required
No
