### PR TITLE
[com_fields] Fields aren't updated for Smart Search (finder) on item save

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -416,14 +416,15 @@ class FinderIndexerHelper
 	 * Method to get extra data for a content before being indexed. This is how
 	 * we add Comments, Tags, Labels, etc. that should be available to Finder.
 	 *
-	 * @param   FinderIndexerResult  &$item  The item to index as an FinderIndexerResult object.
+	 * @param   FinderIndexerResult  &$item      The item to index as a FinderIndexerResult object.
+	 * @param   string               $extension  Extension name.
 	 *
 	 * @return  boolean  True on success, false on failure.
 	 *
 	 * @since   2.5
 	 * @throws  Exception on database error.
 	 */
-	public static function getContentExtras(FinderIndexerResult &$item)
+	public static function getContentExtras(FinderIndexerResult &$item, $extension = '')
 	{
 		// Get the event dispatcher.
 		$dispatcher = JEventDispatcher::getInstance();
@@ -432,7 +433,7 @@ class FinderIndexerHelper
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the event.
-		$results = $dispatcher->trigger('onPrepareFinderContent', array(&$item));
+		$results = $dispatcher->trigger('onPrepareFinderContent', array(&$item, $extension));
 
 		// Check the returned results. This is for plugins that don't throw
 		// exceptions when they encounter serious errors.

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -504,13 +504,15 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
+		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
+
 		// Add the extra custom fields to the item to be indexed.
 		foreach ($fields as $field)
 		{
 			// Add an instruction to index the field value.
 			$indexFieldName = 'jfield_' . $field->alias;
 			$item->addInstruction(FinderIndexer::TEXT_CONTEXT, $indexFieldName);
-			$item->{$indexFieldName} = $field->value;
+			$item->{$indexFieldName} = $model->getFieldValue($field->id, $extension . '.' . $section, $item->id);
 		}
 
 		return true;

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -488,7 +488,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onPrepareFinderContent(FinderIndexerResult &$item, $extension = '')
 	{
-		$section = strtolower($item->layout);
+		$context = $extension . '.' . strtolower($item->layout);
 
 		// Create a dummy object with the required fields
 		$tmp     = new stdClass;
@@ -496,7 +496,7 @@ class PlgSystemFields extends JPlugin
 		$tmp->catid = $item->catid;
 
 		// Getting the fields for the constructed context
-		$fields = FieldsHelper::getFields($extension . '.' . $section, $tmp, true);
+		$fields = FieldsHelper::getFields($context, $tmp, true);
 
 		// No extra data to add to this content item.
 		if (empty($fields))
@@ -512,7 +512,7 @@ class PlgSystemFields extends JPlugin
 			// Add an instruction to index the field value.
 			$indexFieldName = 'jfield_' . $field->alias;
 			$item->addInstruction(FinderIndexer::TEXT_CONTEXT, $indexFieldName);
-			$item->{$indexFieldName} = $model->getFieldValue($field->id, $extension . '.' . $section, $item->id);
+			$item->{$indexFieldName} = $model->getFieldValue($field->id, $context, $item->id);
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issue #12829 .

### Summary of Changes
This doesn't fully fix the issue, but hopefully it's a step in the right direction.

I've added an `$extension` argument to the _onPrepareFinderContent_ handler and the `FinderIndexerHelper::getContentExtras` method because `FieldsHelper::getFields` needs to know the extension name in order to retrieve the correct fields.  Perhaps there's a better way?  There's also an implied equivalence between the finder layout name and the second part of the field context variable.  Is that assumption always valid?  I'm not sure.

I've added a prefix of "jfield_" to the field name saved in the index so as to avoid possible collisions between user-defined custom field aliases and existing fields in the content item.

The code assumes that all custom fields have values that are searchable strings (I don't know whether that's true) and that the terms will have the same weight as body text.  I think it would be advisable to allow the user to determine whether a particular field is searchable and perhaps for some field types not to be searchable at all.  At the moment, even numeric fields are going to be indexed.  If a field is searchable, it would also be good to have the option of determining which weight multiplier group it belongs to.

As far as I can tell, the only reason this doesn't work right now is that the `FieldsHelper::getFields` call in the _onPrepareFinderContent_ method is returning the old custom field values rather than the new ones.  Consequently, you need to save changes to content items twice before the index will correctly reflect the new field values.  I thought at first that this might be because of the order in which the plugins fire, but that doesn't appear to be case as `PlgSystemFields::onContentAfterSave` is called before `PlgContentFinder::onContentAfterSave` (which cascades down to the _onPrepareFinderContent_ handler).

Note: The CLI indexer will not currently work with the _onPrepareFinderContent_ handler in a system plugin because system plugins are not loaded by the CLI indexer.  Personally, I would suggest moving _onPrepareFinderContent_ into a finder plugin so all the finder events are handled within the same plugin group and I'll happily provide a PR to do that if folks agree.  Otherwise, I'll do a PR to load the system plugins in the CLI indexer.

### Testing Instructions
See #12829 

### Documentation Changes Required
None.
