### PR TITLE
Limit number of tags returned in Ajax calls

### DIFF
--- a/components/com_tags/controllers/tags.php
+++ b/components/com_tags/controllers/tags.php
@@ -28,11 +28,13 @@ class TagsControllerTags extends JControllerLegacy
 
 		// Receive request data
 		$filters = array(
-			'like'      => trim($app->input->get('like', null)),
-			'title'     => trim($app->input->get('title', null)),
+			'like'      => trim($app->input->getString('like', null)),
+			'title'     => trim($app->input->getString('title', null)),
 			'flanguage' => $app->input->get('flanguage', null),
 			'published' => $app->input->get('published', 1, 'integer'),
-			'parent_id' => $app->input->get('parent_id', null)
+			'parent_id' => $app->input->get('parent_id', null),
+			'limit'		=> $app->input->get('limit', null),
+			'exclude'	=> $app->input->getString('exclude', null),
 		);
 
 		if ($results = JHelperTags::searchTags($filters))

--- a/layouts/joomla/html/tag.php
+++ b/layouts/joomla/html/tag.php
@@ -18,10 +18,10 @@ use Joomla\Registry\Registry;
  * @var  string   $selector       The id of the field
  * @var  string   $minTermLength  The minimum number of characters for the tag
  * @var  boolean  $allowCustom    Can we insert custom tags?
+ * @var  string   $language       Language code
  */
 
 extract($displayData);
-
 
 // Tags field ajax
 $chosenAjaxSettings = new Registry(
@@ -45,6 +45,12 @@ if ($allowCustom)
 		jQuery(document).ready(function ($) {
 
 			var customTagPrefix = '#new#';
+			var tagList = [];
+
+			// Initialise list of currently selected tags.
+			$('" . $selector . " option').filter(':selected').each(function() {
+				tagList.push(parseInt(this.value));
+			});
 
 			// Method to add tags pressing enter
 			$('" . $selector . "_chzn input').keyup(function(event) {
@@ -93,6 +99,54 @@ if ($allowCustom)
 					event.preventDefault();
 
 				}
+			});
+
+			// Event handler called whenever a tag is selected or deselected.
+			$('" . $selector . "').on('change', function(event, params) {
+
+				// Tag selected so add it to the internal list.
+				if (params.hasOwnProperty('selected'))
+				{
+					tagList.push(parseInt(params.selected));
+				}
+
+				// Tag deselected so remove it from the internal list.
+				if (params.hasOwnProperty('deselected'))
+				{
+					var index = tagList.indexOf(parseInt(params.deselected));
+
+					if (index > -1)
+					{
+						tagList.splice(index, 1);
+					}
+				}
+
+				// Make an Ajax call to get a list of tags, excluding those already in the internal list.
+				$.ajax('" . JUri::root() . "index.php?option=com_tags&task=tags.searchAjax', {
+					data: {
+						flanguage: '" . $language . "',
+						published: 1,
+						limit: " . (int) JComponentHelper::getParams('com_tags')->get('maximum', 200) . ",
+						exclude: tagList.join(',')
+					}
+				}).done(function(data) {
+
+					var dataArray = JSON.parse(data);
+
+					if (dataArray.length)
+					{
+						// Check each tag to see if it's already in the select list.
+						$.each(JSON.parse(data), function (key, val) {
+
+							// If the tag is not already in the select list, add it.
+							if (!$('" . $selector . " option[value=' + val.value + ']').length)
+							{
+								// Append the option and repopulate the chosen field.
+								$('" . $selector . "').append($('<option>').text(val.text).val(val.value)).trigger('liszt:updated');
+							}
+						});
+					}
+				});
 			});
 		});
 		"

