### PR TITLE
[com_search] Refactoring + fixing results-highlighting

### DIFF
--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -238,12 +238,14 @@ class SearchViewSearch extends JViewLegacy
 							if ($mbString)
 							{
 								$highlightWordLen = mb_strlen($highlightWord);
-								$row              = mb_substr($row, 0, $pos) . $hl1 . mb_substr($row, $pos, $highlightWordLen) . $hl2 . mb_substr($row, $pos + $highlightWordLen);
+								$row              = mb_substr($row, 0, $pos) . $hl1 . mb_substr($row, $pos, $highlightWordLen)
+									. $hl2 . mb_substr($row, $pos + $highlightWordLen);
 							}
 							else
 							{
 								$highlightWordLen = StringHelper::strlen($highlightWord);
-								$row              = StringHelper::substr($row, 0, $pos) . $hl1 . StringHelper::substr($row, $pos, StringHelper::strlen($highlightWord))
+								$row              = StringHelper::substr($row, 0, $pos)
+									. $hl1 . StringHelper::substr($row, $pos, StringHelper::strlen($highlightWord))
 									. $hl2 . StringHelper::substr($row, $pos + StringHelper::strlen($highlightWord));
 							}
 

--- a/media/com_finder/css/finder.css
+++ b/media/com_finder/css/finder.css
@@ -46,7 +46,7 @@
 span.highlight {
 	background-color:#FFFFCC;
 	font-weight:bold;
-	padding:1px 4px;
+	padding:1px 0;
 }
 
 ul.autocompleter-choices {

--- a/media/plg_system_highlight/highlight.css
+++ b/media/plg_system_highlight/highlight.css
@@ -1,5 +1,5 @@
 span.highlight {
 	background-color:#FFFFCC;
 	font-weight:bold;
-	padding:1px 4px;
+	padding:1px 0;
 }

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7642,7 +7642,7 @@ code {
 .search span.highlight {
 	background-color: #FFFFCC;
 	font-weight: bold;
-	padding: 1px 4px;
+	padding: 1px 0;
 }
 dt.result-title {
 	word-wrap: break-word;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -632,7 +632,7 @@ code {
 .search span.highlight {
 	background-color:#FFFFCC;
 	font-weight:bold;
-	padding:1px 4px;
+	padding:1px 0;
 }
 
 /* Com_search break long titles & text */

--- a/templates/system/css/system.css
+++ b/templates/system/css/system.css
@@ -16,7 +16,7 @@
 span.highlight {
 	background-color:#FFFFCC;
 	font-weight:bold;
-	padding:1px 4px;
+	padding:1px 0;
 }
 
 .img-fulltext-float-right {


### PR DESCRIPTION
New issue: 
Positioning of highlighting was off sometimes when special characters were used.
Also the css padding for highlighting feels 'unnatural'.

Please look below for example images showing the before and after the patch.

### Summary of Changes
- [com_search] Refactoring + fixing results-highlighting 
- Fixed css sitewide to display highlight more naturally.

### Testing Instructions
1) Do not apply patch. Do some searches using words with ascii and non-ascii. 
2) Apply patch. Check that the correct words are highlighted.

### Documentation Changes Required
None 

Note: It would probably be better to make the functionality of highlighting reusable in it's own class. It then could also be reused from other parts of Joomla itself or extensions. It would also allow us to extend its functionality.
I would do that, in another PR, if this one gets merged.

#### Examples:

Notice the wrong positioning of the highlighting in the text at some places and the unnatural padding on the highlight. Both issues are fixed in the image after this one, where the patch is applied.

__The word to search for, in these examples, was: Österreich__

__(image showing the issues)__

![screenshot-joomla-patch-tester-1 2017-01-07 03-59-27](https://cloud.githubusercontent.com/assets/825497/21739453/fcad6c10-d4a3-11e6-9814-c73c151033a5.png)

__(image showing issues fixed)__

![screenshot-joomla-patch-tester-1 2017-01-07 04-46-57](https://cloud.githubusercontent.com/assets/825497/21739462/2f7b068e-d4a4-11e6-867f-63245cca8653.png)
