### PR TITLE
Speed up of saving new articles

### DIFF
--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -140,6 +140,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
 		pg_query($this->connection, 'SET standard_conforming_strings=off');
 		pg_query($this->connection, 'SET escape_string_warning=off');
+		pg_query($this->connection, 'CREATE TEMP SEQUENCE ROW_NUMBER');
 	}
 
 	/**

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -140,7 +140,6 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		pg_set_error_verbosity($this->connection, PGSQL_ERRORS_DEFAULT);
 		pg_query($this->connection, 'SET standard_conforming_strings=off');
 		pg_query($this->connection, 'SET escape_string_warning=off');
-		pg_query($this->connection, 'CREATE TEMP SEQUENCE ROW_NUMBER');
 	}
 
 	/**

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -56,6 +56,57 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 	}
 
 	/**
+	 * Connects to the database if needed.
+	 *
+	 * @return  void  Returns void if the database connected successfully.
+	 *
+	 * @since   12.1
+	 * @throws  RuntimeException
+	 */
+	public function connect()
+	{
+		if ($this->connection)
+		{
+			return;
+		}
+
+		parent::connect();
+
+		$this->connection->sqliteCreateFunction(
+			'ROW_NUMBER',
+			function($init = null)
+			{
+				static $rownum, $partition;
+
+				if ($init !== null)
+				{
+					$rownum = $init;
+					$partition = null;
+
+					return $rownum;
+				}
+
+				$args = func_get_args();
+				array_shift($args);
+
+				$partitionBy = $args ? implode(',', $args) : null;
+
+				if ($partitionBy === null || $partitionBy === $partition)
+				{
+					$rownum++;
+				}
+				else
+				{
+					$rownum    = 1;
+					$partition = $partitionBy;
+				}
+
+				return $rownum;
+			}
+		);
+	}
+
+	/**
 	 * Disconnects the database.
 	 *
 	 * @return  void

--- a/libraries/joomla/database/query/mysqli.php
+++ b/libraries/joomla/database/query/mysqli.php
@@ -29,6 +29,47 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	protected $limit;
 
 	/**
+	 * Magic function to convert the query to a string.
+	 *
+	 * @return  string  The completed query.
+	 *
+	 * @since   11.1
+	 */
+	public function __toString()
+	{
+		switch ($this->type)
+		{
+			case 'select':
+				if ($this->selectRowNumber)
+				{
+					$orderBy      = $this->selectRowNumber['orderBy'];
+					$tmpOffset    = $this->offset;
+					$tmpLimit     = $this->limit;
+					$this->offset = 0;
+					$this->limit  = 0;
+					$tmpOrder     = $this->order;
+					$this->order  = null;
+					$query        = parent::__toString();
+					$this->order  = $tmpOrder;
+					$this->offset = $tmpOffset;
+					$this->limit  = $tmpLimit;
+
+					// Add support for second order by, offset and limit
+					$query = PHP_EOL . 'SELECT * FROM (' . $query . PHP_EOL . "ORDER BY $orderBy" . PHP_EOL . ') w';
+
+					if ($this->order)
+					{
+						$query .= (string) $this->order;
+					}
+
+					return $this->processLimit($query, $this->limit, $this->offset);
+				}
+		}
+
+		return parent::__toString();
+	}
+
+	/**
 	 * Method to modify a query already in string format with the needed
 	 * additions to make the query limited to a particular number of
 	 * results, or start at a particular offset.
@@ -161,5 +202,24 @@ class JDatabaseQueryMysqli extends JDatabaseQuery implements JDatabaseQueryLimit
 	public function findInSet($value, $set)
 	{
 		return ' find_in_set(' . $value . ', ' . $set . ')';
+	}
+
+	/**
+	 * Return the number of the current row.
+	 *
+	 * @param   string  $orderBy           An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias  An alias for new ordering column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function selectRowNumber($orderBy, $orderColumnAlias)
+	{
+		$this->validateRowNumber($orderBy, $orderColumnAlias);
+		$this->select("(SELECT @rownum := @rownum + 1 FROM (SELECT @rownum := 0) AS r) AS $orderColumnAlias");
+
+		return $this;
 	}
 }

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -66,6 +66,46 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 		switch ($this->type)
 		{
 			case 'select':
+				if ($this->selectRowNumber)
+				{
+					$orderBy          = $this->selectRowNumber['orderBy'];
+					$orderColumnAlias = $this->selectRowNumber['orderColumnAlias'];
+
+					$columns = "nextval('ROW_NUMBER') - 1 AS $orderColumnAlias";
+
+					if ($this->select === null)
+					{
+						$query = PHP_EOL . "SELECT 1"
+							. (string) $this->from
+							. (string) $this->where;
+					}
+					else
+					{
+						$tmpOffset    = $this->offset;
+						$tmpLimit     = $this->limit;
+						$this->offset = 0;
+						$this->limit  = 0;
+						$tmpOrder     = $this->order;
+						$this->order  = null;
+						$query        = parent::__toString();
+						$columns      = "w.*, $columns";
+						$this->order  = $tmpOrder;
+						$this->offset = $tmpOffset;
+						$this->limit  = $tmpLimit;
+					}
+
+					// Add support for second order by, offset and limit
+					$query = PHP_EOL . "SELECT $columns FROM (" . $query . PHP_EOL . "ORDER BY $orderBy"
+						. PHP_EOL . ") w,(SELECT setval('ROW_NUMBER', 1)) AS r";
+
+					if ($this->order)
+					{
+						$query .= (string) $this->order;
+					}
+
+					break;
+				}
+
 				$query .= (string) $this->select;
 				$query .= (string) $this->from;
 
@@ -688,5 +728,23 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	public function findInSet($value, $set)
 	{
 		return " $value = ANY (string_to_array($set, ',')::integer[]) ";
+	}
+
+	/**
+	 * Return the number of the current row.
+	 *
+	 * @param   string  $orderBy           An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias  An alias for new ordering column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function selectRowNumber($orderBy, $orderColumnAlias)
+	{
+		$this->validateRowNumber($orderBy, $orderColumnAlias);
+
+		return $this;
 	}
 }

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -273,4 +273,124 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	{
 		return 'CURRENT_TIMESTAMP';
 	}
+
+	/**
+	 * Magic function to convert the query to a string.
+	 *
+	 * @return  string  The completed query.
+	 *
+	 * @since   11.1
+	 */
+	public function __toString()
+	{
+		switch ($this->type)
+		{
+			case 'select':
+				if ($this->selectRowNumber)
+				{
+					$orderBy          = $this->selectRowNumber['orderBy'];
+					$orderColumnAlias = $this->selectRowNumber['orderColumnAlias'];
+
+					$column = "ROW_NUMBER() AS $orderColumnAlias";
+
+					if ($this->select === null)
+					{
+						$query = PHP_EOL . "SELECT 1"
+							. (string) $this->from
+							. (string) $this->where;
+					}
+					else
+					{
+						$tmpOffset    = $this->offset;
+						$tmpLimit     = $this->limit;
+						$this->offset = 0;
+						$this->limit  = 0;
+						$tmpOrder    = $this->order;
+						$this->order = null;
+						$query       = parent::__toString();
+						$column      = "w.*, $column";
+						$this->order = $tmpOrder;
+						$this->offset = $tmpOffset;
+						$this->limit  = $tmpLimit;
+					}
+
+					// Special sqlite query to count ROW_NUMBER
+					$query = PHP_EOL . "SELECT $column"
+						. PHP_EOL . "FROM ($query" . PHP_EOL . "ORDER BY $orderBy"
+						. PHP_EOL . ") AS w,(SELECT ROW_NUMBER(0)) AS r"
+						// Forbid to flatten subqueries.
+						. ((string) $this->order ?: PHP_EOL . 'ORDER BY NULL');
+
+					return $this->processLimit($query, $this->limit, $this->offset);
+				}
+
+				break;
+
+			case 'update':
+				if ($this->join)
+				{
+					$table = $this->update->getElements();
+					$table = $table[0];
+
+					if ($this->columns === null)
+					{
+						$fields = $this->db->getTableColumns($table);
+
+						foreach ($fields as $key => $value)
+						{
+							$fields[$key] = $key;
+						}
+
+						$this->columns = new JDatabaseQueryElement('()', $fields);
+					}
+
+					$fields   = $this->columns->getElements();
+					$elements = $this->set->getElements();
+
+					foreach ($elements as $nameValue)
+					{
+						$setArray = explode(' = ', $nameValue, 2);
+
+						if ($setArray[0][0] === '`')
+						{
+							// Unquote column name
+							$setArray[0] = substr($setArray[0], 1, -1);
+						}
+
+						$fields[$setArray[0]] = $setArray[1];
+					}
+
+					$select = new JDatabaseQuerySqlite($this->db);
+					$select->select(array_values($fields))
+						->from($table);
+
+					$select->join  = $this->join;
+					$select->where = $this->where;
+
+					return 'INSERT OR REPLACE INTO ' . $table
+						. ' (' . implode(',', array_keys($fields)) . ')'
+						. (string) $select;
+				}
+		}
+
+		return parent::__toString();
+	}
+
+	/**
+	 * Return the number of the current row.
+	 *
+	 * @param   string  $orderBy           An expression of ordering for window function.
+	 * @param   string  $orderColumnAlias  An alias for new ordering column.
+	 *
+	 * @return  JDatabaseQuery  Returns this object to allow chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException
+	 */
+	public function selectRowNumber($orderBy, $orderColumnAlias)
+	{
+		$this->validateRowNumber($orderBy, $orderColumnAlias);
+
+		return $this;
+	}
 }

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -79,19 +79,22 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 					$query .= (string) $this->where;
 				}
 
