### PR TITLE
Add a static flag to check if the event is registered (Fix #13124)

### DIFF
--- a/libraries/cms/installer/adapter/package.php
+++ b/libraries/cms/installer/adapter/package.php
@@ -17,6 +17,14 @@ defined('JPATH_PLATFORM') or die;
 class JInstallerAdapterPackage extends JInstallerAdapter
 {
 	/**
+	 * Flag if the internal event callback has been registered
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private static $eventRegistered = false;
+
+	/**
 	 * An array of extension IDs for each installed extension
 	 *
 	 * @var    array
@@ -116,7 +124,11 @@ class JInstallerAdapterPackage extends JInstallerAdapter
 		}
 
 		// Add a callback for the `onExtensionAfterInstall` event so we can receive the installed extension ID
-		JEventDispatcher::getInstance()->register('onExtensionAfterInstall', array($this, 'onExtensionAfterInstall'));
+		if (!self::$eventRegistered)
+		{
+			self::$eventRegistered = true;
+			JEventDispatcher::getInstance()->register('onExtensionAfterInstall', array($this, 'onExtensionAfterInstall'));
+		}
 
 		foreach ($this->getManifest()->files->children() as $child)
 		{


### PR DESCRIPTION
Pull Request for Issue #13124

### Summary of Changes

Add a static flag inside `JInstallerAdapterPackage` to check if we've already registered the internal event callback to prevent adding it multiple times.  `JEventDispatcher` is apparently supposed to do this but the checks seem woefully inefficient causing the error shown in that issue.

### Testing Instructions

Installing multiple packages together works.

### Documentation Changes Required

N/A