### PR TITLE
Add "id" attribute to calendar <input> element

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -107,7 +107,7 @@ JHtml::_('stylesheet', 'system/fields/calendar-vanilla' . $cssFileExt, array(), 
 	<?php if (!$readonly && !$disabled) : ?>
 	<div class="input-append">
 		<?php endif; ?>
-		<input type="text" name="<?php
+		<input type="text" id="<?php echo $id; ?>" name="<?php
 		echo $name; ?>" value="<?php
 		echo htmlspecialchars(($value != "0000-00-00 00:00:00") ? $value : '', ENT_COMPAT, 'UTF-8'); ?>"<?php echo  $attributes; ?>
 		<?php !empty($hint) ? 'placeholder="' . $hint . '"' : ''; ?> data-alt-value="<?php


### PR DESCRIPTION
Calendar formfield currently don't have an ID attribute set.

### Summary of Changes
Adds the ID attribute to the calendar formfield

### Testing Instructions
Check any calendar formfield (eg article "Start Publishing"). In the HTML sourcecode you should see the ID attribute on the input element.
Also, clicking on the label should now activate the calendar popup.

### Documentation Changes Required
None