### PR TITLE
[com_fields] Normalise data structure for assigned categories

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -3,7 +3,6 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   `asset_id` int(10) NOT NULL DEFAULT 0,
   `context` varchar(255) NOT NULL DEFAULT '',
   `group_id` int(10) NOT NULL DEFAULT 0,
-  `assigned_cat_ids` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
   `alias` varchar(255) NOT NULL DEFAULT '',
   `label` varchar(255) NOT NULL DEFAULT '',
@@ -36,6 +35,12 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   KEY `idx_access` (`access`),
   KEY `idx_context` (`context`),
   KEY `idx_language` (`language`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `#___fields_categories` (
+  `field_id` int(11) NOT NULL DEFAULT 0,
+  `category_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`field_id`,`category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `#__fields_groups` (

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `#___fields_categories` (
+CREATE TABLE `#__fields_categories` (
   `field_id` int(11) NOT NULL DEFAULT 0,
   `category_id` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`field_id`,`category_id`)

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-08-29.sql
@@ -6,7 +6,6 @@ CREATE TABLE "#__fields" (
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "context" varchar(255) DEFAULT '' NOT NULL,
   "group_id" bigint DEFAULT 0 NOT NULL,
-  "assigned_cat_ids" varchar(255) DEFAULT '' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
   "alias" varchar(255) DEFAULT '' NOT NULL,
   "label" varchar(255) DEFAULT '' NOT NULL,
@@ -40,6 +39,15 @@ CREATE INDEX "#__fields_idx_created_user_id" ON "#__fields" ("created_user_id");
 CREATE INDEX "#__fields_idx_access" ON "#__fields" ("access");
 CREATE INDEX "#__fields_idx_context" ON "#__fields" ("context");
 CREATE INDEX "#__fields_idx_language" ON "#__fields" ("language");
+
+--
+-- Table: #__fields_categories
+--
+CREATE TABLE "#__fields_categories" (
+  "field_id" bigint DEFAULT 0 NOT NULL,
+  "category_id" bigint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("field_id", "category_id")
+);
 
 --
 -- Table: #__fields_groups

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -641,7 +641,6 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   `asset_id` int(10) NOT NULL DEFAULT 0,
   `context` varchar(255) NOT NULL DEFAULT '',
   `group_id` int(10) NOT NULL DEFAULT 0,
-  `assigned_cat_ids` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
   `alias` varchar(255) NOT NULL DEFAULT '',
   `label` varchar(255) NOT NULL DEFAULT '',
@@ -674,6 +673,18 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   KEY `idx_access` (`access`),
   KEY `idx_context` (`context`),
   KEY `idx_language` (`language`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `#___fields_categories`
+--
+
+CREATE TABLE `#___fields_categories` (
+  `field_id` int(11) NOT NULL DEFAULT 0,
+  `category_id` int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`field_id`,`category_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -678,10 +678,10 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `#___fields_categories`
+-- Table structure for table `#__fields_categories`
 --
 
-CREATE TABLE `#___fields_categories` (
+CREATE TABLE `#__fields_categories` (
   `field_id` int(11) NOT NULL DEFAULT 0,
   `category_id` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`field_id`,`category_id`)

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -654,7 +654,6 @@ CREATE TABLE "#__fields" (
   "asset_id" bigint DEFAULT 0 NOT NULL,
   "context" varchar(255) DEFAULT '' NOT NULL,
   "group_id" bigint DEFAULT 0 NOT NULL,
-  "assigned_cat_ids" varchar(255) DEFAULT '' NOT NULL,
   "title" varchar(255) DEFAULT '' NOT NULL,
   "alias" varchar(255) DEFAULT '' NOT NULL,
   "label" varchar(255) DEFAULT '' NOT NULL,
@@ -688,6 +687,15 @@ CREATE INDEX "#__fields_idx_created_user_id" ON "#__fields" ("created_user_id");
 CREATE INDEX "#__fields_idx_access" ON "#__fields" ("access");
 CREATE INDEX "#__fields_idx_context" ON "#__fields" ("context");
 CREATE INDEX "#__fields_idx_language" ON "#__fields" ("language");
+
+--
+-- Table: #__fields_categories
+--
+CREATE TABLE "#__fields_categories" (
+  "field_id" bigint DEFAULT 0 NOT NULL,
+  "category_id" bigint DEFAULT 0 NOT NULL,
+  PRIMARY KEY ("field_id", "category_id")
+);
 
 --
 -- Table: #__fields_groups


### PR DESCRIPTION
Pull Request for Issue #13222 .
Currently, the assigned category ids are stored as a coma separated string into the #__fields table.
As Hannes pointed out in the referenced issue that is not optimal.

### Summary of Changes
This PR removes that data field from the #__fields table and moves it to a cross-reference table #__fields_categories.

### Testing Instructions
* Create and edit fields and assign categories to them. Make sure they save correctly. Also try to remove them again so they show "All" again.
* Test that the fields show up as expected in the article/user/contact edit forms and frontend views.

### Documentation Changes Required
None
