### PR TITLE
Don't process value adjusting twice

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -185,44 +185,8 @@ class JFormFieldCalendar extends JFormField implements JFormDomfieldinterface
 	 */
 	protected function getInput()
 	{
-		return $this->getRenderer($this->layout)->render($this->getLayoutData());
-	}
-
-	/**
-	 * Method to get the data to be passed to the layout for rendering.
-	 *
-	 * @return  array
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected function getLayoutData()
-	{
-		$data      = parent::getLayoutData();
-		$tag       = JFactory::getLanguage()->getTag();
-		$calendar  = JFactory::getLanguage()->getCalendar();
 		$config    = JFactory::getConfig();
 		$user      = JFactory::getUser();
-		$direction = strtolower(JFactory::getDocument()->getDirection());
-
-		// Get the appropriate file for the current language date helper
-		$helperPath = 'system/fields/calendar-locales/date/gregorian/date-helper.min.js';
-
-		if (!empty($calendar) && is_dir(JPATH_ROOT . '/media/system/js/fields/calendar-locales/date/' . strtolower($calendar)))
-		{
-			$helperPath = 'system/fields/calendar-locales/date/' . strtolower($calendar) . '/date-helper.min.js';
-		}
-
-		// Get the appropriate locale file for the current language
-		$localesPath = 'system/fields/calendar-locales/en.js';
-
-		if (is_file(JPATH_ROOT . '/media/system/js/fields/calendar-locales/' . strtolower($tag) . '.js'))
-		{
-			$localesPath = 'system/fields/calendar-locales/' . strtolower($tag) . '.js';
-		}
-		elseif (is_file(JPATH_ROOT . '/media/system/js/fields/calendar-locales/' . strtolower(substr($tag, 0, -3)) . '.js'))
-		{
-			$localesPath = 'system/fields/calendar-locales/' . strtolower(substr($tag, 0, -3)) . '.js';
-		}
 
 		// Translate the format if requested
 		$translateFormat = (string) $this->element['translateformat'];
@@ -285,6 +249,43 @@ class JFormFieldCalendar extends JFormField implements JFormDomfieldinterface
 		else
 		{
 			$this->value = '';
+		}
+
+		return $this->getRenderer($this->layout)->render($this->getLayoutData());
+	}
+
+	/**
+	 * Method to get the data to be passed to the layout for rendering.
+	 *
+	 * @return  array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected function getLayoutData()
+	{
+		$data      = parent::getLayoutData();
+		$tag       = JFactory::getLanguage()->getTag();
+		$calendar  = JFactory::getLanguage()->getCalendar();
+		$direction = strtolower(JFactory::getDocument()->getDirection());
+
+		// Get the appropriate file for the current language date helper
+		$helperPath = 'system/fields/calendar-locales/date/gregorian/date-helper.min.js';
+
+		if (!empty($calendar) && is_dir(JPATH_ROOT . '/media/system/js/fields/calendar-locales/date/' . strtolower($calendar)))
+		{
+			$helperPath = 'system/fields/calendar-locales/date/' . strtolower($calendar) . '/date-helper.min.js';
+		}
+
+		// Get the appropriate locale file for the current language
+		$localesPath = 'system/fields/calendar-locales/en.js';
+
+		if (is_file(JPATH_ROOT . '/media/system/js/fields/calendar-locales/' . strtolower($tag) . '.js'))
+		{
+			$localesPath = 'system/fields/calendar-locales/' . strtolower($tag) . '.js';
+		}
+		elseif (is_file(JPATH_ROOT . '/media/system/js/fields/calendar-locales/' . strtolower(substr($tag, 0, -3)) . '.js'))
+		{
+			$localesPath = 'system/fields/calendar-locales/' . strtolower(substr($tag, 0, -3)) . '.js';
 		}
 
 		$extraData = array(


### PR DESCRIPTION
As reported by @brianteeman if you enabled language debuggin, you will get a fatal error when trying to edit an article in backend.
This is because the `getLayoutData` method is run both for the `getInput` and `getLabel` methods and thus the value is processed twice. Now the first round works fine and leaves the value as `**2016-12-15**`, but the second round PHP can't work with that value anymore because it's no longer a valid date string.

### Summary of Changes
This PR moves the value processing from the `getLayoutData` method to the `getInput` one so it is only run once.

### Testing Instructions
* Enable language debugging and edit an article in backend. See that the error occurs. (Form looks broken and there is a funny browser title).
* Apply PR and the form works again.
* Make sure the date eg in "Publish Up" is as expected, also taking also into account timezone settings.
* Make sure the translate dateformat works. You need to add language strings to your second language as explained in https://github.com/joomla/joomla-cms/pull/13158 (when you're at it, test that one as well :smile)

### Documentation Changes Required
None
