### PR TITLE
Issue  #13651 fix

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -34,6 +34,7 @@ abstract class ModMenuHelper
 			->from('#__menu_types AS a')
 			->join('LEFT', '#__menu AS b ON b.menutype = a.menutype AND b.home != 0')
 			->select('b.language')
+			->select('b.client_id')
 			->join('LEFT', '#__languages AS l ON l.lang_code = language')
 			->select('l.image')
 			->select('l.sef')


### PR DESCRIPTION
ModMenuHelper::getMenus() was not returning class field 'client_id' needed in joomla/libraries/vendor/joomla/utilities/src/ArrayHelper.php

Pull Request for Issue #13651 .

### Summary of Changes
Added 'client_id' in SQL query in administrator/modules/mod_menu/helper.php after line 36 :

->select('b.client_id')

### Testing Instructions
Open Administrator  Panel page when Error Reporting is set to 'Development'. The page does not contain errors.

### Documentation Changes Required
No