### PR TITLE
Removed some unnecessary strtotime() calls

### DIFF
--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -111,19 +111,19 @@ class BannersHelper extends JHelperContent
 					$reset = $nullDate;
 					break;
 				case 2:
-					$date = JFactory::getDate('+1 year ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 year ' . date('Y-m-d'));
 					$reset = $db->quote($date->toSql());
 					break;
 				case 3:
-					$date = JFactory::getDate('+1 month ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 month ' . date('Y-m-d'));
 					$reset = $db->quote($date->toSql());
 					break;
 				case 4:
-					$date = JFactory::getDate('+7 day ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+7 day ' . date('Y-m-d'));
 					$reset = $db->quote($date->toSql());
 					break;
 				case 5:
-					$date = JFactory::getDate('+1 day ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 day ' . date('Y-m-d'));
 					$reset = $db->quote($date->toSql());
 					break;
 			}

--- a/administrator/components/com_banners/tables/banner.php
+++ b/administrator/components/com_banners/tables/banner.php
@@ -196,19 +196,19 @@ class BannersTableBanner extends JTable
 					$this->reset = $this->_db->getNullDate();
 					break;
 				case 2:
-					$date = JFactory::getDate('+1 year ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 year ' . date('Y-m-d'));
 					$this->reset = $date->toSql();
 					break;
 				case 3:
-					$date = JFactory::getDate('+1 month ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 month ' . date('Y-m-d'));
 					$this->reset = $date->toSql();
 					break;
 				case 4:
-					$date = JFactory::getDate('+7 day ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+7 day ' . date('Y-m-d'));
 					$this->reset = $date->toSql();
 					break;
 				case 5:
-					$date = JFactory::getDate('+1 day ' . date('Y-m-d', strtotime('now')));
+					$date = JFactory::getDate('+1 day ' . date('Y-m-d'));
 					$this->reset = $date->toSql();
 					break;
 			}


### PR DESCRIPTION
There were some strtotime("now") calls, which were not necessary as date() automatically uses the current timestamp if none is given.

This PR removes those calls.

