### PR TITLE
2 to 1 loop optimization in plugins/search/categories/categories.php

### DIFF
--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -184,13 +184,14 @@ class PlgSearchCategories extends JPlugin
 
 		if ($rows)
 		{
-			foreach ($rows as &$row)
+			foreach ($rows as $i => $row)
 			{
-				$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
-				$row->section = JText::_('JCATEGORY');
 
 				if (searchHelper::checkNoHtml($row, $searchText, array('name', 'title', 'text')))
 				{
+					$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
+					$row->section = JText::_('JCATEGORY');
+
 					$return[] = $row;
 				}
 			}

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -184,7 +184,7 @@ class PlgSearchCategories extends JPlugin
 
 		if ($rows)
 		{
-			foreach ($rows as $row)
+			foreach ($rows as &$row)
 			{
 				$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
 				$row->section = JText::_('JCATEGORY');

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -188,13 +188,10 @@ class PlgSearchCategories extends JPlugin
 			{
 				$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
 				$row->section = JText::_('JCATEGORY');
-			}
 
-			foreach ($rows as $category)
-			{
-				if (searchHelper::checkNoHtml($category, $searchText, array('name', 'title', 'text')))
+				if (searchHelper::checkNoHtml($row, $searchText, array('name', 'title', 'text')))
 				{
-					$return[] = $category;
+					$return[] = $row;
 				}
 			}
 		}

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -184,12 +184,10 @@ class PlgSearchCategories extends JPlugin
 
 		if ($rows)
 		{
-			$count = count($rows);
-
-			for ($i = 0; $i < $count; $i++)
+			foreach ($rows as $row)
 			{
-				$rows[$i]->href = ContentHelperRoute::getCategoryRoute($rows[$i]->slug);
-				$rows[$i]->section = JText::_('JCATEGORY');
+				$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
+				$row->section = JText::_('JCATEGORY');
 			}
 
 			foreach ($rows as $category)


### PR DESCRIPTION
### Summary of Changes
This PR optimizes two independent loops of the same  (one `for` and one `foreach`) into a single loop.
Additionally, the costly assignments are now only executed, when it makes sense (aka the condition is true).

This PR is an optimized extension of the rejected PR #12299

### Testing Instructions
Should not change behavior. 
Code review

### Documentation Changes Required
None