### PR TITLE
[Unit Test CS] Cast Statements and Concat Operator spacing issues

### DIFF
--- a/tests/unit/core/mock/menu.php
+++ b/tests/unit/core/mock/menu.php
@@ -87,7 +87,7 @@ class TestMockMenu
 		foreach (self::$data as $id => $item)
 		{
 			$return[] = array($id, $item);
-			$return[] = array((string)$id, $item);
+			$return[] = array((string) $id, $item);
 		}
 
 		return $return;

--- a/tests/unit/suites/libraries/cms/html/JHtmlTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlTest.php
@@ -1348,7 +1348,7 @@ class JHtmlTest extends TestCase
 
 		$this->assertEquals(
 			JHtml::tooltip('Content', 'Title', 'tooltip.png', null, null, 'MyAlt', 'hasTooltip2'),
-			'<span class="hasTooltip2" title="'.
+			'<span class="hasTooltip2" title="' .
 			'&lt;strong&gt;Title&lt;/strong&gt;&lt;br /&gt;Content' .
 			'"><img src="' . JUri::base(true) .
 			'/media/system/images/tooltip.png" alt="MyAlt" /></span>',
@@ -1449,8 +1449,8 @@ class JHtmlTest extends TestCase
 			);
 			$readonly = isset($data['attribs']['readonly']) ? 'readonly="readonly"' : '';
 
