### PR TITLE
TinyMCE builder: use usergroup instead of viewlevel for each set. Plus fix some BC issue.

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -137,7 +137,7 @@ PLG_TINY_FIELD_VISUALCHARS_DESC="See invisible characters, specifically non-brea
 PLG_TINY_FIELD_VISUALCHARS_LABEL="Visualchars"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Turn on/off Wordcount."
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Wordcount"
-PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> was updated. It is for now using your legacy parameters. By editing the plugin, you can now assign various layouts to specific user groups."
+PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> has been updated. At the moment, it uses your legacy configuration. By editing the plugin, you can now assign various layouts to specific user groups."
 PLG_TINY_SET_TITLE="Set %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Use advanced preset"
 PLG_TINY_SET_PRESET_BUTTON_MEDIUM="Use medium preset"

--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -137,6 +137,7 @@ PLG_TINY_FIELD_VISUALCHARS_DESC="See invisible characters, specifically non-brea
 PLG_TINY_FIELD_VISUALCHARS_LABEL="Visualchars"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Turn on/off Wordcount."
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Wordcount"
+PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">Editor TinyMCE Plugin</a> was updated. Please resave the plugin parameters to apply the changes."
 PLG_TINY_SET_TITLE="Set %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Use advanced preset"
 PLG_TINY_SET_PRESET_BUTTON_MEDIUM="Use medium preset"

--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -137,7 +137,7 @@ PLG_TINY_FIELD_VISUALCHARS_DESC="See invisible characters, specifically non-brea
 PLG_TINY_FIELD_VISUALCHARS_LABEL="Visualchars"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Turn on/off Wordcount."
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Wordcount"
-PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">Editor TinyMCE Plugin</a> was updated. Please resave the plugin parameters to apply the changes."
+PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> was updated. It is for now using your legacy parameters. By editing the plugin, you can now assign various layouts to specific user groups."
 PLG_TINY_SET_TITLE="Set %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Use advanced preset"
 PLG_TINY_SET_PRESET_BUTTON_MEDIUM="Use medium preset"

--- a/media/editors/tinymce/js/tinymce-builder.js
+++ b/media/editors/tinymce/js/tinymce-builder.js
@@ -283,5 +283,36 @@
             event.preventDefault();
             $(this).tab("show");
         });
+
+        // Allow to select the group only once per the set
+        var $accessSelects = $('#joomla-tinymce-builder').find('.access-select');
+        toggleAvailableOption();
+        $accessSelects.on('change', function () {
+            toggleAvailableOption();
+        });
+
+        function toggleAvailableOption () {
+            $accessSelects.find('option[disabled]').removeAttr('disabled');
+
+            // Disable already selected options
+            $accessSelects.each(function () {
+                var $select = $(this), val = $select.val(), query = [],
+                    $otherSelects = $accessSelects.not(this),
+                    $options = $otherSelects.find('option');
+
+                for (var i = 0, l = val.length; i < l; i++ ) {
+                    if (!val[i]) continue;
+
+                    query.push('[value="' + val[i] + '"]');
+                }
+
+                if (query.length) {
+                    $options.filter(query.join(',')).attr('disabled', 'disabled');
+                }
+            });
+
+            // Update Chosen
+            $accessSelects.trigger('liszt:updated');
+        }
     });
 }(jQuery));

