### PR TITLE
Reduce the usage of the variable

### DIFF
--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -167,9 +167,7 @@ class InstallerModelLanguages extends JModelList
 		// Count the non-paginated list
 		$this->languageCount = count($languages);
 
-		$languages = array_slice($languages, $this->getStart(), $this->getState('list.limit'));
-
-		return $languages;
+		return array_slice($languages, $this->getStart(), $this->getState('list.limit'));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This reduces 2 lines of unneeded code

### Testing Instructions

Apply this patch and confirm that you can still install and show the translations in the backend:
BE -> Extensions -> manage -> language -> Find languages

### Documentation Changes Required

none