### PR TITLE
[com_fields] Changes the contact user groups form field to fieldgroups

### DIFF
--- a/administrator/components/com_contact/models/forms/contact.xml
+++ b/administrator/components/com_contact/models/forms/contact.xml
@@ -430,7 +430,8 @@
 
 	<fields name="params" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
 
-		<fieldset name="display" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS">
+		<fieldset name="display" label="JGLOBAL_FIELDSET_DISPLAY_OPTIONS"
+			 addfieldpath="/administrator/components/com_fields/models/fields">
 
 			<field
 				name="show_contact_category"
@@ -723,9 +724,9 @@
 			
 			<field
 				name="show_user_custom_fields"
-				type="category"
+				type="fieldgroups"
 				multiple="true"
-				extension="com_users.user.fields"
+				context="com_users.user"
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				description="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_DESC"
 				>


### PR DESCRIPTION
Pull Request for PR #13019.

### Summary of Changes
With the move away from categories the field groups I forgot to adaptch the contact param to the new form field in PR #13103.

### Testing Instructions
- Create a user fields groups
- Edit a contact
- Navigate to the Tab Display

### Expected result
The field "Show User Custom Fields" should list the user fields groups.
![image](https://cloud.githubusercontent.com/assets/251072/21974968/2f9b25c2-dbca-11e6-85c2-576d686d9cf4.png)