### PR TITLE
Use the database's server type element where able

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -112,9 +112,7 @@ class JoomlaInstallerScript
 	 */
 	protected function updateDatabase()
 	{
-		$db = JFactory::getDbo();
-
-		if (strpos($db->name, 'mysql') !== false)
+		if (JFactory::getDbo()->getServerType() === 'mysql')
 		{
 			$this->updateDatabaseMysql();
 		}
@@ -1841,12 +1839,10 @@ class JoomlaInstallerScript
 
 		try
 		{
-			switch ($db->name)
+			switch ($db->getServerType())
 			{
 				// MySQL database, use TRUNCATE (faster, more resilient)
-				case 'pdomysql':
 				case 'mysql':
-				case 'mysqli':
 					$db->truncateTable('#__session');
 					break;
 

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -101,19 +101,16 @@ abstract class FinderIndexer
 	public static function getInstance()
 	{
 		// Setup the adapter for the indexer.
-		$format = JFactory::getDbo()->name;
+		$serverType = JFactory::getDbo()->getServerType();
 
-		if ($format == 'mysqli' || $format == 'pdomysql')
+		// For `mssql` server types, convert the type to `sqlsrv`
+		if ($serverType === 'mssql')
 		{
-			$format = 'mysql';
-		}
-		elseif ($format == 'sqlazure')
-		{
-			$format = 'sqlsrv';
+			$serverType = 'sqlsrv';
 		}
 
-		$path = __DIR__ . '/driver/' . $format . '.php';
-		$class = 'FinderIndexerDriver' . ucfirst($format);
+		$path = __DIR__ . '/driver/' . $serverType . '.php';
+		$class = 'FinderIndexerDriver' . ucfirst($serverType);
 
 		// Check if a parser exists for the format.
 		if (file_exists($path))
@@ -125,7 +122,7 @@ abstract class FinderIndexer
 		}
 
 		// Throw invalid format exception.
-		throw new RuntimeException(JText::sprintf('COM_FINDER_INDEXER_INVALID_DRIVER', $format));
+		throw new RuntimeException(JText::sprintf('COM_FINDER_INDEXER_INVALID_DRIVER', $serverType));
 	}
 
 	/**

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -299,7 +299,7 @@ class InstallationModelDatabase extends JModelBase
 			return false;
 		}
 
-		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		if ($db->getServerType() === 'mysql')
 		{
 			// @internal MySQL versions pre 5.1.6 forbid . / or \ or NULL.
 			if (preg_match('#[\\\/\.\0]#', $options->db_name) && (!version_compare($db_version, '5.1.6', '>=')))
@@ -327,7 +327,7 @@ class InstallationModelDatabase extends JModelBase
 		}
 
 		// PostgreSQL database older than version 9.0.0 needs to run 'CREATE LANGUAGE' to create function.
-		if (($options->db_type == 'postgresql') && (!version_compare($db_version, '9.0.0', '>=')))
+		if ($db->getServerType() === 'postgresql' && !version_compare($db_version, '9.0.0', '>='))
 		{
 			$db->setQuery("select lanpltrusted from pg_language where lanname='plpgsql'");
 
@@ -487,11 +487,11 @@ class InstallationModelDatabase extends JModelBase
 		$this->setDatabaseCharset($db, $options->db_name);
 
 		// Set the appropriate schema script based on UTF-8 support.
-		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		if ($db->getServerType() === 'mysql')
 		{
 			$schema = 'sql/mysql/joomla.sql';
 		}
-		elseif ($type == 'sqlsrv' || $type == 'sqlazure')
+		elseif ($db->getServerType() === 'mssql')
 		{
 			$schema = 'sql/sqlazure/joomla.sql';
 		}
@@ -542,11 +542,11 @@ class InstallationModelDatabase extends JModelBase
 		// Attempt to update the table #__schema.
 		$pathPart = JPATH_ADMINISTRATOR . '/components/com_admin/sql/updates/';
 
-		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		if ($serverType === 'mysql')
 		{
 			$pathPart .= 'mysql/';
 		}
-		elseif ($type == 'sqlsrv' || $type == 'sqlazure')
+		elseif ($serverType === 'mssql')
 		{
 			$pathPart .= 'sqlazure/';
 		}
@@ -628,11 +628,11 @@ class InstallationModelDatabase extends JModelBase
 		}
 
 		// Load the localise.sql for translating the data in joomla.sql.
-		if (($type == 'mysql') || ($type == 'mysqli') || ($type == 'pdomysql'))
+		if ($serverType === 'mysql')
 		{
 			$dblocalise = 'sql/mysql/localise.sql';
 		}
-		elseif ($type == 'sqlsrv' || $type == 'sqlazure')
+		elseif ($serverType === 'mssql')
 		{
 			$dblocalise = 'sql/sqlazure/localise.sql';
 		}
@@ -722,11 +722,11 @@ class InstallationModelDatabase extends JModelBase
 		// Build the path to the sample data file.
 		$type = $options->db_type;
 
-		if ($type == 'mysqli' || $type == 'pdomysql')
+		if ($db->getServerType() === 'mysql')
 		{
 			$type = 'mysql';
 		}
-		elseif ($type == 'sqlsrv')
+		elseif ($db->getServerType() === 'mssql')
 		{
 			$type = 'sqlazure';
 		}

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -940,9 +940,11 @@ class JInstaller extends JAdapter
 		}
 
 		$db = & $this->_db;
+
+		// TODO - At 4.0 we can change this to use `getServerType()` since SQL Server will not be supported
 		$dbDriver = strtolower($db->name);
 
-		if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
+		if ($db->getServerType() === 'mysql')
 		{
 			$dbDriver = 'mysql';
 		}
@@ -1041,7 +1043,7 @@ class JInstaller extends JAdapter
 			{
 				$dbDriver = strtolower($db->name);
 
-				if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
+				if ($db->getServerType() === 'mysql')
 				{
 					$dbDriver = 'mysql';
 				}
@@ -1106,9 +1108,10 @@ class JInstaller extends JAdapter
 
 			if (count($schemapaths))
 			{
+				// TODO - At 4.0 we can change this to use `getServerType()` since SQL Server will not be supported
 				$dbDriver = strtolower($db->name);
 
-				if ($dbDriver == 'mysqli' || $dbDriver == 'pdomysql')
+				if ($db->getServerType() === 'mysql')
 				{
 					$dbDriver = 'mysql';
 				}

--- a/libraries/cms/schema/changeitem.php
+++ b/libraries/cms/schema/changeitem.php
@@ -139,18 +139,15 @@ abstract class JSchemaChangeitem
 	public static function getInstance($db, $file, $query)
 	{
 		// Get the class name
-		$dbname = $db->name;
+		$serverType = $db->getServerType();
 
-		if ($dbname == 'mysqli' || $dbname == 'pdomysql')
+		// For `mssql` server types, convert the type to `sqlsrv`
+		if ($serverType === 'mssql')
 		{
-			$dbname = 'mysql';
-		}
-		elseif ($dbname == 'sqlazure')
-		{
-			$dbname = 'sqlsrv';
+			$serverType = 'sqlsrv';
 		}
 
-		$class = 'JSchemaChangeitem' . ucfirst($dbname);
+		$class = 'JSchemaChangeitem' . ucfirst($serverType);
 
 		// If the class exists, return it.
 		if (class_exists($class))
@@ -158,7 +155,7 @@ abstract class JSchemaChangeitem
 			return new $class($db, $file, $query);
 		}
 
-		throw new RuntimeException(sprintf('JSchemaChangeitem child class not found for the %s database driver', $dbname), 500);
+		throw new RuntimeException(sprintf('JSchemaChangeitem child class not found for the %s database driver', $serverType), 500);
 	}
 
 	/**

--- a/libraries/cms/schema/changeset.php
+++ b/libraries/cms/schema/changeset.php
@@ -93,9 +93,7 @@ class JSchemaChangeset
 		}
 
 		// If on mysql, add a query at the end to check for utf8mb4 conversion status
-		$serverType = $this->db->getServerType();
-
-		if ($serverType == 'mysql')
+		if ($this->db->getServerType() == 'mysql')
 		{
 			// Let the update query be something harmless which should always succeed
 			$tmpSchemaChangeItem = JSchemaChangeitem::getInstance(
@@ -256,13 +254,10 @@ class JSchemaChangeset
 	private function getUpdateFiles()
 	{
 		// Get the folder from the database name
-		$sqlFolder = $this->db->name;
+		$sqlFolder = $this->db->getServerType();
 
-		if ($sqlFolder == 'mysqli' || $sqlFolder == 'pdomysql')
-		{
-			$sqlFolder = 'mysql';
-		}
-		elseif ($sqlFolder == 'sqlsrv')
+		// For `mssql` server types, convert the type to `sqlazure`
+		if ($sqlFolder === 'mssql')
 		{
 			$sqlFolder = 'sqlazure';
 		}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -873,7 +873,7 @@ class PlgSystemDebug extends JPlugin
 				// Run a SHOW PROFILE query.
 				$profile = '';
 
-				if (in_array($db->name, array('mysqli', 'mysql', 'pdomysql')))
+				if ($db->getServerType() === 'mysql')
 				{
 					if (isset($this->sqlShowProfileEach[$id]))
 					{
@@ -1464,7 +1464,7 @@ class PlgSystemDebug extends JPlugin
 
 		$this->totalQueries = $db->getCount();
 
-		$dbVersion5037 = (strpos($db->name, 'mysql') !== false) && version_compare($db->getVersion(), '5.0.37', '>=');
+		$dbVersion5037 = $db->getServerType() === 'mysql' && version_compare($db->getVersion(), '5.0.37', '>=');
 
 		if ($dbVersion5037)
 		{
@@ -1501,13 +1501,13 @@ class PlgSystemDebug extends JPlugin
 			}
 		}
 
-		if (in_array($db->name, array('mysqli', 'mysql', 'pdomysql', 'postgresql')))
+		if (in_array($db->getServerType(), array('mysql', 'postgresql')))
 		{
 			$log = $db->getLog();
 
 			foreach ($log as $k => $query)
 			{
-				$dbVersion56 = (strpos($db->name, 'mysql') !== false) && version_compare($db->getVersion(), '5.6', '>=');
+				$dbVersion56 = $db->getServerType() === 'mysql' && version_compare($db->getVersion(), '5.6', '>=');
 
 				if ((stripos($query, 'select') === 0) || ($dbVersion56 && ((stripos($query, 'delete') === 0) || (stripos($query, 'update') === 0))))
 				{

--- a/tests/unit/suites/finderIndexer/FinderIndexerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTest.php
@@ -8,6 +8,7 @@
  */
 
 require_once JPATH_ADMINISTRATOR . '/components/com_finder/helpers/indexer/indexer.php';
+require_once JPATH_TESTS . '/suites/libraries/joomla/database/stubs/nosqldriver.php';
 
 use Joomla\Registry\Registry;
 
@@ -93,7 +94,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testGetInstanceSqlazure()
 	{
-		JFactory::$database->name = 'sqlazure';
+		JFactory::$database = $this->getMockDatabase('Sqlazure');
 
 		$this->assertInstanceOf(
 			'FinderIndexerDriverSqlsrv',
@@ -111,7 +112,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 */
 	public function testGetInstanceException()
 	{
-		JFactory::$database->name = 'nosql';
+		JFactory::$database = $this->getMockDatabase('Nosql');
 
 		FinderIndexer::getInstance();
 	}


### PR DESCRIPTION
### Summary of Changes

There are many places using the database name to determine if an action can be taken.  Since 3.5 there is a `getServerType()` method that can be used to do the same.  Use it.

### Testing Instructions

Methods taking different actions based on the database engine should still work and produce the same result.

### Documentation Changes Required

N/A