### PR TITLE
Coding style - PHP code tag and control structures III

### DIFF
--- a/administrator/components/com_admin/views/help/tmpl/default.php
+++ b/administrator/components/com_admin/views/help/tmpl/default.php
@@ -23,7 +23,7 @@ JHtml::_('bootstrap.tooltip');
 					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_GLOSSARY'), JText::_('COM_ADMIN_GLOSSARY'), array('target' => 'helpFrame')) ?></li>
 					<hr class="hr-condensed" />
 					<li class="nav-header"><?php echo JText::_('COM_ADMIN_ALPHABETICAL_INDEX'); ?></li>
-					<?php foreach ($this->toc as $k => $v): ?>
+					<?php foreach ($this->toc as $k => $v) : ?>
 						<li>
 							<?php $url = JHelp::createUrl('JHELP_' . strtoupper($k)); ?>
 							<?php echo JHtml::_('link', $url, $v, array('target' => 'helpFrame')); ?>

--- a/administrator/components/com_admin/views/help/tmpl/default.php
+++ b/administrator/components/com_admin/views/help/tmpl/default.php
@@ -17,10 +17,10 @@ JHtml::_('bootstrap.tooltip');
 			<div class="clearfix"></div>
 			<div class="sidebar-nav">
 				<ul class="nav nav-list">
-					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_START_HERE'), JText::_('COM_ADMIN_START_HERE'), array('target' => 'helpFrame')) ?></li>
-					<li><?php echo JHtml::_('link', $this->latest_version_check, JText::_('COM_ADMIN_LATEST_VERSION_CHECK'), array('target' => 'helpFrame')) ?></li>
-					<li><?php echo JHtml::_('link', 'http://www.gnu.org/licenses/gpl-2.0.html', JText::_('COM_ADMIN_LICENSE'), array('target' => 'helpFrame')) ?></li>
-					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_GLOSSARY'), JText::_('COM_ADMIN_GLOSSARY'), array('target' => 'helpFrame')) ?></li>
+					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_START_HERE'), JText::_('COM_ADMIN_START_HERE'), array('target' => 'helpFrame')); ?></li>
+					<li><?php echo JHtml::_('link', $this->latest_version_check, JText::_('COM_ADMIN_LATEST_VERSION_CHECK'), array('target' => 'helpFrame')); ?></li>
+					<li><?php echo JHtml::_('link', 'http://www.gnu.org/licenses/gpl-2.0.html', JText::_('COM_ADMIN_LICENSE'), array('target' => 'helpFrame')); ?></li>
+					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_GLOSSARY'), JText::_('COM_ADMIN_GLOSSARY'), array('target' => 'helpFrame')); ?></li>
 					<hr class="hr-condensed" />
 					<li class="nav-header"><?php echo JText::_('COM_ADMIN_ALPHABETICAL_INDEX'); ?></li>
 					<?php foreach ($this->toc as $k => $v) : ?>

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -61,7 +61,7 @@ $fieldsets = $this->form->getFieldsets();
 				<div class="control-group">
 					<div class="controls"><?php echo $field->input; ?></div>
 				</div>
-			<?php else: ?>
+			<?php else : ?>
 				<div class="control-group">
 					<div class="control-label"><?php echo $field->label; ?></div>
 					<div class="controls"><?php echo $field->input; ?></div>

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default_config.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default_config.php
@@ -28,7 +28,7 @@ defined('_JEXEC') or die;
 			</tr>
 		</tfoot>
 		<tbody>
-			<?php foreach ($this->config as $key => $value): ?>
+			<?php foreach ($this->config as $key => $value) : ?>
 				<tr>
 					<td>
 						<?php echo $key; ?>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -143,9 +143,9 @@ $params     = (isset($this->state->params)) ? $this->state->params : new JObject
 									<?php echo $item->count_trashed; ?></a>
 							</td>
 							<td class="small hidden-phone">
-								<?php if ($item->purchase_type < 0): ?>
+								<?php if ($item->purchase_type < 0) : ?>
 									<?php echo JText::sprintf('COM_BANNERS_DEFAULT', JText::_('COM_BANNERS_FIELD_VALUE_' . $purchaseTypes[$params->get('purchase_type')])); ?>
-								<?php else: ?>
+								<?php else : ?>
 									<?php echo JText::_('COM_BANNERS_FIELD_VALUE_' . $purchaseTypes[$item->purchase_type]); ?>
 								<?php endif; ?>
 							</td>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -248,7 +248,7 @@ if ($saveOrder)
 							</td>
 							<?php if ($this->assoc) : ?>
 								<td class="hidden-phone hidden-tablet">
-									<?php if ($item->association): ?>
+									<?php if ($item->association) : ?>
 										<?php echo JHtml::_('CategoriesAdministrator.association', $item->id, $extension); ?>
 									<?php endif; ?>
 								</td>

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -82,25 +82,25 @@ if ($saveOrder)
 							<th width="1%" class="nowrap center hidden-phone hidden-tablet">
 								<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>"></i>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) :
 							$columns++; ?>
 							<th width="1%" class="nowrap center hidden-phone hidden-tablet">
 								<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>"></i>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) :
 							$columns++; ?>
 							<th width="1%" class="nowrap center hidden-phone hidden-tablet">
 								<i class="icon-archive hasTooltip" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>"></i>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) :
 							$columns++; ?>
 							<th width="1%" class="nowrap center hidden-phone hidden-tablet">
 								<i class="icon-trash hasTooltip" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>"></i>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
@@ -220,28 +220,28 @@ if ($saveOrder)
 							</td>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=1' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_published; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=0' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_unpublished; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_ARCHIVED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=2' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_archived; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 							<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 								<td class="center btns hidden-phone hidden-tablet">
-									<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=' . (int) $item->level);?>">
+									<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_CATEGORY_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($section ? '&view=' . $section : '') . '&filter[category_id]=' . (int) $item->id . '&filter[published]=-2' . '&filter[level]=' . (int) $item->level); ?>">
 										<?php echo $item->count_trashed; ?></a>
 								</td>
-							<?php endif;?>
+							<?php endif; ?>
 
 							<td class="small hidden-phone">
 								<?php echo $this->escape($item->access_level); ?>

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -37,7 +37,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 				</label>
 				<div id="batch-choose-action" class="combo controls">
 					<select name="batch[category_id]" id="batch-category-id">
-						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY') ?></option>
+						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 						<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
 					</select>
 				</div>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -60,7 +60,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
 						<th width="15%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder);	?>
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>

--- a/administrator/components/com_categories/views/category/tmpl/modal_options.php
+++ b/administrator/components/com_categories/views/category/tmpl/modal_options.php
@@ -33,7 +33,7 @@ $i = 0;
 		</div>
 	<?php endforeach; ?>
 
-	<?php if ($name == 'basic'): ?>
+	<?php if ($name == 'basic') : ?>
 		<div class="control-group">
 			<div class="control-label">
 				<?php echo $this->form->getLabel('note'); ?>

--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -24,7 +24,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 		<div class="clearfix"></div>
 		<?php if (empty($this->items)) : ?>
@@ -65,7 +65,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -49,7 +49,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				</tfoot>
 				<tbody>
 					<?php $i = 0; ?>
-					<?php foreach ($this->items as $table => $count): ?>
+					<?php foreach ($this->items as $table => $count) : ?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<td class="center"><?php echo JHtml::_('grid.id', $i, $table); ?></td>
 							<td>

--- a/administrator/components/com_config/view/application/tmpl/default_navigation.php
+++ b/administrator/components/com_config/view/application/tmpl/default_navigation.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <ul class="nav nav-list">
-	<?php if ($this->userIsSuperAdmin): ?>
+	<?php if ($this->userIsSuperAdmin) : ?>
 		<li class="nav-header"><?php echo JText::_('COM_CONFIG_SYSTEM'); ?></li>
 		<li class="active">
 			<a href="index.php?option=com_config"><?php echo JText::_('COM_CONFIG_GLOBAL_CONFIGURATION'); ?></a>

--- a/administrator/components/com_config/view/component/tmpl/default_navigation.php
+++ b/administrator/components/com_config/view/component/tmpl/default_navigation.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <ul class="nav nav-list">
-	<?php if ($this->userIsSuperAdmin): ?>
+	<?php if ($this->userIsSuperAdmin) : ?>
 		<li class="nav-header"><?php echo JText::_('COM_CONFIG_SYSTEM'); ?></li>
 		<li><a href="index.php?option=com_config"><?php echo JText::_('COM_CONFIG_GLOBAL_CONFIGURATION'); ?></a></li>
 		<li class="divider"></li>

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -36,7 +36,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 	<?php else : ?>
 	<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"></div>
 		<?php if (empty($this->items)) : ?>
@@ -69,7 +69,7 @@ if ($saveOrder)
 						<th width="5%" class="nowrap hidden-phone hidden-tablet">
 							<?php echo JHtml::_('searchtools.sort', 'COM_CONTACT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 						</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="15%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
 						</th>
@@ -168,7 +168,7 @@ if ($saveOrder)
 								<?php echo JHtml::_('contact.association', $item->id); ?>
 							<?php endif; ?>
 						</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<td class="small hidden-phone">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>
@@ -193,7 +193,7 @@ if ($saveOrder)
 					$this->loadTemplate('batch_body')
 				); ?>
 			<?php endif; ?>
-		<?php endif;?>
+		<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -108,7 +108,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>"></span>
 						</td>
 						<td>
-							<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function);?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+							<a href="javascript:void(0);" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(ContactHelperRoute::getContactRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
 							<?php echo $this->escape($item->name); ?></a>
 							<div class="small">
 								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -172,9 +172,9 @@ $assoc = JLanguageAssociations::isEnabled();
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 								<?php endif; ?>
-								<?php if ($item->language == '*'): ?>
+								<?php if ($item->language == '*') : ?>
 									<?php $language = JText::alt('JALL', 'language'); ?>
-								<?php else: ?>
+								<?php else : ?>
 									<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 								<?php endif; ?>
 								<?php if ($canEdit || $canEditOwn) : ?>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -53,7 +53,7 @@ $assoc = JLanguageAssociations::isEnabled();
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
@@ -86,7 +86,7 @@ $assoc = JLanguageAssociations::isEnabled();
 							<th width="5%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort',  'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 						</th>
@@ -108,7 +108,7 @@ $assoc = JLanguageAssociations::isEnabled();
 							<th width="1%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -172,11 +172,11 @@ $assoc = JLanguageAssociations::isEnabled();
 								<?php if ($item->checked_out) : ?>
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 								<?php endif; ?>
-								<?php if ($item->language == '*'):?>
+								<?php if ($item->language == '*'): ?>
 									<?php $language = JText::alt('JALL', 'language'); ?>
-								<?php else:?>
+								<?php else: ?>
 									<?php $language = $item->language_title ? $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
-								<?php endif;?>
+								<?php endif; ?>
 								<?php if ($canEdit || $canEditOwn) : ?>
 									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 										<?php echo $this->escape($item->title); ?></a>
@@ -200,7 +200,7 @@ $assoc = JLanguageAssociations::isEnabled();
 								<?php echo JHtml::_('contentadministrator.association', $item->id); ?>
 							<?php endif; ?>
 						</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<td class="small hidden-phone">
 							<?php if ($item->created_by_alias) : ?>
 								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
@@ -258,7 +258,7 @@ $assoc = JLanguageAssociations::isEnabled();
 					$this->loadTemplate('batch_body')
 				); ?>
 			<?php endif; ?>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<?php echo $this->pagination->getListFooter(); ?>
 

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -50,7 +50,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 		<?php else : ?>
 		<div id="j-main-container">
-			<?php endif;?>
+			<?php endif; ?>
 			<?php
 			// Search tools bar
 			echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
@@ -99,7 +99,7 @@ if ($saveOrder)
 							<th width="1%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_RATINGS', 'rating', $listDirn, $listOrder); ?>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>

