### PR TITLE
TinyMCE builder: Make sure that the Public group used only once

### DIFF
--- a/media/editors/tinymce/js/tinymce-builder.js
+++ b/media/editors/tinymce/js/tinymce-builder.js
@@ -296,7 +296,7 @@
 
             // Disable already selected options
             $accessSelects.each(function () {
-                var $select = $(this), val = $select.val(), query = [],
+                var $select = $(this), val = $select.val() || [], query = [],
                     $options = $accessSelects.not(this).find('option');
 
                 for (var i = 0, l = val.length; i < l; i++ ) {

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -72,8 +72,6 @@ class JFormFieldTinymceBuilder extends JFormField
 			$data['setsNames'][$i] = JText::sprintf('PLG_TINY_SET_TITLE', $i);
 		}
 
-		krsort($data['setsNames']);
-
 		// Prepare the forms for each set
 		$setsForms  = array();
 		$formsource = JPATH_PLUGINS . '/editors/tinymce/form/setoptions.xml';
@@ -92,6 +90,10 @@ class JFormFieldTinymceBuilder extends JFormField
 			}
 		}
 
+		// Collect already used groups
+		$groupsInUse = array();
+
+		// Prepare the Set forms, for the set options
 		foreach (array_keys($data['setsNames']) as $num)
 		{
 			$formname = 'set.form.' . $num;
@@ -109,16 +111,30 @@ class JFormFieldTinymceBuilder extends JFormField
 				 * Set 0: for Administrator, Editor, Super Users (4,7,8)
 				 * Set 1: for Registered, Manager (2,6), all else are public
 				 */
-				$formValues->access = !$num ? array(4,7,8) : ($num === 1 ? array(2,6) : 1);
+				$formValues->access = !$num ? array(4,7,8) : ($num === 1 ? array(2,6) : array());
+
+				// Assign Public to the new Set, but only when it not in use already
+				if (empty($formValues->access) && !in_array(1, $groupsInUse))
+				{
+					$formValues->access = array(1);
+				}
 			}
 			else
 			{
-				$formValues = $this->value['setoptions'][$num];
+				$formValues = (object) $this->value['setoptions'][$num];
+			}
+
+			// Collect already used groups
+			if (!empty($formValues->access))
+			{
+				$groupsInUse = array_merge($groupsInUse, $formValues->access);
 			}
 
 			// Bind the values
 			$setsForms[$num]->bind($formValues);
 		}
+
+		krsort($data['setsNames']);
 
 		$data['setsForms'] = $setsForms;
 


### PR DESCRIPTION
Pull Request for Issue #13344 .

### Summary of Changes
When add new Set it will be assigned to nothing when the Public group already in use

### Testing Instructions
Try create new Set and make sure there no error when select `usergroup`.

### Documentation Changes Required
nope