### PR TITLE
[com_fields] Catch "expects parameter 2 to be string" error

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -169,7 +169,7 @@ abstract class FieldsPlugin extends JPlugin
 				$param = count($param) == count($param, COUNT_RECURSIVE) ? implode(',', $param) : '';
 			}
 
-			if ($param === '')
+			if ($param === '' || !is_string($param))
 			{
 				continue;
 			}


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/13319#issuecomment-271272419.

### Summary of Changes
No error should be shown when only the radio or checkboxes plugin contains options.

### Testing Instructions
- Define options in the checkbox plugin.
- Create a checkbox custom field with no options.

Do the same for radio.

### Expected result
No error should be shown and the options from the checkbox plugin should be selectable when editing an article. The selected options should also be shown on the front end.

The same result should be when using the radio custom field.
