### PR TITLE
Smart Search Indexes Categories for Disabled Components

### DIFF
--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -249,6 +249,12 @@ class PlgFinderCategories extends FinderIndexerAdapter
 			return;
 		}
 
+		// Check if the extension that owns the category is also enabled.
+		if (JComponentHelper::isEnabled($item->extension) == false)
+		{
+			return;
+		}
+
 		$item->setLanguage();
 
 		$extension = ucfirst(substr($item->extension, 4));


### PR DESCRIPTION
Pull Request for Issue #13118  .

### Summary of Changes
Smart Search categories plugin fails to check that the extension that owns a category is enabled before indexing the category.

### Testing Instructions
See #13118 

### Documentation Changes Required
None.