### PR TITLE
[Unit Test CS] Spaces instead of tabs

### DIFF
--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -133,12 +133,12 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 
 		if (!empty(self::$_options['host']))
 		{
-		        $dsn .= 'host=' . self::$_options['host'] . ';';
+			$dsn .= 'host=' . self::$_options['host'] . ';';
 		}
 
 		if (!empty(self::$_options['port']))
 		{
-		        $dsn .= 'port=' . self::$_options['port'] . ';';
+			$dsn .= 'port=' . self::$_options['port'] . ';';
 		}
 
 		$dsn .= 'dbname=' . self::$_options['database'];

--- a/tests/unit/suites/libraries/joomla/date/JDateTest.php
+++ b/tests/unit/suites/libraries/joomla/date/JDateTest.php
@@ -208,36 +208,36 @@ class JDateTest extends TestCase
 				false,
 				'122007 164456',
 			),
- 			'Long' => array(
- 				'D F j, Y H:i:s',
+			'Long' => array(
+				'D F j, Y H:i:s',
 				true,
- 				'Thu December 20, 2007 11:44:56',
- 			),
- 			'LongGMT' => array(
- 				'D F j, Y H:i:s',
- 				false,
- 				'Thu December 20, 2007 16:44:56',
- 			),
- 			'Long2' => array(
- 				'H:i:s D F j, Y',
- 				false,
- 				'16:44:56 Thu December 20, 2007',
- 			),
- 			'Long3' => array(
- 				'H:i:s l F j, Y',
- 				false,
- 				'16:44:56 Thursday December 20, 2007',
- 			),
- 			'Long4' => array(
- 				'H:i:s l M j, Y',
- 				false,
- 				'16:44:56 Thursday Dec 20, 2007',
- 			),
- 			'RFC822' => array(
- 				'r',
- 				false,
- 				'Thu, 20 Dec 2007 16:44:56 +0000',
- 			),
+				'Thu December 20, 2007 11:44:56',
+			),
+			'LongGMT' => array(
+				'D F j, Y H:i:s',
+				false,
+				'Thu December 20, 2007 16:44:56',
+			),
+			'Long2' => array(
+				'H:i:s D F j, Y',
+				false,
+				'16:44:56 Thu December 20, 2007',
+			),
+			'Long3' => array(
+				'H:i:s l F j, Y',
+				false,
+				'16:44:56 Thursday December 20, 2007',
+			),
+			'Long4' => array(
+				'H:i:s l M j, Y',
+				false,
+				'16:44:56 Thursday Dec 20, 2007',
+			),
+			'RFC822' => array(
+				'r',
+				false,
+				'Thu, 20 Dec 2007 16:44:56 +0000',
+			),
 		);
 	}
 
@@ -535,10 +535,10 @@ class JDateTest extends TestCase
 			$this->equalTo($expectedTime)
 		);
 
- 		$this->assertThat(
- 			$jdate->format('D m/d/Y H:i', true, false),
- 			$this->equalTo($expectedTime)
- 		);
+		$this->assertThat(
+			$jdate->format('D m/d/Y H:i', true, false),
+			$this->equalTo($expectedTime)
+		);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
+++ b/tests/unit/suites/libraries/joomla/document/JDocumentTest.php
@@ -69,7 +69,7 @@ class JDocumentTest extends PHPUnit_Framework_TestCase
 					'tab' => "\11",
 					'link' => '',
 					'base' => '',
-				    'mediaversion' => '1a2b3c4d'
+					'mediaversion' => '1a2b3c4d'
 				)
 			),
 			array(

--- a/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
+++ b/tests/unit/suites/libraries/joomla/document/html/JDocumentHTMLTest.php
@@ -63,9 +63,9 @@ class JDocumentHtmlTest extends TestCase
 		'custom' => array(
 			"<script>var html5 = true;</script>"
 		),
-	    'scriptText' => array(
-		    'JYES'
-	    )
+		'scriptText' => array(
+			'JYES'
+		)
 	);
 
 	/**

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageOrgsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageOrgsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageOrgsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageOrgs
-     */
-    protected $object;
+	 * @var JGithubPackageOrgs
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -75,60 +75,60 @@ class JGithubPackageOrgsTest extends PHPUnit_Framework_TestCase
 		parent::tearDown();
 	}
 
