### PR TITLE
Unnecessary double quotes in site components

### DIFF
--- a/components/com_banners/models/banners.php
+++ b/components/com_banners/models/banners.php
@@ -152,14 +152,14 @@ class BannersModelBanners extends JModelList
 				foreach ($keywords as $keyword)
 				{
 					$keyword = trim($keyword);
-					$condition1 = "a.own_prefix=1 "
-						. " AND a.metakey_prefix=SUBSTRING(" . $db->quote($keyword) . ",1,LENGTH( a.metakey_prefix)) "
-						. " OR a.own_prefix=0 "
-						. " AND cl.own_prefix=1 "
-						. " AND cl.metakey_prefix=SUBSTRING(" . $db->quote($keyword) . ",1,LENGTH(cl.metakey_prefix)) "
-						. " OR a.own_prefix=0 "
-						. " AND cl.own_prefix=0 "
-						. " AND " . ($prefix == substr($keyword, 0, strlen($prefix)) ? '1' : '0');
+					$condition1 = 'a.own_prefix=1 '
+						. ' AND a.metakey_prefix=SUBSTRING(' . $db->quote($keyword) . ',1,LENGTH( a.metakey_prefix)) '
+						. ' OR a.own_prefix=0 '
+						. ' AND cl.own_prefix=1 '
+						. ' AND cl.metakey_prefix=SUBSTRING(' . $db->quote($keyword) . ',1,LENGTH(cl.metakey_prefix)) '
+						. ' OR a.own_prefix=0 '
+						. ' AND cl.own_prefix=0 '
+						. ' AND ' . ($prefix == substr($keyword, 0, strlen($prefix)) ? '1' : '0');
 
 					$condition2 = "a.metakey REGEXP '[[:<:]]" . $db->escape($keyword) . "[[:>:]]'";
 

--- a/components/com_content/helpers/route.php
+++ b/components/com_content/helpers/route.php
@@ -37,7 +37,7 @@ abstract class ContentHelperRoute
 			$link .= '&catid=' . $catid;
 		}
 
-		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+		if ($language && $language != '*' && JLanguageMultilang::isEnabled())
 		{
 			$link .= '&lang=' . $language;
 		}
@@ -74,7 +74,7 @@ abstract class ContentHelperRoute
 		{
 			$link = 'index.php?option=com_content&view=category&id=' . $id;
 
-			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+			if ($language && $language != '*' && JLanguageMultilang::isEnabled())
 			{
 				$link .= '&lang=' . $language;
 			}

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -245,7 +245,7 @@ class ContentModelArticles extends JModelList
 
 		// Join over the users for the author and modified_by names.
 		$query->select("CASE WHEN a.created_by_alias > ' ' THEN a.created_by_alias ELSE ua.name END AS author")
-			->select("ua.email AS author_email")
+			->select('ua.email AS author_email')
 
 			->join('LEFT', '#__users AS ua ON ua.id = a.created_by')
 			->join('LEFT', '#__users AS uam ON uam.id = a.modified_by');

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -136,8 +136,8 @@ class ContentViewArchive extends JViewLegacy
 		$this->params     = &$params;
 		$this->user       = &$user;
 		$this->pagination = &$pagination;
-		$this->pagination->setAdditionalUrlParam("month", $state->get('filter.month'));
-		$this->pagination->setAdditionalUrlParam("year", $state->get('filter.year'));
+		$this->pagination->setAdditionalUrlParam('month', $state->get('filter.month'));
+		$this->pagination->setAdditionalUrlParam('year', $state->get('filter.year'));
 
 		$this->_prepareDocument();
 

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -33,13 +33,11 @@ if (!empty($this->items))
 }
 
 // For B/C we also add the css classes inline. This will be removed in 4.0.
-JFactory::getDocument()->addStyleDeclaration(
-	'
+JFactory::getDocument()->addStyleDeclaration('
 .hide { display: none; }
 .table-noheader { border-collapse: collapse; }
 .table-noheader thead { display: none; }
-'
-);
+');
 
 $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 ?>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -33,11 +33,13 @@ if (!empty($this->items))
 }
 
 // For B/C we also add the css classes inline. This will be removed in 4.0.
