### PR TITLE
[com_fields] Fix name of component helper in fieldshelper

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -43,7 +43,7 @@ class FieldsHelper
 		$component = $parts[0];
 		$eName = str_replace('com_', '', $component);
 
-		$path = JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component . '/helpers/' . $component . '.php');
+		$path = JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component . '/helpers/' . $eName . '.php');
 
 		if (file_exists($path))
 		{


### PR DESCRIPTION
In current staging, custom fields aren't saved when editing an article (or other items) in frontend. The old values just stays. In backend everything works.

### Summary of Changes
This is a bug in the new method introduced with https://github.com/joomla/joomla-cms/pull/12968.
Currently it looks for a helperfile name eg `com_content.php` while in fact it is named `content.php`
This PR just changes the lookup to the expected name of that helper.

### Testing Instructions
Edit an article in frontend and adjust a value of a custom field. Save and check that the value sticks.

### Documentation Changes Required
None