### PR TITLE
Store tabstate in sessionStorage instead localStorage

### DIFF
--- a/media/system/js/tabs-state.js
+++ b/media/system/js/tabs-state.js
@@ -5,7 +5,7 @@
 
 /**
  * JavaScript behavior to allow selected tab to be remained after save or page reload
- * keeping state in localstorage
+ * keeping state in sessionStorage
  */
 
 jQuery(function($) {
@@ -13,8 +13,8 @@ jQuery(function($) {
         function saveActiveTab(href) {
             // Remove the old entry if exists, key is always dependant on the url
             // This should be removed in the future
-            if (localStorage.getItem('active-tab')) {
-                localStorage.removeItem('active-tab');
+            if (sessionStorage.getItem('active-tab')) {
+                sessionStorage.removeItem('active-tab');
             }
 
             // Reset the array
@@ -23,8 +23,8 @@ jQuery(function($) {
             // Save clicked tab href to the array
             activeTabsHrefs.push(href);
 
-            // Store the selected tabs hrefs in localStorage
-            localStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''), JSON.stringify(activeTabsHrefs));
+            // Store the selected tabs hrefs in sessionStorage
+            sessionStorage.setItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''), JSON.stringify(activeTabsHrefs));
         }
 
         function activateTab(href) {
@@ -36,7 +36,7 @@ jQuery(function($) {
         }
 
         // Array with active tabs hrefs
-        var activeTabsHrefs = JSON.parse(localStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, '')));
+        var activeTabsHrefs = JSON.parse(sessionStorage.getItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, '')));
 
         // jQuery object with all tabs links
         var $tabs = $('a[data-toggle="tab"]');
@@ -52,7 +52,7 @@ jQuery(function($) {
             // When moving from tab area to a different view
             $.each(activeTabsHrefs, function(index, tabHref) {
                 if (!hasTab(tabHref)) {
-                    localStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''));
+                    sessionStorage.removeItem(window.location.href.toString().split(window.location.host)[1].replace(/&return=[a-zA-Z0-9%]+/, '').replace(/&[a-zA-Z-_]+=[0-9]+/, ''));
 
                     return true;
                 }


### PR DESCRIPTION
This PR is a different approach from https://github.com/joomla/joomla-cms/pull/13105

Currently, the last active tab of any edited item is stored forever locally in your browser. This can cause some unexpected behavior of edit forms. Eg you edit an article and had the permission tab open when you saved the article. Now you go on with your regular business and when you're going to edit an article again on that site (may be the same day or another month), it will open with the permission tab active again. That comes quite unexpected because you certainly have forgotten by now that you had the permission tab open last time :smile: 

### Summary of Changes
Changes the storage place for the tabstate data from localStorage to sessionStorage which means it is specific to the active tab and gets deleted when the tab is closed.
That should greatly reduce the confusing behavior of tab states we currently have.

### Testing Instructions
* Edit an article (or module, plugin, whatever) and change the tab.
* Click "Save" (not "Save & Close"), the form should reload with the same tab active.
* Click "Save & Close" and then re-edit the item. The form should open with the same tab active again.
* Edit an article in another browser tab. The first tab should be active.

If you want you can also inspect the data in the browser tools.

### Documentation Changes Required
None