### PR TITLE
Multilanguage: When installing Joomla the showon should be replaced by js

### DIFF
--- a/installation/model/forms/defaultlanguage.xml
+++ b/installation/model/forms/defaultlanguage.xml
@@ -20,7 +20,6 @@
 			class="btn-group"
 			label="INSTL_DEFAULTLANGUAGE_INSTALL_LOCALISED_CONTENT"
 			filter="integer"
-			showon="activateMultilanguage:1"
 			default="1"
 		>
 			<option value="1">JYES</option>
@@ -33,7 +32,6 @@
 			class="btn-group"
 			label="INSTL_DEFAULTLANGUAGE_ACTIVATE_LANGUAGE_CODE_PLUGIN"
 			filter="integer"
-			showon="activateMultilanguage:1"
 			default="0"
 		>
 			<option value="1">JYES</option>

--- a/installation/view/defaultlanguage/tmpl/default.php
+++ b/installation/view/defaultlanguage/tmpl/default.php
@@ -63,7 +63,7 @@ JS
 		</div>
 	</div>
 	<div id="multilanguageOptions">
-		<div class="control-group" id="installLocalisedContent" style="display:auto;">
+		<div class="control-group" id="installLocalisedContent" style="display:none;">
 			<div class="control-label">
 				<?php echo $this->form->getLabel('installLocalisedContent'); ?>
 			</div>
@@ -74,7 +74,7 @@ JS
 				</p>
 			</div>
 		</div>
-		<div class="control-group" id="activatePluginLanguageCode" style="display:auto;">
+		<div class="control-group" id="activatePluginLanguageCode" style="display:none;">
 			<div class="control-label">
 				<?php echo $this->form->getLabel('activatePluginLanguageCode'); ?>
 			</div>
@@ -198,3 +198,14 @@ JS
 	<input type="hidden" name="task" value="setdefaultlanguage" />
 	<?php echo JHtml::_('form.token'); ?>
 </form>
+
+<script type="text/javascript">
+	jQuery('input[name="jform[activateMultilanguage]"]').each(function(index, el) {
+		jQuery(el).on('click', function() {
+			Install.toggle('installLocalisedContent', 'activateMultilanguage', 1);
+			Install.toggle('activatePluginLanguageCode', 'activateMultilanguage', 1);
+		});
+		Install.toggle('installLocalisedContent', 'activateMultilanguage', 1);
+		Install.toggle('activatePluginLanguageCode', 'activateMultilanguage', 1);
+	});
+</script>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13445

Issue: although the xml contains a showon, both multilang content and languagecode plugin fields are displayed.

### Summary of Changes
Using js instead of showon in Joomla installation

### Testing Instructions
Install Joomla as multilang.
Before patch, toggle will not work:
![multilang1](https://cloud.githubusercontent.com/assets/869724/21588520/c85a91aa-d0e7-11e6-9d04-39fd6a4523c8.gif)

Patch and install again Joomla
Now you will get
![multilang](https://cloud.githubusercontent.com/assets/869724/21588522/d8c1b0a0-d0e7-11e6-9141-813651b8fd6d.gif)


### Documentation Changes Required
None

@ggppdk @AlexRed @dgt41 @andrepereiradasilva 