### PR TITLE
Fixing search for MySQL

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -262,7 +262,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Join over Fields.
-			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = '. $query->castAsChar('a.id'))
+			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = ' . $query->castAsChar('a.id'))
 				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
 				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
 				->where('(f.state IS NULL OR f.state = 1)')

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -183,7 +183,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Join over Fields.
-			$query->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id')
+			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = ' . $query->castAsChar('a.id'))
 				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
 				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
 				->where('(f.state IS NULL OR f.state = 1)')
@@ -262,7 +262,7 @@ class PlgSearchContent extends JPlugin
 				->order($order);
 
 			// Join over Fields.
-			$query->join('LEFT', '#__fields_values AS fv ON CAST(fv.item_id AS INTEGER) = a.id')
+			$query->join('LEFT', '#__fields_values AS fv ON fv.item_id = '. $query->castAsChar('a.id'))
 				->join('LEFT', '#__fields AS f ON f.id = fv.field_id')
 				->where('(fv.context IS NULL OR fv.context = ' . $db->q('com_content.article') . ')')
 				->where('(f.state IS NULL OR f.state = 1)')


### PR DESCRIPTION
Pull Request for Issue #13569 .
Apparently, MySQL can't cast to INTEGER while PostgreSQL and MariaDB can.

### Summary of Changes
This PR changes the casting the other way around and makes use of the existing `castAsChar()` method we have in the querybuilder.

### Testing Instructions
Test regular search (not smart search) on various database engines (MySQL, PostgreSQL)

### Documentation Changes Required
None