### PR TITLE
[com_fields] Store fields in 'com_fields' property instead of reusing 'params'

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -75,7 +75,7 @@ class FieldsHelper
 	 * Should the value being prepared to be shown in an HTML context then
 	 * prepareValue must be set to true. No further escaping needs to be done.
 	 * The values of the fields can be overridden by an associative array where the keys
-	 * can be an id or an alias and it's corresponding value.
+	 * has to be an id or an alias and it's corresponding value.
 	 *
 	 * @param   string    $context           The context of the content passed to the helper
 	 * @param   stdClass  $item              item
@@ -355,7 +355,7 @@ class FieldsHelper
 		// Creating the dom
 		$xml = new DOMDocument('1.0', 'UTF-8');
 		$fieldsNode = $xml->appendChild(new DOMElement('form'))->appendChild(new DOMElement('fields'));
-		$fieldsNode->setAttribute('name', 'params');
+		$fieldsNode->setAttribute('name', 'com_fields');
 
 		// Organizing the fields according to their group
 		$fieldsPerGroup = array(
@@ -508,7 +508,7 @@ class FieldsHelper
 			if (!is_array($value) && $value !== '')
 			{
 				// Function getField doesn't cache the fields, so we try to do it only when necessary
-				$formField = $form->getField($field->alias, 'params');
+				$formField = $form->getField($field->alias, 'com_fields');
 
 				if ($formField && $formField->forceMultiple)
 				{
@@ -517,7 +517,7 @@ class FieldsHelper
 			}
 
 			// Setting the value on the field
-			$form->setValue($field->alias, 'params', $value);
+			$form->setValue($field->alias, 'com_fields', $value);
 		}
 
 		return true;

--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -199,7 +199,7 @@ class ContactControllerContact extends JControllerForm
 			$body   = $prefix . "\n" . $name . ' <' . $email . '>' . "\r\n\r\n" . stripslashes($body);
 
 			// Load the custom fields
-			if ($data['params'] && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['params']))
+			if ($data['com_fields'] && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields']))
 			{
 				$output = FieldsHelper::render(
 							'com_contact.mail',

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -14,6 +14,8 @@ JHtml::_('behavior.keepalive');
 JHtml::_('behavior.formvalidator');
 JHtml::_('formbehavior.chosen', '#jform_catid', null, array('disable_search_threshold' => 0));
 JHtml::_('formbehavior.chosen', 'select');
+$this->tab_name = 'com-content-form';
+$this->ignore_fieldsets = array('image-intro', 'image-full', 'jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
 $params = $this->state->get('params');
@@ -48,9 +50,9 @@ JFactory::getDocument()->addScriptDeclaration("
 
 	<form action="<?php echo JRoute::_('index.php?option=com_content&a_id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="adminForm" class="form-validate form-vertical">
 		<fieldset>
-			<?php echo JHtml::_('bootstrap.startTabSet', 'com-content-form', array('active' => 'editor')); ?>
+			<?php echo JHtml::_('bootstrap.startTabSet', $this->tab_name, array('active' => 'editor')); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'editor', JText::_('COM_CONTENT_ARTICLE_CONTENT')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'editor', JText::_('COM_CONTENT_ARTICLE_CONTENT')); ?>
 				<?php echo $this->form->renderField('title'); ?>
 
 				<?php if (is_null($this->item->id)) : ?>
@@ -65,7 +67,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 			<?php if ($params->get('show_urls_images_frontend')) : ?>
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'images', JText::_('COM_CONTENT_IMAGES_AND_URLS')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'images', JText::_('COM_CONTENT_IMAGES_AND_URLS')); ?>
 				<?php echo $this->form->renderField('image_intro', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_alt', 'images'); ?>
 				<?php echo $this->form->renderField('image_intro_caption', 'images'); ?>
@@ -98,18 +100,9 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 			<?php endif; ?>
 
-			<?php foreach ($this->form->getFieldsets('params') as $name => $fieldSet) : ?>
-				<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'params-' . $name, JText::_($fieldSet->label)); ?>
-					<?php if (isset($fieldSet->description) && trim($fieldSet->description)) : ?>
-						<?php echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>'; ?>
-					<?php endif; ?>
-					<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-						<?php echo $field->renderField(); ?>
-					<?php endforeach; ?>
-				<?php echo JHtml::_('bootstrap.endTab'); ?>
-			<?php endforeach; ?>
+			<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'publishing', JText::_('COM_CONTENT_PUBLISHING')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'publishing', JText::_('COM_CONTENT_PUBLISHING')); ?>
 				<?php echo $this->form->renderField('catid'); ?>
 				<?php echo $this->form->renderField('tags'); ?>
 				<?php if ($params->get('save_history', 0)) : ?>
@@ -134,11 +127,11 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php endif; ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'language', JText::_('JFIELD_LANGUAGE_LABEL')); ?>
 				<?php echo $this->form->renderField('language'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', 'com-content-form', 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
+			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
 				<?php echo $this->form->renderField('metadesc'); ?>
 				<?php echo $this->form->renderField('metakey'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -21,6 +21,7 @@ if (empty($fieldSets))
 $ignoreFieldsets = $displayData->get('ignore_fieldsets') ?: array();
 $ignoreFields    = $displayData->get('ignore_fields') ?: array();
 $extraFields     = $displayData->get('extra_fields') ?: array();
+$tabName         = $displayData->get('tab_name') ?: 'myTab';
 
 if (!empty($displayData->hiddenFieldsets))
 {
@@ -62,7 +63,7 @@ if ($displayData->get('show_options', 1))
 			$label = JText::_($label);
 		}
 
-		echo JHtml::_('bootstrap.addTab', 'myTab', 'attrib-' . $name, $label);
+		echo JHtml::_('bootstrap.addTab', $tabName, 'attrib-' . $name, $label);
 
 		if (isset($fieldSet->description) && trim($fieldSet->description))
 		{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -122,19 +122,10 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		$userData['params'] = json_decode($userData['params'], true);
-		$user               = JFactory::getUser($userData['id']);
+		$user = JFactory::getUser($userData['id']);
 
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);
-
-		// Save the user with the modified params
-		$db    = JFactory::getDbo();
-		$query = $db->getQuery(true)->update('#__users')
-			->set(array('params = ' . $db->quote($user->params)))
-			->where('id = ' . $user->id);
-		$db->setQuery($query);
-		$db->execute();
 
 		return true;
 	}
@@ -405,7 +396,7 @@ class PlgSystemFields extends JPlugin
 					$component = 'com_' . $component;
 				}
 
-				// Transofrm com_article to com_content
+				// Transform com_article to com_content
 				if ($component === 'com_article')
 				{
 					$component = 'com_content';

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -31,61 +31,6 @@ class PlgSystemFields extends JPlugin
 	/**
 	 * The save event.
 	 *
-	 * @param   string    $context  The context
-	 * @param   stdClass  $item     The item
-	 * @param   boolean   $isNew    Is new
-	 *
-	 * @return  boolean
-	 *
-	 * @since   3.7.0
-	 */
-	public function onContentBeforeSave($context, $item, $isNew)
-	{
-		if (!isset($item->params))
-		{
-			return true;
-		}
-
-		// Create correct context for category
-		if ($context == 'com_categories.category')
-		{
-			$context = $item->extension . '.categories';
-		}
-
-		$parts = FieldsHelper::extract($context, $item);
-
-		if (!$parts)
-		{
-			return true;
-		}
-
-		$context = $parts[0] . '.' . $parts[1];
-
-		// Loading the fields
-		$fieldsObjects = FieldsHelper::getFields($context, $item);
-
-		if (!$fieldsObjects)
-		{
-			return true;
-		}
-
-		$params = (array) json_decode($item->params);
-
-		foreach ($fieldsObjects as $field)
-		{
-			// Remove it from the params array
-			unset($params[$field->alias]);
-		}
-
-		// Set the cleaned up params array
-		$item->params = json_encode($params);
-
-		return true;
-	}
-
-	/**
-	 * The save event.
-	 *
 	 * @param   string   $context  The context
 	 * @param   JTable   $item     The table
 	 * @param   boolean  $isNew    Is new item
@@ -97,7 +42,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
-		if (!is_array($data) || empty($data['params']))
+		if (!is_array($data) || empty($data['com_fields']))
 		{
 			return true;
 		}
@@ -108,7 +53,7 @@ class PlgSystemFields extends JPlugin
 			$context = $item->extension . '.categories';
 		}
 
-		$fieldsData = $data['params'];
+		$fieldsData = $data['com_fields'];
 		$parts      = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
@@ -288,31 +233,6 @@ class PlgSystemFields extends JPlugin
 		FieldsHelper::prepareForm($parts[0] . '.' . $parts[1], $form, $data);
 
 		return true;
-	}
-
-	/**
-	 * The prepare data event.
-	 *
-	 * @param   string    $context  The context
-	 * @param   stdClass  $data     The data
-	 *
-	 * @return  void
-	 *
-	 * @since   3.7.0
-	 */
-	public function onContentPrepareData($context, $data)
-	{
-		$parts = FieldsHelper::extract($context, $data);
-
-		if (!$parts)
-		{
-			return;
-		}
-
-		if (isset($data->params) && $data->params instanceof Registry)
-		{
-			$data->params = $data->params->toArray();
-		}
 	}
 
 	/**


### PR DESCRIPTION
This decouples a part of https://github.com/joomla/joomla-cms/pull/13182 since we don't seem to get an agreement there anytime soon 😄 

### Summary of Changes
* Store fields in 'com_fields' property instead of reusing the already existing 'params'. This eliminates possible conflicts.
* Show custom fields in frontend article edit using the joomla.edit.params JLayout.
* Adjusted the JLayout to take a custom tab name so it is reusable better. If no tab name is specified it uses the current behavior ('myTab').

### Testing Instructions
* Test that you can still save values into custom fields both in frontend and backend.
* Inspect the HTML code and see that the ID attribute of the field has changed from `jform_params_alias`  to `jform_com_fields_alias` and the name from `jform[params][alias]` to `jform[com_fields][alias]`.

### Documentation Changes Required
None