### PR TITLE
Changes on continue statements

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -1196,6 +1196,7 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 						$this->notify($message);
 					}
 					$this->runState = AK_STATE_NOFILE;
+					continue;
 			}
 		}
 

--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -1196,7 +1196,6 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 						$this->notify($message);
 					}
 					$this->runState = AK_STATE_NOFILE;
-					continue;
 			}
 		}
 

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -97,6 +97,8 @@ class ModMenuHelper
 					switch ($item->type)
 					{
 						case 'separator':
+							break;
+
 						case 'heading':
 							// No further action needed.
 							break;

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -99,7 +99,7 @@ class ModMenuHelper
 						case 'separator':
 						case 'heading':
 							// No further action needed.
-							continue;
+							continue 2;
 
 						case 'url':
 							if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false))

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -99,7 +99,7 @@ class ModMenuHelper
 						case 'separator':
 						case 'heading':
 							// No further action needed.
-							continue 2;
+							break;
 
 						case 'url':
 							if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false))


### PR DESCRIPTION
### Summary of Changes
- Remove unnecessary 'continue' function
- Change 'continue' so that it breaks out of the 'switch', as there is no need to compare against the rest.

### Testing Instructions

None, should not change behavior


### Documentation Changes Required

None.
