### PR TITLE
Always show the release news in the right side of postinstall

### DIFF
--- a/administrator/components/com_postinstall/views/messages/tmpl/default.php
+++ b/administrator/components/com_postinstall/views/messages/tmpl/default.php
@@ -33,41 +33,42 @@ JHtml::_('formbehavior.chosen', 'select');
 	<?php echo JHtml::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'input-xlarge'), 'value', 'text', $this->eid, 'eid'); ?>
 </form>
 
-<?php if (empty($this->items)) : ?>
-<div class="hero-unit">
-	<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
-	<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
-	<a href="index.php?option=com_postinstall&amp;view=messages&amp;task=reset&amp;eid=<?php echo $this->eid; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-warning btn-large">
-		<span class="icon icon-eye-open"></span>
-		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET'); ?>
-	</a>
-</div>
-<?php else : ?>
 <?php if ($this->eid == 700) : ?>
 <div class="row-fluid">
 	<div class="span8">
 <?php endif; ?>
-	<?php foreach ($this->items as $item) : ?>
-	<fieldset>
-		<legend><?php echo JText::_($item->title_key); ?></legend>
-		<p class="small">
-			<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced); ?>
-		</p>
-		<p><?php echo JText::_($item->description_key); ?></p>
-		<div>
-			<?php if ($item->type !== 'message') : ?>
-			<a href="index.php?option=com_postinstall&amp;view=messages&amp;task=action&amp;id=<?php echo $item->postinstall_message_id; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-primary">
-				<?php echo JText::_($item->action_key); ?>
-			</a>
-			<?php endif; ?>
-			<?php if (JFactory::getUser()->authorise('core.edit.state', 'com_postinstall')) : ?>
-			<a href="index.php?option=com_postinstall&amp;view=message&amp;task=unpublish&amp;id=<?php echo $item->postinstall_message_id; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-inverse btn-small">
-				<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE'); ?>
-			</a>
-			<?php endif; ?>
-		</div>
-	</fieldset>
-	<?php endforeach; ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="hero-unit">
+				<h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
+				<p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
+				<a href="index.php?option=com_postinstall&amp;view=messages&amp;task=reset&amp;eid=<?php echo $this->eid; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-warning btn-large">
+					<span class="icon icon-eye-open"></span>
+					<?php echo JText::_('COM_POSTINSTALL_BTN_RESET'); ?>
+				</a>
+			</div>
+		<?php else : ?>
+			<?php foreach ($this->items as $item) : ?>
+			<fieldset>
+				<legend><?php echo JText::_($item->title_key); ?></legend>
+				<p class="small">
+					<?php echo JText::sprintf('COM_POSTINSTALL_LBL_SINCEVERSION', $item->version_introduced); ?>
+				</p>
+				<p><?php echo JText::_($item->description_key); ?></p>
+				<div>
+					<?php if ($item->type !== 'message') : ?>
+					<a href="index.php?option=com_postinstall&amp;view=messages&amp;task=action&amp;id=<?php echo $item->postinstall_message_id; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-primary">
+						<?php echo JText::_($item->action_key); ?>
+					</a>
+					<?php endif; ?>
+					<?php if (JFactory::getUser()->authorise('core.edit.state', 'com_postinstall')) : ?>
+					<a href="index.php?option=com_postinstall&amp;view=message&amp;task=unpublish&amp;id=<?php echo $item->postinstall_message_id; ?>&amp;<?php echo $this->token; ?>=1" class="btn btn-inverse btn-small">
+						<?php echo JText::_('COM_POSTINSTALL_BTN_HIDE'); ?>
+					</a>
+					<?php endif; ?>
+				</div>
+			</fieldset>
+			<?php endforeach; ?>
+		<?php endif; ?>
 <?php if ($this->eid == 700) : ?>
 	</div>
 	<div class="span4">
@@ -75,5 +76,4 @@ JHtml::_('formbehavior.chosen', 'select');
 		<?php echo $renderer->render($mod, $params, $options); ?>
 	</div>
 </div>
-<?php endif; ?>
 <?php endif; ?>

--- a/administrator/templates/hathor/html/com_postinstall/messages/default.php
+++ b/administrator/templates/hathor/html/com_postinstall/messages/default.php
@@ -19,17 +19,27 @@ $param          = array("rssurl" => "https://www.joomla.org/announcements/releas
 						"rssitems" => 5,
 						"rssitemdesc" => 1,
 						"word_count" => 200,
-						"cache" => 0);
+						"cache" => 0,
+						"moduleclass_sfx" => ' list-striped');
 $params         = array('params' => json_encode($param));
 ?>
 
 <?php if (empty($this->items)): ?>
 <h2><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE') ?></h2>
 <p><?php echo JText::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC') ?></p>
-<button onclick="window.location='index.php?option=com_postinstall&view=messages&task=reset&eid=<?php echo $this->eid; ?>&<?php echo $this->token ?>=1'; return false;" class="btn btn-warning">
-	<span class="icon icon-eye-open"></span>
-	<?php echo JText::_('COM_POSTINSTALL_BTN_RESET') ?>
-</button>
+<div>
+	<button onclick="window.location='index.php?option=com_postinstall&view=messages&task=reset&eid=<?php echo $this->eid; ?>&<?php echo $this->token ?>=1'; return false;" class="btn btn-warning">
+		<span class="icon icon-eye-open"></span>
+		<?php echo JText::_('COM_POSTINSTALL_BTN_RESET') ?>
+	</button>
+</div>
+<?php if ($this->eid == 700): ?>
+	<br/>
+	<div>
+		<h3><?php echo JText::_('COM_POSTINSTALL_LBL_RELEASENEWS'); ?></h3>
+		<?php echo $renderer->render($mod, $params, $options); ?>
+	</div>
+<?php endif; ?>
 <?php else: ?>
 <?php
 	if ($this->eid == 700):


### PR DESCRIPTION
Currently when you hide all postinstall messages, it will also hide the release news in the right area of the page.

### Summary of Changes
This PR changes the layout so the release news are always shown if "Joomla CMS" is selected.

### Testing Instructions
* Hide all messages and check that the releae news still show
* Optional: Change the extension_id in the #__postinstall_messages table to another value for at least one entry. Now you should see another option in the dropdown list. When changing, the "Release News" should no longer show.
