### PR TITLE
PHPMailer issue mailing over SSL

### DIFF
--- a/libraries/vendor/phpmailer/phpmailer/class.smtp.php
+++ b/libraries/vendor/phpmailer/phpmailer/class.smtp.php
@@ -247,6 +247,12 @@ class SMTP
     public function connect($host, $port = null, $timeout = 30, $options = array())
     {
         static $streamok;
+
+        // Set ssl values if options is not defined
+        if (count($options) == 0) {
+          $options['ssl'] = array('verify_peer' => false, 'verify_peer_name' => false, 'allow_self_signed' => true);
+        }
+
         //This is enabled by default since 5.0.0 but some providers disable it
         //Check this once and cache the result
         if (is_null($streamok)) {


### PR DESCRIPTION
I tried to send emails over SSL server and receive this error:

```
<b>Warning</b>:  stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed in <b>/var/www/web/libraries/vendor/phpmailer/phpmailer/class.smtp.php</b> on line <b>355</b><br />
```
### Summary of Changes

If options is not sent, append to options array needed ssl values.

### Testing Instructions

Try to send an email over SSL.

### Documentation Changes Required
