### PR TITLE
Field calendar plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
@@ -5,6 +5,6 @@
 
 PLG_FIELDS_CALENDAR="Fields - Calendar"
 PLG_FIELDS_CALENDAR_LABEL="Calendar (%s)"
-PLG_FIELDS_CALENDAR_PARAMS_FORMAT_DESC="The date format to be used. This is in the format used by PHP to specify date string formats (see below). If no format argument is given, '%Y-%m-%d' is assumed (giving dates like '2008-04-16')."
-PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL="Format"
-PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'calendar' in the extensions where custom fields are implemented."
+PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_DESC="If enabled, the calendar field expects a date and time and will also display the time. The formats are localised using the regular language strings."
+PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_LABEL="Show Time"
+PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'Calendar' in the extensions where custom fields are implemented."

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -1171,7 +1171,7 @@ abstract class JModelAdmin extends JModelForm
 			}
 
 			// Trigger the before save event.
-			$result = $dispatcher->trigger($this->event_before_save, array($context, $table, $isNew));
+			$result = $dispatcher->trigger($this->event_before_save, array($context, $table, $isNew, $data));
 
 			if (in_array(false, $result, true))
 			{
@@ -1192,7 +1192,7 @@ abstract class JModelAdmin extends JModelForm
 			$this->cleanCache();
 
 			// Trigger the after save event.
-			$dispatcher->trigger($this->event_after_save, array($context, $table, $isNew));
+			$dispatcher->trigger($this->event_after_save, array($context, $table, $isNew, $data));
 		}
 		catch (Exception $e)
 		{

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -376,6 +376,8 @@ abstract class JModelForm extends JModelLegacy
 			$data['tags'] = $data['metadata']['tags'];
 		}
 
+		$dispatcher->trigger('onAfterDataValidation', array($form, &$data));
+
 		return $data;
 	}
 }

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -376,8 +376,6 @@ abstract class JModelForm extends JModelLegacy
 			$data['tags'] = $data['metadata']['tags'];
 		}
 
-		$dispatcher->trigger('onAfterDataValidation', array($form, &$data));
-
 		return $data;
 	}
 }

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -344,10 +344,7 @@ abstract class JModelForm extends JModelLegacy
 		JPluginHelper::importPlugin($this->events_map['validate']);
 
 		$dispatcher = JEventDispatcher::getInstance();
-
-		// "onUserBeforeDataValidation" is deprecated, use the "onBeforeDataValidation" event instead.
 		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
-		$dispatcher->trigger('onBeforeDataValidation', array($form, &$data));
 
 		// Filter and validate the form data.
 		$data = $form->filter($data);

--- a/libraries/legacy/model/form.php
+++ b/libraries/legacy/model/form.php
@@ -344,7 +344,10 @@ abstract class JModelForm extends JModelLegacy
 		JPluginHelper::importPlugin($this->events_map['validate']);
 
 		$dispatcher = JEventDispatcher::getInstance();
+
+		// "onUserBeforeDataValidation" is deprecated, use the "onBeforeDataValidation" event instead.
 		$dispatcher->trigger('onUserBeforeDataValidation', array($form, &$data));
+		$dispatcher->trigger('onBeforeDataValidation', array($form, &$data));
 
 		// Filter and validate the form data.
 		$data = $form->filter($data);

--- a/plugins/fields/calendar/calendar.php
+++ b/plugins/fields/calendar/calendar.php
@@ -43,6 +43,10 @@ class PlgFieldsCalendar extends FieldsPlugin
 		// Set filter to user UTC
 		$fieldNode->setAttribute('filter', 'USER_UTC');
 
+		// Set field to use translated formats
+		$fieldNode->setAttribute('translateformat', '1');
+		$fieldNode->setAttribute('showtime', $field->fieldparams->get('showtime', 0) ? 'true' : 'false');
+
 		return $fieldNode;
 	}
 }

