### PR TITLE
[com_fields] No need for an alias in fields groups.

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -43,7 +43,6 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
   `asset_id` int(10) NOT NULL DEFAULT 0,
   `extension` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(255) NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
   `state` tinyint(1) NOT NULL DEFAULT '0',

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
@@ -49,7 +49,6 @@ CREATE TABLE "#__fields_groups" (
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "extension" varchar(255) DEFAULT '' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "alias" varchar(255) DEFAULT '' NOT NULL,
   "note" varchar(255) DEFAULT '' NOT NULL,
   "description" text DEFAULT '' NOT NULL,
   "state" smallint DEFAULT 0 NOT NULL,

--- a/administrator/components/com_fields/models/forms/group.xml
+++ b/administrator/components/com_fields/models/forms/group.xml
@@ -35,15 +35,6 @@
 		/>
 
 		<field
-			name="alias"
-			type="text"
-			label="JFIELD_ALIAS_LABEL"
-			description="JFIELD_ALIAS_DESC"
-			hint="JFIELD_ALIAS_PLACEHOLDER"
-			size="45"
-		/>
-
-		<field
 			name="state"
 			type="list"
 			label="JSTATUS"

--- a/administrator/components/com_fields/models/group.php
+++ b/administrator/components/com_fields/models/group.php
@@ -31,25 +31,9 @@ class FieldsModelGroup extends JModelAdmin
 		// Alter the title for save as copy
 		$input = JFactory::getApplication()->input;
 
+		// Save new group as unpublished
 		if ($input->get('task') == 'save2copy')
 		{
-			$origTable = clone $this->getTable();
-			$origTable->load($input->getInt('id'));
-
-			if ($data['title'] == $origTable->title)
-			{
-				list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
-				$data['title'] = $title;
-				$data['alias'] = $alias;
-			}
-			else
-			{
-				if ($data['alias'] == $origTable->alias)
-				{
-					$data['alias'] = '';
-				}
-			}
-
 			$data['state'] = 0;
 		}
 
@@ -71,31 +55,6 @@ class FieldsModelGroup extends JModelAdmin
 	public function getTable($name = 'Group', $prefix = 'FieldsTable', $options = array())
 	{
 		return JTable::getInstance($name, $prefix, $options);
-	}
-
-	/**
-	 * Method to change the title & alias.
-	 *
-	 * @param   integer  $category_id  The id of the category.
-	 * @param   string   $alias        The alias.
-	 * @param   string   $title        The title.
-	 *
-	 * @return  array  Contains the modified title and alias.
-	 *
-	 * @since    __DEPLOY_VERSION__
-	 */
-	protected function generateNewTitle($category_id, $alias, $title)
-	{
-		// Alter the title & alias
-		$table = $this->getTable();
-
-		while ($table->load(array('alias' => $alias)))
-		{
-			$title = StringHelper::increment($title);
-			$alias = StringHelper::increment($alias, 'dash');
-		}
-
-		return array($title, $alias);
 	}
 
 	/**

--- a/administrator/components/com_fields/models/groups.php
+++ b/administrator/components/com_fields/models/groups.php
@@ -42,7 +42,6 @@ class FieldsModelGroups extends JModelList
 				'id', 'a.id',
 				'title', 'a.title',
 				'type', 'a.type',
-				'alias', 'a.alias',
 				'state', 'a.state',
 				'access', 'a.access',
 				'access_level',
@@ -125,7 +124,7 @@ class FieldsModelGroups extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.note' .
+				'a.id, a.title, a.checked_out, a.checked_out_time, a.note' .
 				', a.state, a.access, a.created, a.created_by, a.ordering, a.language'
 			)
 		);
@@ -195,7 +194,7 @@ class FieldsModelGroups extends JModelList
 			else
 			{
 				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-				$query->where('(a.title LIKE ' . $search . ' OR a.alias LIKE ' . $search . ')');
+				$query->where('a.title LIKE ' . $search);
 			}
 		}
 

--- a/administrator/components/com_fields/tables/group.php
+++ b/administrator/components/com_fields/tables/group.php
@@ -84,20 +84,6 @@ class FieldsTableGroup extends JTable
 			return false;
 		}
 
-		$this->alias = trim($this->alias);
-
-		if (empty($this->alias))
-		{
-			$this->alias = $this->title;
-		}
-
-		$this->alias = JApplicationHelper::stringURLSafe($this->alias, $this->language);
-
-		if (trim(str_replace('-', '', $this->alias)) == '')
-		{
-			$this->alias = JFactory::getDate()->format('Y-m-d-H-i-s');
-		}
-
 		$date = JFactory::getDate();
 		$user = JFactory::getUser();
 

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -123,10 +123,8 @@ if ($saveOrder)
 										<?php echo $this->escape($item->title); ?>
 									<?php endif; ?>
 									<span class="small break-word">
-										<?php if (empty($item->note)) : ?>
-											<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-										<?php else : ?>
-											<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+										<?php if ($item->note) : ?>
+											<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 										<?php endif; ?>
 									</span>
 								</div>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -687,7 +687,6 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
   `asset_id` int(10) NOT NULL DEFAULT 0,
   `extension` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(255) NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
   `state` tinyint(1) NOT NULL DEFAULT '0',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -698,7 +698,6 @@ CREATE TABLE "#__fields_groups" (
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "extension" varchar(255) DEFAULT '' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "alias" varchar(255) DEFAULT '' NOT NULL,
   "note" varchar(255) DEFAULT '' NOT NULL,
   "description" text NOT NULL,
   "state" smallint DEFAULT '0' NOT NULL,


### PR DESCRIPTION
When I rewrote com_fields to use groups instead of categories, I just copy-pasted the alias field. But it is in fact not used anywhere and thus can be removed.

### Summary of Changes
This PR removes all traces to an alias in fields groups

### Testing Instructions
* Delete the alias column from your database table #__fields_groups
* Check that creating/editing/saving/deleting field groups still works
* Check that fields behave as expected

### Documentation Changes Required
None