### PR TITLE
Replacements for deprecated JFile::read()

### DIFF
--- a/libraries/fof/utils/installscript/installscript.php
+++ b/libraries/fof/utils/installscript/installscript.php
@@ -1308,7 +1308,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = file_get_contents($target . '/version.txt');
+				$rawData = JFile::read($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$fofVersion['installed'] = array(
@@ -1432,7 +1432,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = file_get_contents($target . '/version.txt');
+				$rawData = JFile::read($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$strapperVersion['installed'] = array(
@@ -1448,7 +1448,7 @@ abstract class FOFUtilsInstallscript
 				);
 			}
 
-			$rawData = file_get_contents($source . '/version.txt');
+			$rawData = JFile::read($source . '/version.txt');
 			$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 			$info = explode("\n", $rawData);
 			$strapperVersion['package'] = array(
@@ -1478,7 +1478,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = file_get_contents($target . '/version.txt');
+				$rawData = JFile::read($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$strapperVersion['installed'] = array(
@@ -1494,7 +1494,7 @@ abstract class FOFUtilsInstallscript
 				);
 			}
 
-			$rawData = file_get_contents($source . '/version.txt');
+			$rawData = JFile::read($source . '/version.txt');
 			$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 			$info = explode("\n", $rawData);
 

--- a/libraries/fof/utils/installscript/installscript.php
+++ b/libraries/fof/utils/installscript/installscript.php
@@ -1308,7 +1308,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = JFile::read($target . '/version.txt');
+				$rawData = file_get_contents($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$fofVersion['installed'] = array(
@@ -1432,7 +1432,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = JFile::read($target . '/version.txt');
+				$rawData = file_get_contents($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$strapperVersion['installed'] = array(
@@ -1448,7 +1448,7 @@ abstract class FOFUtilsInstallscript
 				);
 			}
 
-			$rawData = JFile::read($source . '/version.txt');
+			$rawData = file_get_contents($source . '/version.txt');
 			$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 			$info = explode("\n", $rawData);
 			$strapperVersion['package'] = array(
@@ -1478,7 +1478,7 @@ abstract class FOFUtilsInstallscript
 
 			if (JFile::exists($target . '/version.txt'))
 			{
-				$rawData = JFile::read($target . '/version.txt');
+				$rawData = file_get_contents($target . '/version.txt');
 				$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 				$info = explode("\n", $rawData);
 				$strapperVersion['installed'] = array(
@@ -1494,7 +1494,7 @@ abstract class FOFUtilsInstallscript
 				);
 			}
 
-			$rawData = JFile::read($source . '/version.txt');
+			$rawData = file_get_contents($source . '/version.txt');
 			$rawData = ($rawData === false) ? "0.0.0\n2011-01-01\n" : $rawData;
 			$info = explode("\n", $rawData);
 

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -1158,7 +1158,7 @@ abstract class JFormField
 
 		if (JFile::exists($fileName))
 		{
-			return JFile::read($fileName);
+			return file_get_contents($fileName);
 		}
 
 		return '';

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -396,7 +396,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 				throw new RuntimeException("Inappropriate file type.");
 			}
 
-			if (!($data = JFile::read($file)))
+			if (!($data = file_get_contents($file)))
 			{
 				throw new RuntimeException("Cannot access file: `$file`");
 			}

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -340,7 +340,7 @@ class PlgEditorCodemirror extends JPlugin
 
 		if (!$fonts)
 		{
-			$fonts = json_decode(JFile::read(__DIR__ . '/fonts.json'), true);
+			$fonts = json_decode(file_get_contents(__DIR__ . '/fonts.json'), true);
 		}
 
 		return isset($fonts[$font]) ? (object) $fonts[$font] : null;

--- a/plugins/editors/codemirror/fonts.php
+++ b/plugins/editors/codemirror/fonts.php
@@ -36,7 +36,7 @@ class JFormFieldFonts extends JFormAbstractlist
 	 */
 	protected function getOptions()
 	{
-		$fonts = json_decode(JFile::read(__DIR__ . '/fonts.json'));
+		$fonts = json_decode(file_get_contents(__DIR__ . '/fonts.json'));
 		$options = array();
 
 		foreach ($fonts as $key => $info)


### PR DESCRIPTION
As the title says: Replacements for deprecated JFile::read()

I did intentionally not change the wrapper class's read function, so people using this still get the deprecation warning.