### PR TITLE
Simplify some ternary operations using elvis operator and remove unnecessary parentheses in templates

### DIFF
--- a/templates/beez3/html/com_contact/contact/default_links.php
+++ b/templates/beez3/html/com_contact/contact/default_links.php
@@ -33,7 +33,7 @@ if ($this->params->get('presentation_style') == 'sliders') : ?>
 			$link = (0 === strpos($link, 'http')) ? $link : 'http://'.$link;
 
 			// If no label is present, take the link
-			$label = ($label) ?: $link;
+			$label = $label ?: $link;
 			?>
 			<li>
 				<a href="<?php echo $link; ?>">

--- a/templates/beez3/html/com_contact/contact/default_links.php
+++ b/templates/beez3/html/com_contact/contact/default_links.php
@@ -33,7 +33,7 @@ if ($this->params->get('presentation_style') == 'sliders') : ?>
 			$link = (0 === strpos($link, 'http')) ? $link : 'http://'.$link;
 
 			// If no label is present, take the link
-			$label = ($label) ? $label : $link;
+			$label = ($label) ?: $link;
 			?>
 			<li>
 				<a href="<?php echo $link; ?>">

--- a/templates/beez3/html/com_contact/contact/default_user_custom_fields.php
+++ b/templates/beez3/html/com_contact/contact/default_user_custom_fields.php
@@ -32,13 +32,13 @@ $userFieldGroups    = array();
 <?php foreach ($userFieldGroups as $categoryTitle => $fields) :?>
 	<?php $id = JApplicationHelper::stringURLSafe($categoryTitle); ?>
 	<?php if ($this->params->get('presentation_style') == 'sliders') :
-		echo JHtml::_('sliders.panel', $categoryTitle ? $categoryTitle : JText::_('COM_CONTACT_USER_FIELDS'), 'display-' . $id); ?>
+		echo JHtml::_('sliders.panel', $categoryTitle ?: JText::_('COM_CONTACT_USER_FIELDS'), 'display-' . $id); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'tabs') : ?>
-		<?php echo JHtmlTabs::panel($categoryTitle ? $categoryTitle : JText::_('COM_CONTACT_USER_FIELDS'), 'display-' . $id); ?>
+		<?php echo JHtmlTabs::panel($categoryTitle ?: JText::_('COM_CONTACT_USER_FIELDS'), 'display-' . $id); ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('presentation_style') == 'plain'):?>
-		<?php echo '<h3>'. ( $categoryTitle ? $categoryTitle : JText::_('COM_CONTACT_USER_FIELDS')).'</h3>'; ?>
+		<?php echo '<h3>'. ( $categoryTitle ?: JText::_('COM_CONTACT_USER_FIELDS')).'</h3>'; ?>
 	<?php endif; ?>
 
 	<div class="contact-profile" id="user-custom-fields-<?php echo $id; ?>">

--- a/templates/beez3/html/com_content/archive/default_items.php
+++ b/templates/beez3/html/com_content/archive/default_items.php
@@ -79,7 +79,7 @@ $params = &$this->params;
 <?php if ($params->get('show_author') && !empty($item->author )) : ?>
 	<dd class="createdby">
 		<?php $author = $item->author; ?>
-		<?php $author = ($item->created_by_alias ? $item->created_by_alias : $author);?>
+		<?php $author = ($item->created_by_alias ?: $author);?>
 			<?php if (!empty($item->contact_link ) &&  $params->get('link_author') == true):?>
 				<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $item->contact_link, $author)); ?>
 			<?php else :?>

--- a/templates/beez3/html/com_content/archive/default_items.php
+++ b/templates/beez3/html/com_content/archive/default_items.php
@@ -34,7 +34,7 @@ $params = &$this->params;
 		</h2>
 
 
