### PR TITLE
Fix register to read redirect

### DIFF
--- a/components/com_users/models/login.php
+++ b/components/com_users/models/login.php
@@ -69,12 +69,6 @@ class UsersModelLogin extends JModelForm
 			}
 		}
 
-		// Set the return URL if empty.
-		if (!isset($data['return']) || empty($data['return']))
-		{
-			$data['return'] = 'index.php?option=com_users&view=profile';
-		}
-
 		$app->setUserState('users.login.form.data', $data);
 
 		$this->preprocessData('com_users.login', $data);

--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -79,11 +79,8 @@ JHtml::_('behavior.formvalidator');
 				</div>
 			</div>
 
-			<?php if ($this->params->get('login_redirect_url')) : ?>
-				<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('login_redirect_url', $this->form->getValue('return'))); ?>" />
-			<?php else : ?>
-				<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('login_redirect_menuitem', $this->form->getValue('return'))); ?>" />
-			<?php endif; ?>
+			<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem'))); ?>
+			<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>" />
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 	</form>


### PR DESCRIPTION
Pull Request for Issue #https://github.com/joomla/joomla-cms/issues/12945 .

### Summary of Changes
* Changes code so the return value passed in the request (eg from a readmore link) takes precedence over redirect settings from a menu item param.
* Removed the "fallback to profile view" code in the model. This is not needed since the controller does the same as well.

### Testing Instructions
From original issue:

* Install a clean staging.
* Create an article set to registered with a Read More and set  Show Unauthorised Links to Yes.
* Create a menu item to display that article and set Show Unauthorised Links to Yes.
* Create a Login Menu item which will display on the same page as the single article menu item.
* Add a login redirection to that login menu item to anything else that the single article menu item created above.
* Display the article in frontend.
* Click on the "Register to Read More..."

After login, it is expected to be redirected to the full article after this PR, prior you were redirected according to menu item settings.

Of course try other settings (eg no redirect set, regular login, ...)

### Documentation Changes Required
None