### PR TITLE
Update for menu, sync menutype and client_id

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -1,0 +1,2 @@
+-- Sync menutype for admin menu and set client_id correct
+UPDATE `#__menu` SET `menutype` = 'main', `client_id` = 1  WHERE `menutype` = 'main' OR `menutype` = 'menu';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -1,0 +1,3 @@
+-- Sync menutype for admin menu and set client_id correct
+UPDATE "#__menu" SET "client_id" = 1 WHERE "menutype" = 'main' OR "menutype" = 'menu';
+UPDATE "#__menu" SET "menutype" = 'main' WHERE "menutype" = 'main' OR "menutype" = 'menu';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -1,0 +1,3 @@
+-- Sync menutype for admin menu and set client_id correct
+UPDATE [#__menu] SET [client_id] = 1 WHERE [menutype] = 'main' OR [menutype] = 'menu';
+UPDATE [#__menu] SET [menutype] = 'main' WHERE [menutype] = 'main' OR [menutype] = 'menu';


### PR DESCRIPTION
### Summary of Changes
We use different menutype values for the admin menu. This PR syncs the used name for updating old installations. It also sets the client_id for admin menus to 1

### Testing Instructions
* Install Joomla
* Install an extension

Make sure everything works. 

### Documentation Changes Required
None