### PR TITLE
Set correct default values for user creation in the sample data

### DIFF
--- a/installation/sql/mysql/sample_learn.sql
+++ b/installation/sql/mysql/sample_learn.sql
@@ -766,6 +766,6 @@ INSERT IGNORE INTO `#__viewlevels` (`id`, `title`, `ordering`, `rules`) VALUES
 (5, 'Guest', 1, '[13]'),
 (6, 'Super Users', 5, '[8]');
 
-UPDATE `#__extensions` SET `params`='{"allowUserRegistration":"0","new_usertype":"2","guest_usergroup":"13","sendpassword":"1","useractivation":"1","mail_to_admin":"0","captcha":"","frontend_userparams":"1","site_language":"0","change_login_name":"0","reset_count":"10","reset_time":"1","mailSubjectPrefix":"","mailBodySuffix":"","save_history":"1","history_limit":5}' WHERE extension_id=25;
+UPDATE `#__extensions` SET `params`='{"allowUserRegistration":"0","new_usertype":"2","guest_usergroup":"13","sendpassword":"1","useractivation":"2","mail_to_admin":"0","captcha":"","frontend_userparams":"1","site_language":"0","change_login_name":"0","reset_count":"10","reset_time":"1","mailSubjectPrefix":"","mailBodySuffix":"","save_history":"1","history_limit":5}' WHERE extension_id=25;
 
 SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
https://github.com/joomla/joomla-cms/blob/3.6.4/administrator/components/com_users/config.xml#L45-L68
Default values should be send mail to admin and admin activation.
The default value for the useractivation param is 2

### Testing Instructions
Install Joomla 3.7.0 and use the sample_learn.sql sample data,
confirm the "New User Account Activation" setting is **Administrator**

### Documentation Changes Required

None.