### PR TITLE
Moved JPluginHelper::importPlugin() call outside loops, project-wide.

### DIFF
--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -43,6 +43,8 @@ class ContentViewArchive extends JViewLegacy
 		// Get the page/component configuration
 		$params = &$state->params;
 
+		JPluginHelper::importPlugin('content');
+
 		foreach ($items as $item)
 		{
 			$item->catslug     = $item->category_alias ? ($item->catid . ':' . $item->category_alias) : $item->catid;
@@ -64,7 +66,6 @@ class ContentViewArchive extends JViewLegacy
 				$item->text = $item->introtext;
 			}
 
-			JPluginHelper::importPlugin('content');
 			$dispatcher->trigger('onContentPrepare', array ('com_content.archive', &$item, &$item->params, 0));
 
 			// Old plugins: Use processed text as introtext

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -79,6 +79,8 @@ class ContentViewCategory extends JViewCategory
 		$numLinks   = $params->def('num_links', 4);
 		$this->vote = JPluginHelper::isEnabled('content', 'vote');
 
+		JPluginHelper::importPlugin('content');
+
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($this->items as $item)
 		{
@@ -103,7 +105,6 @@ class ContentViewCategory extends JViewCategory
 				$item->text = $item->introtext;
 			}
 
-			JPluginHelper::importPlugin('content');
 			$dispatcher->trigger('onContentPrepare', array ('com_content.category', &$item, &$item->params, 0));
 
 			// Old plugins: Use processed text as introtext

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -71,6 +71,8 @@ class ContentViewFeatured extends JViewLegacy
 		$numLeading = (int) $params->def('num_leading_articles', 1);
 		$numIntro   = (int) $params->def('num_intro_articles', 4);
 
+		JPluginHelper::importPlugin('content');
+
 		// Compute the article slugs and prepare introtext (runs content plugins).
 		foreach ($items as &$item)
 		{
@@ -93,7 +95,6 @@ class ContentViewFeatured extends JViewLegacy
 				$item->text = $item->introtext;
 			}
 
-			JPluginHelper::importPlugin('content');
 			$dispatcher->trigger('onContentPrepare', array ('com_content.featured', &$item, &$item->params, 0));
 
 			// Old plugins: Use processed text as introtext

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -85,6 +85,8 @@ class TagsViewTag extends JViewLegacy
 
 		if ($items !== false)
 		{
+			JPluginHelper::importPlugin('content');
+
 			foreach ($items as $itemElement)
 			{
 				$itemElement->event = new stdClass;
@@ -94,7 +96,6 @@ class TagsViewTag extends JViewLegacy
 
 				$dispatcher = JEventDispatcher::getInstance();
 
-				JPluginHelper::importPlugin('content');
 				$dispatcher->trigger('onContentPrepare', array ('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
 
 				$results = $dispatcher->trigger('onContentAfterTitle', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -163,6 +163,8 @@ class JViewCategory extends JViewLegacy
 
 		if ($this->runPlugins)
 		{
+			JPluginHelper::importPlugin('content');
+
 			foreach ($items as $itemElement)
 			{
 				$itemElement = (object) $itemElement;
@@ -172,7 +174,6 @@ class JViewCategory extends JViewLegacy
 				!empty($itemElement->description)? $itemElement->text = $itemElement->description : $itemElement->text = null;
 
 				$dispatcher = JEventDispatcher::getInstance();
-				JPluginHelper::importPlugin('content');
 
 				$dispatcher->trigger('onContentPrepare', array($this->extension . '.category', &$itemElement, &$itemElement->params, 0));
 


### PR DESCRIPTION
### Summary of Changes
- Moved `JPluginHelper::importPlugin()` call outside loops.

### Testing Instructions

None, should not change behavior


### Documentation Changes Required

None.
