### PR TITLE
Make JPluginHelper::load() resilient to cache error

### DIFF
--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -295,26 +295,34 @@ abstract class JPluginHelper
 		/** @var JCacheControllerCallback $cache */
 		$cache = JFactory::getCache('com_plugins', 'callback');
 
-		static::$plugins = $cache->get(
-			function () use ($levels)
-			{
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select(array($db->quoteName('folder', 'type'), $db->quoteName('element', 'name'), $db->quoteName('params')))
-					->from('#__extensions')
-					->where('enabled = 1')
-					->where('type = ' . $db->quote('plugin'))
-					->where('state IN (0,1)')
-					->where('access IN (' . $levels . ')')
-					->order('ordering');
-				$db->setQuery($query);
+		$loader = function () use ($levels)
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select(array($db->quoteName('folder', 'type'), $db->quoteName('element', 'name'), $db->quoteName('params')))
+				->from('#__extensions')
+				->where('enabled = 1')
+				->where('type = ' . $db->quote('plugin'))
+				->where('state IN (0,1)')
+				->where('access IN (' . $levels . ')')
+				->order('ordering');
+			$db->setQuery($query);
 
-				return $db->loadObjectList();
-			},
-			array(),
-			md5($levels),
-			false
-		);
+			return $db->loadObjectList();
+		};
+
+		try
+		{
+			static::$plugins = $cache->get($loader, array(), md5($levels), false);
+		}
+		catch (JCacheExceptionConnecting $cacheException)
+		{
+			static::$plugins = $loader();
+		}
+		catch (JCacheExceptionUnsupported $cacheException)
+		{
+			static::$plugins = $loader();
+		}
 
 		return static::$plugins;
 	}


### PR DESCRIPTION
Partial Pull Request for Issue #13357

### Summary of Changes

Similar to #13524 this tries to make the admin `JPluginHelper` class resilient to cache related issues.

1. The lambda function is now stored in a variable for use in the error handling cases.

2. Cache exceptions are caught and the lambda function will attempt to be run directly instead.

3. On a database failure, we're out of luck; sorry.

### Testing Instructions

If the cache store fails to connect or the cache configuration is bad, the exceptions thrown by the cache API should be caught and `JPluginHelper::load()` try to manually execute the lambda function to load the data.  The method is already not dealing with database errors so no new error handling is added regarding that.

### Documentation Changes Required

N/A