### PR TITLE
Various changes in libraries legacy

### DIFF
--- a/libraries/legacy/application/application.php
+++ b/libraries/legacy/application/application.php
@@ -305,7 +305,7 @@ class JApplication extends JApplicationBase
 		$this->triggerEvent('onBeforeRender');
 
 		// Render the document.
-		$caching = ($this->get('caching') >= 2) ? true : false;
+		$caching = ($this->get('caching') >= 2);
 		JResponse::setBody($document->render($caching, $params));
 
 		// Trigger the onAfterRender event.

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -440,16 +440,13 @@ class JControllerLegacy extends JObject
 	 */
 	protected function addPath($type, $path)
 	{
-		// Just force path to array
-		settype($path, 'array');
-
 		if (!isset($this->paths[$type]))
 		{
 			$this->paths[$type] = array();
 		}
 
 		// Loop through the path directories
-		foreach ($path as $dir)
+		foreach ((array) $path as $dir)
 		{
 			// No surrounding spaces allowed!
 			$dir = rtrim(JPath::check($dir, '/'), '/') . '/';

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -100,12 +100,7 @@ abstract class JModelLegacy extends JObject
 		{
 			jimport('joomla.filesystem.path');
 
-			if (!is_array($path))
-			{
-				$path = array($path);
-			}
-
-			foreach ($path as $includePath)
+			foreach ((array) $path as $includePath)
 			{
 				if (!in_array($includePath, $paths[$prefix]))
 				{

--- a/libraries/legacy/request/request.php
+++ b/libraries/legacy/request/request.php
@@ -60,9 +60,7 @@ class JRequest
 	 */
 	public static function getMethod()
 	{
-		$method = strtoupper($_SERVER['REQUEST_METHOD']);
-
-		return $method;
+		return strtoupper($_SERVER['REQUEST_METHOD']);
 	}
 
 	/**
@@ -452,9 +450,7 @@ class JRequest
 				break;
 		}
 
-		$result = self::_cleanVar($input, $mask);
-
-		return $result;
+		return self::_cleanVar($input, $mask);
 	}
 
 	/**

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -781,11 +781,8 @@ class JViewLegacy extends JObject
 	{
 		jimport('joomla.filesystem.path');
 
-		// Just force to array
-		settype($path, 'array');
-
 		// Loop through the path directories
-		foreach ($path as $dir)
+		foreach ((array) $path as $dir)
 		{
 			// Clean up the path
 			$dir = JPath::clean($dir);

--- a/libraries/legacy/view/legacy.php
+++ b/libraries/legacy/view/legacy.php
@@ -678,8 +678,7 @@ class JViewLegacy extends JObject
 		if ($this->_template != false)
 		{
 			// Unset so as not to introduce into template scope
-			unset($tpl);
-			unset($file);
+			unset($tpl, $file);
 
 			// Never allow a 'this' property
 			if (isset($this->this))


### PR DESCRIPTION
### Summary of Changes
- Inline one-time use variables
- Removed unnecessary ternary operators
- Merge unset() calls
- Use modern day type-casting
- This can be replaced with type-casting

This PR is part of a set to try to separate some of the changes done in one of my previous batch PR's for the libraries/legacy directory, which is still on hold (#12220).
Once the new set is merged it will hopefully reduce the changes in that PR, so it can be reviewed easier and finally be merged.

The changes in this PR should be fairly easy to review. In hope that  this will get merged quickly. ;)

### Testing Instructions

None, should not change behavior


### Documentation Changes Required

None.
