### PR TITLE
Drop index idx_image in #__languages table

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-11-21.sql
@@ -1,3 +1,2 @@
 -- Replace language image UNIQUE index for a normal INDEX.
 ALTER TABLE `#__languages` DROP INDEX `idx_image`;
-ALTER TABLE `#__languages` ADD INDEX `idx_image` (`image`);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-11-21.sql
@@ -1,3 +1,2 @@
 -- Replace language image UNIQUE index for a normal INDEX.
 ALTER TABLE "#__languages" DROP CONSTRAINT "#__idx_image";
-CREATE INDEX "#__idx_image" ON "#__languages" ("image");

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-11-21.sql
@@ -1,5 +1,2 @@
 -- Replace language image UNIQUE index for a normal INDEX.
 ALTER TABLE [#__languages] DROP CONSTRAINT [#__languages$idx_image];
-CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
-	[image] ASC
-) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1300,7 +1300,6 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   PRIMARY KEY (`lang_id`),
   UNIQUE KEY `idx_sef` (`sef`),
   UNIQUE KEY `idx_langcode` (`lang_code`),
-  KEY `idx_image` (`image`),
   KEY `idx_access` (`access`),
   KEY `idx_ordering` (`ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1232,7 +1232,6 @@ CREATE TABLE "#__languages" (
   CONSTRAINT "#__languages_idx_sef" UNIQUE ("sef"),
   CONSTRAINT "#__languages_idx_langcode" UNIQUE ("lang_code")
 );
-CREATE INDEX "#__languages_idx_image" ON "#__languages" ("image");
 CREATE INDEX "#__languages_idx_ordering" ON "#__languages" ("ordering");
 CREATE INDEX "#__languages_idx_access" ON "#__languages" ("access");
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2014,10 +2014,6 @@ CREATE UNIQUE INDEX [idx_access] ON [#__languages]
 	[access] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_image] ON [#__languages] (
-	[image] ASC
-) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
-
 SET IDENTITY_INSERT [#__languages] ON;
 
 INSERT INTO [#__languages] ([lang_id], [lang_code], [title], [title_native], [sef], [image], [description], [metakey], [metadesc], [sitename], [published], [access], [ordering])


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13122.

### Summary of Changes

Drop index idx_image in #__languages table
This index is dropped because ordering by this field is only used very rarely in backend content languages view.

### Testing Instructions

- Apply patch
- Install joomla clean install form staging
- Check if don't have a non unique idx_image index in `#__languages` table
- Check the db schema checker now work fine.

### Documentation Changes Required

None.
