### PR TITLE
Proper escaping for various JS strings

### DIFF
--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -20,9 +20,10 @@ $field = $input->getCmd('field');
 $function = 'jSelectContenthistory_' . $field;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn = $this->escape($this->state->get('list.direction'));
-$message = addslashes(JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_ONE'));
-$compareMessage = addslashes(JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_TWO'));
-$deleteMessage = addslashes(JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));
+$message = JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_ONE', true);
+$compareMessage = JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_TWO', true);
+JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+$deleteMessage = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 $aliasArray = explode('.', $this->state->type_alias);
 $option = (end($aliasArray) == 'category') ? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 1)) : $aliasArray[0];
 $filter = JFilterInput::getInstance();
@@ -96,9 +97,9 @@ JFactory::getDocument()->addScriptDeclaration("
 			<span class="icon-search"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span></button>
 		<button id="toolbar-compare" type="button" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1'); ?>">
 			<span class="icon-zoom-in"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span></button>
-		<button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
+		<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
 			<span class="icon-lock"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span></button>
-		<button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.delete')}" class="btn hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
+		<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
 			<span class="icon-delete"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span></button>
 	</div>
 

--- a/administrator/templates/hathor/html/com_contenthistory/history/modal.php
+++ b/administrator/templates/hathor/html/com_contenthistory/history/modal.php
@@ -20,9 +20,10 @@ $field = $input->getCmd('field');
 $function = 'jSelectContenthistory_' . $field;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn = $this->escape($this->state->get('list.direction'));
-$message = addslashes(JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_ONE'));
-$compareMessage = addslashes(JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_TWO'));
-$deleteMessage = addslashes(JText::_('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));
+$message = JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_ONE', true);
+$compareMessage = JText::_('COM_CONTENTHISTORY_BUTTON_SELECT_TWO', true);
+JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+$deleteMessage = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 $aliasArray = explode('.', $this->state->type_alias);
 $option = (end($aliasArray) == 'category') ? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 1)) : $aliasArray[0];
 $filter = JFilterInput::getInstance();
@@ -100,9 +101,9 @@ JFactory::getDocument()->addScriptDeclaration("
 			<span class="icon-search"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span></button>
 		<button id="toolbar-compare" type="button" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo JRoute::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . JSession::getFormToken() . '=1');?>">
 			<span class="icon-zoom-in"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span></button>
-		<button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.keep')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
+		<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
 			<span class="icon-lock"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span></button>
-		<button onclick="if (document.adminForm.boxchecked.value==0){alert('<?php echo $deleteMessage; ?>');}else{ Joomla.submitbutton('history.delete')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
+		<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn pointer hasTooltip" title="<?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
 			<span class="icon-delete"></span><span class="hidden-phone"><?php echo JText::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span></button>
 	</div>
 

--- a/components/com_mailto/views/mailto/tmpl/default.php
+++ b/components/com_mailto/views/mailto/tmpl/default.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration("
 		// do field validation
 		if (form.mailto.value == '' || form.from.value == '')
 		{
-			alert('" . JText::_('COM_MAILTO_EMAIL_ERR_NOINFO') . "');
+			alert('" . JText::_('COM_MAILTO_EMAIL_ERR_NOINFO', true) . "');
 			return false;
 		}
 		form.submit();

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		// do field validation 
 		if (form.install_directory.value == "")
 		{
-			alert("' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH') . '");
+			alert("' . JText::_('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH', true) . '");
 		}
 		else
 		{

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -19,7 +19,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		// do field validation 
 		if (form.install_package.value == "")
 		{
-			alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE') . '");
+			alert("' . JText::_('PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE', true) . '");
 		}
 		else
 		{


### PR DESCRIPTION
This PR to complete https://github.com/joomla/joomla-cms/pull/13425 in various places where JS language strings are incorrect.
https://github.com/joomla/joomla-cms/pull/13425 deals only with toolbar buttons.

### Summary of Changes
Files modified:
/plugins/installer/folderinstaller/tmpl/default.php
/plugins/installer/packageinstaller/tmpl/default.php
/components/com_mailto/views/mailto/tmpl/default.php
/administrator/templates/hathor/html/com_contenthistory/history/modal.php
/administrator/components/com_contenthistory/views/history/tmpl/modal.php

I did not touch at fof
strapper, joomla.php
Let me know if this should be added.
### Testing Instructions
On a staging create 2 `en-GB.override.ini`

For back-end:
```ini
JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST="Please first make a "_QQ_"selection"_QQ_" \"from\" the list."
PLG_INSTALLER_PACKAGEINSTALLER_NO_PACKAGE="Checking if "_QQ_"QQ between double quotes"_QQ_" and escaped \"strings\" work. No Package."
PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH="Checking if "_QQ_"QQ between double quotes"_QQ_" and escaped \"strings\" work. No folder path."
COM_CONTENTHISTORY_BUTTON_SELECT_ONE="Checking if "_QQ_"QQ between double quotes"_QQ_" and escaped \"strings\" work. Preview and restore."
COM_CONTENTHISTORY_BUTTON_SELECT_TWO="Checking if "_QQ_"QQ between double quotes"_QQ_" and escaped \"strings\" work. Compare."
```
For frontend:
```ini
COM_MAILTO_EMAIL_ERR_NOINFO="Checking if "_QQ_"QQ between double quotes"_QQ_" and escaped \"strings\" work. Invalid mail."
```
Testing places:
**Extensions Manager->Install**
Make sure the field for the Upload Package File tab is empty and click `Upload & Install` button.
Then Make sure the field for the Install from Folder is empty and click `Check and Install` button

**Content History Modal**
In Hathor as well as in Isis, edit an article and Click on the `Versions` Toolbar button.
Do NOT select any item in the list and click on each button.

![screen shot 2017-01-03 at 09 46 06](https://cloud.githubusercontent.com/assets/869724/21602931/82974b06-d199-11e6-9e7c-e8444129551b.png)

**Frontend Mailto**
Display the `Email this link to friend` popup. Do not enter anything in the fields and Click on the `Send` button.

RESULT: for each of these operations, there will be a JS error and the alerts will not display.

PATCH and test again (after clearing all caches)

You should now get all these alerts correctly.
Example:

![screen shot 2017-01-03 at 09 20 14](https://cloud.githubusercontent.com/assets/869724/21603004/2f978230-d19a-11e6-84ff-1584f0a5bb7b.png)

### Documentation Changes Required
None. This is a bug.
None