### PR TITLE
Move calendar form field translations to Joomla's ini files

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -102,6 +102,7 @@ JHtml::_('script', $localesPath, false, true, false, false, true);
 JHtml::_('script', $helperPath, false, true, false, false, true);
 JHtml::_('script', 'system/fields/calendar-vanilla.min.js', false, true, false, false, true);
 JHtml::_('stylesheet', 'system/fields/calendar-vanilla' . $cssFileExt, array(), true);
+JText::script('JLIB_HTML_BEHAVIOR_TODAY', true);
 ?>
 <div class="field-calendar">
 	<?php if (!$readonly && !$disabled) : ?>

--- a/media/system/js/fields/calendar-locales/en.js
+++ b/media/system/js/fields/calendar-locales/en.js
@@ -1,5 +1,4 @@
 window.JoomlaCalLocale = {
-	today : "Today",
 	weekend : [0, 6],
 	wk : "wk",
 	time : "Time:",

--- a/media/system/js/fields/calendar-vanilla.js
+++ b/media/system/js/fields/calendar-vanilla.js
@@ -1028,7 +1028,7 @@
 
 		// Fall back for translation strings
 		window.JoomlaCalLocale = window.JoomlaCalLocale ? JoomlaCalLocale : {};
-		JoomlaCalLocale.today = JoomlaCalLocale.today ? JoomlaCalLocale.today : 'today';
+		JoomlaCalLocale.today = Joomla.JText._('JLIB_HTML_BEHAVIOR_TODAY', true) ? Joomla.JText._('JLIB_HTML_BEHAVIOR_TODAY', true) : 'today';
 		JoomlaCalLocale.weekend = JoomlaCalLocale.weekend ? JoomlaCalLocale.weekend : [0,6];
 		JoomlaCalLocale.localLangNumbers = JoomlaCalLocale.localLangNumbers ? JoomlaCalLocale.localLangNumbers : [0,1,2,3,4,5,6,7,8,9];
 		JoomlaCalLocale.wk = JoomlaCalLocale.wk ? JoomlaCalLocale.wk : 'wk';


### PR DESCRIPTION
### Summary of Changes
As we have all translations in our famous ini files. It would make sense to use the strings of the new calendar form field from them as well. This PR is not completed. It showcases only the "Today" button string. I would like to get feedback if this is the way to go, or if I did miss something.

### Testing Instructions
The actual back end language must be en-GB.

- Open an article
- Open the calendar for the "Start Publishing" field.

### Expected result
The "Today" button must be translated like
![image](https://cloud.githubusercontent.com/assets/251072/21060418/8f9d508a-be47-11e6-8c29-02b722d65dfd.png)


