### PR TITLE
Unified language ini file parsing & some other changes concerning that

### DIFF
--- a/administrator/components/com_languages/helpers/languages.php
+++ b/administrator/components/com_languages/helpers/languages.php
@@ -72,7 +72,7 @@ class LanguagesHelper
 	 *
 	 * @since   2.5
 	 *
-	 * @deprecated  4.0  Use JLanguageHelper::parseIniFile($filename)
+	 * @deprecated  4.0  Use JLanguageHelper::parseIniFile($fileName)
 	 */
 	public static function parseFile($fileName)
 	{

--- a/administrator/components/com_languages/helpers/languages.php
+++ b/administrator/components/com_languages/helpers/languages.php
@@ -66,29 +66,17 @@ class LanguagesHelper
 	/**
 	 * Method for parsing ini files.
 	 *
-	 * @param   string  $filename  Path and name of the ini file to parse.
+	 * @param   string  $fileName  Path and name of the ini file to parse.
 	 *
 	 * @return  array   Array of strings found in the file, the array indices will be the keys. On failure an empty array will be returned.
 	 *
 	 * @since   2.5
+	 *
+	 * @deprecated  4.0  Use JLanguageHelper::parseIniFile($filename)
 	 */
-	public static function parseFile($filename)
+	public static function parseFile($fileName)
 	{
-		if (!is_file($filename))
-		{
-			return array();
-		}
-
-		$contents = file_get_contents($filename);
-		$contents = str_replace('_QQ_', '"\""', $contents);
-		$strings  = @parse_ini_string($contents);
-
-		if ($strings === false)
-		{
-			return array();
-		}
-
-		return $strings;
+		return JLanguageHelper::parseIniFile($fileName);
 	}
 
 	/**

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -398,13 +398,8 @@ class JLanguageHelper
 	public static function parseIniFile($fileName)
 	{
 		$contents = file_get_contents($fileName);
-		$strings = @parse_ini_string($contents);
+		$strings  = @parse_ini_string($contents);
 
-		if (!is_array($strings))
-		{
-			$strings = array();
-		}
-
-		return $strings;
+		return is_array($strings) ? $strings : array();
 	}
 }

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -182,7 +182,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getInstalledLanguages($clientId = null, $processMetaData = false, $processManifest = false, $pivot = 'element',
-												 $orderField = null, $orderDirection = null)
+		$orderField = null, $orderDirection = null)
 	{
 		static $installedLanguages = null;
 
@@ -329,7 +329,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getContentLanguages($checkPublished = true, $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-											   $orderDirection = null)
+		$orderDirection = null)
 	{
 		static $contentLanguages = null;
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -182,7 +182,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getInstalledLanguages($clientId = null, $processMetaData = false, $processManifest = false, $pivot = 'element',
-	                                             $orderField = null, $orderDirection = null)
+												 $orderField = null, $orderDirection = null)
 	{
 		static $installedLanguages = null;
 

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -329,7 +329,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getContentLanguages($checkPublished = true, $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-	                                           $orderDirection = null)
+											   $orderDirection = null)
 	{
 		static $contentLanguages = null;
 
@@ -387,7 +387,9 @@ class JLanguageHelper
 	}
 
 	/**
-	 * @param   string  $filename  Path and name of the ini file to parse.
+	 * Parses a language ini file.
+	 *
+	 * @param   string  $fileName  Path and name of the ini file to parse.
 	 *
 	 * @return  array   Array of strings found in the file, the array indices will be the keys. On failure an empty array will be returned.
 	 *

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -397,8 +397,7 @@ class JLanguageHelper
 	 */
 	public static function parseIniFile($fileName)
 	{
-		$contents = file_get_contents($fileName);
-		$strings  = @parse_ini_string($contents);
+		$strings = @parse_ini_file($fileName);
 
 		return is_array($strings) ? $strings : array();
 	}

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -12,6 +12,11 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\Utilities\ArrayHelper;
 
 /**
+ * Allows for quoting in language .ini files.
+ */
+define('_QQ_', '"');
+
+/**
  * Language helper class
  *
  * @since  11.1
@@ -177,7 +182,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getInstalledLanguages($clientId = null, $processMetaData = false, $processManifest = false, $pivot = 'element',
-		$orderField = null, $orderDirection = null)
+	                                             $orderField = null, $orderDirection = null)
 	{
 		static $installedLanguages = null;
 
@@ -230,7 +235,7 @@ class JLanguageHelper
 					{
 						$lang->metadata = JLanguage::parseXMLLanguageFile($metafile);
 					}
-					// Not able to process xml language file. Fail silently.
+						// Not able to process xml language file. Fail silently.
 					catch (Exception $e)
 					{
 						JLog::add(JText::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), JLog::WARNING, 'language');
@@ -254,7 +259,7 @@ class JLanguageHelper
 					{
 						$lang->manifest = JInstaller::parseXMLInstallFile($metafile);
 					}
-					// Not able to process xml language file. Fail silently.
+						// Not able to process xml language file. Fail silently.
 					catch (Exception $e)
 					{
 						JLog::add(JText::sprintf('JLIB_LANGUAGE_ERROR_CANNOT_LOAD_METAFILE', $language->element, $metafile), JLog::WARNING, 'language');
@@ -324,7 +329,7 @@ class JLanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getContentLanguages($checkPublished = true, $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-		$orderDirection = null)
+	                                           $orderDirection = null)
 	{
 		static $contentLanguages = null;
 
@@ -379,5 +384,25 @@ class JLanguageHelper
 		}
 
 		return $languages;
+	}
+
+	/**
+	 * @param   string  $filename  Path and name of the ini file to parse.
+	 *
+	 * @return  array   Array of strings found in the file, the array indices will be the keys. On failure an empty array will be returned.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function parseIniFile($fileName)
+	{
+		$contents = file_get_contents($fileName);
+		$strings = @parse_ini_string($contents);
+
+		if (!is_array($strings))
+		{
+			$strings = array();
+		}
+
+		return $strings;
 	}
 }

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -12,11 +12,6 @@ defined('JPATH_PLATFORM') or die;
 use Joomla\String\StringHelper;
 
 /**
- * Allows for quoting in language .ini files.
- */
-define('_QQ_', '"');
-
-/**
  * Languages/translation handler class
  *
  * @since  11.1
@@ -821,13 +816,13 @@ class JLanguage
 	/**
 	 * Parses a language file.
 	 *
-	 * @param   string  $filename  The name of the file.
+	 * @param   string  $fileName  The name of the file.
 	 *
 	 * @return  array  The array of parsed strings.
 	 *
 	 * @since   11.1
 	 */
-	protected function parse($filename)
+	protected function parse($fileName)
 	{
 		if ($this->debug)
 		{
@@ -837,21 +832,14 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-		$contents = file_get_contents($filename);
-		$contents = str_replace('_QQ_', '"\""', $contents);
-		$strings = @parse_ini_string($contents);
-
-		if (!is_array($strings))
-		{
-			$strings = array();
-		}
+		$strings = JLanguageHelper::parseIniFile($fileName);
 
 		if ($this->debug)
 		{
 			// Restore error tracking to what it was before.
 			ini_set('track_errors', $track_errors);
 
-			$this->debugFile($filename);
+			$this->debugFile($fileName);
 		}
 
 		return $strings;


### PR DESCRIPTION
Inspired by the changes @andrepereiradasilva  did in #13427
### Summary of Changes
- unify language ini file parsing by introducing a `JLanguageHelper::parseIniFile($fileName)` method.
- remove unnecessary str_replace call (which is also producing unnecessary ""), because the _QQ_ is automatically taken care of the defined _QQ_ constant. Didn't detect any issues by removing it. Please correct me if I am wrong here.
- Some minor variable name fixes that were in the scope of code changes that I did

### Testing Instructions
1) Code review
2) a) Test normal `"_qq_"` string translation in site and administrator
    b) Test introducing overrides with `"_qq_"` string translation in site and administrator

### Documentation Changes Required
No, if fully automated generation
