### PR TITLE
Remove invalid ordering options from language installer

### DIFF
--- a/administrator/components/com_installer/models/forms/filter_languages.xml
+++ b/administrator/components/com_installer/models/forms/filter_languages.xml
@@ -23,8 +23,6 @@
 			<option value="name DESC">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="element ASC">COM_INSTALLER_HEADING_LANGUAGE_TAG_ASC</option>
 			<option value="element DESC">COM_INSTALLER_HEADING_LANGUAGE_TAG_DESC</option>
-			<option value="update_id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="update_id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>
 		<field
 			name="limit"


### PR DESCRIPTION
PR https://github.com/joomla/joomla-cms/pull/13256 changed the way the language installer works.
I forgot to remove the ordering option for ID which is now invalid.

### Summary of Changes
Removes the options from the dropdown

### Testing Instructions
* Go to Extension -> Manage -> Install Languages
* After applying this PR, the options to order by ID are no longer present.

### Documentation Changes Required
None