### PR TITLE
Mssql - fix escape() and add support for unicode chars

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -255,6 +255,28 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	}
 
 	/**
+	 * Quotes and optionally escapes a string to database requirements for use in database queries.
+	 *
+	 * @param   mixed    $text    A string or an array of strings to quote.
+	 * @param   boolean  $escape  True (default) to escape the string, false to leave it unchanged.
+	 *
+	 * @return  string  The quoted input string.
+	 *
+	 * @note    Accepting an array of strings was added in 12.3.
+	 * @since   11.1
+	 */
+	public function quote($text, $escape = true)
+	{
+		if (is_array($text))
+		{
+			return parent::quote($text, $escape);
+		}
+
+		// To support unicode on MSSQL we have to add prefix N
+		return 'N\'' . ($escape ? $this->escape($text) : $text) . '\'';
+	}
+
+	/**
 	 * Determines if the connection to the server is active.
 	 *
 	 * @return  boolean  True if connected to the database engine.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -232,15 +232,23 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	public function escape($text, $extra = false)
 	{
-		$result = addslashes($text);
-		$result = str_replace("\'", "''", $result);
-		$result = str_replace('\"', '"', $result);
-		$result = str_replace('\/', '/', $result);
+		$result = str_replace("'", "''", $text);
+
+		// Fix for SQL Sever escape sequence, see https://support.microsoft.com/en-us/kb/164291
+		$result = str_replace(
+			array("\\\n",     "\\\r",     "\\\\\r\r\n"),
+			array("\\\\\n\n", "\\\\\r\r", "\\\\\r\n\r\n"),
+			$result
+		);
 
 		if ($extra)
 		{
-			// We need the below str_replace since the search in sql server doesn't recognize _ character.
-			$result = str_replace('_', '[_]', $result);
+			// Escape special chars
+			$result = str_replace(
+				array('[',   '_',   '%'),
+				array('[[]', '[_]', '[%]'),
+				$result
+			);
 		}
 
 		return $result;
@@ -909,21 +917,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchArray($cursor = null)
 	{
-		$row = sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_NUMERIC);
-
-		if (is_array($row))
-		{
-			// For SQLServer - we need to strip slashes
-			foreach ($row as &$value)
-			{
-				if ($value !== null)
-				{
-					$value = stripslashes($value);
-				}
-			}
-		}
-
-		return $row;
+		return sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_NUMERIC);
 	}
 
 	/**
@@ -937,21 +931,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchAssoc($cursor = null)
 	{
-		$row = sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_ASSOC);
-
-		if (is_array($row))
-		{
-			// For SQLServer - we need to strip slashes
-			foreach ($row as &$value)
-			{
-				if ($value !== null)
-				{
-					$value = stripslashes($value);
-				}
-			}
-		}
-
-		return $row;
+		return sqlsrv_fetch_array($cursor ? $cursor : $this->cursor, SQLSRV_FETCH_ASSOC);
 	}
 
 	/**
@@ -966,22 +946,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
-		$row = sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
-
-		if (is_object($row))
-		{
-			// For SQLServer - we need to strip slashes
-			foreach (get_object_vars($row) as $key => $value)
-			{
-				// Check public variable from object including those from $class, ex. JMenuItem
-				if (is_string($value))
-				{
-					$row->$key = stripslashes($value);
-				}
-			}
-		}
-
-		return $row;
+		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
 	}
 
 	/**

--- a/libraries/joomla/database/iterator/sqlsrv.php
+++ b/libraries/joomla/database/iterator/sqlsrv.php
@@ -38,22 +38,7 @@ class JDatabaseIteratorSqlsrv extends JDatabaseIterator
 	 */
 	protected function fetchObject()
 	{
-		$row = sqlsrv_fetch_object($this->cursor, $this->class);
-
-		if (is_object($row))
-		{
-			// For SQLServer - we need to strip slashes
-			foreach (get_object_vars($row) as $key => $value)
-			{
-				// Check public variable from object including those from $class, ex. JMenuItem
-				if (is_string($value))
-				{
-					$row->$key = stripslashes($value);
-				}
-			}
-		}
-
-		return $row;
+		return sqlsrv_fetch_object($this->cursor, $this->class);
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
@@ -25,8 +25,8 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 	public function dataTestEscape()
 	{
 		return array(
-			array("'%_abc123", false, "''%_abc123"),
-			array("'%_abc123", true, "''%[_]abc123"),
+			array("'%_abc123[]", false, "''%_abc123[]"),
+			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
 		);
 	}
 


### PR DESCRIPTION
Pull Request for better version of #13534

### Summary of Changes

* Fix escape sequences - see https://support.microsoft.com/en-us/kb/164291
* Repair `$db->escape()`
* stripslashes() added in #13534 is now not needed
* In `$db->quote()` add prefix N, means instead column = 'text'  there will be column = N'text' which add support for unicode, international chars (ex. Polish chars ąęćółńżź)

### Testing Instructions

1. Install fresh joomla staging, (if you have installed joomla with some modification in database then JSON Decode error may occur).
2. Edit or add some article:
* change `Meta Description` field to (add some national chars like ąęśżźół):
```
xęą
\
\
x
```
* change `Title` to "TEST 1 - ale[x]"
3. Save and check result.
4. You should see that `Meta Description` field is not saved properly (new line has been removed, national chars disapears).
5. Edit template file at `templates/protostar/index.php`
6. Add php code at the bottom of the file (before `</body>`):
```php
<?php
$db = JFactory::getDbo();
$query = $db->getQuery(true)
	->select('title')
	->from('#__content')
	->where('title LIKE ' . $db->quote('%' . $db->escape('ale[x]', true) . '%', false));

$title = $db->setQuery($query)->loadResult() ?: 'NOT FOUND';
echo '<p>Result 1: "' . $title . '"</p>';

$query = $db->getQuery(true)
	->select('COUNT(*)')
	->from('#__content')
	->where('title LIKE ' . $db->quote('%' . $db->escape('%%%', true) . '%', false));

echo '<p>Result 2: "' . $db->setQuery($query)->loadResult() . '"</p>';
?>
```
7. Go to front page and check results:
* Result 1: "NOT FOUND"
* Result 2: "67" 
or similar (number bigger than 0) - sample testing data installed

8. Apply current PR by PatchTester.
9. Repeat point 2,3,4. Now `Meta Description` is saved OK.
10. Set `Content Rights` field (json column) to:
```
Author\"\
rights.
```
*Note: If you added above text before applying patch you get Json error on joomla with applied patch. Before adding patch please reset that field.*
11. Save and check whether content rights is correct.
12. Go to front page and check results: 
* Result 1: "TEST 1 - ale[x]"
* Result 2: "0"


#### Explanation for tests:
- %%% - there is no article with text '%%%' and should not found any articles. If found then `escape` does not work if correct way.
- ale[x] - should find one article because there is one title with these chars. But before patch it treats brackets as a special chars and try to find only "alex".
- backslash at the end of line test fix for https://support.microsoft.com/en-us/kb/164291
- `Content Rights` - is stored, encoded to json. This test check whether json which contains backslashes or quotes works correctly.

### Documentation Changes Required
N/A