### PR TITLE
Advanced MSSQL query workaround for  limit, offset and for sql with aggregate functions

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -1032,28 +1032,21 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function limit($query, $limit, $offset)
 	{
-		if ($limit == 0 && $offset == 0)
+		if ($limit)
+		{
+			$total = $offset + $limit;
+			$query = substr_replace($query, 'SELECT TOP ' . (int) $total, stripos($query, 'SELECT'), 6);
+		}
+
+		if (!$offset)
 		{
 			return $query;
 		}
 
-		$start = $offset + 1;
-		$end   = $offset + $limit;
-
-		$orderBy = stristr($query, 'ORDER BY');
-
-		if (is_null($orderBy) || empty($orderBy))
-		{
-			$orderBy = 'ORDER BY (select 0)';
-		}
-
-		$query = str_ireplace($orderBy, '', $query);
-
-		$rowNumberText = ', ROW_NUMBER() OVER (' . $orderBy . ') AS RowNumber FROM ';
-
-		$query = preg_replace('/\sFROM\s/i', $rowNumberText, $query, 1);
-
-		return $query;
+		return PHP_EOL
+			. 'SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber FROM ('
+			. $query
+			. PHP_EOL . ') AS A) AS A WHERE RowNumber > ' . (int) $offset;
 	}
 
 	/**

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -992,6 +992,12 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				{
 					unset($orderColumns[$i]);
 				}
+
+				if (str_ireplace($aFuncs, '', $column) != $column)
+				{
+					// Do not add aggregate expression
+					unset($orderColumns[$i]);
+				}
 			}
 
 			$groupColumns = array_merge($groupColumns, $orderColumns);

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -334,29 +334,21 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
-		if ($limit == 0 && $offset == 0)
+		if ($limit)
+		{
+			$total = $offset + $limit;
+			$query = substr_replace($query, 'SELECT TOP ' . (int) $total, stripos($query, 'SELECT'), 6);
+		}
+
+		if (!$offset)
 		{
 			return $query;
 		}
 
-		$start = $offset + 1;
-		$end   = $offset + $limit;
-
-		$orderBy = stristr($query, 'ORDER BY');
-
-		if (is_null($orderBy) || empty($orderBy))
-		{
-			$orderBy = 'ORDER BY (select 0)';
-		}
-
-		$query = str_ireplace($orderBy, '', $query);
-
-		$rowNumberText = ', ROW_NUMBER() OVER (' . $orderBy . ') AS RowNumber FROM ';
-
-		$query = preg_replace('/\sFROM\s/i', $rowNumberText, $query, 1);
-		$query = 'SELECT * FROM (' . $query . ') A WHERE A.RowNumber BETWEEN ' . $start . ' AND ' . $end;
-
-		return $query;
+		return PHP_EOL
+			. 'SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber FROM ('
+			. $query
+			. PHP_EOL . ') AS A) AS A WHERE RowNumber > ' . (int) $offset;
 	}
 
 	/**

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -62,7 +62,16 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 		switch ($this->type)
 		{
 			case 'select':
-				$query .= (string) $this->select;
+				// Add required aliases for offset or fixGroupColumns method
+				$columns = $this->fixSelectAliases();
+
+				$query = (string) $this->select;
+
+				if ($this->group)
+				{
+					$this->fixGroupColumns($columns);
+				}
+
 				$query .= (string) $this->from;
 
 				if ($this->join)
@@ -212,6 +221,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 
 			default:
 				$query = parent::__toString();
+
 				break;
 		}
 
@@ -374,95 +384,621 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	}
 
 	/**
-	 * Add a grouping column to the GROUP clause of the query.
+	 * Split a string of sql expression into an array of individual columns.
+	 * Single line or line end comments and multi line comments are stripped off.
+	 * Always return at least one column.
 	 *
-	 * Usage:
-	 * $query->group('id');
+	 * @param   string  $string  Input string of sql expression like select expression.
 	 *
-	 * @param   mixed  $columns  A string or array of ordering columns.
+	 * @return  array[]  The columns from the input string separated into an array.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function splitSqlExpression($string)
+	{
+		// Append whitespace as equivalent to the last comma
+		$string .= ' ';
+
+		$colIdx    = 0;
+		$start     = 0;
+		$open      = false;
+		$openC     = 0;
+		$comment   = false;
+		$endString = '';
+		$length    = strlen($string);
+		$columns   = array();
+		$column    = array();
+		$current   = '';
+		$previous  = null;
+		$operators = array(
+			'+' => '',
+			'-' => '',
+			'*' => '',
+			'/' => '',
+			'%' => '',
+			'&' => '',
+			'|' => '',
+			'~' => '',
+			'^' => '',
+		);
+
+		$addBlock = function ($block) use (&$column, &$colIdx)
+		{
+			if (isset($column[$colIdx]))
+			{
+				$column[$colIdx] .= $block;
+			}
+			else
+			{
+				$column[$colIdx] = $block;
+			}
+		};
+
+		for ($i = 0; $i < $length; $i++)
+		{
+			$current      = substr($string, $i, 1);
+			$current2     = substr($string, $i, 2);
+			$current3     = substr($string, $i, 3);
+			$lenEndString = strlen($endString);
+			$testEnd      = substr($string, $i, $lenEndString);
+
+			if ($current == '[' || $current == '"' || $current == "'" || $current2 == '--'
+				|| ($current2 == '/*') || ($current == '#' && $current3 != '#__')
+				|| ($lenEndString && $testEnd == $endString))
+			{
+				if ($open)
+				{
+					if ($testEnd === $endString)
+					{
+						if ($comment)
+						{
+							if ($lenEndString > 1)
+							{
+								$i += ($lenEndString - 1);
+							}
+
+							// Move cursor after close tag of comment
+							$start = $i + 1;
+							$comment = false;
+						}
+						elseif ($current == "'" || $current == ']' || $current == '"')
+						{
+							// Check for escaped quote like '', ]] or ""
+							$n = 1;
+
+							while ($i + $n < $length && $string[$i + $n] == $current)
+							{
+								$n++;
+							}
+
+							// Jump to the last quote
+							$i += $n - 1;
+
+							if ($n % 2 === 0)
+							{
+								// There is only escaped quote
+								continue;
+							}
+							elseif ($n > 2)
+							{
+								// The last right close quote is not escaped
+								$current = $string[$i];
+							}
+						}
+
+						$open = false;
+						$endString = '';
+					}
+				}
+				else
+				{
+					$open = true;
+
+					if ($current == '#' || $current2 == '--')
+					{
+						$endString = "\n";
+						$comment = true;
+					}
+					elseif ($current2 == '/*')
+					{
+						$endString = '*/';
+						$comment = true;
+					}
+					elseif ($current == '[')
+					{
+						$endString = ']';
+					}
+					else
+					{
+						$endString = $current;
+					}
+
+					if ($comment && $start < $i)
+					{
+						// Add string exists before comment
+						$addBlock(substr($string, $start, $i - $start));
+						$previous = $string[$i - 1];
+						$start = $i;
+					}
+				}
+			}
+			elseif (!$open)
+			{
+				if ($current == '(')
+				{
+					$openC++;
+					$previous = $current;
+				}
+				elseif ($current == ')')
+				{
+					$openC--;
+					$previous = $current;
+				}
+				elseif ($current == '.')
+				{
+					if ($i === $start && $colIdx > 0 && !isset($column[$colIdx]))
+					{
+						// Remove whitepace placed before dot
+						$colIdx--;
+					}
+
+					$previous = $current;
+				}
+				elseif ($openC === 0)
+				{
+					if (ctype_space($current))
+					{
+						// Normalize whitepace
+						$string[$i] = ' ';
+
+						if ($start < $i)
+						{
+							// Add text placed before whitespace
+							$addBlock(substr($string, $start, $i - $start));
+							$colIdx++;
+							$previous = $string[$i - 1];
+						}
+						elseif (isset($column[$colIdx]))
+						{
+							if ($colIdx > 1 || !isset($operators[$previous]))
+							{
+								// There was whitespace after comment
+								$colIdx++;
+							}
+						}
+
+						// Move cursor forward
+						$start = $i + 1;
+					}
+					elseif (isset($operators[$current]) && ($current !== '*' || $previous !== '.'))
+					{
+						if ($start < $i)
+						{
+							// Add text before operator
+							$addBlock(substr($string, $start, $i - $start));
+							$colIdx++;
+						}
+						elseif (!isset($column[$colIdx]) && isset($operators[$previous]))
+						{
+							// Do not create whitespace between operators
+							$colIdx--;
+						}
+
+						// Add operator
+						$addBlock($current);
+						$previous = $current;
+						$colIdx++;
+
+						// Move cursor forward
+						$start = $i + 1;
+					}
+					else
+					{
+						$previous = $current;
+					}
+				}
+			}
+
+			if (($current == ',' && !$open && $openC == 0) || $i == $length - 1)
+			{
+				if ($start < $i && !$comment)
+				{
+					// Save remaining text
+					$addBlock(substr($string, $start, $i - $start));
+				}
+
+				$columns[] = $column;
+
+				// Reset values
+				$column   = array();
+				$colIdx   = 0;
+				$previous = null;
+
+				// Column saved, move cursor forward after comma
+				$start = $i + 1;
+			}
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Add required aliases to columns for select statement in subquery.
+	 *
+	 * @return  array[]  Array of columns with added missing aliases.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function fixSelectAliases()
+	{
+		$operators = array(
+			'+' => '',
+			'-' => '',
+			'*' => '',
+			'/' => '',
+			'%' => '',
+			'&' => '',
+			'|' => '',
+			'~' => '',
+			'^' => '',
+		);
+
+		// Split into array and remove comments
+		$columns = $this->splitSqlExpression(implode(',', $this->select->getElements()));
+
+		foreach ($columns as $i => $column)
+		{
+			$size = count($column);
+
+			if ($size == 0)
+			{
+				continue;
+			}
+
+			if ($size > 2 && strcasecmp($column[$size - 2], 'AS') === 0)
+			{
+				// Alias exists, replace it to uppercase
+				$columns[$i][$size - 2] = 'AS';
+				continue;
+			}
+
+			if ($i == 0 && stripos(' DISTINCT ALL ', " $column[0] ") !== false)
+			{
+				// This words are reserved, they are not column names
+				array_shift($column);
+				$size--;
+			}
+
+			$lastWord = strtoupper($column[$size - 1]);
+			$length   = strlen($lastWord);
+			$lastChar = $lastWord[$length - 1];
+
+			if ($lastChar == '*')
+			{
+				// Skip on wildcard
+				continue;
+			}
+
+			if ($lastChar == ')'
+				|| ($size == 1 && $lastChar == "'")
+				|| $lastWord[0] == '@'
+				|| $lastWord == 'NULL'
+				|| $lastWord == 'END'
+				|| is_numeric($lastWord))
+			{
+				/* Ends with:
+				 * - SQL function
+				 * - single static value like 'only '+'string'
+				 * - @@var
+				 * - NULL
+				 * - CASE ... END
+				 * - Numeric
+				 */
+				$columns[$i][] = 'AS';
+				$columns[$i][] = $this->quoteName('columnAlias' . $i);
+				continue;
+			}
+
+			if ($size == 1)
+			{
+				continue;
+			}
+
+			$lastChar2 = substr($column[$size - 2], -1);
+
+			// Check if column ends with  '- a.x' or '- a. x'
+			if (isset($operators[$lastChar2])
+				|| ($size > 2 && $lastChar2 === '.' && isset($operators[substr($column[$size - 3], -1)])))
+			{
+				// Ignore plus signs if column start with them
+				if ($size != 2 || ltrim($column[0], '+') !== '' || $column[1][0] === "'")
+				{
+					// If operator exists before last word then alias is required for subquery
+					$columns[$i][] = 'AS';
+					$columns[$i][] = $this->quoteName('columnAlias' . $i);
+					continue;
+				}
+			}
+			elseif ($column[$size - 1][0] !== '.' && $lastChar2 !== '.')
+			{
+				// If columns is like name name2 then second word is alias.
+				// Add missing AS before the alias, exception for 'a. x' and 'a .x'
+				array_splice($columns[$i], -1, 0, 'AS');
+			}
+		}
+
+		$selectColumns = array();
+
+		foreach ($columns as $i => $column)
+		{
+			$selectColumns[$i] = implode(' ', $column);
+		}
+
+		$this->select = new JDatabaseQueryElement('SELECT', $selectColumns);
+
+		return $columns;
+	}
+
+	/**
+	 * Add missing columns names to GROUP BY clause.
+	 *
+	 * @param   array[]  $selectColumns  Array of columns from splitSqlExpression method.
 	 *
 	 * @return  JDatabaseQuery  Returns this object to allow chaining.
 	 *
-	 * @since   11.1
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function group($columns)
+	protected function fixGroupColumns($selectColumns)
 	{
-		// Transform $columns into an array for filtering purposes
-		is_string($columns) && $columns = explode(',', str_replace(' ', '', $columns));
+		// Cache tables columns
+		static $cacheCols = array();
 
-		// Get the _formatted_ FROM string and remove everything except `table AS alias`
-		$fromStr = str_replace(array('[', ']'), '', str_replace('#__', $this->db->getPrefix(), str_replace('FROM ', '', (string) $this->from)));
+		// Known columns of all included tables
+		$knownColumnsByAlias = array();
 
-		// Start setting up an array of alias => table
-		list($table, $alias) = preg_split("/\sAS\s/i", $fromStr);
+		$iquotes  = array('"' => '', '[' => '', "'" => '');
+		$nquotes = array('"', '[', ']');
 
-		$tmpCols = $this->db->getTableColumns(trim($table));
-		$cols = array();
+		// Aggregate functions
+		$aFuncs = array(
+			'AVG(',
+			'CHECKSUM_AGG(',
+			'COUNT(',
+			'COUNT_BIG(',
+			'GROUPING(',
+			'GROUPING_ID(',
+			'MIN(',
+			'MAX(',
+			'SUM(',
+			'STDEV(',
+			'STDEVP(',
+			'VAR(',
+			'VARP(',
+		);
 
-		foreach ($tmpCols as $name => $type)
+		// Aggregated columns
+		$filteredColumns = array();
+
+		// Aliases found in SELECT statement
+		$knownAliases = array();
+		$wildcardTables = array();
+
+		foreach ($selectColumns as $i => $column)
 		{
-			$cols[] = $alias . '.' . $name;
+			$size = count($column);
+
+			if ($size === 0)
+			{
+				continue;
+			}
+
+			if ($size > 2 && $column[$size - 2] === 'AS')
+			{
+				// Save and remove AS alias
+				$alias = $column[$size - 1];
+
+				if (isset($iquotes[$alias[0]]))
+				{
+					$alias = substr($alias, 1, -1);
+				}
+
+				// Remove alias
+				$selectColumns[$i] = $column = array_slice($column, 0, -2);
+
+				if ($size === 3 || ($size === 4 && strpos('+-*/%&|~^', $column[0][0]) !== false))
+				{
+					$lastWord = $column[$size - 3];
+
+					if ($lastWord[0] === "'" || $lastWord === 'NULL' || is_numeric($lastWord))
+					{
+						unset($selectColumns[$i]);
+
+						continue;
+					}
+				}
+
+				// Remember pair alias => column expression
+				$knownAliases[$alias] = implode(' ', $column);
+			}
+
+			$aggregated = false;
+
+			foreach ($column as $j => $block)
+			{
+				if (substr($block, -2) === '.*')
+				{
+					// Found column ends with .*
+					if (isset($iquotes[$block[0]]))
+					{
+						// Quoted table
+						$wildcardTables[] = substr($block, 1, -3);
+					}
+					else
+					{
+						$wildcardTables[] = substr($block, 0, -2);
+					}
+				}
+				elseif (str_ireplace($aFuncs, '', $block) != $block)
+				{
+					$aggregated = true;
+				}
+
+				if ($block[0] === "'")
+				{
+					// Shrink static strings which could contain column name
+					$column[$j] = "''";
+				}
+			}
+
+			if (!$aggregated)
+			{
+				// Without aggregated columns and aliases
+				$filteredColumns[] = implode(' ', $selectColumns[$i]);
+			}
+
+			// Without aliases and static strings
+			$selectColumns[$i] = implode(' ', $column);
 		}
 
