### PR TITLE
[com_fields] Notice when saving a user

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -450,7 +450,7 @@ class FieldsHelper
 					 * If the field belongs to an assigned_cat_id but the assigned_cat_ids in the data
 					 * is not known, set the required flag to false on any circumstance.
 					 */
-					if (! $assignedCatids && $field->assigned_cat_ids && $form->getField($field->alias))
+					if (!$assignedCatids && !empty($field->assigned_cat_ids) && $form->getField($field->alias))
 					{
 						$form->setFieldAttribute($field->alias, 'required', 'false');
 					}


### PR DESCRIPTION
Pull Request for Issue #13565.

### Summary of Changes
Changing the boolean check to `!empty()` which has an additional `isset()` check integrated.

### Testing Instructions
* Create a field for users
* Edit a user and check that the field appears and you can save a value
* Additionally test fields for other extensions and make sure the assigned categories work as expected.

### Documentation Changes Required
None