### PR TITLE
[com_fields] Register extension path for formfield lookup in com_fields

### DIFF
--- a/administrator/components/com_fields/models/fields/type.php
+++ b/administrator/components/com_fields/models/fields/type.php
@@ -66,7 +66,7 @@ class JFormFieldType extends JFormAbstractlist
 		if ($parts)
 		{
 			$component = $parts[0];
-			$paths[] = JPATH_ADMINISTRATOR . '/components/' . $component . '/models/fields';
+			$paths = JFormHelper::addFieldPath(JPATH_ADMINISTRATOR . '/components/' . $component . '/models/fields');
 			JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR);
 			JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 		}


### PR DESCRIPTION
Currently, formfields from components aren't registered as custom fields. The code is actually there to look them up but it fails.

### Summary of Changes
Instead of just adding the path to the internal array, it now properly registers the path in the form. This way `JFormHelper::loadFieldClass()` a few lines below will actually find the field.

### Testing Instructions
You should see additional fields if an extension has custom ones that implement `JFormDomfieldinterface`
In core, we don't have that case but you can try it by adding `implements JFormDomfieldinterface`to eg this line: https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_users/models/fields/levels.php#L17
This should give you a new formfield "level" in com_users fields.

### Documentation Changes Required
None