### PR TITLE
Fixes #13177: Added where clause with block state

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -134,7 +134,8 @@ class UsersModelRegistration extends JModelForm
 			$query->clear()
 				->select($db->quoteName(array('name', 'email', 'sendEmail', 'id')))
 				->from($db->quoteName('#__users'))
-				->where($db->quoteName('sendEmail') . ' = ' . 1);
+				->where($db->quoteName('sendEmail') . ' = 1')
+				->where($db->quoteName('block') . ' = 0');
 
 			$db->setQuery($query);
 
@@ -582,7 +583,8 @@ class UsersModelRegistration extends JModelForm
 			$query->clear()
 				->select($db->quoteName(array('name', 'email', 'sendEmail')))
 				->from($db->quoteName('#__users'))
-				->where($db->quoteName('sendEmail') . ' = ' . 1);
+				->where($db->quoteName('sendEmail') . ' = 1')
+				->where($db->quoteName('block') . ' = 0');
 
 			$db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue #13177  .

### Summary of Changes
Added where clause to check User's block state to prevent registration notification emails to be sent to users who are blocked.

### Testing Instructions

[added by @zero-24]

- Install joomla
- set registration mal to admin
- add a user with `System Mail => Yes` that is blocked
- try to register 
- confirm that all 3 the mails still get out but also to the blocked admin
- apply this patch
- confirm that the 3 mails only get out for the non-blocked admin

### Documentation Changes Required
None