### PR TITLE
Clean up legacy controller + model classes

### DIFF
--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -381,7 +381,7 @@ class JControllerForm extends JControllerLegacy
 
 		// Get the previous record id (if any) and the current record id.
 		$recordId = (int) (count($cid) ? $cid[0] : $this->input->getInt($urlVar));
-		$checkin = property_exists($table, 'checked_out');
+		$checkin = property_exists($table, $table->getColumnAlias('checked_out'));
 
 		// Access check.
 		if (!$this->allowEdit(array($key => $recordId), $key))
@@ -622,11 +622,10 @@ class JControllerForm extends JControllerLegacy
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		$app   = JFactory::getApplication();
-		$lang  = JFactory::getLanguage();
 		$model = $this->getModel();
 		$table = $model->getTable();
 		$data  = $this->input->post->get('jform', array(), 'array');
-		$checkin = property_exists($table, 'checked_out');
+		$checkin = property_exists($table, $table->getColumnAlias('checked_out'));
 		$context = "$this->option.edit.$this->context";
 		$task = $this->getTask();
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -11,6 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Prototype admin model.
@@ -190,7 +191,7 @@ abstract class JModelAdmin extends JModelForm
 	{
 		// Sanitize ids.
 		$pks = array_unique($pks);
-		JArrayHelper::toInteger($pks);
+		$pks = ArrayHelper::toInteger($pks);
 
 		// Remove any values of zero.
 		if (array_search(0, $pks, true))
@@ -225,7 +226,7 @@ abstract class JModelAdmin extends JModelForm
 
 		if ($this->batch_copymove && !empty($commands[$this->batch_copymove]))
 		{
-			$cmd = JArrayHelper::getValue($commands, 'move_copy', 'c');
+			$cmd = ArrayHelper::getValue($commands, 'move_copy', 'c');
 
 			if ($cmd == 'c')
 			{
@@ -694,12 +695,14 @@ abstract class JModelAdmin extends JModelForm
 			$pks = array((int) $this->getState($this->getName() . '.id'));
 		}
 
+		$checkedOutField = $table->getColumnAlias('checked_out');
+
 		// Check in all items.
 		foreach ($pks as $pk)
 		{
 			if ($table->load($pk))
 			{
-				if ($table->checked_out > 0)
+				if ($table->{$checkedOutField} > 0)
 				{
 					if (!parent::checkin($pk))
 					{
@@ -904,7 +907,7 @@ abstract class JModelAdmin extends JModelForm
 
 		// Convert to the JObject before adding other data.
 		$properties = $table->getProperties(1);
-		$item = JArrayHelper::toObject($properties, 'JObject');
+		$item = ArrayHelper::toObject($properties, 'JObject');
 
 		if (property_exists($item, 'params'))
 		{
@@ -1210,7 +1213,7 @@ abstract class JModelAdmin extends JModelForm
 			$associations = $data['associations'];
 
 			// Unset any invalid associations
-			$associations = Joomla\Utilities\ArrayHelper::toInteger($associations);
+			$associations = ArrayHelper::toInteger($associations);
 
 			// Unset any invalid associations
 			foreach ($associations as $tag => $id)

--- a/libraries/legacy/model/list.php
+++ b/libraries/legacy/model/list.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Model class for handling lists of items.
  *
@@ -375,7 +377,7 @@ class JModelList extends JModelLegacy
 	protected function loadForm($name, $source = null, $options = array(), $clear = false, $xpath = false)
 	{
 		// Handle the optional arguments.
-		$options['control'] = JArrayHelper::getValue($options, 'control', false);
+		$options['control'] = ArrayHelper::getValue((array) $options, 'control', false);
 
 		// Create a signature hash.
 		$hash = md5($source . serialize($options));
@@ -640,7 +642,7 @@ class JModelList extends JModelLegacy
 		JPluginHelper::importPlugin($group);
 
 		// Get the dispatcher.
-		$dispatcher = JDispatcher::getInstance();
+		$dispatcher = JEventDispatcher::getInstance();
 
 		// Trigger the form preparation event.
 		$results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes some small cleanup to legacy controller + model classes:

1. JControllerForm

- Allow using column alias for **checked_out** field in JTable object
- Remove unused $lang variable

2. JModelAdmin

- Replace deprecated JArrayHelper class with Joomla\Utilities\ArrayHelper
- Allow using column alias for **checked_out** field in JTable object

3. JModelList

- Replace deprecated JArrayHelper class with Joomla\Utilities\ArrayHelper
- Replace deprecated JDispatcher class with JEventDispatcher

### Testing Instructions

- For developers, please help review the code
- For testers, please add/edit article, make sure it is still working as expected

### Documentation Changes Required
None