--- a/administrator/components/com_contenthistory/views/compare/tmpl/compare.php
+++ b/administrator/components/com_contenthistory/views/compare/tmpl/compare.php
@@ -65,9 +65,9 @@ JFactory::getDocument()->addScriptDeclaration("
 	<?php if (is_object($value->value)) : ?>
 		<td><strong><?php echo $value->label; ?></strong></td>
 		<td /><td /><td />
-		<?php foreach ($value->value as $subName => $subValue): ?>
+		<?php foreach ($value->value as $subName => $subValue) : ?>
 			<?php $newSubValue = isset($object2->$name->value->$subName->value) ? $object2->$name->value->$subName->value : ''; ?>
-			<?php if ($subValue->value || $newSubValue): ?>
+			<?php if ($subValue->value || $newSubValue) : ?>
 				<?php $rowClass = ($subValue->value == $newSubValue) ? 'items-equal' : 'items-not-equal'; ?>
 				<tr class="<?php echo $rowClass; ?>">
 				<td><i>&nbsp;&nbsp;<?php echo $subValue->label; ?></i></td>
@@ -80,7 +80,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				</tr>
 			<?php endif; ?>
 		<?php endforeach; ?>
-	<?php else: ?>
+	<?php else : ?>
 		<td><strong><?php echo $value->label; ?></strong></td>
 		<td class="originalhtml" style="display:none" ><?php echo htmlspecialchars($value->value); ?></td>
 		<?php $object2->$name->value = is_object($object2->$name->value) ? json_encode($object2->$name->value) : $object2->$name->value; ?>

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -90,11 +90,11 @@ JFactory::getDocument()->addScriptDeclaration("
 <div class="container-popup">
 
 	<div class="btn-group pull-right">
-		<button id="toolbar-load" type="submit" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" data-url="<?php echo JRoute::_($loadUrl);?>">
+		<button id="toolbar-load" type="submit" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" data-url="<?php echo JRoute::_($loadUrl); ?>">
 			<span class="icon-upload"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span></button>
-		<button id="toolbar-preview" type="button" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1');?>">
+		<button id="toolbar-preview" type="button" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1'); ?>">
 			<span class="icon-search"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span></button>
-		<button id="toolbar-compare" type="button" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1');?>">
+		<button id="toolbar-compare" type="button" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1'); ?>">
 			<span class="icon-zoom-in"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span></button>
 		<button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
 			<span class="icon-lock"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span></button>
@@ -105,7 +105,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	<div class="clearfix"></div>
 	<hr class="hr-condensed" />
 
-	<form action="<?php echo JRoute::_($formUrl);?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_($formUrl); ?>" method="post" name="adminForm" id="adminForm">
 		<table class="table table-striped table-condensed">
 			<thead>
 				<tr>
@@ -145,10 +145,10 @@ JFactory::getDocument()->addScriptDeclaration("
 					</td>
 					<td>
 						<a class="save-date" onclick="window.open(this.href,'win2','width=800,height=600,resizable=yes,scrollbars=yes'); return false;"
-							href="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1&version_id=' . $item->version_id);?>">
+							href="<?php echo JRoute::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . JSession::getFormToken() . '=1&version_id=' . $item->version_id); ?>">
 							<?php echo JHtml::_('date', $item->save_date, 'Y-m-d H:i:s'); ?>
 						</a>
-						<?php if ($item->sha1_hash == $hash) :?>
+						<?php if ($item->sha1_hash == $hash) : ?>
 							<span class="icon-featured"></span>&nbsp;
 						<?php endif; ?>
 					</td>

--- a/administrator/components/com_contenthistory/views/preview/tmpl/preview.php
+++ b/administrator/components/com_contenthistory/views/preview/tmpl/preview.php
@@ -25,18 +25,18 @@ JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
 <tbody>
 <?php foreach ($this->item->data as $name => $value) : ?>
 	<tr>
-	<?php if (is_object($value->value)): ?>
+	<?php if (is_object($value->value)) : ?>
 		<td><strong><?php echo $value->label; ?></strong></td>
 		<td></td><tr>
-		<?php foreach ($value->value as $subName => $subValue): ?>
-			<?php if ($subValue): ?>
+		<?php foreach ($value->value as $subName => $subValue) : ?>
+			<?php if ($subValue) : ?>
 				<tr>
 				<td><i>&nbsp;&nbsp;<?php echo $subValue->label; ?></i></td>
 				<td><?php echo $subValue->value; ?></td>
 				</tr>
 			<?php endif; ?>
 		<?php endforeach; ?>
-	<?php else: ?>
+	<?php else : ?>
 		<td><strong><?php echo $value->label; ?></strong></td>
 		<td><?php echo $value->value; ?></td>
 	<?php endif; ?>

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -154,7 +154,7 @@ if ($saveOrder)
 													<?php continue; ?>
 												<?php endif; ?>
 												<?php $c = $category->get($cat); ?>
-												<?php if (!$c || $c->id == 'root') :  ?>
+												<?php if (!$c || $c->id == 'root') : ?>
 													<?php continue; ?>
 												<?php endif; ?>
 												<?php $buffer .= ' ' . $c->title . ','; ?>
@@ -166,7 +166,7 @@ if ($saveOrder)
 							</td>
 							<td class="small">
 								<?php $label = 'COM_FIELDS_TYPE_' . strtoupper($item->type); ?>
-								<?php if (!JFactory::getLanguage()->hasKey($label)) :  ?>
+								<?php if (!JFactory::getLanguage()->hasKey($label)) : ?>
 									<?php $label = Joomla\String\StringHelper::ucfirst($item->type); ?>
 								<?php endif; ?>
 								<?php echo $this->escape(JText::_($label)); ?>

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -99,6 +99,6 @@ JFactory::getDocument()->addStyleDeclaration(
 	</div>
 
 	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd');?>" />
+	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd'); ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -58,7 +58,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<table class="table table-striped">
 			<thead>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -45,7 +45,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_finder/views/statistics/tmpl/default.php
+++ b/administrator/components/com_finder/views/statistics/tmpl/default.php
@@ -20,15 +20,15 @@ defined('_JEXEC') or die;
 			<thead>
 				<tr>
 					<th>
-						<?php echo JText::_('COM_FINDER_STATISTICS_LINK_TYPE_HEADING');?>
+						<?php echo JText::_('COM_FINDER_STATISTICS_LINK_TYPE_HEADING'); ?>
 					</th>
 					<th>
-						<?php echo JText::_('COM_FINDER_STATISTICS_LINK_TYPE_COUNT');?>
+						<?php echo JText::_('COM_FINDER_STATISTICS_LINK_TYPE_COUNT'); ?>
 					</th>
 				</tr>
 			</thead>
 			<tbody>
-				<?php foreach ($this->data->type_list as $type) :?>
+				<?php foreach ($this->data->type_list as $type) : ?>
 				<tr>
 					<td>
 						<?php
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
 						?>
 					</td>
 					<td>
-						<span class="badge badge-info"><?php echo number_format($type->link_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR'));?></span>
+						<span class="badge badge-info"><?php echo number_format($type->link_count, 0, JText::_('DECIMALS_SEPARATOR'), JText::_('THOUSANDS_SEPARATOR')); ?></span>
 					</td>
 				</tr>
 				<?php endforeach; ?>

--- a/administrator/components/com_finder/views/statistics/tmpl/default.php
+++ b/administrator/components/com_finder/views/statistics/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <h3>
-	<?php echo JText::_('COM_FINDER_STATISTICS_TITLE') ?>
+	<?php echo JText::_('COM_FINDER_STATISTICS_TITLE'); ?>
 </h3>
 
 <div class="row-fluid">

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 ?>
 <div id="installer-database" class="clearfix">
-	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=database');?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=database'); ?>" method="post" name="adminForm" id="adminForm">
 
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 		<div id="j-main-container" class="span10">
 	<?php else : ?>
 		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php if ($this->errorCount === 0) : ?>
 			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'other')); ?>
 		<?php else : ?>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -25,7 +25,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<div id="j-main-container" class="span10">
 		<?php else : ?>
 		<div id="j-main-container">
-		<?php endif;?>
+		<?php endif; ?>
 			<?php if ($this->showMessage) : ?>
 				<?php echo $this->loadTemplate('message'); ?>
 			<?php endif; ?>
@@ -78,12 +78,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				</tfoot>
 				<tbody>
 				<?php foreach ($this->items as $i => $item) : ?>
-					<tr class="row<?php echo $i % 2;?>">
+					<tr class="row<?php echo $i % 2; ?>">
 						<td class="center">
 							<?php echo JHtml::_('grid.id', $i, $item->extension_id); ?>
 						</td>
 						<td>
-							<label for="cb<?php echo $i;?>">
+							<label for="cb<?php echo $i; ?>">
 								<span class="bold hasTooltip" title="<?php echo JHtml::tooltipText($item->name, $item->description, 0); ?>"><?php echo $item->name; ?></span>
 							</label>
 						</td>

--- a/administrator/components/com_installer/views/discover/tmpl/default_item.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default_item.php
@@ -11,8 +11,8 @@ defined('_JEXEC') or die;
 ?>
 <tr class="<?php echo "row" . $this->item->index % 2; ?>" <?php echo $this->item->style; ?>>
 	<td>
-			<input type="checkbox" id="cb<?php echo $this->item->index;?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />
-<!--		<input type="checkbox" id="cb<?php echo $this->item->index;?>" name="eid" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />-->
+			<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />
+<!--		<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />-->
 		<span class="bold"><?php echo $this->item->name; ?></span>
 	</td>
 	<td>
@@ -22,7 +22,7 @@ defined('_JEXEC') or die;
 		<?php if (!$this->item->element) : ?>
 		<strong>X</strong>
 		<?php else : ?>
-		<a href="index.php?option=com_installer&amp;type=manage&amp;task=<?php echo $this->item->task; ?>&amp;eid[]=<?php echo $this->item->extension_id; ?>&amp;limitstart=<?php echo $this->pagination->limitstart; ?>&amp;<?php echo JSession::getFormToken();?>=1"><?php echo JHtml::_('image', 'images/' . $this->item->img, $this->item->alt, array('title' => $this->item->action)); ?></a>
+		<a href="index.php?option=com_installer&amp;type=manage&amp;task=<?php echo $this->item->task; ?>&amp;eid[]=<?php echo $this->item->extension_id; ?>&amp;limitstart=<?php echo $this->pagination->limitstart; ?>&amp;<?php echo JSession::getFormToken(); ?>=1"><?php echo JHtml::_('image', 'images/' . $this->item->img, $this->item->alt, array('title' => $this->item->action)); ?></a>
 		<?php endif; ?>
 	</td>
 	<td class="center"><?php echo @$this->item->folder != '' ? $this->item->folder : 'N/A'; ?></td>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -25,7 +25,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<div id="j-main-container" class="span10">
 		<?php else : ?>
 		<div id="j-main-container">
-		<?php endif;?>
+		<?php endif; ?>
 			<?php if ($this->showMessage) : ?>
 				<?php echo $this->loadTemplate('message'); ?>
 			<?php endif; ?>

--- a/administrator/components/com_installer/views/warnings/tmpl/default.php
+++ b/administrator/components/com_installer/views/warnings/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <div id="installer-warnings" class="clearfix">
-	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=warnings');?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=warnings'); ?>" method="post" name="adminForm" id="adminForm">
 	<?php if (!empty( $this->sidebar)) : ?>
 		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 		<div id="j-main-container" class="span10">
 	<?php else : ?>
 		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php if (count($this->messages)) : ?>
 			<?php echo JHtml::_('bootstrap.startAccordion', 'warnings', array('active' => 'warning0')); ?>
 				<?php $i = 0; ?>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 
 <fieldset>
 	<legend>
-		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING') ?>
+		<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING'); ?>
 	</legend>
 	<p class="alert alert-success">
 		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE', JVERSION); ?>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
@@ -62,14 +62,14 @@ JFactory::getDocument()->addStyleDeclaration($css);
 <div class="alert alert-info">
 	<p>
 		<span class="icon icon-info"></span>
-		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPLOAD_INTRO', 'https://downloads.joomla.org/latest') ?>
+		<?php echo JText::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_UPLOAD_INTRO', 'https://downloads.joomla.org/latest'); ?>
 	</p>
 </div>
 
 <?php if (count($this->warnings)) : ?>
 <fieldset>
 	<legend>
-		<?php echo JText::_('COM_INSTALLER_SUBMENU_WARNINGS') ?>
+		<?php echo JText::_('COM_INSTALLER_SUBMENU_WARNINGS'); ?>
 	</legend>
 
 	<?php $i = 0; ?>

--- a/administrator/components/com_joomlaupdate/views/update/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/update/tmpl/default.php
@@ -36,7 +36,7 @@ JFactory::getDocument()->addScriptDeclaration(
 );
 ?>
 
-<p class="nowarning"><?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_INPROGRESS') ?></p>
+<p class="nowarning"><?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_INPROGRESS'); ?></p>
 
 <div id="update-progress">
 	<div id="extprogress">

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -34,7 +34,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"></div>
 		<?php if (empty($this->items)) : ?>
@@ -158,7 +158,7 @@ if ($saveOrder)
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
@@ -17,10 +17,10 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 	<?php if (!$this->language_filter && $this->switchers == 0) : ?>
 		<?php if ($this->homes == 1) : ?>
 			<div class="alert alert-info"><?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_NONE'); ?></div>
-		<?php else: ?>
+		<?php else : ?>
 			<div class="alert alert-info"><?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_USELESS_HOMES'); ?></div>
 		<?php endif; ?>
-	<?php else: ?>
+	<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<tbody>
 		<?php if ($notice_homes) : ?>

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -19,7 +19,7 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
 $opposite_client   = $this->state->get('filter.client') == '1' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
-$opposite_filename = constant('JPATH_' . strtoupper(1 - $this->state->get('filter.client')? 'administrator' : 'site')) 
+$opposite_filename = constant('JPATH_' . strtoupper(1 - $this->state->get('filter.client')? 'administrator' : 'site'))
 	. '/language/overrides/' . $this->state->get('filter.language', 'en-GB') . '.override.ini';
 $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 ?>
@@ -94,13 +94,13 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 							<?php endif; ?>
 						</td>
 						<td class="hidden-phone">
-							<span id="string[<?php	echo $this->escape($key); ?>]"><?php echo $this->escape($text); ?></span>
+							<span id="string[<?php echo $this->escape($key); ?>]"><?php echo $this->escape($text); ?></span>
 						</td>
 						<td class="hidden-phone">
 							<?php echo $language; ?>
 						</td>
 						<td class="hidden-phone">
-							<?php echo $client; ?><?php 
+							<?php echo $client; ?><?php
 							if (isset($opposite_strings[$key]) && ($opposite_strings[$key] == $text))
 							{
 								echo '/' . $opposite_client;

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -89,7 +89,7 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 						<td>
 							<?php if ($canEdit) : ?>
 								<a id="key[<?php echo $this->escape($key); ?>]" href="<?php echo JRoute::_('index.php?option=com_languages&task=override.edit&id=' . $key); ?>"><?php echo $this->escape($key); ?></a>
-							<?php else: ?>
+							<?php else : ?>
 								<?php echo $this->escape($key); ?>
 							<?php endif; ?>
 						</td>

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -32,7 +32,7 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<div id="filter-bar" class="btn-toolbar clearfix">
 			<div class="filter-search btn-group pull-left">
 				<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="hasTooltip" title="<?php echo JHtml::tooltipText('COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC'); ?>" />

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -98,7 +98,7 @@ else // XTD Image plugin
 						<input type="text" id="f_url" value="" />
 					</div>
 				</div>
-				<?php if (!$this->state->get('field.id')): ?>
+				<?php if (!$this->state->get('field.id')) : ?>
 					<div class="span6 control-group">
 						<div class="control-label">
 							<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
@@ -114,7 +114,7 @@ else // XTD Image plugin
 					</div>
 				<?php endif; ?>
 			</div>
-			<?php if (!$this->state->get('field.id')): ?>
+			<?php if (!$this->state->get('field.id')) : ?>
 				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -86,7 +86,7 @@ else // XTD Image plugin
 			</div>
 		</div>
 
-		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>"></iframe>
+		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder; ?>&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>"></iframe>
 
 		<div class="well">
 			<div class="row-fluid">

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -60,7 +60,7 @@ else // XTD Image plugin
 ?>
 <div class="container-popup">
 
-	<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
+	<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
 
 		<div id="messages" style="display: none;">
 			<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
@@ -86,7 +86,7 @@ else // XTD Image plugin
 			</div>
 		</div>
 
-		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>"></iframe>
+		<iframe id="imageframe" name="imageframe" src="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder?>&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>"></iframe>
 
 		<div class="well">
 			<div class="row-fluid">
@@ -98,7 +98,7 @@ else // XTD Image plugin
 						<input type="text" id="f_url" value="" />
 					</div>
 				</div>
-				<?php if (!$this->state->get('field.id')):?>
+				<?php if (!$this->state->get('field.id')): ?>
 					<div class="span6 control-group">
 						<div class="control-label">
 							<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
@@ -112,9 +112,9 @@ else // XTD Image plugin
 							</select>
 						</div>
 					</div>
-				<?php endif;?>
+				<?php endif; ?>
 			</div>
-			<?php if (!$this->state->get('field.id')):?>
+			<?php if (!$this->state->get('field.id')): ?>
 				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">
@@ -156,7 +156,7 @@ else // XTD Image plugin
 						</div>
 					</div>
 				</div>
-			<?php endif;?>
+			<?php endif; ?>
 
 			<input type="hidden" id="dirPath" name="dirPath" />
 			<input type="hidden" id="f_file" name="f_file" />
@@ -166,7 +166,7 @@ else // XTD Image plugin
 	</form>
 
 	<?php if ($user->authorise('core.create', 'com_media')) : ?>
-		<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
+		<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken(); ?>=1&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>&amp;view=images" id="uploadForm" class="form-horizontal" name="uploadForm" method="post" enctype="multipart/form-data">
 			<div id="uploadform" class="well">
 				<fieldset id="upload-noflash" class="actions">
 					<div class="control-group">

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -63,25 +63,25 @@ else // XTD Image plugin
 	<form action="index.php?option=com_media&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>" class="form-vertical" id="imageForm" method="post" enctype="multipart/form-data">
 
 		<div id="messages" style="display: none;">
-			<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true) ?>
+			<span id="message"></span><?php echo JHtml::_('image', 'media/dots.gif', '...', array('width' => 22, 'height' => 12), true); ?>
 		</div>
 
 		<div class="well">
 			<div class="row">
 				<div class="span12 control-group">
 					<div class="control-label">
-						<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY') ?></label>
+						<label class="control-label" for="folder"><?php echo JText::_('COM_MEDIA_DIRECTORY'); ?></label>
 					</div>
 					<div class="controls">
 						<?php echo $this->folderList; ?>
-						<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP') ?>"><?php echo JText::_('COM_MEDIA_UP') ?></button>
+						<button class="btn" type="button" id="upbutton" title="<?php echo JText::_('COM_MEDIA_DIRECTORY_UP'); ?>"><?php echo JText::_('COM_MEDIA_UP'); ?></button>
 					</div>
 				</div>
 				<div class="pull-right">
 					<button class="btn btn-success button-save-selected" type="button" <?php if (!empty($onClick)) :
-					// This is for Mootools compatibility ?>onclick="<?php echo $onClick; ?>"<?php endif; ?> data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT') ?></button>
+					// This is for Mootools compatibility ?>onclick="<?php echo $onClick; ?>"<?php endif; ?> data-dismiss="modal"><?php echo JText::_('COM_MEDIA_INSERT'); ?></button>
 					<button class="btn button-cancel" type="button" onclick="window.parent.jQuery('.modal.in').modal('hide');<?php if (!empty($onClick)) :
-						// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL') ?></button>
+						// This is for Mootools compatibility ?>parent.jModalClose();<?php endif ?>" data-dismiss="modal"><?php echo JText::_('JCANCEL'); ?></button>
 				</div>
 			</div>
 		</div>
@@ -92,7 +92,7 @@ else // XTD Image plugin
 			<div class="row-fluid">
 				<div class="span6 control-group">
 					<div class="control-label">
-						<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL') ?></label>
+						<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL'); ?></label>
 					</div>
 					<div class="controls">
 						<input type="text" id="f_url" value="" />
@@ -101,14 +101,14 @@ else // XTD Image plugin
 				<?php if (!$this->state->get('field.id')) : ?>
 					<div class="span6 control-group">
 						<div class="control-label">
-							<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN') ?></label>
+							<label title="<?php echo JText::_('COM_MEDIA_ALIGN_DESC'); ?>" class="noHtmlTip" for="f_align"><?php echo JText::_('COM_MEDIA_ALIGN'); ?></label>
 						</div>
 						<div class="controls">
 							<select size="1" id="f_align">
-								<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET') ?></option>
-								<option value="left"><?php echo JText::_('JGLOBAL_LEFT') ?></option>
-								<option value="center"><?php echo JText::_('JGLOBAL_CENTER') ?></option>
-								<option value="right"><?php echo JText::_('JGLOBAL_RIGHT') ?></option>
+								<option value="" selected="selected"><?php echo JText::_('COM_MEDIA_NOT_SET'); ?></option>
+								<option value="left"><?php echo JText::_('JGLOBAL_LEFT'); ?></option>
+								<option value="center"><?php echo JText::_('JGLOBAL_CENTER'); ?></option>
+								<option value="right"><?php echo JText::_('JGLOBAL_RIGHT'); ?></option>
 							</select>
 						</div>
 					</div>
@@ -118,7 +118,7 @@ else // XTD Image plugin
 				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">
-							<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION') ?></label>
+							<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION'); ?></label>
 						</div>
 						<div class="controls">
 							<input type="text" id="f_alt" value="" />
@@ -126,7 +126,7 @@ else // XTD Image plugin
 					</div>
 					<div class="span6 control-group">
 						<div class="control-label">
-							<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE') ?></label>
+							<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE'); ?></label>
 						</div>
 						<div class="controls">
 							<input type="text" id="f_title" value="" />
@@ -136,7 +136,7 @@ else // XTD Image plugin
 				<div class="row-fluid">
 					<div class="span6 control-group">
 						<div class="control-label">
-							<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION') ?></label>
+							<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION'); ?></label>
 						</div>
 						<div class="controls">
 							<input type="text" id="f_caption" value="" />
@@ -144,7 +144,7 @@ else // XTD Image plugin
 					</div>
 					<div class="span6 control-group">
 						<div class="control-label">
-							<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL') ?></label>
+							<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL'); ?></label>
 						</div>
 						<div class="controls">
 							<input type="text" list="d_caption_class" id="f_caption_class" value="" />

--- a/administrator/components/com_media/views/imageslist/tmpl/default_folder.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default_folder.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 $input = JFactory::getApplication()->input;
 ?>
 <li class="imgOutline thumbnail height-80 width-80 center">
-	<a href="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->_tmp_folder->path_relative; ?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>" target="imageframe">
+	<a href="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->_tmp_folder->path_relative; ?>&amp;asset=<?php echo $input->getCmd('asset'); ?>&amp;author=<?php echo $input->getCmd('author'); ?>" target="imageframe">
 		<div class="height-50">
 			<span class="icon-folder-2"></span>
 		</div>

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -47,7 +47,7 @@ if ($lang->isRtl())
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
 		<div class="j-toggle-sidebar-header">
-		<h3 style="padding-left: 10px;"><?php echo JText::_('COM_MEDIA_FOLDERS');?> </h3>
+		<h3 style="padding-left: 10px;"><?php echo JText::_('COM_MEDIA_FOLDERS'); ?> </h3>
 		</div>
 		<div id="treeview" class="sidebar">
 			<div id="media-tree_tree" class="sidebar-nav">
@@ -80,10 +80,10 @@ if ($lang->isRtl())
 			<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>" />
 		</form>
 
-		<?php if ($user->authorise('core.create', 'com_media')):?>
+		<?php if ($user->authorise('core.create', 'com_media')): ?>
 		<!-- File Upload Form -->
 		<div id="collapseUpload" class="collapse">
-			<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken();?>=1&amp;format=html" id="uploadForm" class="form-inline" name="uploadForm" method="post" enctype="multipart/form-data">
+			<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken(); ?>=1&amp;format=html" id="uploadForm" class="form-inline" name="uploadForm" method="post" enctype="multipart/form-data">
 				<div id="uploadform">
 					<fieldset id="upload-noflash" class="actions">
 							<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
@@ -100,7 +100,7 @@ if ($lang->isRtl())
 			</form>
 		</div>
 		<div id="collapseFolder" class="collapse">
-			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index');?>" name="folderForm" id="folderForm" class="form-inline" method="post">
+			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index'); ?>" name="folderForm" id="folderForm" class="form-inline" method="post">
 					<div class="path">
 						<input type="text" id="folderpath" readonly="readonly" class="update-folder" />
 						<input required type="text" id="foldername" name="foldername" />
@@ -110,12 +110,12 @@ if ($lang->isRtl())
 					<?php echo JHtml::_('form.token'); ?>
 			</form>
 		</div>
-		<?php endif;?>
+		<?php endif; ?>
 
-		<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index');?>" name="folderForm" id="folderForm" method="post">
+		<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index'); ?>" name="folderForm" id="folderForm" method="post">
 			<div id="folderview">
 				<div class="view">
-					<iframe class="thumbnail" src="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder;?>" id="folderframe" name="folderframe" width="100%" height="500px" marginwidth="0" marginheight="0" scrolling="auto"></iframe>
+					<iframe class="thumbnail" src="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $this->state->folder; ?>" id="folderframe" name="folderframe" width="100%" height="500px" marginwidth="0" marginheight="0" scrolling="auto"></iframe>
 				</div>
 				<?php echo JHtml::_('form.token'); ?>
 			</div>

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -80,7 +80,7 @@ if ($lang->isRtl())
 			<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>" />
 		</form>
 
-		<?php if ($user->authorise('core.create', 'com_media')): ?>
+		<?php if ($user->authorise('core.create', 'com_media')) : ?>
 		<!-- File Upload Form -->
 		<div id="collapseUpload" class="collapse">
 			<form action="<?php echo JUri::base(); ?>index.php?option=com_media&amp;task=file.upload&amp;tmpl=component&amp;<?php echo $this->session->getName() . '=' . $this->session->getId(); ?>&amp;<?php echo JSession::getFormToken(); ?>=1&amp;format=html" id="uploadForm" class="form-inline" name="uploadForm" method="post" enctype="multipart/form-data">

--- a/administrator/components/com_media/views/media/tmpl/default_navigation.php
+++ b/administrator/components/com_media/views/media/tmpl/default_navigation.php
@@ -13,8 +13,8 @@ $style = $app->getUserStateFromRequest('media.list.layout', 'layout', 'thumbs', 
 ?>
 
 <div class="media btn-group">
-	<a href="#" id="thumbs" onclick="MediaManager.setViewType('thumbs')" class="btn <?php echo ($style == "thumbs") ? 'active' : '';?>">
+	<a href="#" id="thumbs" onclick="MediaManager.setViewType('thumbs')" class="btn <?php echo ($style == "thumbs") ? 'active' : ''; ?>">
 	<span class="icon-grid-view-2"></span> <?php echo JText::_('COM_MEDIA_THUMBNAIL_VIEW'); ?></a>
-	<a href="#" id="details" onclick="MediaManager.setViewType('details')" class="btn <?php echo ($style == "details") ? 'active' : '';?>">
+	<a href="#" id="details" onclick="MediaManager.setViewType('details')" class="btn <?php echo ($style == "details") ? 'active' : ''; ?>">
 	<span class="icon-list-view"></span> <?php echo JText::_('COM_MEDIA_DETAIL_VIEW'); ?></a>
 </div>

--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -101,7 +101,7 @@ $doc->addScriptDeclaration(
 					<th width="1%">
 						<?php echo JHtml::_('grid.checkall'); ?>
 					</th>
-				<?php endif;?>
+				<?php endif; ?>
 				<th width="1%"><?php echo JText::_('JGLOBAL_PREVIEW'); ?></th>
 				<th><?php echo JText::_('COM_MEDIA_NAME'); ?></th>
 				<th width="15%"><?php echo JText::_('COM_MEDIA_PIXEL_DIMENSIONS'); ?></th>
@@ -111,7 +111,7 @@ $doc->addScriptDeclaration(
 					<th width="8%">
 						<?php echo JText::_('JACTION_DELETE'); ?>
 					</th>
-				<?php endif;?>
+				<?php endif; ?>
 			</tr>
 		</thead>
 		<tbody>

--- a/administrator/components/com_media/views/medialist/tmpl/details_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_docs.php
@@ -19,7 +19,7 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->documents as $i => $doc) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $doc->name, false, 'rm', 'cb-document'); ?>
 			</td>

--- a/administrator/components/com_media/views/medialist/tmpl/details_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_docs.php
@@ -19,11 +19,11 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->documents as $i => $doc) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete):?>
+		<?php if ($this->canDelete): ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $doc->name, false, 'rm', 'cb-document'); ?>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<td>
 			<a title="<?php echo $doc->name; ?>">