-		// Now we need to get all tables from any joins
-		// Go through all joins and add them to the tables array
-		if ($this->join)
+		// If select statement use table.* expression
+		if ($wildcardTables)
 		{
-			foreach ($this->join as $join)
+			// Split FROM statement into list of tables
+			$tables = $this->splitSqlExpression(implode(',', $this->from->getElements()));
+
+			foreach ($tables as $i => $table)
 			{
-				$joinTbl = str_replace('#__', $this->db->getPrefix(), str_replace(']', '', preg_replace("/.*(#.+\sAS\s[^\s]*).*/i", "$1", (string) $join)));
+				$table = implode(' ', $table);
 
-				list($table, $alias) = preg_split("/\sAS\s/i", $joinTbl);
-
-				$tmpCols = $this->db->getTableColumns(trim($table));
-
-				foreach ($tmpCols as $name => $tmpColType)
+				// Exclude subquery from the FROM clause
+				if (strpos($table, '(') === false)
 				{
-					$cols[] = $alias . '.' . $name;
+					// Unquote
+					$table = str_replace($nquotes, '', $table);
+					$table = str_replace('#__', $this->db->getPrefix(), $table);
+					$table = explode(' ', $table);
+					$alias = end($table);
+					$table = $table[0];
+
+					// Chek if exists a wildcard with current alias table?
+					if (in_array($alias, $wildcardTables, true))
+					{
+						if (!isset($cacheCols[$table]))
+						{
+							$cacheCols[$table] = $this->db->getTableColumns($table);
+						}
+
+						if ($this->join || $table != $alias)
+						{
+							foreach ($cacheCols[$table] as $name => $type)
+							{
+								$knownColumnsByAlias[$alias][] = $alias . '.' . $name;
+							}
+						}
+						else
+						{
+							foreach ($cacheCols[$table] as $name => $type)
+							{
+								$knownColumnsByAlias[$alias][] = $name;
+							}
+						}
+					}
+				}
+			}
+
+			// Now we need to get all tables from any joins
+			// Go through all joins and add them to the tables array
+			if ($this->join)
+			{
+				foreach ($this->join as $join)
+				{
+					// Unquote and replace prefix
+					$joinTbl = str_replace($nquotes, '', (string) $join);
+					$joinTbl = str_replace("#__", $this->db->getPrefix(), $joinTbl);
+
+					// Exclude subquery
+					if (preg_match('/JOIN\s+(\w+)(?:\s+AS)?(?:\s+(\w+))?/i', $joinTbl, $matches))
+					{
+						$table = $matches[1];
+						$alias = isset($matches[2]) ? $matches[2] : $table;
+
+						// Chek if exists a wildcard with current alias table?
+						if (in_array($alias, $wildcardTables, true))
+						{
+							if (!isset($cacheCols[$table]))
+							{
+								$cacheCols[$table] = $this->db->getTableColumns($table);
+							}
+
+							foreach ($cacheCols[$table] as $name => $type)
+							{
+								$knownColumnsByAlias[$alias][] = $alias . '.' . $name;
+							}
+						}
+					}
 				}
 			}
 		}
 
