### PR TITLE
Use JPATH_ADMINISTRATOR instead of JPATH_ROOT/administrator.

### DIFF
--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -369,7 +369,7 @@ class ContenthistoryModelHistory extends JModelList
 		$typeId = JFactory::getApplication()->input->getInteger('type_id', 0);
 		$typeTable->load($typeId);
 		$typeAliasArray = explode('.', $typeTable->type_alias);
-		JTable::addIncludePath(JPATH_ROOT . '/administrator/components/' . $typeAliasArray[0] . '/tables');
+		JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $typeAliasArray[0] . '/tables');
 		$contentTable = $typeTable->getContentTable();
 		$keyValue = JFactory::getApplication()->input->getInteger('item_id', 0);
 

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1106,7 +1106,7 @@ class MenusModelItem extends JModelAdmin
 		else
 		{
 			// We don't have a component. Load the form XML to get the help path
-			$xmlFile = JPath::find(JPATH_ROOT . '/administrator/components/com_menus/models/forms', 'item_' . $type . '.xml');
+			$xmlFile = JPath::find(JPATH_ADMINISTRATOR . '/components/com_menus/models/forms', 'item_' . $type . '.xml');
 
 			// Attempt to load the xml file.
 			if ($xmlFile && !$xml = simplexml_load_file($xmlFile))


### PR DESCRIPTION
User MaxPowerHamburg [reported](http://www.joomla-bugs.de/forum/index.php/topic,731.0.html) that after renaming his administrator folder (and changing the JPATH_ADMINISTRATOR constant to point to the new directory), he is no longer able to create new menu items.
I'm aware that renaming the administrator folder is not recommended for various reasons, including problems with updating, extensions and paths stored in the database. But I don't see any reason against this change, because it is according to the usage of path constants all over the CMS.

### Summary of Changes

This PR changes two occurrences of `JPATH_ROOT . '/administrator'` to `JPATH_ADMINISTRATOR`. For normal environments


### Testing Instructions
1. Rename your `administrator` folder to something else, e.g. `adm`.
2. In includes/defines.php and adm/includes/defines.php, change the following line:
```
define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
```
to
```
define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'adm');
```
3. Login into your renamed administrator center. Navigate to "Menus" - "Some menu" - "Add New Menu Item". 
4. You should see a "Fatal error: Call to a member function xpath() on a non-object...".
5. Apply this pull request (attention: change the files in your renamed folder, not in the administrator folder!).
6. Repeat step 3, it should work now.

Unfortunately, the second change (administrator/components/com_contenthistory/models/history.php) can't really be tested, because the legacy JTableContent will be loaded if the other one can't be found. Maybe this can be merged by a maintainer on review? 

### Documentation Changes Required
None