### PR TITLE
[com_content] - fix empty filter sql error

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -324,12 +324,6 @@ class ContentModelArticles extends JModelList
 		$orderCol = $this->state->get('list.ordering', 'a.id');
 		$orderDirn = $this->state->get('list.direction', 'desc');
 
-		if (JPluginHelper::isEnabled('content', 'vote'))
-		{
-			$orderCol  = $this->state->get('list.fullordering', 'a.id');
-			$orderDirn = '';
-		}
-
 		$query->order($db->escape($orderCol) . ' ' . $orderDirn);
 
 		return $query;

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -321,10 +321,16 @@ class ContentModelArticles extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$orderCol = $this->state->get('list.ordering', 'a.id');
-		$orderDirn = $this->state->get('list.direction', 'desc');
+		$orderCol  = $this->state->get('list.fullordering', 'a.id');
+		$orderDirn = '';
 
-		$query->order($db->escape($orderCol) . ' ' . $orderDirn);
+		if (empty($orderCol))
+		{
+			$orderCol  = $this->state->get('list.ordering', 'a.id');
+			$orderDirn = $this->state->get('list.direction', 'DESC');
+		}
+
+		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
 		return $query;
 	}

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -212,6 +212,14 @@ class ContentModelFeatured extends ContentModelArticles
 		}
 
 		// Add the list ordering clause.
+		$orderCol  = $this->state->get('list.fullordering', 'a.title');
+		$orderDirn = '';
+
+		if (empty($orderCol))
+		{
+			$orderCol  = $this->state->get('list.ordering', 'a.title');
+			$orderDirn = $this->state->get('list.direction', 'ASC');
+		}
 		$query->order($db->escape($this->getState('list.ordering', 'a.title')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
 		return $query;

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -221,7 +221,7 @@ class ContentModelFeatured extends ContentModelArticles
 			$orderDirn = $this->state->get('list.direction', 'ASC');
 		}
 
-		$query->order($db->escape($this->getState('list.ordering', 'a.title')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
+		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 
 		return $query;
 	}

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -220,6 +220,7 @@ class ContentModelFeatured extends ContentModelArticles
 			$orderCol  = $this->state->get('list.ordering', 'a.title');
 			$orderDirn = $this->state->get('list.direction', 'ASC');
 		}
+
 		$query->order($db->escape($this->getState('list.ordering', 'a.title')) . ' ' . $db->escape($this->getState('list.direction', 'ASC')));
 
 		return $query;


### PR DESCRIPTION
Pull Request for Issue #13114.

### Summary of Changes
Fixed the list ordering clause.

### Testing Instructions

- see https://github.com/joomla/joomla-cms/issues/13114#issue-194011943
- the Articles/Featured ordering work as before
