### PR TITLE
Delete assigned categories when field is deleted

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -312,9 +312,18 @@ class FieldsModelField extends JModelAdmin
 
 			if (!empty($pks))
 			{
+				// Delete Values
 				$query = $this->getDbo()->getQuery(true);
 
 				$query->delete($query->qn('#__fields_values'))
+					->where($query->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
+
+				$this->getDbo()->setQuery($query)->execute();
+
+				// Delete Assigned Categories
+				$query = $this->getDbo()->getQuery(true);
+
+				$query->delete($query->qn('#__fields_categories'))
 					->where($query->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
 
 				$this->getDbo()->setQuery($query)->execute();


### PR DESCRIPTION
Pull Request for Issue #13312 .

### Summary of Changes
Adds a delete query to `FieldsModelField` which deletes assigned categories when field is deleted.

### Testing Instructions
* Create a field and assign some categories to it.
* Delete that field and check the #__fields_categories table that the respective entry is deleted.

### Documentation Changes Required
None