### PR TITLE
Remove font-weight:200 from Bootstrap

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -535,7 +535,7 @@ p {
 .lead {
 	margin-bottom: 18px;
 	font-size: 19.5px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 small {
@@ -3090,7 +3090,7 @@ input[type="submit"].btn.btn-mini {
 	padding: 11px 20px 11px;
 	margin-left: -20px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	color: #555;
 	text-shadow: 0 1px 0 #ffffff;
 }
@@ -4512,7 +4512,7 @@ a.badge:focus {
 	padding: 60px;
 	margin-bottom: 30px;
 	font-size: 18px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 	color: inherit;
 	background-color: #eee;
@@ -5609,7 +5609,7 @@ a.disabled:hover {
 .hero-unit .lead {
 	margin-bottom: 18px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 .btn .caret {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -535,7 +535,7 @@ p {
 .lead {
 	margin-bottom: 18px;
 	font-size: 19.5px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 small {
@@ -3090,7 +3090,7 @@ input[type="submit"].btn.btn-mini {
 	padding: 11px 20px 11px;
 	margin-left: -20px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	color: #555;
 	text-shadow: 0 1px 0 #ffffff;
 }
@@ -4512,7 +4512,7 @@ a.badge:focus {
 	padding: 60px;
 	margin-bottom: 30px;
 	font-size: 18px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 	color: inherit;
 	background-color: #eee;
@@ -5609,7 +5609,7 @@ a.disabled:hover {
 .hero-unit .lead {
 	margin-bottom: 18px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 .btn .caret {

--- a/media/jui/css/bootstrap-extended.css
+++ b/media/jui/css/bootstrap-extended.css
@@ -53,7 +53,7 @@ a.disabled:hover {
 .hero-unit .lead {
 	margin-bottom: 18px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 .btn .caret {

--- a/media/jui/less/bootstrap-extended.less
+++ b/media/jui/less/bootstrap-extended.less
@@ -33,7 +33,7 @@ a.disabled:hover {
 .hero-unit .lead {
 	margin-bottom: 18px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 .btn .caret {

--- a/media/jui/less/hero-unit.less
+++ b/media/jui/less/hero-unit.less
@@ -7,7 +7,7 @@
   padding: 60px;
   margin-bottom: 30px;
   font-size: 18px;
-  font-weight: 200;
+  font-weight: 400;
   line-height: @baseLineHeight * 1.5;
   color: @heroUnitLeadColor;
   background-color: @heroUnitBackground;

--- a/media/jui/less/navbar.less
+++ b/media/jui/less/navbar.less
@@ -53,7 +53,7 @@
   padding: ((@navbarHeight - @baseLineHeight) / 2) 20px ((@navbarHeight - @baseLineHeight) / 2);
   margin-left: -20px; // negative indent to left-align the text down the page
   font-size: 20px;
-  font-weight: 200;
+  font-weight: 400;
   color: @navbarBrandColor;
   text-shadow: 0 1px 0 @navbarBackgroundHighlight;
   &:hover,

--- a/media/jui/less/type.less
+++ b/media/jui/less/type.less
@@ -12,7 +12,7 @@ p {
 .lead {
   margin-bottom: @baseLineHeight;
   font-size: @baseFontSize * 1.5;
-  font-weight: 200;
+  font-weight: 400;
   line-height: @baseLineHeight * 1.5;
 }
 

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -553,7 +553,7 @@ p {
 .lead {
 	margin-bottom: 18px;
 	font-size: 19.5px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 small {
@@ -3279,7 +3279,7 @@ input[type="submit"].btn.btn-mini {
 	padding: 11px 20px 11px;
 	margin-left: -20px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	color: #555;
 	text-shadow: 0 1px 0 #ffffff;
 }
@@ -4694,7 +4694,7 @@ a.badge:focus {
 	padding: 60px;
 	margin-bottom: 30px;
 	font-size: 18px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 	color: inherit;
 	background-color: #eee;
@@ -5791,7 +5791,7 @@ a.disabled:hover {
 .hero-unit .lead {
 	margin-bottom: 18px;
 	font-size: 20px;
-	font-weight: 200;
+	font-weight: 400;
 	line-height: 27px;
 }
 .btn .caret {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13070#issuecomment-264690357 .

### Summary of Changes
A font-weight of 200 is not available with Arial and not available unless installed with Helvetica, If installed it causes inconsistent styling. This PR removes all CSS properties of font-weight 200 in Bootstrap.

**Before Patch**
![font-weight](https://cloud.githubusercontent.com/assets/2803503/20902777/8c6ca290-bb30-11e6-8575-ea6f57d3ac75.png)

**After Patch**
![reset-msg](https://cloud.githubusercontent.com/assets/2803503/20902757/778f0156-bb30-11e6-9c99-0438b11ffb5f.png)