@@ -47,7 +47,7 @@ $dispatcher = JEventDispatcher::getInstance();
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 
 	</tr>
 	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$doc, &$params)); ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_folders.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_folders.php
@@ -14,11 +14,11 @@ JHtml::_('bootstrap.tooltip');
 <?php foreach ($this->folders as $i => $folder) : ?>
 	<?php $link = 'index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=' . $folder->path_relative; ?>
 	<tr>
-		<?php if ($this->canDelete):?>
+		<?php if ($this->canDelete): ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 		<td class="imgTotal">
 			<a href="<?php echo $link; ?>" target="folderframe"><span class="icon-folder-2"></span></a>
 		</td>
@@ -37,6 +37,6 @@ JHtml::_('bootstrap.tooltip');
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 	</tr>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_folders.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_folders.php
@@ -14,7 +14,7 @@ JHtml::_('bootstrap.tooltip');
 <?php foreach ($this->folders as $i => $folder) : ?>
 	<?php $link = 'index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=' . $folder->path_relative; ?>
 	<tr>
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>
 			</td>

--- a/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
@@ -21,11 +21,11 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->images as $i => $image) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$image, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete):?>
+		<?php if ($this->canDelete): ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $image->name, false, 'rm', 'cb-image'); ?>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<td>
 			<a class="img-preview" href="<?php echo COM_MEDIA_BASEURL, '/', $image->path_relative; ?>" title="<?php echo $image->name; ?>">
