### PR TITLE
Add stripslashes to mssql result columns

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -544,39 +544,6 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
-	 * Method to get the first field of the first row of the result set from the database query.
-	 *
-	 * @return  mixed  The return value or null if the query failed.
-	 *
-	 * @since   12.1
-	 * @throws  RuntimeException
-	 */
-	public function loadResult()
-	{
-		$ret = null;
-
-		// Execute the query and get the result set cursor.
-		if (!($cursor = $this->execute()))
-		{
-			return;
-		}
-
-		// Get the first row from the result set as an array.
-		if ($row = sqlsrv_fetch_array($cursor, SQLSRV_FETCH_NUMERIC))
-		{
-			$ret = $row[0];
-		}
-
-		// Free up system resources and return.
-		$this->freeResult($cursor);
-
-		// For SQLServer - we need to strip slashes
-		$ret = stripslashes($ret);
-
-		return $ret;
-	}
-
-	/**
 	 * Execute the SQL statement.
 	 *
 	 * @return  mixed  A database cursor resource on success, boolean false on failure.
@@ -942,7 +909,21 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchArray($cursor = null)
 	{
-		return sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_NUMERIC);
+		$row = sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_NUMERIC);
+
+		if (is_array($row))
+		{
+			// For SQLServer - we need to strip slashes
+			foreach ($row as &$value)
+			{
+				if ($value !== null)
+				{
+					$value = stripslashes($value);
+				}
+			}
+		}
+
+		return $row;
 	}
 
 	/**
@@ -956,7 +937,21 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchAssoc($cursor = null)
 	{
-		return sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_ASSOC);
+		$row = sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_ASSOC);
+
+		if (is_array($row))
+		{
+			// For SQLServer - we need to strip slashes
+			foreach ($row as &$value)
+			{
+				if ($value !== null)
+				{
+					$value = stripslashes($value);
+				}
+			}
+		}
+
+		return $row;
 	}
 
 	/**
@@ -971,7 +966,22 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
-		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
+		$row = sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
+
+		if (is_object($row))
+		{
+			// For SQLServer - we need to strip slashes
+			foreach (get_object_vars($row) as $key => $value)
+			{
+				// Check public variable from object including those from $class, ex. JMenuItem
+				if (is_string($value))
+				{
+					$row->$key = stripslashes($value);
+				}
+			}
+		}
+
+		return $row;
 	}
 
 	/**

--- a/libraries/joomla/database/iterator/sqlsrv.php
+++ b/libraries/joomla/database/iterator/sqlsrv.php
@@ -38,7 +38,22 @@ class JDatabaseIteratorSqlsrv extends JDatabaseIterator
 	 */
 	protected function fetchObject()
 	{
-		return sqlsrv_fetch_object($this->cursor, $this->class);
+		$row = sqlsrv_fetch_object($this->cursor, $this->class);
+
+		if (is_object($row))
+		{
+			// For SQLServer - we need to strip slashes
+			foreach (get_object_vars($row) as $key => $value)
+			{
+				// Check public variable from object including those from $class, ex. JMenuItem
+				if (is_string($value))
+				{
+					$row->$key = stripslashes($value);
+				}
+			}
+		}
+
+		return $row;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #13507 .

### Summary of Changes
SQL Server database always escape backslash in result.
This PR `stripslashes` for each column from result query. 

### Testing Instructions

#### TEST 1
Before patch
1. Go to article, change some text or nothing, save article a few times.
2. Go to "Versions" (button at the top), there should open a modal window with list of dates and versions.
3. Click on some date row which open popup window.
4. You should see warnings and no data information about changes between versions.
```
Warning: Invalid argument supplied for foreach() in .../administrator/components/com_contenthistory/helpers/contenthistory.php on line 32

Warning: Invalid argument supplied for foreach() in .../administrator/components/com_contenthistory/helpers/contenthistory.php on line 295
```
**After patch the warning does not appears and you see some information.**

#### TEST 2
Before patch
1. Edit new article, and write two chars in full text: `\"`
2. Re-save a few times without changing anything more.
3. You should see more and more backslashes, ignore html tags in ex. `\\"`, next `\\\\"`, etc.

After patch the number of backslashes are not increased on each save.

#### TEST 3
Before patch:
1. Edit article and add to `Link A Text` (Images and Links Tab): `A""B`.
2. After you save article you get `Error decoding JSON data: Syntax error`. 

After patch
1. Do the same and save and load article works as expected.

### Documentation Changes Required
N/A