### PR TITLE
Add SMS to External URL menu item type

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -297,7 +297,7 @@ class MenusControllerItem extends JControllerForm
 				$segments = explode(':', $data['link']);
 				$protocol = strtolower($segments[0]);
 				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais', 'url',
-					'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
+					'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
 
 				if (!in_array($protocol, $scheme))
 				{


### PR DESCRIPTION
Allows data like sms://+15555555555 to be used instead of getting "Save Not Permitted"

Pull Request for Issue #13614

### Summary of Changes
Adds sms to the list of allowed schemes

### Testing Instructions

Apply patch and check to make sure sms://+15555555555 can be saved as an external menu item

### Documentation Changes Required

Maybe https://docs.joomla.org/Help36:Menus_Menu_Item_External_URL