-				if ($this->group)
+				if ($this->selectRowNumber === null)
 				{
-					$query .= (string) $this->group;
+					if ($this->group)
+					{
+						$query .= (string) $this->group;
+					}
+
+					if ($this->having)
+					{
+						$query .= (string) $this->having;
+					}
 				}
 
 				if ($this->order)
 				{
 					$query .= (string) $this->order;
-				}
-
-				if ($this->having)
-				{
-					$query .= (string) $this->having;
 				}
 
 				if ($this instanceof JDatabaseQueryLimitable && ($this->limit > 0 || $this->offset > 0))
@@ -162,18 +165,38 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				break;
 
 			case 'update':
-				$query .= (string) $this->update;
-
 				if ($this->join)
 				{
+					$tmpUpdate    = $this->update;
+					$tmpFrom      = $this->from;
+					$this->update = null;
+					$this->from   = null;
+
+					$updateElem  = $tmpUpdate->getElements();
+					$updateArray = explode(' ', $updateElem[0]);
+
+					// Use table alias if exists
+					$this->update(end($updateArray));
+					$this->from($updateElem[0]);
+
+					$query .= (string) $this->update;
+					$query .= (string) $this->set;
+					$query .= (string) $this->from;
+
+					$this->update = $tmpUpdate;
+					$this->from   = $tmpFrom;
+
 					// Special case for joins
 					foreach ($this->join as $join)
 					{
 						$query .= (string) $join;
 					}
 				}