--- a/media/editors/tinymce/js/tinymce-builder.js
+++ b/media/editors/tinymce/js/tinymce-builder.js
@@ -297,12 +297,10 @@
             // Disable already selected options
             $accessSelects.each(function () {
                 var $select = $(this), val = $select.val(), query = [],
-                    $otherSelects = $accessSelects.not(this),
-                    $options = $otherSelects.find('option');
+                    $options = $accessSelects.not(this).find('option');
 
                 for (var i = 0, l = val.length; i < l; i++ ) {
                     if (!val[i]) continue;
-
                     query.push('[value="' + val[i] + '"]');
                 }
 

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -44,8 +44,8 @@ class JFormFieldTinymceBuilder extends JFormField
 	protected function getLayoutData()
 	{
 		$data       = parent::getLayoutData();
-		$valueAll   = (object) $this->form->getValue('params');
-		$setsAmount = empty($valueAll->sets_amount) ? 3 : $valueAll->sets_amount;
+		$paramsAll  = (object) $this->form->getValue('params');
+		$setsAmount = empty($paramsAll->sets_amount) ? 3 : $paramsAll->sets_amount;
 
 		// Get the plugin
 		require_once JPATH_PLUGINS . '/editors/tinymce/tinymce.php';
@@ -78,11 +78,16 @@ class JFormFieldTinymceBuilder extends JFormField
 		$setsForms  = array();
 		$formsource = JPATH_PLUGINS . '/editors/tinymce/form/setoptions.xml';
 
-		// Check the old values for B/C
-		$valueOld = new stdClass;
-		if ($this->value && empty($this->value['setoptions']))
+		// Preload an old params for B/C
+		$setParams = new stdClass;
+		if ($paramsAll && empty($paramsAll->configuration['setoptions']))
 		{
-			$valueOld = $valueAll;
+			$plugin = JPluginHelper::getPlugin('editors', 'tinymce');
+
+			if (is_object($plugin) && !empty($plugin->params))
+			{
+				$setParams = (object) json_decode($plugin->params);
+			}
 		}
 
 		foreach (array_keys($data['setsNames']) as $num)
@@ -92,10 +97,10 @@ class JFormFieldTinymceBuilder extends JFormField
 
 			$setsForms[$num] = JForm::getInstance($formname, $formsource, array('control' => $control));
 
-			// Bind the values
+			// Check whether we already have saved values or it first time or even old params
 			if (empty($this->value['setoptions'][$num]))
 			{
-				$formValues = $valueOld;
+				$formValues = $setParams;
 
 				// Predefine group:
 				// Set 0: for Administrator, Editor, Super Users (4,7,8)
@@ -107,6 +112,7 @@ class JFormFieldTinymceBuilder extends JFormField
 				$formValues = $this->value['setoptions'][$num];
 			}
 
+			// Bind the values
 			$setsForms[$num]->bind($formValues);
 		}
 

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -93,13 +93,14 @@ class JFormFieldTinymceBuilder extends JFormField
 			$setsForms[$num] = JForm::getInstance($formname, $formsource, array('control' => $control));
 
 			// Bind the values
-
 			if (empty($this->value['setoptions'][$num]))
 			{
 				$formValues = $valueOld;
 
-				// Predefine access: 0 for special, 1 for registered, all else is public
-				$formValues->access = !$num ? 3 : ($num === 1 ? 2 : 1);
+				// Predefine group:
+				// Set 0: for Administrator, Editor, Super Users (4,7,8)
+				// Set 1: for Registered, Manager (2,6), all else are public
+				$formValues->access = !$num ? array(4,7,8) : ($num === 1 ? array(2,6) : 1);
 			}
 			else
 			{

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -80,9 +80,11 @@ class JFormFieldTinymceBuilder extends JFormField
 
 		// Preload an old params for B/C
 		$setParams = new stdClass;
-		if ($paramsAll && empty($paramsAll->configuration['setoptions']))
+		if (!empty($paramsAll->html_width) && empty($paramsAll->configuration['setoptions']))
 		{
 			$plugin = JPluginHelper::getPlugin('editors', 'tinymce');
+
+			JFactory::getApplication()->enqueueMessage(JText::sprintf('PLG_TINY_LEGACY_WARNING', '#'), 'warning');
 
 			if (is_object($plugin) && !empty($plugin->params))
 			{

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -102,9 +102,11 @@ class JFormFieldTinymceBuilder extends JFormField
 			{
 				$formValues = $setParams;
 
-				// Predefine group:
-				// Set 0: for Administrator, Editor, Super Users (4,7,8)
-				// Set 1: for Registered, Manager (2,6), all else are public
+				/*
+				 * Predefine group:
+				 * Set 0: for Administrator, Editor, Super Users (4,7,8)
+				 * Set 1: for Registered, Manager (2,6), all else are public
+				 */
 				$formValues->access = !$num ? array(4,7,8) : ($num === 1 ? array(2,6) : 1);
 			}
 			else

--- a/plugins/editors/tinymce/form/setoptions.xml
+++ b/plugins/editors/tinymce/form/setoptions.xml
@@ -4,6 +4,7 @@
             name="access"
             type="usergrouplist"
             multiple="true"
+            class="access-select"
             label="JFIELD_ACCESS_LABEL"
             description="JFIELD_ACCESS_DESC"
     />

--- a/plugins/editors/tinymce/form/setoptions.xml
+++ b/plugins/editors/tinymce/form/setoptions.xml
@@ -2,7 +2,8 @@
 <form>
     <field
             name="access"
-            type="accesslevel"
+            type="usergrouplist"
+            multiple="true"
             label="JFIELD_ACCESS_LABEL"
             description="JFIELD_ACCESS_DESC"
     />

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -124,12 +124,15 @@ class PlgEditorTinymce extends JPlugin
 
 		// Check for old params for B/C
 		$config_warn_count = $app->getUserState('plg_editors_tinymce.config_legacy_warn_count', 0);
-		if ($app->isClient('administrator') && $this->params->exists('mode') && $this->params->exists('alignment')
-			&& $config_warn_count < 2)
+
+		if ($this->params->exists('mode') && $this->params->exists('alignment'))
 		{
-			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->getPluginId());
-			$app->enqueueMessage(JText::sprintf('PLG_TINY_LEGACY_WARNING', $link), 'warning');
-			$app->setUserState('plg_editors_tinymce.config_legacy_warn_count', ++$config_warn_count);
+			if ($app->isClient('administrator') && $config_warn_count < 2)
+			{
+				$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->getPluginId());
+				$app->enqueueMessage(JText::sprintf('PLG_TINY_LEGACY_WARNING', $link), 'warning');
+				$app->setUserState('plg_editors_tinymce.config_legacy_warn_count', ++$config_warn_count);
+			}
 
 			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author);
 		}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -172,7 +172,7 @@ class PlgEditorTinymce extends JPlugin
 		$ugroups  = array_combine($user->getAuthorisedGroups(), $user->getAuthorisedGroups());
 
 		// Prepare the parameters
-		$levelParams      = new Joomla\Registry\Registry();
+		$levelParams      = new Joomla\Registry\Registry;
 		$extraOptions     = new stdClass;
 		$toolbarParams    = new stdClass;
 		$extraOptionsAll  = $this->params->get('configuration.setoptions', array());
@@ -394,10 +394,13 @@ class PlgEditorTinymce extends JPlugin
 			// Get from preset
 			$presets = static::getToolbarPreset();
 
-			// Predefine group:
-			// Set 0: for Administrator, Editor, Super Users (4,7,8)
-			// Set 1: for Registered, Manager (2,6), all else are public
-			switch (true){
+			/*
+			 * Predefine group as:
+			 * Set 0: for Administrator, Editor, Super Users (4,7,8)
+			 * Set 1: for Registered, Manager (2,6), all else are public
+			 */
+			switch (true)
+			{
 				case isset($ugroups[4]) || isset($ugroups[7]) || isset($ugroups[8]):
 					$preset = $presets['advanced'];
 					break;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -120,9 +120,14 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
 	{
+		$app = JFactory::getApplication();
+
 		// Check for old params for B/C
 		if ($this->params->exists('mode') && $this->params->exists('alignment'))
 		{
+			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->getPluginId());
+			$app->enqueueMessage(JText::sprintf('PLG_TINY_LEGACY_WARNING', $link), 'warning');
+
 			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author);
 		}
 
@@ -165,13 +170,12 @@ class PlgEditorTinymce extends JPlugin
 		$doc      = JFactory::getDocument();
 		$options  = $doc->getScriptOptions('plg_editor_tinymce');
 
-		// Check whether we alredy have them
+		// Check whether we already have them
 		if (!empty($options['tinyMCE']['default']))
 		{
 			return $editor;
 		}
 
-		$app      = JFactory::getApplication();
 		$user     = JFactory::getUser();
 		$language = JFactory::getLanguage();
 		$theme    = 'modern';
@@ -1135,6 +1139,26 @@ class PlgEditorTinymce extends JPlugin
 		);
 
 		return $preset;
+	}
+
+	/**
+	 * Gets the plugin extension id.
+	 *
+	 * @return  int  The plugin id.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function getPluginId()
+	{
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+					->select($db->quoteName('extension_id'))
+					->from($db->quoteName('#__extensions'))
+					->where($db->quoteName('folder') . ' = ' . $db->quote($this->_type))
+					->where($db->quoteName('element') . ' = ' . $db->quote($this->_name));
+		$db->setQuery($query);
+
+		return (int) $db->loadResult();
 	}
 
 	/**

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -120,6 +120,12 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
 	{
+		// Check for old params for B/C
+		if ($this->params->exists('mode') && $this->params->exists('alignment'))
+		{
+			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author);
+		}
+
 		if (empty($id))
 		{
 			$id = $name;
@@ -192,12 +198,6 @@ class PlgEditorTinymce extends JPlugin
 					$toolbarParams = $toolbarParamsAll->$set;
 				}
 			}
-		}
-
-		// Check for old params for B/C, and load them first
-		if ($this->params->exists('mode') && $this->params->exists('alignment'))
-		{
-			$levelParams->merge($this->params);
 		}
 
 		// Merge the params
@@ -1135,5 +1135,832 @@ class PlgEditorTinymce extends JPlugin
 		);
 
 		return $preset;
+	}
+
+	/**
+	 * Display the editor area.
+	 *
+	 * @param   string   $name     The name of the editor area.
+	 * @param   string   $content  The content of the field.
+	 * @param   string   $width    The width of the editor area.
+	 * @param   string   $height   The height of the editor area.
+	 * @param   int      $col      The number of columns for the editor area.
+	 * @param   int      $row      The number of rows for the editor area.
+	 * @param   boolean  $buttons  True and the editor buttons will be displayed.
+	 * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
+	 * @param   string   $asset    The object asset
+	 * @param   object   $author   The author.
+	 *
+	 * @return  string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private function onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
+	{
+		if (empty($id))
+		{
+			$id = $name;
+		}
+
+		$id = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
+
+		// Only add "px" to width and height if they are not given as a percentage
+		if (is_numeric($width))
+		{
+			$width .= 'px';
+		}
+
+		if (is_numeric($height))
+		{
+			$height .= 'px';
+		}
+
+		// Data object for the layout
+		$textarea = new stdClass;
+		$textarea->name    = $name;
+		$textarea->id      = $id;
+		$textarea->class   = 'mce_editable joomla-editor-tinymce';
+		$textarea->cols    = $col;
+		$textarea->rows    = $row;
+		$textarea->width   = $width;
+		$textarea->height  = $height;
+		$textarea->content = $content;
+
+		// Render Editor markup
+		$editor = '<div class="editor">';
+		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
+		$editor .= $this->_toogleButton($id);
+		$editor .= '</div>';
+
+		// Setup Default options for the Editor script
+		$doc      = JFactory::getDocument();
+		$options  = $doc->getScriptOptions('plg_editor_tinymce');
+
+		// Check whether we already have them
+		if (!empty($options['tinyMCE']['default']))
+		{
+			return $editor;
+		}
+
+		$app      = JFactory::getApplication();
+		$user     = JFactory::getUser();
+		$language = JFactory::getLanguage();
+		$mode     = (int) $this->params->get('mode', 1);
+		$theme    = 'modern';
+
+		// List the skins
+		$skindirs = glob(JPATH_ROOT . '/media/editors/tinymce/skins' . '/*', GLOB_ONLYDIR);
+
+
+		// Set the selected skin
+		$skin = 'lightgray';
+		$side = $app->isAdmin() ? 'skin_admin' : 'skin';
+
+		if ((int) $this->params->get($side, 0) < count($skindirs))
+		{
+			$skin = basename($skindirs[(int) $this->params->get($side, 0)]);
+		}
+
+		$langMode        = $this->params->get('lang_mode', 0);
+		$langPrefix      = $this->params->get('lang_code', 'en');
+
+		if ($langMode)
+		{
+			if (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . $language->getTag() . ".js"))
+			{
+				$langPrefix = $language->getTag();
+			}
+			elseif (file_exists(JPATH_ROOT . "/media/editors/tinymce/langs/" . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . ".js"))
+			{
+				$langPrefix = substr($language->getTag(), 0, strpos($language->getTag(), '-'));
+			}
+			else
+			{
+				$langPrefix = "en";
+			}
+		}
+
+		$text_direction = 'ltr';
+
+		if ($language->isRtl())
+		{
+			$text_direction = 'rtl';
+		}
+
+		$use_content_css    = $this->params->get('content_css', 1);
+		$content_css_custom = $this->params->get('content_css_custom', '');
+
+		/*
+		 * Lets get the default template for the site application
+		 */
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true)
+		            ->select('template')
+		            ->from('#__template_styles')
+		            ->where('client_id=0 AND home=' . $db->quote('1'));
+
+		$db->setQuery($query);
+
+		try
+		{
+			$template = $db->loadResult();
+		}
+		catch (RuntimeException $e)
+		{
+			$app->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+
+			return;
+		}
+
+		$content_css    = null;
+		$templates_path = JPATH_SITE . '/templates';
+
+		// Loading of css file for 'styles' dropdown
+		if ($content_css_custom)
+		{
+			// If URL, just pass it to $content_css
+			if (strpos($content_css_custom, 'http') !== false)
+			{
+				$content_css = $content_css_custom;
+			}
+
+			// If it is not a URL, assume it is a file name in the current template folder
+			else
+			{
+				$content_css = JUri::root(true) . '/templates/' . $template . '/css/' . $content_css_custom;
+
+				// Issue warning notice if the file is not found (but pass name to $content_css anyway to avoid TinyMCE error
+				if (!file_exists($templates_path . '/' . $template . '/css/' . $content_css_custom))
+				{
+					$msg = sprintf(JText::_('PLG_TINY_ERR_CUSTOMCSSFILENOTPRESENT'), $content_css_custom);
+					JLog::add($msg, JLog::WARNING, 'jerror');
+				}
+			}
+		}
+		else
+		{
+			// Process when use_content_css is Yes and no custom file given
+			if ($use_content_css)
+			{
+				// First check templates folder for default template
+				// if no editor.css file in templates folder, check system template folder
+				if (!file_exists($templates_path . '/' . $template . '/css/editor.css'))
+				{
+					// If no editor.css file in system folder, show alert
+					if (!file_exists($templates_path . '/system/css/editor.css'))
+					{
+						JLog::add(JText::_('PLG_TINY_ERR_EDITORCSSFILENOTPRESENT'), JLog::WARNING, 'jerror');
+					}
+					else
+					{
+						$content_css = JUri::root(true) . '/templates/system/css/editor.css';
+					}
+				}
+				else
+				{
+					$content_css = JUri::root(true) . '/templates/' . $template . '/css/editor.css';
+				}
+			}
+		}
+
+		$ignore_filter = false;
+
+		// Text filtering
+		if ($this->params->get('use_config_textfilters', 0))
+		{
+			// Use filters from com_config
+			$filter = static::getGlobalFilters();
+
+			$ignore_filter = $filter === false;
+
+			$tagBlacklist  = !empty($filter->tagBlacklist) ? $filter->tagBlacklist : array();
+			$attrBlacklist = !empty($filter->attrBlacklist) ? $filter->attrBlacklist : array();
+			$tagArray      = !empty($filter->tagArray) ? $filter->tagArray : array();
+			$attrArray     = !empty($filter->attrArray) ? $filter->attrArray : array();
+
+			$invalid_elements  = implode(',', array_merge($tagBlacklist, $attrBlacklist, $tagArray, $attrArray));
+
+			// Valid elements are all whitelist entries in com_config, which are now missing in the tagBlacklist
+			$default_filter = JFilterInput::getInstance();
+			$valid_elements =	implode(',', array_diff($default_filter->tagBlacklist, $tagBlacklist));
+
+			$extended_elements = '';
+		}
+		else
+		{
+			// Use filters from TinyMCE params
+			$invalid_elements  = $this->params->get('invalid_elements', 'script,applet,iframe');
+			$extended_elements = $this->params->get('extended_elements', '');
+			$valid_elements    = $this->params->get('valid_elements', '');
+		}
+
+		// Advanced Options
+		$access = $user->getAuthorisedViewLevels();
+
+		// Flip for performance, so we can direct check for the key isset($access[$key])
+		$access = array_flip($access);
+
+		$html_height = $this->params->get('html_height', '550');
+		$html_width  = $this->params->get('html_width', '');
+
+		if ($html_width == 750)
+		{
+			$html_width = '';
+		}
+
+		// Image advanced options
+		$image_advtab = $this->params->get('image_advtab', true);
+
+		if (isset($access[$image_advtab]))
+		{
+			$image_advtab = true;
+		}
+		else
+		{
+			$image_advtab = false;
+		}
+
+		// The param is true for vertical resizing only, false or both
+		$resizing          = $this->params->get('resizing', '1');
+		$resize_horizontal = $this->params->get('resize_horizontal', '1');
+
+		if ($resizing || $resizing == 'true')
+		{
+			if ($resize_horizontal || $resize_horizontal == 'true')
+			{
+				$resizing = 'both';
+			}
+			else
+			{
+				$resizing = true;
+			}
+		}
+		else
+		{
+			$resizing = false;
+		}
+
+		$toolbar1_add   = array();
+		$toolbar2_add   = array();
+		$toolbar3_add   = array();
+		$toolbar4_add   = array();
+		$elements       = array();
+		$plugins        = array(
+			'autolink',
+			'lists',
+			'image',
+			'charmap',
+			'print',
+			'preview',
+			'anchor',
+			'pagebreak',
+			'code',
+			'save',
+			'textcolor',
+			'colorpicker',
+			'importcss');
+		$toolbar1_add[] = 'bold';
+		$toolbar1_add[] = 'italic';
+		$toolbar1_add[] = 'underline';
+		$toolbar1_add[] = 'strikethrough';
+
+		// Alignment buttons
+		$alignment = $this->params->get('alignment', 1);
+
+		if (isset($access[$alignment]))
+		{
+			$toolbar1_add[] = '|';
+			$toolbar1_add[] = 'alignleft';
+			$toolbar1_add[] = 'aligncenter';
+			$toolbar1_add[] = 'alignright';
+			$toolbar1_add[] = 'alignjustify';
+		}
+
+		$toolbar1_add[] = '|';
+		$toolbar1_add[] = 'styleselect';
+		$toolbar1_add[] = '|';
+		$toolbar1_add[] = 'formatselect';
+
+		// Fonts
+		$fonts = $this->params->get('fonts', 1);
+
+		if (isset($access[$fonts]))
+		{
+			$toolbar1_add[] = 'fontselect';
+			$toolbar1_add[] = 'fontsizeselect';
+		}
+
+		// Search & replace
+		$searchreplace = $this->params->get('searchreplace', 1);
+
+		if (isset($access[$searchreplace]))
+		{
+			$plugins[]      = 'searchreplace';
+			$toolbar2_add[] = 'searchreplace';
+		}
+
+		$toolbar2_add[] = '|';
+		$toolbar2_add[] = 'bullist';
+		$toolbar2_add[] = 'numlist';
+		$toolbar2_add[] = '|';
+		$toolbar2_add[] = 'outdent';
+		$toolbar2_add[] = 'indent';
+		$toolbar2_add[] = '|';
+		$toolbar2_add[] = 'undo';
+		$toolbar2_add[] = 'redo';
+		$toolbar2_add[] = '|';
+
+		// Insert date and/or time plugin
+		$insertdate = $this->params->get('insertdate', 1);
+
+		if (isset($access[$insertdate]))
+		{
+			$plugins[]      = 'insertdatetime';
+			$toolbar4_add[] = 'inserttime';
+		}
+
+		// Link plugin
+		$link = $this->params->get('link', 1);
+
+		if (isset($access[$link]))
+		{
+			$plugins[]      = 'link';
+			$toolbar2_add[] = 'link';
+			$toolbar2_add[] = 'unlink';
+		}
+
+		$toolbar2_add[] = 'anchor';
+		$toolbar2_add[] = 'image';
+		$toolbar2_add[] = '|';
+		$toolbar2_add[] = 'code';
+
+		// Colors
+		$colors = $this->params->get('colors', 1);
+
+		if (isset($access[$colors]))
+		{
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'forecolor,backcolor';
+		}
+
+		// Fullscreen
+		$fullscreen = $this->params->get('fullscreen', 1);
+
+		if (isset($access[$fullscreen]))
+		{
+			$plugins[]      = 'fullscreen';
+			$toolbar2_add[] = '|';
+			$toolbar2_add[] = 'fullscreen';
+		}
+
+		// Table
+		$table = $this->params->get('table', 1);
+
+		if (isset($access[$table]))
+		{
+			$plugins[]      = 'table';
+			$toolbar3_add[] = 'table';
+			$toolbar3_add[] = '|';
+		}
+
+		$toolbar3_add[] = 'subscript';
+		$toolbar3_add[] = 'superscript';
+		$toolbar3_add[] = '|';
+		$toolbar3_add[] = 'charmap';
+
+		// Emotions
+		$smilies = $this->params->get('smilies', 1);
+
+		if (isset($access[$smilies]))
+		{
+			$plugins[]      = 'emoticons';
+			$toolbar3_add[] = 'emoticons';
+		}
+
+		// Media plugin
+		$media = $this->params->get('media', 1);
+
+		if (isset($access[$media]))
+		{
+			$plugins[]      = 'media';
+			$toolbar3_add[] = 'media';
+		}
+
+		// Horizontal line
+		$hr = $this->params->get('hr', 1);
+
+		if (isset($access[$hr]))
+		{
+			$plugins[]      = 'hr';
+			$elements[]     = 'hr[id|title|alt|class|width|size|noshade]';
+			$toolbar3_add[] = 'hr';
+		}
+		else
+		{
+			$elements[] = 'hr[id|class|title|alt]';
+		}
+
+		// RTL/LTR buttons
+		$directionality = $this->params->get('directionality', 1);
+
+		if (isset($access[$directionality]))
+		{
+			$plugins[]      = 'directionality';
+			$toolbar3_add[] = 'ltr rtl';
+		}
+
+		if ($extended_elements != "")
+		{
+			$elements = explode(',', $extended_elements);
+		}
+
+		$toolbar4_add[] = 'cut';
+		$toolbar4_add[] = 'copy';
+
+		// Paste
+		$paste = $this->params->get('paste', 1);
+
+		if (isset($access[$paste]))
+		{
+			$plugins[]      = 'paste';
+			$toolbar4_add[] = 'paste';
+		}
+
+		$toolbar4_add[] = '|';
+
+		// Visualchars
+		$visualchars = $this->params->get('visualchars', 1);
+
+		if (isset($access[$visualchars]))
+		{
+			$plugins[]      = 'visualchars';
+			$toolbar4_add[] = 'visualchars';
+		}
+
+		// Visualblocks
+		$visualblocks = $this->params->get('visualblocks', 1);
+
+		if (isset($access[$visualblocks]))
+		{
+			$plugins[]      = 'visualblocks';
+			$toolbar4_add[] = 'visualblocks';
+		}
+
+		// Non-breaking
+		$nonbreaking = $this->params->get('nonbreaking', 1);
+
+		if (isset($access[$nonbreaking]))
+		{
+			$plugins[]      = 'nonbreaking';
+			$toolbar4_add[] = 'nonbreaking';
+		}
+
+		// Blockquote
+		$blockquote = $this->params->get('blockquote', 1);
+
+		if (isset($access[$blockquote]))
+		{
+			$toolbar4_add[] = 'blockquote';
+		}
+
+		// Template
+		$template = $this->params->get('template', 1);
+		$templates = array();
+
+		if (isset($access[$template]))
+		{
+			$plugins[]      = 'template';
+			$toolbar4_add[] = 'template';
+
+			// Note this check for the template_list.js file will be removed in Joomla 4.0
+			if (is_file(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js"))
+			{
+				// If using the legacy file we need to include and input the files the new way
+				$str = file_get_contents(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js");
+
+				// Find from one [ to the last ]
+				$matches = array();
+				preg_match_all('/\[.*\]/', $str, $matches);
+
+				// Set variables
+				foreach ($matches['0'] as $match)
+				{
+					$values = array();
+					preg_match_all('/\".*\"/', $match, $values);
+					$result       = trim($values["0"]["0"], '"');
+					$final_result = explode(',', $result);
+
+					$templates[] = array(
+						'title' => trim($final_result['0'], ' " '),
+						'description' => trim($final_result['2'], ' " '),
+						'url' => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
+					);
+				}
+
+			}
+			else
+			{
+				foreach (glob(JPATH_ROOT . '/media/editors/tinymce/templates/*.html') as $filename)
+				{
+					$filename = basename($filename, '.html');
+
+					if ($filename !== 'index')
+					{
+						$lang        = JFactory::getLanguage();
+						$title       = $filename;
+						$description = ' ';
+
+						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE'))
+						{
+							$title = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_TITLE');
+						}
+
+						if ($lang->hasKey('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC'))
+						{
+							$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
+						}
+
+						$templates[] = array(
+							'title' => $title,
+							'description' => $description,
+							'url' => JUri::root(true) . '/media/editors/tinymce/templates/' . $filename . '.html',
+						);
+					}
+				}
+			}
+		}
+
+		// Print
+		$print = $this->params->get('print', 1);
+
+		if (isset($access[$print]))
+		{
+			$plugins[]      = 'print';
+			$toolbar4_add[] = '|';
+			$toolbar4_add[] = 'print';
+			$toolbar4_add[] = 'preview';
+		}
+
+		// Spellchecker
+		$spell = $this->params->get('spell', 0);
+
+		if (isset($access[$spell]))
+		{
+			$plugins[]      = 'spellchecker';
+			$toolbar4_add[] = '|';
+			$toolbar4_add[] = 'spellchecker';
+		}
+
+		// Wordcount
+		$wordcount = $this->params->get('wordcount', 1);
+
+		if (isset($access[$wordcount]))
+		{
+			$plugins[] = 'wordcount';
+		}
+
+		// Advlist
+		$advlist = $this->params->get('advlist', 1);
+
+		if (isset($access[$advlist]))
+		{
+			$plugins[] = 'advlist';
+		}
+
+		// Codesample
+		$advlist = $this->params->get('code_sample', 1);
+
+		if (isset($access[$advlist]))
+		{
+			$plugins[]      = 'codesample';
+			$toolbar4_add[] = 'codesample';
+		}
+
+		// Autosave
+		$autosave = $this->params->get('autosave', 1);
+
+		if (isset($access[$autosave]))
+		{
+			$plugins[] = 'autosave';
+		}
+
+		// Context menu
+		$contextmenu = $this->params->get('contextmenu', 1);
+
+		if (isset($access[$contextmenu]))
+		{
+			$plugins[] = 'contextmenu';
+		}
+
+		$custom_plugin = $this->params->get('custom_plugin', '');
+
+		if ($custom_plugin != "")
+		{
+			$plugins[] = $custom_plugin;
+		}
+
+		$custom_button = $this->params->get('custom_button', '');
+
+		if ($custom_button != "")
+		{
+			$toolbar4_add[] = $custom_button;
+		}
+
+		// We shall put the XTD button inside tinymce
+		$btns      = $this->tinyButtons($id, $buttons);
+		$btnsNames = $btns['names'];
+		$tinyBtns  = $btns['script'];
+
+		if (!empty($btnsNames))
+		{
+			JHtml::_('script', 'system/tiny-close.min.js', array('version' => 'auto', 'relative' => true), array('defer' => 'defer'));
+		}
+
+		// Drag and drop Images
+		$allowImgPaste = false;
+		$dragDropPlg   = '';
+		$dragdrop      = $this->params->get('drag_drop', 1);
+
+		if ($dragdrop && $user->authorise('core.create', 'com_media'))
+		{
+			$allowImgPaste = true;
+			$isSubDir      = '';
+			$session       = JFactory::getSession();
+			$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
+			                 . $session->getName() . '=' . $session->getId()
+			                 . '&' . JSession::getFormToken() . '=1'
+			                 . '&asset=image&format=json';
+
+			if ($app->isSite())
+			{
+				$uploadUrl = htmlentities($uploadUrl, null, 'UTF-8', null);
+			}
+
+			// Is Joomla installed in subdirectory
+			if (JUri::root(true) != '/')
+			{
+				$isSubDir = JUri::root(true);
+			}
+
+			// Get specific path
+			$tempPath = $this->params->get('path', '');
+
+			if (!empty($tempPath))
+			{
+				$tempPath = rtrim($tempPath, '/');
+				$tempPath = ltrim($tempPath, '/');
+			}
+
+			$dragDropPlg = 'jdragdrop';
+
+			JText::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
+			$doc->addScriptDeclaration(
+				"
+		var setCustomDir    = '" . $isSubDir . "';
+		var mediaUploadPath = '" . $tempPath . "';
+		var uploadUri       = '" . $uploadUrl . "';
+			"
+			);
+		}
+
+		// Prepare config variables
+		$plugins  = implode(',', $plugins);
+		$elements = implode(',', $elements);
+
+		// Prepare config variables
+		$toolbar1 = implode(' ', $toolbar1_add) . ' | '
+		            . implode(' ', $toolbar2_add) . ' | '
+		            . implode(' ', $toolbar3_add) . ' | '
+		            . implode(' ', $toolbar4_add) . ' | '
+		            . implode(" | ", $btnsNames);
+		$toolbar5 = implode(" | ", $btnsNames);
+
+		// The buttons script
+		$tinyBtns = implode("; ", $tinyBtns);
+
+		// See if mobileVersion is activated
+		$mobileVersion = $this->params->get('mobile', 0);
+
+		$scriptOptions = array(
+			'suffix'  => '.min',
+			'baseURL' => JUri::root(true) . '/media/editors/tinymce',
+			'directionality' => $text_direction,
+			'language' => $langPrefix,
+			'autosave_restore_when_empty' => false,
+			'skin'   => $skin,
+			'theme'  => $theme,
+			'schema' => 'html5',
+
+			// Cleanup/Output
+			'inline_styles'    => true,
+			'gecko_spellcheck' => true,
+			'entity_encoding'  => $this->params->get('entity_encoding', 'raw'),
+			'verify_html'      => !$ignore_filter,
+
+			// URL
+			'relative_urls'      => (bool) $this->params->get('relative_urls', true),
+			'remove_script_host' => false,
+
+			// Layout
+			'content_css'        => $content_css,
+			'document_base_url'  => JUri::root(true) . '/',
+			'paste_data_images'  => $allowImgPaste,
+
+			'setupCallbackString' => $tinyBtns,
+		);
+
+		if ($this->params->get('newlines'))
+		{
+			// Break
+			$scriptOptions['force_br_newlines'] = true;
+			$scriptOptions['force_p_newlines']  = false;
+			$scriptOptions['forced_root_block'] = '';
+		}
+		else
+		{
+			// Paragraph
+			$scriptOptions['force_br_newlines'] = false;
+			$scriptOptions['force_p_newlines']  = true;
+			$scriptOptions['forced_root_block'] = 'p';
+		}
+
+		/**
+		 * Shrink the buttons if not on a mobile or if mobile view is off.
+		 * If mobile view is on force into simple mode and enlarge the buttons
+		 **/
+		if (!$this->app->client->mobile)
+		{
+			$scriptOptions['toolbar_items_size'] = 'small';
+		}
+		elseif ($mobileVersion)
+		{
+			$mode = 0;
+		}
+
+		switch ($mode)
+		{
+			case 0: /* Simple mode*/
+				$scriptOptions['menubar']  = false;
+				$scriptOptions['toolbar1'] = 'bold italics underline strikethrough | undo redo | bullist numlist | code | ' . $toolbar5;
+				$scriptOptions['plugins']  = $dragDropPlg . ' code';
+
+				break;
+
+			case 1:
+			default: /* Advanced mode*/
+				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
+				            . "| outdent indent | undo redo | link unlink anchor code | hr table | subscript superscript | charmap";
+
+				$scriptOptions['valid_elements'] = $valid_elements;
+				$scriptOptions['extended_valid_elements'] = $elements;
+				$scriptOptions['invalid_elements'] = $invalid_elements;
+				$scriptOptions['plugins']  = 'table link code hr charmap autolink lists importcss ' . $dragDropPlg;
+				$scriptOptions['toolbar1'] = $toolbar1 . ' | ' . $toolbar5;
+				$scriptOptions['removed_menuitems'] = 'newdocument';
+				$scriptOptions['importcss_append']  = true;
+				$scriptOptions['height'] = $html_height;
+				$scriptOptions['width']  = $html_width;
+				$scriptOptions['resize'] = $resizing;
+
+				break;
+
+			case 2: /* Extended mode*/
+				$scriptOptions['valid_elements'] = $valid_elements;
+				$scriptOptions['extended_valid_elements'] = $elements;
+				$scriptOptions['invalid_elements'] = $invalid_elements;
+				$scriptOptions['plugins']  = $plugins . ' ' . $dragDropPlg;
+				$scriptOptions['toolbar1'] = $toolbar1;
+				$scriptOptions['removed_menuitems'] = 'newdocument';
+				$scriptOptions['rel_list'] = array(
+					array('title' => 'Alternate', 'value' => 'alternate'),
+					array('title' => 'Author', 'value' => 'author'),
+					array('title' => 'Bookmark', 'value' => 'bookmark'),
+					array('title' => 'Help', 'value' => 'help'),
+					array('title' => 'License', 'value' => 'license'),
+					array('title' => 'Lightbox', 'value' => 'lightbox'),
+					array('title' => 'Next', 'value' => 'next'),
+					array('title' => 'No Follow', 'value' => 'nofollow'),
+					array('title' => 'No Referrer', 'value' => 'noreferrer'),
+					array('title' => 'Prefetch', 'value' => 'prefetch'),
+					array('title' => 'Prev', 'value' => 'prev'),
+					array('title' => 'Search', 'value' => 'search'),
+					array('title' => 'Tag', 'value' => 'tag'),
+				);
+				$scriptOptions['importcss_append'] = true;
+				$scriptOptions['image_advtab']     = $image_advtab;
+				$scriptOptions['height']    = $html_height;
+				$scriptOptions['width']     = $html_width;
+				$scriptOptions['resize']    = $resizing;
+				$scriptOptions['templates'] = $templates;
+
+				break;
+		}
+
+		$options['tinyMCE']['default'] = $scriptOptions;
+
+		$doc->addStyleDeclaration(".mce-in { padding: 5px 10px !important;}");
+		$doc->addScriptOptions('plg_editor_tinymce', $options);
+
+		return $editor;
 	}
 }

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1255,9 +1255,9 @@ class PlgEditorTinymce extends JPlugin
 		 */
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true)
-		            ->select('template')
-		            ->from('#__template_styles')
-		            ->where('client_id=0 AND home=' . $db->quote('1'));
+					->select('template')
+					->from('#__template_styles')
+					->where('client_id=0 AND home=' . $db->quote('1'));
 
 		$db->setQuery($query);
 
