### PR TITLE
[Deprecate _QQ_ 1] Remove information about _QQ_ in 4 ini files.

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -5,7 +5,6 @@
 
 ; Common boolean values
 ; Note: YES, NO, TRUE, FALSE are reserved words in INI format.
-; Double quotes in the values have to be formatted as "_QQ_".
 
 ; Keep this string on top
 JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"

--- a/administrator/language/en-GB/en-GB.lib_joomla.ini
+++ b/administrator/language/en-GB/en-GB.lib_joomla.ini
@@ -5,7 +5,6 @@
 
 ; Common boolean values
 ; Note: YES, NO, TRUE, FALSE are reserved words in INI format.
-; Double quotes in the values have to be formatted as "_QQ_".
 
 ; Keep this string on top
 JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -5,7 +5,6 @@
 
 ; Common boolean values
 ; Note: YES, NO, TRUE, FALSE are reserved words in INI format.
-; Double quotes in the values have to be formatted as "_QQ_"
 
 ; Keep this string on top
 JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"

--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -5,7 +5,6 @@
 
 ; Common boolean values
 ; Note: YES, NO, TRUE, FALSE are reserved words in INI format.
-; Double quotes in the values have to be formatted as "_QQ_".
 
 ; Keep this string on top
 JERROR_PARSING_LANGUAGE_FILE="&#160;: error(s) in line(s) %s"


### PR DESCRIPTION
### Summary of Changes

As discussed in https://github.com/joomla/joomla-cms/issues/13421
Remove information about `"_QQ_"` usage in 4 ini files.

### Testing Instructions

Merge on code review.

### Documentation Changes Required

This doc changes are not for this PR in particular, but for the deprected `"_QQ_"` usage as a whole.
- In 4.0 B/C break changes inform this `"_QQ_"` usage will not be supported anymore.
- If there is any doc with reference to the `"_QQ_"` usage to quote strings in ini files needs to be updated to usage of  escaped double quotes (`\"`).