### PR TITLE
TinyMCE: Correcting wrong tip

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -94,6 +94,7 @@ PLG_TINY_FIELD_SAVEWARNING_DESC="Save Warning: gives warning if you cancel witho
 PLG_TINY_FIELD_SAVEWARNING_LABEL="Save Warning"
 PLG_TINY_FIELD_SEARCH-REPLACE_DESC="Show or hide the Search &amp; Replace button."
 PLG_TINY_FIELD_SEARCH-REPLACE_LABEL="Search &amp; Replace"
+PLG_TINY_FIELD_SETACCESS_DESC="Restrict users that will use this set to those in the selected user groups.<br>If a user belongs to multiple groups, the set used will be the one which belongs to a group higher in the hierarchy.<br>Example: if a set is assigned to Author and a another set to Publishers, if the user belongs to both groups, the set assigned to Publishers will be used."
 PLG_TINY_FIELD_SETACCESS_LABEL="Assign this Set to"
 PLG_TINY_FIELD_SKIN_ADMIN_DESC="Select skin for the Administrator Backend interface."
 PLG_TINY_FIELD_SKIN_ADMIN_LABEL="Administrator Skin"

--- a/plugins/editors/tinymce/form/setoptions.xml
+++ b/plugins/editors/tinymce/form/setoptions.xml
@@ -6,7 +6,7 @@
             multiple="true"
             class="access-select"
             label="PLG_TINY_FIELD_SETACCESS_LABEL"
-            description="JFIELD_ACCESS_DESC"
+            description="PLG_TINY_FIELD_SETACCESS_DESC"
             labelclass="label label-success"
     />
 


### PR DESCRIPTION
New issue.

As the new TinyMCE Sets are no more assigned depending on Access Levels but on User Groups, the tip was wrong.
To test, edit the Tiny Editor plugin

Before patch:

![screen shot 2017-01-06 at 09 44 19](https://cloud.githubusercontent.com/assets/869724/21712683/62b125a0-d3f6-11e6-8936-9a00f3dcc232.png)
After patch:

![screen shot 2017-01-06 at 09 48 28](https://cloud.githubusercontent.com/assets/869724/21712697/75ce69ea-d3f6-11e6-8332-41f4fd004254.png)

@Fedik @ggppdk @AlexRed 


Note: if someone has a better text to submit, I am open to proposals.