### PR TITLE
Move weblinks stats to weblinks repo

### DIFF
--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -123,33 +123,6 @@ class ModStatsHelper
 				$rows[$i]->data  = $items;
 				$i++;
 			}
-
-			if (JComponentHelper::isInstalled('com_weblinks'))
-			{
-				$query->clear()
-					->select('COUNT(id) AS count_links')
-					->from('#__weblinks')
-					->where('state = 1');
-				$db->setQuery($query);
-
-				try
-				{
-					$links = $db->loadResult();
-				}
-				catch (RuntimeException $e)
-				{
-					$links = false;
-				}
-
-				if ($links)
-				{
-					$rows[$i]        = new stdClass;
-					$rows[$i]->title = JText::_('MOD_STATS_WEBLINKS');
-					$rows[$i]->icon  = 'out-2';
-					$rows[$i]->data  = $links;
-					$i++;
-				}
-			}
 		}
 
 		if ($counter)


### PR DESCRIPTION
Pull Request for Issue #13386 .

### Summary of Changes
Move web links statistics shown on the admin control panel from Joomla core to a system plugin in the web links package.

### Testing Instructions
* Create at least one published web link.
* You should now not have any web links entries shown on the admin control panel.  Unless this PR is merged and installed first https://github.com/joomla-extensions/weblinks/pull/288.

### Documentation Changes Required
None?