### PR TITLE
PostgreSQL - return the same string each time of call __toString() on update query with join

### DIFF
--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -123,23 +123,36 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 
 				if ($this->join)
 				{
-					$onWord = ' ON ';
+					$tmpFrom     = $this->from;
+					$tmpWhere    = $this->where ? clone $this->where : null;
+					$this->from  = null;
 
 					// Workaround for special case of JOIN with UPDATE
 					foreach ($this->join as $join)
 					{
 						$joinElem = $join->getElements();
 
-						$joinArray = explode($onWord, $joinElem[0]);
+						$joinArray = preg_split('/\sON\s/i', $joinElem[0], 2);
 
 						$this->from($joinArray[0]);
-						$this->where($joinArray[1]);
+
+						if (isset($joinArray[1]))
+						{
+							$this->where($joinArray[1]);
+						}
 					}
 
 					$query .= (string) $this->from;
-				}
 
-				if ($this->where)
+					if ($this->where)
+					{
+						$query .= (string) $this->where;
+					}
+
+					$this->from  = $tmpFrom;
+					$this->where = $tmpWhere;
+				}
+				elseif ($this->where)
 				{
 					$query .= (string) $this->where;
 				}

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -190,19 +190,43 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function test__toStringUpdate()
 	{
-		$q = new JDatabaseQueryPostgresql($this->dbo);
+		// Test on ugly query
+		$this->_instance
+			->update('#__foo AS a')
+			->join('INNER', "b\roN\nb.id = a.id")
+			->set('a.hits = 0');
 
-		$q->update('#__foo AS a')
+		$string = (string) $this->_instance;
+
+		$this->assertEquals(
+			PHP_EOL . "UPDATE #__foo AS a" .
+			PHP_EOL . "SET a.hits = 0" .
+			PHP_EOL . "FROM b" .
+			PHP_EOL . "WHERE b.id = a.id",
+			$string
+		);
+
+		$this->_instance
+			->clear()
+			->update('#__foo AS a')
 			->join('INNER', 'b ON b.id = a.id')
 			->set('a.id = 2')
 			->where('b.id = 1');
+
+		$string = (string) $this->_instance;
 
 		$this->assertEquals(
 			PHP_EOL . "UPDATE #__foo AS a" .
 			PHP_EOL . "SET a.id = 2" .
 			PHP_EOL . "FROM b" .
 			PHP_EOL . "WHERE b.id = 1 AND b.id = a.id",
-			(string) $q
+			$string
+		);
+
+		// Run method __toString() again on the same query
+		$this->assertEquals(
+			$string,
+			(string) $this->_instance
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue:
- Update (with join) query (JDatabaseQueryPostgresql) on each call method `__toString()` generates different string.

### Summary of Changes
- Fix PostgreSQL update query to return the same string each time of call method  `__toString()`
- this PR become from #12839

### Testing Instructions

Test by travis.
Code review.

### Documentation Changes Required
N/A
