### PR TITLE
Apply fixes to InstantiateNewClasses Sniff

### DIFF
--- a/build/phpcs/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
+++ b/build/phpcs/Joomla/Sniffs/Classes/InstantiateNewClassesSniff.php
@@ -72,7 +72,11 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                     case T_LNUMBER :
                     case T_CONSTANT_ENCAPSED_STRING :
                     case T_DOUBLE_QUOTED_STRING :
-                        if($started)
+                    case T_ARRAY :
+                    case T_TRUE :
+                    case T_FALSE :
+                    case T_NULL :
+                        if($started === true)
                         {
                             $valid = true;
                             $running = false;
@@ -81,7 +85,7 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                         break;
 
                     case T_CLOSE_PARENTHESIS :
-                        if( ! $started)
+                        if($started === false)
                         {
                             $valid = true;
                         }
@@ -96,9 +100,9 @@ class Joomla_Sniffs_Classes_InstantiateNewClassesSniff implements PHP_CodeSniffe
                 $cnt ++;
             }
         }
-        while ($running == true);
+        while ($running === true);
 
-        if( ! $valid)
+        if($valid === false)
         {
             $error = 'Instanciating new classes without parameters does not require brackets.';
             $phpcsFile->addError($error, $stackPtr, 'New class');


### PR DESCRIPTION
Pull Request for Issue multiline new class instantiation would error on code style checks

### Summary of Changes
Applies most of the [PHPCS 2.x changes](https://github.com/joomla/coding-standards/pull/109) to fix a case where multiline new class instantiation would error as `Instantiating new classes without parameters does not require brackets.` if the first parameter was an empty array `array()`, `true`,  `false`, or `null`

### Testing Instructions
merge by code review

### Documentation Changes Required
none