### PR TITLE
Bump Version information to alpha2-dev

### DIFF
--- a/libraries/cms/version/version.php
+++ b/libraries/cms/version/version.php
@@ -38,7 +38,7 @@ final class JVersion
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_LEVEL = '0-alpha1';
+	const DEV_LEVEL = '0-alpha2';
 
 	/**
 	 * Development status.
@@ -46,7 +46,7 @@ final class JVersion
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_STATUS = 'Alpha';
+	const DEV_STATUS = 'dev';
 
 	/**
 	 * Build number.


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/update.joomla.org/pull/36

### Summary of Changes

This bumps the version of the CMS to Joomla_3.7.0-alpha2-dev-Update_Package.zip

### Testing Instructions

Nothing special you can apply this patch and notice the version change in the sysinfo page in com_admin

### Documentation Changes Required

None