### PR TITLE
Fixing Showon in plugins/modules/templates

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -60,7 +60,7 @@ JFactory::getDocument()->addScriptDeclaration(
 					<?php if (!empty($fieldSet->showon)) : ?>
 						<?php JHtml::_('jquery.framework'); ?>
 						<?php JHtml::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true)); ?>
-						<?php $dataShowOn = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($this->formControl, $fieldSet->showon)) . '\''; ?>
+						<?php $dataShowOn = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($fieldSet->showon, $this->formControl)) . '\''; ?>
 					<?php endif; ?>
 					<?php $label = empty($fieldSet->label) ? 'COM_CONFIG_' . $name . '_FIELDSET_LABEL' : $fieldSet->label; ?>
 					<li<?php echo $dataShowOn; ?>><a data-toggle="tab" href="#<?php echo $name; ?>"><?php echo JText::_($label); ?></a></li>
@@ -80,7 +80,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							<?php if ($field->showon) : ?>
 								<?php JHtml::_('jquery.framework'); ?>
 								<?php JHtml::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true)); ?>
-								<?php $dataShowOn = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->formControl, $field->showon)) . '\''; ?>
+								<?php $dataShowOn = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\''; ?>
 							<?php endif; ?>
 							<?php if ($field->hidden) : ?>
 								<?php echo $field->input; ?>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -30,7 +30,7 @@ defined('JPATH_BASE') or die;
 			{
 				JHtml::_('jquery.framework');
 				JHtml::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true));
-				$datashowon = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->formControl, $field->showon)) . '\'';
+				$datashowon = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\'';
 			}
 			?>
 			<div class="control-group"<?php echo $datashowon; ?>>

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -24,7 +24,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<?php if ($field->showon) : ?>
 				<?php JHtml::_('jquery.framework'); ?>
 				<?php JHtml::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true)); ?>
-				<?php $dataShowOn = " data-showon='" . json_encode(JFormHelper::parseShowOnConditions($field->formControl, $field->showon)) . "'"; ?>
+				<?php $dataShowOn = " data-showon='" . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . "'"; ?>
 			<?php endif; ?>
 			<div class="js-stools-field-filter"<?php echo $dataShowOn; ?>>
 				<?php echo $field->input; ?>

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -952,7 +952,7 @@ abstract class JFormField
 
 		if ($this->showon)
 		{
-			$options['rel']           = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($this->formControl, $this->showon)) . '\'';
+			$options['rel']           = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($this->showon, $this->formControl, $this->group)) . '\'';
 			$options['showonEnabled'] = true;
 		}
 

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -952,7 +952,8 @@ abstract class JFormField
 
 		if ($this->showon)
 		{
-			$options['rel']           = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($this->showon, $this->formControl, $this->group)) . '\'';
+			$options['rel']           = ' data-showon=\'' .
+				json_encode(JFormHelper::parseShowOnConditions($this->showon, $this->formControl, $this->group)) . '\'';
 			$options['showonEnabled'] = true;
 		}
 

--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -320,14 +320,15 @@ class JFormHelper
 	/**
 	 * Parse the show on conditions
 	 *
-	 * @param   string  $formControl  Form name.
 	 * @param   string  $showOn       Show on conditions.
+	 * @param   string  $formControl  Form name.
+	 * @param   string  $group        The dot-separated form group path.
 	 *
 	 * @return  array   Array with show on conditions.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function parseShowOnConditions($formControl, $showOn)
+	public static function parseShowOnConditions($showOn, $formControl = null, $group = null)
 	{
 		// Process the showon data.
 		if (!$showOn)
@@ -338,13 +339,20 @@ class JFormHelper
 		$showOnData  = array();
 		$showOnParts = preg_split('#\[AND\]|\[OR\]#', $showOn);
 
+		$formPath = $formControl ?: '';
+
+		if ($formPath && $group)
+		{
+			$formPath .= '[' . $group . ']';
+		}
+
 		foreach ($showOnParts as $showOnPart)
 		{
 			$compareEqual     = strpos($showOnPart, '!:') === false;
 			$showOnPartBlocks = explode(($compareEqual ? ':' : '!:'), $showOnPart, 2);
 
 			$showOnData[] = array(
-				'field'  => $formControl ? $formControl . '[' . $showOnPartBlocks[0] . ']' : $showOnPartBlocks[0],
+				'field'  => $formPath ? $formPath . '[' . $showOnPartBlocks[0] . ']' : $showOnPartBlocks[0],
 				'values' => explode(',', $showOnPartBlocks[1]),
 				'sign'   => $compareEqual === true ? '=' : '!=',
 				'op'     => preg_match('#^\[(AND|OR)\]#', $showOnPart, $matches) ? $matches[1] : '',


### PR DESCRIPTION
Pull Request for Issue #13540.

### Summary of Changes
The method `JFormHelper::parseShowOnConditions` was missing the field group.
I have added that group as an argument to the method.
I also changed the argument order so `$showOn` is first. `$formControl` and `$group` come afterwards and are optional (since the code works without them).

### Testing Instructions
Test showon behaviour in the various places. Some examples:
* Component Options - com_content - "Show Title"
* Module - Login - "Show Greeting"
* Plugin - CAPTCHA - reCAPTCHA - "Version"
* Template - Protostar - "Google Font for Headings"
* Global Configuration - "Enable FTP"

### Documentation Changes Required
None