### PR TITLE
Misc. fixes in database session storage

### DIFF
--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -18,6 +18,75 @@ defined('JPATH_PLATFORM') or die;
 class JSessionStorageDatabase extends JSessionStorage
 {
 	/**
+	 * Flag whether gc() has been called
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $gcCalled = false;
+
+	/**
+	 * Lifetime for garbage collection
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $gcLifetime;
+
+	/**
+	 * Close the session
+	 *
+	 * @return  boolean  True on success, false otherwise
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function close()
+	{
+		$db = JFactory::getDbo();
+
+		if ($this->gcCalled)
+		{
+			$query = $db->getQuery(true)
+				->delete($db->quoteName('#__session'))
+				->where($db->quoteName('time') . ' < ' . $db->quote((int) $this->gcLifetime));
+
+			// Remove expired sessions from the database.
+			try
+			{
+				$db->setQuery($query)->execute();
+			}
+			catch (JDatabaseExceptionExecuting $e)
+			{
+				// Executing garbage collection should not cause closing the session to fatally error out, so we can safely ignore this Exception
+			}
+
+			$this->gcCalled   = false;
+			$this->gcLifetime = null;
+		}
+
+		$db->disconnect();
+
+		return true;
+	}
+
+	/**
+	 * Initialize session
+	 *
+	 * @param   string  $save_path  The path where to store/retrieve the session
+	 * @param   string  $id         The session id
+	 *
+	 * @return  boolean  True on success, false otherwise
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function open($save_path, $id)
+	{
+		JFactory::getDbo()->connect();
+
+		return true;
+	}
+
+	/**
 	 * Read the data for a particular session identifier from the SessionHandler backend.
 	 *
 	 * @param   string  $id  The session identifier.
@@ -36,8 +105,8 @@ class JSessionStorageDatabase extends JSessionStorage
 			// Get the session data from the database table.
 			$query = $db->getQuery(true)
 				->select($db->quoteName('data'))
-			->from($db->quoteName('#__session'))
-			->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+				->from($db->quoteName('#__session'))
+				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
 
 			$db->setQuery($query);
 
@@ -49,7 +118,7 @@ class JSessionStorageDatabase extends JSessionStorage
 		}
 		catch (RuntimeException $e)
 		{
-			return false;
+			return '';
 		}
 	}
 
@@ -72,21 +141,33 @@ class JSessionStorageDatabase extends JSessionStorage
 
 		try
 		{
+			// Figure out if a row exists for the session ID
 			$query = $db->getQuery(true)
-				->update($db->quoteName('#__session'))
-				->set($db->quoteName('data') . ' = ' . $db->quote($data))
-				->set($db->quoteName('time') . ' = ' . $db->quote((int) time()))
+				->select($db->quoteName('session_id'))
+				->from($db->quoteName('#__session'))
 				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
 
-			// Try to update the session data in the database table.
-			$db->setQuery($query);
-			$db->execute();
+			$idExists = $db->setQuery($query)->loadResult();
 
-			/*
-			 * Since $db->execute did not throw an exception, so the query was successful.
-			 * Either the data changed, or the data was identical.
-			 * In either case we are done.
-			 */
+			$query = $db->getQuery(true);
+
+			if ($idExists)
+			{
+				$query->update($db->quoteName('#__session'))
+					->set($db->quoteName('data') . ' = ' . $db->quote($data))
+					->set($db->quoteName('time') . ' = ' . $db->quote((int) time()))
+					->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
+			}
+			else
+			{
+				$query->insert($db->quoteName('#__session'))
+					->columns(array($db->quoteName('data'), $db->quoteName('time'), $db->quoteName('session_id')))
+					->values(implode(', ', array($db->quote($data), (int) time(), $db->quote($id))));
+			}
+
+			// Try to insert the session data in the database table.
+			$db->setQuery($query)->execute();
+
 			return true;
 		}
 		catch (RuntimeException $e)
@@ -116,9 +197,9 @@ class JSessionStorageDatabase extends JSessionStorage
 				->where($db->quoteName('session_id') . ' = ' . $db->quote($id));
 
 			// Remove a session from the database.
-			$db->setQuery($query);
+			$db->setQuery($query)->execute();
 
-			return (boolean) $db->execute();
+			return true;
 		}
 		catch (RuntimeException $e)
 		{
@@ -137,26 +218,10 @@ class JSessionStorageDatabase extends JSessionStorage
 	 */
 	public function gc($lifetime = 1440)
 	{
-		// Get the database connection object and verify its connected.
-		$db = JFactory::getDbo();
+		// We'll delay garbage collection until the session is closed to prevent potential issues mid-cycle
+		$this->gcLifetime = time() - $lifetime;
+		$this->gcCalled   = true;
 
-		// Determine the timestamp threshold with which to purge old sessions.
-		$past = time() - $lifetime;
-
-		try
-		{
-			$query = $db->getQuery(true)
-				->delete($db->quoteName('#__session'))
-				->where($db->quoteName('time') . ' < ' . $db->quote((int) $past));
-
-			// Remove expired sessions from the database.
-			$db->setQuery($query);
-
-			return (boolean) $db->execute();
-		}
-		catch (RuntimeException $e)
-		{
-			return false;
-		}
+		return true;
 	}
 }


### PR DESCRIPTION
### Summary of Changes

This is only the changes for the database session storage from #10905

- Right now, `JSessionStorageDatabase::write()` depends on the application having inserted a record into the `#__session` database table to work correctly, the method is changed to query for the presence of the record first and to be able to insert it if not already present
- Garbage collection in PHP's session module happens when the session is started.  Instead of running this cleanup operation at the beginning of the request cycle, we'll catch that garbage collection has been requested and run this when the session is closed at the end of the request cycle.  This defers the cleanup operation to a point after the user should have gotten the HTML response instead of this cleanup being a blocking operation (at least for the default database handler).
- Try to explicitly initialize the database connection when the session is opened instead of waiting for the connection to be lazy started; the only practical benefit here is if there is a database connection issue the error is raised sooner
- A session handler's `read()` method should always return a string, so if an exception is caught in `JSessionStorageDatabase::read()` we'll return an empty string instead of a boolean false now

### Testing Instructions

Sessions using the database storage should continue to work correctly

### Documentation Changes Required

N/A