### PR TITLE
Merge list field options using Registry->merge

### DIFF
--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -65,16 +65,13 @@ class FieldsListPlugin extends FieldsPlugin
 		$data = array();
 
 		// Fetch the options from the plugin
-		foreach ($this->params->get('options', array()) as $option)
+		$params = clone($this->params);
+		$params->merge($field->fieldparams);
+
+		foreach ($params->get('options', array()) as $option)
 		{
 			$op = (object) $option;
 			$data[$op->value] = $op->name;
-		}
-
-		// Fetch the options from the field
-		foreach ($field->fieldparams->get('options', array()) as $option)
-		{
-			$data[$option->value] = $option->name;
 		}
 
 		return $data;


### PR DESCRIPTION
Pull Request for Issue #13558.

### Summary of Changes
Currently, list field options defined in the field are added to the ones defined in the plugin.
After this PR they are merged using `Registry->merge()` where parameters defined in the field overwrite the ones defined in the plugin.

### Testing Instructions
See in issue for some pics
* Create some options in the list/checkboxes/radio plugin.
* Create the respective fields and define some options in them.
* See what options will be available when you edit the item (eg the article).
Before this PR, you should see all options you defined, both from plugin and field. After this PR you will only see the ones from the field. The plugin ones are only shown if none are defined in the field.

### Documentation Changes Required
None