### PR TITLE
Fix calendar's translation for debug language, thanks @brianteeman 

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -233,11 +233,11 @@ class JFormFieldCalendar extends JFormField implements JFormDomfieldinterface
 
 			if ($showTime && $showTime != 'false')
 			{
-				$this->format = JText::_('DATE_FORMAT_CALENDAR_DATETIME');
+				$this->format = str_replace('**', '', JText::_('DATE_FORMAT_CALENDAR_DATETIME'));
 			}
 			else
 			{
-				$this->format = JText::_('DATE_FORMAT_CALENDAR_DATE');
+				$this->format = str_replace('**', '', JText::_('DATE_FORMAT_CALENDAR_DATE'));
 			}
 		}
 		else


### PR DESCRIPTION
Pull Request for Issue reported by @brianteeman on twitter

### Summary of Changes
Remove the appended `**` that debug lang introduces to the strings, for the strings:
- DATE_FORMAT_CALENDAR_DATETIME
- DATE_FORMAT_CALENDAR_DATE

### Testing Instructions
Use current staging
Enable debug and debug language
try to open an article for editing in isis

### Documentation Changes Required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joomla/joomla-cms/13232)
<!-- Reviewable:end -->