-JFactory::getDocument()->addStyleDeclaration("
+JFactory::getDocument()->addStyleDeclaration(
+	'
 .hide { display: none; }
 .table-noheader { border-collapse: collapse; }
 .table-noheader thead { display: none; }
-");
+'
+);
 
 $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 ?>
@@ -97,11 +99,11 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 				</th>
 				<?php if ($date = $this->params->get('list_show_date')) : ?>
 					<th scope="col" id="categorylist_header_date">
-						<?php if ($date == "created") : ?>
+						<?php if ($date == 'created') : ?>
 							<?php echo JHtml::_('grid.sort', 'COM_CONTENT_' . $date . '_DATE', 'a.created', $listDirn, $listOrder); ?>
-						<?php elseif ($date == "modified") : ?>
+						<?php elseif ($date == 'modified') : ?>
 							<?php echo JHtml::_('grid.sort', 'COM_CONTENT_' . $date . '_DATE', 'a.modified', $listDirn, $listOrder); ?>
-						<?php elseif ($date == "published") : ?>
+						<?php elseif ($date == 'published') : ?>
 							<?php echo JHtml::_('grid.sort', 'COM_CONTENT_' . $date . '_DATE', 'a.publish_up', $listDirn, $listOrder); ?>
 						<?php endif; ?>
 					</th>

--- a/components/com_content/views/category/view.feed.php
+++ b/components/com_content/views/category/view.feed.php
@@ -41,7 +41,7 @@ class ContentViewCategory extends JViewCategoryfeed
 		$obj = json_decode($item->images);
 		$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
 
-		if (isset($introImage) && ($introImage != "")) 
+		if (isset($introImage) && ($introImage != ''))
 		{
 			$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;
 			$item->description = '<p><img src="' . $image . '" /></p>';

--- a/components/com_content/views/featured/view.feed.php
+++ b/components/com_content/views/featured/view.feed.php
@@ -63,7 +63,7 @@ class ContentViewFeatured extends JViewLegacy
 			$obj = json_decode($row->images);
 			$introImage = ( isset( $obj->{'image_intro'} ) ) ? $obj->{'image_intro'} : '';
 
-			if (isset($introImage) && ($introImage != "")) 
+			if (isset($introImage) && ($introImage != ''))
 			{
 				$image = preg_match('/http/', $introImage)? $introImage : JURI::root() . $introImage;
 				$description = '<p><img src="' . $image . '" /></p>';

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -47,9 +47,9 @@ JFactory::getDocument()->addScriptDeclaration("
 
 	<form action="<?php echo JRoute::_('index.php?option=com_content&a_id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="adminForm" class="form-validate form-vertical">
 		<fieldset>
-			<?php echo JHtml::_("bootstrap.startTabSet", "com-content-form", array("active" => "editor")); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', 'com-content-form', array('active' => 'editor')); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "editor", JText::_("COM_CONTENT_ARTICLE_CONTENT")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'editor', JText::_('COM_CONTENT_ARTICLE_CONTENT')); ?>
 				<?php echo $this->form->renderField('title'); ?>
 
 				<?php if (is_null($this->item->id)) : ?>
@@ -61,10 +61,10 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php if ($this->captchaEnabled) : ?>
 					<?php echo $this->form->renderField('captcha'); ?>
 				<?php endif; ?>
-			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($params->get('show_urls_images_frontend')) : ?>
-			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "images", JText::_("COM_CONTENT_IMAGES_AND_URLS")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'images', JText::_('COM_CONTENT_IMAGES_AND_URLS')); ?>
 				<?php echo $this->form->renderField('image_intro', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
@@ -94,21 +94,21 @@ JFactory::getDocument()->addScriptDeclaration("
 						<?php echo $this->form->getInput('targetc', 'urls'); ?>
 					</div>
 				</div>
-			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
 			<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-				<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "params-" . $name, JText::_($fieldSet->label)); ?>
+				<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'params-' . $name, JText::_($fieldSet->label)); ?>
 					<?php if (isset($fieldSet->description) && trim($fieldSet->description)) : ?>
 						<?php echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>'; ?>
 					<?php endif; ?>
 					<?php foreach ($this->form->getFieldset($name) as $field) : ?>
 						<?php echo $field->renderField(); ?>
 					<?php endforeach; ?>
-				<?php echo JHtml::_("bootstrap.endTab"); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endforeach; ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "publishing", JText::_("COM_CONTENT_PUBLISHING")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'publishing', JText::_('COM_CONTENT_PUBLISHING')); ?>
 				<?php echo $this->form->renderField('catid'); ?>
 				<?php echo $this->form->renderField('tags'); ?>
 				<?php if ($params->get('save_history', 0)) : ?>
@@ -131,18 +131,18 @@ JFactory::getDocument()->addScriptDeclaration("
 						</div>
 					</div>
 				<?php endif; ?>
-			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "language", JText::_("JFIELD_LANGUAGE_LABEL")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
 				<?php echo $this->form->renderField('language'); ?>
-			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_("bootstrap.addTab", "com-content-form", "metadata", JText::_("COM_CONTENT_METADATA")); ?>
+			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
 				<?php echo $this->form->renderField('metadesc'); ?>
 				<?php echo $this->form->renderField('metakey'); ?>
-			<?php echo JHtml::_("bootstrap.endTab"); ?>
+			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_("bootstrap.endTabSet"); ?>
+			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -26,6 +26,6 @@ if ($value == '')
 ?>
 
 <dd class="field-entry <?php echo $class; ?>" id="field-entry-<?php echo $field->id; ?>">
-	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, "UTF-8"); ?>: </span>
+	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 	<span class="field-value"><?php echo $value; ?></span>
 </dd>

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -172,8 +172,8 @@ abstract class JHtmlFilter
 			);
 
 			// Populate the toggle button.
-			$html .= '<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery(\'[id=tax-'
-				. $bk . ']\').each(function(){this.click();});"><span class="icon-checkbox-partial"></span> '
+			$html .= '<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery(\'[id="tax-'
+				. $bk . '"]\').each(function(){this.click();});"><span class="icon-checkbox-partial"></span> '
 				. JText::_('JGLOBAL_SELECTION_INVERT') . '</button><hr/>';
 
 			// Populate the group with nodes.

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -172,9 +172,9 @@ abstract class JHtmlFilter
 			);
 
 			// Populate the toggle button.