-		$selectStr = str_replace('SELECT ', '', (string) $this->select);
+		$selectExpression = implode(',', $selectColumns);
 
-		// Remove any functions (e.g. COUNT(), SUM(), CONCAT())
-		$selectCols = preg_replace("/([^,]*\([^\)]*\)[^,]*,?)/", '', $selectStr);
+		// Split into the right columns
+		$groupColumns = $this->splitSqlExpression(implode(',', $this->group->getElements()));
 
-		// Remove any "as alias" statements
-		$selectCols = preg_replace("/(\sas\s[^,]*)/i", '', $selectCols);
-
-		// Remove any extra commas
-		$selectCols = preg_replace('/,{2,}/', ',', $selectCols);
-
-		// Remove any trailing commas and all whitespaces
-		$selectCols = trim(str_replace(' ', '', preg_replace("/,?$/", '', $selectCols)));
-
-		// Get an array to compare against
-		$selectCols = explode(',', $selectCols);
-
-		// Find all alias.* and fill with proper table column names
-		foreach ($selectCols as $key => $aliasColName)
+		// Remove column aliases from GROUP statement - SQLSRV does not support it
+		foreach ($groupColumns as $i => $column)
 		{
-			if (preg_match("/.+\*/", $aliasColName, $match))
+			$groupColumns[$i] = implode(' ', $column);
+			$column = str_replace($nquotes, '', $groupColumns[$i]);
+
+			if (isset($knownAliases[$column]))
 			{
-				// Grab the table alias minus the .*
-				$aliasStar = preg_replace("/(.+)\.\*/", "$1", $aliasColName);
-
-				// Unset the array key
-				unset($selectCols[$key]);
-
-				// Get the table name
-				$tableColumns = preg_grep("/{$aliasStar}\.+/", $cols);
-				$columns = array_merge($columns, $tableColumns);
+				// Be sure that this is not a valid column name
+				if (!preg_match('/\b' . preg_quote($column, '/') . '\b/', $selectExpression))
+				{
+					// Replace column alias by column expression
+					$groupColumns[$i] = $knownAliases[$column];
+				}
 			}
 		}
 
