### PR TITLE
[com_fields] - remove duplicate extension id for mssql

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-29.sql
@@ -149,7 +149,5 @@ INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder]
 SELECT 33, 'com_fields', 'component', 'com_fields', '', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
 SELECT 461, 'plg_system_fields', 'plugin', 'fields', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
-UNION ALL
-SELECT 462, 'plg_fields_gallery', 'plugin', 'gallery', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT [#__extensions] OFF; 


### PR DESCRIPTION
removed id 462 to avoid duplicated id with #13626

cause now fields are managed with plugins

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/13616#issuecomment-273303712


