### PR TITLE
Responsive site title for protostar

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7125,10 +7125,16 @@ body.site.fluid {
 }
 .site-title {
 	font-size: 40px;
-	font-size: calc(16px + 1vw);
+	font-size: calc(18px + 1.50vw);
 	line-height: 48px;
-	line-height: calc(20px + 1vw);
+	line-height: calc(20px + 1.90vw);
 	font-weight: bold;
+}
+@media (min-width: 1470px) {
+	.site-title {
+		font-size: 40px;
+		line-height: 48px;
+	}
 }
 .brand {
 	color: #001a27;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7125,15 +7125,13 @@ body.site.fluid {
 }
 .site-title {
 	font-size: 40px;
-	font-size: calc(18px + 1.50vw);
+	font-size: calc(16px + 2.16vw);
 	line-height: 48px;
-	line-height: calc(20px + 1.90vw);
 	font-weight: bold;
 }
-@media (min-width: 1470px) {
+@media (min-width: 1024px) {
 	.site-title {
 		font-size: 40px;
-		line-height: 48px;
 	}
 }
 .brand {

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7125,7 +7125,9 @@ body.site.fluid {
 }
 .site-title {
 	font-size: 40px;
+	font-size: calc(16px + 1vw);
 	line-height: 48px;
+	line-height: calc(20px + 1vw);
 	font-weight: bold;
 }
 .brand {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -108,15 +108,13 @@ body.site.fluid{
 /* Site Title (if no logo) */
 .site-title {
 	font-size: 40px;
-	font-size: calc(~"18px + 1.50vw");
+	font-size: calc(~"16px + 2.16vw");
 	line-height: 48px;
-	line-height: calc(~"20px + 1.90vw");
 	font-weight: bold;
 }
-@media (min-width: 1470px) {
+@media (min-width: 1024px) {
 	.site-title {
 		font-size: 40px;
-		line-height: 48px;
 	}
 }
 .brand {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -108,6 +108,9 @@ body.site.fluid{
 /* Site Title (if no logo) */
 .site-title {
 	font-size: 40px;
+	font-size: calc(16px + 1vw);
+	line-height: 48px;
+	line-height: calc(20px + 1vw);
 	font-weight: bold;
 }
 .brand {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -108,7 +108,6 @@ body.site.fluid{
 /* Site Title (if no logo) */
 .site-title {
 	font-size: 40px;
-	line-height: 48px;
 	font-weight: bold;
 }
 .brand {

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -108,10 +108,16 @@ body.site.fluid{
 /* Site Title (if no logo) */
 .site-title {
 	font-size: 40px;
-	font-size: calc(16px + 1vw);
+	font-size: calc(~"18px + 1.50vw");
 	line-height: 48px;
-	line-height: calc(20px + 1vw);
+	line-height: calc(~"20px + 1.90vw");
 	font-weight: bold;
+}
+@media (min-width: 1470px) {
+	.site-title {
+		font-size: 40px;
+		line-height: 48px;
+	}
 }
 .brand {
 	color: darken(@linkColor, 20%);


### PR DESCRIPTION
Pull Request for Issues #13056 , #11053

### Summary of Changes
Make the site title 's **font-size**,
responsive to the viewport while maintaining 
-- a minimum of 22px+ and a maximum of 40px
-- lowest: 22px, at 480px: 26px, at 800px: 33px, at 1024px: 40px

Browsers supported: almost all browsers (includes IE9+)
NOTE: for non-supporting browsers (e.g. IE8) the old CSS values will be used as fallback
(that is why you have font-size defined twice)

**[EDIT]**
Also the LESS compiling works, (**reported below as broken, i fixed it**)

### Testing Instructions
Apply patch and visit the site frontend,
-- then resize your browser window to see that site title scale up / down, but also notice that it maintains a minimum of 22px and a maximum of 40px

A note: i think, it will be good to start making use of calc() in more places
(while of course using a fallback for non-supporting browsers)

### Documentation Changes Required
none