### PR TITLE
Fix unnecessary vertical scrollbar

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7114,6 +7114,7 @@ body {
 	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	box-sizing: border-box;
 }
 a:hover,
 a:active,

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7114,6 +7114,7 @@ body {
 	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	box-sizing: border-box;
 }
 a:hover,
 a:active,

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -85,6 +85,7 @@ body {
 	height: 100%;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	box-sizing: border-box;
 }
 
 a:hover,


### PR DESCRIPTION
### Summary of Changes
Isis always displays a vertical scrollbar due to a box sizing issue. 

### Testing Instructions
Apply PR and navigate to any page that shouldn't display a vertical scroll bar.

**Before Patch**
![overflow1](https://cloud.githubusercontent.com/assets/2803503/21296605/57866494-c567-11e6-9f8e-ba450343f348.png)

**After Patch**
![overflow2](https://cloud.githubusercontent.com/assets/2803503/21296606/5f9e4e8a-c567-11e6-9aca-43cd0bb3ad0f.png)

### Documentation Changes Required
No