### PR TITLE
Replacements for deprecated getCfg()

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -202,11 +202,11 @@ class JApplication extends JApplicationBase
 
 		// Set user specific editor.
 		$user = JFactory::getUser();
-		$editor = $user->getParam('editor', $this->getCfg('editor'));
+		$editor = $user->getParam('editor', $this->get('editor'));
 
 		if (!JPluginHelper::isEnabled('editors', $editor))
 		{
-			$editor = $this->getCfg('editor');
+			$editor = $this->get('editor');
 
 			if (!JPluginHelper::isEnabled('editors', $editor))
 			{
@@ -305,7 +305,7 @@ class JApplication extends JApplicationBase
 		$this->triggerEvent('onBeforeRender');
 
 		// Render the document.
-		$caching = ($this->getCfg('caching') >= 2) ? true : false;
+		$caching = ($this->get('caching') >= 2) ? true : false;
 		JResponse::setBody($document->render($caching, $params));
 
 		// Trigger the onAfterRender event.
@@ -972,14 +972,14 @@ class JApplication extends JApplicationBase
 		switch ($this->_clientId)
 		{
 			case 0:
-				if ($this->getCfg('force_ssl') == 2)
+				if ($this->get('force_ssl') == 2)
 				{
 					$options['force_ssl'] = true;
 				}
 				break;
 
 			case 1:
-				if ($this->getCfg('force_ssl') >= 1)
+				if ($this->get('force_ssl') >= 1)
 				{
 					$options['force_ssl'] = true;
 				}
@@ -1012,7 +1012,7 @@ class JApplication extends JApplicationBase
 		}
 
 		// Check to see the the session already exists.
-		$handler = $this->getCfg('session_handler');
+		$handler = $this->get('session_handler');
 
 		if (($handler != 'database' && ($time % 2 || $session->isNew()))
 			|| ($handler == 'database' && $session->isNew()))
@@ -1197,7 +1197,7 @@ class JApplication extends JApplicationBase
 	 */
 	public function __toString()
 	{
-		$compress = $this->getCfg('gzip', false);
+		$compress = $this->get('gzip', false);
 
 		return JResponse::toString($compress);
 	}

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -260,7 +260,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since   3.2
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function testGet()
 	{

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -256,6 +256,23 @@ class JApplicationCmsTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Tests the JApplicationCms::get method.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function testGet()
+	{
+		$config = new Registry(array('foo' => 'bar'));
+
+		TestReflection::setValue($this->class, 'config', $config);
+
+		$this->assertEquals('bar', $this->class->get('foo', 'car'));
+		$this->assertEquals('car', $this->class->get('goo', 'car'));
+	}
+
+	/**
 	 * Tests the JApplicationCms::getCfg method.
 	 *
 	 * @return  void


### PR DESCRIPTION
Replaces deprecated getCfg() with get()

