### PR TITLE
Make columns centered, where it makes sense (in one file only for now, to get a discussion going)

### DIFF
--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -17,14 +17,14 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div id="installer-update" class="clearfix">
-    <form action="<?php echo JRoute::_('index.php?option=com_installer&view=update'); ?>" method="post" name="adminForm" id="adminForm">
+	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=update'); ?>" method="post" name="adminForm" id="adminForm">
 		<?php if (!empty( $this->sidebar)) : ?>
-        <div id="j-sidebar-container" class="span2">
+		<div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
-        </div>
-        <div id="j-main-container" class="span10">
+		</div>
+		<div id="j-main-container" class="span10">
 			<?php else : ?>
-            <div id="j-main-container">
+			<div id="j-main-container">
 				<?php endif; ?>
 				<?php if ($this->showMessage) : ?>
 					<?php echo $this->loadTemplate('message'); ?>
@@ -35,104 +35,104 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php endif; ?>
 
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-                <div class="clearfix"></div>
+				<div class="clearfix"></div>
 				<?php if (empty($this->items)) : ?>
-                    <div class="alert alert-no-items alert-info">
+					<div class="alert alert-no-items alert-info">
 						<?php echo JText::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'); ?>
-                    </div>
+					</div>
 				<?php else : ?>
-                    <table class="table table-striped">
-                        <thead>
-                        <tr>
-                            <th width="1%" class="nowrap">
+					<table class="table table-striped">
+						<thead>
+						<tr>
+							<th width="1%" class="nowrap">
 								<?php echo JHtml::_('grid.checkall'); ?>
-                            </th>
-                            <th class="nowrap">
+							</th>
+							<th class="nowrap">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_NAME', 'u.name', $listDirn, $listOrder); ?>
-                            </th>
-                            <th class="nowrap center">
+							</th>
+							<th class="nowrap center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_LOCATION', 'client_translated', $listDirn, $listOrder); ?>
-                            </th>
-                            <th class="nowrap center">
+							</th>
+							<th class="nowrap center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_TYPE', 'type_translated', $listDirn, $listOrder); ?>
-                            </th>
-                            <th class="nowrap hidden-phone center">
+							</th>
+							<th class="nowrap hidden-phone center">
 								<?php echo JText::_('COM_INSTALLER_CURRENT_VERSION'); ?>
-                            </th>
-                            <th class="nowrap center">
+							</th>
+							<th class="nowrap center">
 								<?php echo JText::_('COM_INSTALLER_NEW_VERSION'); ?>
-                            </th>
-                            <th class="nowrap hidden-phone center">
+							</th>
+							<th class="nowrap hidden-phone center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_FOLDER', 'folder_translated', $listDirn, $listOrder); ?>
-                            </th>
-                            <th class="nowrap hidden-phone center">
+							</th>
+							<th class="nowrap hidden-phone center">
 								<?php echo JText::_('COM_INSTALLER_HEADING_INSTALLTYPE'); ?>
-                            </th>
-                            <th width="40%" class="nowrap hidden-phone hidden-tablet">
+							</th>
+							<th width="40%" class="nowrap hidden-phone hidden-tablet">
 								<?php echo JText::_('COM_INSTALLER_HEADING_DETAILSURL'); ?>
-                            </th>
-                        </tr>
-                        </thead>
-                        <tfoot>
-                        <tr>
-                            <td colspan="9">
+							</th>
+						</tr>
+						</thead>
+						<tfoot>
+						<tr>
+							<td colspan="9">
 								<?php echo $this->pagination->getListFooter(); ?>
-                            </td>
-                        </tr>
-                        </tfoot>
-                        <tbody>
+							</td>
+						</tr>
+						</tfoot>
+						<tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<?php
 							$client          = $item->client_id ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
 							$manifest        = json_decode($item->manifest_cache);
 							$current_version = isset($manifest->version) ? $manifest->version : JText::_('JLIB_UNKNOWN');
 							?>
-                            <tr class="row<?php echo $i % 2; ?>">
-                                <td>
+							<tr class="row<?php echo $i % 2; ?>">
+								<td>
 									<?php echo JHtml::_('grid.id', $i, $item->update_id); ?>
-                                </td>
-                                <td>
-                                    <label for="cb<?php echo $i; ?>">
+								</td>
+								<td>
+									<label for="cb<?php echo $i; ?>">
 								<span class="editlinktip hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('JGLOBAL_DESCRIPTION'), $item->description ? $item->description : JText::_('COM_INSTALLER_MSG_UPDATE_NODESC'), 0); ?>">
 								<?php echo $this->escape($item->name); ?>
 								</span>
-                                    </label>
-                                </td>
-                                <td class="center">
+									</label>
+								</td>
+								<td class="center">
 									<?php echo $item->client_translated; ?>
-                                </td>
-                                <td class="center">
+								</td>
+								<td class="center">
 									<?php echo $item->type_translated; ?>
