### PR TITLE
[com_fields] Remove assigned_cat_ids from FieldsTable

### DIFF
--- a/administrator/components/com_fields/tables/field.php
+++ b/administrator/components/com_fields/tables/field.php
@@ -110,11 +110,6 @@ class FieldsTableField extends JTable
 			$this->type = 'text';
 		}
 
-		if (is_array($this->assigned_cat_ids))
-		{
-			$this->assigned_cat_ids = implode(',', $this->assigned_cat_ids);
-		}
-
 		$date = JFactory::getDate();
 		$user = JFactory::getUser();
 


### PR DESCRIPTION
Pull Request for Issue #13331 .

### Summary of Changes
Removes no longer needed `assigned_cat_ids` from the FieldsTable

### Testing Instructions
Test that assigning categories to fields work as expected and no notices are thrown. See Issue for screencast of problem.

### Documentation Changes Required
None