### PR TITLE
Lazy session starting

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -494,24 +494,11 @@ final class InstallationApplicationWeb extends JApplicationCms
 			'force_ssl' => $this->get('force_ssl'),
 		);
 
+		$this->registerEvent('onAfterSessionStart', array($this, 'afterSessionStart'));
+
 		// Instantiate the session object.
 		$session = JSession::getInstance($handler, $options);
 		$session->initialise($this->input, $this->dispatcher);
-
-		if ($session->getState() == 'expired')
-		{
-			$session->restart();
-		}
-		else
-		{
-			$session->start();
-		}
-
-		if (!$session->get('registry') instanceof Registry)
-		{
-			// Registry has been corrupted somehow.
-			$session->set('registry', new Registry);
-		}
 
 		// Set the session object.
 		$this->session = $session;

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -783,14 +783,13 @@ class JApplicationCms extends JApplicationWeb
 
 		/*
 		 * Note: The below code CANNOT change from instantiating a session via JFactory until there is a proper dependency injection container supported
-		 * by the application. The current default behaviours result in this method being called each time an application class is instantiated meaning
-		 * each application will attempt to start a new session. https://github.com/joomla/joomla-cms/issues/12108 explains why things will crash and
-		 * burn if you ever attempt to make this change without a proper dependency injection container.
+		 * by the application. The current default behaviours result in this method being called each time an application class is instantiated.
+		 * https://github.com/joomla/joomla-cms/issues/12108 explains why things will crash and burn if you ever attempt to make this change
+		 * without a proper dependency injection container.
 		 */
 
 		$session = JFactory::getSession($options);
 		$session->initialise($this->input, $this->dispatcher);
-		$session->start();
 
 		// TODO: At some point we need to get away from having session data always in the db.
 		$db = JFactory::getDbo();

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -313,9 +313,7 @@ class JSession implements IteratorAggregate
 
 		if (!$app->input->$method->get($token, '', 'alnum'))
 		{
-			$session = JFactory::getSession();
-
-			if ($session->isNew())
+			if (JFactory::getSession()->isNew())
 			{
 				// Redirect to login screen.
 				$app->enqueueMessage(JText::_('JLIB_ENVIRONMENT_SESSION_EXPIRED'), 'warning');
@@ -323,15 +321,11 @@ class JSession implements IteratorAggregate
 
 				return true;
 			}
-			else
-			{
-				return false;
-			}
+
+			return false;
 		}
-		else
-		{
-			return true;
-		}
+
+		return true;
 	}
 
 	/**
@@ -343,7 +337,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function getName()
 	{
-		if ($this->_state === 'destroyed')
+		if ($this->getState() === 'destroyed')
 		{
 			// @TODO : raise error
 			return;
@@ -361,7 +355,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function getId()
 	{
-		if ($this->_state === 'destroyed')
+		if ($this->getState() === 'destroyed')
 		{
 			// @TODO : raise error
 			return;
@@ -434,7 +428,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function isActive()
 	{
-		return (bool) ($this->_state == 'active');
+		return (bool) ($this->getState() == 'active');
 	}
 
 	/**
@@ -446,9 +440,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function isNew()
 	{
-		$counter = $this->get('session.counter');
-
-		return (bool) ($counter === 1);
+		return (bool) ($this->get('session.counter') === 1);
 	}
 
 	/**
@@ -489,10 +481,15 @@ class JSession implements IteratorAggregate
 	 */
 	public function get($name, $default = null, $namespace = 'default')
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		// Add prefix to namespace to avoid collisions
 		$namespace = '__' . $namespace;
 