@@ -50,10 +50,10 @@ $dispatcher = JEventDispatcher::getInstance();
 		<?php if ($this->canDelete) : ?>
 			<td>
 				<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $image->name; ?>" rel="<?php echo $image->name; ?>">
-					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE');?>"></span>
+					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 	</tr>
 	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$image, &$params)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
@@ -21,7 +21,7 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->images as $i => $image) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$image, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $image->name, false, 'rm', 'cb-image'); ?>
 			</td>

--- a/administrator/components/com_media/views/medialist/tmpl/details_up.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_up.php
@@ -13,7 +13,7 @@ $user = JFactory::getUser();
 ?>
 <?php if ($this->state->folder != '') : ?>
 <tr>
-	<?php if ($this->canDelete): ?>
+	<?php if ($this->canDelete) : ?>
 		<td>&#160;</td>
 	<?php endif; ?>
 	<td class="imgTotal">
@@ -25,7 +25,7 @@ $user = JFactory::getUser();
 	</td>
 	<td>&#160;</td>
 	<td>&#160;</td>
-	<?php if ($user->authorise('core.delete', 'com_media')): ?>
+	<?php if ($user->authorise('core.delete', 'com_media')) : ?>
 		<td>&#160;</td>
 	<?php endif; ?>
 </tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_up.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_up.php
@@ -13,9 +13,9 @@ $user = JFactory::getUser();
 ?>
 <?php if ($this->state->folder != '') : ?>
 <tr>
-	<?php if ($this->canDelete):?>
+	<?php if ($this->canDelete): ?>
 		<td>&#160;</td>
-	<?php endif;?>
+	<?php endif; ?>
 	<td class="imgTotal">
 		<a href="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $this->state->parent; ?>" target="folderframe">
 			<span class="icon-arrow-up"></span></a>
@@ -25,8 +25,8 @@ $user = JFactory::getUser();
 	</td>
 	<td>&#160;</td>
 	<td>&#160;</td>
-	<?php if ($user->authorise('core.delete', 'com_media')):?>
+	<?php if ($user->authorise('core.delete', 'com_media')): ?>
 		<td>&#160;</td>
-	<?php endif;?>
+	<?php endif; ?>
 </tr>
 <?php endif; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_videos.php
@@ -28,11 +28,11 @@ jQuery(document).ready(function($){
 <?php foreach ($this->videos as $i => $video) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete):?>
+		<?php if ($this->canDelete): ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<td>
 			<a class="video-preview" href="<?php echo COM_MEDIA_BASEURL, '/', $video->name; ?>" title="<?php echo $video->title; ?>">
@@ -60,7 +60,7 @@ jQuery(document).ready(function($){
 					<span class="icon-remove hasTooltip" title="<?php echo JHtml::tooltipText('JACTION_DELETE'); ?>"></span>
 				</a>
 			</td>
-		<?php endif;?>
+		<?php endif; ?>
 	</tr>
 
 	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$video, &$params)); ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_videos.php
@@ -28,7 +28,7 @@ jQuery(document).ready(function($){
 <?php foreach ($this->videos as $i => $video) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
 	<tr>
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<td>
 				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>
 			</td>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_docs.php
@@ -19,12 +19,12 @@ $dispatcher = JEventDispatcher::getInstance();
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
 		<?php if ($this->canDelete) : ?>
-			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $doc->name; ?>" rel="<?php echo $doc->name; ?>" title="<?php echo JText::_('JACTION_DELETE');?>">&#215;</a>
+			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $doc->name; ?>" rel="<?php echo $doc->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 			<div class="pull-left">
 				<?php echo JHtml::_('grid.id', $i, $doc->name, false, 'rm', 'cb-document'); ?>
 			</div>
 			<div class="clearfix"></div>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<div class="height-50">
 			<a style="display: block; width: 100%; height: 100%" title="<?php echo $doc->name; ?>" >

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_folders.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_folders.php
@@ -12,13 +12,13 @@ defined('_JEXEC') or die;
 ?>
 <?php foreach ($this->folders as $i => $folder) : ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete):?>
-			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=folder.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $folder->name; ?>" rel="<?php echo $folder->name; ?> :: <?php echo $folder->files + $folder->folders; ?>" title="<?php echo JText::_('JACTION_DELETE');?>">&#215;</a>
+		<?php if ($this->canDelete): ?>
+			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=folder.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $folder->name; ?>" rel="<?php echo $folder->name; ?> :: <?php echo $folder->files + $folder->folders; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 			<div class="pull-left">
 				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>
 			</div>
 			<div class="clearfix"></div>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<div class="height-50">
 			<a href="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $folder->path_relative; ?>" target="folderframe">

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_folders.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_folders.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 ?>
 <?php foreach ($this->folders as $i => $folder) : ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=folder.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $folder->name; ?>" rel="<?php echo $folder->name; ?> :: <?php echo $folder->files + $folder->folders; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 			<div class="pull-left">
 				<?php echo JHtml::_('grid.id', $i, $folder->name, false, 'rm', 'cb-folder'); ?>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
@@ -18,7 +18,7 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->images as $i => $img) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete):?>
+		<?php if ($this->canDelete): ?>
 			<a class="close delete-item" target="_top"
 			href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $img->name; ?>"
 			rel="<?php echo $img->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
@@ -18,7 +18,7 @@ $dispatcher = JEventDispatcher::getInstance();
 <?php foreach ($this->images as $i => $img) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top"
 			href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $img->name; ?>"
 			rel="<?php echo $img->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
@@ -25,7 +25,7 @@ jQuery(document).ready(function($){
 <?php foreach ($this->videos as $i => $video) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete): ?>
+		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $video->name; ?>" rel="<?php echo $video->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 			<div class="pull-left">
 				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
@@ -25,13 +25,13 @@ jQuery(document).ready(function($){
 <?php foreach ($this->videos as $i => $video) : ?>
 	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
-		<?php if ($this->canDelete):?>
-			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $video->name; ?>" rel="<?php echo $video->name; ?>" title="<?php echo JText::_('JACTION_DELETE');?>">&#215;</a>
+		<?php if ($this->canDelete): ?>
+			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $video->name; ?>" rel="<?php echo $video->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
 			<div class="pull-left">
 				<?php echo JHtml::_('grid.id', $i, $video->name, false, 'rm', 'cb-video'); ?>
 			</div>
 			<div class="clearfix"></div>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<div class="height-50">
 			<?php echo JHtml::_('image', $video->icon_32, $video->title, null, true); ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -97,7 +97,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 				</td>
 				<td id="menus-<?php echo $module->id; ?>">
 					<?php if (is_null($module->menuid)) : ?>
-						<?php if ($module->except): ?>
+						<?php if ($module->except) : ?>
 							<span class="label label-success">
 								<?php echo JText::_('JYES'); ?>
 							</span>
@@ -121,7 +121,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					<?php endif; ?>
 				</td>
 				<td id="status-<?php echo $module->id; ?>">
-						<?php if ($module->published): ?>
+						<?php if ($module->published) : ?>
 							<span class="label label-success">
 								<?php echo JText::_('JYES'); ?>
 							</span>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -69,20 +69,20 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 		</thead>
 		<tbody>
 		<?php foreach ($this->modules as $i => &$module) : ?>
-			<?php  if (is_null($module->menuid)) : ?>
-				<?php  if (!$module->except || $module->menuid < 0) : ?>
-					<?php  $no = "no "; ?>
-				<?php  else : ?>
-					<?php  $no = ""; ?>
-				<?php  endif; ?>
-			<?php  else : ?>
-				<?php  $no = ""; ?>
-			<?php  endif; ?>
-			<?php  if ($module->published) : ?>
-				<?php  $status = ""; ?>
-			<?php  else : ?>
-				<?php  $status = "unpublished "; ?>
-			<?php  endif; ?>
+			<?php if (is_null($module->menuid)) : ?>
+				<?php if (!$module->except || $module->menuid < 0) : ?>
+					<?php $no = "no "; ?>
+				<?php else : ?>
+					<?php $no = ""; ?>
+				<?php endif; ?>
+			<?php else : ?>
+				<?php $no = ""; ?>
+			<?php endif; ?>
+			<?php if ($module->published) : ?>
+				<?php $status = ""; ?>
+			<?php else : ?>
+				<?php $status = "unpublished "; ?>
+			<?php endif; ?>
 			<tr class="<?php echo $no;?><?php echo $status;?>row<?php echo $i % 2;?>" id="tr-<?php echo $module->id; ?>" style="display:table-row">
 				<td id="<?php echo $module->id; ?>">
 					<?php $link = 'index.php?option=com_modules&amp;client_id=0&amp;task=module.edit&amp;id=' . $module->id . '&amp;tmpl=component&amp;view=module&amp;layout=modal'; ?>

--- a/administrator/components/com_menus/views/item/tmpl/edit_modules.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_modules.php
@@ -51,19 +51,19 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 		<thead>
 		<tr>
 			<th class="left">
-				<?php echo JText::_('COM_MENUS_HEADING_ASSIGN_MODULE');?>
+				<?php echo JText::_('COM_MENUS_HEADING_ASSIGN_MODULE'); ?>
 			</th>
 			<th>
-				<?php echo JText::_('COM_MENUS_HEADING_LEVELS');?>
+				<?php echo JText::_('COM_MENUS_HEADING_LEVELS'); ?>
 			</th>
 			<th>
-				<?php echo JText::_('COM_MENUS_HEADING_POSITION');?>
+				<?php echo JText::_('COM_MENUS_HEADING_POSITION'); ?>
 			</th>
 			<th>
-				<?php echo JText::_('COM_MENUS_HEADING_DISPLAY');?>
+				<?php echo JText::_('COM_MENUS_HEADING_DISPLAY'); ?>
 			</th>
 			<th>
-				<?php echo JText::_('COM_MENUS_HEADING_PUBLISHED_ITEMS');?>
+				<?php echo JText::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?>
 			</th>
 		</tr>
 		</thead>
@@ -83,10 +83,10 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 			<?php else : ?>
 				<?php $status = "unpublished "; ?>
 			<?php endif; ?>
-			<tr class="<?php echo $no;?><?php echo $status;?>row<?php echo $i % 2;?>" id="tr-<?php echo $module->id; ?>" style="display:table-row">
+			<tr class="<?php echo $no; ?><?php echo $status; ?>row<?php echo $i % 2; ?>" id="tr-<?php echo $module->id; ?>" style="display:table-row">
 				<td id="<?php echo $module->id; ?>">
 					<?php $link = 'index.php?option=com_modules&amp;client_id=0&amp;task=module.edit&amp;id=' . $module->id . '&amp;tmpl=component&amp;view=module&amp;layout=modal'; ?>
-					<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS');?>" id="title-<?php echo $module->id; ?>">
+					<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="btn btn-link" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>" id="title-<?php echo $module->id; ?>">
 						<?php echo $this->escape($module->title); ?></a>
 				</td>
 				<td id="access-<?php echo $module->id; ?>">
@@ -97,7 +97,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 				</td>
 				<td id="menus-<?php echo $module->id; ?>">
 					<?php if (is_null($module->menuid)) : ?>
-						<?php if ($module->except):?>
+						<?php if ($module->except): ?>
 							<span class="label label-success">
 								<?php echo JText::_('JYES'); ?>
 							</span>
@@ -105,7 +105,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 							<span class="label label-important">
 								<?php echo JText::_('JNO'); ?>
 							</span>
-						<?php endif;?>
+						<?php endif; ?>
 					<?php elseif ($module->menuid > 0) : ?>
 						<span class="label label-success">
 							<?php echo JText::_('JYES'); ?>
@@ -121,7 +121,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 					<?php endif; ?>
 				</td>
 				<td id="status-<?php echo $module->id; ?>">
-						<?php if ($module->published):?>
+						<?php if ($module->published): ?>
 							<span class="label label-success">
 								<?php echo JText::_('JYES'); ?>
 							</span>
@@ -129,7 +129,7 @@ echo JLayoutHelper::render('joomla.menu.edit_modules', $this); ?>
 							<span class="label label-important">
 								<?php echo JText::_('JNO'); ?>
 							</span>
-						<?php endif;?>
+						<?php endif; ?>
 				</td>
 			<?php echo JHtml::_(
 					'bootstrap.renderModal',

--- a/administrator/components/com_menus/views/item/tmpl/edit_options.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_options.php
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
 					<?php endforeach;
 			echo JHtml::_('bootstrap.endSlide');
 		endif;
-	endforeach;?>
+	endforeach; ?>
 <?php
 
 echo JHtml::_('bootstrap.endAccordion');

--- a/administrator/components/com_menus/views/item/tmpl/modal_options.php
+++ b/administrator/components/com_menus/views/item/tmpl/modal_options.php
@@ -38,7 +38,7 @@ defined('_JEXEC') or die;
 					<?php endforeach;
 			echo JHtml::_('bootstrap.endSlide');
 		endif;
-	endforeach;?>
+	endforeach; ?>
 <?php
 
 echo JHtml::_('bootstrap.endAccordion');

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -143,7 +143,7 @@ if ($menuType == '')
 						$parentsStr = "";
 					}
 					?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id; ?>" parents="<?php echo $parentsStr; ?>" level="<?php echo $item->level; ?>">
 						<?php if ($menuType) : ?>
 							<td class="order nowrap center hidden-phone">
 								<?php

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -48,7 +48,7 @@ if ($menuType == '')
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this), null, array('debug' => false));
@@ -88,7 +88,7 @@ if ($menuType == '')
 							<th width="5%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 							</th>
-						<?php endif;?>
+						<?php endif; ?>
 						<th width="15%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
 						</th>
@@ -107,7 +107,7 @@ if ($menuType == '')
 
 				<tbody>
 				<?php
-				
+
 				foreach ($this->items as $i => $item) :
 					$orderkey   = array_search($item->id, $this->ordering[$item->parent_id]);
 					$canCreate  = $user->authorise('core.create',     'com_menus.menu.' . $item->menutype_id);
@@ -143,7 +143,7 @@ if ($menuType == '')
 						$parentsStr = "";
 					}
 					?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id;?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
 						<?php if ($menuType) : ?>
 							<td class="order nowrap center hidden-phone">
 								<?php
