### PR TITLE
[com_fields] Create media home directory on user_id

### DIFF
--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -19,7 +19,6 @@ defined('_JEXEC') or die;
 				<?php foreach ($group as $item) : ?>
 					<li>
 						<?php if ($params->get('link_titles') == 1) : ?>
-							<?php echo JHtml::link($item->link, $item->title, array("class" => "mod-articles-category-title " . $item->active)); ?>
 							<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>">
 								<?php echo $item->title; ?>
 							</a>
@@ -84,7 +83,6 @@ defined('_JEXEC') or die;
 		<?php foreach ($list as $item) : ?>
 			<li>
 				<?php if ($params->get('link_titles') == 1) : ?>
-					<?php echo JHtml::link($item->link, $item->title, array("class" => "mod-articles-category-title " . $item->active)); ?>
 					<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>">
 						<?php echo $item->title; ?>
 					</a>

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -19,6 +19,7 @@ defined('_JEXEC') or die;
 				<?php foreach ($group as $item) : ?>
 					<li>
 						<?php if ($params->get('link_titles') == 1) : ?>
+							<?php echo JHtml::link($item->link, $item->title, array("class" => "mod-articles-category-title " . $item->active)); ?>
 							<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>">
 								<?php echo $item->title; ?>
 							</a>
@@ -83,6 +84,7 @@ defined('_JEXEC') or die;
 		<?php foreach ($list as $item) : ?>
 			<li>
 				<?php if ($params->get('link_titles') == 1) : ?>
+					<?php echo JHtml::link($item->link, $item->title, array("class" => "mod-articles-category-title " . $item->active)); ?>
 					<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>">
 						<?php echo $item->title; ?>
 					</a>

--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -44,15 +44,17 @@ class PlgFieldsMedia extends FieldsPlugin
 
 		if ($field->fieldparams->get('home'))
 		{
-			$userName = JFactory::getUser()->username;
+			$userId = JFactory::getUser()->id;
 			$root     = $field->fieldparams->get('directory');
 
-			if (!$root)
+			if (empty($root))
 			{
-				$root = 'images';
+				$directory = JPATH_ROOT . '/images/' . $userId;
 			}
-
-			$directory = JPATH_ROOT . '/images/' . $root . '/' . $userName;
+			else
+			{
+				$directory = JPATH_ROOT . '/images/' . $root . '/' . $userId;
+			}
 
 			if (!JFolder::exists($directory))
 			{


### PR DESCRIPTION
Pull Request for Issue #13399 

### Summary of Changes
- Home directory is now created by userid instead of username
- Home directory is created directly in the `/images` folder instead of `/images/images`

The old behaviour was that a new folder was created by username on the location `/images/images/username`. The problem with this behaviour is that if the username contains special characters (ü, é, etc.) the folder is created with this characters. Since a url does not support this characters this behaviour is wrong. Also Joomla! media manager is not able to reach folders with this kind of names.

Using the userid instead of the username makes sure that the folder name is always valid.

### Testing Instructions
1. Go to Content -> Fields and create a custom field of the type "Media"
2. Set the parameter "Home Directory" on Yes
3. Create a new article and upload a file with the custom field
4. Confirm your file is uploaded at and available at `/images/<userid>`
5. Change the parameter "Directory" to another path and confirm the file upload is correct