-    /**
-     * @covers JGithubPackageOrgs::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgs::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/users/joomla/orgs')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/users/joomla/orgs')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgs::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgs::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgs::edit
-     */
-    public function testEdit()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgs::edit
+	 */
+	public function testEdit()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('patch')
-		    ->with('/orgs/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('patch')
+			->with('/orgs/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->edit('joomla', 'email@example.com'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->edit('joomla', 'email@example.com'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/JGithubPackageSearchTest.php
+++ b/tests/unit/suites/libraries/joomla/github/JGithubPackageSearchTest.php
@@ -23,9 +23,9 @@ class JGithubPackageSearchTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageSearch
-     */
-    protected $object;
+	 * @var JGithubPackageSearch
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -75,24 +75,24 @@ class JGithubPackageSearchTest extends PHPUnit_Framework_TestCase
 		parent::tearDown();
 	}
 
-    /**
-     * @covers JGithubPackageSearch::issues
-     */
-    public function testIssues()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageSearch::issues
+	 */
+	public function testIssues()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/legacy/issues/search/joomla/joomla-platform/open/github')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/legacy/issues/search/joomla/joomla-platform/open/github')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->issues('joomla', 'joomla-platform', 'open', 'github'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->issues('joomla', 'joomla-platform', 'open', 'github'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageSearch::issues
@@ -108,60 +108,60 @@ class JGithubPackageSearchTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageSearch::repositories
-     */
-    public function testRepositories()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageSearch::repositories
+	 */
+	public function testRepositories()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/legacy/repos/search/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/legacy/repos/search/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->repositories('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->repositories('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageSearch::users
-     */
-    public function testUsers()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageSearch::users
+	 */
+	public function testUsers()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/legacy/user/search/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/legacy/user/search/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->users('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->users('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageSearch::email
-     */
-    public function testEmail()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageSearch::email
+	 */
+	public function testEmail()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/legacy/user/email/email@joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/legacy/user/email/email@joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->email('email@joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->email('email@joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 }

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityNotificationsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityNotificationsTest.php
@@ -82,16 +82,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/notifications?&all=1&participating=1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/notifications?&all=1&participating=1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList(),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -121,16 +119,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/notifications?&all=1&participating=1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/notifications?&all=1&participating=1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getListRepository('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -161,16 +157,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/notifications', '{"unread":true,"read":true}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/notifications', '{"unread":true,"read":true}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->markRead(),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	public function testMarkReadLastRead()
@@ -182,16 +176,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$data = '{"unread":true,"read":true,"last_read_at":"1966-09-14T00:00:00+00:00"}';
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/notifications', $data, 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/notifications', $data, 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->markRead(true, true, $date),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	/**
@@ -224,16 +216,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$data = '{"unread":true,"read":true}';
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/repos/joomla/joomla-platform/notifications', $data, 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/repos/joomla/joomla-platform/notifications', $data, 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->markReadRepository('joomla', 'joomla-platform', true, true),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	public function testMarkReadRepositoryLastRead()
@@ -245,16 +235,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$data = '{"unread":true,"read":true,"last_read_at":"1966-09-14T00:00:00+00:00"}';
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/repos/joomla/joomla-platform/notifications', $data, 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/repos/joomla/joomla-platform/notifications', $data, 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->markReadRepository('joomla', 'joomla-platform', true, true, $date),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	/**
@@ -276,16 +264,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/notifications/threads/1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/notifications/threads/1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->viewThread(1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -313,16 +299,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('patch')
-		             ->with('/notifications/threads/1', '{"unread":true,"read":true}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('patch')
+			->with('/notifications/threads/1', '{"unread":true,"read":true}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->markReadThread(1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -335,8 +319,6 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 	 * Status: 200 OK
 	 * X-RateLimit-Limit: 5000
 	 * X-RateLimit-Remaining: 4999
-
-
 	 */
 	public function testGetThreadSubscription()
 	{
@@ -344,16 +326,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/notifications/threads/1/subscription', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/notifications/threads/1/subscription', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getThreadSubscription(1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -373,9 +353,6 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 	 * Status: 200 OK
 	 * X-RateLimit-Limit: 5000
 	 * X-RateLimit-Remaining: 4999
-
-
-
 	 */
 	public function testSetThreadSubscription()
 	{
@@ -383,16 +360,14 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/notifications/threads/1/subscription', '{"subscribed":true,"ignored":false}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/notifications/threads/1/subscription', '{"subscribed":true,"ignored":false}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->setThreadSubscription(1, true, false),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -405,7 +380,6 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 	 * Status: 204 No Content
 	 * X-RateLimit-Limit: 5000
 	 * X-RateLimit-Remaining: 4999
-
 	 */
 	public function testDeleteThreadSubscription()
 	{
@@ -413,15 +387,13 @@ class JGithubPackageActivityNotificationsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/notifications/threads/1/subscription', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/notifications/threads/1/subscription', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->deleteThreadSubscription(1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityStarringTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityStarringTest.php
@@ -77,16 +77,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/stargazers', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/stargazers', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -120,16 +118,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/starred', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/starred', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRepositories(),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -158,16 +154,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = true;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/starred/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/starred/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->check('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	public function testCheckFalse()
@@ -176,16 +170,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = false;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/starred/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/starred/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->check('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -197,16 +189,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = false;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/starred/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/starred/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->check('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -229,16 +219,14 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/user/starred/joomla/joomla-platform', '', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/user/starred/joomla/joomla-platform', '', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->star('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -261,15 +249,13 @@ class JGithubPackageActivityStarringTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/user/starred/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/user/starred/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->unstar('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityWatchingTest.php
+++ b/tests/unit/suites/libraries/joomla/github/activity/JGithubPackageActivityWatchingTest.php
@@ -74,16 +74,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/subscribers', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/subscribers', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -109,16 +107,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/subscriptions', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/subscriptions', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRepositories(),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	public function testGetRepositoriesUser()
@@ -127,16 +123,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/users/joomla/subscriptions', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/users/joomla/subscriptions', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRepositories('joomla'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -156,16 +150,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/subscription', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/subscription', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getSubscription('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -192,16 +184,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/repos/joomla/joomla-platform/subscription', '{"subscribed":true,"ignored":false}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/repos/joomla/joomla-platform/subscription', '{"subscribed":true,"ignored":false}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->setSubscription('joomla', 'joomla-platform', true, false),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -221,16 +211,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/subscription', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/subscription', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->deleteSubscription('joomla', 'joomla-platform'),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	/**
@@ -256,16 +244,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->check('joomla', 'joomla-platform'),
 			$this->equalTo(true)
-		)
-		;
+		);
 	}
 
 	public function testCheckFalse()
@@ -274,16 +260,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->check('joomla', 'joomla-platform'),
 			$this->equalTo(false)
-		)
-		;
+		);
 	}
 
 	/**
@@ -295,10 +279,9 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->object->check('joomla', 'joomla-platform');
 	}
@@ -320,16 +303,14 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/user/subscriptions/joomla/joomla-platform', '', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/user/subscriptions/joomla/joomla-platform', '', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->watch('joomla', 'joomla-platform'),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 
 	/**
@@ -349,15 +330,13 @@ class JGithubPackageActivityWatchingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/user/subscriptions/joomla/joomla-platform', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->unwatch('joomla', 'joomla-platform'),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataBlobsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataBlobsTest.php
@@ -79,16 +79,14 @@ class JGithubPackageDataBlobsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/git/blobs/12345', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/git/blobs/12345', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -120,15 +118,13 @@ class JGithubPackageDataBlobsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/git/blobs', '{"content":"Hello w\u00f6rld","encoding":"utf-8"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/git/blobs', '{"content":"Hello w\u00f6rld","encoding":"utf-8"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 'Hello wörld'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataCommitsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataCommitsTest.php
@@ -72,16 +72,14 @@ class JGithubPackageDataCommitsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/git/commits/12345', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/git/commits/12345', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -146,15 +144,13 @@ class JGithubPackageDataCommitsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/git/commits', '{"message":"My Message","tree":"12345","parents":[]}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/git/commits', '{"message":"My Message","tree":"12345","parents":[]}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 'My Message', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTagsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTagsTest.php
@@ -72,16 +72,14 @@ class JGithubPackageDataTagsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/git/tags/12345', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/git/tags/12345', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -120,15 +118,13 @@ class JGithubPackageDataTagsTest extends PHPUnit_Framework_TestCase
 
 		$data = '{"tag":"0.1","message":"Message","object":"12345","type":"commit","tagger_name":"elkuku","tagger_email":"email@example.com","tagger_date":"123456789"}';
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/git/tags', $data, 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/git/tags', $data, 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', '0.1', 'Message', '12345', 'commit', 'elkuku', 'email@example.com', '123456789'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTreesTest.php
+++ b/tests/unit/suites/libraries/joomla/github/data/JGithubPackageDataTreesTest.php
@@ -72,16 +72,14 @@ class JGithubPackageDataTreesTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/git/trees/12345', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/git/trees/12345', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -101,16 +99,14 @@ class JGithubPackageDataTreesTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/git/trees/12345?recursive=1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/git/trees/12345?recursive=1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRecursively('joomla', 'joomla-platform', '12345'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -158,15 +154,13 @@ class JGithubPackageDataTreesTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/git/trees', '{"tree":"12345","base_tree":"678"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/git/trees', '{"tree":"12345","base_tree":"678"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', '12345', '678'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesCommentsTest.php
@@ -74,16 +74,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/1/comments', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/1/comments', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -114,16 +112,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRepositoryList('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -156,16 +152,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$date = new JDate('1966-09-15 12:34:56');
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc&since=1966-09-15T12:34:56+00:00', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/comments?sort=created&direction=asc&since=1966-09-15T12:34:56+00:00', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getRepositoryList('joomla', 'joomla-platform', 'created', 'asc', $date),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -201,16 +195,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/comments/1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/comments/1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', 1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -254,16 +246,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('patch')
-		             ->with('/repos/joomla/joomla-platform/issues/comments/1', '{"body":"Hello"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('patch')
+			->with('/repos/joomla/joomla-platform/issues/comments/1', '{"body":"Hello"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->edit('joomla', 'joomla-platform', 1, 'Hello'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -308,16 +298,14 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/issues/1/comments', '{"body":"Hello"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/issues/1/comments', '{"body":"Hello"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 1, 'Hello'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -337,15 +325,13 @@ class JGithubPackageIssuesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = '';
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/issues/comments/1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/issues/comments/1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->delete('joomla', 'joomla-platform', 1, 'Hello'),
 			$this->equalTo(true)
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesEventsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesEventsTest.php
@@ -74,16 +74,14 @@ class JGithubPackageIssuesEventsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/1/events', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/1/events', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -105,16 +103,14 @@ class JGithubPackageIssuesEventsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/1/comments', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/1/comments', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getListRepository('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -134,15 +130,13 @@ class JGithubPackageIssuesEventsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/events/1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/events/1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesLabelsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/issues/JGithubPackageIssuesLabelsTest.php
@@ -71,16 +71,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/labels', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/labels', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -100,16 +98,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/labels/1', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/labels/1', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', '1'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -148,16 +144,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 'foobar', 'red'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -169,16 +163,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->errorString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/labels', '{"name":"foobar","color":"red"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 'foobar', 'red'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -216,16 +208,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('patch')
-		             ->with('/repos/joomla/joomla-platform/labels/foobar', '{"name":"boofaz","color":"red"}', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('patch')
+			->with('/repos/joomla/joomla-platform/labels/foobar', '{"name":"boofaz","color":"red"}', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->update('joomla', 'joomla-platform', 'foobar', 'boofaz', 'red'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -245,16 +235,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/labels/foobar', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/labels/foobar', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->delete('joomla', 'joomla-platform', 'foobar'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -274,16 +262,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/issues/1/labels', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/issues/1/labels', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getListByIssue('joomla', 'joomla-platform', 1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -318,16 +304,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->add('joomla', 'joomla-platform', 1, array('A', 'B')),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -355,16 +339,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/issues/1/labels/foobar', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/issues/1/labels/foobar', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->removeFromIssue('joomla', 'joomla-platform', 1, 'foobar'),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -400,16 +382,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('put')
-		             ->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('put')
+			->with('/repos/joomla/joomla-platform/issues/1/labels', '["A","B"]', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->replace('joomla', 'joomla-platform', 1, array('A', 'B')),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -429,16 +409,14 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/issues/1/labels', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/issues/1/labels', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->removeAllFromIssue('joomla', 'joomla-platform', 1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 
 	/**
@@ -466,15 +444,13 @@ class JGithubPackageIssuesLabelsTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/milestones/1/labels', 0, 0)
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/milestones/1/labels', 0, 0)
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getListByMilestone('joomla', 'joomla-platform', 1),
 			$this->equalTo(json_decode($this->response->body))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsMembersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsMembersTest.php
@@ -23,9 +23,9 @@ class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageOrgsMembers
-     */
-    protected $object;
+	 * @var JGithubPackageOrgsMembers
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,24 +58,24 @@ class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageOrgsMembers($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageOrgsMembers::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsMembers::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla/members')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla/members')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsMembers::getList
@@ -118,23 +118,23 @@ class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsMembers::check
-     */
-    public function testCheck()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsMembers::check
+	 */
+	public function testCheck()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla/members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla/members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->check('joomla', 'elkuku'),
-		    $this->equalTo(true)
-	    );
-    }
+		$this->assertThat(
+			$this->object->check('joomla', 'elkuku'),
+			$this->equalTo(true)
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsMembers::check
@@ -196,61 +196,61 @@ class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsMembers::remove
-     */
-    public function testRemove()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsMembers::remove
+	 */
+	public function testRemove()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/orgs/joomla/members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/orgs/joomla/members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->remove('joomla', 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->remove('joomla', 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsMembers::getListPublic
-     */
-    public function testGetListPublic()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsMembers::getListPublic
+	 */
+	public function testGetListPublic()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla/public_members')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla/public_members')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListPublic('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListPublic('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsMembers::checkPublic
-     */
-    public function testCheckPublic()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsMembers::checkPublic
+	 */
+	public function testCheckPublic()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla/public_members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla/public_members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->checkPublic('joomla', 'elkuku'),
-		    $this->equalTo(true)
-	    );
-    }
+		$this->assertThat(
+			$this->object->checkPublic('joomla', 'elkuku'),
+			$this->equalTo(true)
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsMembers::checkPublic
@@ -293,40 +293,40 @@ class JGithubPackageOrgsMembersTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsMembers::publicize
-     */
-    public function testPublicize()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsMembers::publicize
+	 */
+	public function testPublicize()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('put')
-		    ->with('/orgs/joomla/public_members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('put')
+			->with('/orgs/joomla/public_members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->publicize('joomla', 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->publicize('joomla', 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsMembers::conceal
-     */
-    public function testConceal()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsMembers::conceal
+	 */
+	public function testConceal()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/orgs/joomla/public_members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/orgs/joomla/public_members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->conceal('joomla', 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->conceal('joomla', 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsTeamsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/orgs/JGithubPackageOrgsTeamsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageOrgsTeams
-     */
-    protected $object;
+	 * @var JGithubPackageOrgsTeams
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,62 +58,62 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageOrgsTeams($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/orgs/joomla/teams')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/orgs/joomla/teams')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/teams/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/teams/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get(123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get(123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::create
-     */
-    public function testCreate()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::create
+	 */
+	public function testCreate()
+	{
+		$this->response->code = 201;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('/orgs/joomla/teams')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('/orgs/joomla/teams')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->create('joomla', 'TheTeam', array('joomla-platform'), 'admin'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->create('joomla', 'TheTeam', array('joomla-platform'), 'admin'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsTeams::create
@@ -129,23 +129,23 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsTeams::edit
-     */
-    public function testEdit()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsTeams::edit
+	 */
+	public function testEdit()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('patch')
-		    ->with('/teams/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('patch')
+			->with('/teams/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->edit(123, 'TheTeam', 'admin'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->edit(123, 'TheTeam', 'admin'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsTeams::edit
@@ -161,61 +161,61 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsTeams::delete
-     */
-    public function testDelete()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsTeams::delete
+	 */
+	public function testDelete()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/teams/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/teams/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->delete(123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->delete(123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::getListMembers
-     */
-    public function testGetListMembers()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::getListMembers
+	 */
+	public function testGetListMembers()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/teams/123/members')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/teams/123/members')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListMembers(123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListMembers(123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::isMember
-     */
-    public function testIsMember()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::isMember
+	 */
+	public function testIsMember()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/teams/123/members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/teams/123/members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->isMember(123, 'elkuku'),
-		    $this->equalTo(json_decode(true))
-	    );
-    }
+		$this->assertThat(
+			$this->object->isMember(123, 'elkuku'),
+			$this->equalTo(json_decode(true))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsTeams::isMember
@@ -258,80 +258,80 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsTeams::addMember
-     */
-    public function testAddMember()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsTeams::addMember
+	 */
+	public function testAddMember()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('put')
-		    ->with('/teams/123/members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('put')
+			->with('/teams/123/members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->addMember(123, 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->addMember(123, 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::removeMember
-     */
-    public function testRemoveMember()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::removeMember
+	 */
+	public function testRemoveMember()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/teams/123/members/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/teams/123/members/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->removeMember(123, 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->removeMember(123, 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::getListRepos
-     */
-    public function testGetListRepos()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::getListRepos
+	 */
+	public function testGetListRepos()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/teams/123/repos')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/teams/123/repos')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListRepos(123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListRepos(123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::checkRepo
-     */
-    public function testCheckRepo()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::checkRepo
+	 */
+	public function testCheckRepo()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/teams/123/repos/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/teams/123/repos/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->checkRepo(123, 'joomla'),
-		    $this->equalTo(true)
-	    );
-    }
+		$this->assertThat(
+			$this->object->checkRepo(123, 'joomla'),
+			$this->equalTo(true)
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageOrgsTeams::checkRepo
@@ -374,40 +374,40 @@ class JGithubPackageOrgsTeamsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageOrgsTeams::addRepo
-     */
-    public function testAddRepo()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageOrgsTeams::addRepo
+	 */
+	public function testAddRepo()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('put')
-		    ->with('/teams/123/repos/joomla/joomla-platform')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('put')
+			->with('/teams/123/repos/joomla/joomla-platform')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->addRepo(123, 'joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->addRepo(123, 'joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageOrgsTeams::removeRepo
-     */
-    public function testRemoveRepo()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageOrgsTeams::removeRepo
+	 */
+	public function testRemoveRepo()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/teams/123/repos/joomla/joomla-platform')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/teams/123/repos/joomla/joomla-platform')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->removeRepo(123, 'joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->removeRepo(123, 'joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCollaboratorsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCollaboratorsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageRepositoriesCollaboratorsTest extends PHPUnit_Framework_Test
 	protected $response;
 
 	/**
-     * @var JGithubPackageRepositoriesCollaborators
-     */
-    protected $object;
+	 * @var JGithubPackageRepositoriesCollaborators
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,43 +58,43 @@ class JGithubPackageRepositoriesCollaboratorsTest extends PHPUnit_Framework_Test
 		$this->object = new JGithubPackageRepositoriesCollaborators($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageRepositoriesCollaborators::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesCollaborators::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/collaborators')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/collaborators')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesCollaborators::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = true;
+	/**
+	 * @covers JGithubPackageRepositoriesCollaborators::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 204;
+		$this->response->body = true;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/collaborators/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/collaborators/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get('joomla', 'joomla-platform', 'elkuku'),
-		    $this->equalTo($this->response->body)
-	    );
-    }
+		$this->assertThat(
+			$this->object->get('joomla', 'joomla-platform', 'elkuku'),
+			$this->equalTo($this->response->body)
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageRepositoriesCollaborators::get
@@ -137,40 +137,40 @@ class JGithubPackageRepositoriesCollaboratorsTest extends PHPUnit_Framework_Test
 	}
 
 	/**
-     * @covers JGithubPackageRepositoriesCollaborators::add
-     */
-    public function testAdd()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageRepositoriesCollaborators::add
+	 */
+	public function testAdd()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('put')
-		    ->with('/repos/joomla/joomla-platform/collaborators/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('put')
+			->with('/repos/joomla/joomla-platform/collaborators/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->add('joomla', 'joomla-platform', 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->add('joomla', 'joomla-platform', 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesCollaborators::remove
-     */
-    public function testRemove()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesCollaborators::remove
+	 */
+	public function testRemove()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/repos/joomla/joomla-platform/collaborators/elkuku')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/collaborators/elkuku')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->remove('joomla', 'joomla-platform', 'elkuku'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->remove('joomla', 'joomla-platform', 'elkuku'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCommentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesCommentsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageRepositoriesCommentsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageRepositoriesComments
-     */
-    protected $object;
+	 * @var JGithubPackageRepositoriesComments
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,117 +58,117 @@ class JGithubPackageRepositoriesCommentsTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageRepositoriesComments($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::getListRepository
-     */
-    public function testGetListRepository()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::getListRepository
+	 */
+	public function testGetListRepository()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/comments')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/comments')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListRepository('joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListRepository('joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/commits/123/comments')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/commits/123/comments')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla', 'joomla-platform', '123'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla', 'joomla-platform', '123'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/comments/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/comments/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get('joomla', 'joomla-platform', 123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get('joomla', 'joomla-platform', 123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::edit
-     */
-    public function testEdit()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::edit
+	 */
+	public function testEdit()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('patch')
-		    ->with('/repos/joomla/joomla-platform/comments/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('patch')
+			->with('/repos/joomla/joomla-platform/comments/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->edit('joomla', 'joomla-platform', 123, 'My Comment'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->edit('joomla', 'joomla-platform', 123, 'My Comment'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::delete
-     */
-    public function testDelete()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::delete
+	 */
+	public function testDelete()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/repos/joomla/joomla-platform/comments/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/comments/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->delete('joomla', 'joomla-platform', 123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->delete('joomla', 'joomla-platform', 123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesComments::create
-     */
-    public function testCreate()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesComments::create
+	 */
+	public function testCreate()
+	{
+		$this->response->code = 201;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('/repos/joomla/joomla-platform/commits/123abc/comments')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('/repos/joomla/joomla-platform/commits/123abc/comments')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->create('joomla', 'joomla-platform', '123abc', 'My Comment', 456, 'path/file.php', 789),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->create('joomla', 'joomla-platform', '123abc', 'My Comment', 456, 'path/file.php', 789),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesContentsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesContentsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageRepositoriesContentsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageRepositoriesContents
-     */
-    protected $object;
+	 * @var JGithubPackageRepositoriesContents
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,24 +58,24 @@ class JGithubPackageRepositoriesContentsTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageRepositoriesContents($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageRepositoriesContents::getReadme
-     */
-    public function testGetReadme()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesContents::getReadme
+	 */
+	public function testGetReadme()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/readme')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/readme')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getReadme('joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getReadme('joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageRepositoriesContents::getReadme
@@ -97,23 +97,23 @@ class JGithubPackageRepositoriesContentsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageRepositoriesContents::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageRepositoriesContents::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/contents/path/to/file.php')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/contents/path/to/file.php')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get('joomla', 'joomla-platform', 'path/to/file.php'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get('joomla', 'joomla-platform', 'path/to/file.php'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageRepositoriesContents::get
@@ -135,23 +135,23 @@ class JGithubPackageRepositoriesContentsTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageRepositoriesContents::getArchiveLink
-     */
-    public function testGetArchiveLink()
-    {
-	    $this->response->code = 302;
-	    $this->response->body = $this->sampleString;
+	 * @covers JGithubPackageRepositoriesContents::getArchiveLink
+	 */
+	public function testGetArchiveLink()
+	{
+		$this->response->code = 302;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/zipball')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/zipball')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getArchiveLink('joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getArchiveLink('joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageRepositoriesContents::getArchiveLink

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesDownloadsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesDownloadsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageRepositoriesDownloadsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageRepositoriesDownloads
-     */
-    protected $object;
+	 * @var JGithubPackageRepositoriesDownloads
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,98 +58,98 @@ class JGithubPackageRepositoriesDownloadsTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageRepositoriesDownloads($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageRepositoriesDownloads::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesDownloads::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/downloads')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/downloads')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList('joomla', 'joomla-platform'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList('joomla', 'joomla-platform'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesDownloads::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesDownloads::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/repos/joomla/joomla-platform/downloads/123abc')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/repos/joomla/joomla-platform/downloads/123abc')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get('joomla', 'joomla-platform', '123abc'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get('joomla', 'joomla-platform', '123abc'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesDownloads::create
-     */
-    public function testCreate()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesDownloads::create
+	 */
+	public function testCreate()
+	{
+		$this->response->code = 201;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('/repos/joomla/joomla-platform/downloads')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('/repos/joomla/joomla-platform/downloads')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->create('joomla', 'joomla-platform', 'aaa.zip', 1234, 'Description', 'content_type'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->create('joomla', 'joomla-platform', 'aaa.zip', 1234, 'Description', 'content_type'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesDownloads::upload
-     */
-    public function testUpload()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = true;
+	/**
+	 * @covers JGithubPackageRepositoriesDownloads::upload
+	 */
+	public function testUpload()
+	{
+		$this->response->code = 201;
+		$this->response->body = true;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('https://github.s3.amazonaws.com/')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('https://github.s3.amazonaws.com/')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->upload('joomla', 'joomla-platform', 123, 'a/b/aaa.zip', 'acl', 201, 'aaa.zip', '123abc', '123abc', '123abc','content_type', '@aaa.zip'),
-		    $this->equalTo($this->response->body)
-	    );
-    }
+		$this->assertThat(
+			$this->object->upload('joomla', 'joomla-platform', 123, 'a/b/aaa.zip', 'acl', 201, 'aaa.zip', '123abc', '123abc', '123abc','content_type', '@aaa.zip'),
+			$this->equalTo($this->response->body)
+		);
+	}
 
-    /**
-     * @covers JGithubPackageRepositoriesDownloads::delete
-     */
-    public function testDelete()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageRepositoriesDownloads::delete
+	 */
+	public function testDelete()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/repos/joomla/joomla-platform/downloads/123')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/downloads/123')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->delete('joomla', 'joomla-platform', 123),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->delete('joomla', 'joomla-platform', 123),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesKeysTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesKeysTest.php
@@ -85,16 +85,14 @@ class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/keys')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/keys')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->getList('joomla', 'joomla-platform'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -121,16 +119,14 @@ class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('get')
-		             ->with('/repos/joomla/joomla-platform/keys/1')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('get')
+			->with('/repos/joomla/joomla-platform/keys/1')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->get('joomla', 'joomla-platform', 1),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -165,16 +161,14 @@ class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/keys')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/keys')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->create('joomla', 'joomla-platform', 'email@example.com', '123abc'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -208,16 +202,14 @@ class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('patch')
-		             ->with('/repos/joomla/joomla-platform/keys/1')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('patch')
+			->with('/repos/joomla/joomla-platform/keys/1')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->edit('joomla', 'joomla-platform', 1, 'email@example.com', '123abc'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -237,15 +229,13 @@ class JGithubPackageRepositoriesKeysTest extends PHPUnit_Framework_TestCase
 		$this->response->body = true;
 
 		$this->client->expects($this->once())
-		             ->method('delete')
-		             ->with('/repos/joomla/joomla-platform/keys/1')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('delete')
+			->with('/repos/joomla/joomla-platform/keys/1')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->delete('joomla', 'joomla-platform', 1),
 			$this->equalTo($this->response->body)
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesMergingTest.php
+++ b/tests/unit/suites/libraries/joomla/github/repositories/JGithubPackageRepositoriesMergingTest.php
@@ -178,16 +178,14 @@ class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/merges')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/merges')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->perform('joomla', 'joomla-platform', '123', '456', 'My Message'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -199,16 +197,14 @@ class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/merges')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/merges')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->perform('joomla', 'joomla-platform', '123', '456', 'My Message'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -220,16 +216,14 @@ class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/merges')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/merges')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->perform('joomla', 'joomla-platform', '123', '456', 'My Message'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -241,16 +235,14 @@ class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/merges')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/merges')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->perform('joomla', 'joomla-platform', '123', '456', 'My Message'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 
 	/**
@@ -262,15 +254,13 @@ class JGithubPackageRepositoriesMergingTest extends PHPUnit_Framework_TestCase
 		$this->response->body = $this->sampleString;
 
 		$this->client->expects($this->once())
-		             ->method('post')
-		             ->with('/repos/joomla/joomla-platform/merges')
-		             ->will($this->returnValue($this->response))
-		;
+			->method('post')
+			->with('/repos/joomla/joomla-platform/merges')
+			->will($this->returnValue($this->response));
 
 		$this->assertThat(
 			$this->object->perform('joomla', 'joomla-platform', '123', '456', 'My Message'),
 			$this->equalTo(json_decode($this->sampleString))
-		)
-		;
+		);
 	}
 }

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersEmailsTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersEmailsTest.php
@@ -23,9 +23,9 @@ class JGithubPackageUsersEmailsTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageUsersEmails
-     */
-    protected $object;
+	 * @var JGithubPackageUsersEmails
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,60 +58,60 @@ class JGithubPackageUsersEmailsTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageUsersEmails($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageUsersEmails::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersEmails::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/user/emails')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/user/emails')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList(),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList(),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersEmails::add
-     */
-    public function testAdd()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersEmails::add
+	 */
+	public function testAdd()
+	{
+		$this->response->code = 201;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('/user/emails')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('/user/emails')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->add('email@example.com'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->add('email@example.com'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersEmails::delete
-     */
-    public function testDelete()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersEmails::delete
+	 */
+	public function testDelete()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/user/emails')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/user/emails')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->delete('email@example.com'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->delete('email@example.com'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersFollowersTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersFollowersTest.php
@@ -23,9 +23,9 @@ class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageUsersFollowers
-     */
-    protected $object;
+	 * @var JGithubPackageUsersFollowers
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,24 +58,24 @@ class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageUsersFollowers($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageUsersFollowers::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersFollowers::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/user/followers')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/user/followers')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList(),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList(),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageUsersFollowers::getList
@@ -96,24 +96,24 @@ class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 		);
 	}
 
-    /**
-     * @covers JGithubPackageUsersFollowers::getListFollowedBy
-     */
-    public function testGetListFollowedBy()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersFollowers::getListFollowedBy
+	 */
+	public function testGetListFollowedBy()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/user/following')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/user/following')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListFollowedBy(),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListFollowedBy(),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageUsersFollowers::getListFollowedBy
@@ -135,23 +135,23 @@ class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageUsersFollowers::check
-     */
-    public function testCheck()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = true;
+	 * @covers JGithubPackageUsersFollowers::check
+	 */
+	public function testCheck()
+	{
+		$this->response->code = 204;
+		$this->response->body = true;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/user/following/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/user/following/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->check('joomla'),
-		    $this->equalTo($this->response->body)
-	    );
-    }
+		$this->assertThat(
+			$this->object->check('joomla'),
+			$this->equalTo($this->response->body)
+		);
+	}
 
 	/**
 	 * @covers JGithubPackageUsersFollowers::check
@@ -194,40 +194,40 @@ class JGithubPackageUsersFollowersTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-     * @covers JGithubPackageUsersFollowers::follow
-     */
-    public function testFollow()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = '';
+	 * @covers JGithubPackageUsersFollowers::follow
+	 */
+	public function testFollow()
+	{
+		$this->response->code = 204;
+		$this->response->body = '';
 
-	    $this->client->expects($this->once())
-		    ->method('put')
-		    ->with('/user/following/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('put')
+			->with('/user/following/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->follow('joomla'),
-		    $this->equalTo($this->response->body)
-	    );
-    }
+		$this->assertThat(
+			$this->object->follow('joomla'),
+			$this->equalTo($this->response->body)
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersFollowers::unfollow
-     */
-    public function testUnfollow()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = '';
+	/**
+	 * @covers JGithubPackageUsersFollowers::unfollow
+	 */
+	public function testUnfollow()
+	{
+		$this->response->code = 204;
+		$this->response->body = '';
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/user/following/joomla')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/user/following/joomla')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->unfollow('joomla'),
-		    $this->equalTo($this->response->body)
-	    );
-    }
+		$this->assertThat(
+			$this->object->unfollow('joomla'),
+			$this->equalTo($this->response->body)
+		);
+	}
 }

--- a/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersKeysTest.php
+++ b/tests/unit/suites/libraries/joomla/github/users/JGithubPackageUsersKeysTest.php
@@ -23,9 +23,9 @@ class JGithubPackageUsersKeysTest extends PHPUnit_Framework_TestCase
 	protected $response;
 
 	/**
-     * @var JGithubPackageUsersKeys
-     */
-    protected $object;
+	 * @var JGithubPackageUsersKeys
+	 */
+	protected $object;
 
 	/**
 	 * @var    string  Sample JSON string.
@@ -58,117 +58,117 @@ class JGithubPackageUsersKeysTest extends PHPUnit_Framework_TestCase
 		$this->object = new JGithubPackageUsersKeys($this->options, $this->client);
 	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::getListUser
-     */
-    public function testGetListUser()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::getListUser
+	 */
+	public function testGetListUser()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/users/joomla/keys')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/users/joomla/keys')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getListUser('joomla'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getListUser('joomla'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::getList
-     */
-    public function testGetList()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::getList
+	 */
+	public function testGetList()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/users/keys')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/users/keys')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->getList(),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->getList(),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::get
-     */
-    public function testGet()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::get
+	 */
+	public function testGet()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('get')
-		    ->with('/users/keys/1')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('get')
+			->with('/users/keys/1')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->get(1),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->get(1),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::create
-     */
-    public function testCreate()
-    {
-	    $this->response->code = 201;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::create
+	 */
+	public function testCreate()
+	{
+		$this->response->code = 201;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('post')
-		    ->with('/users/keys')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('post')
+			->with('/users/keys')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->create('email@example.com', '12345'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->create('email@example.com', '12345'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::edit
-     */
-    public function testEdit()
-    {
-	    $this->response->code = 200;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::edit
+	 */
+	public function testEdit()
+	{
+		$this->response->code = 200;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('patch')
-		    ->with('/users/keys/1')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('patch')
+			->with('/users/keys/1')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->edit(1, 'email@example.com', '12345'),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->edit(1, 'email@example.com', '12345'),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 
-    /**
-     * @covers JGithubPackageUsersKeys::delete
-     */
-    public function testDelete()
-    {
-	    $this->response->code = 204;
-	    $this->response->body = $this->sampleString;
+	/**
+	 * @covers JGithubPackageUsersKeys::delete
+	 */
+	public function testDelete()
+	{
+		$this->response->code = 204;
+		$this->response->body = $this->sampleString;
 
-	    $this->client->expects($this->once())
-		    ->method('delete')
-		    ->with('/users/keys/1')
-		    ->will($this->returnValue($this->response));
+		$this->client->expects($this->once())
+			->method('delete')
+			->with('/users/keys/1')
+			->will($this->returnValue($this->response));
 
-	    $this->assertThat(
-		    $this->object->delete(1),
-		    $this->equalTo(json_decode($this->sampleString))
-	    );
-    }
+		$this->assertThat(
+			$this->object->delete(1),
+			$this->equalTo(json_decode($this->sampleString))
+		);
+	}
 }

--- a/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
+++ b/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
@@ -18,106 +18,106 @@ require JPATH_BASE . '/plugins/content/emailcloak/emailcloak.php';
  */
 class PlgContentEmailcloakTest extends TestCaseDatabase
 {
-    /**
-     * An instance of the class to test.
-     *
-     * @var    PlgContentEmailcloak
-     * @since  3.6.2
-     */
-    protected $class;
+	/**
+	 * An instance of the class to test.
+	 *
+	 * @var    PlgContentEmailcloak
+	 * @since  3.6.2
+	 */
+	protected $class;
 
-    /**
-     * Setup for testing.
-     *
-     * @return  void
-     *
-     * @since   3.6.2
-     */
-    public function setup()
-    {
-        JFactory::$application = $this->getMockCmsApp();
-        JFactory::$session = $this->getMockSession();
+	/**
+	 * Setup for testing.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.6.2
+	 */
+	public function setup()
+	{
+		JFactory::$application = $this->getMockCmsApp();
+		JFactory::$session = $this->getMockSession();
 
-        // force the cloak JS inline so that we can unit test it easier than messing with script head in document
-        JFactory::getApplication()->input->server->set('HTTP_X_REQUESTED_WITH', 'xmlhttprequest');
+		// force the cloak JS inline so that we can unit test it easier than messing with script head in document
+		JFactory::getApplication()->input->server->set('HTTP_X_REQUESTED_WITH', 'xmlhttprequest');
 
-        /**
-         * Create a mock dispatcher instance
-         *
-         * @var $dispatcher Mock_JEventDispatcher_f5646d4b e.g
-         */
-        $dispatcher = TestCaseDatabase::getMockDispatcher();
+		/**
+		 * Create a mock dispatcher instance
+		 *
+		 * @var $dispatcher Mock_JEventDispatcher_f5646d4b e.g
+		 */
+		$dispatcher = TestCaseDatabase::getMockDispatcher();
 
-        $plugin = array(
-            'name'   => 'emailcloak',
-            'type'   => 'Content',
-            'params' => new \JRegistry
-        );
+		$plugin = array(
+			'name'   => 'emailcloak',
+			'type'   => 'Content',
+			'params' => new \JRegistry
+		);
 
-        $this->class = new PlgContentEmailcloak($dispatcher, $plugin);
-    }
+		$this->class = new PlgContentEmailcloak($dispatcher, $plugin);
+	}
 
-    /**
-     * Provides the data to test the constructor method.
-     * more examples to add can be found here:
-     *  - https://github.com/joomla/joomla-cms/pull/4182#issuecomment-53395318
-     *  - https://github.com/joomla/joomla-cms/pull/3735#issue-35215540
-     *
-     * @return  array
-     *
-     * @since   3.4
-     */
-    public function dataTestOnContentPrepare()
-    {
-        return array(
+	/**
+	 * Provides the data to test the constructor method.
+	 * more examples to add can be found here:
+	 *  - https://github.com/joomla/joomla-cms/pull/4182#issuecomment-53395318
+	 *  - https://github.com/joomla/joomla-cms/pull/3735#issue-35215540
+	 *
+	 * @return  array
+	 *
+	 * @since   3.4
+	 */
+	public function dataTestOnContentPrepare()
+	{
+		return array(
 
-            # 0
-            array(
-                // This first row is the input, this is what would be in the article
-                'this should not be parsed as it has no (at) sign in it - see what I did there? ;)',
+			# 0
+			array(
+				// This first row is the input, this is what would be in the article
+				'this should not be parsed as it has no (at) sign in it - see what I did there? ;)',
 
-                /**
-                 * This second row is what you would expect the JS, after rendering in a browser
-                 * At the moment there is a slight unit test bug in that what you see here will start with
-                 * the opening <a> tag, and not the full surrounding html from the article - I might fix that in future
-                 * but for now we are testing the actual replacement inside the <a> tags and not the surrounding html
-                 * due to the crazyness of the unit tests converting from JS to HTML to compare
-                 */
-                'this should not be parsed as it has no (at) sign in it - see what I did there? ;)',
+				/**
+				 * This second row is what you would expect the JS, after rendering in a browser
+				 * At the moment there is a slight unit test bug in that what you see here will start with
+				 * the opening <a> tag, and not the full surrounding html from the article - I might fix that in future
+				 * but for now we are testing the actual replacement inside the <a> tags and not the surrounding html
+				 * due to the crazyness of the unit tests converting from JS to HTML to compare
+				 */
+				'this should not be parsed as it has no (at) sign in it - see what I did there? ;)',
 
-                // this third row is the full output of the cloak with inline javascript mode enabled
-                ''
+				// this third row is the full output of the cloak with inline javascript mode enabled
+				''
 
-            ),
+			),
 
-            # ? - see: https://github.com/joomla/joomla-cms/pull/11378#issuecomment-237829598
-            /**
-             * This is failing at the moment so Im excluding it while the above PR #11378 is worked on
-             * and while this unit test suite is being improved - but this test highlights the fact we need these tests!
-             *
-             * array(
-             * '<a href="mailto:toto@toto.com?subject=Mysubject" class="myclass" >email</a>',
-             * "<a href='mailto:toto@toto.com?subject=Mysubject' class='myclass' >email</a>",
-             * "
-             * <span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
-             * document.getElementById('cloak__HASH__').innerHTML = '';
-             * var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
-             * var path = 'hr' + 'ef' + '=';
-             * var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
-             * addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m?s&#117;bj&#101;ct=Mys&#117;bj&#101;ct';
-             * var addy_text__HASH__ = '&#101;m&#97;&#105;l';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
-             * </script>
-             * "
-             * ),*/
+			# ? - see: https://github.com/joomla/joomla-cms/pull/11378#issuecomment-237829598
+			/**
+			 * This is failing at the moment so Im excluding it while the above PR #11378 is worked on
+			 * and while this unit test suite is being improved - but this test highlights the fact we need these tests!
+			 *
+			 * array(
+			 * '<a href="mailto:toto@toto.com?subject=Mysubject" class="myclass" >email</a>',
+			 * "<a href='mailto:toto@toto.com?subject=Mysubject' class='myclass' >email</a>",
+			 * "
+			 * <span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+			 * document.getElementById('cloak__HASH__').innerHTML = '';
+			 * var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
+			 * var path = 'hr' + 'ef' + '=';
+			 * var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
+			 * addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m?s&#117;bj&#101;ct=Mys&#117;bj&#101;ct';
+			 * var addy_text__HASH__ = '&#101;m&#97;&#105;l';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
+			 * </script>
+			 * "
+			 * ),*/
 
 
-            # 1
-            array(
-                '<a href="http://mce_host/ourdirectory/email@example.org">anytext</a>',
+			# 1
+			array(
+				'<a href="http://mce_host/ourdirectory/email@example.org">anytext</a>',
 
-                "<a href='mailto:email@example.org'>anytext</a>",
+				"<a href='mailto:email@example.org'>anytext</a>",
 
-                "<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				"<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
 				document.getElementById('cloak__HASH__').innerHTML = '';
 				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
 				var path = 'hr' + 'ef' + '=';
@@ -125,44 +125,44 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 				addy__HASH__ = addy__HASH__ + '&#101;x&#97;mpl&#101;' + '&#46;' + '&#111;rg';
 				var addy_text__HASH__ = '&#97;nyt&#101;xt';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
 		</script>
-                "
-            ),
+				"
+			),
 
-            # 2
-            array(
-                '<p><a href="mailto:joe@nowhere.com"><span style="font-style: 8pt;">Joe_fontsize8</span></a></p>',
+			# 2
+			array(
+				'<p><a href="mailto:joe@nowhere.com"><span style="font-style: 8pt;">Joe_fontsize8</span></a></p>',
 
-                // This is out expected output - note the comment in above for the reason it doesnt have the surrounding <p> tags
-                "<a href='mailto:joe@nowhere.com'><span style=\"font-style: 8pt;\">Joe_fontsize8</span></a>",
+				// This is out expected output - note the comment in above for the reason it doesnt have the surrounding <p> tags
+				"<a href='mailto:joe@nowhere.com'><span style=\"font-style: 8pt;\">Joe_fontsize8</span></a>",
 
-                "<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
-                document.getElementById('cloak__HASH__').innerHTML = '';
+				"<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
 				var prefix = 'ma' + 'il' + 'to';
 				var path = 'hr' + 'ef' + '=';
 				var addy__HASH__ = 'joe' + '@';
 				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com';
 				var addy_text__HASH__ = '<span style=\"font-style: 8pt;\">Joe_fontsize8</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
 		</script></p>
-                "
-            ),
+				"
+			),
 
-            # 3
-            array(
-                '<p><a href="mailto:joe@nowhere13.com?subject= A text"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></p>',
+			# 3
+			array(
+				'<p><a href="mailto:joe@nowhere13.com?subject= A text"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></p>',
 
-                '<a href=\'mailto:joe@nowhere13.com?subject= A text\'?subject= A text><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a>',
+				'<a href=\'mailto:joe@nowhere13.com?subject= A text\'?subject= A text><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a>',
 
-                "
-                <p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
-                document.getElementById('cloak__HASH__').innerHTML = '';
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
 				var prefix = 'ma' + 'il' + 'to';
 				var path = 'hr' + 'ef' + '=';
 				var addy__HASH__ = 'joe' + '@';
 				addy__HASH__ = addy__HASH__ + 'nowhere13' + '.' + 'com?subject= A text';
 				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'?subject= A text>'+addy_text__HASH__+'<\/a>';
 		</script></p>
-                "
-            ),
+				"
+			),
 
 
 //            [
@@ -209,134 +209,134 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 //                '<a href="mailto:email@example.org">email@example.org</a>',
 //                '<a href="mailto:email@example.org">email@example.org</a>'
 //            ],
-        );
-    }
+		);
+	}
 
-    /**
-     * Tests PlgContentEmailcloakTest::_cloak()
-     *
-     * @param   string $input The text to test.
-     * @param   string $expected The expectation of the filtering.
-     *
-     * @return  void
-     *
-     * @dataProvider  dataTestOnContentPrepare
-     * @since         3.6.2
-     */
-    public function testOnContentPrepareWithRowNoFinder($input, $expectedHTML = NULL, $expectedJs)
-    {
-        $row = new \stdClass;
-        $row->text = $input;
-        $params = new JRegistry;
+	/**
+	 * Tests PlgContentEmailcloakTest::_cloak()
+	 *
+	 * @param   string $input The text to test.
+	 * @param   string $expected The expectation of the filtering.
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider  dataTestOnContentPrepare
+	 * @since         3.6.2
+	 */
+	public function testOnContentPrepareWithRowNoFinder($input, $expectedHTML = NULL, $expectedJs)
+	{
+		$row = new \stdClass;
+		$row->text = $input;
+		$params = new JRegistry;
 
-        // assert we have the correct event
-        $this->assertInstanceOf('PlgContentEmailcloak', $this->class);
+		// assert we have the correct event
+		$this->assertInstanceOf('PlgContentEmailcloak', $this->class);
 
-        // assert that we are getting a clean process
-        $res = $this->class->onContentPrepare('com_content.article', $row, $params);
-        $this->assertEquals(1, $res);
-
-
-        // Get the md5 hash
-        preg_match("/addy_text([0-9a-z]{32})/", $row->text, $output_array);
-
-        // If we did some cloaking then test the JS
-        if (count($output_array)) {
-            $hash = $output_array[1];
-
-            // assert the JLIB_HTML_CLOAKING span is intact
-            $this->assertRegExp('/\<span\sid\=\"cloak[0-9a-z]{32}\"\>JLIB_HTML_CLOAKING\<\/span\>/', $row->text);
-            $cloakHTML = '<span id="cloak' . $hash . '">JLIB_HTML_CLOAKING</span>';
-            $this->assertContains($cloakHTML, $row->text);
+		// assert that we are getting a clean process
+		$res = $this->class->onContentPrepare('com_content.article', $row, $params);
+		$this->assertEquals(1, $res);
 
 
-            if ($expectedJs) {
-                // need to do this to overcome whitespace comparison issue in phpunit for some reason...
-                preg_match_all("/\<script type=\'text\/javascript\'\>(.*)<\/script>/ism", $row->text, $innerJS);
-                $result = trim($innerJS[1][0]);
+		// Get the md5 hash
+		preg_match("/addy_text([0-9a-z]{32})/", $row->text, $output_array);
 
-                preg_match_all("/\<script type=\'text\/javascript\'\>(.*)<\/script>/ism", $expectedJs, $innerJS);
-                $expected = trim($innerJS[1][0]);
+		// If we did some cloaking then test the JS
+		if (count($output_array)) {
+			$hash = $output_array[1];
 
-                // assert the render is as the expected render with injected hash
-                $this->assertEquals(trim(str_replace('__HASH__', $hash, $expected)), $result);
-
-                if (null !== $expectedHTML) {
-                    $html = $this->convertJStoHTML($result, $hash);
-                    $this->assertEquals($html, $expectedHTML);
-                }
-            }
+			// assert the JLIB_HTML_CLOAKING span is intact
+			$this->assertRegExp('/\<span\sid\=\"cloak[0-9a-z]{32}\"\>JLIB_HTML_CLOAKING\<\/span\>/', $row->text);
+			$cloakHTML = '<span id="cloak' . $hash . '">JLIB_HTML_CLOAKING</span>';
+			$this->assertContains($cloakHTML, $row->text);
 
 
-        } else {
+			if ($expectedJs) {
+				// need to do this to overcome whitespace comparison issue in phpunit for some reason...
+				preg_match_all("/\<script type=\'text\/javascript\'\>(.*)<\/script>/ism", $row->text, $innerJS);
+				$result = trim($innerJS[1][0]);
 
-            // ok we never cloaked an email but lets ensure we did not screw up the article text anyway!
-            $this->assertEquals($expectedHTML, $row->text);
+				preg_match_all("/\<script type=\'text\/javascript\'\>(.*)<\/script>/ism", $expectedJs, $innerJS);
+				$expected = trim($innerJS[1][0]);
 
-        }
-    }
+				// assert the render is as the expected render with injected hash
+				$this->assertEquals(trim(str_replace('__HASH__', $hash, $expected)), $result);
 
-    /**
-     * Because phpunit cannot evaluate JS like a browser rendering testing framework can
-     * we convert the JS back to HTML by converting to PHP first
-     * Yes its probably a fudge, but is better than nothing as Joomla has no JS testing framework
-     *
-     * @param string $js the resultant JS
-     * @param string $hash the md5 hash
-     * @return string $resultantHTML the resultant HTML that would be rendered by JS.
-     */
-    private function convertJStoHTML($js, $hash)
-    {
-        $resultantHTML = null;
-        $debug = false;
+				if (null !== $expectedHTML) {
+					$html = $this->convertJStoHTML($result, $hash);
+					$this->assertEquals($html, $expectedHTML);
+				}
+			}
 
-        $js = html_entity_decode($js);
-        $js = str_replace(sprintf('document.getElementById(\'cloak%s\').innerHTML = \'\';', $hash), '', $js);
-        $js = str_replace(sprintf('document.getElementById(\'cloak%s\').innerHTML +=', $hash), "\n\n" . '$resultantHTML = ', $js);
-        $js = str_replace('var ', '$', $js);
-        $js = str_replace("' + '", "", $js);
-        $js = preg_replace("/\saddy/", '$addy', $js);
-        $js = preg_replace(sprintf("/\'\+addy_text%s\+\'/", $hash), sprintf('\' . \$addy_text%s .\'', $hash), $js);
-        $js = preg_replace(sprintf("/\+\$addy%s\s\+/", $hash), sprintf('\' . \$addy_text%s .\'', $hash), $js);
-        $js = str_replace("+ path +", '. $path .', $js);
-        $js = str_replace("+ prefix +", '. $prefix .', $js);
-        $js = str_replace("+$", '.$', $js);
-        $js = str_replace("\/", '/', $js);
-        $js = str_replace(
-            sprintf('$addy%s +', $hash),
-            sprintf('$addy%s .', $hash),
-            $js);
 
-        // because with all those replaces, you and I will need this a lot :)
-        if (true === $debug) {
-            echo "\n\n" . trim($js) . "\n\n";
-            eval($js);
-            echo "\n\n";
-            var_dump(trim($resultantHTML));
-            die;
-        } else {
-            // EVAL IS EVIL - I know - but here its not a security risk, and is 'ok'-ish.
-            eval($js);
-        }
+		} else {
 
-        return trim($resultantHTML);
-    }
+			// ok we never cloaked an email but lets ensure we did not screw up the article text anyway!
+			$this->assertEquals($expectedHTML, $row->text);
 
-    /**
-     * Tests that if we are the com_finder indexer that we return with no cloaking
-     * Tests also that we can set $row as string instead of a normal object
-     */
-    public function testIndexer()
-    {
-        $row = 'test string';
-        $params = new JRegistry;
+		}
+	}
 
-        // assert we have the correct event
-        $this->assertInstanceOf('PlgContentEmailcloak', $this->class);
+	/**
+	 * Because phpunit cannot evaluate JS like a browser rendering testing framework can
+	 * we convert the JS back to HTML by converting to PHP first
+	 * Yes its probably a fudge, but is better than nothing as Joomla has no JS testing framework
+	 *
+	 * @param string $js the resultant JS
+	 * @param string $hash the md5 hash
+	 * @return string $resultantHTML the resultant HTML that would be rendered by JS.
+	 */
+	private function convertJStoHTML($js, $hash)
+	{
+		$resultantHTML = null;
+		$debug = false;
 
-        // assert that we are getting a clean process
-        $res = $this->class->onContentPrepare('com_finder.indexer', $row, $params);
-        $this->assertEquals(1, $res);
-        $this->assertEquals('test string', $row);
-    }
+		$js = html_entity_decode($js);
+		$js = str_replace(sprintf('document.getElementById(\'cloak%s\').innerHTML = \'\';', $hash), '', $js);
+		$js = str_replace(sprintf('document.getElementById(\'cloak%s\').innerHTML +=', $hash), "\n\n" . '$resultantHTML = ', $js);
+		$js = str_replace('var ', '$', $js);
+		$js = str_replace("' + '", "", $js);
+		$js = preg_replace("/\saddy/", '$addy', $js);
+		$js = preg_replace(sprintf("/\'\+addy_text%s\+\'/", $hash), sprintf('\' . \$addy_text%s .\'', $hash), $js);
+		$js = preg_replace(sprintf("/\+\$addy%s\s\+/", $hash), sprintf('\' . \$addy_text%s .\'', $hash), $js);
+		$js = str_replace("+ path +", '. $path .', $js);
+		$js = str_replace("+ prefix +", '. $prefix .', $js);
+		$js = str_replace("+$", '.$', $js);
+		$js = str_replace("\/", '/', $js);
+		$js = str_replace(
+			sprintf('$addy%s +', $hash),
+			sprintf('$addy%s .', $hash),
+			$js);
+
+		// because with all those replaces, you and I will need this a lot :)
+		if (true === $debug) {
+			echo "\n\n" . trim($js) . "\n\n";
+			eval($js);
+			echo "\n\n";
+			var_dump(trim($resultantHTML));
+			die;
+		} else {
+			// EVAL IS EVIL - I know - but here its not a security risk, and is 'ok'-ish.
+			eval($js);
+		}
+
+		return trim($resultantHTML);
+	}
+
+	/**
+	 * Tests that if we are the com_finder indexer that we return with no cloaking
+	 * Tests also that we can set $row as string instead of a normal object
+	 */
+	public function testIndexer()
+	{
+		$row = 'test string';
+		$params = new JRegistry;
+
+		// assert we have the correct event
+		$this->assertInstanceOf('PlgContentEmailcloak', $this->class);
+
+		// assert that we are getting a clean process
+		$res = $this->class->onContentPrepare('com_finder.indexer', $row, $params);
+		$this->assertEquals(1, $res);
+		$this->assertEquals('test string', $row);
+	}
 }


### PR DESCRIPTION
This is the first of a set of PR's that's hopefully going to result in us using the code sniffer on the unit tests folder as well (so far ignored because it's a nightmare effort). This fixes issues where we are using spaces instead of tabs as a start for 10

Looking at this diff https://github.com/joomla/joomla-cms/pull/13409/files?w=1 (with whitespace changes ignored) should help with some of the larger file changes where everything was space indented :)