--- a/layouts/joomla/html/tag.php
+++ b/layouts/joomla/html/tag.php
@@ -113,7 +113,7 @@ if ($allowCustom)
 				// Tag deselected so remove it from the internal list.
 				if (params.hasOwnProperty('deselected'))
 				{
-					var index = tagList.indexOf(parseInt(params.deselected));
+					var index = $.inArray(parseInt(params.deselected), tagList);
 
 					if (index > -1)
 					{

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -898,24 +898,35 @@ class JHelperTags extends JHelper
 	 */
 	public static function searchTags($filters = array())
 	{
+		$published = $filters['published'] ? $filters['published'] : array(0, 1);
+
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select('a.id AS value')
 			->select('a.path AS text')
 			->select('a.path')
 			->from('#__tags AS a')
-			->join('LEFT', $db->quoteName('#__tags', 'b') . ' ON a.lft > b.lft AND a.rgt < b.rgt');
+			;
 
-		// Filter language
+		// Filter language.
 		if (!empty($filters['flanguage']))
 		{
-			$query->where('a.language IN (' . $db->quote($filters['flanguage']) . ',' . $db->quote('*') . ') ');
+			if (strpos($filters['flanguage'], ',') !== false)
+			{
+				$language = implode(',', $db->quote(explode(',', $filters['flanguage'])));
+			}
+			else
+			{
+				$language = $db->quote($filters['flanguage']);
+			}
+
+			$query->where($db->quoteName('a.language') . ' IN (' . $language . ',' . $db->quote('*') . ')');
 		}
 
-		// Do not return root
+		// Do not return root.
 		$query->where($db->quoteName('a.alias') . ' <> ' . $db->quote('root'));
 
-		// Search in title or path
+		// Search in title or path.
 		if (!empty($filters['like']))
 		{
 			$query->where(
@@ -924,19 +935,24 @@ class JHelperTags extends JHelper
 			);
 		}
 
-		// Filter title
+		// Filter title.
 		if (!empty($filters['title']))
 		{
 			$query->where($db->quoteName('a.title') . ' = ' . $db->quote($filters['title']));
 		}
 
-		// Filter on the published state
-		if (isset($filters['published']) && is_numeric($filters['published']))
+		// Filter on the published state.
+		if (is_numeric($published))
 		{
-			$query->where('a.published = ' . (int) $filters['published']);
+			$published = (array) $published;
 		}
 
-		// Filter by parent_id
+		if (is_array($published))
+		{
+			$query->where('a.published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
+		}
+
+		// Filter by parent_id.
 		if (!empty($filters['parent_id']))
 		{
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_tags/tables');
@@ -953,8 +969,20 @@ class JHelperTags extends JHelper
 			}
 		}
 
-		$query->group('a.id, a.title, a.level, a.lft, a.rgt, a.parent_id, a.published, a.path')
-			->order('a.lft ASC');
+		// Exclude some tag ids.
+		if (!empty($filters['exclude']))
+		{
+			$exclude = ArrayHelper::toInteger(explode(',', $filters['exclude']));
+			$query->where('a.id NOT IN (' . implode(',', $exclude) . ')');
+		}
+
+		// Limit the number of tags returned.
+		$limit = isset($filters['limit']) ? (int) $filters['limit'] : 0;
+
+		if ($limit)
+		{
+			$query->setLimit($limit);
+		}
 
 		// Get the options.
 		$db->setQuery($query);

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -905,8 +905,7 @@ class JHelperTags extends JHelper
 			->select('a.id AS value')
 			->select('a.path AS text')
 			->select('a.path')
-			->from('#__tags AS a')
-			;
+			->from('#__tags AS a');
 
 		// Filter language.
 		if (!empty($filters['flanguage']))

--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -156,12 +156,13 @@ abstract class JHtmlTag
 	 *
 	 * @param   string   $selector     DOM id of the tag field
 	 * @param   boolean  $allowCustom  Flag to allow custom values
+	 * @param   string   $language     Language code
 	 *
 	 * @return  void
 	 *
 	 * @since   3.1
 	 */
-	public static function ajaxfield($selector = '#jform_tags', $allowCustom = true)
+	public static function ajaxfield($selector = '#jform_tags', $allowCustom = true, $language = '*')
 	{
 		// Get the component parameters
 		$params = JComponentHelper::getParams('com_tags');
@@ -171,6 +172,7 @@ abstract class JHtmlTag
 			'minTermLength' => $minTermLength,
 			'selector'      => $selector,
 			'allowCustom'   => JFactory::getUser()->authorise('core.create', 'com_tags') ? $allowCustom : false,
+			'language'		=> $language,
 		);
 
 		JLayoutHelper::render('joomla.html.tag', $displayData);


### PR DESCRIPTION
Pull Request for Issue #8074 and a replacement for PR https://github.com/joomla/joomla-cms/pull/9155.

### Summary of Changes
Finally got some time to look at this again.  Although it's relatively straightforward to limit the number of tags initially shown in the drop-down (which was a problem for sites with thousands of tags), the list needs to be updated as tags are selected.

The problem is that if you select one or more tags from the list, then deselect them again (without clicking Save), the drop-down list is dramatically shortened to just those tags that have been added or removed since the page was loaded.  The only way to load and select further tags is to start entering characters so that the search function kicks in.

With this PR, whenever a tag is selected an Ajax call is made so that tags are continually added to the drop-down list to replenish it.

In the process of writing this code I also made the JHelperTags::searchTags method a little smarter so that a considerable amount of duplicated code has been removed from JFormFieldTag::getOptions.

### Testing Instructions
* In Components -> Tags -> Options, set Maximum Items to something reasonably small, say 5.
* Make sure you have more than that number of tags already created.
* Edit an article, or some other content item with a tags field.
* In the drop-down, notice that there are exactly 5 un-selected tags listed.
* Select a tag from the list.  In the drop-down, notice that an extra tag has been added to the list to maintain exactly 5 un-selected tags.
* Deselect a tag.  Notice that the drop-down now has 6 un-selected tags (we only add to the list, never remove from it).
* Also check that it works as expected with UTF-8 tags.
* Make sure I haven't broken anything else in the tags implementation.

### Documentation Changes Required
None.
