### PR TITLE
Improve menu associations

### DIFF
--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -30,11 +30,12 @@ abstract class ModLanguagesHelper
 	 */
 	public static function getList(&$params)
 	{
-		$user      = JFactory::getUser();
-		$lang      = JFactory::getLanguage();
-		$languages = JLanguageHelper::getLanguages();
-		$app       = JFactory::getApplication();
-		$menu      = $app->getMenu();
+		$user		= JFactory::getUser();
+		$lang		= JFactory::getLanguage();
+		$languages	= JLanguageHelper::getLanguages();
+		$app		= JFactory::getApplication();
+		$menu		= $app->getMenu();
+		$active		= $menu->getActive();
 
 		// Get menu home items
 		$homes = array();
@@ -55,8 +56,6 @@ abstract class ModLanguagesHelper
 
 		if ($assoc)
 		{
-			$active = $menu->getActive();
-
 			if ($active)
 			{
 				$associations = MenusHelper::getAssociations($active->id);
@@ -121,6 +120,10 @@ abstract class ModLanguagesHelper
 					{
 						$itemid = $associations[$language->lang_code];
 						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $itemid);
+					}
+					elseif ($active && $active->language == '*')
+					{
+						$language->link = JRoute::_('index.php?lang=' . $language->sef . '&Itemid=' . $active->id);
 					}
 					else
 					{


### PR DESCRIPTION
### Summary of Changes
At the moment on a multilingual page if you have a menu item with language == All, the associations in mod_language links to the default menu item. With this patch, just the language changes and the user stays on the same page.

### Testing Instructions
=> Create a multilingual page with at least two installed languages and association option active
=> Create a new menu item (e.g. login) and choose language = All
=> Active the language chooser module
=> Go to the new menu item

Before patch: the link for the second language goes to the "home" menu item
After patch: the link is the same as the current page, just the language changed