### PR TITLE
Robots: replace empty value with index, follow

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -622,7 +622,7 @@
 			label="JFIELD_METADATA_ROBOTS_LABEL"
 			description="JFIELD_METADATA_ROBOTS_DESC"
 			default="">
-			<option value="">JGLOBAL_INDEX_FOLLOW</option>
+			<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
 			<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
 			<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
 			<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>


### PR DESCRIPTION
If you select the default "index, follow" in the Global Configuration the value is empty and no Robot-Tag is set. As remarked in various OnPage Tools this throws an error and additionally you set there index, follow so why this tag shouldn´t be shown as selected.

### Testing Instructions
Before applying the patch: Go into the Global configuration and be sure Robots is set to: index, follow
Check the Sourcecode in Frontend:
<meta name="robots" content="index, follow"> is missing

After applying patch:
Change value from index, follow to another one and then back
Check Frontend Sourcecode
<meta name="robots" content="index, follow"> should be shown.

