### PR TITLE
Replaced 'stdClass' literals with '\\stdClass'. Fixes #11297

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -749,7 +749,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 *
 	 * @since   11.1
 	 */
-	abstract protected function fetchObject($cursor = null, $class = 'stdClass');
+	abstract protected function fetchObject($cursor = null, $class = '\\stdClass');
 
 	/**
 	 * Method to free up the memory used for the result set.
@@ -1239,7 +1239,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * @since   12.1
 	 * @throws  RuntimeException
 	 */
-	public function getIterator($column = null, $class = 'stdClass')
+	public function getIterator($column = null, $class = '\\stdClass')
 	{
 		// Derive the class name from the driver.
 		$iteratorClass = 'JDatabaseIterator' . ucfirst($this->name);
@@ -1563,7 +1563,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * @throws  RuntimeException
 	 * @deprecated  12.3 (Platform) & 4.0 (CMS) - Use getIterator() instead
 	 */
-	public function loadNextObject($class = 'stdClass')
+	public function loadNextObject($class = '\\stdClass')
 	{
 		JLog::add(__METHOD__ . '() is deprecated. Use JDatabaseDriver::getIterator() instead.', JLog::WARNING, 'deprecated');
 		$this->connect();
@@ -1640,7 +1640,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * @since   11.1
 	 * @throws  RuntimeException
 	 */
-	public function loadObject($class = 'stdClass')
+	public function loadObject($class = '\\stdClass')
 	{
 		$this->connect();
 
@@ -1679,7 +1679,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 * @since   11.1
 	 * @throws  RuntimeException
 	 */
-	public function loadObjectList($key = '', $class = 'stdClass')
+	public function loadObjectList($key = '', $class = '\\stdClass')
 	{
 		$this->connect();
 

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -459,7 +459,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 *
 	 * @since   12.1
 	 */
-	protected function fetchObject($cursor = null, $class = 'stdClass')
+	protected function fetchObject($cursor = null, $class = '\\stdClass')
 	{
 		return mysql_fetch_object($cursor ? $cursor : $this->cursor, $class);
 	}

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -881,7 +881,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	protected function fetchObject($cursor = null, $class = 'stdClass')
+	protected function fetchObject($cursor = null, $class = '\\stdClass')
 	{
 		return mysqli_fetch_object($cursor ? $cursor : $this->cursor, $class);
 	}

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -853,7 +853,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	protected function fetchObject($cursor = null, $class = 'stdClass')
+	protected function fetchObject($cursor = null, $class = '\\stdClass')
 	{
 		if (!empty($cursor) && $cursor instanceof PDOStatement)
 		{
@@ -903,7 +903,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	 * @throws  RuntimeException
 	 * @deprecated  4.0 (CMS)  Use getIterator() instead
 	 */
-	public function loadNextObject($class = 'stdClass')
+	public function loadNextObject($class = '\\stdClass')
 	{
 		JLog::add(__METHOD__ . '() is deprecated. Use JDatabaseDriver::getIterator() instead.', JLog::WARNING, 'deprecated');
 		$this->connect();

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -1082,7 +1082,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	protected function fetchObject($cursor = null, $class = 'stdClass')
+	protected function fetchObject($cursor = null, $class = '\\stdClass')
 	{
 		return pg_fetch_object(is_null($cursor) ? $this->cursor : $cursor, null, $class);
 	}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -969,7 +969,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 *
 	 * @since   12.1
 	 */
-	protected function fetchObject($cursor = null, $class = 'stdClass')
+	protected function fetchObject($cursor = null, $class = '\\stdClass')
 	{
 		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
 	}

--- a/libraries/joomla/database/iterator.php
+++ b/libraries/joomla/database/iterator.php
@@ -73,7 +73,7 @@ abstract class JDatabaseIterator implements Countable, Iterator
 	 *
 	 * @throws  InvalidArgumentException
 	 */
-	public function __construct($cursor, $column = null, $class = 'stdClass')
+	public function __construct($cursor, $column = null, $class = '\\stdClass')
 	{
 		if (!class_exists($class))
 		{


### PR DESCRIPTION
Pull Request for Issue #11297  .

### Summary of Changes

Replaced 'stdClass' literals with '\\\\stdClass'.

### Testing Instructions

See [issue](https://issues.joomla.org/tracker/joomla-cms/11297) for testing instructions.

### Documentation Changes Required

No changes required.