### PR TITLE
Fix backend menu manager checks for important menu items in top level only

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -160,14 +160,13 @@ abstract class ModMenuHelper
 	/**
 	 * Load the menu items from database for the given menutype
 	 *
-	 * @param   string   $menutype   The selected menu type
-	 * @param   boolean  $authCheck  An optional switch to turn off the auth check (to support custom layouts 'grey out' behaviour).
+	 * @param   string  $menutype  The selected menu type
 	 *
 	 * @return  array
 	 *
 	 * @since   3.7.0
 	 */
-	public static function getMenuItems($menutype, $authCheck = true)
+	public static function getMenuItems($menutype)
 	{
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true);
@@ -206,10 +205,7 @@ abstract class ModMenuHelper
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 
-		// Parse the list of extensions.
-		$result = self::parseItems($menuItems, $authCheck);
-
-		return $result;
+		return $menuItems;
 	}
 
 	/**
@@ -222,7 +218,7 @@ abstract class ModMenuHelper
 	 *
 	 * @since   3.7.0
 	 */
-	protected static function parseItems($menuItems, $authCheck = true)
+	public static function parseItems($menuItems, $authCheck = true)
 	{
 		$result = array();
 		$user   = JFactory::getUser();

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -389,6 +389,9 @@ class JAdminCssMenu
 				}
 			}
 
+			// Create levels
+			$items = ModMenuHelper::parseItems($items);
+
 			// Menu items for dynamic db driven setup to load here
 			$this->loadItems($items, $enabled);
 		}


### PR DESCRIPTION
Fix backend menu manager checks for important menu items in top level only.

### Summary of Changes
Now joomla should be able to see the menu manager links and module manager links in any level down in the menu tree.

### Testing Instructions
Create menu items for menu manager and module manager in a custom admin menu under some parent menu item. 

Without this patch it will say these does not exist.

After this patch, they will be seen by Joomla and no warning should be shown.

### Documentation Changes Required
None