### PR TITLE
[com_fields] Fix preselect of state, group, access and language for fields

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -724,14 +724,11 @@ class FieldsModelField extends JModelAdmin
 			{
 				// Check for which context the Category Manager is used and
 				// get selected fields
-				$context   = substr($app->getUserState('com_fields.fields.filter.context'), 4);
-				$component = FieldsHelper::extract($context);
-				$component = $component ? $component[0] : null;
+				$filters = (array) $app->getUserState('com_fields.fields.filter');
 
-				$filters = (array) $app->getUserState('com_fields.fields.' . $component . '.filter');
-
-				$data->set('published', $app->input->getInt('published', (!empty($filters['published']) ? $filters['published'] : null)));
+				$data->set('state', $app->input->getInt('state', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+				$data->set('group_id', $app->input->getString('group_id', (!empty($filters['group_id']) ? $filters['group_id'] : null)));
 				$data->set(
 					'access',
 					$app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access')))


### PR DESCRIPTION
Pull Request for Issue #13429.

### Summary of Changes
Fixes preselecting values for state, group, language and access for fields based on filters.

### Testing Instructions
Filter the fields list by state, group, language and/or access and then create a new field. The filtered values should be taken as default for the new field.

### Documentation Changes Required
None