### PR TITLE
Fix “You are not authorised to view this” when mod_expires enabled

### DIFF
--- a/administrator/components/com_languages/controllers/override.php
+++ b/administrator/components/com_languages/controllers/override.php
@@ -28,6 +28,9 @@ class LanguagesControllerOverride extends JControllerForm
 	 */
 	public function edit($key = null, $urlVar = null)
 	{
+		// Do not cache the response to this, its a redirect
+		JFactory::getApplication()->allowCache(false);
+
 		$app     = JFactory::getApplication();
 		$cid     = $this->input->post->get('cid', array(), 'array');
 		$context = "$this->option.edit.$this->context";

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -571,8 +571,7 @@ class JApplicationWeb extends JApplicationBase
 			}
 		}
 
-		// Close the application after the redirect.
-		$this->close();
+		$this->respond();
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -570,7 +570,11 @@ class JApplicationWeb extends JApplicationBase
 			}
 		}
 
+		// Set appropriate headers
 		$this->respond();
+
+		//  Close the application after the redirect.
+		$this->close();
 	}
 
 	/**

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -567,7 +567,6 @@ class JApplicationWeb extends JApplicationBase
 				// All other cases use the more efficient HTTP header for redirection.
 				$this->header($this->responseMap[$status]);
 				$this->header('Location: ' . $url);
-				$this->header('Content-Type: text/html; charset=' . $this->charSet);
 			}
 		}
 

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -359,6 +359,9 @@ class JControllerForm extends JControllerLegacy
 	 */
 	public function edit($key = null, $urlVar = null)
 	{
+		// Do not cache the response to this, its a redirect, and mod_expires and google chrome browser bugs cache it forever!
+		JFactory::getApplication()->allowCache(FALSE);
+
 		$model = $this->getModel();
 		$table = $model->getTable();
 		$cid   = $this->input->post->get('cid', array(), 'array');

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -360,7 +360,7 @@ class JControllerForm extends JControllerLegacy
 	public function edit($key = null, $urlVar = null)
 	{
 		// Do not cache the response to this, its a redirect, and mod_expires and google chrome browser bugs cache it forever!
-		JFactory::getApplication()->allowCache(FALSE);
+		JFactory::getApplication()->allowCache(false);
 
 		$model = $this->getModel();
 		$table = $model->getTable();

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -432,12 +432,24 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 303 See other', true, null),
-				array('Location: ' . $base . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 303 See other', true, null),
+			$this->class->headers[0]
+		);
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[6]
+		);
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[7]
 		);
 	}
 
@@ -481,12 +493,24 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 303 See other', true, null),
-				array('Location: ' . $base . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 303 See other', true, null),
+			$this->class->headers[0]
+		);
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[6]
+		);
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[7]
 		);
 	}
 
@@ -526,12 +550,24 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// The redirect gives a 303 error code
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 303 See other', true, null),
-				array('Location: ' . $base . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 303 See other', true, null),
+			$this->class->headers[0]
+		);
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[6]
+		);
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[7]
 		);
 	}
 
@@ -621,12 +657,24 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 301 Moved Permanently', true, null),
-				array('Location: ' . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 301 Moved Permanently', true, null),
+			$this->class->headers[0]
+		);
+		$this->assertEquals(
+			array('Location: ' . $url, true, null),
+			$this->class->headers[1]
+		);
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[6]
+		);
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[7]
 		);
 	}
 

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -435,21 +435,29 @@ class JApplicationCmsTest extends TestCaseDatabase
 			array('HTTP/1.1 303 See other', true, null),
 			$this->class->headers[0]
 		);
+
 		$this->assertEquals(
 			array('Location: ' . $base . $url, true, null),
 			$this->class->headers[1]
 		);
+
 		$this->assertEquals(
 			array('Content-Type: text/html; charset=utf-8', true, null),
 			$this->class->headers[2]
 		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
 		$this->assertEquals(
 			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-			$this->class->headers[6]
+			$this->class->headers[5]
 		);
+
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
-			$this->class->headers[7]
+			$this->class->headers[6]
 		);
 	}
 
@@ -496,21 +504,29 @@ class JApplicationCmsTest extends TestCaseDatabase
 			array('HTTP/1.1 303 See other', true, null),
 			$this->class->headers[0]
 		);
+
 		$this->assertEquals(
 			array('Location: ' . $base . $url, true, null),
 			$this->class->headers[1]
 		);
+
 		$this->assertEquals(
 			array('Content-Type: text/html; charset=utf-8', true, null),
 			$this->class->headers[2]
 		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
 		$this->assertEquals(
 			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-			$this->class->headers[6]
+			$this->class->headers[5]
 		);
+
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
-			$this->class->headers[7]
+			$this->class->headers[6]
 		);
 	}
 
@@ -553,21 +569,29 @@ class JApplicationCmsTest extends TestCaseDatabase
 			array('HTTP/1.1 303 See other', true, null),
 			$this->class->headers[0]
 		);
+
 		$this->assertEquals(
 			array('Location: ' . $base . $url, true, null),
 			$this->class->headers[1]
 		);
