### PR TITLE
Add more email cloaking unit tests and fix email cloaking bug

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -377,13 +377,13 @@ class PlgContentEmailcloak extends JPlugin
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{
 			$mail = $regs[2][0] . $regs[3][0];
-			$mailText = $regs[4][0] . $regs[5][0] . $regs[6][0] . $regs[7][0];
+			$mailText = $regs[5][0] . $regs[6][0] . $regs[7][0];
 
 			// Check to see if mail text is different from mail addy
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText);
 
 			// Ensure that attributes is not stripped out by email cloaking
-			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));
@@ -398,12 +398,12 @@ class PlgContentEmailcloak extends JPlugin
 		while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE))
 		{
 			$mail = $regs[2][0] . $regs[3][0];
-			$mailText = $regs[4][0] . $regs[5][0] . addslashes($regs[6][0]) . $regs[7][0];
+			$mailText = $regs[5][0] . addslashes($regs[6][0]) . $regs[7][0];
 
 			$replacement = JHtml::_('email.cloak', $mail, $mode, $mailText, 0);
 
 			// Ensure that attributes is not stripped out by email cloaking
-			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[3][0]));
+			$replacement = html_entity_decode($this->_addAttributesToEmail($replacement, $regs[1][0], $regs[4][0]));
 
 			// Replace the found address with the js cloaked email
 			$text = substr_replace($text, $replacement, $regs[0][1], strlen($regs[0][0]));

