### PR TITLE
Fixes #12072: Incorrect warning shown

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1967,24 +1967,21 @@ class JForm
 		// Check if the field is required.
 		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
 
-		if ($required)
-		{
-			// If the field is required and the value is empty return an error message.
-			if (($value === '') || ($value === null))
+		// If the field is required and the value is empty return an error message.
+		if ($required && !$value)
+		{			
+			if ($element['label'])
 			{
-				if ($element['label'])
-				{
-					$message = JText::_($element['label']);
-				}
-				else
-				{
-					$message = JText::_($element['name']);
-				}
-
-				$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_REQUIRED', $message);
-
-				return new RuntimeException($message);
+				$message = JText::_($element['label']);
 			}
+			else
+			{
+				$message = JText::_($element['name']);
+			}
+
+			$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_REQUIRED', $message);
+
+			return new RuntimeException($message);
 		}
 
 		// Get the field validation rule.


### PR DESCRIPTION
Pull Request for Issue #12072 .

### Summary of Changes
Replaced the line
```
if ($required)
        {
            // If the field is required and the value is empty return an error message.
            if (($value === '') || ($value === null))
```
with `if ($required && !$value)`
prevents waring "Field required" even when the field is filled.

### Documentation Changes Required
No