--- a/plugins/fields/calendar/calendar.php
+++ b/plugins/fields/calendar/calendar.php
@@ -18,19 +18,19 @@ JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRA
  */
 class PlgFieldsCalendar extends FieldsPlugin
 {
-/**
- * Transforms the field into an XML element and appends it as child on the given parent. This
- * is the default implementation of a field. Form fields which do support to be transformed into
- * an XML Element mut implemet the JFormDomfieldinterface.
- *
- * @param   stdClass    $field   The field.
- * @param   DOMElement  $parent  The field node parent.
- * @param   JForm       $form    The form.
- *
- * @return  DOMElement
- *
- * @since   __DEPLOY_VERSION__
- */
+	/**
+	 * Transforms the field into an XML element and appends it as child on the given parent. This
+	 * is the default implementation of a field. Form fields which do support to be transformed into
+	 * an XML Element mut implemet the JFormDomfieldinterface.
+	 *
+	 * @param   stdClass    $field   The field.
+	 * @param   DOMElement  $parent  The field node parent.
+	 * @param   JForm       $form    The form.
+	 *
+	 * @return  DOMElement
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
 	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
 	{
 		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);

--- a/plugins/fields/calendar/calendar.php
+++ b/plugins/fields/calendar/calendar.php
@@ -18,4 +18,31 @@ JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRA
  */
 class PlgFieldsCalendar extends FieldsPlugin
 {
+/**
+ * Transforms the field into an XML element and appends it as child on the given parent. This
+ * is the default implementation of a field. Form fields which do support to be transformed into
+ * an XML Element mut implemet the JFormDomfieldinterface.
+ *
+ * @param   stdClass    $field   The field.
+ * @param   DOMElement  $parent  The field node parent.
+ * @param   JForm       $form    The form.
+ *
+ * @return  DOMElement
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
+	{
+		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);
+
+		if (!$fieldNode)
+		{
+			return $fieldNode;
+		}
+
+		// Set filter to user UTC
+		$fieldNode->setAttribute('filter', 'USER_UTC');
+
+		return $fieldNode;
+	}
 }

--- a/plugins/fields/calendar/params/calendar.xml
+++ b/plugins/fields/calendar/params/calendar.xml
@@ -3,13 +3,17 @@
 	<fields name="fieldparams">
 		<fieldset name="fieldparams">
 			<field
-				name="format"
-				type="text"
-				class="input-xxlarge"
-				label="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL"
-				description="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_DESC"
+				name="showtime"
+				type="radio"
+				class="btn-group btn-group-yesno"
+				label="PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_LABEL"
+				description="PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_DESC"
 				size="20"
-			/>
+				default="0"
+				>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
 		</fieldset>
 	</fields>
 </form>

--- a/plugins/fields/calendar/tmpl/calendar.php
+++ b/plugins/fields/calendar/tmpl/calendar.php
@@ -21,4 +21,6 @@ if (is_array($value))
 	$value = implode(', ', $value);
 }
 
-echo htmlentities(JHtml::_('date', $value, JText::_('DATE_FORMAT_LC4')));
+$formatString =  $field->fieldparams->get('showtime', 0) ? 'DATE_FORMAT_LC5' : 'DATE_FORMAT_LC4';
+
+echo htmlentities(JHtml::_('date', $value, JText::_($formatString)));

--- a/plugins/fields/calendar/tmpl/calendar.php
+++ b/plugins/fields/calendar/tmpl/calendar.php
@@ -21,4 +21,4 @@ if (is_array($value))
 	$value = implode(', ', $value);
 }
 
-echo htmlentities($value);
+echo htmlentities(JHtml::_('date', $value, JText::_('DATE_FORMAT_LC4')));

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -31,10 +31,10 @@ class PlgSystemFields extends JPlugin
 	/**
 	 * The save event.
 	 *
-	 * @param   string    $context  The context
-	 * @param   JTable    $item     The table
-	 * @param   boolean   $isNew    Is new item
-	 * @param   array     $data     The validated data
+	 * @param   string   $context  The context
+	 * @param   JTable   $item     The table
+	 * @param   boolean  $isNew    Is new item
+	 * @param   array    $data     The validated data
 	 *
 	 * @return  boolean
 	 *

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -120,7 +120,7 @@ class PlgSystemFields extends JPlugin
 		$user->params = (string) $user->getParameters();
 
 		// Trigger the events with a real user
-		$this->onContentAfterSave('com_users.user', $user, false);
+		$this->onContentAfterSave('com_users.user', $user, false, $userData);
 
 		// Save the user with the modified params
 		$db    = JFactory::getDbo();

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -39,8 +39,8 @@ class PlgSystemFields extends JPlugin
 	/**
 	 * The onAfterDataValidation event.
 	 *
-	 * @param   JForm  $form   The form
-	 * @param   array  $data   The validated data
+	 * @param   JForm  $form  The form
+	 * @param   array  $data  The validated data
 	 *
 	 * @return  void
 	 *

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -29,51 +29,26 @@ class PlgSystemFields extends JPlugin
 	protected $autoloadLanguage = true;
 
 	/**
-	 * Validated fields data is stored here.
-	 *
-	 * @var    array
-	 * @since   __DEPLOY_VERSION__
-	 */
-	private $validFieldData = array();
-
-	/**
-	 * The onAfterDataValidation event.
-	 *
-	 * @param   JForm  $form  The form
-	 * @param   array  $data  The validated data
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function onAfterDataValidation($form, $data)
-	{
-		if (!empty($data['params']))
-		{
-			// Store the validated data in the plugin for use after the save was successful
-			$this->validFieldData = $data['params'];
-		}
-	}
-
-	/**
 	 * The save event.
 	 *
 	 * @param   string    $context  The context
-	 * @param   stdClass  $item     The item
-	 * @param   boolean   $isNew    Is new
+	 * @param   JTable    $item     The table
+	 * @param   boolean   $isNew    Is new item
+	 * @param   array     $data     The validated data
 	 *
 	 * @return  boolean
 	 *
 	 * @since   3.7.0
 	 */
-	public function onContentAfterSave($context, $item, $isNew)
+	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
-		if (!$this->validFieldData)
+		if (!$data || !is_array($data) || empty($data['params']))
 		{
 			return true;
 		}
 
-		$parts = FieldsHelper::extract($context);
+		$fieldsData = $data['params'];
+		$parts      = FieldsHelper::extract($context);
 
 		if (!$parts)
 		{
@@ -96,7 +71,7 @@ class PlgSystemFields extends JPlugin
 		foreach ($fieldsObjects as $field)
 		{
 			// Only save the fields with the alias from the data
-			if (!key_exists($field->alias, $this->validFieldData))
+			if (!key_exists($field->alias, $fieldsData))
 			{
 				continue;
 			}
@@ -114,7 +89,7 @@ class PlgSystemFields extends JPlugin
 			}
 
 			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $context, $id, $this->validFieldData[$field->alias]);
+			$model->setFieldValue($field->id, $context, $id, $fieldsData[$field->alias]);
 		}
 
 		return true;

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -42,7 +42,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
-		if (!$data || !is_array($data) || empty($data['params']))
+		if (!is_array($data) || empty($data['params']))
 		{
 			return true;
 		}


### PR DESCRIPTION
Pull Request for Issue #13606 .

Currently, when you have a calendar field the timezone with each save the timezone is added/substracted from the date, resulting in a shift of the date/time with each save. This is especially bad if you only want to store the date plus have a negative timezone (eg New York), then the date shifts one day back with each save.
Also when the date is displayed in frontend, it is off by the timezone as well.

Main issue is that the calendar formfield expects the value stored as UTC and applies the timezone when shown in the form. But currently, the value isn't converted to UTC during save which results in that shift.
Also the timezone isn't applied when the value is shown in frontend.

### Summary of Changes
* Using `JHtml::date` to show the date in frontend. This automatically applies the user timezone to the value.
* Using `JText::_()` to show the date in a localised format. ~With this PR this format is hardcoded to `DATE_FORMAT_LC4` which will only show the date. That likely needs to be improved but I'm not yet sure how. It's not directly in the scope of this PR and can be done later fine.~ Also overrides are possible to change that format easily.
* The `format` parameter of the field is replaced with a `showtime` parameter. It will control if the time is displayed or not both in forms and when the item is shown in frontend. It takes translated format strings.
* ~Introduces a new plugin event "onAfterDataValidation". Also adds a new "onBeforeDataValidation" event and deprecates the existing "onUserBeforeDataValidation". Here I need input from @wilsonge as he initially created this event with https://github.com/joomla/joomla-cms/pull/10751. Imho the name of the event is misleading as it has nothing to do with com_users (it's a general event).~
* ~During that new event, the fields plugin will take the validated fields data, store it in a private property and use it in the onContentAfterSave event to store it into database. The "onContentBeforeSave" method isn't needed anymore in the fields plugin.~
* Expanded the current `onContentBeforeSave` and `onContentAfterSave` events so they not only pass the table object but also the validated data. The fields data can then be taken simply from that $data array. I'm sure other extensions will find that useful as well.

### Testing Instructions
* Make sure editing field values works as expected.
* Make especially sure calendar formfields don't change the value on repeated saves and that the displayed value is same in frontend and backend. Especially also check with negative timezones.

### Documentation Changes Required
The ~~new~~ adjusted event needs to be documented on https://docs.joomla.org/Plugin/Events.