### PR TITLE
Displaying the correct tip in Global Configuration Permissions

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -432,7 +432,7 @@ class JFormFieldRules extends JFormField
 		$html[] = '<div class="clr"></div>';
 		$html[] = '<div class="alert">';
 
-		if ($section === 'component' || $section === null || $section == '')
+		if ($section === 'component' || !$section)
 		{
 			$html[] = JText::_('JLIB_RULES_SETTING_NOTES');
 		}

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -432,7 +432,7 @@ class JFormFieldRules extends JFormField
 		$html[] = '<div class="clr"></div>';
 		$html[] = '<div class="alert">';
 
-		if ($section === 'component' || $section === null)
+		if ($section === 'component' || $section === null || $section == '')
 		{
 			$html[] = JText::_('JLIB_RULES_SETTING_NOTES');
 		}


### PR DESCRIPTION
Display the Global Configuration Permissions tab
We get a wrong tip at the bottom:

![screen shot 2016-12-09 at 11 47 45](https://cloud.githubusercontent.com/assets/869724/21046502/592c838c-be05-11e6-9c7a-1a88a35088a6.png)

Patch

Now you will get the correct one:

![screen shot 2016-12-09 at 11 47 19](https://cloud.githubusercontent.com/assets/869724/21046526/69c2a05a-be05-11e6-8eee-3ee01ec1f40d.png)

The reason of that error was the fact that `=== null` is not equal to `''`
