### PR TITLE
Add Clearfix to Smart Search filters

### DIFF
--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -365,7 +365,7 @@ abstract class JHtmlFilter
 			$html .= JHtml::_('filter.dates', $idxQuery, $options);
 		}
 
-		$html .= '<div class="filter-branch' . $classSuffix . ' control-group">';
+		$html .= '<div class="filter-branch' . $classSuffix . ' control-group clearfix">';
 
 		// Iterate through all branches and build code.
 		foreach ($branches as $bk => $bv)


### PR DESCRIPTION
Pull Request for Issue #13486.

### Summary of Changes
Adding the class "clearfix" to the Smart Search filters

### Testing Instructions
* Make sure Smart Search is properly set up (plugin active and some content indexed).
* Create a menu item for Smart Search and try the "Advanced Search" button without doing any search yet
* Notice the position of the breadcrumbs module below.

See screenshots in original issue.

### Documentation Changes Required
None.