### PR TITLE
File extensions are not uninstalling correctly on package install rollback

### DIFF
--- a/libraries/cms/installer/adapter/file.php
+++ b/libraries/cms/installer/adapter/file.php
@@ -271,9 +271,9 @@ class JInstallerAdapterFile extends JInstallerAdapter
 				);
 			}
 
-			// Since we have created a module item, we add it to the installation step stack
+			// Since we have installed a file extension, we add it to the installation step stack
 			// so that if we have to rollback the changes we can undo it.
-			$this->parent->pushStep(array('type' => 'extension', 'extension_id' => $this->extension->extension_id));
+			$this->parent->pushStep(array('type' => 'extension', 'id' => $this->extension->extension_id));
 		}
 	}
 


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

The file installer adapter is not working correct when a install error exists and the system needs to rollback the changes.
This PR intends to fix that.

### Testing Instructions

I don't have an example of a package with a file extension inside,but the issue is the same as https://github.com/joomla/joomla-cms/pull/13324

So...

Use latest staging and a package with a file extension + other extensions and make one of the extensions (other than the file extension) fail on install (unzip, add `<folder>whatever</folder>` to a extension manifest to produce an error and zip again)

- Reproduce the issue

  - Install the corrupted package you will get and error and install of the package should rollback
  - Check extensions manage, order by id, and check you have the file extension installed

- Test patch: Apply patch, install the package and you will see the file extension is now uninstalled correctly on rollback

### Documentation Changes Required

None

### More info

You can see in the other extension adapters that the var name shoudl be called `id`, not `extension_id`, exmaple for [plugins](https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/installer/adapter/plugin.php#L444) and [libraries](https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/installer/adapter/library.php#L287).

Also that is the `id` that is checked in the [installer abort method](https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/installer/installer.php#L408)
