### PR TITLE
[PHP 7.1] Adapt JDate to reflect that php now sets DateTime() with microseconds

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -107,7 +107,8 @@ class JDate extends DateTime
 		date_default_timezone_set('UTC');
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
-		// If now, add the microseconds to date.
+		// If php version below 7.1 and current time, add the microseconds to date.
+		// See http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
 		if (version_compare(PHP_VERSION, '7.1.0', '<'))
 		{
 			$date = $date === 'now' ? parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u') : $date;

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -108,7 +108,10 @@ class JDate extends DateTime
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
 		// If now, add the microseconds to date.
-		$date = $date === 'now' ? parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u') : $date;
+		if (version_compare(PHP_VERSION, '7.1.0', '<'))
+		{
+			$date = $date === 'now' ? parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u') : $date;
+		}
 
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -109,9 +109,9 @@ class JDate extends DateTime
 
 		// If php version below 7.1 and current time, add the microseconds to date.
 		// See http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
-		if (version_compare(PHP_VERSION, '7.1.0', '<'))
+		if ($date === 'now' && version_compare(PHP_VERSION, '7.1.0', '<'))
 		{
-			$date = $date === 'now' ? parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u') : $date;
+			$date = parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u');
 		}
 
 		// Call the DateTime constructor.


### PR DESCRIPTION
### Summary of Changes

In 3.7 JDate will override DateTime default behaviour to set the microseconds to current time (see https://github.com/joomla/joomla-cms/pull/11890)

It seems that, as of php 7.1, the new DateTime() will do the same, ie, set the microseconds when creating a date with the current time.

> DateTime and DateTimeImmutable now properly incorporate microseconds when constructed from the current time, either explicitly or with a relative string (e.g. "first day of next month"). This means that naive comparisons of two newly created instances will now more likely return FALSE instead of TRUE:
> 
> Source  http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds

So probably is best to have a php version check here for pre-7.1 versions to not override php 7.1+ behaviour.

This is what this PR proposes.

### Testing Instructions

- Code review.
- Add to protostar/isis index.php

``` php
$date1 = new JDate('now'); usleep(1000); $date2 = new JDate('now');
JFactory::getApplication()->enqueueMessage($date1->format('Y-m-d H:i:s.u') . '<br />' . $date2->format('Y-m-d H:i:s.u'), 'notice');
```
-  In pre-php 7.1 and in php 7.1+ the two dates should continue to have different microseconds.
![image](https://cloud.githubusercontent.com/assets/9630530/20865653/c2bb05a2-ba0f-11e6-9e13-237b0e59578a.png)

Note: don't have php 7.1 to test, if anyone can test if in php 7.1 is all ok

### Documentation Changes Required

None.