### PR TITLE
TYPO - Change Color to Colour as it is en-GB

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_color.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_color.ini
@@ -3,6 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_COLOR="Fields - Color"
-PLG_FIELDS_COLOR_LABEL="Color"
-PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Color' in the extensions where custom fields are implemented."
+PLG_FIELDS_COLOR="Fields - Colour"
+PLG_FIELDS_COLOR_LABEL="Colour"
+PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Colour' in the extensions where custom fields are implemented."


### PR DESCRIPTION
As `en-GB` is the official Joomla! Language, `color` must be changed to `colour` and then be consistent with all other uses.

Easy fix on review