### PR TITLE
Improve doc blocks for JMenu

### DIFF
--- a/libraries/cms/menu/menu.php
+++ b/libraries/cms/menu/menu.php
@@ -137,7 +137,7 @@ class JMenu
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  mixed    The item object, or null if not found
+	 * @return  JMenuItem|null  The item object if the ID exists or null if not found
 	 *
 	 * @since   1.5
 	 */
@@ -157,9 +157,9 @@ class JMenu
 	 * Set the default item by id and language code.
 	 *
 	 * @param   integer  $id        The menu item id.
-	 * @param   string   $language  The language cod (since 1.6).
+	 * @param   string   $language  The language code (since 1.6).
 	 *
-	 * @return  boolean  True, if successful
+	 * @return  boolean  True if a menu item with the given ID exists
 	 *
 	 * @since   1.5
 	 */
@@ -180,7 +180,7 @@ class JMenu
 	 *
 	 * @param   string  $language  The language code, default value of * means all.
 	 *
-	 * @return  mixed  The item object or null when not found for given language
+	 * @return  JMenuItem|null  The item object or null when not found for given language
 	 *
 	 * @since   1.5
 	 */
@@ -204,7 +204,7 @@ class JMenu
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  mixed  If successful the active item, otherwise null
+	 * @return  JMenuItem|null  The menu item representing the given ID if present or null otherwise
 	 *
 	 * @since   1.5
 	 */
@@ -224,7 +224,7 @@ class JMenu
 	/**
 	 * Get menu item by id.
 	 *
-	 * @return  object  The item object.
+	 * @return  JMenuItem|null  The item object if an active menu item has been set or null
 	 *
 	 * @since   1.5
 	 */
@@ -248,7 +248,7 @@ class JMenu
 	 *                                each attribute may have multiple values to lookup for.
 	 * @param   boolean  $firstonly   If true, only returns the first item found
 	 *
-	 * @return  array
+	 * @return  JMenuItem|JMenuItem[]  An array of menu item objects or a single object if the $firstonly parameter is true
 	 *
 	 * @since   1.5
 	 */
@@ -307,7 +307,7 @@ class JMenu
 	 *
 	 * @param   integer  $id  The item id
 	 *
-	 * @return  Registry  A Registry object
+	 * @return  Registry
 	 *
 	 * @since   1.5
 	 */
@@ -324,7 +324,7 @@ class JMenu
 	/**
 	 * Getter for the menu array
 	 *
-	 * @return  array
+	 * @return  JMenuItem[]
 	 *
 	 * @since   1.5
 	 */
@@ -334,12 +334,11 @@ class JMenu
 	}
 
 	/**
-	 * Method to check JMenu object authorization against an access control
-	 * object and optionally an access extension object
+	 * Method to check JMenu object authorization against an access control object and optionally an access extension object
 	 *
 	 * @param   integer  $id  The menu id
 	 *
-	 * @return  boolean  True if authorised
+	 * @return  boolean
 	 *
 	 * @since   1.5
 	 */

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -136,7 +136,7 @@ class JMenuSite extends JMenu
 	 * @param   string   $values      The value of the field
 	 * @param   boolean  $firstonly   If true, only returns the first item found
 	 *
-	 * @return  array
+	 * @return  JMenuItem|JMenuItem[]  An array of menu item objects or a single object if the $firstonly parameter is true
 	 *
 	 * @since   1.6
 	 */
@@ -187,7 +187,7 @@ class JMenuSite extends JMenu
 	 *
 	 * @param   string  $language  The language code.
 	 *
-	 * @return  mixed  The item object or null when not found for given language
+	 * @return  JMenuItem|null  The item object or null when not found for given language
 	 *
 	 * @since   1.6
 	 */


### PR DESCRIPTION
### Summary of Changes

Improve doc blocks to highlight the returned `JMenuItem` object from the `JMenu` API.

### Testing Instructions

Review

### Documentation Changes Required

This is the documentation.