### PR TITLE
update template.css so that there is no gradient

### DIFF
--- a/installation/template/css/template.css
+++ b/installation/template/css/template.css
@@ -22,14 +22,7 @@
 
 .header {
 	background-color: #ffffff;
-	background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#d9effa), color-stop(25%, #d9effa), to(#ffffff));
-	background-image: -webkit-linear-gradient(#d9effa, #d9effa 25%, #ffffff);
-	background-image: -moz-linear-gradient(top, #d9effa, #d9effa 25%, #ffffff);
-	background-image: -ms-linear-gradient(#d9effa, #d9effa 25%, #ffffff);
-	background-image: -o-linear-gradient(#d9effa, #d9effa 25%, #ffffff);
-	background-image: linear-gradient(#d9effa, #d9effa 25%, #ffffff);
 	background-repeat: no-repeat;
-	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#d9effa', endColorstr='#ffffff', GradientType=0);
 	border-top: 3px solid #0088cc;
 	padding: 20px 0;
 	text-align: center;


### PR DESCRIPTION
There is a gradient on template.css which causes there to be a gradient behind the Joomla! logo.  This is against the Joomla! brand guidelines found here https://www.joomla.org/images/logos/Joomla_Brand_Manual_10-02-2005.pdf

Subjectively I don't think it looks good either, but objectively, there are clear guidelines set out.

Pull Request for Issue # .

### Summary of Changes
Removed header gradient

### Testing Instructions
Install Joomla! using this link https://github.com/uglyeoin/joomla-cms/archive/patch-3.zip and see if there is a gradient in the header as you go through the installation.

### Documentation Changes Required
None