### PR TITLE
validate="options" doesn't work with useglobal="true"

### DIFF
--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -257,7 +257,6 @@
 			<field name="initial_sort" type="list"
 				description="COM_CONTACT_FIELD_INITIAL_SORT_DESC"
 				label="COM_CONTACT_FIELD_INITIAL_SORT_LABEL"
-				validate="options"
 				useglobal="true"
 			>
 				<option value="name">COM_CONTACT_FIELD_VALUE_NAME</option>


### PR DESCRIPTION
In https://github.com/joomla/joomla-cms/pull/12861 I forgot to delete one `validate="options"` line.

### Summary of Changes
Removes that line

### Testing Instructions
Try to create a menu item for a contact category with the "Sort By" parameter set to "Use Global". It will fail with an error message.
After this PR it will save.

### Documentation Changes Required
None