-<?php if (($params->get('show_author')) or ($params->get('show_parent_category')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date'))  or ($params->get('show_hits'))) : ?>
+<?php if ($params->get('show_author') or $params->get('show_parent_category') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_hits')) : ?>
  <dl class="article-info">
  <dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
 <?php endif; ?>
@@ -92,7 +92,7 @@ $params = &$this->params;
 		<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $item->hits); ?>
 		</dd>
 <?php endif; ?>
-<?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date'))  or ($params->get('show_hits'))) :?>
+<?php if ($params->get('show_author') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_hits')) :?>
 	 </dl>
 <?php endif; ?>
 

--- a/templates/beez3/html/com_content/article/default.php
+++ b/templates/beez3/html/com_content/article/default.php
@@ -126,7 +126,7 @@ if ($params->get('show_title')) : ?>
 <?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
 	<dd class="createdby">
 		<?php $author = $this->item->author; ?>
-		<?php $author = ($this->item->created_by_alias ? $this->item->created_by_alias : $author);?>
+		<?php $author = ($this->item->created_by_alias ?: $author);?>
 		<?php if (!empty($this->item->contact_link ) &&  $params->get('link_author') == true) : ?>
 			<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
 		<?php else : ?>

--- a/templates/beez3/html/com_content/article/default.php
+++ b/templates/beez3/html/com_content/article/default.php
@@ -78,9 +78,9 @@ if ($params->get('show_title')) : ?>
 
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
-<?php $useDefList = (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_parent_category'))
-	or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date'))
-	or ($params->get('show_hits'))); ?>
+<?php $useDefList = ($params->get('show_author') or $params->get('show_category') or $params->get('show_parent_category')
+	or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date')
+	or $params->get('show_hits')); ?>
 
 <?php if ($useDefList) : ?>
  <dl class="article-info">
@@ -153,7 +153,7 @@ if ($params->get('show_title')) : ?>
 	<?php echo $this->loadTemplate('links'); ?>
 <?php endif; ?>
 	<?php  if (isset($images->image_fulltext) and !empty($images->image_fulltext)) : ?>
-	<?php $imgfloat = (empty($images->float_fulltext)) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
+	<?php $imgfloat = empty($images->float_fulltext) ? $params->get('float_fulltext') : $images->float_fulltext; ?>
 
 	<div class="img-fulltext-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?>">
 	<img

--- a/templates/beez3/html/com_content/article/default_links.php
+++ b/templates/beez3/html/com_content/article/default_links.php
@@ -35,7 +35,7 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 				endif;
 
 				// If no label is present, take the link
-				$label = ($label) ?: $link;
+				$label = $label ?: $link;
 
 				// If no target is present, use the default
 				$target = $target ?: $params->get('target'.$id);

--- a/templates/beez3/html/com_content/article/default_links.php
+++ b/templates/beez3/html/com_content/article/default_links.php
@@ -35,10 +35,10 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 				endif;
 
 				// If no label is present, take the link
-				$label = ($label) ? $label : $link;
+				$label = ($label) ?: $link;
 
 				// If no target is present, use the default
-				$target = $target ? $target : $params->get('target'.$id);
+				$target = $target ?: $params->get('target'.$id);
 				?>
 			<li class="content-links-<?php echo $id; ?>">
 				<?php

--- a/templates/beez3/html/com_content/category/blog.php
+++ b/templates/beez3/html/com_content/category/blog.php
@@ -66,7 +66,7 @@ $cparams = JComponentHelper::getParams('com_media');
 </div>
 <?php endif; ?>
 <?php
-	$introcount = (count($this->intro_items));
+	$introcount = count($this->intro_items);
 	$counter = 0;
 ?>
 <?php if (!empty($this->intro_items)) : ?>

--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -104,7 +104,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 <?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
 	<dd class="createdby">
 		<?php $author = $this->item->author; ?>
-		<?php $author = ($this->item->created_by_alias ? $this->item->created_by_alias : $author);?>
+		<?php $author = ($this->item->created_by_alias ?: $author);?>
 		<?php if (!empty($this->item->contact_link ) &&  $params->get('link_author') == true) : ?>
 			<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
 		<?php else :?>

--- a/templates/beez3/html/com_content/category/blog_item.php
+++ b/templates/beez3/html/com_content/category/blog_item.php
@@ -60,7 +60,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 <?php // to do not that elegant would be nice to group the params ?>
 
-<?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) : ?>
+<?php if ($params->get('show_author') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_parent_category') or $params->get('show_hits')) : ?>
  <dl class="article-info">
  <dt class="article-info-term"><?php echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
 <?php endif; ?>
@@ -117,11 +117,11 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 		<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 		</dd>
 <?php endif; ?>
-<?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) :?>
+<?php if ($params->get('show_author') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_parent_category') or $params->get('show_hits')) :?>
  	</dl>
 <?php endif; ?>
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
-	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
+	<?php $imgfloat = empty($images->float_intro) ? $params->get('float_intro') : $images->float_intro; ?>
 	<div class="img-intro-<?php echo htmlspecialchars($imgfloat); ?>">
 	<img
 		<?php if ($images->image_intro_caption):
@@ -150,13 +150,13 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 					elseif ($readmore = $this->item->alternative_readmore) :
 						echo $readmore;
 						if ($params->get('show_readmore_title', 0) != 0) :
-							echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+							echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 						endif;
 					elseif ($params->get('show_readmore_title', 0) == 0) :
 						echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
 					else :
 						echo JText::_('COM_CONTENT_READ_MORE');
-						echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+						echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 					endif; ?></a>
 		</p>
 <?php endif; ?>

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -110,12 +110,12 @@ if (!empty($this->items))
 					<?php echo JHtml::_('grid.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 				</th>
 				<?php endif; ?>
-				<?php if (($this->params->get('list_show_votes', 0)) && ($this->vote)) : ?>
+				<?php if ($this->params->get('list_show_votes', 0) && $this->vote) : ?>
 					<th id="categorylist_header_votes">
 						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_VOTES', 'rating_count', $listDirn, $listOrder); ?>
 					</th>
 				<?php endif; ?>
-				<?php if (($this->params->get('list_show_ratings', 0)) && ($this->vote)) : ?>
+				<?php if ($this->params->get('list_show_ratings', 0) && $this->vote) : ?>
 					<th id="categorylist_header_ratings">
 						<?php echo JHtml::_('grid.sort', 'COM_CONTENT_RATINGS', 'rating', $listDirn, $listOrder); ?>
 					</th>
@@ -171,12 +171,12 @@ if (!empty($this->items))
 					</td>
 					<?php endif; ?>
 
-					<?php if (($this->params->get('list_show_votes', 0)) && ($this->vote)) : ?>
+					<?php if ($this->params->get('list_show_votes', 0) && $this->vote) : ?>
 						<td class="list-votes">
 							<?php echo $article->rating_count; ?>
 						</td>
 					<?php endif; ?>
-					<?php if (($this->params->get('list_show_ratings', 0)) && ($this->vote)) : ?>
+					<?php if ($this->params->get('list_show_ratings', 0) && $this->vote) : ?>
 						<td class="list-ratings">
 							<?php echo $article->rating; ?>
 						</td>

--- a/templates/beez3/html/com_content/category/default_articles.php
+++ b/templates/beez3/html/com_content/category/default_articles.php
@@ -155,7 +155,7 @@ if (!empty($this->items))
 					<td class="list-author">
 						<?php if (!empty($article->author) || !empty($article->created_by_alias)) : ?>
 							<?php $author = $article->author ?>
-							<?php $author = ($article->created_by_alias ? $article->created_by_alias : $author); ?>
+							<?php $author = ($article->created_by_alias ?: $author); ?>
 							<?php if (!empty($article->contact_link) &&  $this->params->get('link_author') == true):?>
 								<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $article->contact_link, $author)); ?>
 							<?php else :?>

--- a/templates/beez3/html/com_content/featured/default.php
+++ b/templates/beez3/html/com_content/featured/default.php
@@ -37,7 +37,7 @@ JHtml::_('behavior.caption');
 </div>
 <?php endif; ?>
 <?php
-	$introcount = (count($this->intro_items));
+	$introcount = count($this->intro_items);
 	$counter = 0;
 ?>
 <?php if (!empty($this->intro_items)) : ?>

--- a/templates/beez3/html/com_content/featured/default_item.php
+++ b/templates/beez3/html/com_content/featured/default_item.php
@@ -69,7 +69,7 @@ $templateparams = $app->getTemplate(true)->params;
 <?php if ($params->get('show_parent_category') && $this->item->parent_id != 1) : ?>
 		<dd class="parent-category-name">
 			<?php $title = $this->escape($this->item->parent_title);
-				$title = ($title) ? $title : JText::_('JGLOBAL_UNCATEGORISED');
+				$title = ($title) ?: JText::_('JGLOBAL_UNCATEGORISED');
 				$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>'; ?>
 			<?php if ($params->get('link_parent_category') and $this->item->parent_slug) : ?>
 				<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
@@ -81,7 +81,7 @@ $templateparams = $app->getTemplate(true)->params;
 <?php if ($params->get('show_category')) : ?>
 		<dd class="category-name">
 			<?php 	$title = $this->escape($this->item->category_title);
-					$title = ($title) ? $title : JText::_('JGLOBAL_UNCATEGORISED');
+					$title = ($title) ?: JText::_('JGLOBAL_UNCATEGORISED');
 					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
 			<?php if ($params->get('link_category') and $this->item->catslug) : ?>
 				<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
@@ -108,7 +108,7 @@ $templateparams = $app->getTemplate(true)->params;
 <?php if ($params->get('show_author') && !empty($this->item->author )) : ?>
 	<dd class="createdby">
 		<?php $author = $this->item->author; ?>
-		<?php $author = ($this->item->created_by_alias ? $this->item->created_by_alias : $author);?>
+		<?php $author = ($this->item->created_by_alias ?: $author);?>
 		<?php if (!empty($this->item->contact_link ) &&  $params->get('link_author') == true) : ?>
 			<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $this->item->contact_link, $author)); ?>
 		<?php else :?>

