### PR TITLE
Add an option to defer writing logs.

### DIFF
--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -53,6 +53,23 @@ class FormattedtextLogger extends Logger
 	protected $path;
 
 	/**
+	 * If true, all writes will be deferred as long as possible.
+	 * NOTE: Deferred logs may never be written if the application encounters a fatal error.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $defer = false;
+
+	/**
+	 * If deferring, entries will be stored here prior to writing.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $deferredEntries = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   array  &$options  Log object options.
@@ -91,9 +108,40 @@ class FormattedtextLogger extends Logger
 			$this->format = (string) $this->options['text_entry_format'];
 		}
 
+		// Wait as long as possible before writing logs
+		if (!empty($this->options['defer']))
+		{
+			$this->defer = (boolean) $this->options['defer'];
+		}
+
 		// Build the fields array based on the format string.
 		$this->parseFields();
 	}
+
+    /**
+     * If deferred, write all pending logs.
+     *
+	 * @since  __DEPLOY_VERSION__
+     */
+    function __destruct()
+    {
+        // Nothing to do
+        if (!$this->defer || empty($this->deferredEntries))
+        {
+            return;
+        }
+
+		// Initialise the file if not already done.
+		$this->initFile();
+
+        // Format all lines and write to file.
+        $lines = array_map(array($this, 'formatLine'), $this->deferredEntries);
+
+		if (!JFile::append($this->path, implode("\n", $lines) . "\n"))
+		{
+			throw new RuntimeException('Cannot write to log file.');
+		}
+    }
 
 	/**
 	 * Method to add an entry to the log.
@@ -107,9 +155,39 @@ class FormattedtextLogger extends Logger
 	 */
 	public function addEntry(LogEntry $entry)
 	{
-		// Initialise the file if not already done.
-		$this->initFile();
+        // Store the entry to be written later.
+        if ($this->defer)
+        {
+            $this->deferredEntries[] = $entry;
+        }
+        // Write it immediately.
+        else
+        {
+            // Initialise the file if not already done.
+            $this->initFile();
 
+            // Write the new entry to the file.
+            $line = $this->formatLine($entry);
+            $line .= "\n";
+
+            if (!JFile::append($this->path, $line))
+            {
+            	throw new RuntimeException('Cannot write to log file.');
+            }
+        }
+	}
+
+    /**
+     * Format a line for the log file.
+     *
+     * @param   JLogEntry  $entry  The log entry to format as a string.
+     *
+     * @return  String
+     *
+	 * @since  __DEPLOY_VERSION__
+     */
+	protected function formatLine(JLogEntry $entry)
+	{
 		// Set some default field values if not already set.
 		if (!isset($entry->clientIP))
 		{

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -137,7 +137,7 @@ class FormattedtextLogger extends Logger
 		// Format all lines and write to file.
 		$lines = array_map(array($this, 'formatLine'), $this->deferredEntries);
 
-		if (!JFile::append($this->path, implode("\n", $lines) . "\n"))
+		if (!\JFile::append($this->path, implode("\n", $lines) . "\n"))
 		{
 			throw new RuntimeException('Cannot write to log file.');
 		}
@@ -170,7 +170,7 @@ class FormattedtextLogger extends Logger
 			$line = $this->formatLine($entry);
 			$line .= "\n";
 
-			if (!JFile::append($this->path, $line))
+			if (!\JFile::append($this->path, $line))
 			{
 				throw new RuntimeException('Cannot write to log file.');
 			}
@@ -186,7 +186,7 @@ class FormattedtextLogger extends Logger
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected function formatLine(JLogEntry $entry)
+	protected function formatLine(LogEntry $entry)
 	{
 		// Set some default field values if not already set.
 		if (!isset($entry->clientIP))

--- a/libraries/src/Log/Logger/FormattedtextLogger.php
+++ b/libraries/src/Log/Logger/FormattedtextLogger.php
@@ -118,30 +118,30 @@ class FormattedtextLogger extends Logger
 		$this->parseFields();
 	}
 
-    /**
-     * If deferred, write all pending logs.
-     *
+	/**
+	 * If deferred, write all pending logs.
+	 *
 	 * @since  __DEPLOY_VERSION__
-     */
-    function __destruct()
-    {
-        // Nothing to do
-        if (!$this->defer || empty($this->deferredEntries))
-        {
-            return;
-        }
+	 */
+	public function __destruct()
+	{
+		// Nothing to do
+		if (!$this->defer || empty($this->deferredEntries))
+		{
+			return;
+		}
 
 		// Initialise the file if not already done.
 		$this->initFile();
 
-        // Format all lines and write to file.
-        $lines = array_map(array($this, 'formatLine'), $this->deferredEntries);
+		// Format all lines and write to file.
+		$lines = array_map(array($this, 'formatLine'), $this->deferredEntries);
 
 		if (!JFile::append($this->path, implode("\n", $lines) . "\n"))
 		{
 			throw new RuntimeException('Cannot write to log file.');
 		}
-    }
+	}
 
 	/**
 	 * Method to add an entry to the log.
@@ -155,37 +155,37 @@ class FormattedtextLogger extends Logger
 	 */
 	public function addEntry(LogEntry $entry)
 	{
-        // Store the entry to be written later.
-        if ($this->defer)
-        {
-            $this->deferredEntries[] = $entry;
-        }
-        // Write it immediately.
-        else
-        {
-            // Initialise the file if not already done.
-            $this->initFile();
+		// Store the entry to be written later.
+		if ($this->defer)
+		{
+			$this->deferredEntries[] = $entry;
+		}
+		// Write it immediately.
+		else
+		{
+			// Initialise the file if not already done.
+			$this->initFile();
 
-            // Write the new entry to the file.
-            $line = $this->formatLine($entry);
-            $line .= "\n";
+			// Write the new entry to the file.
+			$line = $this->formatLine($entry);
+			$line .= "\n";
 
-            if (!JFile::append($this->path, $line))
-            {
-            	throw new RuntimeException('Cannot write to log file.');
-            }
-        }
+			if (!JFile::append($this->path, $line))
+			{
+				throw new RuntimeException('Cannot write to log file.');
+			}
+		}
 	}
 
-    /**
-     * Format a line for the log file.
-     *
-     * @param   JLogEntry  $entry  The log entry to format as a string.
-     *
-     * @return  String
-     *
+	/**
+	 * Format a line for the log file.
+	 *
+	 * @param   JLogEntry  $entry  The log entry to format as a string.
+	 *
+	 * @return  String
+	 *
 	 * @since  __DEPLOY_VERSION__
-     */
+	 */
 	protected function formatLine(JLogEntry $entry)
 	{
 		// Set some default field values if not already set.

--- a/tests/unit/suites/libraries/joomla/log/loggers/JLogLoggerFormattedTextTest.php
+++ b/tests/unit/suites/libraries/joomla/log/loggers/JLogLoggerFormattedTextTest.php
@@ -125,6 +125,35 @@ class JLogLoggerFormattedTextTest extends TestCase
 	}
 
 	/**
+	 * Test the JLogLoggerFormattedText::__construct method.
+	 *
+	 * @return void
+	 */
+	public function testConstructor05()
+	{
+		// Setup the basic configuration.
+		$config = array(
+			'text_file_path' => JPATH_TESTS . '/tmp',
+			'text_file' => '',
+			'text_entry_format' => null,
+			'defer' => true,
+		);
+		$logger = new JLogLoggerFormattedTextInspector($config);
+
+		// Default format string.
+		$this->assertEquals($logger->format, '{DATETIME}	{PRIORITY}	{CATEGORY}	{MESSAGE}', 'Line: ' . __LINE__);
+
+		// Default format string.
+		$this->assertEquals($logger->fields, array('DATETIME', 'PRIORITY', 'CATEGORY', 'MESSAGE'), 'Line: ' . __LINE__);
+
+		// Default file name.
+		$this->assertEquals($logger->path, JPATH_TESTS . '/tmp/error.php', 'Line: ' . __LINE__);
+
+		// Defer writing to file.
+		$this->assertEquals($logger->defer, true, 'Line: ' . __LINE__);
+	}
+
+	/**
 	 * Test the JLogLoggerFormattedText::addEntry method.
 	 *
 	 * @return void
@@ -165,6 +194,61 @@ class JLogLoggerFormattedTextTest extends TestCase
 
 		// Remove the log file if it exists.
 		@ unlink($logger->path);
+	}
+
+	/**
+	 * Test the JLogLoggerFormattedText::addEntry method with defer option.
+	 *
+	 * @return void
+	 */
+	public function testDeferWritingEntry()
+	{
+		// Setup the basic configuration.
+		$config = array(
+			'text_file_path' => JPATH_TESTS . '/tmp',
+			'text_file' => '',
+			'text_entry_format' => '{PRIORITY}	{CATEGORY}	{MESSAGE}',
+			'defer' => true,
+		);
+		$logger = new JLogLoggerFormattedTextInspector($config);
+		$path = $logger->path;
+
+		// Remove the log file if it exists.
+		@ unlink($path);
+
+		$logger->addEntry(new JLogEntry('Testing Entry 01'));
+		$this->assertFileNotExists(
+			$path,
+			'Line: ' . __LINE__
+		);
+
+		$logger->addEntry(new JLogEntry('Testing 02', JLog::ERROR));
+		$this->assertFileNotExists(
+			$path,
+			'Line: ' . __LINE__
+		);
+
+		$logger->addEntry(new JLogEntry('Testing3', JLog::EMERGENCY, 'deprecated'));
+		$this->assertFileNotExists(
+			$path,
+			'Line: ' . __LINE__
+		);
+
+		unset($logger);
+
+		$this->assertFileExists(
+			$path,
+			'Line: ' . __LINE__
+		);
+
+		$this->assertEquals(
+			$this->getLastLine($path),
+			'EMERGENCY	deprecated	Testing3',
+			'Line: ' . __LINE__
+		);
+
+		// Remove the log file if it exists.
+		@ unlink($path);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/log/loggers/stubs/formattedtext/inspector.php
+++ b/tests/unit/suites/libraries/joomla/log/loggers/stubs/formattedtext/inspector.php
@@ -29,4 +29,6 @@ class JLogLoggerFormattedTextInspector extends JLogLoggerFormattedtext
 	public $fields;
 
 	public $path;
+
+	public $defer;
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This adds a `defer` option to the `formatted_text` logger. The option is not enabled by default so the logger will continue to function in the usual way unless specifically configured. 

The normal way for this logger to function is to format each received log entry as a line of text and write it to a file as it is received. 

When using the `defer` option, received log entries will just be stored in an array when received. It will not be until the logger is destroyed (basically this happens in the shutdown process, so after the response has been sent) that the stored entries are formatted as lines of text and all written to the log file at once. This may be better for performance since multiple write operations are combined as one and (more importantly) not performed until the response has already been sent. 

There is a small caveat which should be considered when deciding whether or not to use the `defer` option. If php encounters a fatal error, the class' `__destruct` function may never be called and all unwritten logs will be lost. If you are writing logs to help you determine why your fatal errors are happening, this option is not for you.

### Testing Instructions
Configure a `formatted_text` logger and include `'defer' => true` in its options array. A simple way to do this is to use the logging features of the `Debug` plugin. There are two `formatted_text` loggers already configured in that plugin (must be activated in the plugin settings) so you only need to make a minor modification to their options arrays.

### Documentation Changes Required
If there is some documentation about using the `formatted_text` logger, it should be updated to include this option. If there isn't any, there probably should be.

__Discuss?__
I'm using the class `__destruct` function to trigger the writing of deferred logs. It's pretty convenient and it works because we can rely on the logger instance not being destroyed until the program shuts down. However, it's possible that `register_shutdown_function` is a better choice. I haven't tested it or even thought about it much so, if anyone has any thoughts about it, please let me know.