-		// Finally, get a unique string of all column names that need to be included in the group statement
-		$columns = array_unique(array_merge($columns, $selectCols));
-		$columns = implode(',', $columns);
+		// Find all alias.* and fill with proper table column names
+		foreach ($filteredColumns as $i => $column)
+		{
+			if (substr($column, -2) === '.*')
+			{
+				unset($filteredColumns[$i]);
 
-		// Recreate it every time, to ensure we have checked _all_ select statements
-		$this->group = new JDatabaseQueryElement('GROUP BY', $columns);
+				// Extract alias.* columns into GROUP BY statement
+				$groupColumns = array_merge($groupColumns, $knownColumnsByAlias[substr($column, 0, -2)]);
+			}
+		}
+
+		$groupColumns = array_merge($groupColumns, $filteredColumns);
+
+		if ($this->order)
+		{
+			// Remove direction suffixes
+			$dir = array(" DESC\v", " ASC\v");
+
+			$orderColumns = $this->splitSqlExpression(implode(',', $this->order->getElements()));
+
+			foreach ($orderColumns as $i => $column)
+			{
+				$column = implode(' ', $column);
+				$orderColumns[$i] = $column = trim(str_ireplace($dir, '', "$column\v"), "\v");
+
+				if (isset($knownAliases[str_replace($nquotes, '', $column)]))
+				{
+					unset($orderColumns[$i]);
+				}
+			}
+
+			$groupColumns = array_merge($groupColumns, $orderColumns);
+		}
+
+		// Get a unique string of all column names that need to be included in the group statement
+		$this->group = new JDatabaseQueryElement('GROUP BY', array_unique($groupColumns));
 
 		return $this;
 	}

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
@@ -52,8 +52,8 @@ class JDatabaseIteratorSqlsrvTest extends TestCaseDatabaseSqlsrv
 				2,
 				0,
 				array(
-					(object) array('title' => 'Testing', 'RowNumber' => '1'),
-					(object) array('title' => 'Testing2', 'RowNumber' => '2')
+					(object) array('title' => 'Testing'),
+					(object) array('title' => 'Testing2')
 				),
 				null
 			),

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -439,18 +439,37 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			(string) $this->_instance
 		);
 
