### PR TITLE
Container added to all batch modals

### DIFF
--- a/administrator/components/com_banners/views/banners/tmpl/default_batch_body.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default_batch_body.php
@@ -12,24 +12,26 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('banner.clients'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
+<div class="container-fluid">
+	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.item', 'com_banners'); ?>
+				<?php echo JHtml::_('batch.language'); ?>
 			</div>
 		</div>
-	<?php endif; ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('banner.clients'); ?>
+			</div>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.item', 'com_banners'); ?>
+				</div>
+			</div>
+		<?php endif; ?>
+	</div>
 </div>

--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -16,41 +16,43 @@ $published = $this->state->get('filter.published');
 $extension = $this->escape($this->state->get('filter.extension'));
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.language'); ?>
+			</div>
+		</div>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
 		</div>
 	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
-		<div class="span6">
-			<div class="control-group">
-				<label id="batch-choose-action-lbl" for="batch-category-id" class="control-label">
-					<?php echo JText::_('JLIB_HTML_BATCH_MENU_LABEL'); ?>
-				</label>
-				<div id="batch-choose-action" class="combo controls">
-					<select name="batch[category_id]" id="batch-category-id">
-						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
-						<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
-					</select>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="span6">
+				<div class="control-group">
+					<label id="batch-choose-action-lbl" for="batch-category-id" class="control-label">
+						<?php echo JText::_('JLIB_HTML_BATCH_MENU_LABEL'); ?>
+					</label>
+					<div id="batch-choose-action" class="combo controls">
+						<select name="batch[category_id]" id="batch-category-id">
+							<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
+							<?php echo JHtml::_('select.options', JHtml::_('category.categories', $extension, array('filter.published' => $published))); ?>
+						</select>
+					</div>
+				</div>
+				<div id="batch-copy-move" class="control-group radio">
+					<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+					<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
 				</div>
 			</div>
-			<div id="batch-copy-move" class="control-group radio">
-				<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
-				<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+		<?php endif; ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.tag'); ?>
 			</div>
-		</div>
-	<?php endif; ?>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.tag'); ?>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default_batch_body.php
@@ -10,34 +10,36 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
+<div class="container-fluid">
+	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.item', 'com_contact'); ?>
+				<?php echo JHtml::_('batch.language'); ?>
 			</div>
 		</div>
-	<?php endif; ?>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.tag'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
 		</div>
 	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.user'); ?>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.item', 'com_contact'); ?>
+				</div>
+			</div>
+		<?php endif; ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.tag'); ?>
+			</div>
+		</div>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.user'); ?>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
+++ b/administrator/components/com_content/views/articles/tmpl/default_batch_body.php
@@ -10,29 +10,31 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
+<div class="container-fluid">
+	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.item', 'com_content'); ?>
+				<?php echo JHtml::_('batch.language'); ?>
 			</div>
 		</div>
