### PR TITLE
Multilingual: correcting alternates when associated menu items are com_users items

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -774,15 +774,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
 					case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 
-						// Special case for com_users menu items
-						if (strpos($item->link, 'option=com_users'))
-						{
-							$language->link = JRoute::_('index.php?&Itemid=' . $item->id . '&lang=' . $language->sef);
-						}
-						else
-						{
-							$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
-						}
+						$language->link = JRoute::_('index.php?&Itemid=' . $item->id . '&lang=' . $language->sef);
 						break;
 
 					// Too bad...

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -774,7 +774,15 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
 					case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 
-						$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+						// Special case for com_users menu items
+						if (strpos($item->link, 'option=com_users'))
+						{
+							$language->link = JRoute::_('index.php?&Itemid=' . $item->id . '&lang=' . $language->sef);
+						}
+						else
+						{
+							$language->link = JRoute::_($item->link . '&Itemid=' . $item->id . '&lang=' . $language->sef);
+						}
 						break;
 
 					// Too bad...

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -774,7 +774,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Heads up! "$item = $menu" here below is an assignment, *NOT* comparison
 					case (isset($associations[$i]) && ($item = $menu->getItem($associations[$i]))):
 
-						$language->link = JRoute::_('index.php?&Itemid=' . $item->id . '&lang=' . $language->sef);
+						$language->link = JRoute::_('index.php?Itemid=' . $item->id . '&lang=' . $language->sef);
 						break;
 
 					// Too bad...


### PR DESCRIPTION
### Issue: https://github.com/joomla/joomla-cms/issues/13142
See description there.
### Summary of Changes
Adding a special case when associating com_users menu items (login. logout, password reset, reminder, registration, etc.)
EDIT: as we only need the itemid and lang, simplified code.

### Testing Instructions
Install a multilingual site with associations.
Make sure `Add Alternate Meta Tags` is set to Yes in the languagefilter parameter.
Set SEF to on.
Create various menu items with different aliases using com_users menu item in each language and associate them.
Display these menu items in frontend.
Check the source of the page.

Before patch, the alternate will always display the same url in the alternate for all languages.
(I have also set here one of the login menu item as child of another different menu item)

![screen shot 2016-12-10 at 08 33 51](https://cloud.githubusercontent.com/assets/869724/21072018/72d6c856-beb4-11e6-8cc9-a6400d618a90.png)


After patch
Now the alternate are correct

![screen shot 2016-12-10 at 08 33 05](https://cloud.githubusercontent.com/assets/869724/21072020/783f6186-beb4-11e6-9db3-cb4560294b5f.png)



### Documentation Changes Required
None. This is solving a bug due, I guess, to the com_users router

@ioweb-gr @mbabker @andrepereiradasilva 

Thank you for testing.