+		// Column from ORDER BY will be added to GROUP BY
+		$this->_instance
+			->clear()
+			->select('id, catid AS acatid, COUNT(*)')
+			->from('#__content')
+			->group('acatid')
+			->order('hits');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,catid AS acatid,COUNT(*) AS [columnAlias2]' .
+			PHP_EOL . 'FROM #__content' .
+			PHP_EOL . 'GROUP BY catid,id,hits' .
+			PHP_EOL . 'ORDER BY hits',
+			(string) $this->_instance
+		);
+
+		// Aggregate expression from ORDER BY will not be added to GROUP BY
 		$this->_instance
 			->clear()
 			->select('[a].[id], c.id AS catid,c.name AS     [ x ]   , COUNT(*)  count')
 			->from('#__content AS a')
 			->innerJoin('(SELECT * FROM #__categories) c ON a.catid = c.id')
-			->group('catid,[ x ]');
+			->group('catid,[ x ]')
+			->order('COUNT(*)');
 
 		$this->assertEquals(
 			PHP_EOL . 'SELECT [a].[id],c.id AS catid,c.name AS [ x ],COUNT(*) AS count' .
 			PHP_EOL . 'FROM #__content AS a' .
 			PHP_EOL . 'INNER JOIN (SELECT * FROM #__categories) c ON a.catid = c.id' .
-			PHP_EOL . 'GROUP BY c.id,c.name,[a].[id]',
+			PHP_EOL . 'GROUP BY c.id,c.name,[a].[id]' .
+			PHP_EOL . 'ORDER BY COUNT(*)',
 			(string) $this->_instance
 		);
 	}

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -189,6 +189,273 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQuerySqlsrv::__splitSqlExpression method.
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__splitSqlExpression()
+	{
+		$columns = ' DISTINCT -[catid] AS [\\"] '
+			. ',/* /*/a.id/*"*//*x */'
+			. ', a .title /*  */AS [a\'title]]x]'
+			. ',\'\'\'\'\'\' /* AS */ '
+			. ',[catid] AS """" '
+			. ",-- x'x\n# comment(x\na.lft/* AS x*/ AS lft  /**/  "
+			. ',LOWER(SUBSTRING(/*x.title(*/a.language, /**/1,/*,,x.title,,*/ 7)) AS columnAlias3'
+			. ',LOWER("const(a,b,c,/*COMent in string STAY*/") "alias"'
+			. ",/**/+ /**/ +/**/ /**/- +/**/a.end /**/ + /**/ 1-3"
+			. ",'sta''tic' 'static'"
+			. ", 1. AS x";
+
+		$expected = array(
+			'DISTINCT - [catid] AS [\\"]',
+			'a.id',
+			'a.title AS [a\'title]]x]',
+			'\'\'\'\'\'\'',
+			'[catid] AS """"',
+			'a.lft AS lft',
+			'LOWER(SUBSTRING(a.language, 1, 7)) AS columnAlias3',
+			'LOWER("const(a,b,c,/*COMent in string STAY*/") "alias"',
+			'++-+ a.end + 1 - 3',
+			"'sta''tic' 'static'",
+			'1. AS x',
+		);
+
+		$columns = TestReflection::invoke($this->_instance, 'splitSqlExpression', $columns);
+
+		foreach ($columns as $i => $column)
+		{
+			$columns[$i] = implode(' ', $column);
+		}
+
+		$this->assertEquals(
+			$expected,
+			$columns
+		);
+
+		$columns = "ALL-[catid] AS []]] "
+			. ', - id';
+
+		$expected = array(
+			'ALL - [catid] AS []]]',
+			'- id',
+		);
+
+		$columns = TestReflection::invoke($this->_instance, 'splitSqlExpression', $columns);
+
+		foreach ($columns as $i => $column)
+		{
+			$columns[$i] = implode(' ', $column);
+		}
+
+		$this->assertEquals(
+			$expected,
+			$columns
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseQuerySqlsrv::fixSelectAliases method.
+	 *
+	 * @return  JDatabaseQuerySqlsrv
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__fixSelectAliases()
+	{
+		$this->_instance->select('*'
+			. ',a.*'
+			. ',id_9'
+			. ',a.id/*()*/'
+			. ',a.title AS atitle'
+			. ',  [a] ./**/ [column] /**/ALIAS_  '
+			. ',#__content.id id'
+			. ',#__content.id'
+			. ',\'static\' as  "alias"'
+			. ',\'static\' \'static\''
+			. ',LOWER(SUBSTRING(a.language, 1, 7)) AS [very lower]'
+			. ',LOWER("const(a,b,c")'
+			. ",DAY('2016-12-31') +\na.end"
+			. ',a +*+b'
+			. ',[a] *b/**/ +([a] / /**/[b]) + + /**/ +[c]/**/ -\'static\''
+			. ',\'static\'+ \'static\''
+			. ',\'static\''
+			. ', 0'
+			. ', 1.1 + + + 1'
+			. ', COUNT(#__content.*)'
+			. ', CAST(e AS d_type(10)) + \'\''
+			. ', NULL'
+			. ', @@IDENTITY'
+			. ', -a.id'
+			. ', eNULL'
+			. ','
+		);
+
+		$expected = array(
+			'*',
+			'a.*',
+			'id_9',
+			'a.id',
+			'a.title AS atitle',
+			'[a]. [column] AS ALIAS_',
+			'#__content.id AS id',
+			'#__content.id',
+			'\'static\' AS "alias"',
+			'\'static\' AS \'static\'',
+			'LOWER(SUBSTRING(a.language, 1, 7)) AS [very lower]',
+			'LOWER("const(a,b,c") AS [columnAlias11]',
+			'DAY(\'2016-12-31\') + a.end AS [columnAlias12]',
+			'a +*+ b AS [columnAlias13]',
+			'[a] * b + ([a] / [b]) +++ [c] - \'static\' AS [columnAlias14]',
+			'\'static\' + \'static\' AS [columnAlias15]',
+			'\'static\' AS [columnAlias16]',
+			'0 AS [columnAlias17]',
+			'1.1 +++ 1 AS [columnAlias18]',
+			'COUNT(#__content.*) AS [columnAlias19]',
+			'CAST(e AS d_type(10)) + \'\' AS [columnAlias20]',
+			'NULL AS [columnAlias21]',
+			'@@IDENTITY AS [columnAlias22]',
+			'- a.id AS [columnAlias23]',
+			'eNULL',
+			'',
+		);
+
+		TestReflection::invoke($this->_instance, 'fixSelectAliases');
+
+		$this->assertEquals(
+			$expected,
+			$this->_instance->select->getElements()
+		);
+
+		$this->_instance
+			->clear()
+			->select('DISTINCT + + + id'
+			. ", - +- +-a . [id_9]"
+			. ", - +- +-a. [id_9]"
+			. ", - +- +-a .[id_9]"
+			. ", - +- +-a.[id_9]"
+			. ", + - + ix"
+			. ", ++ ix"
+		);
+
+		$expected = array(
+			'DISTINCT +++ id',
+			'-+-+- a. [id_9] AS [columnAlias1]',
+			'-+-+- a. [id_9] AS [columnAlias2]',
+			'-+-+- a.[id_9] AS [columnAlias3]',
+			'-+-+- a.[id_9] AS [columnAlias4]',
+			'+-+ ix AS [columnAlias5]',
+			'++ ix',
+		);
+
+		TestReflection::invoke($this->_instance, 'fixSelectAliases');
+
+		$this->assertEquals(
+			$expected,
+			$this->_instance->select->getElements()
+		);
+
+		$this->_instance
+			->clear()
+			->select('DISTINCT - + + + [a] . id'
+			. ", [a] . [id_9]"
+			. ", c + /**/ + [a].[b]"
+			. ", [a].[b] + c"
+		);
+
+		$expected = array(
+			'DISTINCT -+++ [a]. id AS [columnAlias0]',
+			'[a]. [id_9]',
+			'c ++ [a].[b] AS [columnAlias2]',
+			'[a].[b] + c AS [columnAlias3]',
+		);
+
+		TestReflection::invoke($this->_instance, 'fixSelectAliases');
+
+		$this->assertEquals(
+			$expected,
+			$this->_instance->select->getElements()
+		);
+
+		$this->_instance
+			->clear()
+			->select('DISTINCT +id'
+			. ", ''+a . id_9 'alias'"
+		);
+
+		$expected = array(
+			'DISTINCT + id',
+			"'' + a. id_9 AS 'alias'",
+		);
+
+		TestReflection::invoke($this->_instance, 'fixSelectAliases');
+
+		$this->assertEquals(
+			$expected,
+			$this->_instance->select->getElements()
+		);
+	}
+
+	/**
+	 * Test for the JDatabaseQuerySqlsrv::fixGroupColumns method.
+	 *
+	 * @return  JDatabaseQuerySqlsrv
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__fixGroupColumns()
+	{
+		$this->_instance
+			->clear()
+			->select('a.id, a.catid AS acatid, 1 AS state, COUNT(*), \'const\'\'\'\'text: \' + \'E\', \'"\' + a.name + \'"\'')
+			->select('123 - (12 % 5) * 4')
+			->select('+ 2, NULL, +\'s\'')
+			->from('#__content AS a')
+			->group('acatid');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT a.id,a.catid AS acatid,1 AS state,COUNT(*) AS [columnAlias3]' .
+			',\'const\'\'\'\'text: \' + \'E\' AS [columnAlias4],\'"\' + a.name + \'"\' AS [columnAlias5]' .
+			',123 - (12 % 5) * 4 AS [columnAlias6]' .
+			',+ 2 AS [columnAlias7],NULL AS [columnAlias8],+ \'s\' AS [columnAlias9]' .
+			PHP_EOL . 'FROM #__content AS a' .
+			PHP_EOL . "GROUP BY a.catid,a.id,'const''''text: ' + 'E','\"' + a.name + '\"',123 - (12 % 5) * 4",
+			(string) $this->_instance
+		);
+
+		// Alias in GROUP BY statement
+		$this->_instance
+			->clear()
+			->select('id, catid AS acatid, COUNT(*)')
+			->from('#__content')
+			->group('acatid');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,catid AS acatid,COUNT(*) AS [columnAlias2]' .
+			PHP_EOL . 'FROM #__content' .
+			PHP_EOL . 'GROUP BY catid,id',
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear()
+			->select('[a].[id], c.id AS catid,c.name AS     [ x ]   , COUNT(*)  count')
+			->from('#__content AS a')
+			->innerJoin('(SELECT * FROM #__categories) c ON a.catid = c.id')
+			->group('catid,[ x ]');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT [a].[id],c.id AS catid,c.name AS [ x ],COUNT(*) AS count' .
+			PHP_EOL . 'FROM #__content AS a' .
+			PHP_EOL . 'INNER JOIN (SELECT * FROM #__categories) c ON a.catid = c.id' .
+			PHP_EOL . 'GROUP BY c.id,c.name,[a].[id]',
+			(string) $this->_instance
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void
@@ -206,11 +473,11 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 		$string = (string) $this->_instance;
 
 		$this->assertEquals(
-			PHP_EOL . "UPDATE a" .
-			PHP_EOL . "SET a.id = 2" .
-			PHP_EOL . "FROM #__foo AS a" .
-			PHP_EOL . "INNER JOIN b ON b.id = a.id" .
-			PHP_EOL . "WHERE b.id = 1",
+			PHP_EOL . 'UPDATE a' .
+			PHP_EOL . 'SET a.id = 2' .
+			PHP_EOL . 'FROM #__foo AS a' .
+			PHP_EOL . 'INNER JOIN b ON b.id = a.id' .
+			PHP_EOL . 'WHERE b.id = 1',
 			$string
 		);
 

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -151,6 +151,44 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQuerySqlsrv::__processLimit method.
+	 *
+	 * @return  JDatabaseQuerySqlsrv
+	 *
+	 * @since   3.7.0
+	 */
+	public function test__processLimit()
+	{
+		$this->_instance
+			->select('id, COUNT(*) AS count')
+			->from('a')
+			->where('id = 1');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1',
+			$this->_instance->processLimit((string) $this->_instance, 0)
+		);
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT TOP 30 id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1',
+			$this->_instance->processLimit((string) $this->_instance, 30)
+		);
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber FROM (' .
+			PHP_EOL . 'SELECT TOP 4 id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . ') AS A) AS A WHERE RowNumber > 3',
+			$this->_instance->processLimit((string) $this->_instance, 1, 3)
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void