--- a/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
+++ b/tests/unit/suites/plugins/content/emailcloak/PlgContentEmailcloakTest.php
@@ -70,8 +70,7 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 	public function dataTestOnContentPrepare()
 	{
 		return array(
-
-			# 0
+			// 0
 			array(
 				// This first row is the input, this is what would be in the article
 				'this should not be parsed as it has no (at) sign in it - see what I did there? ;)',
@@ -90,28 +89,22 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 
 			),
 
-			# ? - see: https://github.com/joomla/joomla-cms/pull/11378#issuecomment-237829598
-			/**
-			 * This is failing at the moment so Im excluding it while the above PR #11378 is worked on
-			 * and while this unit test suite is being improved - but this test highlights the fact we need these tests!
-			 *
-			 * array(
-			 * '<a href="mailto:toto@toto.com?subject=Mysubject" class="myclass" >email</a>',
-			 * "<a href='mailto:toto@toto.com?subject=Mysubject' class='myclass' >email</a>",
-			 * "
-			 * <span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
-			 * document.getElementById('cloak__HASH__').innerHTML = '';
-			 * var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
-			 * var path = 'hr' + 'ef' + '=';
-			 * var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
-			 * addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m?s&#117;bj&#101;ct=Mys&#117;bj&#101;ct';
-			 * var addy_text__HASH__ = '&#101;m&#97;&#105;l';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
-			 * </script>
-			 * "
-			 * ),*/
+			// 1
+			array(
+				'<a href="mailto:toto@toto.com?subject=Mysubject" class="myclass" >email</a>',
+				"<a href='mailto:toto@toto.com?subject=Mysubject' class=\"myclass\" >email</a>",
+				"<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
+				addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m?s&#117;bj&#101;ct=Mys&#117;bj&#101;ct';
+				var addy_text__HASH__ = '&#101;m&#97;&#105;l';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
+				</script>
+				"
+			),
 
-
-			# 1
+			// 2
 			array(
 				'<a href="http://mce_host/ourdirectory/email@example.org">anytext</a>',
 
@@ -128,7 +121,7 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 				"
 			),
 
-			# 2
+			// 3
 			array(
 				'<p><a href="mailto:joe@nowhere.com"><span style="font-style: 8pt;">Joe_fontsize8</span></a></p>',
 
@@ -146,11 +139,11 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 				"
 			),
 
-			# 3
+			// 4
 			array(
 				'<p><a href="mailto:joe@nowhere13.com?subject= A text"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></p>',
 
-				'<a href=\'mailto:joe@nowhere13.com?subject= A text\'?subject= A text><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a>',
+				'<a href=\'mailto:joe@nowhere13.com?subject= A text\'><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a>',
 
 				"
 				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
@@ -159,56 +152,204 @@ class PlgContentEmailcloakTest extends TestCaseDatabase
 				var path = 'hr' + 'ef' + '=';
 				var addy__HASH__ = 'joe' + '@';
 				addy__HASH__ = addy__HASH__ + 'nowhere13' + '.' + 'com?subject= A text';
-				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'?subject= A text>'+addy_text__HASH__+'<\/a>';
+				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
 		</script></p>
 				"
 			),
 
+			// 5
+			array(
+				'<p><a href="mailto:joe@nowhere.com"><strong>something</strong></a></p>',
 
-//            [
-//                '<p><a href="mailto:joe@nowhere14.com"><span style="font-style: 14pt;">joe@nowhere14.com</span></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nowhere16.com?subject= A text"><span style="font-size: 16pt;">joe@nowhere16.com</span></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nowhere.com"><strong>something</strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nobody.com"><strong>mymail@mysite.com</strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nowhere.com?subject= A text"><strong><span style="font-size: 16px;">joe@nowhere.com</span></strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nobody.com"><strong><span style="font-size: 14px;">mymail@mysite.com</span></strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nobody.com"><strong><span style="font-size: 9px;">Joe Nobody</span></strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<p><a href="mailto:joe@nobody.com"><strong><span>strong and span</span></strong></a></p>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<a href="mailto:email@amail.com?subject=Text"><img src="path/to/something.jpg">email@amail.com</img></a>',
-//                '<span style="font-style: 8pt;">Joe_fontsize8</span>'
-//            ],
-//            [
-//                '<a href="http://mce_host/ourdirectory/email@example.org">email@example.org</a>',
-//                '<a href="http://mce_host/ourdirectory/email@example.org">email@example.org</a>'
-//            ],
-//            [
-//                '<a href="mailto:email@example.org">email@example.org</a>',
-//                '<a href="mailto:email@example.org">email@example.org</a>'
-//            ],
+				'<a href=\'mailto:joe@nowhere.com\'><strong>something</strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com';
+				var addy_text__HASH__ = '<strong>something</strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 6
+			// TODO: I would expect that the email in the strong tag should ALSO be converted?
+			array(
+				'<p><a href="mailto:joe@nowhere.com"><strong>mymail@mysite.com</strong></a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com\'><strong>mymail@mysite.com</strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com';
+				var addy_text__HASH__ = '<strong>mymail' + '@' + 'mysite' + '.' + 'com</strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 7
+			array(
+				'<p><a href="mailto:joe@nowhere.com"><strong><span style="font-size: 14px;">mymail@mysite.com</span></strong></a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com\'><strong><span style="font-size: 14px;">mymail@mysite.com</span></strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com';
+				var addy_text__HASH__ = '<strong><span style=\"font-size: 14px;\">mymail' + '@' + 'mysite' + '.' + 'com</span></strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 8
+			array(
+				'<p><a href="mailto:joe@nowhere.com"><strong><span style="font-size: 14px;">Joe Nobody</span></strong></a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com\'><strong><span style="font-size: 14px;">Joe Nobody</span></strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com';
+				var addy_text__HASH__ = '<strong><span style=\"font-size: 14px;\">Joe Nobody</span></strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 9
+			// TODO: I would expect that the email in the strong tag should ALSO be converted?
+			array(
+				'<p><a href="mailto:joe@nowhere.com?subject= A text"><strong><span style="font-size: 16px;">joe@nowhere.com</span></strong></a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com?subject= A text\'><strong><span style="font-size: 16px;">joe@nowhere.com</span></strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com?subject= A text';
+				var addy_text__HASH__ = '<strong><span style=\"font-size: 16px;\">joe' + '@' + 'nowhere' + '.' + 'com</span></strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 10
+			array(
+				'<p><a href="mailto:joe@nowhere.com?subject=Text"><img src="path/to/something.jpg" />joe@nowhere.com</a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com?subject=Text\'><img src="path/to/something.jpg" />joe@nowhere.com</a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com?subject=Text';
+				var addy_text__HASH__ = '<img src=\"path/to/something.jpg\" />joe' + '@' + 'nowhere' + '.' + 'com';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 11
+			array(
+				'<a href="http://mce_host/ourdirectory/email@example.org">email@example.org</a>',
+
+				"<a href='mailto:email@example.org'>email@example.org</a>",
+
+				"<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = '&#101;m&#97;&#105;l' + '&#64;';
+				addy__HASH__ = addy__HASH__ + '&#101;x&#97;mpl&#101;' + '&#46;' + '&#111;rg';
+				var addy_text__HASH__ = '&#101;m&#97;&#105;l' + '&#64;' + '&#101;x&#97;mpl&#101;' + '&#46;' + '&#111;rg';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\'>'+addy_text__HASH__+'<\/a>';
+		</script>
+				"
+			),
+
+			// 12 - similar to test 9 but with the addition of classes
+			// TODO: I would expect that the email in the strong tag should ALSO be converted?
+			array(
+				'<p><a href="mailto:joe@nowhere.com?subject= A text" class="class1 class2"><strong><span style="font-size: 16px;">joe@nowhere.com</span></strong></a></p>',
+
+				'<a href=\'mailto:joe@nowhere.com?subject= A text\' class="class1 class2"><strong><span style="font-size: 16px;">joe@nowhere.com</span></strong></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere' + '.' + 'com?subject= A text';
+				var addy_text__HASH__ = '<strong><span style=\"font-size: 16px;\">joe' + '@' + 'nowhere' + '.' + 'com</span></strong>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"class1 class2\">'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 13 - Similar to test 4 but with the addition of classes
+			array(
+				'<p><a href="mailto:joe@nowhere13.com?subject= A text" class="class 1 class 2"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></p>',
+
+				'<a href=\'mailto:joe@nowhere13.com?subject= A text\' class="class 1 class 2"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a>',
+
+				"
+				<p><span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = 'ma' + 'il' + 'to';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 'joe' + '@';
+				addy__HASH__ = addy__HASH__ + 'nowhere13' + '.' + 'com?subject= A text';
+				var addy_text__HASH__ = '<span style=\"font-size: 14pt;\">Joe_subject_ fontsize13</span>';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"class 1 class 2\">'+addy_text__HASH__+'<\/a>';
+		</script></p>
+				"
+			),
+
+			// 14
+			array(
+				'<a href="mailto:toto@toto.com" class="myclass" >toto@toto.com</a>',
+				"<a href='mailto:toto@toto.com' class=\"myclass\" >toto@toto.com</a>",
+				"<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
+				addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m';
+				var addy_text__HASH__ = 't&#111;t&#111;' + '&#64;' + 't&#111;t&#111;' + '&#46;' + 'c&#111;m';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
+				</script>
+				"
+			),
+
+			// 15
+			array(
+				'<a href="mailto:toto@toto.com" class="myclass" >Click Here</a>',
+				"<a href='mailto:toto@toto.com' class=\"myclass\" >Click Here</a>",
+				"<span id=\"cloak__HASH__\">JLIB_HTML_CLOAKING</span><script type='text/javascript'>
+				document.getElementById('cloak__HASH__').innerHTML = '';
+				var prefix = '&#109;a' + 'i&#108;' + '&#116;o';
+				var path = 'hr' + 'ef' + '=';
+				var addy__HASH__ = 't&#111;t&#111;' + '&#64;';
+				addy__HASH__ = addy__HASH__ + 't&#111;t&#111;' + '&#46;' + 'c&#111;m';
+				var addy_text__HASH__ = 'Cl&#105;ck H&#101;r&#101;';document.getElementById('cloak__HASH__').innerHTML += '<a ' + path + '\'' + prefix + ':' + addy__HASH__ + '\' class=\"myclass\" >'+addy_text__HASH__+'<\/a>';
+				</script>
+				"
+			),
 		);
 	}
 


### PR DESCRIPTION
### Summary of Changes
Fixes a bug with two test cases in the email cloaking plugin and adds a load of extra unit tests

### Testing Instructions
Test email cloaking continues to work. Unit tests pass (note the corrected expected result of unit tests 4)

For something in browser try using `<p><a href="mailto:joe@nowhere13.com?subject= A text" class="class 1 class 2"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></p>`. But please make sure you are using codemirror or none as the editor and NOT TinyMCE (as tiny swaps the order of the class and href attribute around). You'll see before the patch what gets rendered is

```
<p><span id="cloak8969bf0d491b7d014d5815b4edc75189"><a href="mailto:joe@nowhere13.com?subject= A text" ?subject="A" text=""> class="class 1 class 2"<span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></span></p>
```

(note that the class is rendered on the page and there is the weird subject property instead the `a` tag and after the patch the following correctly is rendered

```
<p><span id="cloak3e0b7379f07410f902a5c4b48ed1a893"><a href="mailto:joe@nowhere13.com?subject= A text" class="class 1 class 2"><span style="font-size: 14pt;">Joe_subject_ fontsize13</span></a></span></p>
```

### Documentation Changes Required
None