### PR TITLE
[JLanguage] Simplify language file parse

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -829,32 +829,24 @@ class JLanguage
 	 */
 	protected function parse($filename)
 	{
+		// Capture hidden PHP errors from the parsing.
 		if ($this->debug)
 		{
-			// Capture hidden PHP errors from the parsing.
-			$php_errormsg = null;
-			$track_errors = ini_get('track_errors');
+			$trackErrors = ini_get('track_errors');
 			ini_set('track_errors', true);
 		}
 
-		$contents = file_get_contents($filename);
-		$contents = str_replace('_QQ_', '"\""', $contents);
-		$strings = @parse_ini_string($contents);
+		$strings = @parse_ini_file($filename);
 
-		if (!is_array($strings))
-		{
-			$strings = array();
-		}
-
+		// Restore error tracking to what it was before.
 		if ($this->debug)
 		{
-			// Restore error tracking to what it was before.
-			ini_set('track_errors', $track_errors);
+			ini_set('track_errors', $trackErrors);
 
 			$this->debugFile($filename);
 		}
 
-		return $strings;
+		return is_array($strings) ? $strings : array();
 	}
 
 	/**

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -832,7 +832,7 @@ class JLanguage
 		// Capture hidden PHP errors from the parsing.
 		if ($this->debug)
 		{
-			// See http://php.net/manual/en/reserved.variables.phperrormsg.php
+			// See https://secure.php.net/manual/en/reserved.variables.phperrormsg.php
 			$php_errormsg = null;
 
 			$trackErrors = ini_get('track_errors');

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -832,6 +832,9 @@ class JLanguage
 		// Capture hidden PHP errors from the parsing.
 		if ($this->debug)
 		{
+			// See http://php.net/manual/en/reserved.variables.phperrormsg.php
+			$php_errormsg = null;
+
 			$trackErrors = ini_get('track_errors');
 			ini_set('track_errors', true);
 		}


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

1. Remove the `_QQ_` str_replace since parse_ini_file already does that as we already have [defined constant](https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/language/language.php#L17) `_QQ_`

> Constants may also be parsed in the ini file so if you define a constant as an ini value before running parse_ini_file(), it will be integrated into the results. Only ini values are evaluated.

Source: http://php.net/manual/en/function.parse-ini-file.php

2. Some other micro optimizations

### Testing Instructions

1. Apply patch in latest staging
2. Make sure all string with `"_QQ_"` are still translated to `"`.

### Documentation Changes Required

None.

### Notes

When i have time i plan to make a PR to remove all `_QQ_` from the language files.