### PR DESCRIPTION
Competition for https://github.com/joomla/joomla-cms/pull/11938

### Summary of Changes
Fix various  problems with sqlsrv queries:

* Add alias to column (or expression) which does not have it, but it is required if query will use `OFFSET`, which means use wrapped query to emulate offset. **Every column in `SELECT` statement required alias if it is placed in subquery.**
* If `SELECT` contains a wild column `x.*` then load and put all columns from x table to `GROUP BY`
* If `GROUP BY` contains alias to (column or expression) then replace it with expression. 
Ex:
`SELECT LOWER(name) AS name, catid AS cc, count(*) ... GROUP BY name, cc`
will be replaced to
`SELECT LOWER(name) AS name, count(*) ... GROUP BY LOWER(name), catid`
* Add column from `ORDER BY` to GROUP BY if not yet exists. If this is an alias then replace it with expression as mentioned earlier.
* Add columns from `SELECT` to `GROUP BY` if missing (related to mysql `ONLY_FULL_GROUP_BY`). Probably it would be better to fix joomla queries than create such workaround.
Example of fixed query:
`SELECT id, name, COUNT(*) FROM #__x GROUP BY id`
    will be replaced by:
`SELECT id, name, COUNT(*) AS columnAlias0 FROM #__x GROUP BY id, name`


Fixed issue: https://github.com/joomla/joomla-cms/issues/11279

Removes notices, warnings and errors from:
* /administrator/index.php?option=com_banners
* /administrator/index.php?option=com_categories&extension=com_banners
* /administrator/index.php?option=com_banners&view=clients
* /administrator/index.php?option=com_finder&view=maps
* /administrator/index.php?option=com_categories&extension=com_newsfeeds
* /administrator/index.php?option=com_categories&extension=com_contact
* /administrator/index.php?option=com_postinstall

Fix issue with Popular Tags module on the front end.

### Testing Instructions
Be sure that you can see PHP Notices.
Test above links and module Popular Tags before and after patch.

* Install a new staging version of joomla (without sample data because currently joomla on mssql is broken - menu assets)
* Create a category and two articles with a few tags.
* Be sure that you have module Popular Tags enabled (ex. position-7)
* Go to the front page
* I should see some similar sql error as on image but with less details

![joomla_win_3 6 6](https://cloud.githubusercontent.com/assets/9054379/21304731/7d5bb56a-c5c7-11e6-84ea-9749ee79dee8.jpeg)

### Documentation Changes Required
No