### PR TITLE
Admin app - catch exceptions thrown by JLog::add()

### DIFF
--- a/administrator/components/com_admin/helpers/html/phpsetting.php
+++ b/administrator/components/com_admin/helpers/html/phpsetting.php
@@ -63,11 +63,14 @@ abstract class JHtmlPhpSetting
 	 */
 	public static function integer($val)
 	{
-		JLog::add(
-			'JHtmlPhpSetting::integer() is deprecated. Use intval() or casting instead.',
-			JLog::WARNING,
-			'deprecated'
-		);
+		try
+		{
+			JLog::add(sprintf('%s() is deprecated. Use intval() or casting instead.', __METHOD__), JLog::WARNING, 'deprecated');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return (int) $val;
 	}

--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -445,7 +445,17 @@ class AdminModelSysInfo extends JModelLegacy
 		}
 		catch (Exception $e)
 		{
-			JLog::add(JText::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()), JLog::WARNING, 'jerror');
+			try
+			{
+				JLog::add(JText::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()), JLog::WARNING, 'jerror');
+			}
+			catch (RuntimeException $exception)
+			{
+				JFactory::getApplication()->enqueueMessage(
+					JText::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()),
+					'warning'
+				);
+			}
 
 			return $installed;
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -29,7 +29,15 @@ class JoomlaInstallerScript
 		$options['text_file'] = 'joomla_update.php';
 
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_DELETE_FILES'), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_DELETE_FILES'), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// This needs to stay for 2.5 update compatibility
 		$this->deleteUnexistingFiles();

