### PR TITLE
Fix for Issue #13588 - mod_articles_categories - Fatal error: Class 'ContentHelperRoute' not found...

### DIFF
--- a/modules/mod_articles_categories/helper.php
+++ b/modules/mod_articles_categories/helper.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
-
 /**
  * Helper for mod_articles_categories
  *

--- a/modules/mod_articles_categories/mod_articles_categories.php
+++ b/modules/mod_articles_categories/mod_articles_categories.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 // Include the helper functions only once
 JLoader::register('ModArticlesCategoriesHelper', __DIR__ . '/helper.php');
 
+JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/helpers/route.php');
+
 JLoader::register('JCategoryNode', JPATH_BASE . '/libraries/legacy/categories/categories.php');
 
 $cacheid = md5($module->id);


### PR DESCRIPTION
Pull Request for Issue #13588.

### Summary of Changes
Moved the inclusion of ContentHelperRoute Class from the helper.php to the mod_articles_categories.php

### Testing Instructions
Create a module to list categories of a parent category. The module should work.

### Documentation Changes Required
No changes are required.