### PR TITLE
[com_fields] Save as Copy should use the group_id

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -118,8 +118,9 @@ class FieldsModelField extends JModelAdmin
 
 			if ($data['title'] == $origTable->title)
 			{
-				list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
+				list($title, $alias) = $this->generateNewTitle($data['group_id'], $data['alias'], $data['title']);
 				$data['title'] = $title;
+				$data['label'] = $title;
 				$data['alias'] = $alias;
 			}
 			else


### PR DESCRIPTION
### Summary of Changes
When a field is copied then the following error happens:

    Notice: Undefined index: catid in /joomla-cms/administrator/components/com_fields/models/field.php on line 121

### Testing Instructions
- Set Error reporting to maximum in your Joomla configuration
- On the back end go to Articles -> Fields
- Create a new field and save it
- Hit the _Save as Copy_ button

### Expected result
Copy of the field should be created and no error should be shown.

### Actual result
Error is thrown.