### PR TITLE
Load system plugins in Smart Search indexer

### DIFF
--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -52,6 +52,7 @@ require_once JPATH_CONFIGURATION . '/configuration.php';
 
 // System configuration.
 $config = new JConfig;
+define('JDEBUG', $config->debug);
 
 // Configure error reporting to maximum for CLI output.
 error_reporting(E_ALL);
@@ -167,7 +168,8 @@ class FinderCli extends JApplicationCli
 		// Reset the indexer state.
 		FinderIndexer::resetState();
 
-		// Import the finder plugins.
+		// Import the plugins.
+		JPluginHelper::importPlugin('system');
 		JPluginHelper::importPlugin('finder');
 
 		// Starting Indexer.


### PR DESCRIPTION
As noted in #13338 the Smart Search CLI indexer does not load the system plugins so event handlers not in "finder" plugins will not be called.  This PR loads the system plugins as well as the finder plugins.

### Summary of Changes
Loads system plugins.  Also defines the JDEBUG constant which was causing some spurious warning messages.

### Testing Instructions
Testing would require creating a system plugin containing a finder event handler.  I doubt anyone will go to that much trouble so I suggest this can be simply merged on review.

### Documentation Changes Required
None.
