### PR TITLE
hide full mysql query appears in http status code

### DIFF
--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -131,11 +131,15 @@ class JDocumentError extends JDocument
 			$status = 500;
 		}
 
-		if(JFactory::getConfig()->get( 'error_reporting' ) == "development" || JFactory::getConfig()->get( 'error_reporting' ) == "maximum"){
-			JFactory::getApplication()->setHeader('status', $status . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
-		}else{
-			JFactory::getApplication()->setHeader('status', $status);
+		$errorReporting = JFactory::getConfig()->get('error_reporting');
+
+		if ($errorReporting === "development" || $errorReporting === "maximum")
+		{
+			$status .= ' ' . str_replace("\n", ' ', $this->_error->getMessage());
 		}
+
+		JFactory::getApplication()->setHeader('status', $status);
+
 		$file = 'error.php';
 
 		// Check template

--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -131,7 +131,11 @@ class JDocumentError extends JDocument
 			$status = 500;
 		}
 
-		JFactory::getApplication()->setHeader('status',  $status . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
+		if(JFactory::getConfig()->get( 'error_reporting' ) == "development" || JFactory::getConfig()->get( 'error_reporting' ) == "maximum"){
+			JFactory::getApplication()->setHeader('status', $status . ' ' . str_replace("\n", ' ', $this->_error->getMessage()));
+		}else{
+			JFactory::getApplication()->setHeader('status', $status);
+		}
 		$file = 'error.php';
 
 		// Check template


### PR DESCRIPTION
Pull Request for Issue # 13180

### Summary of Changes

### Testing Instructions

switch $error_reporting in configuration.php to none
public $error_reporting = 'none'; 

make a mistake in any mysql query on purpose  and look up the status HTTP status code in Chrome or any other tool (https://httpstatus.io/)

### Documentation Changes Required

show full MySQL query or the actually error message that appears in HTTP status code, only if error_reporting set to development and hide it from the public view

Issue tracker link: https://github.com/joomla/joomla-cms/issues/13180#issuecomment-266820356