### PR TITLE
[com_fields] Add base list plugin class which activates the list plugin

### DIFF
--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -28,7 +28,7 @@ class FieldsListPlugin extends FieldsPlugin
 	 *
 	 * @return  DOMElement
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
 	{
@@ -58,7 +58,7 @@ class FieldsListPlugin extends FieldsPlugin
 	 *
 	 * @return  array
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getOptionsFromField($field)
 	{

--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_fields
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRATOR);
+
+/**
+ * Base plugin for all list based plugins
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class FieldsListPlugin extends FieldsPlugin
+{
+	/**
+	 * Transforms the field into an XML element and appends it as child on the given parent. This
+	 * is the default implementation of a field. Form fields which do support to be transformed into
+	 * an XML Element mut implemet the JFormDomfieldinterface.
+	 *
+	 * @param   stdClass    $field   The field.
+	 * @param   DOMElement  $parent  The field node parent.
+	 * @param   JForm       $form    The form.
+	 *
+	 * @return  DOMElement
+	 *
+	 * @since   3.7.0
+	 */
+	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
+	{
+		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);
+
+		if (!$fieldNode)
+		{
+			return $fieldNode;
+		}
+
+		foreach ($this->getOptionsFromField($field) as $value => $name)
+		{
+			$option = new DOMElement('option', $value);
+			$option->nodeValue = JText::_($name);
+
+			$element = $fieldNode->appendChild($option);
+			$element->setAttribute('value', $value);
+		}
+
+		return $fieldNode;
+	}
+
+	/**
+	 * Returns an array of key values to put in a list from the given field.
+	 *
+	 * @param   stdClass  $field  The field.
+	 *
+	 * @return  array
+	 *
+	 * @since   3.7.0
+	 */
+	public function getOptionsFromField($field)
+	{
+		$data = array();
+
+		// Fetch the options from the plugin
+		foreach ($this->params->get('options', array()) as $option)
+		{
+			$op = (object) $option;
+			$data[$op->value] = $op->name;
+		}
+
+		// Fetch the options from the field
+		foreach ($field->fieldparams->get('options', array()) as $option)
+		{
+			$data[$option->value] = $option->name;
+		}
+
+		return $data;
+	}
+}

--- a/plugins/fields/checkboxes/checkboxes.php
+++ b/plugins/fields/checkboxes/checkboxes.php
@@ -9,13 +9,13 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('fields.list.list', JPATH_PLUGINS);
+JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields Checkboxes Plugin
  *
  * @since  __DEPLOY_VERSION__
  */
-class PlgFieldsCheckboxes extends PlgFieldsList
+class PlgFieldsCheckboxes extends FieldsListPlugin
 {
 }

--- a/plugins/fields/imagelist/imagelist.php
+++ b/plugins/fields/imagelist/imagelist.php
@@ -9,14 +9,14 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('fields.list.list', JPATH_PLUGINS);
+JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields Imagelist Plugin
  *
  * @since  __DEPLOY_VERSION__
  */
-class PlgFieldsImagelist extends PlgFieldsList
+class PlgFieldsImagelist extends FieldsListPlugin
 {
 	/**
 	 * Transforms the field into an XML element and appends it as child on the given parent. This

--- a/plugins/fields/list/list.php
+++ b/plugins/fields/list/list.php
@@ -9,75 +9,13 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRATOR);
+JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields list Plugin
  *
  * @since  __DEPLOY_VERSION__
  */
-class PlgFieldsList extends FieldsPlugin
+class PlgFieldsList extends FieldsListPlugin
 {
-	/**
-	 * Transforms the field into an XML element and appends it as child on the given parent. This
-	 * is the default implementation of a field. Form fields which do support to be transformed into
-	 * an XML Element mut implemet the JFormDomfieldinterface.
-	 *
-	 * @param   stdClass    $field   The field.
-	 * @param   DOMElement  $parent  The field node parent.
-	 * @param   JForm       $form    The form.
-	 *
-	 * @return  DOMElement
-	 *
-	 * @since   3.7.0
-	 */
-	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
-	{
-		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);
-
-		if (!$fieldNode)
-		{
-			return $fieldNode;
-		}
-
-		foreach ($this->getOptionsFromField($field) as $value => $name)
-		{
-			$option = new DOMElement('option', $value);
-			$option->nodeValue = JText::_($name);
-
-			$element = $fieldNode->appendChild($option);
-			$element->setAttribute('value', $value);
-		}
-
-		return $fieldNode;
-	}
-
-	/**
-	 * Returns an array of key values to put in a list from the given field.
-	 *
-	 * @param   stdClass  $field  The field.
-	 *
-	 * @return  array
-	 *
-	 * @since   3.7.0
-	 */
-	public function getOptionsFromField($field)
-	{
-		$data = array();
-
-		// Fetch the options from the plugin
-		foreach ($this->params->get('options', array()) as $option)
-		{
-			$op = (object) $option;
-			$data[$op->value] = $op->name;
-		}
-
-		// Fetch the options from the field
-		foreach ($field->fieldparams->get('options', array()) as $option)
-		{
-			$data[$option->value] = $option->name;
-		}
-
-		return $data;
-	}
 }

--- a/plugins/fields/radio/radio.php
+++ b/plugins/fields/radio/radio.php
@@ -9,13 +9,13 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('fields.list.list', JPATH_PLUGINS);
+JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields Radio Plugin
  *
  * @since  __DEPLOY_VERSION__
  */
-class PlgFieldsRadio extends PlgFieldsList
+class PlgFieldsRadio extends FieldsListPlugin
 {
 }

--- a/plugins/fields/sql/sql.php
+++ b/plugins/fields/sql/sql.php
@@ -9,14 +9,14 @@
 
 defined('_JEXEC') or die;
 
-JLoader::import('fields.list.list', JPATH_PLUGINS);
+JLoader::import('components.com_fields.libraries.fieldslistplugin', JPATH_ADMINISTRATOR);
 
 /**
  * Fields Sql Plugin
  *
  * @since  __DEPLOY_VERSION__
  */
-class PlgFieldsSql extends PlgFieldsList
+class PlgFieldsSql extends FieldsListPlugin
 {
 	/**
 	 * Transforms the field into an XML element and appends it as child on the given parent. This


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/13319#issuecomment-271272419.

### Summary of Changes
Introduces a new list base plugin class where all list based plugins should extend from. When a plugin extends from another plugin class, then this one doesn't receive the triggered event. This was the cause why the list plugin was not available in the types plugin when creating a new field.

### Testing Instructions
Create a new list custom field and check if it works as expected when editing an article and viewing on the front.