-		if ($this->_state === 'destroyed')
+		if ($this->getState() === 'destroyed')
 		{
 			// @TODO :: generated error here
 			$error = null;
@@ -516,10 +513,15 @@ class JSession implements IteratorAggregate
 	 */
 	public function set($name, $value = null, $namespace = 'default')
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		// Add prefix to namespace to avoid collisions
 		$namespace = '__' . $namespace;
 
-		if ($this->_state !== 'active')
+		if ($this->getState() !== 'active')
 		{
 			// @TODO :: generated error here
 			return;
@@ -543,10 +545,15 @@ class JSession implements IteratorAggregate
 	 */
 	public function has($name, $namespace = 'default')
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		// Add prefix to namespace to avoid collisions.
 		$namespace = '__' . $namespace;
 
-		if ($this->_state !== 'active')
+		if ($this->getState() !== 'active')
 		{
 			// @TODO :: generated error here
 			return;
@@ -567,10 +574,15 @@ class JSession implements IteratorAggregate
 	 */
 	public function clear($name, $namespace = 'default')
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		// Add prefix to namespace to avoid collisions
 		$namespace = '__' . $namespace;
 
-		if ($this->_state !== 'active')
+		if ($this->getState() !== 'active')
 		{
 			// @TODO :: generated error here
 			return;
@@ -588,7 +600,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function start()
 	{
-		if ($this->_state === 'active')
+		if ($this->getState() === 'active')
 		{
 			return;
 		}
@@ -693,7 +705,7 @@ class JSession implements IteratorAggregate
 	public function destroy()
 	{
 		// Session was already destroyed
-		if ($this->_state === 'destroyed')
+		if ($this->getState() === 'destroyed')
 		{
 			return true;
 		}
@@ -721,7 +733,7 @@ class JSession implements IteratorAggregate
 	{
 		$this->destroy();
 
-		if ($this->_state !== 'destroyed')
+		if ($this->getState() !== 'destroyed')
 		{
 			// @TODO :: generated error here
 			return false;
@@ -760,7 +772,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function fork()
 	{
-		if ($this->_state !== 'active')
+		if ($this->getState() !== 'active')
 		{
 			// @TODO :: generated error here
 			return false;
@@ -941,10 +953,10 @@ class JSession implements IteratorAggregate
 		}
 
 		// Check if session has expired
-		if ($this->_expire)
+		if ($this->getExpire())
 		{
 			$curTime = $this->get('session.timer.now', 0);
-			$maxTime = $this->get('session.timer.last', 0) + $this->_expire;
+			$maxTime = $this->get('session.timer.last', 0) + $this->getExpire();
 
 			// Empty session variables
 			if ($maxTime < $curTime)

--- a/tests/unit/suites/libraries/cms/component/router/JComponentRouterViewTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/JComponentRouterViewTest.php
@@ -41,6 +41,10 @@ class JComponentRouterViewTest extends TestCaseDatabase
 		parent::setUp();
 
 		$app = $this->getMockCmsApp();
+
+		JFactory::$application = $app;
+		JFactory::$session = $this->getMockSession();
+
 		$this->object = new JComponentRouterViewInspector($app, $app->getMenu());
 	}
 

--- a/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlMenuTest.php
@@ -17,6 +17,38 @@
 class JHtmlMenuTest extends TestCaseDatabase
 {
 	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->saveFactoryState();
+
+		JFactory::$session = $this->getMockSession();
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Gets the data set to be loaded into the database during setup
 	 *
 	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRulesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRulesTest.php
@@ -30,6 +30,7 @@ class JFormFieldRulesTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$session = $this->getMockSession();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/legacy/model/JModelListTest.php
+++ b/tests/unit/suites/libraries/legacy/model/JModelListTest.php
@@ -40,6 +40,7 @@ class JModelListTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$session = $this->getMockSession();
 
 		$this->object = new JModelList(array("filter_fields" => array("field1", "field2")));
 	}


### PR DESCRIPTION
### Summary of Changes

This is only the lazy session starting code from #10905.

- `JSession` can now lazy start a session; calls to `get()`, `set()`, `has()`, and `clear()` will start the session if it hasn't explicitly been started previously
- The application classes are restructured to not explicitly start the session; this defers the point `JSession::start()` is called from the application constructors to one of the first actions done after `$app->execute()` is called.  The advantage here is that now sessions are started after the application has been instantiated and set to `JFactory::$application`, meaning a session startup error should result in a real error page instead of the plain "Application Instantiation Error" message.

### Testing Instructions

Sessions should continue to work just fine, https://github.com/joomla/joomla-cms/issues/12108 should not be reintroduced.

### Documentation Changes Required

N/A