### PR TITLE
Remove Isis Bootstrap grid override

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7722,9 +7722,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	body {
 		padding-top: 30px;
 	}
-	.row-fluid [class*="span"] {
-		margin-left: 15px;
-	}
 	.row-fluid .modal-batch [class*="span"] {
 		margin-left: 0;
 	}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7722,9 +7722,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	body {
 		padding-top: 30px;
 	}
-	.row-fluid [class*="span"] {
-		margin-left: 15px;
-	}
 	.row-fluid .modal-batch [class*="span"] {
 		margin-left: 0;
 	}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -734,10 +734,6 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 		padding-top: 30px;
 	}
 
-	.row-fluid [class*="span"] {
-		margin-left: 15px;
-	}
-
 	.row-fluid .modal-batch [class*="span"] {
 		margin-left: 0;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR removes the following, fixing a multi column margin issue where all fluid bootstrap columns (excluding first column) shift to the left on most screen sizes.. 

```
.row-fluid [class*="span"] {
	margin-left: 15px;
}
```

I can't imagine the original purpose for this CSS, regardless it is incorrect as row-fluid span margins should be in %. Issue becomes more noticeable the larger the screen size. Removing the CSS reverts back to the bootstrap default.

### Testing Instructions
Apply patch and check Control Panel or any view with bootstrap columns.

**Before Patch**
![bs-grid1](https://cloud.githubusercontent.com/assets/2803503/21845242/c1b8c7d2-d7e9-11e6-83cc-9a3a5f239af8.png)

**After Patch**
![bs-grid2](https://cloud.githubusercontent.com/assets/2803503/21845247/c50829a0-d7e9-11e6-826a-2c759bb2e9ef.png)

### Documentation Changes Required
None