### PR TITLE
Fix fatel error in normal registration process.

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -304,7 +304,7 @@ class UsersModelRegistration extends JModelForm
 		{
 			return false;
 		}
-		
+
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -300,15 +300,15 @@ class UsersModelRegistration extends JModelForm
 		// Get the form.
 		$form = $this->loadForm('com_users.registration', 'registration', array('control' => 'jform', 'load_data' => $loadData));
 
+		if (empty($form))
+		{
+			return false;
+		}
+		
 		// When multilanguage is set, a user's default site language should also be a Content Language
 		if (JLanguageMultilang::isEnabled())
 		{
 			$form->setFieldAttribute('language', 'type', 'frontend_language', 'params');
-		}
-
-		if (empty($form))
-		{
-			return false;
 		}
 
 		return $form;


### PR DESCRIPTION
Pull Request for Issue.

**Summary of Changes**

**Fatal error:** Call to a member function setFieldAttribute() on boolean in /.../public_html/components/com_users/models/registration.ph‌​p on line 307

**Testing Instructions**

**Fatal error:** Call to a member function setFieldAttribute() on boolean in /.../public_html/components/com_users/models/registration.ph‌​p on line 307

To check this issue 
1.Set multi language site.
2. Try to register through normal registration module (with joomla registration is working fine)
    ie. Easyprofile etc.

Documentation Changes Required
No