### PR TITLE
[sql] - GROUP_CONCAT() portable other than mysql

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -178,9 +178,9 @@ class FieldsModelFields extends JModelList
 		}
 
 		// Join over the assigned categories
-		$query->select("GROUP_CONCAT(fc.category_id SEPARATOR ',') AS assigned_cat_ids")
+		$query->select($query->groupConcat('fc.category_id', ',') . " AS assigned_cat_ids")
 			->join('LEFT', $db->quoteName('#__fields_categories') . ' AS fc ON fc.field_id = a.id')
-			->group('a.id');
+			->group('a.id, l.title, l.image, uc.name, ag.title, ua.name, g.title, g.access, g.state');
 
 		if (($categories = $this->getState('filter.assigned_cat_ids')) && $context)
 		{

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -162,4 +162,23 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	{
 		return " find_in_set(" . $value . ", " . $set . ")";
 	}
+
+	/**
+	 * Translate the mysql GROUP_CONCAT() function.
+	 *
+	 * Usage:
+	 * $query->groupConcat($field, $separator)
+	 *
+	 * @param   string  $field      The field to group .
+	 *
+	 * @param   string  $separator  The separator.
+	 *
+	 * @return  string  Returns the GROUP_CONCAT() mysql translation.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($field, $separator = ',')
+	{
+		return " GROUP_CONCAT(" . $field . " SEPARATOR '" . $separator . "')";
+	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -676,4 +676,23 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	{
 		return " $value = ANY (string_to_array($set, ',')::integer[]) ";
 	}
+
+	/**
+	 * Translate the mysql GROUP_CONCAT() function.
+	 *
+	 * Usage:
+	 * $query->groupConcat($field, $separator)
+	 *
+	 * @param   string  $field      The field to group .
+	 *
+	 * @param   string  $separator  The separator.
+	 *
+	 * @return  string  Returns the GROUP_CONCAT() postgresql translation.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function groupConcat($field, $separator = ',')
+	{
+		return " array_to_string(array_agg($field), '$separator') ";
+	}
 }

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -176,7 +176,9 @@ class PlgSearchContent extends JPlugin
 				->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid')
 				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
+				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id 
+						AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article')
+				)
 				->where(
 					'(' . $where . ') AND a.state=1 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups . ') '
 						. 'AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '
@@ -252,7 +254,9 @@ class PlgSearchContent extends JPlugin
 			$query->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid AND c.access IN (' . $groups . ')')
 				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
+				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id 
+						AND fv.field_id = f.id AND fv.context = '$db->q('com_content.article')
+				)
 				->where(
 					'(' . $where . ') AND a.state = 2 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups
 						. ') AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -255,7 +255,7 @@ class PlgSearchContent extends JPlugin
 				->join('INNER', '#__categories AS c ON c.id=a.catid AND c.access IN (' . $groups . ')')
 				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
 				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id 
-						AND fv.field_id = f.id AND fv.context = '$db->q('com_content.article')
+						AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article')
 				)
 				->where(
 					'(' . $where . ') AND a.state = 2 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -176,7 +176,7 @@ class PlgSearchContent extends JPlugin
 				->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid')
 				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
+				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
 				->where(
 					'(' . $where . ') AND a.state=1 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups . ') '
 						. 'AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '
@@ -252,13 +252,14 @@ class PlgSearchContent extends JPlugin
 			$query->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid AND c.access IN (' . $groups . ')')
 				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
+				->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
 				->where(
 					'(' . $where . ') AND a.state = 2 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups
 						. ') AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '
 						. 'AND (a.publish_up = ' . $db->quote($nullDate) . ' OR a.publish_up <= ' . $db->quote($now) . ') '
 						. 'AND (a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')'
 				)
+				->group('a.title, a.metadesc, a.metakey, a.created,text,slug,catslug, section')
 				->order($order);
 
 			// Filter by language.

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -170,7 +170,7 @@ class PlgSearchContent extends JPlugin
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language, a.catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
-				->select('GROUP_CONCAT(fv.value SEPARATOR \', \') AS fields')
+				->select($query->groupConcat('fv.value', ", ") . " AS fields")
 				->select('c.title AS section, ' . $case_when . ',' . $case_when1 . ', ' . '\'2\' AS browsernav')
 
 				->from('#__content AS a')
@@ -246,7 +246,7 @@ class PlgSearchContent extends JPlugin
 					. $case_when . ',' . $case_when1 . ', '
 					. 'c.title AS section, \'2\' AS browsernav'
 			)
-			->select('GROUP_CONCAT(fv.value SEPARATOR \', \') AS fields');
+			->select($query->groupConcat('fv.value', ', ') . " AS fields");
 
 			// .'CONCAT_WS("/", c.title) AS section, \'2\' AS browsernav' );
 			$query->from('#__content AS a')


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13246#issuecomment-267957631 .
see #13246 and #13285 and #13308

### Summary of Changes

- added the postgresql  `GROUP_CONCAT()`  translation
- fixed group by
- fixed typecast on join


### How to test

- content search plugin work as before
- com_fields work as before

### To do

- add the mssql translation