--- a/administrator/components/com_categories/controllers/categories.php
+++ b/administrator/components/com_categories/controllers/categories.php
@@ -78,7 +78,14 @@ class CategoriesControllerCategories extends JControllerAdmin
 	{
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		JLog::add('CategoriesControllerCategories::saveorder() is deprecated. Function will be removed in 4.0', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(sprintf('%s() is deprecated. Function will be removed in 4.0.', __METHOD__), JLog::WARNING, 'deprecated');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get the arrays from the Request
 		$order = $this->input->post->get('order', null, 'array');

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -83,7 +83,18 @@ class CategoriesHelper
 	public static function getActions($extension, $categoryId = 0)
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated, use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
 		return JHelperContent::getActions($extension, 'category', $categoryId);

--- a/administrator/components/com_config/controller.php
+++ b/administrator/components/com_config/controller.php
@@ -40,11 +40,18 @@ class ConfigController extends JControllerLegacy
 		// Set the default view name and format from the Request.
 		$vName = $this->input->get('view', 'application');
 
-		JLog::add(
-			'ConfigController is deprecated. Use ConfigControllerApplicationDisplay or ConfigControllerComponentDisplay instead.',
-			JLog::WARNING,
-			'deprecated'
-		);
+		try
+		{
+			JLog::add(
+				sprintf('%s is deprecated. Use ConfigControllerApplicationDisplay or ConfigControllerComponentDisplay instead.', __CLASS__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		if (ucfirst($vName) == 'Application')
 		{

--- a/administrator/components/com_config/controllers/application.php
+++ b/administrator/components/com_config/controllers/application.php
@@ -43,7 +43,18 @@ class ConfigControllerApplication extends JControllerLegacy
 	 */
 	public function save()
 	{
-		JLog::add('ConfigControllerApplication is deprecated. Use ConfigControllerApplicationSave instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use ConfigControllerApplicationSave instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$controller = new ConfigControllerApplicationSave;
 
@@ -59,7 +70,18 @@ class ConfigControllerApplication extends JControllerLegacy
 	 */
 	public function cancel()
 	{
-		JLog::add('ConfigControllerApplication is deprecated. Use ConfigControllerApplicationCancel instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use ConfigControllerApplicationCancel instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$controller = new ConfigControllerApplicationCancel;
 
@@ -76,7 +98,18 @@ class ConfigControllerApplication extends JControllerLegacy
 	 */
 	public function removeroot()
 	{
-		JLog::add('ConfigControllerApplication is deprecated. Use ConfigControllerApplicationRemoveroot instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use ConfigControllerApplicationRemoveroot instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$controller = new ConfigControllerApplicationRemoveroot;
 

--- a/administrator/components/com_config/controllers/component.php
+++ b/administrator/components/com_config/controllers/component.php
@@ -43,7 +43,18 @@ class ConfigControllerComponent extends JControllerLegacy
 	 */
 	public function cancel()
 	{
-		JLog::add('ConfigControllerComponent is deprecated. Use ConfigControllerComponentCancel instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use ConfigControllerComponentCancel instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$controller = new ConfigControllerComponentCancel;
 
@@ -59,7 +70,18 @@ class ConfigControllerComponent extends JControllerLegacy
 	 */
 	public function save()
 	{
-		JLog::add('ConfigControllerComponent is deprecated. Use ConfigControllerComponentSave instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use ConfigControllerComponentSave instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$controller = new ConfigControllerComponentSave;
 

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -328,7 +328,15 @@ class ConfigModelApplication extends ConfigModelForm
 
 			if ($error)
 			{
-				JLog::add(JText::sprintf('COM_CONFIG_ERROR_CACHE_PATH_NOTWRITABLE', $path), JLog::WARNING, 'jerror');
+				try
+				{
+					JLog::add(JText::sprintf('COM_CONFIG_ERROR_CACHE_PATH_NOTWRITABLE', $path), JLog::WARNING, 'jerror');
+				}
+				catch (RuntimeException $exception)
+				{
+					$app->enqueueMessage(JText::sprintf('COM_CONFIG_ERROR_CACHE_PATH_NOTWRITABLE', $path), 'warning');
+				}
+
 				$data['caching'] = 0;
 			}
 		}

--- a/administrator/components/com_config/models/application.php
+++ b/administrator/components/com_config/models/application.php
@@ -9,10 +9,17 @@
 
 defined('_JEXEC') or die;
 
-JLog::add(
-	'ConfigModelApplication has moved from ' . __DIR__ . '/application.php to ' . dirname(__DIR__) . '/model/application.',
-	JLog::WARNING,
-	'deprecated'
-);
+try
+{
+	JLog::add(
+		sprintf('ConfigModelApplication has moved from %1$s to %2$s', __FILE__, dirname(__DIR__) . '/model/application.php'),
+		JLog::WARNING,
+		'deprecated'
+	);
+}
+catch (RuntimeException $exception)
+{
+	// Informational log only
+}
 
 include_once JPATH_ADMINISTRATOR . '/components/com_config/model/application.php';

--- a/administrator/components/com_config/models/component.php
+++ b/administrator/components/com_config/models/component.php
@@ -9,10 +9,17 @@
 
 defined('_JEXEC') or die;
 
-JLog::add(
-	'ConfigModelComponent has moved from ' . __FILE__ . ' to ' . dirname(__DIR__) . '/model/component.php.',
-	JLog::WARNING,
-	'deprecated'
-);
+try
+{
+	JLog::add(
+		sprintf('ConfigModelComponent has moved from %1$s to %2$s', __FILE__, dirname(__DIR__) . '/model/component.php'),
+		JLog::WARNING,
+		'deprecated'
+	);
+}
+catch (RuntimeException $exception)
+{
+	// Informational log only
+}
 
 include_once JPATH_ADMINISTRATOR . '/components/com_config/model/component.php';

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -72,7 +72,18 @@ class ContentHelper extends JHelperContent
 	 */
 	public static function filterText($text)
 	{
-		JLog::add('ContentHelper::filterText() is deprecated. Use JComponentHelper::filterText() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JComponentHelper::filterText() instead', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return JComponentHelper::filterText($text);
 	}

--- a/administrator/components/com_contenthistory/models/history.php
+++ b/administrator/components/com_contenthistory/models/history.php
@@ -137,13 +137,27 @@ class ContenthistoryModelHistory extends JModelList
 
 					if ($error)
 					{
-						JLog::add($error, JLog::WARNING, 'jerror');
+						try
+						{
+							JLog::add($error, JLog::WARNING, 'jerror');
+						}
+						catch (RuntimeException $exception)
+						{
+							JFactory::getApplication()->enqueueMessage($error, 'warning');
+						}
 
 						return false;
 					}
 					else
 					{
-						JLog::add(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+						try
+						{
+							JLog::add(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+						}
+						catch (RuntimeException $exception)
+						{
+							JFactory::getApplication()->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning');
+						}
 
 						return false;
 					}
@@ -264,13 +278,27 @@ class ContenthistoryModelHistory extends JModelList
 
 					if ($error)
 					{
-						JLog::add($error, JLog::WARNING, 'jerror');
+						try
+						{
+							JLog::add($error, JLog::WARNING, 'jerror');
+						}
+						catch (RuntimeException $exception)
+						{
+							JFactory::getApplication()->enqueueMessage($error, 'warning');
+						}
 
 						return false;
 					}
 					else
 					{
-						JLog::add(JText::_('COM_CONTENTHISTORY_ERROR_KEEP_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+						try
+						{
+							JLog::add(JText::_('COM_CONTENTHISTORY_ERROR_KEEP_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+						}
+						catch (RuntimeException $exception)
+						{
+							JFactory::getApplication()->enqueueMessage(JText::_('COM_CONTENTHISTORY_ERROR_KEEP_NOT_PERMITTED'), 'warning');
+						}
 
 						return false;
 					}

--- a/administrator/components/com_finder/controllers/indexer.json.php
+++ b/administrator/components/com_finder/controllers/indexer.json.php
@@ -38,7 +38,14 @@ class FinderControllerIndexer extends JControllerLegacy
 		}
 
 		// Log the start
-		JLog::add('Starting the indexer', JLog::INFO);
+		try
+		{
+			JLog::add('Starting the indexer', JLog::INFO);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// We don't want this form to be cached.
 		$app = JFactory::getApplication();
@@ -102,7 +109,14 @@ class FinderControllerIndexer extends JControllerLegacy
 		}
 
 		// Log the start
-		JLog::add('Starting the indexer batch process', JLog::INFO);
+		try
+		{
+			JLog::add('Starting the indexer batch process', JLog::INFO);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// We don't want this form to be cached.
 		$app = JFactory::getApplication();
@@ -187,7 +201,14 @@ class FinderControllerIndexer extends JControllerLegacy
 			$app = $admin;
 
 			// Log batch completion and memory high-water mark.
-			JLog::add('Batch completed, peak memory usage: ' . number_format(memory_get_peak_usage(true)) . ' bytes', JLog::INFO);
+			try
+			{
+				JLog::add('Batch completed, peak memory usage: ' . number_format(memory_get_peak_usage(true)) . ' bytes', JLog::INFO);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
 
 			// Send the response.
 			$this->sendResponse($state);
@@ -277,7 +298,15 @@ class FinderControllerIndexer extends JControllerLegacy
 		// Send the assigned error code if we are catching an exception.
 		if ($data instanceof Exception)
 		{
-			JLog::add($data->getMessage(), JLog::ERROR);
+			try
+			{
+				JLog::add($data->getMessage(), JLog::ERROR);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
+
 			$app->setHeader('status', $data->getCode());
 		}
 
@@ -329,7 +358,14 @@ class FinderIndexerResponse
 		if ($state instanceof Exception)
 		{
 			// Log the error
-			JLog::add($state->getMessage(), JLog::ERROR);
+			try
+			{
+				JLog::add($state->getMessage(), JLog::ERROR);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
 
 			// Prepare the error response.
 			$this->error = true;

--- a/administrator/components/com_finder/helpers/finder.php
+++ b/administrator/components/com_finder/helpers/finder.php
@@ -92,7 +92,18 @@ class FinderHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
 		return JHelperContent::getActions('com_finder');

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -132,12 +132,21 @@ class InstallerHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_installer');
-
-		return $result;
+		return JHelperContent::getActions('com_installer');
 	}
 
 	/**

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -31,7 +31,15 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
 		$user = JFactory::getUser();
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, JVERSION), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, JVERSION), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$this->_applyCredentials();
 
@@ -46,7 +54,15 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		{
 			JFactory::getApplication()->setUserState('com_joomlaupdate.file', $file);
 			$url = 'index.php?option=com_joomlaupdate&task=update.install&' . JFactory::getSession()->getFormToken() . '=1';
-			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $file), JLog::INFO, 'Update');
+
+			try
+			{
+				JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $file), JLog::INFO, 'Update');
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
 		}
 		else
 		{
@@ -73,7 +89,15 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_INSTALL'), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_INSTALL'), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$this->_applyCredentials();
 
@@ -109,7 +133,16 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_FINALISE'), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$this->_applyCredentials();
 
 		/** @var JoomlaupdateModelDefault $model */
@@ -144,7 +177,16 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		$options['format'] = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
 		$options['text_file'] = 'joomla_update.php';
 		JLog::addLogger($options, JLog::INFO, array('Update', 'databasequery', 'jerror'));
-		JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::_('COM_JOOMLAUPDATE_UPDATE_LOG_CLEANUP'), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$this->_applyCredentials();
 
 		/** @var JoomlaupdateModelDefault $model */
@@ -154,7 +196,15 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		$url = 'index.php?option=com_joomlaupdate&view=default&layout=complete';
 		$this->setRedirect($url);
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', JVERSION), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 	}
 
 	/**
@@ -297,7 +347,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		// Set the update source in the session
 		JFactory::getApplication()->setUserState('com_joomlaupdate.file', basename($tempFile));
 
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $tempFile), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $tempFile), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Redirect to the actual update page
 		$url = 'index.php?option=com_joomlaupdate&task=update.install&' . JFactory::getSession()->getFormToken() . '=1';
@@ -404,7 +461,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 		// The login fails?
 		if (!$result)
 		{
-			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_CONFIRM_FINALISE_FAIL'), JLog::INFO, 'Update');
+			try
+			{
+				JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_CONFIRM_FINALISE_FAIL'), JLog::INFO, 'Update');
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational log only
+			}
 
 			JFactory::getApplication()->enqueueMessage(JText::_('JGLOBAL_AUTH_INVALID_PASS'), 'warning');
 			$this->setRedirect('index.php?option=com_joomlaupdate&view=update&layout=finaliseconfirm');
@@ -412,7 +476,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 			return false;
 		}
 
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_CONFIRM_FINALISE'), JLog::INFO, 'Update');
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_CONFIRM_FINALISE'), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Redirect back to the actual finalise page
 		$this->setRedirect('index.php?option=com_joomlaupdate&task=update.finalise&' . JFactory::getSession()->getFormToken() . '=1');

--- a/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
+++ b/administrator/components/com_joomlaupdate/helpers/joomlaupdate.php
@@ -27,11 +27,20 @@ class JoomlaupdateHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_joomlaupdate');
-
-		return $result;
+		return JHelperContent::getActions('com_joomlaupdate');
 	}
 }

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -309,7 +309,15 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	protected function downloadPackage($url, $target)
 	{
 		JLoader::import('helpers.download', JPATH_COMPONENT_ADMINISTRATOR);
-		JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $url), JLog::INFO, 'Update');
+
+		try
+		{
+			JLog::add(JText::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $url), JLog::INFO, 'Update');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get the handler to download the package
 		try

--- a/administrator/components/com_languages/helpers/jsonresponse.php
+++ b/administrator/components/com_languages/helpers/jsonresponse.php
@@ -71,7 +71,14 @@ class JJsonResponse
 	 */
 	public function __construct($response = null, $message = null, $error = false)
 	{
-		JLog::add('Class JJsonResponse is deprecated. Use class JResponseJson instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(sprintf('%s is deprecated, use JResponseJson instead.', __CLASS__), JLog::WARNING, 'deprecated');
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		$this->message = $message;
 

--- a/administrator/components/com_languages/helpers/languages.php
+++ b/administrator/components/com_languages/helpers/languages.php
@@ -55,12 +55,21 @@ class LanguagesHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function.
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions.
-		$result = JHelperContent::getActions('com_languages');
-
-		return $result;
+		return JHelperContent::getActions('com_languages');
 	}
 
 	/**

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -83,7 +83,18 @@ abstract class MultilangstatusHelper
 	 */
 	public static function getSitelangs()
 	{
-		JLog::add(__METHOD__ . ' is deprecated, use JLanguageHelper::getInstalledLanguages(0) instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated, use JLanguageHelper::getInstalledLanguages(0) instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return JLanguageHelper::getInstalledLanguages(0);
 	}
@@ -97,7 +108,18 @@ abstract class MultilangstatusHelper
 	 */
 	public static function getHomepages()
 	{
-		JLog::add(__METHOD__ . ' is deprecated, use JLanguageMultilang::getSiteHomePages() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated, use JLanguageHelper::getSiteHomePages() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return JLanguageMultilang::getSiteHomePages();
 	}

--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -95,7 +95,14 @@ class MediaControllerFile extends JControllerLegacy
 
 			if (!$mediaHelper->canUpload($file, 'com_media'))
 			{
-				JLog::add('Invalid: ' . $filepath, JLog::INFO, 'upload');
+				try
+				{
+					JLog::add('Invalid: ' . $filepath, JLog::INFO, 'upload');
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$response = array(
 					'status'  => '0',
@@ -118,7 +125,18 @@ class MediaControllerFile extends JControllerLegacy
 			if (in_array(false, $result, true))
 			{
 				// There are some errors in the plugins
-				JLog::add('Errors before save: ' . $object_file->filepath . ' : ' . implode(', ', $object_file->getErrors()), JLog::INFO, 'upload');
+				try
+				{
+					JLog::add(
+						'Errors before save: ' . $object_file->filepath . ' : ' . implode(', ', $object_file->getErrors()),
+						JLog::INFO,
+						'upload'
+					);
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$response = array(
 					'status'  => '0',
@@ -134,7 +152,14 @@ class MediaControllerFile extends JControllerLegacy
 			if (JFile::exists($object_file->filepath))
 			{
 				// File exists
-				JLog::add('File exists: ' . $object_file->filepath . ' by user_id ' . $user->id, JLog::INFO, 'upload');
+				try
+				{
+					JLog::add('File exists: ' . $object_file->filepath . ' by user_id ' . $user->id, JLog::INFO, 'upload');
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$response = array(
 					'status'   => '0',
@@ -150,7 +175,14 @@ class MediaControllerFile extends JControllerLegacy
 			elseif (!$user->authorise('core.create', 'com_media'))
 			{
 				// File does not exist and user is not authorised to create
-				JLog::add('Create not permitted: ' . $object_file->filepath . ' by user_id ' . $user->id, JLog::INFO, 'upload');
+				try
+				{
+					JLog::add('Create not permitted: ' . $object_file->filepath . ' by user_id ' . $user->id, JLog::INFO, 'upload');
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$response = array(
 					'status'  => '0',
@@ -166,7 +198,14 @@ class MediaControllerFile extends JControllerLegacy
 			if (!JFile::upload($object_file->tmp_name, $object_file->filepath))
 			{
 				// Error in upload
-				JLog::add('Error on upload: ' . $object_file->filepath, JLog::INFO, 'upload');
+				try
+				{
+					JLog::add('Error on upload: ' . $object_file->filepath, JLog::INFO, 'upload');
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$response = array(
 					'status'  => '0',
@@ -182,7 +221,15 @@ class MediaControllerFile extends JControllerLegacy
 			{
 				// Trigger the onContentAfterSave event.
 				$dispatcher->trigger('onContentAfterSave', array('com_media.file', &$object_file, true));
-				JLog::add($folder, JLog::INFO, 'upload');
+
+				try
+				{
+					JLog::add($folder, JLog::INFO, 'upload');
+				}
+				catch (RuntimeException $exception)
+				{
+					// Informational log only
+				}
 
 				$returnUrl = str_replace(JPATH_ROOT, '',  $object_file->filepath);
 

--- a/administrator/components/com_media/helpers/media.php
+++ b/administrator/components/com_media/helpers/media.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /**
  * Media helper class.
- * 
+ *
  * @since       1.6
  * @deprecated  4.0  Use JHelperMedia instead
  */
@@ -29,7 +29,19 @@ abstract class MediaHelper
 	 */
 	public static function isImage($fileName)
 	{
-		JLog::add('MediaHelper::isImage() is deprecated. Use JHelperMedia::isImage() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperMedia::isImage() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->isImage($fileName);
@@ -47,7 +59,19 @@ abstract class MediaHelper
 	 */
 	public static function getTypeIcon($fileName)
 	{
-		JLog::add('MediaHelper::getTypeIcon() is deprecated. Use JHelperMedia::getTypeIcon() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperMedia::getTypeIcon() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->getTypeIcon($fileName);
@@ -66,7 +90,19 @@ abstract class MediaHelper
 	 */
 	public static function canUpload($file, $error = '')
 	{
-		JLog::add('MediaHelper::canUpload() is deprecated. Use JHelperMedia::canUpload() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperMedia::canUpload() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->canUpload($file, 'com_media');
@@ -80,11 +116,22 @@ abstract class MediaHelper
 	 * @return  string  The converted file size
 	 *
 	 * @since   1.6
-	 * @deprecated  4.0  Use JHtmlNumber::bytes() instead
+	 * @deprecated  4.0  Use JHtml::_('number.bytes') instead
 	 */
 	public static function parseSize($size)
 	{
-		JLog::add('MediaHelper::parseSize() is deprecated. Use JHtmlNumber::bytes() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf("%s() is deprecated. Use JHtml::_('number.bytes') instead.", __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return JHtml::_('number.bytes', $size);
 	}
@@ -103,7 +150,19 @@ abstract class MediaHelper
 	 */
 	public static function imageResize($width, $height, $target)
 	{
-		JLog::add('MediaHelper::countFiles() is deprecated. Use JHelperMedia::countFiles() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperMedia::imageResize() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->imageResize($width, $height, $target);
@@ -121,7 +180,19 @@ abstract class MediaHelper
 	 */
 	public static function countFiles($dir)
 	{
-		JLog::add('MediaHelper::countFiles() is deprecated. Use JHelperMedia::countFiles() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperMedia::countFiles() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		$mediaHelper = new JHelperMedia;
 
 		return $mediaHelper->countFiles($dir);

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -90,7 +90,18 @@ class MenusControllerItems extends JControllerAdmin
 	{
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		JLog::add('MenusControllerItems::saveorder() is deprecated. Function will be removed in 4.0', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Function will be removed in 4.0.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get the arrays from the Request
 		$order = $this->input->post->get('order', null, 'array');
@@ -190,7 +201,14 @@ class MenusControllerItems extends JControllerAdmin
 
 		if (empty($cid))
 		{
-			JLog::add(JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), JLog::WARNING, 'jerror');
+			try
+			{
+				JLog::add(JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), JLog::WARNING, 'jerror');
+			}
+			catch (RuntimeException $exception)
+			{
+				JFactory::getApplication()->enqueueMessage(JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), 'warning');
+			}
 		}
 		else
 		{

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -57,12 +57,21 @@ class MenusHelper
 	public static function getActions($parentId = 0)
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_menus');
-
-		return $result;
+		return JHelperContent::getActions('com_menus');
 	}
 
 	/**

--- a/administrator/components/com_messages/helpers/html/messages.php
+++ b/administrator/components/com_messages/helpers/html/messages.php
@@ -34,11 +34,18 @@ class JHtmlMessages
 	public static function state($value = 0, $i = 0, $canChange = false)
 	{
 		// Log deprecated message
-		JLog::add(
-			'JHtmlMessages::state() is deprecated. Use JHtmlMessages::status() instead.',
-			JLog::WARNING,
-			'deprecated'
-		);
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlMessages::status() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Note: $i is required but has to be an optional argument in the function call due to argument order
 		if (null === $i)

--- a/administrator/components/com_messages/helpers/messages.php
+++ b/administrator/components/com_messages/helpers/messages.php
@@ -50,12 +50,21 @@ class MessagesHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_messages');
-
-		return $result;
+		return JHelperContent::getActions('com_messages');
 	}
 
 	/**

--- a/administrator/components/com_messages/models/message.php
+++ b/administrator/components/com_messages/models/message.php
@@ -74,7 +74,15 @@ class MessagesModelMessage extends JModelAdmin
 				{
 					// Prune items that you can't change.
 					unset($pks[$i]);
-					JLog::add(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+
+					try
+					{
+						JLog::add(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+					}
+					catch (RuntimeException $exception)
+					{
+						JFactory::getApplication()->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning');
+					}
 
 					return false;
 				}
@@ -254,7 +262,15 @@ class MessagesModelMessage extends JModelAdmin
 				{
 					// Prune items that you can't change.
 					unset($pks[$i]);
-					JLog::add(JText::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+
+					try
+					{
+						JLog::add(JText::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), JLog::WARNING, 'jerror');
+					}
+					catch (RuntimeException $exception)
+					{
+						JFactory::getApplication()->enqueueMessage(JText::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), 'warning');
+					}
 
 					return false;
 				}

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -42,7 +42,18 @@ abstract class ModulesHelper
 	public static function getActions($moduleId = 0)
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
 		if (empty($moduleId))

--- a/administrator/components/com_modules/helpers/xml.php
+++ b/administrator/components/com_modules/helpers/xml.php
@@ -9,7 +9,14 @@
 
 defined('_JEXEC') or die;
 
-JLog::add('ModulesHelperXML is deprecated. Do not use.', JLog::WARNING, 'deprecated');
+try
+{
+	JLog::add('ModulesHelperXML is deprecated. Do not use.', JLog::WARNING, 'deprecated');
+}
+catch (RuntimeException $exception)
+{
+	// Informational log only
+}
 
 /**
  * Helper for parse XML module files

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -40,12 +40,21 @@ class PluginsHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function.
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions.
-		$result = JHelperContent::getActions('com_plugins');
-
-		return $result;
+		return JHelperContent::getActions('com_plugins');
 	}
 
 	/**

--- a/administrator/components/com_redirect/helpers/redirect.php
+++ b/administrator/components/com_redirect/helpers/redirect.php
@@ -44,12 +44,21 @@ class RedirectHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_redirect');
-
-		return $result;
+		return JHelperContent::getActions('com_redirect');
 	}
 
 	/**

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -42,12 +42,21 @@ class SearchHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function.
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions.
-		$result = JHelperContent::getActions('com_search');
-
-		return $result;
+		return JHelperContent::getActions('com_search');
 	}
 
 	/**
@@ -150,7 +159,18 @@ class SearchHelper
 	 */
 	public static function logSearch($search_term)
 	{
-		JLog::add(__METHOD__ . '() is deprecated, use JSearchHelper::logSearch() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JSearchHelper::logSearch() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		JSearchHelper::logSearch($search_term, 'com_search');
 	}

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -47,12 +47,21 @@ class TemplatesHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_templates');
-
-		return $result;
+		return JHelperContent::getActions('com_templates');
 	}
 
 	/**

--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -91,12 +91,21 @@ class UsersHelper
 	public static function getActions()
 	{
 		// Log usage of deprecated function
-		JLog::add(__METHOD__ . '() is deprecated, use JHelperContent::getActions() with new arguments order instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHelperContent::getActions() with new arguments order instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		// Get list of actions
-		$result = JHelperContent::getActions('com_users');
-
-		return $result;
+		return JHelperContent::getActions('com_users');
 	}
 
 	/**

--- a/administrator/includes/subtoolbar.php
+++ b/administrator/includes/subtoolbar.php
@@ -58,7 +58,19 @@ abstract class JSubMenuHelper
 	 */
 	public static function addEntry($name, $link = '', $active = false)
 	{
-		JLog::add('JSubMenuHelper::addEntry() is deprecated. Use JHtmlSidebar::addEntry() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::addEntry() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		self::$entries[] = array($name, $link, $active);
 	}
 
@@ -72,7 +84,18 @@ abstract class JSubMenuHelper
 	 */
 	public static function getEntries()
 	{
-		JLog::add('JSubMenuHelper::getEntries() is deprecated. Use JHtmlSidebar::getEntries() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::getEntries() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return self::$entries;
 	}
@@ -92,7 +115,19 @@ abstract class JSubMenuHelper
 	 */
 	public static function addFilter($label, $name, $options, $noDefault = false)
 	{
-		JLog::add('JSubMenuHelper::addFilter() is deprecated. Use JHtmlSidebar::addFilter() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::addFilter() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		self::$filters[] = array('label' => $label, 'name' => $name, 'options' => $options, 'noDefault' => $noDefault);
 	}
 
@@ -106,7 +141,18 @@ abstract class JSubMenuHelper
 	 */
 	public static function getFilters()
 	{
-		JLog::add('JSubMenuHelper::getFilters() is deprecated. Use JHtmlSidebar::getFilters() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::getFilters() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return self::$filters;
 	}
@@ -123,7 +169,19 @@ abstract class JSubMenuHelper
 	 */
 	public static function setAction($action)
 	{
-		JLog::add('JSubMenuHelper::setAction() is deprecated. Use JHtmlSidebar::setAction() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::setAction() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
+
 		self::$action = $action;
 	}
 
@@ -137,7 +195,18 @@ abstract class JSubMenuHelper
 	 */
 	public static function getAction()
 	{
-		JLog::add('JSubMenuHelper::getAction() is deprecated. Use JHtmlSidebar::getAction() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated. Use JHtmlSidebar::getAction() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return self::$action;
 	}

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -82,7 +82,18 @@ abstract class ModLoginHelper
 	 */
 	public static function getTwoFactorMethods()
 	{
-		JLog::add(__METHOD__ . ' is deprecated, use JAuthenticationHelper::getTwoFactorMethods() instead.', JLog::WARNING, 'deprecated');
+		try
+		{
+			JLog::add(
+				sprintf('%s() is deprecated, use JAuthenticationHelper::getTwoFactorMethods() instead.', __METHOD__),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational log only
+		}
 
 		return JAuthenticationHelper::getTwoFactorMethods();
 	}


### PR DESCRIPTION
Partial Pull Request for Issue #13357

### Summary of Changes

Logging is not an action that should result in an unhandled error and the user seeing an error page, so catch if a `RuntimeException` is thrown through the course of calling `JLog::add()`.  This exception may be thrown if `JLog::addLogEntry()` cannot create the `JLogLogger` object or an implementation of `JLogLogger::addEntry()` throws one on a fail state (i.e. the database logger failing to connect to the database or insert the record, or the formatted text logger failing to write to the filesystem).

### Testing Instructions

For all cases where logging to a category other than `jerror` is performed, the exception is just silently ignored.  As these are informational log messages only (mainly deprecation notices), there is no need to trigger an error to the UI and notify the user of a failed log statement.  For messages categorized as `jerror`, the catch block will do exactly what `JLogLoggerMessagequeue::addEntry()` does and call `JFactory::getApplication()->enqueueMessage()`.

This should mean if you make your log directory unwritable, log messages triggered by code in the admin app should not result in the error page being triggered.  You might have to programmatically issue a `chmod()` command before one of these log statements and reset it after to adequately test this until all log statements are wrapped in try/catch.

### Documentation Changes Required

N/A