### PR TITLE
First test if variable exists before making a comparison

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -478,7 +478,7 @@ class JMail extends PHPMailer
 				}
 
 				// Check for boolean false return if exception handling is disabled
-				if ($result === false)
+				if (!isset($result) || $result === false)
 				{
 					return false;
 				}


### PR DESCRIPTION
PHP Notice: Undefined variable: result in /var/www/html/joomla/libraries/joomla/mail/mail.php on line 479

Pull Request for Issue #13494.

### Summary of Changes

Just test if variable exists before doing a comparison

### Testing Instructions

Try to attach a non-existent file to a mail.

### Documentation Changes Required