--- a/templates/beez3/html/com_content/featured/default_item.php
+++ b/templates/beez3/html/com_content/featured/default_item.php
@@ -62,14 +62,14 @@ $templateparams = $app->getTemplate(true)->params;
 
 <?php // to do not that elegant would be nice to group the params ?>
 
-<?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) : ?>
+<?php if ($params->get('show_author') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_parent_category') or $params->get('show_hits')) : ?>
  <dl class="article-info">
  <dt class="article-info-term"><?php  echo JText::_('COM_CONTENT_ARTICLE_INFO'); ?></dt>
 <?php endif; ?>
 <?php if ($params->get('show_parent_category') && $this->item->parent_id != 1) : ?>
 		<dd class="parent-category-name">
 			<?php $title = $this->escape($this->item->parent_title);
-				$title = ($title) ?: JText::_('JGLOBAL_UNCATEGORISED');
+				$title = $title ?: JText::_('JGLOBAL_UNCATEGORISED');
 				$url = '<a href="' . JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->parent_slug)) . '">' . $title . '</a>'; ?>
 			<?php if ($params->get('link_parent_category') and $this->item->parent_slug) : ?>
 				<?php echo JText::sprintf('COM_CONTENT_PARENT', $url); ?>
@@ -81,7 +81,7 @@ $templateparams = $app->getTemplate(true)->params;
 <?php if ($params->get('show_category')) : ?>
 		<dd class="category-name">
 			<?php 	$title = $this->escape($this->item->category_title);
