### PR TITLE
[postgresql] - no need to set default to NULL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2016-10-02.sql
@@ -1,2 +1,1 @@
 ALTER TABLE "#__session" ALTER COLUMN "client_id" DROP NOT NULL;
-ALTER TABLE "#__session" ALTER COLUMN "client_id" SET DEFAULT NULL;


### PR DESCRIPTION
Pull Request for Issue #13416.

### Summary of Changes
removed the SQL for setting the default to NULL on `#__session.client_id`

By default values are NULL no real reason to default it to Null.


