### PR TITLE
Disabled and readonly properties to the color formfied

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -60,6 +60,7 @@ $class        = ' class="' . trim('minicolors ' . $class) . ($validate == 'color
 $control      = $control ? ' data-control="' . $control . '"' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
 $keywords     = $keywords ? ' data-keywords="' . $keywords . '"' : '';
+$disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : ' placeholder="' . $placeholder . '"';
 $autocomplete = ! $autocomplete ? ' autocomplete="off"' : '';

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -45,7 +45,9 @@ extract($displayData);
  * @var   array    $control         Is this field checked?
  */
 
-$class = ' class="' . trim('simplecolors chzn-done ' . $class) . '"';
+$class    = ' class="' . trim('simplecolors chzn-done ' . $class) . '"';
+$disabled = $disabled ? ' disabled' : '';
+$readonly = $readonly ? ' readonly' : '';
 
 // Include jQuery
 JHtml::_('jquery.framework');
@@ -55,7 +57,7 @@ JHtml::_('stylesheet', 'jui/jquery.simplecolors.css', array('version' => 'auto',
 JHtml::_('script', 'system/color-field-init.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 <select data-chosen="true" name="<?php echo $name; ?>" id="<?php echo $id; ?>"<?php
-echo $disabled; ?><?php echo $required; ?><?php echo $class; ?><?php echo $position; ?><?php
+echo $disabled; ?><?php echo $readonly; ?><?php echo $required; ?><?php echo $class; ?><?php echo $position; ?><?php
 echo $onchange; ?><?php echo $autofocus; ?> style="visibility:hidden;width:22px;height:1px">
 	<?php foreach ($colors as $i => $c) : ?>
 		<option<?php echo ($c == $color ? ' selected="selected"' : ''); ?>><?php echo $c; ?></option>


### PR DESCRIPTION
Pull Request for Issue #13665.

### Summary of Changes
Adds proper disabled and readonly properties to the HTML element of the color formfield.

### Testing Instructions
* Try a custom field of the type color and set the disabled state for it (or don't allow editing the value using the ACL).
* You can also try it by editing a form XML file and add a disabled attribute there. Eg add `disabled="disabled"` to https://github.com/joomla/joomla-cms/blob/staging/templates/protostar/templateDetails.xml#L55 and try editing the color of the Protostar template.

#### Limitations
The readonly state doesn't do anything because the JS color picker doesn't support that. I have still added it to the HTML element in case someone overrides the color picker with one that works.
There is also a "simple" mode for that picker which can be activated by adding `control="simple"` to the form XML, but that doesn't seem to support the disabled state at all.

### Documentation Changes Required
None