### PR TITLE
[com_fields] Remove default value from the field params to inherit from plugin

### DIFF
--- a/plugins/fields/calendar/params/calendar.xml
+++ b/plugins/fields/calendar/params/calendar.xml
@@ -5,7 +5,6 @@
 			<field
 				name="format"
 				type="text"
-				default="%Y-%m-%d"
 				class="input-xxlarge"
 				label="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL"
 				description="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_DESC"


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/13319#issuecomment-271272419.

### Summary of Changes
Removes the default value in the calendar form field parameter. Like that the site admin can control the formats of all calendar fields globally in the plugin parameters.

### Testing Instructions
- Create a new calendar field and make sure the format parameter is empty.
- Change the format in the calendar field plugin.

### Expected result
The selected date when editing the article should be displayed in the format of the plugin. On the front the date should also be displayed in the format of the plugin.