@@ -162,7 +162,7 @@ if ($menuType == '')
 									<span class="icon-menu"></span>
 								</span>
 								<?php if ($canChange && $saveOrder) : ?>
-									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1;?>" />
+									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>" />
 								<?php endif; ?>
 							</td>
 						<?php endif; ?>
@@ -179,7 +179,7 @@ if ($menuType == '')
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'items.', $canCheckin); ?>
 							<?php endif; ?>
 							<?php if ($canEdit) : ?>
-								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_menus&task=item.edit&id=' . (int) $item->id);?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
+								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_menus&task=item.edit&id=' . (int) $item->id); ?>" title="<?php echo JText::_('JACTION_EDIT'); ?>">
 									<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
@@ -187,12 +187,12 @@ if ($menuType == '')
 							<span class="small">
 							<?php if ($item->type != 'url') : ?>
 								<?php if (empty($item->note)) : ?>
-									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?>
+									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								<?php else : ?>
-									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note));?>
+									<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 								<?php endif; ?>
 							<?php elseif ($item->type == 'url' && $item->note) : ?>
-								<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note));?>
+								<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 							<?php endif; ?>
 							</span>
 							<?php echo JHtml::_('MenusHtml.Menus.visibility', $item->params); ?>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -36,7 +36,7 @@ $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype')
 			</label>
 			<div class="controls">
 				<select name="batch[menu_id]" id="batch-menu-id">
-					<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY') ?></option>
+					<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 					<?php echo JHtml::_('select.options', JHtml::_('menu.menuitems', array('published' => $published, 'checkacl' => (int) $this->state->get('menutypeid')))); ?>
 				</select>
 			</div>
@@ -49,6 +49,6 @@ $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype')
 </div>
 <?php else : ?>
 <div class="row-fluid">
-	<p><?php echo JText::_('COM_MENUS_SELECT_MENU_FIRST') ?></p>
+	<p><?php echo JText::_('COM_MENUS_SELECT_MENU_FIRST'); ?></p>
 </div>
 <?php endif; ?>

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -151,7 +151,7 @@ jQuery(document).ready(function($) {
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
 							<td class="small hidden-phone">
-								<?php if ($item->language == ''): ?>
+								<?php if ($item->language == '') : ?>
 									<?php echo JText::_('JDEFAULT'); ?>
 								<?php elseif ($item->language == '*') : ?>
 									<?php echo JText::alt('JALL', 'language'); ?>

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -120,9 +120,9 @@ jQuery(document).ready(function($) {
 									<?php echo $this->escape($item->title); ?></a>
 								<span class="small">
 									<?php if (empty($item->note)) : ?>
-										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 									<?php else : ?>
-										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note));?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 									<?php endif; ?>
 								</span>
 								<div title="<?php echo $this->escape($item->path); ?>">
@@ -151,7 +151,7 @@ jQuery(document).ready(function($) {
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
 							<td class="small hidden-phone">
-								<?php if ($item->language == ''):?>
+								<?php if ($item->language == ''): ?>
 									<?php echo JText::_('JDEFAULT'); ?>
 								<?php elseif ($item->language == '*') : ?>
 									<?php echo JText::alt('JALL', 'language'); ?>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -52,7 +52,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -236,7 +236,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -42,7 +42,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php $menutype = base64_encode(json_encode($menutype)); ?>
 						<a class="choose_type" href="#" title="<?php echo JText::_($item->description); ?>"
 							onclick="javascript:setmenutype('<?php echo $menutype; ?>')">
-							<?php echo $title;?>
+							<?php echo $title; ?>
 							<small class="muted">
 								<?php echo JText::_($item->description); ?>
 							</small>

--- a/administrator/components/com_messages/views/message/tmpl/default.php
+++ b/administrator/components/com_messages/views/message/tmpl/default.php
@@ -19,7 +19,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php echo JText::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
 			</div>
 			<div class="controls">
-				<?php echo $this->item->get('from_user_name');?>
+				<?php echo $this->item->get('from_user_name'); ?>
 			</div>
 		</div>
 		<div class="control-group">
@@ -27,7 +27,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php echo JText::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
 			</div>
 			<div class="controls">
-				<?php echo JHtml::_('date', $this->item->date_time);?>
+				<?php echo JHtml::_('date', $this->item->date_time); ?>
 			</div>
 		</div>
 		<div class="control-group">
@@ -35,7 +35,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php echo JText::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
 			</div>
 			<div class="controls">
-				<?php echo $this->item->subject;?>
+				<?php echo $this->item->subject; ?>
 			</div>
 		</div>
 		<div class="control-group">

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -40,7 +40,7 @@ JFactory::getDocument()->addStyleDeclaration(
 	<div id="j-main-container" class="span10">
 		<?php else : ?>
 		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"></div>
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -112,7 +112,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 									?>
 									<input type="checkbox" class="pull-left novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?> />
 									<label for="<?php echo $id . $link->value; ?>" class="pull-left">
-										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias));?></span>
+										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias)); ?></span>
 										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*') : ?>
 											<?php if ($link->language_image) : ?>
 												<?php echo JHtml::_('image', 'mod_languages/' . $link->language_image . '.gif', $link->language_title, array('title' => $link->language_title), true); ?>
@@ -124,7 +124,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 											<?php echo ' <span class="label">' . JText::_('JUNPUBLISHED') . '</span>'; ?>
 										<?php endif; ?>
 										<?php if ($uselessMenuItem) : ?>
-											<?php echo ' <span class="label">' . JText::_('COM_MODULES_MENU_ITEM_' . strtoupper($link->type)) . '</span>';?>
+											<?php echo ' <span class="label">' . JText::_('COM_MODULES_MENU_ITEM_' . strtoupper($link->type)) . '</span>'; ?>
 										<?php endif; ?>
 									</label>
 								</div>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -33,7 +33,7 @@ $colSpan = $clientId === 1 ? 9 : 10;
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php
 		// Search tools bar and filters
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
@@ -178,7 +178,7 @@ $colSpan = $clientId === 1 ? 9 : 10;
 							<?php endif; ?>
 						</td>
 						<td class="small hidden-phone hidden-tablet">
-							<?php echo $item->name;?>
+							<?php echo $item->name; ?>
 						</td>
 						<?php if ($clientId === 0) : ?>
 						<td class="small hidden-phone hidden-tablet">
@@ -198,7 +198,7 @@ $colSpan = $clientId === 1 ? 9 : 10;
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<?php // Load the batch processing form. ?>
 		<?php if ($user->authorise('core.create', 'com_modules')

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -52,7 +52,7 @@ $attr = array(
 					<?php echo JText::_('COM_MODULES_BATCH_POSITION_LABEL'); ?>
 				</label>
 				<div id="batch-choose-action" class="control-group">
-					<?php echo JHtml::_('select.groupedlist', $positions, 'batch[position_id]', $attr) ?>
+					<?php echo JHtml::_('select.groupedlist', $positions, 'batch[position_id]', $attr); ?>
 					<div id="batch-copy-move" class="control-group radio">
 						<?php echo JHtml::_('modules.batchOptions'); ?>
 					</div>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -128,7 +128,7 @@ modulePosIns = function(position) {
 			<?php endforeach; ?>
 			</tbody>
 		</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_modules/views/positions/tmpl/modal.php
+++ b/administrator/components/com_modules/views/positions/tmpl/modal.php
@@ -22,7 +22,7 @@ $state     = $this->state->get('filter.state');
 $template  = $this->state->get('filter.template');
 $type      = $this->state->get('filter.type');
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_modules&view=positions&layout=modal&tmpl=component&function=' . $function . '&client_id=' . $clientId);?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_modules&view=positions&layout=modal&tmpl=component&function=' . $function . '&client_id=' . $clientId); ?>" method="post" name="adminForm" id="adminForm">
 	<fieldset class="filter clearfix">
 		<div class="left">
 			<label for="filter_search">
@@ -38,18 +38,18 @@ $type      = $this->state->get('filter.type');
 
 		<div class="right">
 			<select name="filter_state" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('modules.templateStates'), 'value', 'text', $state, true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('modules.templateStates'), 'value', 'text', $state, true); ?>
 			</select>
 
 			<select name="filter_type" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_TYPE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('modules.types'), 'value', 'text', $type, true);?>
+				<option value=""><?php echo JText::_('COM_MODULES_OPTION_SELECT_TYPE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('modules.types'), 'value', 'text', $type, true); ?>
 			</select>
 
 			<select name="filter_template" onchange="this.form.submit()">
-				<option value=""><?php echo JText::_('JOPTION_SELECT_TEMPLATE');?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('modules.templates', $clientId), 'value', 'text', $template, true);?>
+				<option value=""><?php echo JText::_('JOPTION_SELECT_TEMPLATE'); ?></option>
+				<?php echo JHtml::_('select.options', JHtml::_('modules.templates', $clientId), 'value', 'text', $template, true); ?>
 			</select>
 		</div>
 	</fieldset>
@@ -74,20 +74,20 @@ $type      = $this->state->get('filter.type');
 		</tfoot>
 		<tbody>
 		<?php $i = 1; foreach ($this->items as $value => $templates) : ?>
-			<tr class="row<?php echo $i = 1 - $i;?>">
+			<tr class="row<?php echo $i = 1 - $i; ?>">
 				<td>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function;?>('<?php echo $value; ?>');"><?php echo $this->escape($value); ?></a>
+					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function; ?>('<?php echo $value; ?>');"><?php echo $this->escape($value); ?></a>
 				</td>
 				<td>
-					<?php if (!empty($templates)):?>
-					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function;?>('<?php echo $value; ?>');">
+					<?php if (!empty($templates)): ?>
+					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function; ?>('<?php echo $value; ?>');">
 						<ul>
-						<?php foreach ($templates as $template => $label):?>
-							<li><?php echo $lang->hasKey($label) ? JText::sprintf('COM_MODULES_MODULE_TEMPLATE_POSITION', JText::_($template), JText::_($label)) : JText::_($template);?></li>
-						<?php endforeach;?>
+						<?php foreach ($templates as $template => $label): ?>
+							<li><?php echo $lang->hasKey($label) ? JText::sprintf('COM_MODULES_MODULE_TEMPLATE_POSITION', JText::_($template), JText::_($label)) : JText::_($template); ?></li>
+						<?php endforeach; ?>
 						</ul>
 					</a>
-					<?php endif;?>
+					<?php endif; ?>
 				</td>
 			</tr>
 			<?php endforeach; ?>

--- a/administrator/components/com_modules/views/positions/tmpl/modal.php
+++ b/administrator/components/com_modules/views/positions/tmpl/modal.php
@@ -79,10 +79,10 @@ $type      = $this->state->get('filter.type');
 					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function; ?>('<?php echo $value; ?>');"><?php echo $this->escape($value); ?></a>
 				</td>
 				<td>
-					<?php if (!empty($templates)): ?>
+					<?php if (!empty($templates)) : ?>
 					<a class="pointer" onclick="if (window.parent) window.parent.<?php echo $function; ?>('<?php echo $value; ?>');">
 						<ul>
-						<?php foreach ($templates as $template => $label): ?>
+						<?php foreach ($templates as $template => $label) : ?>
 							<li><?php echo $lang->hasKey($label) ? JText::sprintf('COM_MODULES_MODULE_TEMPLATE_POSITION', JText::_($template), JText::_($label)) : JText::_($template); ?></li>
 						<?php endforeach; ?>
 						</ul>

--- a/administrator/components/com_modules/views/select/tmpl/default.php
+++ b/administrator/components/com_modules/views/select/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.popover');
 $document = JFactory::getDocument();
 ?>
 
-<h2><?php echo JText::_('COM_MODULES_TYPE_CHOOSE') ?></h2>
+<h2><?php echo JText::_('COM_MODULES_TYPE_CHOOSE'); ?></h2>
 <ul id="new-modules-list" class="list list-striped">
 <?php foreach ($this->items as &$item) : ?>
 	<?php // Prepare variables for the link. ?>

--- a/administrator/components/com_modules/views/select/tmpl/default.php
+++ b/administrator/components/com_modules/views/select/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.popover');
 $document = JFactory::getDocument();
 ?>
 
-<h2><?php echo JText::_('COM_MODULES_TYPE_CHOOSE')?></h2>
+<h2><?php echo JText::_('COM_MODULES_TYPE_CHOOSE') ?></h2>
 <ul id="new-modules-list" class="list list-striped">
 <?php foreach ($this->items as &$item) : ?>
 	<?php // Prepare variables for the link. ?>
@@ -26,7 +26,7 @@ $document = JFactory::getDocument();
 
 	<?php if ($document->direction != "rtl") : ?>
 	<li>
-		<a href="<?php echo JRoute::_($link);?>">
+		<a href="<?php echo JRoute::_($link); ?>">
 			<strong><?php echo $name; ?></strong></a>
 		<small class="hasPopover" data-placement="right" title="<?php echo $name; ?>" data-content="<?php echo $desc; ?>"><?php echo $short_desc; ?></small>
 	</li>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -97,7 +97,7 @@ if ($saveOrder)
 					$canEditOwn = $user->authorise('core.edit.own',   'com_newsfeeds.category.' . $item->catid) && $item->created_by == $user->id;
 					$canChange  = $user->authorise('core.edit.state', 'com_newsfeeds.category.' . $item->catid) && $canCheckin;
 					?>
-					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid?>">
+					<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->catid; ?>">
 						<td class="order nowrap center hidden-phone">
 							<?php
 							$iconClass = '';

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -167,7 +167,7 @@ if ($saveOrder)
 								<?php echo JHtml::_('newsfeed.association', $item->id); ?>
 							<?php endif; ?>
 						</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<td class="small hidden-phone">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -35,7 +35,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -139,7 +139,7 @@ if ($saveOrder)
 				<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -91,7 +91,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</td>
 						<td class="break-word">
 							<?php if ($canEdit) : ?>
-								<a href="<?php echo JRoute::_('index.php?option=com_redirect&task=link.edit&id=' . $item->id);?>" title="<?php echo $this->escape($item->old_url); ?>">
+								<a href="<?php echo JRoute::_('index.php?option=com_redirect&task=link.edit&id=' . $item->id); ?>" title="<?php echo $this->escape($item->old_url); ?>">
 									<?php echo $this->escape(str_replace(JUri::root(), '', rawurldecode($item->old_url))); ?></a>
 							<?php else : ?>
 									<?php echo $this->escape(str_replace(JUri::root(), '', rawurldecode($item->old_url))); ?>
@@ -137,7 +137,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					),
 					$this->loadTemplate('batch_body')
 				); ?>
