### PR TITLE
PHP 7.1 Notice: A non well formed numeric value encountered

### DIFF
--- a/administrator/components/com_installer/models/warnings.php
+++ b/administrator/components/com_installer/models/warnings.php
@@ -35,6 +35,8 @@ class InstallerModelWarnings extends JModelList
 	{
 		$val = trim($val);
 		$last = strtolower($val{strlen($val) - 1});
+		
+		$val = (int) $val;
 
 		switch ($last)
 		{


### PR DESCRIPTION
Correction to a notice encountered while using PHP 7.1 :
"A non well formed numeric value encountered
 in /administrator/components/com_installer/models/warnings.php"

Pull Request for Issue # .

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
