### PR TITLE
Execute sql uninstall query (if exists) on extension install abort

### DIFF
--- a/libraries/cms/installer/adapter.php
+++ b/libraries/cms/installer/adapter.php
@@ -476,6 +476,12 @@ abstract class JInstallerAdapter extends JAdapterInstance
 
 				return false;
 			}
+
+			// If installing with success and there is an uninstall script, add a installer rollback step to rollback if needed
+			if ($route === 'install' && isset($this->getManifest()->uninstall->sql))
+			{
+				$this->parent->pushStep(array('type' => 'query', 'script' => $this->getManifest()->uninstall->sql));
+			}
 		}
 
 		return true;

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -393,9 +393,8 @@ class JInstaller extends JAdapter
 					break;
 
 				case 'query':
-					// Placeholder in case this is necessary in the future
-					// $stepval is always false because if this step was called it invariably failed
-					$stepval = false;
+					// Execute the query.
+					$stepval = $this->parseSQLFiles($step['script']);
 					break;
 
 				case 'extension':

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -192,22 +192,6 @@ class JInstallerTest extends TestCaseDatabase
 	 *
 	 * @return void
 	 */
-	public function testAbortQuery()
-	{
-		$this->object->pushStep(array('type' => 'query'));
-
-		$this->assertFalse(
-			$this->object->abort()
-		);
-	}
-
-	/**
-	 * Test...
-	 *
-	 * @covers  JInstaller::abort
-	 *
-	 * @return void
-	 */
 	public function testAbortDefault()
 	{
 		// Build the mock object.


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

Currently when a extension install is aborted and the install sql query already run we get a broken install.
The extension is uninstalled but the database tables will stay in joomla.

This PR proposes to change that by adding a step to rollback the sql (if an uninstall sql exists).

### Testing Instructions

1. Code review
2. Install this broken [com_test.zip](https://github.com/joomla/joomla-cms/files/673284/com_test.zip) extension  that install with a db table called `#__test`.  Notice you get the extension install rollback but you stay with the `#__test` table in the database
3. Manually delete the `#__test` table
4. Apply patch
5. Repeat step 2 and notice now on failure the `#__test` table is also removed.

### Documentation Changes Required

None.