### PR TITLE
Delete UCM content entries when Joomla articles are deleted

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -374,8 +374,9 @@ class JHelperTags extends JHelper
 		$contentItemId = (array) $contentItemId;
 
 		// Set default values
-		$result = false;
-		$delete = false;
+		$result  = false;
+		$outcome = false;
+		$delete  = array();
 
 		foreach ($contentItemId as $itemId)
 		{
@@ -386,10 +387,18 @@ class JHelperTags extends JHelper
 			 */
 			$ucmContentTable = JTable::getInstance('Corecontent');
 
-			$delete = $ucmContentTable->deleteByContentId($itemId, $this->typeAlias);
+			$delete[] = $ucmContentTable->deleteByContentId($itemId, $this->typeAlias);
 		}
 
-		return $result && $delete;
+		foreach ($delete as $outcome)
+		{
+			if ($outcome === false)
+			{
+				return false;
+			}
+		}
+
+		return $result && $outcome;
 	}
 
 	/**

--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -370,14 +370,26 @@ class JHelperTags extends JHelper
 	 */
 	public function deleteTagData(JTableInterface $table, $contentItemId)
 	{
-		$result = $this->unTagItem($contentItemId, $table);
+		// Make sure it is an array
+		$contentItemId = (array) $contentItemId;
 
-		/**
-		 * @var JTableCorecontent $ucmContentTable
-		 */
-		$ucmContentTable = JTable::getInstance('Corecontent');
+		// Set default values
+		$result = false;
+		$delete = false;
 
-		return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
+		foreach ($contentItemId as $itemId)
+		{
+			$result = $this->unTagItem($itemId, $table);
+
+			/**
+			 * @var JTableCorecontent $ucmContentTable
+			 */
+			$ucmContentTable = JTable::getInstance('Corecontent');
+
+			$delete = $ucmContentTable->deleteByContentId($itemId, $this->typeAlias);
+		}
+
+		return $result && $delete;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #8770 .

### Summary of Changes
Deleting an article doesn't remove the article from the ucm_content table because an array is sent while an integer is expected. This pull request fixes this.

### Testing Instructions
1. Create an article and make sure to assign a tag to the article
2. Check the ucm_content table to see that the article is there as well
3. Trash the article
4. Delete the article from trash
5. Check the ucm_content table and see that the article is still there
6. Apply patch
7. Create an article and make sure to assign a tag to the article
8. Check the ucm_content table to see that the article is there as well
9. Trash the article
10. Delete the article from trash
11. Check the ucm_content table and see that the article has now been removed

### Documentation Changes Required
None