### PR TITLE
Responsive Chosen fields & yes/no button

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -6955,6 +6955,10 @@ div.modal.jviewport-width100 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
+.control-group .chzn-container {
+	width: 100% !important;
+	max-width: 220px;
+}
 .chzn-container-single .chzn-single {
 	background-color: #fff;
 	background-clip: inherit;
@@ -7106,6 +7110,9 @@ div.modal.jviewport-width100 {
 .js-stools .js-stools-container-bar .js-stools-field-filter .chzn-container {
 	margin: 1px 0;
 	padding: 0 !important;
+}
+#jform_tags_chzn.chzn-container {
+	max-width: 440px;
 }
 .CodeMirror {
 	height: calc(100vh - 400px);
@@ -7708,10 +7715,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 #assignment.tab-pane {
 	min-height: 500px;
 }
-.chzn-container,
-.chzn-drop {
-	max-width: 100% !important;
-}
 @media (max-width: 979px) {
 	.navbar .nav {
 		font-size: 13px;
@@ -7789,11 +7792,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.btn-subhead {
 		display: block;
 		margin: 10px 0;
-	}
-	.chzn-container,
-	.chzn-container .chzn-results,
-	.chzn-container-single .chzn-drop {
-		width: 99% !important;
 	}
 	.subhead-collapse.collapse {
 		height: 0;
@@ -8115,9 +8113,14 @@ th .tooltip-inner {
 	min-width: 50px;
 	margin-left: -1px;
 }
+.controls .btn-group.btn-group-yesno {
+	width: 100%;
+	max-width: 220px;
+}
 .controls .btn-group.btn-group-yesno > .btn {
-	min-width: 84px;
-	padding: 2px 12px;
+	width: 50%;
+	min-width: 20px;
+	padding: 2px 0;
 }
 .img-preview > img {
 	max-height: 100%;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -6955,6 +6955,10 @@ div.modal.jviewport-width100 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
+.control-group .chzn-container {
+	width: 100% !important;
+	max-width: 220px;
+}
 .chzn-container-single .chzn-single {
 	background-color: #fff;
 	background-clip: inherit;
@@ -7106,6 +7110,9 @@ div.modal.jviewport-width100 {
 .js-stools .js-stools-container-bar .js-stools-field-filter .chzn-container {
 	margin: 1px 0;
 	padding: 0 !important;
+}
+#jform_tags_chzn.chzn-container {
+	max-width: 440px;
 }
 .CodeMirror {
 	height: calc(100vh - 400px);
@@ -7708,10 +7715,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 #assignment.tab-pane {
 	min-height: 500px;
 }
-.chzn-container,
-.chzn-drop {
-	max-width: 100% !important;
-}
 @media (max-width: 979px) {
 	.navbar .nav {
 		font-size: 13px;
@@ -7789,11 +7792,6 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 	.btn-subhead {
 		display: block;
 		margin: 10px 0;
-	}
-	.chzn-container,
-	.chzn-container .chzn-results,
-	.chzn-container-single .chzn-drop {
-		width: 99% !important;
 	}
 	.subhead-collapse.collapse {
 		height: 0;
@@ -8115,9 +8113,14 @@ th .tooltip-inner {
 	min-width: 50px;
 	margin-left: -1px;
 }
+.controls .btn-group.btn-group-yesno {
+	width: 100%;
+	max-width: 220px;
+}
 .controls .btn-group.btn-group-yesno > .btn {
-	min-width: 84px;
-	padding: 2px 12px;
+	width: 50%;
+	min-width: 20px;
+	padding: 2px 0;
 }
 .img-preview > img {
 	max-height: 100%;

--- a/administrator/templates/isis/less/chzn-override.less
+++ b/administrator/templates/isis/less/chzn-override.less
@@ -3,6 +3,12 @@
         border-radius: 0 0 3px 3px;
     }
 }
+
+.control-group .chzn-container {
+    width: 100% !important;
+    max-width: 220px; 
+}
+
 .chzn-container-single {
     .chzn-single {
         background-color: @white;
@@ -170,4 +176,7 @@
 .js-stools .js-stools-container-bar .js-stools-field-filter .chzn-container {
     margin: 1px 0;
     padding: 0 !important;
+}
+#jform_tags_chzn.chzn-container {
+    max-width: 440px;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -706,11 +706,7 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 #assignment.tab-pane {
 	min-height: 500px;
 }
-/* Chosen Max Width */
-.chzn-container,
-.chzn-drop {
-	max-width: 100% !important;
-}
+
 @media (max-width: 979px) {
 	.navbar {
 		.nav {
@@ -812,12 +808,6 @@ html[dir=rtl] .quick-icons .nav-list [class^="icon-"], html[dir=rtl] .quick-icon
 	.btn-subhead {
 		display: block;
 		margin: 10px 0;
-	}
-
-	.chzn-container,
-	.chzn-container .chzn-results,
-	.chzn-container-single .chzn-drop {
-		width: 99% !important;
 	}
 
 	.subhead-collapse.collapse {
@@ -1214,9 +1204,14 @@ th .tooltip-inner {
 	margin-left: -1px;
 }
 
-.controls .btn-group.btn-group-yesno > .btn {
-	min-width: 84px;
-	padding: 2px 12px;
+.controls .btn-group.btn-group-yesno {
+	width: 100%;
+	max-width: 220px;
+	> .btn {
+		width: 50%;
+		min-width: 20px;
+		padding: 2px 0;
+	}
 }
 .img-preview > img {
 	max-height: 100%;


### PR DESCRIPTION
Pull Request for Issue #13529  .

### Summary of Changes
Makes .control-group chosen fields and the yes/no buttons responsive/fluid. Allows these fields/buttons to reduce in size if the width is not available to accommodate their default size. Doesn't effect 'Search Tools'.

### Testing Instructions
Navigate to article editor and reduce the browser window size. Side buttons/fields should reduce in width with the containing column.

GIF... 
![chzn-fluid1](https://cloud.githubusercontent.com/assets/2803503/21948258/d6ad5ce4-d9e1-11e6-800e-37c88eb04c85.gif)

### Documentation Changes Required
None