@@ -1787,9 +1787,9 @@ class PlgEditorTinymce extends JPlugin
 			$isSubDir      = '';
 			$session       = JFactory::getSession();
 			$uploadUrl     = JUri::base() . 'index.php?option=com_media&task=file.upload&tmpl=component&'
-			                 . $session->getName() . '=' . $session->getId()
-			                 . '&' . JSession::getFormToken() . '=1'
-			                 . '&asset=image&format=json';
+								. $session->getName() . '=' . $session->getId()
+								. '&' . JSession::getFormToken() . '=1'
+								. '&asset=image&format=json';
 
 			if ($app->isSite())
 			{
@@ -1829,10 +1829,10 @@ class PlgEditorTinymce extends JPlugin
 
 		// Prepare config variables
 		$toolbar1 = implode(' ', $toolbar1_add) . ' | '
-		            . implode(' ', $toolbar2_add) . ' | '
-		            . implode(' ', $toolbar3_add) . ' | '
-		            . implode(' ', $toolbar4_add) . ' | '
-		            . implode(" | ", $btnsNames);
+					. implode(' ', $toolbar2_add) . ' | '
+					. implode(' ', $toolbar3_add) . ' | '
+					. implode(' ', $toolbar4_add) . ' | '
+					. implode(" | ", $btnsNames);
 		$toolbar5 = implode(" | ", $btnsNames);
 
 		// The buttons script
@@ -1909,7 +1909,7 @@ class PlgEditorTinymce extends JPlugin
 			case 1:
 			default: /* Advanced mode*/
 				$toolbar1 = "bold italic underline strikethrough | alignleft aligncenter alignright alignjustify | formatselect | bullist numlist "
-				            . "| outdent indent | undo redo | link unlink anchor code | hr table | subscript superscript | charmap";
+							. "| outdent indent | undo redo | link unlink anchor code | hr table | subscript superscript | charmap";
 
 				$scriptOptions['valid_elements'] = $valid_elements;
 				$scriptOptions['extended_valid_elements'] = $elements;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -171,18 +171,21 @@ class PlgEditorTinymce extends JPlugin
 		$theme    = 'modern';
 		$ugroups  = array_combine($user->getAuthorisedGroups(), $user->getAuthorisedGroups());
 
-		// Get configuration depend from User group
+		// Prepare the parameters
+		$levelParams      = new Joomla\Registry\Registry();
 		$extraOptions     = new stdClass;
 		$toolbarParams    = new stdClass;
 		$extraOptionsAll  = $this->params->get('configuration.setoptions', array());
 		$toolbarParamsAll = $this->params->get('configuration.toolbars', array());
 
+		// Get configuration depend from User group
 		foreach ($extraOptionsAll as $set => $val)
 		{
 			$val->access = empty($val->access) ? array() : $val->access;
 
 			// Check whether User in one of allowed group
-			foreach ($val->access as $group) {
+			foreach ($val->access as $group)
+			{
 				if (isset($ugroups[$group]))
 				{
 					$extraOptions  = $val;
@@ -191,8 +194,14 @@ class PlgEditorTinymce extends JPlugin
 			}
 		}
 
+		// Check for old params for B/C, and load them first
+		if ($this->params->exists('mode') && $this->params->exists('alignment'))
+		{
+			$levelParams->merge($this->params);
+		}
+
 		// Merge the params
-		$levelParams = new Joomla\Registry\Registry($toolbarParams);
+		$levelParams->loadObject($toolbarParams);
 		$levelParams->loadObject($extraOptions);
 
 		// List the skins
@@ -202,13 +211,13 @@ class PlgEditorTinymce extends JPlugin
 		$skin = 'lightgray';
 		$side = $app->isClient('administrator') ? 'skin_admin' : 'skin';
 
-		if ((int) $this->params->get($side, 0) < count($skindirs))
+		if ((int) $levelParams->get($side, 0) < count($skindirs))
 		{
-			$skin = basename($skindirs[(int) $this->params->get($side, 0)]);
+			$skin = basename($skindirs[(int) $levelParams->get($side, 0)]);
 		}
 
-		$langMode        = $levelParams->get('lang_mode', 1);
-		$langPrefix      = $levelParams->get('lang_code', 'en');
+		$langMode   = $levelParams->get('lang_mode', 1);
+		$langPrefix = $levelParams->get('lang_code', 'en');
 
 		if ($langMode)
 		{

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -123,10 +123,13 @@ class PlgEditorTinymce extends JPlugin
 		$app = JFactory::getApplication();
 
 		// Check for old params for B/C
-		if ($this->params->exists('mode') && $this->params->exists('alignment'))
+		$config_warn_count = $app->getUserState('plg_editors_tinymce.config_legacy_warn_count', 0);
+		if ($app->isClient('administrator') && $this->params->exists('mode') && $this->params->exists('alignment')
+			&& $config_warn_count < 2)
 		{
 			$link = JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . $this->getPluginId());
 			$app->enqueueMessage(JText::sprintf('PLG_TINY_LEGACY_WARNING', $link), 'warning');
+			$app->setUserState('plg_editors_tinymce.config_legacy_warn_count', ++$config_warn_count);
 
 			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author);
 		}


### PR DESCRIPTION
### Summary of Changes

For TinyMCE plugin I have changed the access check, to use "usergroup" instead of "viewlevel", as @infograf768 sugested.
It seems better idea than use "viewlevel".

**How it works now:**
Each Set can be assigned to multiple Usergroups. 
In case if user assigned to multiple groups, and each of these group has different Sets, then will be used last one allowed Set (order: 3, 2, 1, 0).

Also I have made small changes to allow to use Old parameters, where it possible, for avoid some BC problem. Fallback possible only for the params that available in the Set form.

### Testing Instructions

**test usergroup**
Make user in specific group, then play with TinyMCE plugin access option, try to edit the toolbar. And make sure the changes applies to assigned group.

**test BC**
easy way I found:
Use old site Joomla 3.6, and copy to Joomla 3.7 the values of the  `params` column from `#__extensions` table (for `plg_editors_tinymce` extension). 
And make sure the plugin use the params by default.

### Documentation Changes Required
as part of #11926
