### PR TITLE
Normalize finder tables across 3 db systems and add default values

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-10.sql
@@ -1,0 +1,55 @@
+-- Normalize finder tables default values.
+-- finder_filters table
+ALTER TABLE `#__finder_filters` MODIFY `title` varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_filters` MODIFY `alias` varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_filters` MODIFY `created_by` int(10) unsigned NOT NULL DEFAULT 0;
+ALTER TABLE `#__finder_filters` MODIFY `created_by_alias` varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_filters` MODIFY `data` text NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_filters` MODIFY `params` mediumtext NOT NULL DEFAULT '';
+-- finder_links table
+ALTER TABLE `#__finder_links` MODIFY `url` varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_links` MODIFY `route` varchar(255) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_links` MODIFY `state` int(5) NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links` MODIFY `access` int(5) NOT NULL DEFAULT 0;
+ALTER TABLE `#__finder_links` MODIFY `language` varchar(8) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_links` MODIFY `type_id` int(11) NOT NULL DEFAULT 0;
+ALTER TABLE `#__finder_links` MODIFY `object` mediumblob NOT NULL DEFAULT '';
+-- finder_links_termsx tables
+ALTER TABLE `#__finder_links_terms0` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms1` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms2` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms3` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms4` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms5` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms6` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms7` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms8` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_terms9` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termsa` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termsb` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termsc` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termsd` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termse` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_links_termsf` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+-- finder_terms table
+ALTER TABLE `#__finder_terms` MODIFY `term` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_terms` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_terms` MODIFY `soundex` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_terms` MODIFY `weight` float unsigned NOT NULL DEFAULT 1;
+-- finder_terms table_common
+ALTER TABLE `#__finder_terms` MODIFY `term` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_terms` MODIFY `language` varchar(3) NOT NULL DEFAULT '';
+-- finder_tokens table
+ALTER TABLE `#__finder_tokens` MODIFY `term` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_tokens` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
+-- finder_tokens_aggregate table
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `term_id` int(10) unsigned NOT NULL DEFAULT 0;
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `map_suffix` char(1) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `term` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `stem` varchar(75) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `term_weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `context_weight` float unsigned NOT NULL DEFAULT 1;
+ALTER TABLE `#__finder_tokens_aggregate` MODIFY `total_weight` float unsigned NOT NULL DEFAULT 1;
+-- finder_types table
+ALTER TABLE `#__finder_types` MODIFY `title` varchar(100) NOT NULL DEFAULT '';
+ALTER TABLE `#__finder_types` MODIFY `mime` varchar(100) NOT NULL DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-10.sql
@@ -1,0 +1,56 @@
+-- Normalize finder tables default values.
+-- finder_filters table
+ALTER TABLE "#__finder_filters" ALTER COLUMN "title" SET DEFAULT '';
+ALTER TABLE "#__finder_filters" ALTER COLUMN "alias" SET DEFAULT '';
+ALTER TABLE "#__finder_filters" ALTER COLUMN "created_by" SET DEFAULT 0;
+ALTER TABLE "#__finder_filters" ALTER COLUMN "created_by_alias" SET DEFAULT '';
+ALTER TABLE "#__finder_filters" ALTER COLUMN "data" SET DEFAULT '';
+ALTER TABLE "#__finder_filters" ALTER COLUMN "params" SET DEFAULT '';
+ALTER TABLE "#__finder_filters" ALTER COLUMN "params" SET NOT NULL;
+-- finder_links table
+ALTER TABLE "#__finder_links" ALTER COLUMN "url" SET DEFAULT '';
+ALTER TABLE "#__finder_links" ALTER COLUMN "route" SET DEFAULT '';
+ALTER TABLE "#__finder_links" ALTER COLUMN "state" SET NOT NULL;
+ALTER TABLE "#__finder_links" ALTER COLUMN "access" SET NOT NULL;
+ALTER TABLE "#__finder_links" ALTER COLUMN "type_id" SET DEFAULT 0;
+ALTER TABLE "#__finder_links" ALTER COLUMN "object" SET DEFAULT '';
+-- finder_links_termsx tables
+ALTER TABLE "#__finder_links_terms0" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms1" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms2" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms3" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms4" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms5" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms6" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms7" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms8" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_terms9" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termsa" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termsb" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termsc" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termsd" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termse" ALTER COLUMN "weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_links_termsf" ALTER COLUMN "weight" SET DEFAULT 1;
+-- finder_terms table
+ALTER TABLE "#__finder_terms" ALTER COLUMN "term" SET DEFAULT '';
+ALTER TABLE "#__finder_terms" ALTER COLUMN "stem" SET DEFAULT '';
+ALTER TABLE "#__finder_terms" ALTER COLUMN "soundex" SET DEFAULT '';
+ALTER TABLE "#__finder_terms" ALTER COLUMN "language" SET DEFAULT '';
+ALTER TABLE "#__finder_terms" ALTER COLUMN "weight" SET DEFAULT 1;
+-- finder_terms_common table
+ALTER TABLE "#__finder_terms_common" ALTER COLUMN "term" SET DEFAULT '';
+-- finder_tokens table
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "term" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "stem" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" SET DEFAULT '';
+-- finder_tokens_aggregate table
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "map_suffix" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "stem" SET DEFAULT '';
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term_weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "context_weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "total_weight" SET DEFAULT 1;
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "language" SET DEFAULT '';
+-- finder_types table
+ALTER TABLE "#__finder_types" ALTER COLUMN "title" SET DEFAULT '';
+ALTER TABLE "#__finder_types" ALTER COLUMN "mime" SET DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-10.sql
@@ -44,6 +44,7 @@ ALTER TABLE "#__finder_tokens" ALTER COLUMN "term" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens" ALTER COLUMN "stem" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens" ALTER COLUMN "language" SET DEFAULT '';
 -- finder_tokens_aggregate table
+ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term_id" SET DEFAULT 0;
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "map_suffix" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "term" SET DEFAULT '';
 ALTER TABLE "#__finder_tokens_aggregate" ALTER COLUMN "stem" SET DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-10.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-10.sql
@@ -47,6 +47,7 @@ ALTER TABLE [#__finder_tokens] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAU
 ALTER TABLE [#__finder_tokens] ALTER COLUMN [stem] [nvarchar](75) NOT NULL DEFAULT '';
 ALTER TABLE [#__finder_tokens] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
 -- finder_tokens_aggregate table
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [term_id] [bigint] NOT NULL DEFAULT 0;
 ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [map_suffix] [nchar](1) NOT NULL DEFAULT '';
 ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAULT '';
 ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [stem] [nvarchar](75) NOT NULL DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-10.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-10.sql
@@ -1,0 +1,58 @@
+-- Normalize finder tables default values.
+-- finder_filters table
+ALTER TABLE [#__finder_filters] ALTER COLUMN [title] [nvarchar](255) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [alias] [nvarchar](255) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [created_by] [bigint] NOT NULL DEFAULT 0;
+ALTER TABLE [#__finder_filters] ALTER COLUMN [created_by_alias] [nvarchar](255) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [data] [nvarchar](max) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [params] [nvarchar](max) NOT NULL DEFAULT '';
+-- finder_links table
+ALTER TABLE [#__finder_links] ALTER COLUMN [url] [nvarchar](255) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_links] ALTER COLUMN [route] [nvarchar](255) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_links] ALTER COLUMN [title] [nvarchar](255) DEFAULT NUL;
+ALTER TABLE [#__finder_links] ALTER COLUMN [description] [nvarchar](max) DEFAULT NULL;
+ALTER TABLE [#__finder_links] ALTER COLUMN [md5sum] [nvarchar](32) DEFAULT NULL;
+ALTER TABLE [#__finder_links] ALTER COLUMN [language] [nvarchar](8) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_links] ALTER COLUMN [type_id] [int] NOT NULL DEFAULT 0;
+ALTER TABLE [#__finder_links] ALTER COLUMN [object] [nvarchar](max) NOT NULL DEFAULT '';
+-- finder_links_termsx tables
+ALTER TABLE [#__finder_links_terms0] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms1] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms2] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms3] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms4] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms5] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms6] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms7] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms8] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_terms9] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termsa] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termsb] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termsc] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termsd] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termse] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_links_termsf] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+-- finder_taxonomy table
+ALTER TABLE [#__finder_taxonomy] ALTER COLUMN [title] [nvarchar](255) NOT NULL DEFAULT '';
+-- finder_terms table
+ALTER TABLE [#__finder_terms] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_terms] ALTER COLUMN [stem] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_terms] ALTER COLUMN [soundex] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_terms] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+-- finder_terms_common table
+ALTER TABLE [#__finder_terms_common] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_terms_common] ALTER COLUMN [language] [nvarchar](3) NOT NULL DEFAULT '';
+-- finder_tokens table
+ALTER TABLE [#__finder_tokens] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_tokens] ALTER COLUMN [stem] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_tokens] ALTER COLUMN [weight] [real] NOT NULL DEFAULT 1;
+-- finder_tokens_aggregate table
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [map_suffix] [nchar](1) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [term] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [stem] [nvarchar](75) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [term_weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [context_weight] [real] NOT NULL DEFAULT 1;
+ALTER TABLE [#__finder_tokens_aggregate] ALTER COLUMN [total_weight] [real] NOT NULL DEFAULT 1;
+-- finder_types table
+ALTER TABLE [#__finder_types] ALTER COLUMN [title] [nvarchar](100) NOT NULL DEFAULT '';
+ALTER TABLE [#__finder_types] ALTER COLUMN [mime] [nvarchar](100) NOT NULL DEFAULT '';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -747,7 +747,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_filters` (
   `alias` varchar(255) NOT NULL DEFAULT '',
   `state` tinyint(1) NOT NULL DEFAULT 1,
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `created_by` int(10) unsigned NOT NULL DEFAULT '',
+  `created_by` int(10) unsigned NOT NULL DEFAULT 0,
   `created_by_alias` varchar(255) NOT NULL DEFAULT '',
   `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modified_by` int(10) unsigned NOT NULL DEFAULT 0,
@@ -755,7 +755,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_filters` (
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `map_count` int(10) unsigned NOT NULL DEFAULT 0,
   `data` text NOT NULL DEFAULT '',
-  `params` mediumtext DEFAULT '',
+  `params` mediumtext NOT NULL DEFAULT '',
   PRIMARY KEY (`filter_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -803,7 +803,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms0` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -818,7 +818,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms0` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms1` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -833,7 +833,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms1` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms2` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -848,7 +848,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms2` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms3` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -863,7 +863,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms3` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms4` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -878,7 +878,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms4` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms5` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -893,7 +893,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms5` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms6` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -908,7 +908,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms6` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms7` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -923,7 +923,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms7` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms8` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -938,7 +938,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms8` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms9` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -953,7 +953,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms9` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsa` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -968,7 +968,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsa` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsb` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -983,7 +983,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsb` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsc` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -998,7 +998,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsc` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsd` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1013,7 +1013,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsd` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termse` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1028,7 +1028,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termse` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsf` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1088,7 +1088,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
   `stem` varchar(75) NOT NULL DEFAULT '',
   `common` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `phrase` tinyint(1) unsigned NOT NULL DEFAULT 0,
-  `weight` float unsigned NOT NULL DEFAULT 0,
+  `weight` float unsigned NOT NULL DEFAULT 1,
   `soundex` varchar(75) NOT NULL DEFAULT '',
   `links` int(10) NOT NULL DEFAULT 0,
   `language` char(3) NOT NULL DEFAULT '',
@@ -1106,8 +1106,8 @@ CREATE TABLE IF NOT EXISTS `#__finder_terms` (
 --
 
 CREATE TABLE IF NOT EXISTS `#__finder_terms_common` (
-  `term` varchar(75) NOT NULL,
-  `language` varchar(3) NOT NULL,
+  `term` varchar(75) NOT NULL DEFAULT '',
+  `language` varchar(3) NOT NULL DEFAULT '',
   KEY `idx_word_lang` (`term`,`language`),
   KEY `idx_lang` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -743,19 +743,19 @@ CREATE TABLE IF NOT EXISTS `#__fields_values` (
 
 CREATE TABLE IF NOT EXISTS `#__finder_filters` (
   `filter_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(255) NOT NULL,
-  `alias` varchar(255) NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
+  `alias` varchar(255) NOT NULL DEFAULT '',
   `state` tinyint(1) NOT NULL DEFAULT 1,
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `created_by` int(10) unsigned NOT NULL,
-  `created_by_alias` varchar(255) NOT NULL,
+  `created_by` int(10) unsigned NOT NULL DEFAULT '',
+  `created_by_alias` varchar(255) NOT NULL DEFAULT '',
   `modified` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modified_by` int(10) unsigned NOT NULL DEFAULT 0,
   `checked_out` int(10) unsigned NOT NULL DEFAULT 0,
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `map_count` int(10) unsigned NOT NULL DEFAULT 0,
-  `data` text NOT NULL,
-  `params` mediumtext,
+  `data` text NOT NULL DEFAULT '',
+  `params` mediumtext DEFAULT '',
   PRIMARY KEY (`filter_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;
 
@@ -767,24 +767,24 @@ CREATE TABLE IF NOT EXISTS `#__finder_filters` (
 
 CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `link_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `url` varchar(255) NOT NULL,
-  `route` varchar(255) NOT NULL,
+  `url` varchar(255) NOT NULL DEFAULT '',
+  `route` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(400) DEFAULT NULL,
   `description` varchar(255) DEFAULT NULL,
   `indexdate` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `md5sum` varchar(32) DEFAULT NULL,
   `published` tinyint(1) NOT NULL DEFAULT 1,
-  `state` int(5) DEFAULT 1,
-  `access` int(5) DEFAULT 0,
-  `language` varchar(8) NOT NULL,
+  `state` int(5) NOT NULL DEFAULT 1,
+  `access` int(5) NOT NULL DEFAULT 0,
+  `language` varchar(8) NOT NULL DEFAULT '',
   `publish_start_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `publish_end_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `start_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `end_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `list_price` double unsigned NOT NULL DEFAULT 0,
   `sale_price` double unsigned NOT NULL DEFAULT 0,
-  `type_id` int(11) NOT NULL,
-  `object` mediumblob NOT NULL,
+  `type_id` int(11) NOT NULL DEFAULT 0,
+  `object` mediumblob NOT NULL DEFAULT '',
   PRIMARY KEY (`link_id`),
   KEY `idx_type` (`type_id`),
   KEY `idx_title` (`title`(100)),
@@ -803,7 +803,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms0` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -818,7 +818,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms0` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms1` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -833,7 +833,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms1` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms2` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -848,7 +848,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms2` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms3` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -863,7 +863,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms3` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms4` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -878,7 +878,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms4` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms5` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -893,7 +893,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms5` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms6` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -908,7 +908,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms6` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms7` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -923,7 +923,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms7` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms8` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -938,7 +938,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms8` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_terms9` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -953,7 +953,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_terms9` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsa` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -968,7 +968,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsa` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsb` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -983,7 +983,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsb` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsc` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -998,7 +998,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsc` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsd` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1013,7 +1013,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsd` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termse` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1028,7 +1028,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termse` (
 CREATE TABLE IF NOT EXISTS `#__finder_links_termsf` (
   `link_id` int(10) unsigned NOT NULL,
   `term_id` int(10) unsigned NOT NULL,
-  `weight` float unsigned NOT NULL,
+  `weight` float unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`link_id`,`term_id`),
   KEY `idx_term_weight` (`term_id`,`weight`),
   KEY `idx_link_term_weight` (`link_id`,`term_id`,`weight`)
@@ -1043,7 +1043,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links_termsf` (
 CREATE TABLE IF NOT EXISTS `#__finder_taxonomy` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `parent_id` int(10) unsigned NOT NULL DEFAULT 0,
-  `title` varchar(255) NOT NULL,
+  `title` varchar(255) NOT NULL DEFAULT '',
   `state` tinyint(1) unsigned NOT NULL DEFAULT 1,
   `access` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `ordering` tinyint(1) unsigned NOT NULL DEFAULT 0,
@@ -1084,12 +1084,12 @@ CREATE TABLE IF NOT EXISTS `#__finder_taxonomy_map` (
 
 CREATE TABLE IF NOT EXISTS `#__finder_terms` (
   `term_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `term` varchar(75) NOT NULL,
-  `stem` varchar(75) NOT NULL,
+  `term` varchar(75) NOT NULL DEFAULT '',
+  `stem` varchar(75) NOT NULL DEFAULT '',
   `common` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `phrase` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `weight` float unsigned NOT NULL DEFAULT 0,
-  `soundex` varchar(75) NOT NULL,
+  `soundex` varchar(75) NOT NULL DEFAULT '',
   `links` int(10) NOT NULL DEFAULT 0,
   `language` char(3) NOT NULL DEFAULT '',
   PRIMARY KEY (`term_id`),
@@ -1240,8 +1240,8 @@ INSERT INTO `#__finder_terms_common` (`term`, `language`) VALUES
 --
 
 CREATE TABLE IF NOT EXISTS `#__finder_tokens` (
-  `term` varchar(75) NOT NULL,
-  `stem` varchar(75) NOT NULL,
+  `term` varchar(75) NOT NULL DEFAULT '',
+  `stem` varchar(75) NOT NULL DEFAULT '',
   `common` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `phrase` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `weight` float unsigned NOT NULL DEFAULT 1,
@@ -1258,16 +1258,16 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens` (
 --
 
 CREATE TABLE IF NOT EXISTS `#__finder_tokens_aggregate` (
-  `term_id` int(10) unsigned NOT NULL,
-  `map_suffix` char(1) NOT NULL,
-  `term` varchar(75) NOT NULL,
-  `stem` varchar(75) NOT NULL,
+  `term_id` int(10) unsigned NOT NULL DEFAULT 0,
+  `map_suffix` char(1) NOT NULL DEFAULT '',
+  `term` varchar(75) NOT NULL DEFAULT '',
+  `stem` varchar(75) NOT NULL DEFAULT '',
   `common` tinyint(1) unsigned NOT NULL DEFAULT 0,
   `phrase` tinyint(1) unsigned NOT NULL DEFAULT 0,
-  `term_weight` float unsigned NOT NULL,
+  `term_weight` float unsigned NOT NULL DEFAULT 0,
   `context` tinyint(1) unsigned NOT NULL DEFAULT 2,
-  `context_weight` float unsigned NOT NULL,
-  `total_weight` float unsigned NOT NULL,
+  `context_weight` float unsigned NOT NULL DEFAULT 0,
+  `total_weight` float unsigned NOT NULL DEFAULT 0,
   `language` char(3) NOT NULL DEFAULT '',
   KEY `token` (`term`),
   KEY `keyword_id` (`term_id`)
@@ -1281,8 +1281,8 @@ CREATE TABLE IF NOT EXISTS `#__finder_tokens_aggregate` (
 
 CREATE TABLE IF NOT EXISTS `#__finder_types` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `title` varchar(100) NOT NULL,
-  `mime` varchar(100) NOT NULL,
+  `title` varchar(100) NOT NULL DEFAULT '',
+  `mime` varchar(100) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `title` (`title`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_general_ci;

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -799,7 +799,7 @@ CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("publish
 CREATE TABLE "#__finder_links_terms0" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms0_idx_term_weight" on "#__finder_links_terms0" ("term_id", "weight");
@@ -811,7 +811,7 @@ CREATE INDEX "#__finder_links_terms0_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms1" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms1_idx_term_weight" on "#__finder_links_terms1" ("term_id", "weight");
@@ -823,7 +823,7 @@ CREATE INDEX "#__finder_links_terms1_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms2" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms2_idx_term_weight" on "#__finder_links_terms2" ("term_id", "weight");
@@ -835,7 +835,7 @@ CREATE INDEX "#__finder_links_terms2_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms3" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms3_idx_term_weight" on "#__finder_links_terms3" ("term_id", "weight");
@@ -847,7 +847,7 @@ CREATE INDEX "#__finder_links_terms3_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms4" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms4_idx_term_weight" on "#__finder_links_terms4" ("term_id", "weight");
@@ -859,7 +859,7 @@ CREATE INDEX "#__finder_links_terms4_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms5" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms5_idx_term_weight" on "#__finder_links_terms5" ("term_id", "weight");
@@ -871,7 +871,7 @@ CREATE INDEX "#__finder_links_terms5_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms6" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms6_idx_term_weight" on "#__finder_links_terms6" ("term_id", "weight");
@@ -883,7 +883,7 @@ CREATE INDEX "#__finder_links_terms6_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms7" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms7_idx_term_weight" on "#__finder_links_terms7" ("term_id", "weight");
@@ -895,7 +895,7 @@ CREATE INDEX "#__finder_links_terms7_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms8" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms8_idx_term_weight" on "#__finder_links_terms8" ("term_id", "weight");
@@ -907,7 +907,7 @@ CREATE INDEX "#__finder_links_terms8_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms9" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms9_idx_term_weight" on "#__finder_links_terms9" ("term_id", "weight");
@@ -919,7 +919,7 @@ CREATE INDEX "#__finder_links_terms9_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsa" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsa_idx_term_weight" on "#__finder_links_termsa" ("term_id", "weight");
@@ -931,7 +931,7 @@ CREATE INDEX "#__finder_links_termsa_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsb" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsb_idx_term_weight" on "#__finder_links_termsb" ("term_id", "weight");
@@ -943,7 +943,7 @@ CREATE INDEX "#__finder_links_termsb_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsc" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsc_idx_term_weight" on "#__finder_links_termsc" ("term_id", "weight");
@@ -955,7 +955,7 @@ CREATE INDEX "#__finder_links_termsc_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsd" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsd_idx_term_weight" on "#__finder_links_termsd" ("term_id", "weight");
@@ -967,7 +967,7 @@ CREATE INDEX "#__finder_links_termsd_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termse" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termse_idx_term_weight" on "#__finder_links_termse" ("term_id", "weight");
@@ -979,7 +979,7 @@ CREATE INDEX "#__finder_links_termse_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsf" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsf_idx_term_weight" on "#__finder_links_termsf" ("term_id", "weight");
@@ -1031,7 +1031,7 @@ CREATE TABLE "#__finder_terms" (
   "stem" varchar(75) DEFAULT '' NOT NULL,
   "common" smallint DEFAULT 0 NOT NULL,
   "phrase" smallint DEFAULT 0 NOT NULL,
-  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   "soundex" varchar(75) DEFAULT '' NOT NULL,
   "links" integer DEFAULT 0 NOT NULL,
   "language" varchar(3) DEFAULT '' NOT NULL,
@@ -1198,10 +1198,10 @@ CREATE TABLE "#__finder_tokens_aggregate" (
   "stem" varchar(75) DEFAULT '' NOT NULL,
   "common" smallint DEFAULT 0 NOT NULL,
   "phrase" smallint DEFAULT 0 NOT NULL,
-  "term_weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "term_weight" numeric(8,2) DEFAULT 1 NOT NULL,
   "context" smallint DEFAULT 2 NOT NULL,
-  "context_weight" numeric(8,2) DEFAULT 0 NOT NULL,
-  "total_weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "context_weight" numeric(8,2) DEFAULT 1 NOT NULL,
+  "total_weight" numeric(8,2) DEFAULT 1 NOT NULL,
   "language" varchar(3) DEFAULT '' NOT NULL
 );
 CREATE INDEX "#__finder_tokens_aggregate_token" on "#__finder_tokens_aggregate" ("term");

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1192,7 +1192,7 @@ CREATE INDEX "#__finder_tokens_idx_context" on "#__finder_tokens" ("context");
 -- Table: #__finder_tokens_aggregate
 --
 CREATE TABLE "#__finder_tokens_aggregate" (
-  "term_id" integer NOT NULL,
+  "term_id" integer  DEFAULT 0 NOT NULL,
   "map_suffix" varchar(1) DEFAULT '' NOT NULL,
   "term" varchar(75) DEFAULT '' NOT NULL,
   "stem" varchar(75) DEFAULT '' NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -745,19 +745,19 @@ CREATE INDEX "#__fields_values_idx_item_id" ON "#__fields_values" ("item_id");
 --
 CREATE TABLE "#__finder_filters" (
   "filter_id" serial NOT NULL,
-  "title" varchar(255) NOT NULL,
-  "alias" varchar(255) NOT NULL,
+  "title" varchar(255) DEFAULT '' NOT NULL,
+  "alias" varchar(255) DEFAULT '' NOT NULL,
   "state" smallint DEFAULT 1 NOT NULL,
   "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
-  "created_by" integer NOT NULL,
-  "created_by_alias" varchar(255) NOT NULL,
+  "created_by" integer DEFAULT 0 NOT NULL,
+  "created_by_alias" varchar(255) DEFAULT '' NOT NULL,
   "modified" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "modified_by" integer DEFAULT 0 NOT NULL,
   "checked_out" integer DEFAULT 0 NOT NULL,
   "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "map_count" integer DEFAULT 0 NOT NULL,
-  "data" text NOT NULL,
-  "params" text,
+  "data" text DEFAULT '' NOT NULL,
+  "params" text DEFAULT '' NOT NULL,
   PRIMARY KEY ("filter_id")
 );
 
@@ -766,15 +766,15 @@ CREATE TABLE "#__finder_filters" (
 --
 CREATE TABLE "#__finder_links" (
   "link_id" serial NOT NULL,
-  "url" varchar(255) NOT NULL,
-  "route" varchar(255) NOT NULL,
+  "url" varchar(255) DEFAULT '' NOT NULL,
+  "route" varchar(255) DEFAULT '' NOT NULL,
   "title" varchar(255) DEFAULT NULL,
   "description" varchar(255) DEFAULT NULL,
   "indexdate" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "md5sum" varchar(32) DEFAULT NULL,
   "published" smallint DEFAULT 1 NOT NULL,
-  "state" integer DEFAULT 1,
-  "access" integer DEFAULT 0,
+  "state" integer DEFAULT 1 NOT NULL,
+  "access" integer DEFAULT 0 NOT NULL,
   "language" varchar(8) DEFAULT '' NOT NULL,
   "publish_start_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "publish_end_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
@@ -782,8 +782,8 @@ CREATE TABLE "#__finder_links" (
   "end_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "list_price" numeric(8,2) DEFAULT 0 NOT NULL,
   "sale_price" numeric(8,2) DEFAULT 0 NOT NULL,
-  "type_id" bigint NOT NULL,
-  "object" bytea NOT NULL,
+  "type_id" bigint DEFAULT 0 NOT NULL,
+  "object" bytea DEFAULT '' NOT NULL,
   PRIMARY KEY ("link_id")
 );
 CREATE INDEX "#__finder_links_idx_type" on "#__finder_links" ("type_id");
@@ -799,7 +799,7 @@ CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("publish
 CREATE TABLE "#__finder_links_terms0" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms0_idx_term_weight" on "#__finder_links_terms0" ("term_id", "weight");
@@ -811,7 +811,7 @@ CREATE INDEX "#__finder_links_terms0_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms1" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms1_idx_term_weight" on "#__finder_links_terms1" ("term_id", "weight");
@@ -823,7 +823,7 @@ CREATE INDEX "#__finder_links_terms1_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms2" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms2_idx_term_weight" on "#__finder_links_terms2" ("term_id", "weight");
@@ -835,7 +835,7 @@ CREATE INDEX "#__finder_links_terms2_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms3" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms3_idx_term_weight" on "#__finder_links_terms3" ("term_id", "weight");
@@ -847,7 +847,7 @@ CREATE INDEX "#__finder_links_terms3_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms4" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms4_idx_term_weight" on "#__finder_links_terms4" ("term_id", "weight");
@@ -859,7 +859,7 @@ CREATE INDEX "#__finder_links_terms4_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms5" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms5_idx_term_weight" on "#__finder_links_terms5" ("term_id", "weight");
@@ -871,7 +871,7 @@ CREATE INDEX "#__finder_links_terms5_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms6" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms6_idx_term_weight" on "#__finder_links_terms6" ("term_id", "weight");
@@ -883,7 +883,7 @@ CREATE INDEX "#__finder_links_terms6_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms7" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms7_idx_term_weight" on "#__finder_links_terms7" ("term_id", "weight");
@@ -895,7 +895,7 @@ CREATE INDEX "#__finder_links_terms7_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms8" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms8_idx_term_weight" on "#__finder_links_terms8" ("term_id", "weight");
@@ -907,7 +907,7 @@ CREATE INDEX "#__finder_links_terms8_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_terms9" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_terms9_idx_term_weight" on "#__finder_links_terms9" ("term_id", "weight");
@@ -919,7 +919,7 @@ CREATE INDEX "#__finder_links_terms9_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsa" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsa_idx_term_weight" on "#__finder_links_termsa" ("term_id", "weight");
@@ -931,7 +931,7 @@ CREATE INDEX "#__finder_links_termsa_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsb" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsb_idx_term_weight" on "#__finder_links_termsb" ("term_id", "weight");
@@ -943,7 +943,7 @@ CREATE INDEX "#__finder_links_termsb_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsc" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsc_idx_term_weight" on "#__finder_links_termsc" ("term_id", "weight");
@@ -955,7 +955,7 @@ CREATE INDEX "#__finder_links_termsc_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsd" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsd_idx_term_weight" on "#__finder_links_termsd" ("term_id", "weight");
@@ -967,7 +967,7 @@ CREATE INDEX "#__finder_links_termsd_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termse" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termse_idx_term_weight" on "#__finder_links_termse" ("term_id", "weight");
@@ -979,7 +979,7 @@ CREATE INDEX "#__finder_links_termse_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_links_termsf" (
   "link_id" integer NOT NULL,
   "term_id" integer NOT NULL,
-  "weight" numeric(8,2) NOT NULL,
+  "weight" numeric(8,2) DEFAULT 0 NOT NULL,
   PRIMARY KEY ("link_id", "term_id")
 );
 CREATE INDEX "#__finder_links_termsf_idx_term_weight" on "#__finder_links_termsf" ("term_id", "weight");
@@ -991,7 +991,7 @@ CREATE INDEX "#__finder_links_termsf_idx_link_term_weight" on "#__finder_links_t
 CREATE TABLE "#__finder_taxonomy" (
   "id" serial NOT NULL,
   "parent_id" integer DEFAULT 0 NOT NULL,
-  "title" varchar(255) NOT NULL,
+  "title" varchar(255) DEFAULT '' NOT NULL,
   "state" smallint DEFAULT 1 NOT NULL,
   "access" smallint DEFAULT 0 NOT NULL,
   "ordering" smallint DEFAULT 0 NOT NULL,
@@ -1027,14 +1027,14 @@ CREATE INDEX "#__finder_taxonomy_map_node_id" on "#__finder_taxonomy_map" ("node
 --
 CREATE TABLE "#__finder_terms" (
   "term_id" serial NOT NULL,
-  "term" varchar(75) NOT NULL,
-  "stem" varchar(75) NOT NULL,
+  "term" varchar(75) DEFAULT '' NOT NULL,
+  "stem" varchar(75) DEFAULT '' NOT NULL,
   "common" smallint DEFAULT 0 NOT NULL,
   "phrase" smallint DEFAULT 0 NOT NULL,
   "weight" numeric(8,2) DEFAULT 0 NOT NULL,
-  "soundex" varchar(75) NOT NULL,
+  "soundex" varchar(75) DEFAULT '' NOT NULL,
   "links" integer DEFAULT 0 NOT NULL,
-  "language" varchar(3) NOT NULL,
+  "language" varchar(3) DEFAULT '' NOT NULL,
   PRIMARY KEY ("term_id"),
   CONSTRAINT "#__finder_terms_idx_term" UNIQUE ("term")
 );
@@ -1046,7 +1046,7 @@ CREATE INDEX "#__finder_terms_idx_soundex_phrase" on "#__finder_terms" ("soundex
 -- Table: #__finder_terms_common
 --
 CREATE TABLE "#__finder_terms_common" (
-  "term" varchar(75) NOT NULL,
+  "term" varchar(75) DEFAULT '' NOT NULL,
   "language" varchar(3) DEFAULT '' NOT NULL
 );
 CREATE INDEX "#__finder_terms_common_idx_word_lang" on "#__finder_terms_common" ("term", "language");
@@ -1177,13 +1177,13 @@ INSERT INTO "#__finder_terms_common" ("term", "language") VALUES
 -- Table: #__finder_tokens
 --
 CREATE TABLE "#__finder_tokens" (
-  "term" varchar(75) NOT NULL,
-  "stem" varchar(75) NOT NULL,
+  "term" varchar(75) DEFAULT '' NOT NULL,
+  "stem" varchar(75) DEFAULT '' NOT NULL,
   "common" smallint DEFAULT 0 NOT NULL,
   "phrase" smallint DEFAULT 0 NOT NULL,
   "weight" numeric(8,2) DEFAULT 1 NOT NULL,
   "context" smallint DEFAULT 2 NOT NULL,
-  "language" varchar(3) NOT NULL
+  "language" varchar(3) DEFAULT '' NOT NULL
 );
 CREATE INDEX "#__finder_tokens_idx_word" on "#__finder_tokens" ("term");
 CREATE INDEX "#__finder_tokens_idx_context" on "#__finder_tokens" ("context");
@@ -1193,16 +1193,16 @@ CREATE INDEX "#__finder_tokens_idx_context" on "#__finder_tokens" ("context");
 --
 CREATE TABLE "#__finder_tokens_aggregate" (
   "term_id" integer NOT NULL,
-  "map_suffix" varchar(1) NOT NULL,
-  "term" varchar(75) NOT NULL,
-  "stem" varchar(75) NOT NULL,
+  "map_suffix" varchar(1) DEFAULT '' NOT NULL,
+  "term" varchar(75) DEFAULT '' NOT NULL,
+  "stem" varchar(75) DEFAULT '' NOT NULL,
   "common" smallint DEFAULT 0 NOT NULL,
   "phrase" smallint DEFAULT 0 NOT NULL,
-  "term_weight" numeric(8,2) NOT NULL,
+  "term_weight" numeric(8,2) DEFAULT 0 NOT NULL,
   "context" smallint DEFAULT 2 NOT NULL,
-  "context_weight" numeric(8,2) NOT NULL,
-  "total_weight" numeric(8,2) NOT NULL,
-  "language" varchar(3) NOT NULL
+  "context_weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "total_weight" numeric(8,2) DEFAULT 0 NOT NULL,
+  "language" varchar(3) DEFAULT '' NOT NULL
 );
 CREATE INDEX "#__finder_tokens_aggregate_token" on "#__finder_tokens_aggregate" ("term");
 CREATE INDEX "_#__finder_tokens_aggregate_keyword_id" on "#__finder_tokens_aggregate" ("term_id");
@@ -1212,8 +1212,8 @@ CREATE INDEX "_#__finder_tokens_aggregate_keyword_id" on "#__finder_tokens_aggre
 --
 CREATE TABLE "#__finder_types" (
   "id" serial NOT NULL,
-  "title" varchar(100) NOT NULL,
-  "mime" varchar(100) NOT NULL,
+  "title" varchar(100) DEFAULT '' NOT NULL,
+  "mime" varchar(100) DEFAULT '' NOT NULL,
   PRIMARY KEY ("id"),
   CONSTRAINT "#__finder_types_title" UNIQUE ("title")
 );

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1201,19 +1201,19 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_filters](
 	[filter_id] [bigint] IDENTITY(1,1) NOT NULL,
-	[title] [nvarchar](255) NOT NULL,
-	[alias] [nvarchar](255) NOT NULL,
+	[title] [nvarchar](255) NOT NULL DEFAULT '',
+	[alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[state] [smallint] NOT NULL DEFAULT 1,
 	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[created_by] [bigint] NOT NULL,
-	[created_by_alias] [nvarchar](255) NOT NULL,
+	[created_by] [bigint] NOT NULL DEFAULT 0,
+	[created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
 	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[map_count] [bigint] NOT NULL DEFAULT 0,
-	[data] [nvarchar](max) NOT NULL,
-	[params] [nvarchar](max) NULL,
+	[data] [nvarchar](max) NOT NULL DEFAULT '',
+	[params] [nvarchar](max) NOT NULL DEFAULT '',
  CONSTRAINT [PK_#__finder_filters_filter_id] PRIMARY KEY CLUSTERED
 (
 	[filter_id] ASC
@@ -1226,24 +1226,24 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_links](
 	[link_id] [bigint] IDENTITY(1,1) NOT NULL,
-	[url] [nvarchar](255) NOT NULL,
-	[route] [nvarchar](255) NOT NULL,
-	[title] [nvarchar](255) NULL,
-	[description] [nvarchar](max) NULL,
+	[url] [nvarchar](255) NOT NULL DEFAULT '',
+	[route] [nvarchar](255) NOT NULL DEFAULT '',
+	[title] [nvarchar](255) DEFAULT NULL,
+	[description] [nvarchar](max) DEFAULT NULL,
 	[indexdate] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[md5sum] [nvarchar](32) NULL,
+	[md5sum] [nvarchar](32) DEFAULT NULL,
 	[published] [smallint] NOT NULL DEFAULT 1,
 	[state] [int] NULL DEFAULT 1,
 	[access] [int] NULL DEFAULT 0,
-	[language] [nvarchar](8) NOT NULL,
+	[language] [nvarchar](8) NOT NULL DEFAULT '',
 	[publish_start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[publish_end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
 	[list_price] [float] NOT NULL DEFAULT 0,
 	[sale_price] [float] NOT NULL DEFAULT 0,
-	[type_id] [int] NOT NULL,
-	[object] [nvarchar](max) NOT NULL,
+	[type_id] [int] NOT NULL DEFAULT 0,
+	[object] [nvarchar](max) NOT NULL DEFAULT '',
  CONSTRAINT [PK_#__finder_links_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC
@@ -1271,7 +1271,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms0](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms0_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1298,7 +1298,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms1](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms1_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1325,7 +1325,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms2](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms2_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1352,7 +1352,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms3](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms3_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1379,7 +1379,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms4](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms4_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1406,7 +1406,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms5](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms5_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1433,7 +1433,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms6](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms6_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1460,7 +1460,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms7](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms7_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1487,7 +1487,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms8](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms8_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1514,7 +1514,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms9](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_terms9_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1541,7 +1541,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsa](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termsa_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1568,7 +1568,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsb](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termsb_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1595,7 +1595,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsc](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termsc_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1622,7 +1622,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsd](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termsd_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1649,7 +1649,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termse](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termse_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1676,7 +1676,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsf](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL,
+	[weight] [real] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__finder_links_termsf_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1703,7 +1703,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_taxonomy](
 	[id] [bigint] IDENTITY(2,1) NOT NULL,
 	[parent_id] [bigint] NOT NULL DEFAULT 0,
-	[title] [nvarchar](255) NOT NULL,
+	[title] [nvarchar](255) NOT NULL DEFAULT '',
 	[state] [tinyint] NOT NULL DEFAULT 1,
 	[access] [tinyint] NOT NULL DEFAULT 0,
 	[ordering] [tinyint] NOT NULL DEFAULT 0,
@@ -1775,12 +1775,12 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_terms](
 	[term_id] [bigint] IDENTITY(1,1) NOT NULL,
-	[term] [nvarchar](75) NOT NULL,
-	[stem] [nvarchar](75) NOT NULL,
+	[term] [nvarchar](75) NOT NULL DEFAULT '',
+	[stem] [nvarchar](75) NOT NULL DEFAULT '',
 	[common] [tinyint] NOT NULL DEFAULT 0,
 	[phrase] [tinyint] NOT NULL DEFAULT 0,
 	[weight] [real] NOT NULL DEFAULT 0,
-	[soundex] [nvarchar](75) NOT NULL,
+	[soundex] [nvarchar](75) NOT NULL DEFAULT '',
 	[links] [int] NOT NULL DEFAULT 0,
 	[language] [nvarchar](3) NOT NULL DEFAULT ''
  CONSTRAINT [PK_#__finder_terms_term_id] PRIMARY KEY CLUSTERED
@@ -1815,8 +1815,8 @@ CREATE NONCLUSTERED INDEX [idx_term_phrase] ON [#__finder_terms]
 SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_terms_common](
-	[term] [nvarchar](75) NOT NULL,
-	[language] [nvarchar](3) NOT NULL,
+	[term] [nvarchar](75) NOT NULL DEFAULT '',
+	[language] [nvarchar](3) NOT NULL DEFAULT '',
  CONSTRAINT [PK_#__finder_terms_common] PRIMARY KEY CLUSTERED
 (
 	[term] ASC
@@ -2069,11 +2069,11 @@ SELECT 'yours', 'en';
 SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_tokens](
-	[term] [nvarchar](75) NOT NULL,
-	[stem] [nvarchar](75) NOT NULL,
+	[term] [nvarchar](75) NOT NULL DEFAULT '',
+	[stem] [nvarchar](75) NOT NULL DEFAULT '',
 	[common] [tinyint] NOT NULL DEFAULT 0,
 	[phrase] [tinyint] NOT NULL DEFAULT 0,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
 	[context] [tinyint] NOT NULL DEFAULT 2,
 	[language] [nvarchar](3) NOT NULL DEFAULT ''
 ) ON [PRIMARY];
@@ -2093,15 +2093,15 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_tokens_aggregate](
 	[term_id] [bigint] NOT NULL,
-	[map_suffix] [nchar](1) NULL,
-	[term] [nvarchar](75) NOT NULL,
-	[stem] [nvarchar](75) NOT NULL,
+	[map_suffix] [nchar](1) NOT NULL DEFAULT '',
+	[term] [nvarchar](75) NOT NULL DEFAULT '',
+	[stem] [nvarchar](75) NOT NULL DEFAULT '',
 	[common] [tinyint] NOT NULL DEFAULT 0,
 	[phrase] [tinyint] NOT NULL DEFAULT 0,
-	[term_weight] [real] NOT NULL,
+	[term_weight] [real] NOT NULL DEFAULT 0,
 	[context] [tinyint] NOT NULL DEFAULT 2,
-	[context_weight] [real] NOT NULL,
-	[total_weight] [real] NOT NULL,
+	[context_weight] [real] NOT NULL DEFAULT 0,
+	[total_weight] [real] NOT NULL DEFAULT 0,
 	[language] [nvarchar](3) NOT NULL DEFAULT ''
 ) ON [PRIMARY];
 

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1271,7 +1271,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms0](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms0_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1298,7 +1298,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms1](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms1_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1325,7 +1325,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms2](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms2_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1352,7 +1352,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms3](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms3_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1379,7 +1379,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms4](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms4_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1406,7 +1406,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms5](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms5_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1433,7 +1433,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms6](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms6_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1460,7 +1460,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms7](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms7_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1487,7 +1487,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms8](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms8_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1514,7 +1514,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_terms9](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_terms9_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1541,7 +1541,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsa](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termsa_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1568,7 +1568,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsb](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termsb_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1595,7 +1595,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsc](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termsc_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1622,7 +1622,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsd](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termsd_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1649,7 +1649,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termse](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termse_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1676,7 +1676,7 @@ SET QUOTED_IDENTIFIER ON;
 CREATE TABLE [#__finder_links_termsf](
 	[link_id] [bigint] NOT NULL,
 	[term_id] [bigint] NOT NULL,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__finder_links_termsf_link_id] PRIMARY KEY CLUSTERED
 (
 	[link_id] ASC,
@@ -1779,7 +1779,7 @@ CREATE TABLE [#__finder_terms](
 	[stem] [nvarchar](75) NOT NULL DEFAULT '',
 	[common] [tinyint] NOT NULL DEFAULT 0,
 	[phrase] [tinyint] NOT NULL DEFAULT 0,
-	[weight] [real] NOT NULL DEFAULT 0,
+	[weight] [real] NOT NULL DEFAULT 1,
 	[soundex] [nvarchar](75) NOT NULL DEFAULT '',
 	[links] [int] NOT NULL DEFAULT 0,
 	[language] [nvarchar](3) NOT NULL DEFAULT ''
@@ -2098,10 +2098,10 @@ CREATE TABLE [#__finder_tokens_aggregate](
 	[stem] [nvarchar](75) NOT NULL DEFAULT '',
 	[common] [tinyint] NOT NULL DEFAULT 0,
 	[phrase] [tinyint] NOT NULL DEFAULT 0,
-	[term_weight] [real] NOT NULL DEFAULT 0,
+	[term_weight] [real] NOT NULL DEFAULT 1,
 	[context] [tinyint] NOT NULL DEFAULT 2,
-	[context_weight] [real] NOT NULL DEFAULT 0,
-	[total_weight] [real] NOT NULL DEFAULT 0,
+	[context_weight] [real] NOT NULL DEFAULT 1,
+	[total_weight] [real] NOT NULL DEFAULT 1,
 	[language] [nvarchar](3) NOT NULL DEFAULT ''
 ) ON [PRIMARY];
 
@@ -2120,8 +2120,8 @@ SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_types](
 	[id] [bigint] IDENTITY(1,1) NOT NULL,
-	[title] [nvarchar](100) NOT NULL,
-	[mime] [nvarchar](100) NOT NULL,
+	[title] [nvarchar](100) NOT NULL DEFAULT '',
+	[mime] [nvarchar](100) NOT NULL DEFAULT '',
  CONSTRAINT [PK_#__finder_types_id] PRIMARY KEY CLUSTERED
 (
 	[id] ASC

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2092,7 +2092,7 @@ CREATE NONCLUSTERED INDEX [idx_word] ON [#__finder_tokens]
 SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__finder_tokens_aggregate](
-	[term_id] [bigint] NOT NULL,
+	[term_id] [bigint] NOT NULL  DEFAULT 0,
 	[map_suffix] [nchar](1) NOT NULL DEFAULT '',
 	[term] [nvarchar](75) NOT NULL DEFAULT '',
 	[stem] [nvarchar](75) NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13509 (part) and probably other issues relating finder tables in more strict db systems (which in joomla 4.0 mysql will be also).

### Summary of Changes

Normalize the `#__finder_*` table across db systems.
Only tested in mysql.
@waader please check mssql
@alikon please also check postgresql and mssql.

### Testing Instructions

1. SQL code review 
2. Test update: Apply patch, manually run the sql query for your Db system, confirm db table, confirm all fine
3. Test install: apply patch, delete configuration.php do a normal install, confirm db table, confirm all fine

### Documentation Changes Required

None.