### PR TITLE
[com_fields] Add context selector to fields groups

### DIFF
--- a/administrator/components/com_fields/models/forms/filter_groups.xml
+++ b/administrator/components/com_fields/models/forms/filter_groups.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
+	<fieldset name="group">
+		<field
+			name="context"
+			type="fieldcontexts"
+			onchange="this.form.submit();"
+		/>
+	</fieldset>
 	<fields name="filter">
 		<field
 			name="search"

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -44,6 +44,11 @@ if ($saveOrder)
 		<?php echo $this->sidebar; ?>
 	</div>
 	<div id="j-main-container" class="span10">
+		<div id="filter-bar" class="js-stools-container-bar pull-left">
+			<div class="btn-group pull-left">
+				<?php echo $this->filterForm->getField('context')->input; ?>
+			</div>&nbsp;
+		</div>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 		<?php if (empty($this->items)) : ?>
 			<div class="alert alert-no-items">


### PR DESCRIPTION
Currently, when you have multiple contexts in an extension you can select the context in the fields manager, but not in the fields groups manager.
Since field groups now use the full context instead of just the extension, we need a way to select the correct context.

### Summary of Changes
Adds the context selector to the fields groups similar to how it is in the fields manager.

### Testing Instructions
* Go to com_contact, create a field group and try to assign that group to a field of the context "Mail". The newly created group will only be available for fields of the context "Contact".
* Apply this PR and try again, now changing the context to "Mail" prior of creating the field group. It should work now.

### Documentation Changes Required
None