### PR TITLE
Use the new showon operator in "Multi Column Order" field

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -726,7 +726,9 @@
 			type="list"
 			default="0"
 			label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-			description="JGLOBAL_MULTI_COLUMN_ORDER_DESC">
+			description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
+			showon="num_columns!:,0,1"
+			>
 			<option
 				value="0">JGLOBAL_DOWN</option>
 			<option


### PR DESCRIPTION
Pull Request for simple Improvement.

### Summary of Changes

PR for using the `!:` new showon operator on "Multi Column Order" field.

![column-showon](https://cloud.githubusercontent.com/assets/9630530/21749851/a531fe4a-d59f-11e6-8c8f-3513b824c04e.gif)


### Testing Instructions

Very simple test:
- Apply patch
- Go to com_content options, "Blog/Featured Layouts" tab
- Confirm the "Multi Column Order" field only appear when you put something other than `empty`, `0` or `1` in the "# Columns" text field.

### Documentation Changes Required

None.