### PR TITLE
addString

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -104,7 +104,7 @@ class JLanguage
 	protected $strings = array();
 
 	/**
-	 * Defined on fly
+	 * Translations defined on fly
 	 *
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -359,7 +359,7 @@ class JLanguage
 			}
 		}
 
-		if(!$this->strings[$key])
+		if (!$this->strings[$key])
 		{
 			if ($this->debug)
 			{
@@ -846,7 +846,8 @@ class JLanguage
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function def($constant, $value){
+	public function def($constant, $value)
+	{
 		if (!isset($this->strings[$constant]) && $value)
 		{
 			$this->_strings[$constant] = $value;

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -819,6 +819,25 @@ class JLanguage
 	}
 
 	/**
+	 * Allow extensions to dynamically set new strings
+	 * [Don't allow to reset/change constants so one extension won't damage other]
+	 *
+	 * @param  $constant
+	 * @param  $value
+	 *
+	 * @return  bool
+	 *
+	 * @since  3.7
+	 */
+	public function addString($constant, $value){
+		if(!isset($this->strings[$constant]) && $value){
+			$this->strings[$constant] = $value;
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Parses a language file.
 	 *
 	 * @param   string  $filename  The name of the file.

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -822,8 +822,8 @@ class JLanguage
 	 * Allow extensions to dynamically set new strings
 	 * [Don't allow to reset/change constants so one extension won't damage other]
 	 *
-	 * @param  $constant
-	 * @param  $value
+	 * @param   string  $constant
+	 * @param   string  $value
 	 *
 	 * @return  bool
 	 *

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -831,7 +831,7 @@ class JLanguage
 	 */
 	public function addString($constant, $value)
 	{
-		if(!isset($this->strings[$constant]) && $value)
+		if (!isset($this->strings[$constant]) && $value)
 		{
 			$this->strings[$constant] = $value;
 			return true;

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -829,8 +829,10 @@ class JLanguage
 	 *
 	 * @since  3.7
 	 */
-	public function addString($constant, $value){
-		if(!isset($this->strings[$constant]) && $value){
+	public function addString($constant, $value)
+	{
+		if(!isset($this->strings[$constant]) && $value)
+		{
 			$this->strings[$constant] = $value;
 			return true;
 		}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -359,7 +359,7 @@ class JLanguage
 			}
 		}
 
-		if (!$this->strings[$key])
+		if (!isset($this->strings[$key]))
 		{
 			if ($this->debug)
 			{

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -822,8 +822,8 @@ class JLanguage
 	 * Allow extensions to dynamically set new strings
 	 * [Don't allow to reset/change constants so one extension won't damage other]
 	 *
-	 * @param   string  $constant
-	 * @param   string  $value
+	 * @param   string  $constant  The key of language string.
+	 * @param   string  $value     The value for current language.
 	 *
 	 * @return  bool
 	 *

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -104,6 +104,14 @@ class JLanguage
 	protected $strings = array();
 
 	/**
+	 * Defined on fly
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_strings = array();
+
+	/**
 	 * An array of used text, used during debugging.
 	 *
 	 * @var    array
@@ -325,9 +333,17 @@ class JLanguage
 
 		$key = strtoupper($string);
 
-		if (isset($this->strings[$key]))
+		if (isset($this->strings[$key]) || (isset($this->_strings[$key]) && !$this->debug))
 		{
-			$string = $this->debug ? '**' . $this->strings[$key] . '**' : $this->strings[$key];
+			if (isset($this->strings[$key]))
+			{
+				$string = $this->strings[$key];
+			}
+			elseif (!$this->debug)
+			{
+				$string = $this->_strings[$key];
+			}
+			$string = $this->debug ? '**' . $string . '**' : $string;
 
 			// Store debug information
 			if ($this->debug)
@@ -342,7 +358,8 @@ class JLanguage
 				$this->used[$key][] = $caller;
 			}
 		}
-		else
+
+		if(!$this->strings[$key])
 		{
 			if ($this->debug)
 			{
@@ -819,7 +836,7 @@ class JLanguage
 	}
 
 	/**
-	 * Allow extensions to dynamically set new strings
+	 * Allow extensions to dynamically define if not defined new strings
 	 * [Don't allow to reset/change constants so one extension won't damage other]
 	 *
 	 * @param   string  $constant  The key of language string.
@@ -829,11 +846,10 @@ class JLanguage
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function addString($constant, $value)
-	{
+	public function def($constant, $value){
 		if (!isset($this->strings[$constant]) && $value)
 		{
-			$this->strings[$constant] = $value;
+			$this->_strings[$constant] = $value;
 			return true;
 		}
 		return false;

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -827,7 +827,7 @@ class JLanguage
 	 *
 	 * @return  bool
 	 *
-	 * @since  3.7
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public function addString($constant, $value)
 	{


### PR DESCRIPTION
Dynamically add string for Dynamic strings
For example: COM_EXAMPLE_DYNAMICFIELD_LABEL

### Summary of Changes
Adding ability to set custom strings on fly
Don't allow to force strings change/reset so one extension couldn't damage another

### Test instructions
Add into isis/index.php
```php
JFactory::getLanguage()->def('COM_NOTHING_TEST', 'It works!');
echo JText::_('COM_NOTHING_TEST');
```
and then visit any page in the back end. You should get:
![screen shot 2016-12-18 at 08 48 56](https://issues.joomla.org/uploads/1/98311a0441a04883377a8a4ba6f24074.png)

### Documentation Changes Required
May be added to documentation, but should be marked with:
`Try to avoid use of this if possible; Language files implementation first attitude`

### In the end of the day
Allows
```PHP
JFactory::getLanguage()->def('MY_CONSTANT','My hard my_constant value');
...
echo JText::_('MY_CONSTANT');
```
instead of 
```PHP
echo (JText::_('MY_CONSTANT') && JText::_('MY_CONSTANT')!='MY_CONSTANT')?JText::_('MY_CONSTANT'):'My hard my_constant value';
```
____
Behavior switched off in debugging mode. 