-                                </td>
-                                <td class="hidden-phone center">
-                                    <span class="label label-warning"><?php echo $item->current_version; ?></span>
-                                </td>
-                                <td class="center">
-                                    <span class="label label-success"><?php echo $item->version; ?></span>
-                                </td>
-                                <td class="hidden-phone center">
+								</td>
+								<td class="hidden-phone center">
+									<span class="label label-warning"><?php echo $item->current_version; ?></span>
+								</td>
+								<td class="center">
+									<span class="label label-success"><?php echo $item->version; ?></span>
+								</td>
+								<td class="hidden-phone center">
 									<?php echo $item->folder_translated; ?>
-                                </td>
-                                <td class="hidden-phone center">
+								</td>
+								<td class="hidden-phone center">
 									<?php echo $item->install_type; ?>
-                                </td>
-                                <td class="hidden-phone hidden-tablet">
+								</td>
+								<td class="hidden-phone hidden-tablet">
 							<span class="break-word">
 							<?php echo $item->detailsurl; ?>
 								<?php if (isset($item->infourl)) : ?>
-                                    <br />
-                                    <a href="<?php echo $item->infourl; ?>" target="_blank"><?php echo $this->escape($item->infourl); ?></a>
+									<br />
+									<a href="<?php echo $item->infourl; ?>" target="_blank"><?php echo $this->escape($item->infourl); ?></a>
 								<?php endif; ?>
 							</span>
-                                </td>
-                            </tr>
+								</td>
+							</tr>
 						<?php endforeach; ?>
-                        </tbody>
-                    </table>
+						</tbody>
+					</table>
 				<?php endif; ?>
-                <input type="hidden" name="task" value="" />
-                <input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="" />
+				<input type="hidden" name="boxchecked" value="0" />
 				<?php echo JHtml::_('form.token'); ?>
-            </div>
-    </form>
+			</div>
+	</form>
 </div>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -17,14 +17,14 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
 <div id="installer-update" class="clearfix">
-	<form action="<?php echo JRoute::_('index.php?option=com_installer&view=update'); ?>" method="post" name="adminForm" id="adminForm">
+    <form action="<?php echo JRoute::_('index.php?option=com_installer&view=update'); ?>" method="post" name="adminForm" id="adminForm">
 		<?php if (!empty( $this->sidebar)) : ?>
-		<div id="j-sidebar-container" class="span2">
+        <div id="j-sidebar-container" class="span2">
 			<?php echo $this->sidebar; ?>
-		</div>
-		<div id="j-main-container" class="span10">
+        </div>
+        <div id="j-main-container" class="span10">
 			<?php else : ?>
-			<div id="j-main-container">
+            <div id="j-main-container">
 				<?php endif; ?>
 				<?php if ($this->showMessage) : ?>
 					<?php echo $this->loadTemplate('message'); ?>
@@ -35,104 +35,104 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<?php endif; ?>
 
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-				<div class="clearfix"></div>
+                <div class="clearfix"></div>
 				<?php if (empty($this->items)) : ?>
-					<div class="alert alert-no-items alert-info">
+                    <div class="alert alert-no-items alert-info">
 						<?php echo JText::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'); ?>
-					</div>
+                    </div>
 				<?php else : ?>
-					<table class="table table-striped">
-						<thead>
-						<tr>
-							<th width="1%" class="nowrap">
+                    <table class="table table-striped">
+                        <thead>
+                        <tr>
+                            <th width="1%" class="nowrap">
 								<?php echo JHtml::_('grid.checkall'); ?>
-							</th>
-							<th class="nowrap">
+                            </th>
+                            <th class="nowrap">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_NAME', 'u.name', $listDirn, $listOrder); ?>
-							</th>
-							<th class="nowrap">
+                            </th>
+                            <th class="nowrap center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_LOCATION', 'client_translated', $listDirn, $listOrder); ?>
-							</th>
-							<th class="nowrap">
+                            </th>
+                            <th class="nowrap center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_TYPE', 'type_translated', $listDirn, $listOrder); ?>
-							</th>
-							<th class="nowrap hidden-phone">
+                            </th>
+                            <th class="nowrap hidden-phone center">
 								<?php echo JText::_('COM_INSTALLER_CURRENT_VERSION'); ?>
-							</th>
-							<th class="nowrap">
+                            </th>
+                            <th class="nowrap center">
 								<?php echo JText::_('COM_INSTALLER_NEW_VERSION'); ?>
-							</th>
-							<th class="nowrap hidden-phone">
+                            </th>
+                            <th class="nowrap hidden-phone center">
 								<?php echo JHtml::_('searchtools.sort', 'COM_INSTALLER_HEADING_FOLDER', 'folder_translated', $listDirn, $listOrder); ?>
-							</th>
-							<th class="nowrap hidden-phone">
+                            </th>
+                            <th class="nowrap hidden-phone center">
 								<?php echo JText::_('COM_INSTALLER_HEADING_INSTALLTYPE'); ?>
