### PR TITLE
Fixed issue #11932 (Mssql: article can´t be created)

### DIFF
--- a/libraries/cms/helper/usergroups.php
+++ b/libraries/cms/helper/usergroups.php
@@ -197,7 +197,7 @@ final class JHelperUsergroups
 				->select('count(id)')
 				->from('#__usergroups');
 
-			$db->setQuery($query, 0, 1);
+			$db->setQuery($query);
 
 			$this->total = (int) $db->loadResult();
 		}


### PR DESCRIPTION
Removed an unnecessary range restriction on a SQL query, which caused an
invalid query to be generated for Microsoft SQL Server when certain actions such as creating an article were performed.