### PR TITLE
[com_fields] Remove alias from fields

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   `context` varchar(255) NOT NULL DEFAULT '',
   `group_id` int(10) NOT NULL DEFAULT 0,
   `title` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(255) NOT NULL DEFAULT '',
   `label` varchar(255) NOT NULL DEFAULT '',
   `default_value` text NOT NULL DEFAULT '',
   `type` varchar(255) NOT NULL DEFAULT 'text',

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
@@ -7,7 +7,6 @@ CREATE TABLE "#__fields" (
   "context" varchar(255) DEFAULT '' NOT NULL,
   "group_id" bigint DEFAULT 0 NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "alias" varchar(255) DEFAULT '' NOT NULL,
   "label" varchar(255) DEFAULT '' NOT NULL,
   "default_value" text DEFAULT '' NOT NULL,
   "type" varchar(255) DEFAULT 'text' NOT NULL,

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -151,11 +151,7 @@ class FieldsHelper
 				 */
 				$field = clone $original;
 
-				if ($valuesToOverride && key_exists($field->alias, $valuesToOverride))
-				{
-					$field->value = $valuesToOverride[$field->alias];
-				}
-				elseif ($valuesToOverride && key_exists($field->id, $valuesToOverride))
+				if ($valuesToOverride && key_exists($field->id, $valuesToOverride))
 				{
 					$field->value = $valuesToOverride[$field->id];
 				}
@@ -504,7 +500,7 @@ class FieldsHelper
 			if (!is_array($value) && $value !== '')
 			{
 				// Function getField doesn't cache the fields, so we try to do it only when necessary
-				$formField = $form->getField($field->alias, 'params');
+				$formField = $form->getField($field->id, 'params');
 
 				if ($formField && $formField->forceMultiple)
 				{
@@ -513,7 +509,7 @@ class FieldsHelper
 			}
 
 			// Setting the value on the field
-			$form->setValue($field->alias, 'params', $value);
+			$form->setValue($field->id, 'params', $value);
 		}
 
 		return true;

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -74,7 +74,7 @@ class FieldsHelper
 	 * Should the value being prepared to be shown in an HTML context then
 	 * prepareValue must be set to true. No further escaping needs to be done.
 	 * The values of the fields can be overridden by an associative array where the keys
-	 * can be an id or an alias and it's corresponding value.
+	 * has to be an id or and it's corresponding value.
 	 *
 	 * @param   string    $context           The context of the content passed to the helper
 	 * @param   stdClass  $item              item
@@ -347,7 +347,7 @@ class FieldsHelper
 		// Creating the dom
 		$xml = new DOMDocument('1.0', 'UTF-8');
 		$fieldsNode = $xml->appendChild(new DOMElement('form'))->appendChild(new DOMElement('fields'));
-		$fieldsNode->setAttribute('name', 'params');
+		$fieldsNode->setAttribute('name', 'com_fields');
 
 		// Organizing the fields according to their group
 		$fieldsPerGroup = array(
@@ -500,7 +500,7 @@ class FieldsHelper
 			if (!is_array($value) && $value !== '')
 			{
 				// Function getField doesn't cache the fields, so we try to do it only when necessary
-				$formField = $form->getField($field->id, 'params');
+				$formField = $form->getField($field->id, 'com_fields');
 
 				if ($formField && $formField->forceMultiple)
 				{
@@ -509,7 +509,7 @@ class FieldsHelper
 			}
 
 			// Setting the value on the field
-			$form->setValue($field->id, 'params', $value);
+			$form->setValue($field->id, 'com_fields', $value);
 		}
 
 		return true;

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -138,7 +138,7 @@ abstract class FieldsPlugin extends JPlugin
 		$node = $parent->appendChild(new DOMElement('field'));
 
 		// Set the attributes
-		$node->setAttribute('name', $field->alias);
+		$node->setAttribute('name', $field->id);
 		$node->setAttribute('type', $field->type);
 		$node->setAttribute('default', $field->default_value);
 		$node->setAttribute('label', $field->label);

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -89,29 +89,11 @@ class FieldsModelField extends JModelAdmin
 			unset($data['params']['label']);
 		}
 
-		// Alter the title for save as copy
+		// Save new field as unpublished
 		$input = JFactory::getApplication()->input;
 
 		if ($input->get('task') == 'save2copy')
 		{
-			$origTable = clone $this->getTable();
-			$origTable->load($input->getInt('id'));
-
-			if ($data['title'] == $origTable->title)
-			{
-				list($title, $alias) = $this->generateNewTitle($data['group_id'], $data['alias'], $data['title']);
-				$data['title'] = $title;
-				$data['label'] = $title;
-				$data['alias'] = $alias;
-			}
-			else
-			{
-				if ($data['alias'] == $origTable->alias)
-				{
-					$data['alias'] = '';
-				}
-			}
-
 			$data['state'] = 0;
 		}
 
@@ -265,34 +247,6 @@ class FieldsModelField extends JModelAdmin
 		$table->type = 'text';
 
 		return $table;
-	}
-
-	/**
-	 * Method to change the title & alias.
-	 *
-	 * @param   integer  $category_id  The id of the category.
-	 * @param   string   $alias        The alias.
-	 * @param   string   $title        The title.
-	 *
-	 * @return  array  Contains the modified title and alias.
-	 *
-	 * @since    3.7.0
-	 */
-	protected function generateNewTitle($category_id, $alias, $title)
-	{
-		// Alter the title & alias
-		$table = $this->getTable();
-
-		while ($table->load(array('alias' => $alias)))
-		{
-			$title = StringHelper::increment($title);
-			$alias = StringHelper::increment($alias, 'dash');
-		}
-
-		return array(
-			$title,
-			$alias,
-		);
 	}
 
 	/**

--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -34,7 +34,6 @@ class FieldsModelFields extends JModelList
 				'id', 'a.id',
 				'title', 'a.title',
 				'type', 'a.type',
-				'alias', 'a.alias',
 				'state', 'a.state',
 				'access', 'a.access',
 				'access_level',
@@ -133,7 +132,7 @@ class FieldsModelFields extends JModelList
 		$query->select(
 			$this->getState(
 				'list.select',
-				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.note' .
+				'a.id, a.title, a.checked_out, a.checked_out_time, a.note' .
 				', a.state, a.access, a.created_time, a.created_user_id, a.ordering, a.language' .
 				', a.fieldparams, a.params, a.type, a.default_value, a.context, a.group_id' .
 				', a.label, a.description, a.required'
@@ -284,7 +283,7 @@ class FieldsModelFields extends JModelList
 			else
 			{
 				$search = $db->quote('%' . str_replace(' ', '%', $db->escape(trim($search), true) . '%'));
-				$query->where('(a.title LIKE ' . $search . ' OR a.alias LIKE ' . $search . ' OR a.note LIKE ' . $search . ')');
+				$query->where('(a.title LIKE ' . $search . ' OR a.note LIKE ' . $search . ')');
 			}
 		}
 

--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -51,16 +51,7 @@
 			size="40"
 			required="true"
 		/>
-		
-		<field
-			name="alias"
-			type="text"
-			label="JFIELD_ALIAS_LABEL"
-			description="JFIELD_ALIAS_DESC"
-			hint="JFIELD_ALIAS_PLACEHOLDER"
-			size="45"
-		/>
-	
+
 		<field
 			name="type"
 			type="type"

--- a/administrator/components/com_fields/tables/field.php
+++ b/administrator/components/com_fields/tables/field.php
@@ -91,20 +91,6 @@ class FieldsTableField extends JTable
 			return false;
 		}
 
-		if (empty($this->alias))
-		{
-			$this->alias = $this->title;
-		}
-
-		$this->alias = JApplicationHelper::stringURLSafe($this->alias);
-
-		if (trim(str_replace('-', '', $this->alias)) == '')
-		{
-			$this->alias = Joomla\String\StringHelper::increment($this->alias, 'dash');
-		}
-
-		$this->alias = str_replace(',', '-', $this->alias);
-
 		if (empty($this->type))
 		{
 			$this->type = 'text';

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -135,10 +135,8 @@ if ($saveOrder)
 										<?php echo $this->escape($item->title); ?>
 									<?php endif; ?>
 									<span class="small break-word">
-										<?php if (empty($item->note)) : ?>
-											<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-										<?php else : ?>
-											<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+										<?php if ($item->note) : ?>
+											<?php echo JText::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 										<?php endif; ?>
 									</span>
 									<div class="small">

--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -199,7 +199,7 @@ class ContactControllerContact extends JControllerForm
 			$body   = $prefix . "\n" . $name . ' <' . $email . '>' . "\r\n\r\n" . stripslashes($body);
 
 			// Load the custom fields
-			if ($data['params'] && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['params']))
+			if ($data['com_fields'] && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
 			{
 				$output = FieldsHelper::render(
 							'com_contact.mail',

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * @package     Joomla.Site
@@ -66,7 +67,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($params->get('show_urls_images_frontend')) : ?>
-			<?php echo JHtml::_("bootstrap.addTab", $this->tab_name, "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'images', JText::_('COM_CONTENT_IMAGES_AND_URLS')); ?>
 				<?php echo $this->form->renderField('image_intro', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -13,6 +13,8 @@ JHtml::_('behavior.tabstate');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', 'select');
+$this->tab_name = 'com-content-form';
+$this->ignore_fieldsets = array('image-intro', 'image-full', 'jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');
@@ -47,9 +49,9 @@ JFactory::getDocument()->addScriptDeclaration("
 
 	<form action="<?php echo JRoute::_('index.php?option=com_content&a_id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="adminForm" class="form-validate form-vertical">
 		<fieldset>
-			<?php echo JHtml::_('bootstrap.startTabSet', 'com-content-form', array('active' => 'editor')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', $this->tab_name, array('active' => 'editor')); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'editor', JText::_('COM_CONTENT_ARTICLE_CONTENT')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'editor', JText::_('COM_CONTENT_ARTICLE_CONTENT')); ?>
 				<?php echo $this->form->renderField('title'); ?>
 
 				<?php if (is_null($this->item->id)) : ?>
@@ -64,7 +66,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($params->get('show_urls_images_frontend')) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'images', JText::_('COM_CONTENT_IMAGES_AND_URLS')); ?>
+			<?php echo JHtml::_("bootstrap.addTab", $this->tab_name, "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
 				<?php echo $this->form->renderField('image_intro', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
@@ -97,18 +99,9 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
-			<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-				<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'params-' . $name, JText::_($fieldSet->label)); ?>
-					<?php if (isset($fieldSet->description) && trim($fieldSet->description)) : ?>
-						<?php echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>'; ?>
-					<?php endif; ?>
-					<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-						<?php echo $field->renderField(); ?>
-					<?php endforeach; ?>
-				<?php echo JHtml::_('bootstrap.endTab'); ?>
-			<?php endforeach; ?>
+			<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'publishing', JText::_('COM_CONTENT_PUBLISHING')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'publishing', JText::_('COM_CONTENT_PUBLISHING')); ?>
 				<?php echo $this->form->renderField('catid'); ?>
 				<?php echo $this->form->renderField('tags'); ?>
 				<?php if ($params->get('save_history', 0)) : ?>
@@ -133,11 +126,11 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
 				<?php echo $this->form->renderField('language'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
 				<?php echo $this->form->renderField('metadesc'); ?>
 				<?php echo $this->form->renderField('metakey'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -29,7 +29,7 @@ $customFields = array();
 
 foreach ($tmp as $customField)
 {
-	$customFields[$customField->alias] = $customField;
+	$customFields[$customField->id] = $customField;
 }
 ?>
 <?php foreach ($fieldsets as $group => $fieldset) : ?>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -657,7 +657,6 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   `context` varchar(255) NOT NULL DEFAULT '',
   `group_id` int(10) NOT NULL DEFAULT 0,
   `title` varchar(255) NOT NULL DEFAULT '',
-  `alias` varchar(255) NOT NULL DEFAULT '',
   `label` varchar(255) NOT NULL DEFAULT '',
   `default_value` text NOT NULL DEFAULT '',
   `type` varchar(255) NOT NULL DEFAULT 'text',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -670,7 +670,6 @@ CREATE TABLE "#__fields" (
   "context" varchar(255) DEFAULT '' NOT NULL,
   "group_id" bigint DEFAULT 0 NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
-  "alias" varchar(255) DEFAULT '' NOT NULL,
   "label" varchar(255) DEFAULT '' NOT NULL,
   "default_value" text DEFAULT '' NOT NULL,
   "type" varchar(255) DEFAULT 'text' NOT NULL,

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -21,6 +21,7 @@ if (empty($fieldSets))
 $ignoreFieldsets = $displayData->get('ignore_fieldsets') ?: array();
 $ignoreFields    = $displayData->get('ignore_fields') ?: array();
 $extraFields     = $displayData->get('extra_fields') ?: array();
+$tabName         = $displayData->get('tab_name') ?: 'myTab';
 
 if (!empty($displayData->hiddenFieldsets))
 {
@@ -62,7 +63,7 @@ if ($displayData->get('show_options', 1))
 			$label = JText::_($label);
 		}
 
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-' . $name, $label);
+		echo JHtml::_('bootstrap.addTab', $tabName, 'attrib-' . $name, $label);
 
 		if (isset($fieldSet->description) && trim($fieldSet->description))
 		{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -83,10 +83,10 @@ class PlgSystemFields extends JPlugin
 		foreach ($fieldsObjects as $field)
 		{
 			// Set the param on the fields variable
-			$fields[$field->alias] = key_exists($field->alias, $params) ? $params[$field->alias] : array();
+			$fields[$field->id] = key_exists($field->id, $params) ? $params[$field->id] : array();
 
 			// Remove it from the params array
-			unset($params[$field->alias]);
+			unset($params[$field->id]);
 		}
 
 		$item->_fields = $fields;
@@ -148,8 +148,8 @@ class PlgSystemFields extends JPlugin
 
 		foreach ($fieldsObjects as $field)
 		{
-			// Only save the fields with the alias from the data
-			if (!key_exists($field->alias, $fields))
+			// Only save the fields with the id from the data
+			if (!key_exists($field->id, $fields))
 			{
 				continue;
 			}
@@ -167,7 +167,7 @@ class PlgSystemFields extends JPlugin
 			}
 
 			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $context, $id, $fields[$field->alias]);
+			$model->setFieldValue($field->id, $context, $id, $fields[$field->id]);
 		}
 
 		return true;
@@ -527,10 +527,10 @@ class PlgSystemFields extends JPlugin
 					foreach ($fields as $field)
 					{
 						// Adding the instructions how to handle the text
-						$item->addInstruction(FinderIndexer::TEXT_CONTEXT, $field->alias);
+						$item->addInstruction(FinderIndexer::TEXT_CONTEXT, $field->id);
 
 						// Adding the field value as a field
-						$item->{$field->alias} = $field->value;
+						$item->{$field->id} = $field->value;
 					}
 				}
 			}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -59,43 +59,24 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		$params = new Registry;
-
-		// Load the item params from the request
+		// Load the fields data from the request
 		$data = JFactory::getApplication()->input->post->get('jform', array(), 'array');
 
-		if (key_exists('params', $data))
+		if (!key_exists('com_fields', $data))
 		{
-			$params->loadArray($data['params']);
+			return true;
 		}
-
-		// Load the params from the item itself
-		if (isset($item->params))
-		{
-			$params->loadString($item->params);
-		}
-
-		$params = $params->toArray();
 
 		// Create the new internal fields field
-		$fields = array();
+		$item->_fields = array();
 
 		foreach ($fieldsObjects as $field)
 		{
-			// Set the param on the fields variable
-			$fields[$field->id] = key_exists($field->id, $params) ? $params[$field->id] : array();
-
-			// Remove it from the params array
-			unset($params[$field->id]);
+			// Set the field data on the fields variable
+			$item->_fields[$field->id] = key_exists($field->id, $data['com_fields']) ? $data['com_fields'][$field->id] : array();
 		}
 
-		$item->_fields = $fields;
-
-		// Update the cleaned up params
-		if (isset($item->params))
-		{
-			$item->params = json_encode($params);
-		}
+		unset ($data['com_fields']);
 
 		return true;
 	}


### PR DESCRIPTION
Currently, com_fields uses an alias field as a name for the field in forms. But that alias really isn't used for anything else and can as well be substituted with the id, making the code actually simpler.

### Summary of Changes
Removes the alias from fields and changes its use to use the ID instead.
To avoid conflicts in general, fields are now stored in an own group called "com_fields" instead of the "params" that is used already by most extensions.

### Testing Instructions
Test creating, editing, deleting fields both in backend and frontend.
Test for fields in articles, users and contacts.

### Documentation Changes Required
None.