### PR TITLE
Fix issue with TinyMCE editor

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -47,6 +47,7 @@ class PlgEditorTinymce extends JPlugin
 	public function onInit()
 	{
 		JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
+		JHtml::_('behavior.core');
 		JHtml::_('script', $this->_basePath . '/tinymce.min.js', array('version' => 'auto'));
 		JHtml::_('script', 'system/tinymce-init.min.js', array('version' => 'auto', 'relative' => true));
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This tiny PR fix a small issue with TinyMCE editor. The javascript code defined in tinymce.min.js use code defined in media/system/js/core.js, so we need to call JHtml::_('behavior.core'); in TinyMCE editor plugin before tinymce.min.js is loaded

### Testing Instructions
1. Configure your site to use Tiny MCE editor
2. Open the file administrator/components/com_content/content.php, replace it with simple PHP code
```php
echo JFactory::getEditor()->display('description', '', '100%', '180', '90', '6'); . 
```
Access to Content -> Articles. Instead of seeing a HTML editor, you will only see a large textarea. If you look at the console of web browser, you will see this javascript error **Uncaught ReferenceError: Joomla is not defined at tinymce-init.min.js:1**

3. Apply patch, the editor is being displayed properly, Javascript error is gone

### Documentation Changes Required
None