-					$title = ($title) ?: JText::_('JGLOBAL_UNCATEGORISED');
+					$title = $title ?: JText::_('JGLOBAL_UNCATEGORISED');
 					$url = '<a href="'.JRoute::_(ContentHelperRoute::getCategoryRoute($this->item->catslug)).'">'.$title.'</a>';?>
 			<?php if ($params->get('link_category') and $this->item->catslug) : ?>
 				<?php echo JText::sprintf('COM_CONTENT_CATEGORY', $url); ?>
@@ -121,12 +121,12 @@ $templateparams = $app->getTemplate(true)->params;
 		<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $this->item->hits); ?>
 		</dd>
 <?php endif; ?>
-<?php if (($params->get('show_author')) or ($params->get('show_category')) or ($params->get('show_create_date')) or ($params->get('show_modify_date')) or ($params->get('show_publish_date')) or ($params->get('show_parent_category')) or ($params->get('show_hits'))) : ?>
+<?php if ($params->get('show_author') or $params->get('show_category') or $params->get('show_create_date') or $params->get('show_modify_date') or $params->get('show_publish_date') or $params->get('show_parent_category') or $params->get('show_hits')) : ?>
  </dl>
 <?php endif; ?>
 
 <?php  if (isset($images->image_intro) and !empty($images->image_intro)) : ?>
-	<?php $imgfloat = (empty($images->float_intro)) ? $params->get('float_intro') : $images->float_intro; ?>
+	<?php $imgfloat = empty($images->float_intro) ? $params->get('float_intro') : $images->float_intro; ?>
 	<div class="img-intro-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?>">
 	<img
 		<?php if ($images->image_intro_caption):
@@ -156,13 +156,13 @@ $templateparams = $app->getTemplate(true)->params;
 					elseif ($readmore = $this->item->alternative_readmore) :
 						echo $readmore;
 						if ($params->get('show_readmore_title', 0) != 0) :
-							echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+							echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 						endif;
 					elseif ($params->get('show_readmore_title', 0) == 0) :
 						echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
 					else :
 						echo JText::_('COM_CONTENT_READ_MORE');
-						echo JHtml::_('string.truncate', ($this->item->title), $params->get('readmore_limit'));
+						echo JHtml::_('string.truncate', $this->item->title, $params->get('readmore_limit'));
 					endif; ?></a>
 		</p>
 <?php endif; ?>

