### PR TITLE
Show text "No Information Entered" in users profile when no value is set

### DIFF
--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -45,7 +45,7 @@ foreach ($tmp as $customField)
 						<dt><?php echo $field->title; ?></dt>
 						<dd>
 							<?php if (key_exists($field->fieldname, $customFields)) : ?>
-								<?php echo $customFields[$field->fieldname]->value; ?>
+								<?php echo $customFields[$field->fieldname]->value ?: JText::_('COM_USERS_PROFILE_VALUE_NOT_FOUND'); ?>
 							<?php elseif (JHtml::isRegistered('users.' . $field->id)) : ?>
 								<?php echo JHtml::_('users.' . $field->id, $field->value); ?>
 							<?php elseif (JHtml::isRegistered('users.' . $field->fieldname)) : ?>


### PR DESCRIPTION
Pull Request for Issue mentioned in https://github.com/joomla/joomla-cms/pull/13182#issuecomment-272608019.

In the profile view, fields with no values are not properly displayed. The values of the following fields will move up a row.

### Summary of Changes
Rhis PR will show the text "No Information Entered" similar to regular profile fields where no value is entered.

### Testing Instructions
* Add a few fields for com_users and set some values for them. Make sure one of them stays empty.
* Verify that the values stay on the correct line and that the "No Information Entered" text is displayed for the empty value.

### Documentation Changes Required
None