### PR TITLE
Move PHP 7 checks for MySQL adapter

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -209,12 +209,6 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 				continue;
 			}
 
-			// Block the ext/mysql driver for PHP 7
-			if ($fileName === 'mysql.php' && PHP_MAJOR_VERSION >= 7)
-			{
-				continue;
-			}
-
 			// Derive the class name from the type.
 			$class = str_ireplace('.php', '', 'JDatabaseDriver' . ucfirst(trim($fileName)));
 

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -169,7 +169,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 	 */
 	public static function isSupported()
 	{
-		return function_exists('mysql_connect');
+		return PHP_MAJOR_VERSION < 7 && function_exists('mysql_connect');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Include PHP 7 version check in the MySQL adapter's `isSupported()` method and remove the hardcoded check for support in the base driver's `getConnectors()` method.

### Testing Instructions

Plain "MySQL" still correctly shows (or doesn't) as an option for a database driver.

### Documentation Changes Required

N/A

### Extra Notes

The constructor check is explicitly left in place since it throws an Exception with an explicit message about the lack of environment support versus allowing the class to be instantiated and get through to the normal place where support is checked which results in a generic message.