### PR TITLE
Use $this->connection = null; rather than unset()

### DIFF
--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -88,7 +88,7 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 	public function __destruct()
 	{
 		$this->freeResult();
-		unset($this->connection);
+		$this->connection = null;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue Use $this->connection = null; rather than unset()

### Summary of Changes
unset() will undeclare the class member variable, we don't want to do that.
replicates framework changes

### Testing Instructions
merge by code review

### Documentation Changes Required
none