### PR TITLE
[4.0] ViewType.php (like html.php) in favor of view.ViewType.php for autoloading

### DIFF
--- a/libraries/cms/controller/legacy.php
+++ b/libraries/cms/controller/legacy.php
@@ -212,7 +212,7 @@ class JControllerLegacy implements JControllerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function createOldFilename($parts)
+	protected static function createOldFileName($parts)
 	{
 		if (!empty($parts['type']))
 		{
@@ -597,7 +597,7 @@ class JControllerLegacy implements JControllerInterface
 			// Check for the old file
 			if (!$path)
 			{
-				$path = JPath::find($this->paths['view'], $this->createOldFilename(array('name' => $viewName, 'type' => $viewType)));
+				$path = JPath::find($this->paths['view'], $this->createOldFileName(array('name' => $viewName, 'type' => $viewType)));
 			}
 
 			if (!$path)

--- a/libraries/cms/controller/legacy.php
+++ b/libraries/cms/controller/legacy.php
@@ -191,20 +191,39 @@ class JControllerLegacy implements JControllerInterface
 				break;
 
 			case 'view':
-				if (!empty($parts['type']))
+				if (empty($parts['type']))
 				{
-					$parts['type'] = '.' . $parts['type'];
-				}
-				else
-				{
-					$parts['type'] = '';
+					$parts['type'] = 'view';
 				}
 
-				$filename = strtolower($parts['name'] . '/view' . $parts['type'] . '.php');
+				$filename = strtolower($parts['name'] . '/' . $parts['type'] . '.php');
 				break;
 		}
 
 		return $filename;
+	}
+
+	/**
+	 * Fallback for the old view names
+	 *
+	 * @param   array  $parts  An associative array of filename information. Optional.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function createOldFilename($parts)
+	{
+		if (!empty($parts['type']))
+		{
+			$parts['type'] = '.' . $parts['type'];
+		}
+		else
+		{
+			$parts['type'] = '';
+		}
+
+		return strtolower($parts['name'] . '/view' . $parts['type'] . '.php');
 	}
 
 	/**
@@ -574,6 +593,12 @@ class JControllerLegacy implements JControllerInterface
 		{
 			jimport('joomla.filesystem.path');
 			$path = JPath::find($this->paths['view'], $this->createFileName('view', array('name' => $viewName, 'type' => $viewType)));
+
+			// Check for the old file
+			if (!$path)
+			{
+				$path = JPath::find($this->paths['view'], $this->createOldFilename(array('name' => $viewName, 'type' => $viewType)));
+			}
 
 			if (!$path)
 			{

--- a/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
@@ -109,11 +109,15 @@ class JControllerLegacyTest extends TestCase
 
 		$parts['type'] = 'json';
 
-		$this->assertEquals('test/view.json.php', TestReflection::invoke('JControllerLegacy', 'createFileName', 'view', $parts), __LINE__);
+		$this->assertEquals('test/json.php', TestReflection::invoke('JControllerLegacy', 'createFileName', 'view', $parts), __LINE__);
 
 		$parts = array('type' => 'JSON', 'name' => 'TEST');
 
-		$this->assertEquals('test/view.json.php', TestReflection::invoke('JControllerLegacy', 'createFileName', 'view', $parts), __LINE__);
+		$this->assertEquals('test/json.php', TestReflection::invoke('JControllerLegacy', 'createFileName', 'view', $parts), __LINE__);
+
+		$parts = array('type' => 'JSON', 'name' => 'TEST');
+
+		$this->assertEquals('test/view.json.php', TestReflection::invoke('JControllerLegacy', 'createOldFileName', $parts), __LINE__);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Example: view.html.php -> html.php

Remove `view.` from the view files (like view.html.php) in the controller loading in favor of only having the type as file name.

If the file is not existing we check if there is one with the old filename pattern.

### Testing Instructions

Confirm that everything is still working and if you add a html.php in an component view this should be loaded instead of the view.html.php

### Documentation Changes Required

Dev documentation