### PR TITLE
Proper escaping in toolbar button js strings

### DIFF
--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -12,12 +12,10 @@ defined('JPATH_BASE') or die;
 JHtml::_('behavior.core');
 
 $title = $displayData['title'];
-$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-$message = addslashes($message);
+JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+$message = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 ?>
-<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $message; ?>');  }else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
+<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $message; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
 	<span class="icon-checkbox-partial" title="<?php echo $title; ?>"></span>
 	<?php echo $title; ?>
 </button>
-
-

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -93,7 +93,7 @@ class JToolbarButtonConfirm extends JToolbarButton
 
 		if ($list)
 		{
-			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); }";
+			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } ";
 			$cmd .= "else { " . $cmd . " }";
 		}
 

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -93,7 +93,8 @@ class JToolbarButtonConfirm extends JToolbarButton
 
 		if ($list)
 		{
-			$cmd = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { " . $cmd . " }";
+			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); }";
+			$cmd .= "else { " . $cmd . " }";
 		}
 
 		return $cmd;

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -87,16 +87,13 @@ class JToolbarButtonConfirm extends JToolbarButton
 	 */
 	protected function _getCommand($msg, $name, $task, $list)
 	{
-		$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-		$message = addslashes($message);
+		JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+
+		$cmd = "if (confirm('" . $msg . "')) { Joomla.submitbutton('" . $task . "'); }";
 
 		if ($list)
 		{
-			$cmd = "if (document.adminForm.boxchecked.value==0){alert('$message');}else{if (confirm('$msg')){Joomla.submitbutton('$task');}}";
-		}
-		else
-		{
-			$cmd = "if (confirm('$msg')){Joomla.submitbutton('$task');}";
+			$cmd = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { " . $cmd . " }";
 		}
 
 		return $cmd;

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -93,8 +93,9 @@ class JToolbarButtonConfirm extends JToolbarButton
 
 		if ($list)
 		{
-			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } ";
-			$cmd .= "else { " . $cmd . " }";
+			$alert = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
+			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
+			
 		}
 
 		return $cmd;

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -92,16 +92,13 @@ class JToolbarButtonStandard extends JToolbarButton
 	 */
 	protected function _getCommand($name, $task, $list)
 	{
-		$message = JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-		$message = addslashes($message);
+		JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+
+		$cmd = "Joomla.submitbutton('" . $task . "');";
 
 		if ($list)
 		{
-			$cmd = "if (document.adminForm.boxchecked.value==0){alert('$message');}else{ Joomla.submitbutton('$task')}";
-		}
-		else
-		{
-			$cmd = "Joomla.submitbutton('$task')";
+			$cmd = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { " . $cmd . " }";
 		}
 
 		return $cmd;

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -98,8 +98,8 @@ class JToolbarButtonStandard extends JToolbarButton
 
 		if ($list)
 		{
-			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } ";
-			$cmd .= "else { " . $cmd . " }";
+			$alert = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
+			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
 		}
 
 		return $cmd;

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -98,7 +98,8 @@ class JToolbarButtonStandard extends JToolbarButton
 
 		if ($list)
 		{
-			$cmd = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { " . $cmd . " }";
+			$cmd  = "if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } ";
+			$cmd .= "else { " . $cmd . " }";
 		}
 
 		return $cmd;

--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -124,7 +124,7 @@ class JToolbarButtonTest extends TestCaseDatabase
 		$type = array('Standard', 'test');
 
 		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">" . PHP_EOL
-			. "\t<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{ Joomla.submitbutton('')}\" class=\"btn btn-small\">" . PHP_EOL
+			. "\t<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { Joomla.submitbutton(''); }\" class=\"btn btn-small\">" . PHP_EOL
 			. "\t<span class=\"icon-test\"></span>" . PHP_EOL
 			. "\t</button>" . PHP_EOL
 			. "</div>" . PHP_EOL;

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -92,7 +92,7 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value==0){alert('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');}else{if (confirm('Confirm action?')){Joomla.submitbutton('article.save');}}\" class=\"btn btn-small\">" . PHP_EOL
+		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-small\">" . PHP_EOL
 			. "\t<span class=\"icon-confirm-test\"></span>" . PHP_EOL
 			. "\tConfirm?</button>" . PHP_EOL;
 


### PR DESCRIPTION
Pull Request for New Issue.

### Summary of Changes

Fix improper js escaping in toolbar buttons.

### Testing Instructions

1. Add a language override like `test "test" 'test'"` for admin en-GB `JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST` language var
2. Go to any list view and try to click any button that requires you to use the checkbox (ex: edit button). Javascript error...
3. Apply patch and repeat test.

### Documentation Changes Required

None.