-
-				$query .= (string) $this->set;
+				else
+				{
+					$query .= (string) $this->update;
+					$query .= (string) $this->set;
+				}
 
 				if ($this->where)
 				{

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -1366,41 +1366,37 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 		$quotedOrderingField = $this->_db->quoteName($orderingField);
 
-		// Get the primary keys and ordering values for the selection.
-		$query = $this->_db->getQuery(true)
-			->select(implode(',', $this->_tbl_keys) . ', ' . $quotedOrderingField)
+		$subquery = $this->_db->getQuery(true)
 			->from($this->_tbl)
-			->where($quotedOrderingField . ' >= 0')
-			->order($quotedOrderingField);
+			->selectRowNumber($quotedOrderingField, 'new_ordering');
+
+		$query = $this->_db->getQuery(true)
+			->update($this->_tbl)
+			->set($quotedOrderingField . ' = sq.new_ordering');
+
+		$innerOn = array();
+
+		// Get the primary keys for the selection.
+		foreach ($this->_tbl_keys as $i => $k)
+		{
+			$subquery->select($this->_db->quoteName($k, 'pk__' . $i));
+			$innerOn[] = $this->_db->quoteName($k) . ' = sq.' . $this->_db->quoteName('pk__' . $i);
+		}
 
 		// Setup the extra where and ordering clause data.
 		if ($where)
 		{
+			$subquery->where($where);
 			$query->where($where);
 		}
 
-		$this->_db->setQuery($query);
-		$rows = $this->_db->loadObjectList();
+		$subquery->where($quotedOrderingField . ' >= 0');
+		$query->where($quotedOrderingField . ' >= 0');
 
-		// Compact the ordering values.
-		foreach ($rows as $i => $row)
-		{
-			// Make sure the ordering is a positive integer.
-			if ($row->$orderingField >= 0)
-			{
-				// Only update rows that are necessary.
-				if ($row->$orderingField != $i + 1)
-				{
-					// Update the row ordering field.
-					$query->clear()
-						->update($this->_tbl)
-						->set($quotedOrderingField . ' = ' . ($i + 1));
-					$this->appendPrimaryKeys($query, $row);
-					$this->_db->setQuery($query);
-					$this->_db->execute();
-				}
-			}
-		}
+		$query->innerJoin('(' . (string) $subquery . ') AS sq ON ' . implode(' AND ', $innerOn));
+
+		$this->_db->setQuery($query);
+		$this->_db->execute();
 
 		return true;
 	}

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -182,6 +182,63 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQueryPostgresql::__string method for a 'selectRowNumber' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectRowNumber()
+	{
+		$this->_instance
+			->select('id')
+			->selectRowNumber('ordering', 'new_ordering')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, nextval('ROW_NUMBER') - 1 AS new_ordering FROM (" .
+			PHP_EOL . "SELECT id" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . 'ORDER BY ordering' .
+			PHP_EOL . ") w,(SELECT setval('ROW_NUMBER', 1)) AS r",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear()
+			->selectRowNumber('ordering DESC', $this->_instance->quoteName('ordering'))
+			->select('id')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, nextval('ROW_NUMBER') - 1 AS \"ordering\" FROM (" .
+			PHP_EOL . "SELECT id" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . 'ORDER BY ordering DESC' .
+			PHP_EOL . ") w,(SELECT setval('ROW_NUMBER', 1)) AS r",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->selectRowNumber('ordering DESC', $this->_instance->quoteName('ordering'));
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT nextval('ROW_NUMBER') - 1 AS \"ordering\" FROM (" .
+			PHP_EOL . "SELECT 1" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . 'ORDER BY ordering DESC' .
+			PHP_EOL . ") w,(SELECT setval('ROW_NUMBER', 1)) AS r",
+			(string) $this->_instance
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void

--- a/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
+++ b/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
@@ -118,4 +118,67 @@ class JDatabaseQuerySqliteTest extends TestCase
 			$this->_instance->currentTimestamp()
 		);
 	}
