### PR TITLE
Deprecate PSR-0 class loading

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -380,7 +380,7 @@ abstract class JLoader
 	/**
 	 * Register a namespace to the autoloader. When loaded, namespace paths are searched in a "last in, first out" order.
 	 *
-	 * This function will be changed in J4 to support PRS-4 namespace registering.
+	 * This function will be changed in J4 to support PSR-4 namespace registering.
 	 *
 	 * @param   string   $namespace  A case sensitive Namespace to register.
 	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -474,7 +474,7 @@ abstract class JLoader
 	 *
 	 * @return  boolean  True on success, false otherwise.
 	 *
-	 * @since   13.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function loadByPsr4($class)
 	{

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -160,7 +160,7 @@ abstract class JLoader
 	 */
 	public static function getNamespaces($type = 'psr0')
 	{
-		if ($type != 'psr0' && $type != 'psr4')
+		if ($type !== 'psr0' && $type !== 'psr4')
 		{
 			throw new InvalidArgumentException('Type needs to be prs0 or psr4!');
 		}

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -380,6 +380,8 @@ abstract class JLoader
 	/**
 	 * Register a namespace to the autoloader. When loaded, namespace paths are searched in a "last in, first out" order.
 	 *
+	 * This function will be changed in J4 to support PRS-4 namespace registering.
+	 *
 	 * @param   string   $namespace  A case sensitive Namespace to register.
 	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.
 	 * @param   boolean  $reset      True to reset the namespace with only the given lookup path.
@@ -469,6 +471,8 @@ abstract class JLoader
 	 * @return  boolean  True on success, false otherwise.
 	 *
 	 * @since   13.1
+	 *
+	 * @deprecated 4.0 this method will be renamed to loadByPsr4 in favour to support PSR-4
 	 */
 	public static function loadByPsr0($class)
 	{

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -396,12 +396,12 @@ abstract class JLoader
 	 *
 	 * @throws  RuntimeException
 	 *
-	 * @note    This function will be changed in J4 to support PSR-4 namespace registering.
+	 * @note    The default argument of $type will be changed in J4 to be 'psr4'
 	 * @since   12.3
 	 */
 	public static function registerNamespace($namespace, $path, $reset = false, $prepend = false, $type = 'psr0')
 	{
-		if ($type != 'psr0' && $type != 'psr4')
+		if ($type !== 'psr0' && $type !== 'psr4')
 		{
 			throw new InvalidArgumentException('Type needs to be prs0 or psr4!');
 		}

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -416,9 +416,9 @@ abstract class JLoader
 		}
 
 		// If the namespace is not yet registered or we have an explicit reset flag then set the path.
-		if (!isset(self::$namespaces[$namespace][$type]) || $reset)
+		if (!isset(self::$namespaces[$type][$namespace]) || $reset)
 		{
-			self::$namespaces[$namespace][$type] = array($path);
+			self::$namespaces[$type][$namespace] = array($path);
 		}
 
 		// Otherwise we want to simply add the path to the namespace.
@@ -426,11 +426,11 @@ abstract class JLoader
 		{
 			if ($prepend)
 			{
-				array_unshift(self::$namespaces[$namespace][$type], $path);
+				array_unshift(self::$namespaces[$type][$namespace], $path);
 			}
 			else
 			{
-				self::$namespaces[$namespace][$type][] = $path;
+				self::$namespaces[$type][$namespace][] = $path;
 			}
 		}
 	}

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -152,7 +152,7 @@ abstract class JLoader
 	/**
 	 * Method to get the list of registered namespaces.
 	 *
-	 * @param   string   $type  Defines the type of namespace, can be prs0 or psr4.
+	 * @param   string  $type  Defines the type of namespace, can be prs0 or psr4.
 	 *
 	 * @return  array  The array of namespace => path values for the autoloader.
 	 *
@@ -160,6 +160,10 @@ abstract class JLoader
 	 */
 	public static function getNamespaces($type = 'psr0')
 	{
+		if ($type != 'psr0' && $type != 'psr4')
+		{
+			throw new InvalidArgumentException('Type needs to be prs0 or psr4!');
+		}
 		return self::$namespaces;
 	}
 
@@ -382,7 +386,7 @@ abstract class JLoader
 	/**
 	 * Register a namespace to the autoloader. When loaded, namespace paths are searched in a "last in, first out" order.
 	 *
-	 * This function will be changed in J4 to support PSR-4 namespace registering.
+	 * @note This function will be changed in J4 to support PSR-4 namespace registering.
 	 *
 	 * @param   string   $namespace  A case sensitive Namespace to register.
 	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.
@@ -398,6 +402,11 @@ abstract class JLoader
 	 */
 	public static function registerNamespace($namespace, $path, $reset = false, $prepend = false, $type = 'psr0')
 	{
+		if ($type != 'psr0' && $type != 'psr4')
+		{
+			throw new InvalidArgumentException('Type needs to be prs0 or psr4!');
+		}
+
 		// Verify the library path exists.
 		if (!file_exists($path))
 		{
@@ -506,6 +515,7 @@ abstract class JLoader
 		foreach (self::$namespaces['psr4'] as $ns => $paths)
 		{
 			$nsPath = trim(str_replace('\\', DIRECTORY_SEPARATOR, $ns), DIRECTORY_SEPARATOR);
+
 			if (strpos($class, $ns) === 0)
 			{
 				// Loop through paths registered to this namespace until we find a match.

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -164,7 +164,7 @@ abstract class JLoader
 		{
 			throw new InvalidArgumentException('Type needs to be prs0 or psr4!');
 		}
-		return self::$namespaces;
+		return self::$namespaces[$type];
 	}
 
 	/**

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -386,7 +386,6 @@ abstract class JLoader
 	/**
 	 * Register a namespace to the autoloader. When loaded, namespace paths are searched in a "last in, first out" order.
 	 *
-	 * @note This function will be changed in J4 to support PSR-4 namespace registering.
 	 *
 	 * @param   string   $namespace  A case sensitive Namespace to register.
 	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.
@@ -398,6 +397,7 @@ abstract class JLoader
 	 *
 	 * @throws  RuntimeException
 	 *
+	 * @note    This function will be changed in J4 to support PSR-4 namespace registering.
 	 * @since   12.3
 	 */
 	public static function registerNamespace($namespace, $path, $reset = false, $prepend = false, $type = 'psr0')

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -386,7 +386,6 @@ abstract class JLoader
 	/**
 	 * Register a namespace to the autoloader. When loaded, namespace paths are searched in a "last in, first out" order.
 	 *
-	 *
 	 * @param   string   $namespace  A case sensitive Namespace to register.
 	 * @param   string   $path       A case sensitive absolute file path to the library root where classes of the given namespace can be found.
 	 * @param   boolean  $reset      True to reset the namespace with only the given lookup path.


### PR DESCRIPTION
As PSR-0 is deprecated, this PR offers to register namespaces also for PSR-4. The plan is to remove support for PSR-0 in J4 probably.

Maintainer review.

Ping @wilsonge 