-			<?php endif;?>
+			<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_redirect/views/links/tmpl/default_addform.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_addform.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<div class="accordion-group">
 		<div class="accordion-heading">
 			<a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion2" href="#batch">
-				<?php echo JText::_('COM_REDIRECT_BATCH_UPDATE_WITH_NEW_URL');?>
+				<?php echo JText::_('COM_REDIRECT_BATCH_UPDATE_WITH_NEW_URL'); ?>
 			</a>
 		</div>
 		<div id="batch" class="accordion-body collapse">

--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -27,7 +27,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 	<div id="j-main-container" class="span10">
 	<?php else : ?>
 	<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -66,7 +66,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 						<?php echo (int) $item->hits; ?>
 					</td>
 					<?php if ($this->state->get('show_results')) : ?>
-					
+
 					<td class="center btns">
 						<a class="badge <?php if ($item->returns > 0) echo "badge-success"; ?>" target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_search&amp;view=search&amp;searchword=<?php echo JFilterOutput::stringURLSafe($item->search_term); ?>">
 							<?php echo $item->returns; ?><span class="icon-out-2"><span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span></span></a>

--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -71,7 +71,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 						<a class="badge <?php if ($item->returns > 0) echo "badge-success"; ?>" target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_search&amp;view=search&amp;searchword=<?php echo JFilterOutput::stringURLSafe($item->search_term); ?>">
 							<?php echo $item->returns; ?><span class="icon-out-2"><span class="element-invisible"><?php echo JText::_('JBROWSERTARGET_NEW'); ?></span></span></a>
 					</td>
-					<?php else: ?>
+					<?php else : ?>
 					<td class="center">
 						<?php echo JText::_('COM_SEARCH_NO_RESULTS'); ?>
 					</td>

--- a/administrator/components/com_tags/views/tag/tmpl/edit_metadata.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit_metadata.php
@@ -21,9 +21,9 @@ defined('_JEXEC') or die;
 		<?php echo $this->form->getInput('metakey'); ?>
 	</div>
 </div>
-<?php foreach ($this->form->getGroup('metadata') as $field): ?>
+<?php foreach ($this->form->getGroup('metadata') as $field) : ?>
 <div class="control-group">
-	<?php if (!$field->hidden): ?>
+	<?php if (!$field->hidden) : ?>
 		<?php echo $field->label; ?>
 	<?php endif; ?>
 	<div class="controls">

--- a/administrator/components/com_tags/views/tag/tmpl/edit_options.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit_options.php
@@ -32,7 +32,7 @@ defined('_JEXEC') or die;
 					</div>
 				<?php endforeach; ?>
 
-				<?php if ($name == 'basic'):?>
+				<?php if ($name == 'basic'): ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('note'); ?>

--- a/administrator/components/com_tags/views/tag/tmpl/edit_options.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit_options.php
@@ -32,7 +32,7 @@ defined('_JEXEC') or die;
 					</div>
 				<?php endforeach; ?>
 
-				<?php if ($name == 'basic'): ?>
+				<?php if ($name == 'basic') : ?>
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('note'); ?>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -168,7 +168,7 @@ if ($saveOrder)
 						$parentsStr = "";
 					}
 					?>
-						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
+						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id; ?>" parents="<?php echo $parentsStr; ?>" level="<?php echo $item->level; ?>">
 							<td class="order nowrap center hidden-phone">
 								<?php
 								$iconClass = '';

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -56,7 +56,7 @@ if ($saveOrder)
 	JHtml::_('sortablelist.sortable', 'categoryList', 'adminForm', strtolower($listDirn), $saveOrderingUrl, false, true);
 }
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_tags&view=tags');?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_tags&view=tags'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty($this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -64,7 +64,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
@@ -90,31 +90,31 @@ if ($saveOrder)
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 
-						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) :?>
+						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>"></i>
 							</th>
 							<?php $columns++; ?>
-						<?php endif;?>
-						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) :?>
+						<?php endif; ?>
+						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>"></i>
 							</th>
 							<?php $columns++; ?>
-						<?php endif;?>
-						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) :?>
+						<?php endif; ?>
+						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-archive hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>"></i>
 							</th>
 							<?php $columns++; ?>
-						<?php endif;?>
-						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) :?>
+						<?php endif; ?>
+						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<th width="1%" class="nowrap center hidden-phone">
 								<i class="icon-trash hasTooltip" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>"></i>
 							</th>
 							<?php $columns++; ?>
-						<?php endif;?>
- 
+						<?php endif; ?>
+
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
@@ -168,7 +168,7 @@ if ($saveOrder)
 						$parentsStr = "";
 					}
 					?>
-						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id;?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
+						<tr class="row<?php echo $i % 2; ?>" sortable-group-id="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id?>" parents="<?php echo $parentsStr?>" level="<?php echo $item->level?>">
 							<td class="order nowrap center hidden-phone">
 								<?php
 								$iconClass = '';
@@ -185,7 +185,7 @@ if ($saveOrder)
 									<span class="icon-menu"></span>
 								</span>
 								<?php if ($canChange && $saveOrder) : ?>
-									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1;?>" />
+									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>" />
 								<?php endif; ?>
 							</td>
 							<td class="center">
@@ -210,47 +210,47 @@ if ($saveOrder)
 									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'tags.', $canCheckin); ?>
 								<?php endif; ?>
 								<?php if ($canEdit) : ?>
-									<a href="<?php echo JRoute::_('index.php?option=com_tags&task=tag.edit&id=' . $item->id);?>">
+									<a href="<?php echo JRoute::_('index.php?option=com_tags&task=tag.edit&id=' . $item->id); ?>">
 										<?php echo $this->escape($item->title); ?></a>
 								<?php else : ?>
 									<?php echo $this->escape($item->title); ?>
 								<?php endif; ?>
 								<span class="small" title="<?php echo $this->escape($item->path); ?>">
 									<?php if (empty($item->note)) : ?>
-										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias));?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 									<?php else : ?>
-										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note));?>
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 									<?php endif; ?>
 								</span>
 							</td>
-							
+
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>
 							<td class="center btns hidden-phone">
-								<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_PUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=1');?>">
+								<a class="badge <?php if ($item->count_published > 0) echo "badge-success"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=1'); ?>">
 									<?php echo $item->count_published; ?></a>
 							</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_unpublished')) : ?>
 							<td class="center btns hidden-phone">
-								<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=0');?>">
+								<a class="badge <?php if ($item->count_unpublished > 0) echo "badge-important"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=0'); ?>">
 									<?php echo $item->count_unpublished; ?></a>
 							</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_archived')) : ?>
 							<td class="center btns hidden-phone">
-								<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_ARCHIVED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=2');?>">
+								<a class="badge <?php if ($item->count_archived > 0) echo "badge-info"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_ARCHIVED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=2'); ?>">
 									<?php echo $item->count_archived; ?></a>
 							</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_trashed')) : ?>
 							<td class="center btns hidden-phone">
-								<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS');?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=-2');?>">
+								<a class="badge <?php if ($item->count_trashed > 0) echo "badge-inverse"; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=-2'); ?>">
 									<?php echo $item->count_trashed; ?></a>
 							</td>
-						<?php endif;?>
-							
-							
-							
+						<?php endif; ?>
+
+
+
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->access_title); ?>
 						</td>
@@ -278,7 +278,7 @@ if ($saveOrder)
 					),
 					$this->loadTemplate('batch_body')
 				); ?>
-			<?php endif;?>
+			<?php endif; ?>
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -30,7 +30,7 @@ $colSpan = $clientId === 1 ? 5 : 6;
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<div class="clear"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -91,29 +91,29 @@ $colSpan = $clientId === 1 ? 5 : 6;
 							<?php endif; ?>
 							<?php if ($canEdit) : ?>
 							<a href="<?php echo JRoute::_('index.php?option=com_templates&task=style.edit&id=' . (int) $item->id); ?>">
-								<?php echo $this->escape($item->title);?></a>
+								<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
-								<?php echo $this->escape($item->title);?>
+								<?php echo $this->escape($item->title); ?>
 							<?php endif; ?>
 						</td>
 						<td class="center">
-							<?php if ($item->home == '0' || $item->home == '1'):?>
-								<?php echo JHtml::_('jgrid.isdefault', $item->home != '0', $i, 'styles.', $canChange && $item->home != '1');?>
-							<?php elseif ($canChange):?>
-								<a href="<?php echo JRoute::_('index.php?option=com_templates&task=styles.unsetDefault&cid[]=' . $item->id . '&' . JSession::getFormToken() . '=1');?>">
+							<?php if ($item->home == '0' || $item->home == '1'): ?>
+								<?php echo JHtml::_('jgrid.isdefault', $item->home != '0', $i, 'styles.', $canChange && $item->home != '1'); ?>
+							<?php elseif ($canChange): ?>
+								<a href="<?php echo JRoute::_('index.php?option=com_templates&task=styles.unsetDefault&cid[]=' . $item->id . '&' . JSession::getFormToken() . '=1'); ?>">
 									<?php if ($item->image) : ?>
 										<?php echo JHtml::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => JText::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title)), true); ?>
 									<?php else : ?>
 										<span class="label" title="<?php echo JText::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->language_sef; ?></span>
 									<?php endif; ?>
 								</a>
-							<?php else:?>
+							<?php else: ?>
 								<?php if ($item->image) : ?>
 									<?php echo JHtml::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>
 								<?php else : ?>
 									<span class="label" title="<?php echo $item->language_title; ?>"><?php echo $item->language_sef; ?></span>
 								<?php endif; ?>
-							<?php endif;?>
+							<?php endif; ?>
 						</td>
 						<?php if ($clientId === 0) : ?>
 						<td class="small hidden-phone">
@@ -127,11 +127,11 @@ $colSpan = $clientId === 1 ? 5 : 6;
 								<?php echo JText::_('COM_TEMPLATES_STYLES_PAGES_NONE'); ?>
 							<?php endif; ?>
 						</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<td class="hidden-phone hidden-tablet">
-							<label for="cb<?php echo $i;?>" class="small">
+							<label for="cb<?php echo $i; ?>" class="small">
 								<a href="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . (int) $item->e_id); ?>  ">
-									<?php echo ucfirst($this->escape($item->template));?>
+									<?php echo ucfirst($this->escape($item->template)); ?>
 								</a>
 							</label>
 						</td>
@@ -142,7 +142,7 @@ $colSpan = $clientId === 1 ? 5 : 6;
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -86,7 +86,7 @@ $colSpan = $clientId === 1 ? 5 : 6;
 								<span class="icon-eye-open hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_TEMPLATE_PREVIEW'), $item->title, 0); ?>" ></span></a>
 							<?php elseif ($item->client_id == '1') : ?>
 								<span class="icon-eye-close disabled hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NO_PREVIEW_ADMIN'); ?>" ></span>
-							<?php else: ?>
+							<?php else : ?>
 								<span class="icon-eye-close disabled hasTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_TEMPLATE_NO_PREVIEW'); ?>" ></span>
 							<?php endif; ?>
 							<?php if ($canEdit) : ?>
@@ -97,9 +97,9 @@ $colSpan = $clientId === 1 ? 5 : 6;
 							<?php endif; ?>
 						</td>
 						<td class="center">
-							<?php if ($item->home == '0' || $item->home == '1'): ?>
+							<?php if ($item->home == '0' || $item->home == '1') : ?>
 								<?php echo JHtml::_('jgrid.isdefault', $item->home != '0', $i, 'styles.', $canChange && $item->home != '1'); ?>
-							<?php elseif ($canChange): ?>
+							<?php elseif ($canChange) : ?>
 								<a href="<?php echo JRoute::_('index.php?option=com_templates&task=styles.unsetDefault&cid[]=' . $item->id . '&' . JSession::getFormToken() . '=1'); ?>">
 									<?php if ($item->image) : ?>
 										<?php echo JHtml::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => JText::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title)), true); ?>
@@ -107,7 +107,7 @@ $colSpan = $clientId === 1 ? 5 : 6;
 										<span class="label" title="<?php echo JText::sprintf('COM_TEMPLATES_GRID_UNSET_LANGUAGE', $item->language_title); ?>"><?php echo $item->language_sef; ?></span>
 									<?php endif; ?>
 								</a>
-							<?php else: ?>
+							<?php else : ?>
 								<?php if ($item->image) : ?>
 									<?php echo JHtml::_('image', 'mod_languages/' . $item->image . '.gif', $item->language_title, array('title' => $item->language_title), true); ?>
 								<?php else : ?>

--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -170,13 +170,13 @@ if ($this->type == 'font')
 <?php echo JHtml::_('bootstrap.addTab', 'myTab', 'editor', JText::_('COM_TEMPLATES_TAB_EDITOR')); ?>
 <div class="row-fluid">
 	<div class="span12">
-		<?php if ($this->type == 'file'): ?>
+		<?php if ($this->type == 'file') : ?>
 			<p class="well well-small lead"><?php echo JText::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', $this->source->filename, $this->template->element); ?></p>
 		<?php endif; ?>
-		<?php if ($this->type == 'image'): ?>
+		<?php if ($this->type == 'image') : ?>
 			<p class="well well-small lead"><?php echo JText::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', $this->image['path'], $this->template->element); ?></p>
 		<?php endif; ?>
