### PR TITLE
Replacements for deprecated JApplication::getHash()

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -151,7 +151,7 @@ class JApplication extends JApplicationBase
 		// Create the session if a session name is passed.
 		if ($config['session'] !== false)
 		{
-			$this->_createSession(self::getHash($config['session_name']));
+			$this->_createSession(JApplicationHelper::getHash($config['session_name']));
 		}
 
 		$this->requestTime = gmdate('Y-m-d H:i');

--- a/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
+++ b/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
@@ -79,7 +79,7 @@ class JApplicationTest extends TestCase
 		JFactory::$config = new JObject(array('secret' => 'foo'));
 
 		$this->assertThat(
-			JApplication::getHash('This is a test'),
+			JApplicationHelper::getHash('This is a test'),
 			$this->equalTo(md5('foo' . 'This is a test')),
 			'Tests that the secret string is added to the hash.'
 		);

--- a/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
+++ b/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
@@ -72,7 +72,26 @@ class JApplicationTest extends TestCase
 	 *
 	 * @return  void
 	 */
-	public function testGetHash()
+	public function testJApplicationGetHash()
+	{
+		// Temporarily override the config cache in JFactory.
+		$temp = JFactory::$config;
+		JFactory::$config = new JObject(array('secret' => 'foo'));
+
+		$this->assertThat(
+			JApplication::getHash('This is a test'),
+			$this->equalTo(md5('foo' . 'This is a test')),
+			'Tests that the secret string is added to the hash.'
+		);
+
+		JFactory::$config = $temp;
+	}
+	/**
+	 * Testing JApplicationHelper::getHash
+	 *
+	 * @return  void
+	 */
+	public function testJApplicationHelperGetHash()
 	{
 		// Temporarily override the config cache in JFactory.
 		$temp = JFactory::$config;

--- a/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
+++ b/tests/unit/suites/libraries/legacy/application/JApplicationTest.php
@@ -86,6 +86,7 @@ class JApplicationTest extends TestCase
 
 		JFactory::$config = $temp;
 	}
+
 	/**
 	 * Testing JApplicationHelper::getHash
 	 *


### PR DESCRIPTION
Replacements for deprecated JApplication::getHash()