+
 		$this->assertEquals(
 			array('Content-Type: text/html; charset=utf-8', true, null),
 			$this->class->headers[2]
 		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
 		$this->assertEquals(
 			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-			$this->class->headers[6]
+			$this->class->headers[5]
 		);
+
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
-			$this->class->headers[7]
+			$this->class->headers[6]
 		);
 	}
 
@@ -660,21 +684,29 @@ class JApplicationCmsTest extends TestCaseDatabase
 			array('HTTP/1.1 301 Moved Permanently', true, null),
 			$this->class->headers[0]
 		);
+
 		$this->assertEquals(
-			array('Location: ' . $url, true, null),
+			array('Location: '  . $url, true, null),
 			$this->class->headers[1]
 		);
+
 		$this->assertEquals(
 			array('Content-Type: text/html; charset=utf-8', true, null),
 			$this->class->headers[2]
 		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
 		$this->assertEquals(
 			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-			$this->class->headers[6]
+			$this->class->headers[5]
 		);
+
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
-			$this->class->headers[7]
+			$this->class->headers[6]
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1086,12 +1086,32 @@ class JApplicationWebTest extends TestCase
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 303 See other', true, null),
-				array('Location: ' . $base . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 303 See other', true, null),
+			$this->class->headers[0]
+		);
+
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[5]
+		);
+
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[6]
 		);
 	}
 
@@ -1178,12 +1198,32 @@ class JApplicationWebTest extends TestCase
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
-			array(
-				array('HTTP/1.1 301 Moved Permanently', true, null),
-				array('Location: ' . $url, true, null),
-				array('Content-Type: text/html; charset=utf-8', true, null),
-			),
-			$this->class->headers
+			array('HTTP/1.1 301 Moved Permanently', true, null),
+			$this->class->headers[0]
+		);
+
+		$this->assertEquals(
+			array('Location: ' . $url, true, null),
+			$this->class->headers[1]
+		);
+
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[5]
+		);
+
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[6]
 		);
 	}
 


### PR DESCRIPTION
## THE ULTIMATE FIX !!!!!

Closes #8731 Dec 18, 2015
Closes #8757 Dec 21, 2015
Closes #9013 Jan 28, 2016
Closes #9145 Feb 17, 2016
Closes #9615 Mar 26, 2016
Closes #10753 Jun 7, 2016
and many many more...

### To replicate the root issue with minimal configuration

**To replicate the issue - with 100% reliability:** 

1. Install LAMP & Joomla 
2. Enable expires module in apache
3. Add to .htaccess
```
ExpiresActive On
ExpiresDefault "access plus 30 days"
```
4. Attempt to edit a content item BY **CLICKING ON THE TITLE** of the content item in admin (and NOT using the checkboxes!)

5. Do this twice, note on the second attempt you get

> "You are not permitted to use that link to directly access that page (#n)."

6. Note that on subsequent clicks the error goes away but it is still impossible to get to the edit page by clicking on the title of the content

7. Note that if you open Google Dev Tools Panel, Network Tab, and enable Disable Cache that the problem "disappears" and while disable cache is enabled, you can edit the item by clicking its article title.

### The root cause of the problem 

The root cause of the problem is that with the Expires Module enabled in apache, responses from Joomla, which are redirects, are not outputting the correct headers, which allows browsers to cache the redirects. On subsequent visits the browser "skips" evn asking Joomla for a response, and simply "skips" over the request and opens the redirect destination url. Unfortunately the "skipped" url checks out the item for the user and is a prerequisite to the edit form being able to load - as this is "skipped" there is no check out record in the session and so a not authorised message is displayed instead.

### The solution this PR makes 

The final solution to resolve this issue is two fold:

1) Ensure that any "edit" controller action is not cached by the use of `JFactory::getApplication()->allowCache(FALSE);`
2) Instead of closing the connection at the edit fo the redirect method, correctly run the `->respond()` method which correctly checks if the response is cacheable and if not, sets appropriate headers

### NOTE TO TESTERS 

**IF YOU ALREADY HAVE CACHED URLS IN YOUR BROWSER, (or hitting a known Google Chrome bug https://bugs.chromium.org/p/chromium/issues/detail?id=91740) THEN THIS NEW CODE IS NOT EVEN RUN - DO NOT REPORT THIS PR IS NOT WORKING FOR YOU, BECAUSE IT DOES WORK IF THE CODE IS "RUN". Simply clearing your browser cache IS NOT ENOUGH sometimes, REDIRECTS ARE STILL CACHED!**  

**YOU CANNOT test this on a server you dont have full access to** - like Site Ground demo, people (like @durian808) will not be entertained in this PR comments should they attempt to rail road the comments again. Personal attacks will not be tolerated either. 

**It you do not have FULL CONTROL over your apache server, .htaccess, and a FULL UNDERSTANDING of the above issues, please DO NOT ATTEMPT to test this PR.** 

## Hattips, Thanks, And Patience and pinging others ...

@ggppdk @mbabker @lyquix-owner @gwsdesk @brianteeman @durian808 @karendunne @OzzieBob @MATsxm @andrepereiradasilva @lukasz-pawlowski @revers28  @level420  and many many others. 