### PR TITLE
Logout code needs to account for shared_session parameter

### DIFF
--- a/administrator/components/com_login/controller.php
+++ b/administrator/components/com_login/controller.php
@@ -96,8 +96,17 @@ class LoginController extends JControllerLegacy
 
 		$userid = $this->input->getInt('uid', null);
 
+		if ($app->get('shared_session', '0'))
+		{
+			$clientid = null;
+		}
+		else
+		{
+			$clientid = $userid ? 0 : 1;
+		}
+
 		$options = array(
-			'clientid' => ($userid) ? 0 : 1
+			'clientid' => $clientid,
 		);
 
 		$result = $app->logout($userid, $options);

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -413,6 +413,11 @@ class UsersModelUser extends JModelAdmin
 
 		JPluginHelper::importPlugin($this->events_map['save']);
 
+		// Prepare the logout options.
+		$options = array(
+			'clientid' => $app->get('shared_session', '0') ? null : 0,
+		);
+
 		// Access checks.
 		foreach ($pks as $i => $pk)
 		{
@@ -429,11 +434,6 @@ class UsersModelUser extends JModelAdmin
 
 				// Don't allow non-super-admin to delete a super admin
 				$allow = (!$iAmSuperAdmin && JAccess::check($pk, 'core.admin')) ? false : $allow;
-
-				// Prepare the logout options.
-				$options = array(
-					'clientid' => 0
-				);
 
 				if ($allow)
 				{

--- a/components/com_users/controllers/user.php
+++ b/components/com_users/controllers/user.php
@@ -146,8 +146,13 @@ class UsersControllerUser extends UsersController
 
 		$app = JFactory::getApplication();
 
+		// Prepare the logout options.
+		$options = array(
+			'clientid' => $app->get('shared_session', '0') ? null : 0,
+		);
+
 		// Perform the log out.
-		$error  = $app->logout();
+		$error  = $app->logout(null, $options);
 		$input  = $app->input;
 		$method = $input->getMethod();
 
@@ -166,7 +171,6 @@ class UsersControllerUser extends UsersController
 		{
 			if (JLanguageMultilang::isEnabled())
 			{
-
 				$db = JFactory::getDbo();
 				$query = $db->getQuery(true)
 					->select('language')

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -963,8 +963,8 @@ class JApplicationCms extends JApplicationWeb
 		$parameters['username'] = $user->get('username');
 		$parameters['id'] = $user->get('id');
 
-		// Set clientid in the options array if it hasn't been set already.
-		if (!isset($options['clientid']))
+		// Set clientid in the options array if it hasn't been set already and shared sessions are not enabled.
+		if (!$this->get('shared_session', '0') && !isset($options['clientid']))
 		{
 			$options['clientid'] = $this->getClientId();
 		}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -288,7 +288,7 @@ class PlgUserJoomla extends JPlugin
 		$sharedSessions = $this->app->get('shared_session', '0');
 
 		// Check to see if we're deleting the current session
-		if ($my->id == $user['id'] && (!$sharedSessions && $options['clientid'] == $this->app->getClientId()))
+		if ($my->id == $user['id'] && ($sharedSessions || (!$sharedSessions && $options['clientid'] == $this->app->getClientId())))
 		{
 			// Hit the user last visit field
 			$my->setLastVisit();


### PR DESCRIPTION
Pull Request for Issue N/A

### Summary of Changes

The logout code has checks for a client ID that needs to be accounted for.  Make those adaptions.

### Testing Instructions

Logging out should work correctly.  You may need #13075 applied to be able to create a scenario where logout is not working right.  The branch at https://github.com/mbabker/joomla-cms/tree/logout-database-sessions combines these two PRs for convenience.

### Documentation Changes Required

N/A