### PR TITLE
Read cURL header_size to determine header size

### DIFF
--- a/libraries/joomla/http/transport/curl.php
+++ b/libraries/joomla/http/transport/curl.php
@@ -252,21 +252,37 @@ class JHttpTransportCurl implements JHttpTransport
 		// Create the response object.
 		$return = new JHttpResponse;
 
-		// Get the number of redirects that occurred.
-		$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
+		// Try to get header size
+		if (isset($info['header_size']))
+		{
+			$headerString = trim(substr($content, 0, $info['header_size']));
+			$headerArray  = explode("\r\n\r\n", $headerString);
 
-		/*
-		 * Split the response into headers and body. If cURL encountered redirects, the headers for the redirected requests will
-		 * also be included. So we split the response into header + body + the number of redirects and only use the last two
-		 * sections which should be the last set of headers and the actual body.
-		 */
-		$response = explode("\r\n\r\n", $content, 2 + $redirects);
+			// Get the last set of response headers as an array.
+			$headers = explode("\r\n", array_pop($headerArray));
 
-		// Set the body for the response.
-		$return->body = array_pop($response);
+			// Set the body for the response.
+			$return->body = substr($content, $info['header_size']);
+		}
+		// Fallback and try to guess header count by redirect count
+		else
+		{
+			// Get the number of redirects that occurred.
+			$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
 
-		// Get the last set of response headers as an array.
-		$headers = explode("\r\n", array_pop($response));
+			/*
+			 * Split the response into headers and body. If cURL encountered redirects, the headers for the redirected requests will
+			 * also be included. So we split the response into header + body + the number of redirects and only use the last two
+			 * sections which should be the last set of headers and the actual body.
+			 */
+			$response = explode("\r\n\r\n", $content, 2 + $redirects);
+
+			// Set the body for the response.
+			$return->body = array_pop($response);
+
+			// Get the last set of response headers as an array.
+			$headers = explode("\r\n", array_pop($response));
+		}
 
 		// Get the response code from the first offset of the response headers.
 		preg_match('/[0-9]{3}/', array_shift($headers), $matches);


### PR DESCRIPTION
This PR tries to improve the header/body separation for cURL response objects.
Since the header count can vary (redirects, proxy, ...) there is currently code which takes into acounts possible redirects. However that fails if there are additional headers due to other enviroment (eg a proxy).

When I tried to fix it in my case I found that there is a header_size already present in the cURL info.

### Summary of Changes
This PR changes the way the header is determined by using the cURL info "header_size". If that for some reason isn't present it falls back to the old way. I honestly doon't know if that info is always available or not, so I just kept the fallback case.

### Testing Instructions
The simplest way to test this is probably searching for updates in the Extension manager. If you don't see an error message that the update server wasn't responding or the XML couldn't be parsed or similar, then it should be fine.
If you actually see any updates, then it means it works for sure.

### Documentation Changes Required
None
