### PR TITLE
Simplify JLanguageMultilang::isEnabled()

### DIFF
--- a/libraries/cms/language/multilang.php
+++ b/libraries/cms/language/multilang.php
@@ -26,41 +26,7 @@ class JLanguageMultilang
 	 */
 	public static function isEnabled()
 	{
-		// Flag to avoid doing multiple database queries.
-		static $tested = false;
-
-		// Status of language filter plugin.
-		static $enabled = false;
-
-		// Get application object.
-		$app = JFactory::getApplication();
-
-		// If being called from the frontend, we can avoid the database query.
-		if ($app->isSite())
-		{
-			$enabled = $app->getLanguageFilter();
-
-			return $enabled;
-		}
-
-		// If already tested, don't test again.
-		if (!$tested)
-		{
-			// Determine status of language filter plugin.
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select('enabled')
-				->from($db->quoteName('#__extensions'))
-				->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
-				->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
-				->where($db->quoteName('element') . ' = ' . $db->quote('languagefilter'));
-			$db->setQuery($query);
-
-			$enabled = $db->loadResult();
-			$tested = true;
-		}
-
-		return (bool) $enabled;
+		return JPluginHelper::isEnabled('system', 'languagefilter');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Removes custom code in `JLanguageMultilang::isEnabled()` in favour of `JPluginHelper::isEnabled('system', 'languagefilter')`.

### Testing Instructions

1. Code review
2. Use latest staging, apply patch and joomla multilanguage detection site/admin works as before.

### Documentation Changes Required

None.