### PR TITLE
Add a "contains" method to cache API

### DIFF
--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -135,7 +135,11 @@ class LoginModelLogin extends JModelLegacy
 		$cacheid = md5(serialize(array($clientId, $lang)));
 		$loginmodule = array();
 
-		if (!($clean = $cache->get($cacheid)))
+		if ($cache->contains($cacheid))
+		{
+			$clean = $cache->get($cacheid);
+		}
+		else
 		{
 			$db = JFactory::getDbo();
 

--- a/components/com_banners/models/banner.php
+++ b/components/com_banners/models/banner.php
@@ -147,9 +147,11 @@ class BannersModelBanner extends JModelLegacy
 
 			$id = $this->getState('banner.id');
 
-			$this->_item = $cache->get($id);
-
-			if ($this->_item === false)
+			if ($cache->contains($id))
+			{
+				$this->_item = $cache->get($id);
+			}
+			else
 			{
 				// Redirect to banner url
 				$db = $this->getDbo();

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -226,7 +226,11 @@ abstract class JHtmlFilter
 		$cacheId = 'filter_select_' . serialize(array($idxQuery->filter, $options, $groups, JFactory::getLanguage()->getTag()));
 
 		// Check the cached results.
-		if (!($branches = $cache->get($cacheId)))
+		if ($cache->contains($cacheId))
+		{
+			$branches = $cache->get($cacheId);
+		}
+		else
 		{
 			$db    = JFactory::getDbo();
 			$query = $db->getQuery(true);

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -466,7 +466,13 @@ final class JApplicationSite extends JApplicationCms
 			$tag = '';
 		}
 
-		if (!$templates = $cache->get('templates0' . $tag))
+		$cacheId = 'templates0' . $tag;
+
+		if ($cache->contains($cacheId))
+		{
+			$templates = $cache->get($cacheId);
+		}
+		else
 		{
 			// Load styles
 			$db = JFactory::getDbo();
@@ -498,7 +504,7 @@ final class JApplicationSite extends JApplicationCms
 				$templates[0] = $template_home;
 			}
 
-			$cache->store($templates, 'templates0' . $tag);
+			$cache->store($templates, $cacheId);
 		}
 
 		if (isset($templates[$id]))

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -173,6 +173,37 @@ class JCache
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group = null)
+	{
+		if (!$this->getCaching())
+		{
+			return false;
+		}
+
+		// Get the default group
+		$group = $group ?: $this->_options['defaultgroup'];
+
+		// Get the storage
+		$handler = $this->_getStorage();
+
+		if (!($handler instanceof Exception))
+		{
+			return $handler->contains($id, $group);
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string  $id     The cache data ID

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -177,6 +177,21 @@ class JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return false;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -18,6 +18,21 @@ defined('JPATH_PLATFORM') or die;
 class JCacheStorageApc extends JCacheStorage
 {
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return apc_exists($this->_getCacheId($id, $group));
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/apcu.php
+++ b/libraries/joomla/cache/storage/apcu.php
@@ -18,6 +18,21 @@ defined('JPATH_PLATFORM') or die;
 class JCacheStorageApcu extends JCacheStorage
 {
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return apcu_exists($this->_getCacheId($id, $group));
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/cachelite.php
+++ b/libraries/joomla/cache/storage/cachelite.php
@@ -84,6 +84,21 @@ class JCacheStorageCachelite extends JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return $this->get($id, $group) !== false;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -39,6 +39,21 @@ class JCacheStorageFile extends JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return $this->_checkExpire($id, $group);
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -119,6 +119,21 @@ class JCacheStorageMemcache extends JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return $this->get($id, $group) !== false;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -136,6 +136,23 @@ class JCacheStorageMemcached extends JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		static::$_db->get($this->_getCacheId($id, $group));
+
+		return static::$_db->getResultCode() !== Memcached::RES_NOTFOUND;
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/redis.php
+++ b/libraries/joomla/cache/storage/redis.php
@@ -158,6 +158,26 @@ class JCacheStorageRedis extends JCacheStorage
 	}
 
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		if (static::isConnected() == false)
+		{
+			return false;
+		}
+
+		return static::$_redis->exists($this->_getCacheId($id, $group));
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -18,6 +18,21 @@ defined('JPATH_PLATFORM') or die;
 class JCacheStorageWincache extends JCacheStorage
 {
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return wincache_ucache_exists($this->_getCacheId($id, $group));
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -18,6 +18,21 @@ defined('JPATH_PLATFORM') or die;
 class JCacheStorageXcache extends JCacheStorage
 {
 	/**
+	 * Check if the cache contains data stored by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function contains($id, $group)
+	{
+		return xcache_isset($this->_getCacheId($id, $group));
+	}
+
+	/**
 	 * Get cached data by ID and group
 	 *
 	 * @param   string   $id         The cache data ID

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -131,7 +131,11 @@ class JLanguageHelper
 			{
 				$cache = JFactory::getCache('com_languages', '');
 
-				if (!$languages = $cache->get('languages'))
+				if ($cache->contains('languages'))
+				{
+					$languages = $cache->get('languages');
+				}
+				else
 				{
 					$db = JFactory::getDbo();
 					$query = $db->getQuery(true)
@@ -185,7 +189,11 @@ class JLanguageHelper
 		{
 			$cache = JFactory::getCache('com_languages', '');
 
-			if (!$installedLanguages = $cache->get('installedlanguages'))
+			if ($cache->contains('installedlanguages'))
+			{
+				$installedLanguages = $cache->get('installedlanguages');
+			}
+			else
 			{
 				$db = JFactory::getDbo();
 
@@ -332,7 +340,11 @@ class JLanguageHelper
 		{
 			$cache = JFactory::getCache('com_languages', '');
 
-			if (!$contentLanguages = $cache->get('contentlanguages'))
+			if ($cache->contains('contentlanguages'))
+			{
+				$contentLanguages = $cache->get('contentlanguages');
+			}
+			else
 			{
 				$db = JFactory::getDbo();
 

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -40,7 +40,11 @@ class ModMenuHelper
 		$key = 'menu_items' . $params . implode(',', $levels) . '.' . $base->id;
 		$cache = JFactory::getCache('mod_menu', '');
 
-		if (!($items = $cache->get($key)))
+		if ($cache->contains($key))
+		{
+			$items = $cache->get($key);
+		}
+		else
 		{
 			$path           = $base->tree;
 			$start          = (int) $params->get('startLevel');

--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -71,6 +71,17 @@ abstract class TestCaseCache extends TestCase
 	}
 
 	/**
+	 * @testdox  Data is correctly stored to the cache store and reported as existing
+	 */
+	public function testCacheContains()
+	{
+		$data = 'testData';
+
+		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
+		$this->assertTrue($this->handler->contains($this->id, $this->group), 'Failed validating data exists in the cache store');
+	}
+
+	/**
 	 * @testdox  Data is correctly stored to and retrieved from the cache storage handler
 	 */
 	public function testCacheHit()

--- a/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
+++ b/tests/unit/suites/libraries/joomla/cache/JCacheTest.php
@@ -346,7 +346,7 @@ class JCacheTest extends TestCase
 	}
 
 	/**
-	 * Testing store() and get()
+	 * Testing store(), contains(), and get()
 	 *
 	 * @param   string  $handler   cache handler
 	 * @param   array   $options   options for cache handler
@@ -359,13 +359,17 @@ class JCacheTest extends TestCase
 	 *
 	 * @dataProvider casesStore
 	 */
-	public function testStoreAndGet($handler, $options, $id, $group, $data, $expected)
+	public function testStoreContainsAndGet($handler, $options, $id, $group, $data, $expected)
 	{
 		$this->object = JCache::getInstance($handler, $options);
 		$this->object->setCaching(true);
 
 		$this->assertTrue(
 			$this->object->store($data, $id, $group)
+		);
+
+		$this->assertTrue(
+			$this->object->contains($id, $group)
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
Pull Request for Issue #12893

### Summary of Changes

Creates `JCache::contains()` and `JCacheStorage::contains()` as a means to look into the cache pool to determine if a cache item with a specified key exists.  Implements this method in many places where a `$cache->get() === false` type of check had been in use previously.

### Testing Instructions

With caching enabled, things should still work as expected.  Explicitly, you can store something to the cache then check for its existence with something like this:

```php
$id   = 'testCacheContainsItem';
$data = 'testData';

/** @var JCacheControllerCallback $cache */
$cache = JFactory::getCache('_testing');

if ($cache->store($data, $id) === false)
{
	throw new Exception('Initial Store Failed');
}

var_dump($cache->contains($id));
```

### Documentation Changes Required

None, but it should probably be noted there may be a small (if it's even noticeable) performance hit with this.

Right now, most places just do a single `$cache->get()` call and if the result exists then it is used otherwise it does the operation that generates the cache data and stores it.  With this, two calls to the cache store will be made.  However, except for Memcache (no trailing d) and Cache_Lite, all of the stores have a way to check if a key exists in the store which is more performant.  The `get()` methods will all read the data out of the store and do any processing required to make it usable to the PHP API (for example our filesystem handler does a string replacement to remove the PHP opening tag so the file's contents can be unserialized) while the `contains()` method simply checks the catalog to determine presence, a more efficient lookup operation.