### PR TITLE
[com_fields] Removes the ID attribute from the field when it is shown as part of an item

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -32,9 +32,9 @@ if ($field->context == 'com_contact.mail')
 
 ?>
 
-<dt class="contact-field-entry <?php echo $class; ?>" id="contact-field-entry-label-<?php echo $field->id; ?>">
+<dt class="contact-field-entry <?php echo $class; ?>">
 	<span class="field-label"><?php echo htmlentities($label); ?>: </span>
 </dt>
-<dd class="contact-field-entry <?php echo $class; ?>" id="contact-field-entry-value-<?php echo $field->id; ?>">
+<dd class="contact-field-entry <?php echo $class; ?>">
 	<span class="field-value"><?php echo $value; ?></span>
 </dd>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -26,7 +26,7 @@ if ($value == '')
 
 ?>
 
-<dd class="field-entry <?php echo $class; ?>" id="field-entry-<?php echo $field->id; ?>">
+<dd class="field-entry <?php echo $class; ?>">
 	<?php if ($showlabel == 1) : ?>
 	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 	<?php endif; ?>


### PR DESCRIPTION
Currently, when a field is shown as part of an item (not in a form!), it has an ID attribute following the scheme "field-entry-ID". That means if multiple items (eg articles) are present on a page and all have that field set, you get an invalid HTML markup since IDs have to unique.

### Summary of Changes
Removing the ID since it's not needed anyway.

### Testing Instructions
* Create fields and put values in it in at least two articles
* Create and publish the "Articles - Newsflashmodule"
* Check frontend and see that the field appears in multiple locations. Check the source code and see the id attribute present before this PR and gone after it.

### Documentation Changes Required
None