### PR TITLE
[com_fields] Fixing "Search - Content" plugin and make it work with fields

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -170,28 +170,31 @@ class PlgSearchContent extends JPlugin
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language, a.catid')
 				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
-				->select('GROUP_CONCAT(fv.value SEPARATOR \', \') AS fields')
 				->select('c.title AS section, ' . $case_when . ',' . $case_when1 . ', ' . '\'2\' AS browsernav')
-
 				->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid')
-				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
 				->where(
-					'(' . $where . ') AND a.state=1 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups . ') '
-						. 'AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '
+					'(' . $where . ') AND a.state=1 AND c.published = 1 AND a.access IN (' . $groups . ') '
+						. 'AND c.access IN (' . $groups . ')'
 						. 'AND (a.publish_up = ' . $db->quote($nullDate) . ' OR a.publish_up <= ' . $db->quote($now) . ') '
 						. 'AND (a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')'
 				)
 				->group('a.id, a.title, a.metadesc, a.metakey, a.created, a.language, a.catid, a.introtext, a.fulltext, c.title, a.alias, c.alias, c.id')
 				->order($order);
 
+			// Join over Fields.
+			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id')
+				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
+				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
+				->where('(f.state IS NULL OR f.state = 1)')
+				->where('(f.access IS NULL OR f.access IN (' . $groups . '))');
+
 			// Filter by language.
 			if ($app->isClient('site') && JLanguageMultilang::isEnabled())
 			{
 				$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
 					->where('c.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
-					->where('f.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')');
+					->where('(f.language IS NULL OR f.language in (' . $db->quote($tag) . ',' . $db->quote('*') . '))');
 			}
 
 			$db->setQuery($query, 0, $limit);
@@ -245,28 +248,32 @@ class PlgSearchContent extends JPlugin
 					. $query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text,'
 					. $case_when . ',' . $case_when1 . ', '
 					. 'c.title AS section, \'2\' AS browsernav'
-			)
-			->select('GROUP_CONCAT(fv.value SEPARATOR \', \') AS fields');
+			);
 
 			// .'CONCAT_WS("/", c.title) AS section, \'2\' AS browsernav' );
 			$query->from('#__content AS a')
 				->join('INNER', '#__categories AS c ON c.id=a.catid AND c.access IN (' . $groups . ')')
-				->join('INNER', '#__fields AS f ON f.context = ' . $db->q('com_content.article'))
-				->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id AND fv.field_id = f.id AND fv.context = ' . $db->q('com_content.article'))
 				->where(
-					'(' . $where . ') AND a.state = 2 AND f.state=1 AND c.published = 1 AND a.access IN (' . $groups
-						. ') AND c.access IN (' . $groups . ') AND f.access IN (' . $groups . ') '
+					'(' . $where . ') AND a.state = 2 AND c.published = 1 AND a.access IN (' . $groups
+						. ') AND c.access IN (' . $groups . ') '
 						. 'AND (a.publish_up = ' . $db->quote($nullDate) . ' OR a.publish_up <= ' . $db->quote($now) . ') '
 						. 'AND (a.publish_down = ' . $db->quote($nullDate) . ' OR a.publish_down >= ' . $db->quote($now) . ')'
 				)
 				->order($order);
+
+			// Join over Fields.
+			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id')
+				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
+				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
+				->where('(f.state IS NULL OR f.state = 1)')
+				->where('(f.access IS NULL OR f.access IN (' . $groups . '))');
 
 			// Filter by language.
 			if ($app->isClient('site') && JLanguageMultilang::isEnabled())
 			{
 				$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
 					->where('c.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')')
-					->where('f.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')');
+					->where('(f.language IS NULL OR f.language in (' . $db->quote($tag) . ',' . $db->quote('*') . '))');
 			}
 
 			$db->setQuery($query, 0, $limit);
@@ -311,6 +318,15 @@ class PlgSearchContent extends JPlugin
 
 				foreach ($row as $article)
 				{
+					// Lookup field values so they can be checked, GROUP_CONCAT would work in above queries, but isn't supported by non-MySQL DBs.
+					$query = $db->getQuery(true);
+					$query->select('value')
+						->from('#__fields_values')
+						->where('context = ' . $db->quote('com_content.article'))
+						->where('item_id = ' . (int) $article->slug);
+					$db->setQuery($query);
+					$article->fields = implode(',', $db->loadColumn());
+
 					if (SearchHelper::checkNoHtml($article, $searchText, array('text', 'title', 'fields', 'metadesc', 'metakey')))
 					{
 						$new_row[] = $article;

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -183,7 +183,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Join over Fields.
-			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id')
+			$query->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id')
 				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
 				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
 				->where('(f.state IS NULL OR f.state = 1)')
@@ -262,7 +262,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Join over Fields.
-			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = a.id')
+			$query->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id')
 				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
 				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
 				->where('(f.state IS NULL OR f.state = 1)')
@@ -323,7 +323,7 @@ class PlgSearchContent extends JPlugin
 					$query->select('value')
 						->from('#__fields_values')
 						->where('context = ' . $db->quote('com_content.article'))
-						->where('item_id = ' . (int) $article->slug);
+						->where('item_id = ' . $db->quote((int) $article->slug));
 					$db->setQuery($query);
 					$article->fields = implode(',', $db->loadColumn());
 


### PR DESCRIPTION
Pull Request for Issue #13291 and https://github.com/joomla/joomla-cms/pull/13302#issuecomment-268871460.

While trying to remove the GROUP_CONCAT (that isn't supported by non-MySQL DBs) from the "Content - Search" plugin, I saw it is actually badly broken.
Try to search for an article when there are no valid fields (eg no published, public available fields). It will not show the article.

### Summary of Changes
Rewrites the query so it doesn't use an INNER JOIN over the fields table. Also rewrote the conditionals so they are also fine with a NULL value (since we now have a LEFT JOIN).

The GROUP_CONCAT is replaced by a value lookup per item later down.

### Testing Instructions
* Try the search plugin (the classic one, not Smart Search / Finder)
* Make sure searching for articles text, metadata and fields works and doesn't give duplicate items as result

### Known Limitation
Field values coming from list types (eg selects and checkboxes) will not be searchable because we store the value and not the text of that selection.

### Documentation Changes Required
None