### PR TITLE
Correcting Notice when saving Global Configuration

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -283,11 +283,11 @@ class ConfigModelApplication extends ConfigModelForm
 		 * Look for a custom cache_path
 		 * First check if a path is given in the submitted data, then check if a path exists in the previous data, otherwise use the default
 		 */
-		if ($data['cache_path'])
+		if (!empty($data['cache_path']))
 		{
 			$path = $data['cache_path'];
 		}
-		elseif (!$data['cache_path'] && $prev['cache_path'])
+		elseif (empty($data['cache_path']) && !empty($prev['cache_path']))
 		{
 			$path = $prev['cache_path'];
 		}

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -283,11 +283,11 @@ class ConfigModelApplication extends ConfigModelForm
 		 * Look for a custom cache_path
 		 * First check if a path is given in the submitted data, then check if a path exists in the previous data, otherwise use the default
 		 */
-		if (!empty($data['cache_path']))
+		if ($data['cache_path'])
 		{
 			$path = $data['cache_path'];
 		}
-		elseif (empty($data['cache_path']) && !empty($prev['cache_path']))
+		elseif (!empty($prev['cache_path']))
 		{
 			$path = $prev['cache_path'];
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13608

When saving Global Configuration and `Path to Cache Folder` is empty, we get a Notice in the PHP logs:
`[16-Jan-2017 16:07:25 UTC] PHP Notice:  Undefined index: cache_path in /administrator/components/com_config/model/application.php on line 290`

This came from the merged PR https://github.com/joomla/joomla-cms/pull/13520

Test before and after patch.

@mbabker 