### PR TITLE
Don't load authorised view levels in foreach for tags generation

### DIFF
--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -13,11 +13,13 @@ use Joomla\Registry\Registry;
 
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
+$authorisedViews = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));
+
 ?>
 <?php if (!empty($displayData)) : ?>
 	<ul class="tags inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
-			<?php if (in_array($tag->access, JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id')))) : ?>
+			<?php if (in_array($tag->access, authorisedViews)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
 				<li class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -19,7 +19,7 @@ $authorisedViews = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id
 <?php if (!empty($displayData)) : ?>
 	<ul class="tags inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
-			<?php if (in_array($tag->access, authorisedViews)) : ?>
+			<?php if (in_array($tag->access, $authorisedViews)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
 				<li class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -13,13 +13,13 @@ use Joomla\Registry\Registry;
 
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
-$authorisedViews = JFactory::getUser()->getAuthorisedViewLevels();
+$authorised = JFactory::getUser()->getAuthorisedViewLevels();
 
 ?>
 <?php if (!empty($displayData)) : ?>
 	<ul class="tags inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
-			<?php if (in_array($tag->access, $authorisedViews)) : ?>
+			<?php if (in_array($tag->access, $authorised)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
 				<li class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i ?>" itemprop="keywords">

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 
-$authorisedViews = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));
+$authorisedViews = JFactory::getUser()->getAuthorisedViewLevels();
 
 ?>
 <?php if (!empty($displayData)) : ?>


### PR DESCRIPTION
### Summary of Changes
While tags will be outputted in the layout, the authorised view levels will be loaded for each tag. With this patch it will be loaded only once

### Testing Instructions
Just apply patch, tags should be displayed as before with a (I guess not noticeable) performance improvement