-	<?php endif; ?>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.tag'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.item', 'com_content'); ?>
+				</div>
+			</div>
+		<?php endif; ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.tag'); ?>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_fields/views/fields/tmpl/default_batch_body.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default_batch_body.php
@@ -30,37 +30,39 @@ JFactory::getDocument()->addScriptDeclaration(
 $context   = $this->escape($this->state->get('filter.context'));
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JLayoutHelper::render('joomla.html.batch.language', array()); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JLayoutHelper::render('joomla.html.batch.access', array()); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php $options = array(
-				JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
-				JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
-			);
-			?>
-			<label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo JText::_('COM_FIELDS_BATCH_GROUP_LABEL'); ?></label>
-			<div id="batch-choose-action" class="control-group">
-				<select name="batch[group_id]" class="inputbox" id="batch-group-id">
-					<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
-					<option value="nogroup"><?php echo JText::_('COM_FIELDS_BATCH_GROUP_OPTION_NONE'); ?></option>
-					<?php echo JHtml::_('select.options', $this->get('Groups'), 'value', 'text'); ?>
-				</select>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JLayoutHelper::render('joomla.html.batch.language', array()); ?>
 			</div>
-			<div id="batch-copy-move" class="control-group radio">
-				<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
-				<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+		</div>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JLayoutHelper::render('joomla.html.batch.access', array()); ?>
+			</div>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<div class="control-group span6">
+			<div class="controls">
+				<?php $options = array(
+					JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
+					JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
+				);
+				?>
+				<label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo JText::_('COM_FIELDS_BATCH_GROUP_LABEL'); ?></label>
+				<div id="batch-choose-action" class="control-group">
+					<select name="batch[group_id]" class="inputbox" id="batch-group-id">
+						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
+						<option value="nogroup"><?php echo JText::_('COM_FIELDS_BATCH_GROUP_OPTION_NONE'); ?></option>
+						<?php echo JHtml::_('select.options', $this->get('Groups'), 'value', 'text'); ?>
+					</select>
+				</div>
+				<div id="batch-copy-move" class="control-group radio">
+					<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+					<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/administrator/components/com_fields/views/groups/tmpl/default_batch_body.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default_batch_body.php
@@ -11,15 +11,17 @@ defined('_JEXEC') or die;
 JHtml::_('formbehavior.chosen', 'select');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.language'); ?>
+			</div>
 		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -16,39 +16,41 @@ $published = $this->state->get('filter.published');
 $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 ?>
 <?php if (strlen($menuType) && $menuType != '*') : ?>
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
-		<div id="batch-choose-action" class="combo control-group">
-			<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
-				<?php echo JText::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
-			</label>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
 			<div class="controls">
-				<select name="batch[menu_id]" id="batch-menu-id">
-					<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
-					<?php echo JHtml::_('select.options', JHtml::_('menu.menuitems', array('published' => $published, 'checkacl' => (int) $this->state->get('menutypeid')))); ?>
-				</select>
+				<?php echo JHtml::_('batch.language'); ?>
 			</div>
 		</div>
-		<div id="batch-copy-move" class="control-group radio">
-			<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
-			<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
 		</div>
+	</div>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div id="batch-choose-action" class="combo control-group">
+				<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
+					<?php echo JText::_('COM_MENUS_BATCH_MENU_LABEL'); ?>
+				</label>
+				<div class="controls">
+					<select name="batch[menu_id]" id="batch-menu-id">
+						<option value=""><?php echo JText::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
+						<?php echo JHtml::_('select.options', JHtml::_('menu.menuitems', array('published' => $published, 'checkacl' => (int) $this->state->get('menutypeid')))); ?>
+					</select>
+				</div>
+			</div>
+			<div id="batch-copy-move" class="control-group radio">
+				<?php echo JText::_('JLIB_HTML_BATCH_MOVE_QUESTION'); ?>
+				<?php echo JHtml::_('select.radiolist', $options, 'batch[move_copy]', '', 'value', 'text', 'm'); ?>
+			</div>
+		<?php endif; ?>
+	</div>
+	<?php else : ?>
+	<div class="row-fluid">
+		<p><?php echo JText::_('COM_MENUS_SELECT_MENU_FIRST'); ?></p>
+	</div>
 	<?php endif; ?>
 </div>
-<?php else : ?>
-<div class="row-fluid">
-	<p><?php echo JText::_('COM_MENUS_SELECT_MENU_FIRST'); ?></p>
-</div>
-<?php endif; ?>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -30,9 +30,8 @@ $attr = array(
 );
 
 ?>
-
-<p><?php echo JText::_('COM_MODULES_BATCH_TIP'); ?></p>
 <div class="container-fluid">
+	<p><?php echo JText::_('COM_MODULES_BATCH_TIP'); ?></p>
 	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -32,32 +32,34 @@ $attr = array(
 ?>
 
 <p><?php echo JText::_('COM_MODULES_BATCH_TIP'); ?></p>
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
-		<div class="span6">
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
 			<div class="controls">
-				<label id="batch-choose-action-lbl" for="batch-choose-action">
-					<?php echo JText::_('COM_MODULES_BATCH_POSITION_LABEL'); ?>
-				</label>
-				<div id="batch-choose-action" class="control-group">
-					<?php echo JHtml::_('select.groupedlist', $positions, 'batch[position_id]', $attr); ?>
-					<div id="batch-copy-move" class="control-group radio">
-						<?php echo JHtml::_('modules.batchOptions'); ?>
+				<?php echo JHtml::_('batch.language'); ?>
+			</div>
+		</div>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="span6">
+				<div class="controls">
+					<label id="batch-choose-action-lbl" for="batch-choose-action">
+						<?php echo JText::_('COM_MODULES_BATCH_POSITION_LABEL'); ?>
+					</label>
+					<div id="batch-choose-action" class="control-group">
+						<?php echo JHtml::_('select.groupedlist', $positions, 'batch[position_id]', $attr); ?>
+						<div id="batch-copy-move" class="control-group radio">
+							<?php echo JHtml::_('modules.batchOptions'); ?>
+						</div>
 					</div>
 				</div>
 			</div>
-		</div>
-	<?php endif; ?>
+		<?php endif; ?>
+	</div>
 </div>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default_batch_body.php
@@ -10,29 +10,31 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
-		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
-		</div>
-	</div>
-</div>
-<div class="row-fluid">
-	<?php if ($published >= 0) : ?>
+<div class="container-fluid">
+	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.item', 'com_newsfeeds'); ?>
+				<?php echo JHtml::_('batch.language'); ?>
 			</div>
 		</div>
-	<?php endif; ?>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.tag'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
+		</div>
+	</div>
+	<div class="row-fluid">
+		<?php if ($published >= 0) : ?>
+			<div class="control-group span6">
+				<div class="controls">
+					<?php echo JHtml::_('batch.item', 'com_newsfeeds'); ?>
+				</div>
+			</div>
+		<?php endif; ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.tag'); ?>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -11,10 +11,12 @@ $published = $this->state->get('filter.published');
 ?>
 
 <p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
-<div class="row-fluid">
-	<div class="control-group span12">
-		<div class="controls">
-			<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span12">
+			<div class="controls">
+				<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_tags/views/tags/tmpl/default_batch_body.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default_batch_body.php
@@ -10,15 +10,17 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<div class="row-fluid">
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.language'); ?>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.language'); ?>
+			</div>
 		</div>
-	</div>
-	<div class="control-group span6">
-		<div class="controls">
-			<?php echo JHtml::_('batch.access'); ?>
+		<div class="control-group span6">
+			<div class="controls">
+				<?php echo JHtml::_('batch.access'); ?>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_users/views/users/tmpl/default_batch_body.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_body.php
@@ -24,25 +24,27 @@ $resetOptions = array(
 JHtml::_('formbehavior.chosen', 'select');
 ?>
 
-<div class="row-fluid">
-	<div id="batch-choose-action" class="combo control-group">
-		<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
-			<?php echo JText::_('COM_USERS_BATCH_GROUP'); ?>
-		</label>
-	</div>
-	<div id="batch-choose-action" class="combo controls">
-		<div class="control-group">
-			<select name="batch[group_id]" id="batch-group-id">
-				<option value=""><?php echo JText::_('JSELECT'); ?></option>
-				<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
-			</select>
+<div class="container-fluid">
+	<div class="row-fluid">
+		<div id="batch-choose-action" class="combo control-group">
+			<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
+				<?php echo JText::_('COM_USERS_BATCH_GROUP'); ?>
+			</label>
+		</div>
+		<div id="batch-choose-action" class="combo controls">
+			<div class="control-group">
+				<select name="batch[group_id]" id="batch-group-id">
+					<option value=""><?php echo JText::_('JSELECT'); ?></option>
+					<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
+				</select>
+			</div>
+		</div>
+		<div class="control-group radio">
+			<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add'); ?>
 		</div>
 	</div>
+	<label><?php echo JText::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>
 	<div class="control-group radio">
-		<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add'); ?>
+		<?php echo JHtml::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', ''); ?>
 	</div>
-</div>
-<label><?php echo JText::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>
-<div class="control-group radio">
-	<?php echo JHtml::_('select.radiolist', $resetOptions, 'batch[reset_id]', '', 'value', 'text', ''); ?>
 </div>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7108,7 +7108,6 @@ div.modal.jviewport-width100 {
 	padding: 0 !important;
 }
 body.modal-open {
-	overflow: hidden;
 	-ms-overflow-style: none;
 }
 .modal-header {
@@ -7131,7 +7130,6 @@ body.modal-open {
 	padding: 0;
 	width: 100%;
 	height: auto;
-	overflow: hidden;
 }
 .modal-body .container-fluid {
 	padding-top: 15px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7112,7 +7112,7 @@ body.modal-open {
 	-ms-overflow-style: none;
 }
 .modal-header {
-	padding: 0 15px;
+	padding: 0 20px;
 	text-align: left;
 }
 .modal-header h3 {
@@ -7132,6 +7132,10 @@ body.modal-open {
 	width: 100%;
 	height: auto;
 	overflow: hidden;
+}
+.modal-body .container-fluid {
+	padding-top: 15px;
+	padding-bottom: 15px;
 }
 .modal-footer {
 	clear: both;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7108,7 +7108,6 @@ div.modal.jviewport-width100 {
 	padding: 0 !important;
 }
 body.modal-open {
-	overflow: hidden;
 	-ms-overflow-style: none;
 }
 .modal-header {
@@ -7131,7 +7130,6 @@ body.modal-open {
 	padding: 0;
 	width: 100%;
 	height: auto;
-	overflow: hidden;
 }
 .modal-body .container-fluid {
 	padding-top: 15px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7112,7 +7112,7 @@ body.modal-open {
 	-ms-overflow-style: none;
 }
 .modal-header {
-	padding: 0 15px;
+	padding: 0 20px;
 	text-align: left;
 }
 .modal-header h3 {
@@ -7132,6 +7132,10 @@ body.modal-open {
 	width: 100%;
 	height: auto;
 	overflow: hidden;
+}
+.modal-body .container-fluid {
+	padding-top: 15px;
+	padding-bottom: 15px;
 }
 .modal-footer {
 	clear: both;

--- a/administrator/templates/isis/less/blocks/_modals.less
+++ b/administrator/templates/isis/less/blocks/_modals.less
@@ -6,7 +6,7 @@ body.modal-open {
 }
 
 .modal-header {
-  padding: 0 15px;
+  padding: 0 20px;
   text-align: left;
   h3 {
   	font-weight: normal;
@@ -27,6 +27,10 @@ body.modal-open {
   width: 100%;
   height: auto;
   overflow: hidden;
+  .container-fluid {
+    padding-top: 15px;
+    padding-bottom: 15px;
+  }
 }
 
 .modal-footer {

--- a/administrator/templates/isis/less/blocks/_modals.less
+++ b/administrator/templates/isis/less/blocks/_modals.less
@@ -1,7 +1,6 @@
 // Modals
 
 body.modal-open {
-	overflow: hidden;
 	-ms-overflow-style: none;
 }
 
@@ -26,7 +25,6 @@ body.modal-open {
   padding: 0;
   width: 100%;
   height: auto;
-  overflow: hidden;
   .container-fluid {
     padding-top: 15px;
     padding-bottom: 15px;


### PR DESCRIPTION
Pull Request for Issue #13305 .

### Summary of Changes
Adds a container to the batch modals to stop content from been flush to the modal edges.

### Testing Instructions
Apply patch and check all batch modals.

**Before Patch**
![230ef55e-c6cb-11e6-94ac-166ee15a5843](https://cloud.githubusercontent.com/assets/2803503/21370872/f39a3a1e-c705-11e6-8f70-3f7ce913a469.png)

**After Patch**
![batch](https://cloud.githubusercontent.com/assets/2803503/21358582/1107e5ae-c6d1-11e6-9757-aa6cb77cbb16.png)


### Documentation Changes Required
None