### PR TITLE
Multilanguage: Correcting login form redirect bug introduced in #12932

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -636,7 +636,7 @@ class PlgSystemLanguageFilter extends JPlugin
 						// If any association set to the user preferred site language, redirect to that page.
 						if ($assoc)
 						{
-							$associations = MenusHelper::getAssociations($itemid);
+							$associations = MenusHelper::getAssociations($uri->getVar('Itemid'));
 						}
 
 						if (isset($associations[$lang_code]) && $menu->getItem($associations[$lang_code]))


### PR DESCRIPTION
### Testing Instructions

Create a default Multingual site from staging with 2 languages, for example en-GB and fr-FR.
Set default site language to en-GB.
Set default USER site language to fr-FR
Make sure that the language filter `Automatic Language Change` parameter is set to Yes as well as `Item Associations`.

In the en-GB main menu, create 2 new menu items.
The first one can be for example a Search menu item type. `Search English`
The second one will be a login form. `Login English`

In the fr-FR main menu, create 1 new menu item, can also be a Search menu item type. `Search French`
**Associate this menu item to the en-GB one `Search English`**

Edit the en-GB `Login English` menu item.
In the Options tab, select `Menu item` as `Login Redirect Type`.
Select the `Search English` menu item as Menu Item Login Redirect.
Save.

Go to the frontend en-GB Home page.
Display the `Login English` login form.
Log.
You are redirected to the `Search English` page.

THAT IS WRONG! It should redirect to the `Search French` associated menu item  as the user preferred frontend language is fr-FR and Automatic language change is set to Yes.
Quote from code comments is
```php
// The login form contains a menu item redirection. Try to get associations from that menu item.
// If any association set to the user preferred site language, redirect to that page.
```
The issue comes from the fact that `$itemid` is undefined line 639 of languagefilter.php. Thsi error was introduced in my patch #12932 ... oops.

Now patch. You should be redirected to the correct page, i.e. "Search French"

@alikon @andrepereiradasilva 