--- a/templates/beez3/html/com_weblinks/category/default_items.php
+++ b/templates/beez3/html/com_weblinks/category/default_items.php
@@ -136,10 +136,10 @@ $listDirn     = $this->escape($this->state->get('list.direction'));
 				<?php echo $this->item->tagLayout->render($tagsData); ?>
 			<?php endif; ?>
 
-			<?php if (($this->params->get('show_link_description')) and ($item->description != '')) : ?>
+			<?php if ($this->params->get('show_link_description') and ($item->description != '')) : ?>
 				<?php $images = json_decode($item->images); ?>
 				<?php  if (isset($images->image_first) and !empty($images->image_first)) : ?>
-				<?php $imgfloat = (empty($images->float_first)) ? $this->params->get('float_first') : $images->float_first; ?>
+				<?php $imgfloat = empty($images->float_first) ? $this->params->get('float_first') : $images->float_first; ?>
 				<div class="img-intro-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?>"> <img
 					<?php if ($images->image_first_caption):
 						echo 'class="caption"'.' title="' .htmlspecialchars($images->image_first_caption, ENT_COMPAT, 'UTF-8') .'"';
@@ -147,7 +147,7 @@ $listDirn     = $this->escape($this->state->get('list.direction'));
 					src="<?php echo htmlspecialchars($images->image_first, ENT_COMPAT, 'UTF-8'); ?>" alt="<?php echo htmlspecialchars($images->image_first_alt, ENT_COMPAT, 'UTF-8'); ?>"/> </div>
 				<?php endif; ?>
 				<?php  if (isset($images->image_second) and !empty($images->image_second)) : ?>
-					<?php $imgfloat = (empty($images->float_second)) ? $this->params->get('float_second') : $images->float_second; ?>
+					<?php $imgfloat = empty($images->float_second) ? $this->params->get('float_second') : $images->float_second; ?>
 					<div class="pull-<?php echo htmlspecialchars($imgfloat, ENT_COMPAT, 'UTF-8'); ?> item-image"> <img
 					<?php if ($images->image_second_caption):
 						echo 'class="caption"'.' title="' .htmlspecialchars($images->image_second_caption, ENT_COMPAT, 'UTF-8') .'"';

--- a/templates/protostar/html/layouts/joomla/form/field/media.php
+++ b/templates/protostar/html/layouts/joomla/form/field/media.php
@@ -84,8 +84,7 @@ if ($showPreview)
 
 // The url for the modal
 $url    = ($readonly ? ''
-	: ($link ? $link
-		: 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;asset='
+	: ($link ?: 'index.php?option=com_media&amp;view=images&amp;tmpl=component&amp;asset='
 		. $asset . '&amp;author=' . $authorId)
 	. '&amp;fieldid={field-media-id}&amp;ismoo=0&amp;folder=' . $folder);
 ?>

--- a/templates/protostar/html/pagination.php
+++ b/templates/protostar/html/pagination.php
@@ -219,7 +219,7 @@ function pagination_item_inactive(&$item)
 	}
 
 	// Check if the item is the active page
-	if (isset($item->active) && ($item->active))
+	if (isset($item->active) && $item->active)
 	{
 		return '<li class="active hidden-phone"><a>' . $item->text . '</a></li>';
 	}

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -95,7 +95,7 @@ function modChrome_xhtml($module, &$params, &$attribs)
 
 	// Temporarily store header class in variable
 	$headerClass    = $params->get('header_class');
-	$headerClass    = ($headerClass) ? ' class="' . htmlspecialchars($headerClass, ENT_COMPAT, 'UTF-8') . '"' : '';
+	$headerClass    = $headerClass ? ' class="' . htmlspecialchars($headerClass, ENT_COMPAT, 'UTF-8') . '"' : '';
 
 	if (!empty ($module->content)) : ?>
 		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8') . $moduleClass; ?>">


### PR DESCRIPTION
### Summary of Changes
- Simplify ternary operation using elvis operator
- Remove unneeded parentheses

This PR is part of a set to try to separate some of the changes done in one of my previous batch PR's for the templates directory, which is still on hold (#12233).
Once the new set is merged it will hopefully reduce the changes in that PR, so it can be reviewed easier and finally be merged.

The changes in this PR are only of two types and should be fairly easy to review. In hope that  this will get merged quickly. ;)

### Testing Instructions

None, should not change behavior


### Documentation Changes Required

None.