-			$html .= "<button class=\"btn\" type=\"button\" class=\"jform-rightbtn\" onclick=\"jQuery('[id=tax-"
-				. $bk . "]').each(function(){this.click();});\"><span class=\"icon-checkbox-partial\"></span> "
-				. JText::_('JGLOBAL_SELECTION_INVERT') . "</button><hr/>";
+			$html .= '<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery(\'[id=tax-'
+				. $bk . ']\').each(function(){this.click();});"><span class="icon-checkbox-partial"></span> '
+				. JText::_('JGLOBAL_SELECTION_INVERT') . '</button><hr/>';
 
 			// Populate the group with nodes.
 			foreach ($nodes as $nk => $nv)

--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -15,6 +15,7 @@ if ($this->params->get('show_advanced', 1) || $this->params->get('show_autosugge
 
 	$script = "
 jQuery(function() {";
+
 	if ($this->params->get('show_advanced', 1))
 	{
 		/*
@@ -33,6 +34,7 @@ jQuery(function() {";
 		});
 	});";
 	}
+
 	/*
 	* This segment of code sets up the autocompleter.
 	*/

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -35,7 +35,7 @@ abstract class NewsfeedsHelperRoute
 			$link .= '&catid=' . $catid;
 		}
 
-		if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+		if ($language && $language != '*' && JLanguageMultilang::isEnabled())
 		{
 			$link .= '&lang=' . $language;
 		}
@@ -71,7 +71,7 @@ abstract class NewsfeedsHelperRoute
 			// Create the link
 			$link = 'index.php?option=com_newsfeeds&view=category&id=' . $id;
 
-			if ($language && $language != "*" && JLanguageMultilang::isEnabled())
+			if ($language && $language != '*' && JLanguageMultilang::isEnabled())
 			{
 				$link .= '&lang=' . $language;
 			}

--- a/components/com_newsfeeds/views/newsfeed/tmpl/default.php
+++ b/components/com_newsfeeds/views/newsfeed/tmpl/default.php
@@ -17,31 +17,31 @@ else
 {
 	$lang      = JFactory::getLanguage();
 	$myrtl     = $this->newsfeed->rtl;
-	$direction = " ";
+	$direction = ' ';
 
 		if ($lang->isRtl() && $myrtl == 0)
 		{
-			$direction = " redirect-rtl";
+			$direction = ' redirect-rtl';
 		}
 		elseif ($lang->isRtl() && $myrtl == 1)
 		{
-			$direction = " redirect-ltr";
+			$direction = ' redirect-ltr';
 		}
 		elseif ($lang->isRtl() && $myrtl == 2)
 		{
-			$direction = " redirect-rtl";
+			$direction = ' redirect-rtl';
 		}
 		elseif ($myrtl == 0)
 		{
-			$direction = " redirect-ltr";
+			$direction = ' redirect-ltr';
 		}
 		elseif ($myrtl == 1)
 		{
-			$direction = " redirect-ltr";
+			$direction = ' redirect-ltr';
 		}
 		elseif ($myrtl == 2)
 		{
-			$direction = " redirect-rtl";
+			$direction = ' redirect-rtl';
 		}
 		$images = json_decode($this->item->images);
 	?>

--- a/components/com_tags/views/tag/tmpl/list_items.php
+++ b/components/com_tags/views/tag/tmpl/list_items.php
@@ -68,11 +68,11 @@ JFactory::getDocument()->addScriptDeclaration("
 					</th>
 					<?php if ($date = $this->params->get('tag_list_show_date')) : ?>
 						<th id="categorylist_header_date">
-							<?php if ($date == "created") : ?>
+							<?php if ($date == 'created') : ?>
 								<?php echo JHtml::_('grid.sort', 'COM_TAGS_' . $date . '_DATE', 'c.core_created_time', $listDirn, $listOrder); ?>
-							<?php elseif ($date == "modified") : ?>
+							<?php elseif ($date == 'modified') : ?>
 								<?php echo JHtml::_('grid.sort', 'COM_TAGS_' . $date . '_DATE', 'c.core_modified_time', $listDirn, $listOrder); ?>
-							<?php elseif ($date == "published") : ?>
+							<?php elseif ($date == 'published') : ?>
 								<?php echo JHtml::_('grid.sort', 'COM_TAGS_' . $date . '_DATE', 'c.core_publish_up', $listDirn, $listOrder); ?>
 							<?php endif; ?>
 						</th>

--- a/components/com_tags/views/tag/view.feed.php
+++ b/components/com_tags/views/tag/view.feed.php
@@ -35,7 +35,7 @@ class TagsViewTag extends JViewLegacy
 		$feedEmail        = $app->get('feed_email', 'none');
 		$document->editor = $fromName;
 
-		if ($feedEmail != "none")
+		if ($feedEmail != 'none')
 		{
 			$document->editorEmail = $siteEmail;
 		}

--- a/components/com_tags/views/tags/view.feed.php
+++ b/components/com_tags/views/tags/view.feed.php
@@ -35,7 +35,7 @@ class TagsViewTags extends JViewLegacy
 		$feedEmail        = $app->get('feed_email', 'none');
 		$document->editor = $fromName;
 
-		if ($feedEmail != "none")
+		if ($feedEmail != 'none')
 		{
 			$document->editorEmail = $siteEmail;
 		}

--- a/components/com_users/helpers/html/users.php
+++ b/components/com_users/helpers/html/users.php
@@ -92,7 +92,7 @@ abstract class JHtmlUsers
 
 			$value = htmlspecialchars($value, ENT_COMPAT, 'UTF-8');
 
-			if (substr($value, 0, 4) == "http")
+			if (substr($value, 0, 4) == 'http')
 			{
 				return '<a href="' . $value . '">' . $text . '</a>';
 			}

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -670,11 +670,11 @@ class UsersModelRegistration extends JModelForm
 
 		if ($useractivation == 1)
 		{
-			return "useractivate";
+			return 'useractivate';
 		}
 		elseif ($useractivation == 2)
 		{
-			return "adminactivate";
+			return 'adminactivate';
 		}
 		else
 		{


### PR DESCRIPTION
### Summary of Changes
- Replaced unnecessary double quotes in site/components
- Removed one or two whitespaces at EOLs (sorry, couldn't resist)
- Inserted a line before if statements where I stumbled upon (sorry, couldn't resist)

This PR is part of a set to try to separate some of the changes done in some of my previous batch PR's for site/components, which are still on hold (#12290, #12292, #12293, #12294).

### Testing Instructions

None, should not change behavior


### Documentation Changes Required

None.