-							</th>
-							<th width="40%" class="nowrap hidden-phone hidden-tablet">
+                            </th>
+                            <th width="40%" class="nowrap hidden-phone hidden-tablet">
 								<?php echo JText::_('COM_INSTALLER_HEADING_DETAILSURL'); ?>
-							</th>
-						</tr>
-						</thead>
-						<tfoot>
-						<tr>
-							<td colspan="9">
+                            </th>
+                        </tr>
+                        </thead>
+                        <tfoot>
+                        <tr>
+                            <td colspan="9">
 								<?php echo $this->pagination->getListFooter(); ?>
-							</td>
-						</tr>
-						</tfoot>
-						<tbody>
+                            </td>
+                        </tr>
+                        </tfoot>
+                        <tbody>
 						<?php foreach ($this->items as $i => $item) : ?>
 							<?php
 							$client          = $item->client_id ? JText::_('JADMINISTRATOR') : JText::_('JSITE');
 							$manifest        = json_decode($item->manifest_cache);
 							$current_version = isset($manifest->version) ? $manifest->version : JText::_('JLIB_UNKNOWN');
 							?>
-							<tr class="row<?php echo $i % 2; ?>">
-								<td>
+                            <tr class="row<?php echo $i % 2; ?>">
+                                <td>
 									<?php echo JHtml::_('grid.id', $i, $item->update_id); ?>
-								</td>
-								<td>
-									<label for="cb<?php echo $i; ?>">
+                                </td>
+                                <td>
+                                    <label for="cb<?php echo $i; ?>">
 								<span class="editlinktip hasTooltip" title="<?php echo JHtml::tooltipText(JText::_('JGLOBAL_DESCRIPTION'), $item->description ? $item->description : JText::_('COM_INSTALLER_MSG_UPDATE_NODESC'), 0); ?>">
 								<?php echo $this->escape($item->name); ?>
 								</span>
-									</label>
-								</td>
-								<td>
+                                    </label>
+                                </td>
+                                <td class="center">
 									<?php echo $item->client_translated; ?>
-								</td>
-								<td>
+                                </td>
+                                <td class="center">
 									<?php echo $item->type_translated; ?>
-								</td>
-								<td class="hidden-phone">
-									<span class="label label-warning"><?php echo $item->current_version; ?></span>
-								</td>
-								<td>
-									<span class="label label-success"><?php echo $item->version; ?></span>
-								</td>
-								<td class="hidden-phone">
+                                </td>
+                                <td class="hidden-phone center">
+                                    <span class="label label-warning"><?php echo $item->current_version; ?></span>
+                                </td>
+                                <td class="center">
+                                    <span class="label label-success"><?php echo $item->version; ?></span>
+                                </td>
+                                <td class="hidden-phone center">
 									<?php echo $item->folder_translated; ?>
-								</td>
-								<td class="hidden-phone">
+                                </td>
+                                <td class="hidden-phone center">
 									<?php echo $item->install_type; ?>
-								</td>
-								<td class="hidden-phone hidden-tablet">
+                                </td>
+                                <td class="hidden-phone hidden-tablet">
 							<span class="break-word">
 							<?php echo $item->detailsurl; ?>
 								<?php if (isset($item->infourl)) : ?>
-									<br />
-									<a href="<?php echo $item->infourl; ?>" target="_blank"><?php echo $this->escape($item->infourl); ?></a>
+                                    <br />
+                                    <a href="<?php echo $item->infourl; ?>" target="_blank"><?php echo $this->escape($item->infourl); ?></a>
 								<?php endif; ?>
 							</span>
-								</td>
-							</tr>
+                                </td>
+                            </tr>
 						<?php endforeach; ?>
-						</tbody>
-					</table>
+                        </tbody>
+                    </table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+                <input type="hidden" name="task" value="" />
+                <input type="hidden" name="boxchecked" value="0" />
 				<?php echo JHtml::_('form.token'); ?>
-			</div>
-	</form>
+            </div>
+    </form>
 </div>


### PR DESCRIPTION
### Summary of Changes

- Make columns centered, where it makes sense and looks nicer than left-aligned ones. For example version columns, single or maximum two-word columns

- Also fixed CS on that file

### Testing Instructions
1) Go to Extensions -> Update. Make sure there is a list of updates to view.
2) Leave this tab as it is, for comparison. Open a new tab, apply the patch and revisit the update screen.
3) Compare and comment / review.

Code review: Due to CS fixes, the changes in this files are best viewed with a setting to ignore whitespaces and empty lines (Apply `w=1` argument to files view if viewing on github).

### Documentation Changes Required
Maybe to set some standards for formatting of columns.

### Example:

#### Before:

![screenshot-joomla-patch-tester-1 2017-01-07 19-51-21](https://cloud.githubusercontent.com/assets/825497/21743809/b4e0f400-d512-11e6-909d-3d4fe24752cb.png)


#### After:

![screenshot-joomla-patch-tester-1 2017-01-06 11-42-32](https://cloud.githubusercontent.com/assets/825497/21743788/43614a8c-d512-11e6-8529-f87a6ae761be.png)



