### PR TITLE
Delete UCM content entries when Joomla articles are deleted

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -362,22 +362,37 @@ class JHelperTags extends JHelper
 	 * Method to delete the tag mappings and #__ucm_content record for for an item
 	 *
 	 * @param   JTableInterface  $table          JTable object of content table where delete occurred
-	 * @param   integer          $contentItemId  ID of the content item.
+	 * @param   integer|array    $contentItemId  ID of the content item. Or an array of key/value pairs with array key
+	 *                                           being a primary key name and value being the content item ID. Note
+	 *                                           multiple primary keys are not supported
 	 *
 	 * @return  boolean  true on success, false on failure
 	 *
 	 * @since   3.1
+	 * @throws  InvalidArgumentException
 	 */
 	public function deleteTagData(JTableInterface $table, $contentItemId)
 	{
-		$result = $this->unTagItem($contentItemId, $table);
+		$key = $table->getKeyName();
 
-		/**
-		 * @var JTableCorecontent $ucmContentTable
-		 */
+		if (!is_array($contentItemId))
+		{
+			$contentItemId = array($key => $contentItemId);
+		}
+
+		// If we have multiple items for the content item primary key we currently don't support this so
+		// throw an InvalidArgumentException for now
+		if (count($contentItemId) != 1)
+		{
+			throw new InvalidArgumentException('Multiple primary keys are not supported as a content item id');
+		}
+
+		$result = $this->unTagItem($contentItemId[$key], $table);
+
+		/** @var JTableCorecontent $ucmContentTable */
 		$ucmContentTable = JTable::getInstance('Corecontent');
 
-		return $result && $ucmContentTable->deleteByContentId($contentItemId, $this->typeAlias);
+		return $result && $ucmContentTable->deleteByContentId($contentItemId[$key], $this->typeAlias);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #8770 . Alternative fix to #13584

### Summary of Changes
Deleting an article doesn't remove the article from the ucm_content table because an array is sent (containing `array('primary_key_name' => 'contentItemId')`) while an integer is expected. This pull request fixes this.

### Testing Instructions
1. Create an article and make sure to assign a tag to the article
2. Check the ucm_content table to see that the article is there as well
3. Trash the article
4. Delete the article from trash
5. Check the ucm_content table and see that the article is still there
6. Apply patch
7. Create an article and make sure to assign a tag to the article
8. Check the ucm_content table to see that the article is there as well
9. Trash the article
10. Delete the article from trash
11. Check the ucm_content table and see that the article has now been removed

### Documentation Changes Required
None