-		<?php if ($this->type == 'font'): ?>
+		<?php if ($this->type == 'font') : ?>
 			<p class="well well-small lead"><?php echo JText::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', $this->font['rel_path'], $this->template->element); ?></p>
 		<?php endif; ?>
 	</div>
@@ -186,7 +186,7 @@ if ($this->type == 'font')
 		<?php echo $this->loadTemplate('tree'); ?>
 	</div>
 	<div class="span9">
-		<?php if ($this->type == 'home'): ?>
+		<?php if ($this->type == 'home') : ?>
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 				<input type="hidden" name="task" value="" />
 				<?php echo JHtml::_('form.token'); ?>
@@ -201,7 +201,7 @@ if ($this->type == 'font')
 				</div>
 			</form>
 		<?php endif; ?>
-		<?php if ($this->type == 'file'): ?>
+		<?php if ($this->type == 'file') : ?>
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 
 				<div class="editor-border">
@@ -214,16 +214,16 @@ if ($this->type == 'font')
 
 			</form>
 		<?php endif; ?>
-		<?php if ($this->type == 'archive'): ?>
+		<?php if ($this->type == 'archive') : ?>
 			<legend><?php echo JText::_('COM_TEMPLATES_FILE_CONTENT_PREVIEW'); ?></legend>
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 				<ul class="nav nav-stacked nav-list well">
-					<?php foreach ($this->archive as $file): ?>
+					<?php foreach ($this->archive as $file) : ?>
 						<li>
-							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR): ?>
+							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR) : ?>
 								<span class="icon-folder"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
-							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR): ?>
+							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR) : ?>
 								<span class="icon-file"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 						</li>
@@ -234,7 +234,7 @@ if ($this->type == 'font')
 
 			</form>
 		<?php endif; ?>
-		<?php if ($this->type == 'image'): ?>
+		<?php if ($this->type == 'image') : ?>
 			<img id="image-crop" src="<?php echo $this->image['address'] . '?' . time(); ?>" />
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 				<fieldset class="adminform">
@@ -247,7 +247,7 @@ if ($this->type == 'font')
 				</fieldset>
 			</form>
 		<?php endif; ?>
-		<?php if ($this->type == 'font'): ?>
+		<?php if ($this->type == 'font') : ?>
 			<div class="font-preview">
 				<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 					<fieldset class="adminform">
@@ -311,7 +311,7 @@ if ($this->type == 'font')
 		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_MODULES'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
-			<?php foreach ($this->overridesList['modules'] as $module): ?>
+			<?php foreach ($this->overridesList['modules'] as $module) : ?>
 				<li>
 					<?php
 					$overrideLinkUrl = 'index.php?option=com_templates&view=template&task=template.overrides&folder=' . $module->path
@@ -328,13 +328,13 @@ if ($this->type == 'font')
 		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_COMPONENTS'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
-			<?php foreach ($this->overridesList['components'] as $key => $value): ?>
+			<?php foreach ($this->overridesList['components'] as $key => $value) : ?>
 				<li class="component-folder">
 					<a href="#" class="component-folder-url">
 						<span class="icon-folder"></span>&nbsp;<?php echo $key; ?>
 					</a>
 					<ul class="nav nav-list">
-						<?php foreach ($value as $view): ?>
+						<?php foreach ($value as $view) : ?>
 							<li>
 								<?php
 								$overrideLinkUrl = 'index.php?option=com_templates&view=template&task=template.overrides&folder=' . $view->path
@@ -354,7 +354,7 @@ if ($this->type == 'font')
 		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_LAYOUTS'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
-			<?php foreach ($this->overridesList['layouts'] as $layout): ?>
+			<?php foreach ($this->overridesList['layouts'] as $layout) : ?>
 				<li>
 					<?php
 					$overrideLinkUrl = 'index.php?option=com_templates&view=template&task=template.overrides&folder=' . $layout->path
@@ -389,7 +389,7 @@ $copyModalData = array(
 	<?php echo JLayoutHelper::render('joomla.modal.main', $copyModalData); ?>
 	<?php echo JHtml::_('form.token'); ?>
 </form>
-<?php if ($this->type != 'home'): ?>
+<?php if ($this->type != 'home') : ?>
 	<?php // Rename Modal
 	$renameModalData = array(
 		'selector'	=> 'renameModal',
@@ -405,7 +405,7 @@ $copyModalData = array(
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 <?php endif; ?>
-<?php if ($this->type != 'home'): ?>
+<?php if ($this->type != 'home') : ?>
 	<?php // Delete Modal
 	$deleteModalData = array(
 		'selector'	=> 'deleteModal',
@@ -440,7 +440,7 @@ $folderModalData = array(
 );
 ?>
 <?php echo JLayoutHelper::render('joomla.modal.main', $folderModalData); ?>
-<?php if ($this->type != 'home'): ?>
+<?php if ($this->type != 'home') : ?>
 	<?php // Resize Modal
 	$resizeModalData = array(
 		'selector'	=> 'resizeModal',

--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -183,7 +183,7 @@ if ($this->type == 'font')
 </div>
 <div class="row-fluid">
 	<div class="span3 tree-holder">
-		<?php echo $this->loadTemplate('tree');?>
+		<?php echo $this->loadTemplate('tree'); ?>
 	</div>
 	<div class="span9">
 		<?php if ($this->type == 'home'): ?>
@@ -308,7 +308,7 @@ if ($this->type == 'font')
 <?php echo JHtml::_('bootstrap.addTab', 'myTab', 'overrides', JText::_('COM_TEMPLATES_TAB_OVERRIDES')); ?>
 <div class="row-fluid">
 	<div class="span4">
-		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_MODULES');?></legend>
+		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_MODULES'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
 			<?php foreach ($this->overridesList['modules'] as $module): ?>
@@ -325,7 +325,7 @@ if ($this->type == 'font')
 		</ul>
 	</div>
 	<div class="span4">
-		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_COMPONENTS');?></legend>
+		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_COMPONENTS'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
 			<?php foreach ($this->overridesList['components'] as $key => $value): ?>
@@ -351,7 +351,7 @@ if ($this->type == 'font')
 		</ul>
 	</div>
 	<div class="span4">
-		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_LAYOUTS');?></legend>
+		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_LAYOUTS'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
 			<?php foreach ($this->overridesList['layouts'] as $layout): ?>
@@ -371,7 +371,7 @@ if ($this->type == 'font')
 <?php echo JHtml::_('bootstrap.endTab'); ?>
 
 <?php echo JHtml::_('bootstrap.addTab', 'myTab', 'description', JText::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
-<?php echo $this->loadTemplate('description');?>
+<?php echo $this->loadTemplate('description'); ?>
 <?php echo JHtml::_('bootstrap.endTab'); ?>
 <?php echo JHtml::_('bootstrap.endTabSet'); ?>
 

--- a/administrator/components/com_templates/views/template/tmpl/default_description.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_description.php
@@ -17,4 +17,4 @@ defined('_JEXEC') or die;
 <h2><?php echo ucfirst($this->template->element); ?></h2>
 <?php $client = JApplicationHelper::getClientInfo($this->template->client_id); ?>
 <p><?php $this->template->xmldata = TemplatesHelper::parseXMLTemplateFile($client->path, $this->template->element);?></p>
-<p><?php  echo JText::_($this->template->xmldata->description); ?></p>
+<p><?php echo JText::_($this->template->xmldata->description); ?></p>

--- a/administrator/components/com_templates/views/template/tmpl/default_description.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_description.php
@@ -16,5 +16,5 @@ defined('_JEXEC') or die;
 </div>
 <h2><?php echo ucfirst($this->template->element); ?></h2>
 <?php $client = JApplicationHelper::getClientInfo($this->template->client_id); ?>
-<p><?php $this->template->xmldata = TemplatesHelper::parseXMLTemplateFile($client->path, $this->template->element);?></p>
+<p><?php $this->template->xmldata = TemplatesHelper::parseXMLTemplateFile($client->path, $this->template->element); ?></p>
 <p><?php echo JText::_($this->template->xmldata->description); ?></p>

--- a/administrator/components/com_templates/views/template/tmpl/default_folders.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_folders.php
@@ -12,8 +12,8 @@ ksort($this->files, SORT_STRING);
 ?>
 
 <ul class='nav nav-list directory-tree'>
-	<?php foreach ($this->files as $key => $value): ?>
-		<?php if (is_array($value)): ?>
+	<?php foreach ($this->files as $key => $value) : ?>
+		<?php if (is_array($value)) : ?>
 			<li class="folder-select">
 				<a class='folder-url nowrap' data-id='<?php echo base64_encode($key); ?>' href=''>
 					<span class='icon-folder-close'>&nbsp;<?php $explodeArray = explode('/', $key); echo end($explodeArray); ?></span>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL') ?>
+				<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL'); ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL')?>
+				<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL') ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
@@ -18,5 +18,5 @@ $input = JFactory::getApplication()->input;
 	<input type="hidden" name="file" value="<?php echo $this->file; ?>" />
 	<?php echo JHtml::_('form.token'); ?>
 	<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-	<button type="submit" class="btn btn-danger"><?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?></button>
+	<button type="submit" class="btn btn-danger"><?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE'); ?></button>
 </form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -51,7 +51,7 @@ $input = JFactory::getApplication()->input;
 					<fieldset class="form-inline">
 						<input type="hidden" class="address" name="address" />
 						<label for="new_name" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>">
-							<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL') ?>
+							<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL'); ?>
 						</label>
 						<input type="text" id="new_name" name="new_name" required />
 						<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -46,7 +46,7 @@ $input = JFactory::getApplication()->input;
 					<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
 				</fieldset>
 			</form>
-			<?php if ($this->type != 'home'): ?>
+			<?php if ($this->type != 'home') : ?>
 				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
 					<fieldset class="form-inline">
 						<input type="hidden" class="address" name="address" />

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -16,10 +16,10 @@ $input = JFactory::getApplication()->input;
 		<div class="span6 column-right">
 			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
 				<fieldset class="form-inline">
-					<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME');?></label>
+					<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME'); ?></label>
 					<input type="text" name="name" required />
 					<select class="input-medium" data-chosen="true" name="type" required >
-						<option value="">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT');?> -</option>
+						<option value="">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT'); ?> -</option>
 						<option value="css">css</option>
 						<option value="php">php</option>
 						<option value="js">js</option>
@@ -32,7 +32,7 @@ $input = JFactory::getApplication()->input;
 					</select>
 					<input type="hidden" class="address" name="address" />
 					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
+					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
 				</fieldset>
 			</form>
 			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
@@ -40,7 +40,7 @@ $input = JFactory::getApplication()->input;
 					<input type="hidden" class="address" name="address" />
 					<input type="file" name="files" required />
 					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD');?>" class="btn btn-primary" /><br>
+					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD'); ?>" class="btn btn-primary" /><br>
 					<?php $cMax    = $this->state->get('params')->get('upload_limit'); ?>
 					<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize($cMax . 'MB')); ?>
 					<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
@@ -51,17 +51,17 @@ $input = JFactory::getApplication()->input;
 					<fieldset class="form-inline">
 						<input type="hidden" class="address" name="address" />
 						<label for="new_name" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>">
-							<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?>
+							<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL') ?>
 						</label>
 						<input type="text" id="new_name" name="new_name" required />
 						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE');?>" class="btn btn-primary" />
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE'); ?>" class="btn btn-primary" />
 					</fieldset>
 				</form>
 			<?php endif; ?>
 		</div>
 		<div class="span6 column-left">
-			<?php echo $this->loadTemplate('folders');?>
+			<?php echo $this->loadTemplate('folders'); ?>
 			<hr class="hr-condensed" />
 		</div>
 	</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
@@ -16,16 +16,16 @@ $input = JFactory::getApplication()->input;
 		<div class="span6 column-right">
 			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
 				<fieldset class="form-inline">
-					<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME');?></label>
+					<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME'); ?></label>
 					<input type="text" name="name" required />
 					<input type="hidden" class="address" name="address" />
 					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE');?>" class="btn btn-primary" />
+					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
 				</fieldset>
 			</form>
 		</div>
 		<div class="span6 column-left">
-			<?php echo $this->loadTemplate('folders');?>
+			<?php echo $this->loadTemplate('folders'); ?>
 			<hr class="hr-condensed" />
 		</div>
 	</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
@@ -16,6 +16,6 @@ $input = JFactory::getApplication()->input;
 		<a href="#" class="btn" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
 		<input type="hidden" class="address" name="address" />
 		<?php echo JHtml::_('form.token'); ?>
-		<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE');?>" class="btn btn-danger" />
+		<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE'); ?>" class="btn btn-danger" />
 	</fieldset>
 </form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>">
-				<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?>
+				<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME') ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::tooltipText(JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>">
-				<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME') ?>
+				<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME'); ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="height" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_HEIGHT'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT') ?>
+				<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT'); ?>
 			</label>
 		</div>
 		<div class="controls">
@@ -23,7 +23,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="width" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_WIDTH'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH') ?>
+				<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH'); ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="height" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_HEIGHT'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT')?>
+				<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT') ?>
 			</label>
 		</div>
 		<div class="controls">
@@ -23,7 +23,7 @@ defined('_JEXEC') or die;
 	<div class="control-group">
 		<div class="control-label">
 			<label for="width" class="modalTooltip" title="<?php echo JHtml::tooltipText('COM_TEMPLATES_IMAGE_WIDTH'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH')?>
+				<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH') ?>
 			</label>
 		</div>
 		<div class="controls">

--- a/administrator/components/com_templates/views/template/tmpl/default_tree.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_tree.php
@@ -53,7 +53,7 @@ ksort($this->files, SORT_STRING);
 		<?php endif; ?>
 		<?php if (is_object($value)) : ?>
 			<li>
-				<a class="file nowrap" href='<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $this->id . '&file=' . $value->id) ?>'>
+				<a class="file nowrap" href='<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $this->id . '&file=' . $value->id); ?>'>
 					<span class='icon-file'>&nbsp;<?php echo $value->name; ?></span>
 				</a>
 			</li>

--- a/administrator/components/com_templates/views/template/tmpl/default_tree.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_tree.php
@@ -12,8 +12,8 @@ ksort($this->files, SORT_STRING);
 ?>
 
 <ul class='nav nav-list directory-tree'>
-	<?php foreach ($this->files as $key => $value): ?>
-		<?php if (is_array($value)): ?>
+	<?php foreach ($this->files as $key => $value) : ?>
+		<?php if (is_array($value)) : ?>
 			<?php
 			$keyArray  = explode('/', $key);
 			$fileArray = explode('/', $this->fileName);
@@ -51,7 +51,7 @@ ksort($this->files, SORT_STRING);
 				<?php echo $this->directoryTree($value); ?>
 			</li>
 		<?php endif; ?>
-		<?php if (is_object($value)): ?>
+		<?php if (is_object($value)) : ?>
 			<li>
 				<a class="file nowrap" href='<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $this->id . '&file=' . $value->id) ?>'>
 					<span class='icon-file'>&nbsp;<?php echo $value->name; ?></span>

--- a/administrator/components/com_templates/views/template/tmpl/readonly.php
+++ b/administrator/components/com_templates/views/template/tmpl/readonly.php
@@ -19,7 +19,7 @@ $input = JFactory::getApplication()->input;
 <form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm" class="form-horizontal">
 	<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'description')); ?>
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'description', JText::_('COM_TEMPLATES_TAB_DESCRIPTION')); ?>
-			<?php echo $this->loadTemplate('description');?>
+			<?php echo $this->loadTemplate('description'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -105,7 +105,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-	<?php endif;?>
+	<?php endif; ?>
 
 	<input type="hidden" name="task" value="" />
 	<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -28,7 +28,7 @@ JFactory::getDocument()->addScriptDeclaration("
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="group-form" class="form-validate form-horizontal">
 	<fieldset>
-		<legend><?php echo JText::_('COM_USERS_USERGROUP_DETAILS');?></legend>
+		<legend><?php echo JText::_('COM_USERS_USERGROUP_DETAILS'); ?></legend>
 		<div class="control-group">
 			<div class="control-label">
 				<?php echo $this->form->getLabel('title'); ?>
@@ -38,12 +38,12 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		</div>
 		<div class="control-group">
-			<?php $parent_id = $this->form->getField('parent_id');?>
+			<?php $parent_id = $this->form->getField('parent_id'); ?>
 			<?php if (!$parent_id->hidden) : ?>
 				<div class="control-label">
 					<?php echo $parent_id->label; ?>
 				</div>
-			<?php endif;?>
+			<?php endif; ?>
 			<div class="controls">
 				<?php echo $parent_id->input; ?>
 			</div>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -49,7 +49,7 @@ JFactory::getDocument()->addScriptDeclaration('
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -132,7 +132,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -27,7 +27,7 @@ JFactory::getDocument()->addScriptDeclaration("
 
 <form action="<?php echo JRoute::_('index.php?option=com_users&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="level-form" class="form-validate form-horizontal">
 	<fieldset>
-		<legend><?php echo JText::_('COM_USERS_LEVEL_DETAILS');?></legend>
+		<legend><?php echo JText::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
 		<div class="control-group">
 			<div class="control-label">
 				<?php echo $this->form->getLabel('title'); ?>
@@ -39,7 +39,7 @@ JFactory::getDocument()->addScriptDeclaration("
 	</fieldset>
 
 	<fieldset>
-		<legend><?php echo JText::_('COM_USERS_USER_GROUPS_HAVING_ACCESS');?></legend>
+		<legend><?php echo JText::_('COM_USERS_USER_GROUPS_HAVING_ACCESS'); ?></legend>
 		<?php echo JHtml::_('access.usergroups', 'jform[rules]', $this->item->rules); ?>
 	</fieldset>
 	<input type="hidden" name="task" value="" />

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -28,7 +28,7 @@ if ($saveOrder)
 }
 
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=levels');?>" method="post" id="adminForm" name="adminForm">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=levels'); ?>" method="post" id="adminForm" name="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
 	<div id="j-sidebar-container" class="span2">
 		<?php echo $this->sidebar; ?>
@@ -36,7 +36,7 @@ if ($saveOrder)
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('filterButton' => false))); ?>
 		<div class="clearfix"> </div>
 		<?php if (empty($this->items)) : ?>
@@ -104,7 +104,7 @@ if ($saveOrder)
 						</td>
 						<td>
 							<?php if ($canEdit) : ?>
-							<a href="<?php echo JRoute::_('index.php?option=com_users&task=level.edit&id=' . $item->id);?>">
+							<a href="<?php echo JRoute::_('index.php?option=com_users&task=level.edit&id=' . $item->id); ?>">
 								<?php echo $this->escape($item->title); ?></a>
 							<?php else : ?>
 								<?php echo $this->escape($item->title); ?>
@@ -120,7 +120,7 @@ if ($saveOrder)
 				<?php endforeach; ?>
 				</tbody>
 			</table>
-		<?php endif;?>
+		<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="boxchecked" value="0" />
 		<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -24,7 +24,7 @@ jQuery(document).ready(function() {
 	}
 });');
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id);?>" method="post" name="adminForm" id="note-form" class="form-validate form-horizontal">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form" class="form-validate form-horizontal">
 		<fieldset class="adminform">
 			<div class="control-group">
 				<div class="control-label">

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -25,7 +25,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 	<div id="j-main-container" class="span10">
 <?php else : ?>
 	<div id="j-main-container">
