### PR TITLE
Isis font-weight 200 override

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8551,6 +8551,12 @@ body.modal-open {
 .popover-content {
 	min-height: 33px;
 }
+.lead,
+.navbar .brand,
+.hero-unit,
+.hero-unit .lead {
+	font-weight: 400;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8551,3 +8551,9 @@ body.modal-open {
 .popover-content {
 	min-height: 33px;
 }
+.lead,
+.navbar .brand,
+.hero-unit,
+.hero-unit .lead {
+	font-weight: 400;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1636,3 +1636,8 @@ body.modal-open {
 .popover-content {
     min-height: 33px;
 }
+
+/* Overrid font-weight 200 */
+.lead, .navbar .brand, .hero-unit, .hero-unit .lead {
+	font-weight: 400;
+}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13070#issuecomment-264690357 .

### Summary of Changes
A font-weight of 200 is not available with Arial and not available unless installed with Helvetica, If installed it causes inconsistent styling. This PR adds a font-weight 200 override (400) in Isis.

**Before Patch**
![font-weight](https://cloud.githubusercontent.com/assets/2803503/20902777/8c6ca290-bb30-11e6-8575-ea6f57d3ac75.png)

**After Patch**
![reset-msg](https://cloud.githubusercontent.com/assets/2803503/20902757/778f0156-bb30-11e6-9c99-0438b11ffb5f.png)

