### PR TITLE
Modals style cleanup

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7107,6 +7107,39 @@ div.modal.jviewport-width100 {
 	margin: 1px 0;
 	padding: 0 !important;
 }
+body.modal-open {
+	overflow: hidden;
+	-ms-overflow-style: none;
+}
+.modal-header {
+	padding: 0 15px;
+	text-align: left;
+}
+.modal-header h3 {
+	font-weight: normal;
+	line-height: 50px;
+}
+.modal-header .close {
+	width: 50px;
+	margin-top: 0;
+	margin-right: -15px;
+	font-size: 2rem;
+	line-height: 50px;
+	border-left: 1px solid #ccc;
+}
+.modal-body {
+	padding: 0;
+	width: 100%;
+	height: auto;
+	overflow: hidden;
+}
+.modal-footer {
+	clear: both;
+}
+.contentpane {
+	padding: 10px;
+	height: auto;
+}
 html {
 	height: 100%;
 }
@@ -7688,9 +7721,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	body {
 		padding-top: 30px;
 	}
-	body.component {
-		padding-top: 0;
-	}
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
@@ -7713,11 +7743,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.container-fluid {
 		padding-left: 0;
 		padding-right: 0;
-	}
-}
-@media (min-width: 738px) {
-	body.component {
-		padding-top: 0;
 	}
 }
 @media (max-width: 738px) {
@@ -8395,25 +8420,11 @@ textarea.vert {
 textarea.noResize {
 	resize: none;
 }
-body.modal-open {
-	overflow: hidden;
-	-ms-overflow-style: none;
-}
-.field-media-wrapper .modal .modal-body {
-	padding: 5px 10px;
-	overflow: hidden;
-}
 .js-pstats-data-details dd {
 	margin-left: 240px;
 }
 .js-pstats-data-details dt {
 	width: 220px;
-}
-.modal-footer {
-	clear: both;
-}
-.modal-header {
-	text-align: left;
 }
 #permissions table td,
 #page-permissions table td {
@@ -8696,18 +8707,12 @@ body.modal-open {
 #mediamanager-form .height-50 .icon-folder-2 {
 	font-size: 40px;
 }
-=======
-
 .subform-repeatable {
 	padding-right: 10px;
 }
-=======
-
 .subform-repeatable > .btn-toolbar {
 	margin: 0;
 }
-=======
-
 .subform-repeatable > .btn-toolbar .group-add {
 	line-height: 26px;
 	width: 56px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7107,6 +7107,39 @@ div.modal.jviewport-width100 {
 	margin: 1px 0;
 	padding: 0 !important;
 }
+body.modal-open {
+	overflow: hidden;
+	-ms-overflow-style: none;
+}
+.modal-header {
+	padding: 0 15px;
+	text-align: left;
+}
+.modal-header h3 {
+	font-weight: normal;
+	line-height: 50px;
+}
+.modal-header .close {
+	width: 50px;
+	margin-top: 0;
+	margin-right: -15px;
+	font-size: 2rem;
+	line-height: 50px;
+	border-left: 1px solid #ccc;
+}
+.modal-body {
+	padding: 0;
+	width: 100%;
+	height: auto;
+	overflow: hidden;
+}
+.modal-footer {
+	clear: both;
+}
+.contentpane {
+	padding: 10px;
+	height: auto;
+}
 html {
 	height: 100%;
 }
@@ -7688,9 +7721,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	body {
 		padding-top: 30px;
 	}
-	body.component {
-		padding-top: 0;
-	}
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
@@ -7713,11 +7743,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.container-fluid {
 		padding-left: 0;
 		padding-right: 0;
-	}
-}
-@media (min-width: 738px) {
-	body.component {
-		padding-top: 0;
 	}
 }
 @media (max-width: 738px) {
@@ -8395,25 +8420,11 @@ textarea.vert {
 textarea.noResize {
 	resize: none;
 }
-body.modal-open {
-	overflow: hidden;
-	-ms-overflow-style: none;
-}
-.field-media-wrapper .modal .modal-body {
-	padding: 5px 10px;
-	overflow: hidden;
-}
 .js-pstats-data-details dd {
 	margin-left: 240px;
 }
 .js-pstats-data-details dt {
 	width: 220px;
-}
-.modal-footer {
-	clear: both;
-}
-.modal-header {
-	text-align: left;
 }
 #permissions table td,
 #page-permissions table td {
@@ -8696,18 +8707,12 @@ body.modal-open {
 #mediamanager-form .height-50 .icon-folder-2 {
 	font-size: 40px;
 }
-=======
-
 .subform-repeatable {
 	padding-right: 10px;
 }
-=======
-
 .subform-repeatable > .btn-toolbar {
 	margin: 0;
 }
-=======
-
 .subform-repeatable > .btn-toolbar .group-add {
 	line-height: 26px;
 	width: 56px;

--- a/administrator/templates/isis/less/blocks/_modals.less
+++ b/administrator/templates/isis/less/blocks/_modals.less
@@ -1,0 +1,39 @@
+// Modals
+
+body.modal-open {
+	overflow: hidden;
+	-ms-overflow-style: none;
+}
+
+.modal-header {
+  padding: 0 15px;
+  text-align: left;
+  h3 {
+  	font-weight: normal;
+  	line-height: 50px;
+  }
+  .close {
+    width: 50px;
+    margin-top: 0;
+    margin-right: -15px;
+    font-size: 2rem;
+    line-height: 50px;
+    border-left: 1px solid #ccc;
+  }
+}
+
+.modal-body {
+  padding: 0;
+  width: 100%;
+  height: auto;
+  overflow: hidden;
+}
+
+.modal-footer {
+	clear: both;
+}
+
+.contentpane {
+  padding: 10px;
+  height: auto
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -76,6 +76,11 @@
 @import "icomoon.less";
 // Chosen.css Flat Override 
 @import "chzn-override.less";
+
+// Blocks
+@import "blocks/_modals.less";
+
+
 /* Body */
 html {
 	height: 100%;
@@ -728,10 +733,6 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 		padding-top: 30px;
 	}
 
-	body.component {
-		padding-top: 0;
-	}
-
 	.row-fluid [class*="span"] {
 		margin-left: 15px;
 	}
@@ -759,12 +760,6 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 	.container-fluid {
 		padding-left: 0;
 		padding-right: 0;
-	}
-}
-
-@media (min-width: 738px) {
-	body.component {
-		padding-top: 0;
 	}
 }
 
@@ -1457,18 +1452,6 @@ textarea.noResize {
 	resize: none;
 }
 
-/* Prevent scrolling on the parent window of a modal */
-body.modal-open {
-	overflow: hidden;
-	-ms-overflow-style: none;
-}
-
-/* Corrects the modals padding */
-.field-media-wrapper .modal .modal-body {
-	padding: 5px 10px;
-	overflow: hidden;
-}
-
 /* Stats plugin */
 .js-pstats-data-details dd {
 	margin-left: 240px;
@@ -1477,15 +1460,6 @@ body.modal-open {
 	width: 220px;
 }
 
-/* Clear div after modal-body rendering */
-.modal-footer {
-	clear: both;
-}
-
-/* Modal Header text align left even if parent container centered */
-.modal-header {
-	text-align: left;
-}
 
 /* ACL Permission page */
 #permissions,
@@ -1773,8 +1747,6 @@ body.modal-open {
 
 }
 
-// Media XTD Button
-=======
 /* Repeatable SubForm */
 .subform-repeatable {
 	padding-right: 10px;


### PR DESCRIPTION
### Summary of Changes

- Moves modal template styling to blocks/_modal.less (template.less getting a bit out of control)
- Removes padding outside of scroll
- Styling added to 'close' and some other minor tweaks
- Unnecessary CSS removed

![modal1](https://cloud.githubusercontent.com/assets/2803503/21292920/debc113a-c50c-11e6-9074-728f380f8918.png)

![modal2](https://cloud.githubusercontent.com/assets/2803503/21292921/e447a1a0-c50c-11e6-887c-71f0f149361a.png)

![modal3](https://cloud.githubusercontent.com/assets/2803503/21292922/ea07d452-c50c-11e6-92c6-215df65c7d2d.png)

### Testing Instructions
Apply patch and check non MCE modals

### Documentation Changes Required
No