### PR TITLE
Remove deprecated code JLanguage::parseXMLLanguageFile

### DIFF
--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -304,7 +304,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 		if ((int) $clientId === 0)
 		{
 			// Load the site language manifest.
-			$siteLanguageManifest = JLanguage::parseXMLLanguageFile(JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml');
+			$siteLanguageManifest = JLanguageHelper::parseXMLLanguageFile(JPATH_SITE . '/language/' . $this->tag . '/' . $this->tag . '.xml');
 
 			// Set the content language title as the language metadata name.
 			$contentLanguageTitle = $siteLanguageManifest['name'];


### PR DESCRIPTION
### Summary of Changes

Replace the only deprecated `JLanguage::parseXMLLanguageFile` left in the code base after https://github.com/joomla/joomla-cms/pull/12953 for `JLanguageHelper::parseXMLLanguageFile`

### Testing Instructions

Code review.

### Documentation Changes Required

None.