### PR TITLE
Correcting sidebar display LTR and RTL (replaces #13548)

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8307,7 +8307,7 @@ a.grid_true {
 	width: 16.5%;
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
-	padding-bottom: 10px;
+	padding-bottom: 40px;
 	clear: both;
 	background-color: #F0F0F0;
 	border-bottom: 1px solid #dedede;
@@ -9623,8 +9623,13 @@ a.grid_true {
 	border-right: 0px;
 }
 .j-sidebar-container {
+	position: absolute;
+	display: block;
 	left: auto;
 	right: -16.5%;
+	padding-top: 28px;
+	padding-bottom: 40px;
+	clear: both;
 	margin: -10px -1px 0 0;
 	border-right: 0;
 	border-left: 1px solid #d3d3d3;
@@ -9650,6 +9655,10 @@ a.grid_true {
 .j-toggle-button-wrapper.j-toggle-visible {
 	right: auto;
 	left: 10px;
+}
+.j-sidebar-container .icon-folder-2 {
+	line-height: 15px;
+	padding-left: 0;
 }
 #system-message-container,
 #j-main-container {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8307,7 +8307,7 @@ a.grid_true {
 	width: 16.5%;
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
-	padding-bottom: 10px;
+	padding-bottom: 40px;
 	clear: both;
 	background-color: #F0F0F0;
 	border-bottom: 1px solid #dedede;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -212,8 +212,13 @@ a.grid_true {
 
 /* For collapsible sidebar */
 .j-sidebar-container {
+	position: absolute;
+	display: block;
 	left: auto;
 	right: -16.5%;
+	padding-top: 28px;
+	padding-bottom: 40px;
+	clear: both;
 	margin: -10px -1px 0 0;
 	border-right: 0;
 	border-left: 1px solid #d3d3d3;
@@ -246,6 +251,11 @@ a.grid_true {
 		right: auto;
 		left: 10px;
 	}
+}
+
+.j-sidebar-container .icon-folder-2 {
+    line-height: 15px;
+    padding-left: 0;
 }
 
 #system-message-container,

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1308,7 +1308,7 @@ a.grid_true {
 	width: 16.5%;
 	margin: -10px 0 0 -1px;
 	padding-top: 28px;
-	padding-bottom: 10px;
+	padding-bottom: 40px;
 	clear: both;
 	background-color: @wellBackground;
 	border-bottom: 1px solid darken(@wellBackground, 7%);


### PR DESCRIPTION
Pull Request for Issue #13195 and replaces #13548

### Summary of Changes
A long list of items in the sidebar menu of media manager was unreachable. Rising padding bottom solves the issue.
ALSO: In RTL, the aligment of the folder icon was wrong. It also corrects this.
### Testing Instructions
Patch and test. To test in RTL, just modify the en-GB.xml metadata in backend to `<rtl>1</rtl>`
### Documentation Changes Required
NOne. This is a bug

AFTER PATCH in LTR you will get:

![screen shot 2017-01-15 at 09 21 29](https://cloud.githubusercontent.com/assets/869724/21961304/94c025c0-db06-11e6-9c99-1096a2fa9411.png)

and in RTL

![screen shot 2017-01-15 at 09 19 31](https://cloud.githubusercontent.com/assets/869724/21961305/9f60ac2a-db06-11e6-9f3c-2811c8b68238.png)

@jajodiaraghav
@genesisfan
@franz-wohlkoenig