### PR TITLE
Make sql update index drop/add work with db schema checker

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
@@ -1,3 +1,3 @@
 -- Replace language image UNIQUE index for a normal INDEX.
-ALTER TABLE `#__languages` DROP INDEX `idx_image`;
-ALTER TABLE `#__languages` ADD INDEX `idx_image` (`image`);
+-- Note: This needs to be done in just one query because of the database schema checker.
+ALTER TABLE `#__languages` DROP INDEX `idx_image`, ADD INDEX `idx_image` (`image`);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
@@ -1,3 +1,3 @@
 -- Replace language image UNIQUE index for a normal INDEX.
 -- Note: This needs to be done in just one query because of the database schema checker.
-ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image", ADD CONSTRAINT "#__idx_image" ("image");
+ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image", ADD INDEX "#__idx_image" ("image");

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
@@ -1,3 +1,3 @@
 -- Replace language image UNIQUE index for a normal INDEX.
-ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image";
-CREATE INDEX "#__idx_image" ON "#__languages" ("image");
+-- Note: This needs to be done in just one query because of the database schema checker.
+ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image", ADD CONSTRAINT "#__idx_image" ("image");

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
@@ -1,5 +1,3 @@
 -- Replace language image UNIQUE index for a normal INDEX.
-ALTER TABLE [#__languages] DROP CONSTRAINT [#__languages$idx_image];
-CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
-	[image] ASC
-) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+-- Note: This needs to be done in just one query because of the database schema checker.
+ALTER TABLE [#__languages] DROP CONSTRAINT [#__languages$idx_image], ADD INDEX [#__languages$idx_image] NONCLUSTERED ([image]);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13122.

### Summary of Changes

Makes index drop/add conformant with db schema checker, ie, in one row.

### Testing Instructions

- Apply patch
- Run manuaaly the update query in your db system
-  Check if you have a non unique idx_image index in `#__languages` table

![image](https://cloud.githubusercontent.com/assets/9630530/21007772/41dd1cde-bd36-11e6-8eb9-255fe05805f8.png)

- Go to Extensions database and check all is fine

Needs to be tested in all 3 supported db systems: mysql, postgresql, sqlazure

Note: Only tested in mysql.

### Documentation Changes Required

None.