### PR TITLE
Unittest fix - do not use PDO driver directly

### DIFF
--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -52,7 +52,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	public function __destruct()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**
@@ -65,7 +65,7 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	public function disconnect()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**

--- a/tests/unit/core/case/database.php
+++ b/tests/unit/core/case/database.php
@@ -90,13 +90,10 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 		{
 			// Attempt to instantiate the driver.
 			static::$driver = JDatabaseDriver::getInstance($options);
+			static::$driver->connect();
 
-			// Create a new PDO instance for an SQLite memory database and load the test schema into it.
-			$pdo = new PDO('sqlite::memory:');
-			$pdo->exec(file_get_contents(JPATH_TESTS . '/schema/ddl.sql'));
-
-			// Set the PDO instance to the driver using reflection whizbangery.
-			TestReflection::setValue(static::$driver, 'connection', $pdo);
+			// Get the PDO instance for an SQLite memory database and load the test schema into it.
+			static::$driver->getConnection()->exec(file_get_contents(JPATH_TESTS . '/schema/ddl.sql'));
 		}
 		catch (RuntimeException $e)
 		{
@@ -124,7 +121,12 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/suites/libraries/legacy/model/JModelLegacyTest.php
+++ b/tests/unit/suites/libraries/legacy/model/JModelLegacyTest.php
@@ -65,6 +65,7 @@ class JModelLegacyTest extends TestCaseDatabase
 	{
 		// Reset JTable::$_includePaths
 		TestReflection::setValue('JTable', '_includePaths', array());
+		parent::tearDownAfterClass();
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for another PR #12839 - in order to separate into a few parts.

### Summary of Changes

- do not use `$pdo = new PDO('sqlite::memory:');` directly, use `getInstance()` as in other places
- remove notice "`$this->connection` is undefined" from sqlite driver when you try to re-`connect()` after `disconnect();`
- add missing `parent::tearDownAfterClass();` in `JModelLegancyTest`

### Testing Instructions
Travis. 
Code review.

### Documentation Changes Required
N/A
