### PR TITLE
Fix tinyMCE xtd-buttons

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -779,7 +779,7 @@ class PlgEditorTinymce extends JPlugin
 			})();";
 
 				// The array with the toolbar buttons
-				$btnsNames[] = $name;
+				$btnsNames[] = $name . ' | ';
 
 				// The array with code for each button
 				$tinyBtns[] = $tempConstructor;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Make xtd-buttons behave

### Testing Instructions
Try setting a small width for tinyMCE e.g. https://github.com/joomla/joomla-cms/blob/staging/plugins/editors/tinymce/tinymce.php#L153 `style="max-width: 500px;"`

XTD-Buttons are broken:
![screen shot 2016-12-21 at 23 23 07](https://cloud.githubusercontent.com/assets/3889375/21406608/2517a2b4-c7d5-11e6-87da-105cad769da0.png)

Apply patch:
![screen shot 2016-12-21 at 23 22 40](https://cloud.githubusercontent.com/assets/3889375/21406629/3592c5c4-c7d5-11e6-98a4-90ae8bc2c45e.png)

### Documentation Changes Required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joomla/joomla-cms/13323)
<!-- Reviewable:end -->
