### PR TITLE
JMenuSite::load() should try to work even if cache fails

### DIFF
--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -69,36 +69,59 @@ class JMenuSite extends JMenu
 		// For PHP 5.3 compat we can't use $this in the lambda function below
 		$db = $this->db;
 
+		$loader = function () use ($db)
+		{
+			$query = $db->getQuery(true)
+				->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
+				->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
+				->select('e.element as component')
+				->from('#__menu AS m')
+				->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
+				->where('m.published = 1')
+				->where('m.parent_id > 0')
+				->where('m.client_id = 0')
+				->order('m.lft');
+
+			// Set the query
+			$db->setQuery($query);
+
+			return $db->loadObjectList('id', 'JMenuItem');
+		};
+
 		try
 		{
 			/** @var JCacheControllerCallback $cache */
 			$cache = JFactory::getCache('com_menus', 'callback');
 
-			$this->_items = $cache->get(
-				function () use ($db)
-				{
-					$query = $db->getQuery(true)
-						->select('m.id, m.menutype, m.title, m.alias, m.note, m.path AS route, m.link, m.type, m.level, m.language')
-						->select($db->quoteName('m.browserNav') . ', m.access, m.params, m.home, m.img, m.template_style_id, m.component_id, m.parent_id')
-						->select('e.element as component')
-						->from('#__menu AS m')
-						->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
-						->where('m.published = 1')
-						->where('m.parent_id > 0')
-						->where('m.client_id = 0')
-						->order('m.lft');
-
-					// Set the query
-					$db->setQuery($query);
-
-					return $db->loadObjectList('id', 'JMenuItem');
-				},
-				array(),
-				md5(get_class($this)),
-				false
-			);
+			$this->_items = $cache->get($loader, array(), md5(get_class($this)), false);
 		}
-		catch (RuntimeException $e)
+		catch (JCacheExceptionConnecting $e)
+		{
+			try
+			{
+				$this->_items = $loader();
+			}
+			catch (JDatabaseExceptionExecuting $databaseException)
+			{
+				JError::raiseWarning(500, JText::sprintf('JERROR_LOADING_MENUS', $databaseException->getMessage()));
+
+				return false;
+			}
+		}
+		catch (JCacheExceptionUnsupported $e)
+		{
+			try
+			{
+				$this->_items = $loader();
+			}
+			catch (JDatabaseExceptionExecuting $databaseException)
+			{
+				JError::raiseWarning(500, JText::sprintf('JERROR_LOADING_MENUS', $databaseException->getMessage()));
+
+				return false;
+			}
+		}
+		catch (JDatabaseExceptionExecuting $e)
 		{
 			JError::raiseWarning(500, JText::sprintf('JERROR_LOADING_MENUS', $e->getMessage()));
 

--- a/libraries/cms/menu/site.php
+++ b/libraries/cms/menu/site.php
@@ -95,20 +95,7 @@ class JMenuSite extends JMenu
 
 			$this->_items = $cache->get($loader, array(), md5(get_class($this)), false);
 		}
-		catch (JCacheExceptionConnecting $e)
-		{
-			try
-			{
-				$this->_items = $loader();
-			}
-			catch (JDatabaseExceptionExecuting $databaseException)
-			{
-				JError::raiseWarning(500, JText::sprintf('JERROR_LOADING_MENUS', $databaseException->getMessage()));
-
-				return false;
-			}
-		}
-		catch (JCacheExceptionUnsupported $e)
+		catch (JCacheException $e)
 		{
 			try
 			{

--- a/libraries/joomla/cache/exception.php
+++ b/libraries/joomla/cache/exception.php
@@ -10,10 +10,10 @@
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Exception class defining an unsupported cache storage object
+ * Exception interface defining a cache storage error
  *
- * @since  3.6.3
+ * @since  __DEPLOY_VERSION__
  */
-class JCacheExceptionUnsupported extends RuntimeException implements JCacheException
+interface JCacheException
 {
 }

--- a/libraries/joomla/cache/exception/connecting.php
+++ b/libraries/joomla/cache/exception/connecting.php
@@ -14,6 +14,6 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.6.3
  */
-class JCacheExceptionConnecting extends RuntimeException
+class JCacheExceptionConnecting extends RuntimeException implements JCacheException
 {
 }


### PR DESCRIPTION
Partial Pull Request for #13357

### Summary of Changes

In a lot of places in the code, failing to read from the cache store should not result in an unrecoverable error state.  This PR makes `JMenuSite::load()` resilient to cache related errors by catching exceptions implementing the new `JCacheException` interface and will try to still execute the database query to load the data instead.

The `JCacheException` interface is added to make it easier to implement exception handling for these classes.  I elected an interface to not bind all exceptions explicitly to being subclasses of `RuntimeException`.  So instead of having (currently) two catch blocks if you don't care the type of error you can just have this single block.

I explicitly catch the cache exceptions so we are explicitly aware the error condition is related to the cache failing to connect and not some other `RuntimeException` that gets thrown in the process (i.e. the database exceptions).  I also only explicitly catch `JDatabaseExceptionExecuting` for the database side of the error handling since it is probably an unrecoverable error condition if the menus can't be used and frankly if any other type of `RuntimeException` is getting thrown at this point then there is a part of me that'd be surprised the code ran that far in normal use and there is a part of me that says this method isn't trying to handle all possible error conditions so only handle what it knows how to recover from.

### Testing Instructions

If the cache store fails to connect or the cache configuration is bad, the exceptions thrown by the cache API should be caught and `JMenuSite::load()` try to manually execute the lambda function to load the data.  A database query failure here should still result in the same error message being displayed.  Other types of `RuntimeException` should now go uncaught and bubble up as this method isn't adequately suited to be a general error handler and now explicitly only deals with error types it can respond to.

### Documentation Changes Required

N/A