### PR TITLE
postgresql - fix sql update for com_fields

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
@@ -53,6 +53,8 @@ CREATE TABLE "#__fields_groups" (
   "note" varchar(255) DEFAULT '' NOT NULL,
   "description" text DEFAULT '' NOT NULL,
   "state" smallint DEFAULT 0 NOT NULL,
+  "checked_out" integer DEFAULT 0 NOT NULL,
+  "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "ordering" bigint DEFAULT 0 NOT NULL,
   "language" varchar(7) DEFAULT '' NOT NULL,
   "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,


### PR DESCRIPTION
small fix  after  #13091  merge

### Summary of Changes
added the missed 2 fields `checked_out`, `checked_out_time`  from `#__fields_groups` table