-			$xml = new SimpleXMLElement('<field name="'.$data['name'].'" type="calendar" id="'.$data['id'].'"
-			format="'.$data['format'].'" title="' .$data['friendly_date'] . '" value="' . $data['formattedDate'] . '" '. $readonly . ' />');
+			$xml = new SimpleXMLElement('<field name="' . $data['name'] . '" type="calendar" id="' . $data['id'] . '"
+			format="' . $data['format'] . '" title="' . $data['friendly_date'] . '" value="' . $data['formattedDate'] . '" ' . $readonly . ' />');
 
 			$this->assertEquals(
 				'calendar',
@@ -1461,19 +1461,19 @@ class JHtmlTest extends TestCase
 			$this->assertEquals(
 				$data['friendly_date'],
 				(string) $xml->attributes()->title,
-				'Line:'.__LINE__.' The calendar input should have `title == "' . $data['friendly_date'] . '"`'
+				'Line:' . __LINE__ . ' The calendar input should have `title == "' . $data['friendly_date'] . '"`'
 			);
 
 			$this->assertEquals(
 				$data['name'],
 				(string) $xml->attributes()->name,
-				'Line:'.__LINE__.' The calendar input should have `name == "' . $data['name'] . '"`'
+				'Line:' . __LINE__ . ' The calendar input should have `name == "' . $data['name'] . '"`'
 			);
 
 			$this->assertEquals(
 				$data['id'],
 				(string) $xml->attributes()->id,
-				'Line:'.__LINE__.' The calendar input should have `id == "' . $data['id'] . '"`'
+				'Line:' . __LINE__ . ' The calendar input should have `id == "' . $data['id'] . '"`'
 			);
 
 			$this->assertEquals(
@@ -1494,19 +1494,19 @@ class JHtmlTest extends TestCase
 			$this->assertArrayHasKey(
 				'/media/system/js/fields/calendar-locales/en.js',
 				JFactory::getDocument()->_scripts,
-				'Line:'.__LINE__.' JS file "calendar-vanilla.min.js" should be loaded'
+				'Line:' . __LINE__ . ' JS file "calendar-vanilla.min.js" should be loaded'
 			);
 
 			$this->assertArrayHasKey(
 				'/media/system/js/fields/calendar-locales/date/gregorian/date-helper.min.js',
 				JFactory::getDocument()->_scripts,
-				'Line:'.__LINE__.' JS file "date.js" should be loaded'
+				'Line:' . __LINE__ . ' JS file "date.js" should be loaded'
 			);
 
 			$this->assertArrayHasKey(
 				'/media/system/js/fields/calendar-vanilla.min.js',
 				JFactory::getDocument()->_scripts,
-				'Line:'.__LINE__.' JS file "calendar-vanilla.min.js" should be loaded'
+				'Line:' . __LINE__ . ' JS file "calendar-vanilla.min.js" should be loaded'
 			);
 		}
 	}

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -249,7 +249,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$vars = $object->parse($uri);
 
 		$this->assertEquals($expectedVars, $vars);
-		$this->assertEquals($expectedUris, (string)$uri);
+		$this->assertEquals($expectedUris, (string) $uri);
 	}
 
 	/**
@@ -500,7 +500,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$object->setMode($mode);
 
 		// Check the expected values
-		$this->assertEquals($expected, (string)($object->build($url)));
+		$this->assertEquals($expected, (string) ($object->build($url)));
 	}
 
 	/**
@@ -958,7 +958,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$buildRawRouteMethod->setAccessible(true);
 
 		$buildRawRouteMethod->invokeArgs($object, array(&$uri));
-		$this->assertEquals('index.php', (string)$uri);
+		$this->assertEquals('index.php', (string) $uri);
 	}
 
 	/**
@@ -983,7 +983,7 @@ class JRouterSiteTest extends TestCaseDatabase
 
 		$uri->setVar('option', 'com_test');
 		$buildRawRouteMethod->invokeArgs($object, array(&$uri));
-		$this->assertEquals('index.php?option=com_test&testvar=testvalue', (string)$uri);
+		$this->assertEquals('index.php?option=com_test&testvar=testvalue', (string) $uri);
 	}
 
 	/**
@@ -1009,7 +1009,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$uri->setVar('option', 'com_ te?st');
 		$uri->delVar('testvar');
 		$buildRawRouteMethod->invokeArgs($object, array(&$uri));
-		$this->assertEquals('index.php?option=com_ te?st&testvar=testvalue', (string)$uri);
+		$this->assertEquals('index.php?option=com_ te?st&testvar=testvalue', (string) $uri);
 	}
 
 	/**
@@ -1035,7 +1035,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$uri->setVar('option', 'com_test3');
 		$uri->delVar('testvar');
 		$buildRawRouteMethod->invokeArgs($object, array(&$uri));
-		$this->assertEquals('index.php?option=com_test3', (string)$uri);
+		$this->assertEquals('index.php?option=com_test3', (string) $uri);
 	}
 
 	/**
@@ -1117,7 +1117,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$buildSefRouteMethod->setAccessible(true);
 		$buildSefRouteMethod->invokeArgs($object, array(&$uri));
 
-		$this->assertEquals($expected, (string)$uri);
+		$this->assertEquals($expected, (string) $uri);
 	}
 
 	/**
@@ -1221,7 +1221,7 @@ class JRouterSiteTest extends TestCaseDatabase
 
 		$processBuildRulesMethod->invokeArgs($object, array(&$uri));
 
-		$this->assertEquals($expected, (string)$uri);
+		$this->assertEquals($expected, (string) $uri);
 	}
 
 	/**
@@ -1313,7 +1313,7 @@ class JRouterSiteTest extends TestCaseDatabase
 		$uri = $createUriMethod->invoke($object, $url);
 
 		$this->assertInstanceOf('JUri', $uri);
-		$this->assertEquals($expected, (string)$uri);
+		$this->assertEquals($expected, (string) $uri);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/router/JRouterTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterTest.php
@@ -653,7 +653,7 @@ class JRouterTest extends TestCase
 			$this->object->attachBuildRule($function, $stage);
 		}
 
-		$this->assertEquals($expected, (string)$this->object->build($url));
+		$this->assertEquals($expected, (string) $this->object->build($url));
 	}
 
 	/**
@@ -728,7 +728,7 @@ class JRouterTest extends TestCase
 			JRouter::PROCESS_AFTER
 		);
 
-		$this->assertEquals($expected, (string)$this->object->build($url));
+		$this->assertEquals($expected, (string) $this->object->build($url));
 	}
 
 	/**
@@ -811,7 +811,7 @@ class JRouterTest extends TestCase
 
 		$createUriMethod = new ReflectionMethod('JRouter', 'createUri');
 		$createUriMethod->setAccessible(true);
-		$this->assertEquals($expected, (string)($createUriMethod->invoke($this->object, $url)));
+		$this->assertEquals($expected, (string) ($createUriMethod->invoke($this->object, $url)));
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -362,7 +362,7 @@ class JUserHelperTest extends TestCaseDatabase
 		// Generate the old style password hash used before phpass was implemented.
 		$salt		= JUserHelper::genRandomPassword(32);
 		$crypted	= JUserHelper::getCryptedPassword($password, $salt);
-		$hashed	        = $crypted.':'.$salt;
+		$hashed	        = $crypted . ':' . $salt;
 		$this->assertTrue(
 			JUserHelper::verifyPassword('mySuperSecretPassword', $hashed),
 			'Properly verifies a password which was hashed before phpass was implemented'


### PR DESCRIPTION
This is the second of a set of PR's that's hopefully going to result in us using the code sniffer on the unit tests folder as well (so far ignored because it's a nightmare effort). This fixes issues where we are missing spaces after concat operators and not having a space after casting to a string
