### PR TITLE
Code style fix for administrator/components/com_contenthistory

### DIFF
--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -120,11 +120,11 @@ class ContenthistoryHelper
 					if (isset($expandedObjectArray[$name]))
 					{
 						$optionFieldArray = $field->xpath('option[@value="' . $expandedObjectArray[$name] . '"]');
-						
+
 						$valueText = null;
-						
+
 						if (is_array($optionFieldArray) && count($optionFieldArray))
-						{							
+						{
 							$valueText = trim((string) $optionFieldArray[0]);
 						}
 

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -339,13 +339,13 @@ class ContenthistoryModelHistory extends JModelList
 				'h.character_count, h.sha1_hash, h.version_data, h.keep_forever'
 			)
 		)
-		->from($db->quoteName('#__ucm_history') . ' AS h')
-		->where($db->quoteName('h.ucm_item_id') . ' = ' . (int) $this->getState('item_id'))
-		->where($db->quoteName('h.ucm_type_id') . ' = ' . (int) $this->getState('type_id'))
+			->from($db->quoteName('#__ucm_history') . ' AS h')
+			->where($db->quoteName('h.ucm_item_id') . ' = ' . (int) $this->getState('item_id'))
+			->where($db->quoteName('h.ucm_type_id') . ' = ' . (int) $this->getState('type_id'))
 
 		// Join over the users for the editor
-		->select('uc.name AS editor')
-		->join('LEFT', '#__users AS uc ON uc.id = h.editor_user_id');
+			->select('uc.name AS editor')
+			->join('LEFT', '#__users AS uc ON uc.id = h.editor_user_id');
 
 		// Add the list ordering clause.
 		$orderCol = $this->state->get('list.ordering');

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -33,8 +33,8 @@ class ContenthistoryViewPreview extends JViewLegacy
 	{
 		$this->state = $this->get('State');
 		$this->item  = $this->get('Item');
-		
-		if (false === $this->item) 
+
+		if (false === $this->item)
 		{
 			JFactory::getLanguage()->load('com_content', JPATH_SITE, null, true);
 


### PR DESCRIPTION
Pull Request for Issue code style issues.

### Summary of Changes
[Automatically fixed with PHPCS2 fixers](https://github.com/joomla/coding-standards/pull/109)
- Whitespace found at end of line
- Opening if brace must be on a line by itself
- Object operator not indented correctly

### Testing Instructions
merge by code review

### Documentation Changes Required
none