+
+	/**
+	 * Test for the JDatabaseQuerySqlite::__string method for a 'selectRowNumber' case.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function test__toStringSelectRowNumber()
+	{
+		$this->_instance
+			->select('id')
+			->selectRowNumber('ordering', 'new_ordering')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, ROW_NUMBER() AS new_ordering" .
+			PHP_EOL . "FROM (" .
+			PHP_EOL . "SELECT id" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY ordering" .
+			PHP_EOL . ") AS w,(SELECT ROW_NUMBER(0)) AS r" .
+			PHP_EOL . "ORDER BY NULL",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear()
+			->selectRowNumber('ordering DESC', $this->_instance->quoteName('ordering'))
+			->select('id')
+			->from('a')
+			->where('catid = 1');
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT w.*, ROW_NUMBER() AS `ordering`" .
+			PHP_EOL . "FROM (" .
+			PHP_EOL . "SELECT id" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY ordering DESC" .
+			PHP_EOL . ") AS w,(SELECT ROW_NUMBER(0)) AS r" .
+			PHP_EOL . "ORDER BY NULL",
+			(string) $this->_instance
+		);
+
+		$this->_instance
+			->clear('select')
+			->selectRowNumber('ordering DESC', $this->_instance->quoteName('ordering'));
+
+		$this->assertEquals(
+			PHP_EOL . "SELECT ROW_NUMBER() AS `ordering`" .
+			PHP_EOL . "FROM (" .
+			PHP_EOL . "SELECT 1" .
+			PHP_EOL . "FROM a" .
+			PHP_EOL . "WHERE catid = 1" .
+			PHP_EOL . "ORDER BY ordering DESC" .
+			PHP_EOL . ") AS w,(SELECT ROW_NUMBER(0)) AS r" .
+			PHP_EOL . "ORDER BY NULL",
+			(string) $this->_instance
+		);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #10567.

Related to older implementation at #12839 which requires postgreSQL >= 8.4.2.  

### Summary of Changes

* Big **performance improvement** in `JTable::reorder()` method with B/C.
* It works on sqlite, mysql, postgresql and mssql, (on oracle probably too).
* Do not load any tables to php on "reordering".
* New public method `JDatabaseQuery::selectRowNumber($orderBy, $orderColumnAlias)` which add an additional incremental column to SELECT type query.
* You can use `selectRowNumber` only once per query.
* to reorder articles use multi table UPDATE query with SELECT in subquery.

#### How it works.
- create SELECT sub-query with `row_number` column.
- create  UPDATE query with the same where clause.
- join above queries by primary key or keys if exists.
- update ordering to new values from SELECT sub-query.

#### Details about `selectRowNumber()`
- on MySQL PostgreSQL >= 8.4.0 and SQL Server SELECT query  preserves position of `row_number` column - you can use safely `$db->loadRowList()`, examples:
  * ...select('id')->selectRowNumber('ordering ASC', 'row_number') generates result row with keys as 'id, row_number'
  * ...selectRowNumber('ordering ASC', 'row_number')->select('id') generates result row with keys as 'row_number,id'
- on postgreSQL less that 8.4.0 and SQLite `row_number` is always on the last column, This is related to index column at `loadRow()` and `loadRowList()`.

### Other changes
- PostgreSQL:
  * ~~fix update query with join: #13284~~ - merged
  * ~~add sql var "CREATE TEMP SEQUENCE ROW_NUMBER" after establish a connection.~~
- SQL Server:
  * fix multi table UPDATE to generate correct query
  * In SELECT query move HAVING before ORDER BY
- SQLite:
  * add support for multi table UPDATE query by `INSERT OR REPLACE INTO`
  * add SQLite function `ROW_NUMBER(init=null, partitionBy=null)` after establish a connection.
- Add unit tests for `selectRowNumber` and multi table UPDATE query.
- Fix a few other unit test files that generated error after applied my changes.

### Testing Instruction
* go to back end to list of articles (com_content).
* set order list by "Ordering asceding"
* select any category and set level 1
* add 3 example articles (articleA, articleB, articleC) in the same category as featured.
* back to articles list and you should see articles on the top of list (articleC, articleB, articleA, ...olders...)
* go to Featured Articles list and set order list by "Ordering asceding"
* you should see on the top of list (articleC, articleB, articleA, ...olders...)

If something went wrong then test it first without PR.
After this PR result should be the same.

[UPDATED]
**How to test on postgreSQL**
PostgreSQL Query has 2 versions of code which depend on postgresql server version (< 8.4 or >= 8.4).
So it would be good to test 2 options but as usual there is probably nobody with postgresql >= 8.3.18 and < 8.4.
* first do the test on postgresql as usual,
* then simulate older postgresql by changing line:
https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/database/driver/postgresql.php#L579
from `{`
to `{ return '8.3.18';`
and test again.

### Documentation Changes Required
Probably.

Introduce a new public method `JDatabaseQuery::selectRowNumber()`.
Main database drivers (mysql, postgresql, sqlsrv and sqlite) can use Update with innerJoin.
SQLite driver has a new sqlite function `ROW_NUMBER(init=null, partitionBy=null)`.


### Benchmark (old)

I tested this on MariaDB 10.0.27, php 7.0.8 on my laptop. 
![reorder_test_on_4000](https://cloud.githubusercontent.com/assets/9054379/20777179/9b00fd02-b765-11e6-9b96-3912590bf60e.jpeg)

#### **After patch reorder is almost 100x faster for 4000 articles in one category. Total articles ~233k.**