### PR TITLE
Make ids unique on the frontend login module

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -15,66 +15,66 @@ JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" class="form-inline login-form">
 	<?php if ($params->get('pretext')) : ?>
 		<div class="pretext">
 			<p><?php echo $params->get('pretext'); ?></p>
 		</div>
 	<?php endif; ?>
 	<div class="userdata">
-		<div id="form-login-username" class="control-group">
+		<div class="control-group form-login-username">
 			<div class="controls">
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend">
 						<span class="add-on">
 							<span class="icon-user hasTooltip" title="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>"></span>
-							<label for="modlgn-username" class="element-invisible"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
+							<label for="modlgn-username<?php echo $module->id; ?>" class="element-invisible"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 						</span>
-						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
+						<input id="modlgn-username<?php echo $module->id; ?>" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
 					</div>
 				<?php else : ?>
-					<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
-					<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
+					<label for="modlgn-username<?php echo $module->id; ?>"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
+					<input id="modlgn-username<?php echo $module->id; ?>" type="text" name="username" class="input-small modlgn-username" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
 				<?php endif; ?>
 			</div>
 		</div>
-		<div id="form-login-password" class="control-group">
+		<div class="control-group form-login-password">
 			<div class="controls">
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend">
 						<span class="add-on">
 							<span class="icon-lock hasTooltip" title="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>">
 							</span>
-								<label for="modlgn-passwd" class="element-invisible"><?php echo JText::_('JGLOBAL_PASSWORD'); ?>
+								<label for="modlgn-passwd<?php echo $module->id; ?>" class="element-invisible"><?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 							</label>
 						</span>
-						<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+						<input id="modlgn-passwd<?php echo $module->id; ?>" type="password" name="password" class="input-small modlgn-passwd" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
 					</div>
 				<?php else : ?>
-					<label for="modlgn-passwd"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-					<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+					<label for="modlgn-passwd<?php echo $module->id; ?>"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
+					<input id="modlgn-passwd<?php echo $module->id; ?>" type="password" name="password" class="input-small modlgn-passwd" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
 				<?php endif; ?>
 			</div>
 		</div>
 		<?php if (count($twofactormethods) > 1) : ?>
-		<div id="form-login-secretkey" class="control-group">
+		<div class="control-group form-login-secretkey">
 			<div class="controls">
 				<?php if (!$params->get('usetext')) : ?>
 					<div class="input-prepend input-append">
 						<span class="add-on">
 							<span class="icon-star hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>">
 							</span>
-								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
+								<label for="modlgn-secretkey<?php echo $module->id; ?>" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input id="modlgn-secretkey<?php echo $module->id; ?>" autocomplete="off" type="text" name="secretkey" class="input-small modlgn-secretkey" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
 				</div>
 				<?php else : ?>
-					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+					<label for="modlgn-secretkey<?php echo $module->id; ?>"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
+					<input id="modlgn-secretkey<?php echo $module->id; ?>" autocomplete="off" type="text" name="secretkey" class="input-small modlgn-secretkey" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>
@@ -84,13 +84,14 @@ JHtml::_('bootstrap.tooltip');
 		</div>
 		<?php endif; ?>
 		<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
-		<div id="form-login-remember" class="control-group checkbox">
-			<label for="modlgn-remember" class="control-label"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME'); ?></label> <input id="modlgn-remember" type="checkbox" name="remember" class="inputbox" value="yes"/>
+		<div class="control-group checkbox form-login-remember">
+			<label for="modlgn-remember<?php echo $module->id; ?>" class="control-label"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME'); ?></label>
+			<input id="modlgn-remember<?php echo $module->id; ?>" type="checkbox" name="remember" class="inputbox modlgn-remember" value="yes"/>
 		</div>
 		<?php endif; ?>
-		<div id="form-login-submit" class="control-group">
+		<div class="control-group form-login-submit">
 			<div class="controls">
-				<button type="submit" tabindex="0" name="Submit" class="btn btn-primary"><?php echo JText::_('JLOGIN'); ?></button>
+				<button id="modlng-submit<?php echo $module->id; ?>" type="submit" tabindex="0" name="Submit" class="btn btn-primary modlng-submit"><?php echo JText::_('JLOGIN'); ?></button>
 			</div>
 		</div>
 		<?php

--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-vertical">
+<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" class="form-vertical login-form">
 <?php if ($params->get('greeting')) : ?>
 	<div class="login-greeting">
 	<?php if ($params->get('name') == 0) : ?>


### PR DESCRIPTION
### Summary of Changes
As discussed in #13352 the login module has hardcoded ids, so will invalidate any html markup when used multiple times on the page. This PR makes all ids unique using the module id and / or moves them into CSS class.

### Testing Instructions
Check if mod_login is still working. Review source code

### Documentation Changes Required