-<?php endif;?>
+<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 
 		<?php if (empty($this->items)) : ?>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -89,7 +89,7 @@ $fieldsets = $this->form->getFieldsets();
 				</label>
 			</div>
 			<div class="controls">
-				<?php echo JHtml::_('select.genericlist', Usershelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange()'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false) ?>
+				<?php echo JHtml::_('select.genericlist', Usershelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange()'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
 			</div>
 		</div>
 		<div id="com_users_twofactor_forms_container">
@@ -103,19 +103,19 @@ $fieldsets = $this->form->getFieldsets();
 
 		<fieldset>
 			<legend>
-				<?php echo JText::_('COM_USERS_USER_OTEPS') ?>
+				<?php echo JText::_('COM_USERS_USER_OTEPS'); ?>
 			</legend>
 			<div class="alert alert-info">
-				<?php echo JText::_('COM_USERS_USER_OTEPS_DESC') ?>
+				<?php echo JText::_('COM_USERS_USER_OTEPS_DESC'); ?>
 			</div>
 			<?php if (empty($this->otpConfig->otep)) : ?>
 			<div class="alert alert-warning">
-				<?php echo JText::_('COM_USERS_USER_OTEPS_WAIT_DESC') ?>
+				<?php echo JText::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
 			</div>
 			<?php else : ?>
 			<?php foreach ($this->otpConfig->otep as $otep) : ?>
 			<span class="span3">
-				<?php echo substr($otep, 0, 4) ?>-<?php echo substr($otep, 4, 4) ?>-<?php echo substr($otep, 8, 4) ?>-<?php echo substr($otep, 12, 4) ?>
+				<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
 			</span>
 			<?php endforeach; ?>
 			<div class="clearfix"></div>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -79,7 +79,7 @@ $fieldsets = $this->form->getFieldsets();
 			echo JLayoutHelper::render('joomla.edit.params', $this);
 			?>
 
-		<?php if (!empty($this->tfaform) && $this->item->id): ?>
+		<?php if (!empty($this->tfaform) && $this->item->id) : ?>
 		<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'twofactorauth', JText::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
 		<div class="control-group">
 			<div class="control-label">
@@ -93,7 +93,7 @@ $fieldsets = $this->form->getFieldsets();
 			</div>
 		</div>
 		<div id="com_users_twofactor_forms_container">
-			<?php foreach ($this->tfaform as $form): ?>
+			<?php foreach ($this->tfaform as $form) : ?>
 			<?php $style = $form['method'] == $this->otpConfig->method ? 'display: block' : 'display: none'; ?>
 			<div id="com_users_twofactor_<?php echo $form['method'] ?>" style="<?php echo $style; ?>">
 				<?php echo $form['form'] ?>
@@ -108,12 +108,12 @@ $fieldsets = $this->form->getFieldsets();
 			<div class="alert alert-info">
 				<?php echo JText::_('COM_USERS_USER_OTEPS_DESC') ?>
 			</div>
-			<?php if (empty($this->otpConfig->otep)): ?>
+			<?php if (empty($this->otpConfig->otep)) : ?>
 			<div class="alert alert-warning">
 				<?php echo JText::_('COM_USERS_USER_OTEPS_WAIT_DESC') ?>
 			</div>
-			<?php else: ?>
-			<?php foreach ($this->otpConfig->otep as $otep): ?>
+			<?php else : ?>
+			<?php foreach ($this->otpConfig->otep as $otep) : ?>
 			<span class="span3">
 				<?php echo substr($otep, 0, 4) ?>-<?php echo substr($otep, 4, 4) ?>-<?php echo substr($otep, 8, 4) ?>-<?php echo substr($otep, 12, 4) ?>
 			</span>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -148,9 +148,9 @@ $loggeduser = JFactory::getUser();
 							<?php echo JStringPunycode::emailToUTF8($this->escape($item->email)); ?>
 						</td>
 						<td class="hidden-phone hidden-tablet">
-							<?php if ($item->lastvisitDate != $this->db->getNullDate()): ?>
+							<?php if ($item->lastvisitDate != $this->db->getNullDate()) : ?>
 								<?php echo JHtml::_('date', $item->lastvisitDate, 'Y-m-d H:i:s'); ?>
-							<?php else: ?>
+							<?php else : ?>
 								<?php echo JText::_('JNEVER'); ?>
 							<?php endif; ?>
 						</td>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -25,7 +25,7 @@ $loggeduser = JFactory::getUser();
 		<div id="j-main-container" class="span10">
 	<?php else : ?>
 		<div id="j-main-container">
-	<?php endif;?>
+	<?php endif; ?>
 		<?php
 		// Search tools bar
 		echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this));
@@ -115,7 +115,7 @@ $loggeduser = JFactory::getUser();
 							<?php endif; ?>
 							<?php if (JDEBUG) : ?>
 								<div class="small"><a href="<?php echo JRoute::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $item->id); ?>">
-								<?php echo JText::_('COM_USERS_DEBUG_USER');?></a></div>
+								<?php echo JText::_('COM_USERS_DEBUG_USER'); ?></a></div>
 							<?php endif; ?>
 						</td>
 						<td class="break-word">
@@ -148,11 +148,11 @@ $loggeduser = JFactory::getUser();
 							<?php echo JStringPunycode::emailToUTF8($this->escape($item->email)); ?>
 						</td>
 						<td class="hidden-phone hidden-tablet">
-							<?php if ($item->lastvisitDate != $this->db->getNullDate()):?>
+							<?php if ($item->lastvisitDate != $this->db->getNullDate()): ?>
 								<?php echo JHtml::_('date', $item->lastvisitDate, 'Y-m-d H:i:s'); ?>
-							<?php else:?>
+							<?php else: ?>
 								<?php echo JText::_('JNEVER'); ?>
-							<?php endif;?>
+							<?php endif; ?>
 						</td>
 						<td class="hidden-phone hidden-tablet">
 							<?php echo JHtml::_('date', $item->registerDate, 'Y-m-d H:i:s'); ?>
@@ -177,7 +177,7 @@ $loggeduser = JFactory::getUser();
 					),
 					$this->loadTemplate('batch_body')
 				); ?>
-			<?php endif;?>
+			<?php endif; ?>
 		<?php endif; ?>
 
 		<input type="hidden" name="task" value="" />

--- a/administrator/components/com_users/views/users/tmpl/default_batch_body.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_body.php
@@ -27,22 +27,22 @@ JHtml::_('formbehavior.chosen', 'select');
 <div class="row-fluid">
 	<div id="batch-choose-action" class="combo control-group">
 		<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
-			<?php echo JText::_('COM_USERS_BATCH_GROUP') ?>
+			<?php echo JText::_('COM_USERS_BATCH_GROUP'); ?>
 		</label>
 	</div>
 	<div id="batch-choose-action" class="combo controls">
 		<div class="control-group">
 			<select name="batch[group_id]" id="batch-group-id">
-				<option value=""><?php echo JText::_('JSELECT') ?></option>
+				<option value=""><?php echo JText::_('JSELECT'); ?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
 			</select>
 		</div>
 	</div>
 	<div class="control-group radio">
-		<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add') ?>
+		<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add'); ?>
 	</div>
 </div>
 <label><?php echo JText::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>
 <div class="control-group radio">
-	<?php echo JHtml::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', '') ?>
+	<?php echo JHtml::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', ''); ?>
 </div>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -49,7 +49,7 @@ if ($isMoo)
 		<?php if (!$userRequired) : ?>
 		<div class="pull-left">
 			<button type="button" class="btn button-select" data-user-value="0" data-user-name="<?php echo $this->escape(JText::_('JLIB_FORM_SELECT_USER')); ?>"
-				data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>value="" onclick="window.parent.jSelectUser(this)"<?php endif; ?>><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
+				data-user-field="<?php echo $this->escape($field); ?>" <?php if ($isMoo) : ?>value="" onclick="window.parent.jSelectUser(this)"<?php endif; ?>><?php echo JText::_('JOPTION_NO_USER'); ?></button>&nbsp;
 		</div>
 		<?php endif; ?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
@@ -95,7 +95,7 @@ if ($isMoo)
 				<tr class="row<?php echo $i % 2; ?>">
 					<td>
 						<a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
-							data-user-field="<?php echo $this->escape($field);?>" <?php if ($isMoo) : ?>onclick="<?php echo $onClick; ?>"<?php endif; ?>>
+							data-user-field="<?php echo $this->escape($field); ?>" <?php if ($isMoo) : ?>onclick="<?php echo $onClick; ?>"<?php endif; ?>>
 							<?php echo $this->escape($item->name); ?>
 						</a>
 					</td>


### PR DESCRIPTION
### Summary of Changes

Removed unnecessary spaces after PHP code opening tag.
Removed unnecessary spaces before PHP code closing tag.
Added a white-space before PHP code closing tag where missing.
Fixed style for control structures alternative syntax.
Added a semicolon at the end of statement where missing. 

### Testing Instructions

Code review.

### Documentation Changes Required

None.