### PR TITLE
Implement Countable interface in JFeed

### DIFF
--- a/libraries/joomla/feed/feed.php
+++ b/libraries/joomla/feed/feed.php
@@ -26,7 +26,7 @@ defined('JPATH_PLATFORM') or die();
  *
  * @since  12.3
  */
-class JFeed implements ArrayAccess
+class JFeed implements ArrayAccess, Countable
 {
 	/**
 	 * @var    array  The entry properties.
@@ -166,6 +166,19 @@ class JFeed implements ArrayAccess
 		$this->entries[] = $entry;
 
 		return $this;
+	}
+
+	/**
+	 * Returns a count of the number of entries in the feed.
+	 * 
+	 * This method is here to implement the Countable interface.
+	 * You can call it by doing count($feed) rather than $feed->count();
+	 * 
+	 * @return  integer number of entries in the feed.
+	 */
+	public function count()
+	{
+		return count($this->entries);
 	}
 
 	/**

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -86,13 +86,7 @@ else
 	<?php if (!empty($feed))
 	{ ?>
 		<ul class="newsfeed<?php echo $params->get('moduleclass_sfx'); ?>">
-		<?php for ($i = 0; $i < $params->get('rssitems', 5); $i++)
-		{
-			if (!$feed->offsetExists($i))
-			{
-				break;
-			}
-			?>
+		<?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 5)); $i < $max; $i++) { ?>
 			<?php
 				$uri   = (!empty($feed[$i]->uri) || !is_null($feed[$i]->uri)) ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
 				$uri   = substr($uri, 0, 4) != 'http' ? $params->get('rsslink') : $uri;


### PR DESCRIPTION
JFeed already implements ArrayAccess.  This PR adds the one additional method required to implement Countable.

### Summary of Changes
With this PR you can count the number of entries in a feed using `count($feed)`.

### Testing Instructions
Set up a feed.  Apply PR.  Make sure you get the same results as before.

### Documentation Changes Required
None.
