### PR TITLE
[com-fields]Clarify label

### DIFF
--- a/administrator/language/en-GB/en-GB.com_fields.ini
+++ b/administrator/language/en-GB/en-GB.com_fields.ini
@@ -5,7 +5,7 @@
 
 COM_FIELDS="Fields"
 COM_FIELDS_FIELD_CLASS_DESC="The class attributes of the field in the edit form. If different classes are needed, list them with spaces."
-COM_FIELDS_FIELD_CLASS_LABEL="Class"
+COM_FIELDS_FIELD_CLASS_LABEL="Edit Class"
 COM_FIELDS_FIELD_DEFAULT_VALUE_DESC="The default value of the field."
 COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL="Default Value"
 COM_FIELDS_FIELD_DESCRIPTION_DESC="The description of the field."


### PR DESCRIPTION
It was highlighted in Pull Request for Issue #13051  that the field labeled class was not clear. This PR changes it to say edit class

![9lhi](https://cloud.githubusercontent.com/assets/1296369/20858642/fe54c254-b949-11e6-87cd-d692bf5b50ac.png)