### PR TITLE
Fix issue where fields is false

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -132,6 +132,11 @@ class FieldsHelper
 
 		$fields = self::$fieldsCache->getItems();
 
+		if ($fields === false)
+		{
+			return array();
+		}
+
 		if ($item && isset($item->id))
 		{
 			if (self::$fieldCache === null)


### PR DESCRIPTION
### Summary of Changes
When there is an SQL issue getting the fields (maybe you update from a version before fields to after fields without triggering the sql update etc), then then `JModelList::getItems` will return false https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/model/list.php#L190 and you subsequently get PHP errors trying to do a `foreach` on false.

```
Warning: Invalid argument supplied for foreach() in JROOT/administrator/components/com_fields/helpers/fields.php on line 146
```

Do we want to display a warning in the frontend about such issues? Only show something for super admins? Obviously in the case of the table not existing then you'll get warnings shown in the backend.

### Testing Instructions
Delete the `#__fields` table. Before the patch you get 4 php warnings on an article. After patch no warning

### Documentation Changes Required
None