### PR TITLE
Speed up hhvm unit tests - disable jit

### DIFF
--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -13,6 +13,9 @@ if [[ ( $TRAVIS_PHP_VERSION = 5.* ) || ( $TRAVIS_PHP_VERSION = 7.0 ) ]]; then ph
 # Disable xdebug in hhvm.
 if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'xdebug.enable = 0' >> /etc/hhvm/php.ini; fi
 
+# Disable JIT compilation in hhvm.
+if [[ $TRAVIS_PHP_VERSION = hhv* ]]; then echo 'hhvm.jit = 0' >> /etc/hhvm/php.ini; fi
+
 # Make sure all dev dependencies are installed
 composer install
 


### PR DESCRIPTION
Pull Request for Issue #13168.

### Summary of Changes

Turn off the JIT in hhvm to speed up the unit tests.

Source: https://github.com/facebook/hhvm/issues/6979

### Testing Instructions
Travis.
Code review.

### Documentation Changes Required
N/A
