### PR TITLE
Create a JMenuItem object to represent menu items in the JMenu API

### DIFF
--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Menu
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Object representing a menu item
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JMenuItem extends JObject
+{
+	/**
+	 * Primary key
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $id;
+
+	/**
+	 * The type of menu this item belongs to
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $menutype;
+
+	/**
+	 * The display title of the menu item
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $title;
+
+	/**
+	 * The SEF alias of the menu item
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $alias;
+
+	/**
+	 * A note associated with the menu item
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $note;
+
+	/**
+	 * The computed path of the menu item based on the alias field, this is populated from the `path` field in the `#__menu` table
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $route;
+
+	/**
+	 * The actual link the menu item refers to
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $link;
+
+	/**
+	 * The type of link
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $type;
+
+	/**
+	 * The relative level in the tree
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $level;
+
+	/**
+	 * The assigned language for this item
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $language;
+
+	/**
+	 * The click behaviour of the link
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $browserNav;
+
+	/**
+	 * The access level required to view the menu item
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $access;
+
+	/**
+	 * The menu item parameters
+	 *
+	 * @var    string|Registry
+	 * @since  __DEPLOY_VERSION__
+	 * @note   This field is protected to require reading this field to proxy through the getter to convert the params to a Registry instance
+	 */
+	protected $params;
+
+	/**
+	 * Indicates if this menu item is the home or default page
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $home;
+
+	/**
+	 * The image of the menu item
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $img;
+
+	/**
+	 * The optional template style applied to this menu item
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $template_style_id;
+
+	/**
+	 * The extension ID of the component this menu item is for
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $component_id;
+
+	/**
+	 * The parent menu item in the menu tree
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $parent_id;
+
+	/**
+	 * The name of the component this menu item is for
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $component;
+
+	/**
+	 * The tree of parent menu items
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $tree = array();
+
+	/**
+	 * An array of the query string values for this item
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $query = array();
+
+	/**
+	 * Class constructor
+	 *
+	 * @param   array  $data  The menu item data to load
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($data = array())
+	{
+		foreach ((array) $data as $key => $value)
+		{
+			$this->$key = $value;
+		}
+	}
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to the the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  4.0  Access the item parameters through the `getParams()` method
+	 */
+	public function __get($name)
+	{
+		if ($name === 'params')
+		{
+			return $this->getParams();
+		}
+
+		return $this->get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to the the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  4.0  Set the item parameters through the `setParams()` method
+	 */
+	public function __set($name, $value)
+	{
+		if ($name === 'params')
+		{
+			$this->setParams($value);
+
+			return;
+		}
+
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Returns the menu item parameters
+	 *
+	 * @return  Registry
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getParams()
+	{
+		if (!($this->params instanceof Registry))
+		{
+			try
+			{
+				$this->params = new Registry($this->params);
+			}
+			catch (RuntimeException $e)
+			{
+				/*
+				 * Joomla shipped with a broken sample json string for 4 years which caused fatals with new
+				 * error checks. So for now we catch the exception here - but one day we should remove it and require
+				 * valid JSON.
+				 */
+				$this->params = new Registry;
+			}
+		}
+
+		return $this->params;
+	}
+
+	/**
+	 * Sets the menu item parameters
+	 *
+	 * @param   Registry|string  $params  The data to be stored as the parameters
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setParams($params)
+	{
+		$this->params = $params;
+	}
+}

--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -21,7 +21,7 @@ class JMenu
 	/**
 	 * Array to hold the menu items
 	 *
-	 * @var    array
+	 * @var    JMenuItem[]
 	 * @since  1.5
 	 * @deprecated  4.0  Will convert to $items
 	 */
@@ -78,21 +78,6 @@ class JMenu
 			if ($item->home)
 			{
 				$this->_default[trim($item->language)] = $item->id;
-			}
-
-			// Decode the item params
-			try
-			{
-				$item->params = new Registry($item->params);
-			}
-			catch (RuntimeException $e)
-			{
-				/**
-				 * Joomla shipped with a broken sample json string for 4 years which caused fatals with new
-				 * error checks. So for now we catch the exception here - but one day we should remove it and require
-				 * valid JSON.
-				 */
-				$item->params = new Registry;
 			}
 		}
 

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -91,7 +91,7 @@ class JMenuSite extends JMenu
 					// Set the query
 					$db->setQuery($query);
 
-					return $db->loadObjectList('id');
+					return $db->loadObjectList('id', 'JMenuItem');
 				},
 				array(),
 				md5(get_class($this)),


### PR DESCRIPTION
Pull Request for Issue #13054

### Summary of Changes

Menu items as loaded by `JMenuSite` (as this is the only `JMenu` class actually loading anything) will now be loaded into this new `JMenuItem` object instead of a plain PHP object.  The object's properties are based on the query used by `JMenuSite` instead of a direct mapping to the `#__menu` database table as this is actually what is used in runtime.

All of the class properties are public (emulating the existing behavior) except for the parameters.  This is a protected field and through a magic getter and setter still allow read/write access to this field.  This is required to allow the menu item parameters to be "lazy loaded" into a Registry instance only when the parameters are actually needed.  Thus, the auto-conversion of all parameters in `JMenu::load()` is removed.

The magic getter and setter, and extending from `JObject`, are deprecated and should be removed with 4.0.  These measures are in place now to retain B/C with the existing plain PHP objects that are currently used by the API.  The parameters field has a dedicated getter and setter method which should be used instead and we should discourage adding additional undocumented properties to this object going forward.

### Testing Instructions

When the site's menu tree is loaded into `JMenu`, the data should continue to be loaded correctly but instead of being mapped to a `stdClass` object, each item in the `$_items` array should now be a `JMenuItem` object.  The `params` field should stay in the form of a JSON string until the menu item's parameters are explicitly read, at which time it will be converted to a `Registry` object.

### Documentation Changes Required

N/A