### PR TITLE
Fix fieldgroups list in fields batch modal

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -386,7 +386,7 @@ class FieldsModelFields extends JModelList
 		$query->select('title AS text, id AS value, state');
 		$query->from('#__fields_groups');
 		$query->where('state IN (0,1)');
-		$query->where('context = ' . $db->quote($this->state->get('filter.component')));
+		$query->where('context = ' . $db->quote($this->state->get('filter.context')));
 		$query->where('access IN (' . implode(',', $viewlevels) . ')');
 
 		$db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #13533.

### Summary of Changes
The context for the group list was only using the component part instead of the full context.
This fixes that.

### Testing Instructions
Check in the fields manager that the batch modal shows all existing fields groups for the active context (eg articles fieldsgroups)

### Documentation Changes Required
None