### PR TITLE
[com_fields] Improving fields dropdown for Translation

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -48,8 +48,22 @@ abstract class FieldsPlugin extends JPlugin
 			}
 
 			// Needed attributes
-			$data['type']  = $layout;
-			$data['label'] = JText::_('PLG_FIELDS_' . $key . '_LABEL');
+			$data['type'] = $layout;
+
+			if (JFactory::getLanguage()->hasKey('PLG_FIELDS_' . $key . '_LABEL'))
+			{
+				$data['label'] = JText::sprintf('PLG_FIELDS_' . $key . '_LABEL', strtolower($key));
+
+				// Fix wrongly set parentheses in RTL languages
+				if (JFactory::getLanguage()->isRTL())
+				{
+					$data['label'] = $data['label'] . '&#x200E;';
+				}
+			}
+			else
+			{
+				$data['label'] = $key;
+			}
 
 			$path = $root . '/fields';
 

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -152,11 +152,7 @@ if ($saveOrder)
 								</div>
 							</td>
 							<td class="small">
-								<?php $label = 'COM_FIELDS_TYPE_' . strtoupper($item->type); ?>
-								<?php if (!JFactory::getLanguage()->hasKey($label)) : ?>
-									<?php $label = Joomla\String\StringHelper::ucfirst($item->type); ?>
-								<?php endif; ?>
-								<?php echo $this->escape(JText::_($label)); ?>
+								<?php echo $this->escape($item->type); ?>
 							</td>
 							<td>
 								<?php echo $this->escape($item->group_title); ?>

--- a/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_CALENDAR="Fields - Calendar"
-PLG_FIELDS_CALENDAR_LABEL="Calendar"
+PLG_FIELDS_CALENDAR_LABEL="Calendar (%s)"
 PLG_FIELDS_CALENDAR_PARAMS_FORMAT_DESC="The date format to be used. This is in the format used by PHP to specify date string formats (see below). If no format argument is given, '%Y-%m-%d' is assumed (giving dates like '2008-04-16')."
 PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL="Format"
-PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'Calendar' in the extensions where custom fields are implemented."
+PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'calendar' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_calendar.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_calendar.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_CALENDAR="Fields - Calendar"
-PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'Calendar' in the extensions where custom fields are implemented."
+PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'calendar' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_checkboxes.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_checkboxes.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_CHECKBOXES="Fields - Checkboxes"
-PLG_FIELDS_CHECKBOXES_LABEL="Checkboxes"
+PLG_FIELDS_CHECKBOXES_LABEL="Checkboxes (%s)"
 PLG_FIELDS_CHECKBOXES_PARAMS_OPTIONS_DESC="The values of the checkboxes."
 PLG_FIELDS_CHECKBOXES_PARAMS_OPTIONS_LABEL="Checkboxes Values"
 PLG_FIELDS_CHECKBOXES_PARAMS_OPTIONS_VALUE_LABEL="Value"
 PLG_FIELDS_CHECKBOXES_PARAMS_OPTIONS_NAME_LABEL="Text"
-PLG_FIELDS_CHECKBOXES_XML_DESCRIPTION="This plugin lets create new fields of type 'Checkboxes' in the extensions where custom fields are implemented."
+PLG_FIELDS_CHECKBOXES_XML_DESCRIPTION="This plugin lets create new fields of type 'checkboxes' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_checkboxes.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_checkboxes.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_CHECKBOXES="Fields - Checkboxes"
-PLG_FIELDS_CHECKBOXES_XML_DESCRIPTION="This plugin lets create new fields of type 'Checkboxes' in the extensions where custom fields are implemented."
+PLG_FIELDS_CHECKBOXES_XML_DESCRIPTION="This plugin lets create new fields of type 'checkboxes' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_color.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_color.ini
@@ -3,6 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_COLOR="Fields - Color"
-PLG_FIELDS_COLOR_LABEL="Color"
-PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Color' in the extensions where custom fields are implemented."
+PLG_FIELDS_COLOR="Fields - Colour"
+PLG_FIELDS_COLOR_LABEL="Colour (%s)"
+PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'color' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_color.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_color.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_COLOR="Fields - Color"
-PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Color' in the extensions where custom fields are implemented."
+PLG_FIELDS_COLOR="Fields - Colour"
+PLG_FIELDS_COLOR_XML_DESCRIPTION="This plugin lets create new fields of type 'color' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_editor.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_editor.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_EDITOR="Fields - Editor"
-PLG_FIELDS_EDITOR_LABEL="Editor"
+PLG_FIELDS_EDITOR_LABEL="Editor (%s)"
 PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC="Hide the buttons in the comma separated list."
 PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL="Hide Buttons"
 PLG_FIELDS_EDITOR_PARAMS_HEIGHT_DESC="Defines the height (in pixels) of the WYSIWYG editor and defaults to 250px."
@@ -14,4 +14,4 @@ PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_LABEL="Show Buttons"
 PLG_FIELDS_EDITOR_PARAMS_USE_GLOBAL="Use From Plugin"
 PLG_FIELDS_EDITOR_PARAMS_WIDTH_DESC="Defines the width (in pixels) of the WYSIWYG editor and defaults to 100%."
 PLG_FIELDS_EDITOR_PARAMS_WIDTH_LABEL="Width"
-PLG_FIELDS_EDITOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Editor' in the extensions where custom fields are implemented."
+PLG_FIELDS_EDITOR_XML_DESCRIPTION="This plugin lets create new fields of type 'editor' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_editor.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_editor.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_EDITOR="Fields - Editor"
-PLG_FIELDS_EDITOR_XML_DESCRIPTION="This plugin lets create new fields of type 'Editor' in the extensions where custom fields are implemented."
+PLG_FIELDS_EDITOR_XML_DESCRIPTION="This plugin lets create new fields of type 'editor' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_gallery.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_gallery.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_GALLERY="Fields - Gallery"
-PLG_FIELDS_GALLERY_LABEL="Gallery"
+PLG_FIELDS_GALLERY_LABEL="Gallery (%s)"
 PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed. Root is pointing to images."
 PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_ROOT="Root - Images"
@@ -20,4 +20,4 @@ PLG_FIELDS_GALLERY_PARAMS_RECURSIVE_DESC="Should the images from the subfolders 
 PLG_FIELDS_GALLERY_PARAMS_THUMBNAIL_WIDTH_LABEL="Thumbnail Width"
 PLG_FIELDS_GALLERY_PARAMS_THUMBNAIL_WIDTH_DESC="The width of the thumbnails. The thumbnails will be resized on the fly."
 PLG_FIELDS_GALLERY_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_GALLERY_XML_DESCRIPTION="This plugin lets create new fields of type 'Gallery' in the extensions where custom fields are implemented."
+PLG_FIELDS_GALLERY_XML_DESCRIPTION="This plugin lets create new fields of type 'gallery' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_gallery.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_gallery.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_GALLERY="Fields - Gallery"
-PLG_FIELDS_GALLERY_XML_DESCRIPTION="This plugin lets create new fields of type 'Gallery' in the extensions where custom fields are implemented."
+PLG_FIELDS_GALLERY_XML_DESCRIPTION="This plugin lets create new fields of type 'gallery' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_image.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_image.ini
@@ -4,5 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_IMAGE="Fields - Image"
-PLG_FIELDS_IMAGE_LABEL="Image"
-PLG_FIELDS_IMAGE_XML_DESCRIPTION="This plugin lets create new fields of type 'Image' in the extensions where custom fields are implemented."
+PLG_FIELDS_IMAGE_LABEL="Image (%s)"
+PLG_FIELDS_IMAGE_XML_DESCRIPTION="This plugin lets create new fields of type 'image' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_image.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_image.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_IMAGE="Fields - Image"
-PLG_FIELDS_IMAGE_XML_DESCRIPTION="This plugin lets create new fields of type 'Image' in the extensions where custom fields are implemented."
+PLG_FIELDS_IMAGE_XML_DESCRIPTION="This plugin lets create new fields of type 'image' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_IMAGELIST="Fields - Imagelist"
-PLG_FIELDS_IMAGELIST_LABEL="Imagelist"
+PLG_FIELDS_IMAGELIST_LABEL="List of Images (%s)"
 PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed."
 PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_DESC="The class which is added to the image (src tag)."
@@ -12,4 +12,4 @@ PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_LABEL="Image Class"
 PLG_FIELDS_IMAGELIST_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_IMAGELIST_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_IMAGELIST_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_IMAGELIST_XML_DESCRIPTION="This plugin lets create new fields of type 'Imagelist' in the extensions where custom fields are implemented."
+PLG_FIELDS_IMAGELIST_XML_DESCRIPTION="This plugin lets create new fields of type 'imagelist' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_imagelist.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_imagelist.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_IMAGELIST="Fields - Imagelist"
-PLG_FIELDS_IMAGELIST_XML_DESCRIPTION="This plugin lets create new fields of type 'Imagelist' in the extensions where custom fields are implemented."
+PLG_FIELDS_IMAGELIST_XML_DESCRIPTION="This plugin lets create new fields of type 'imagelist' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_integer.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_integer.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_INTEGER="Fields - Integer"
-PLG_FIELDS_INTEGER_LABEL="Integer"
+PLG_FIELDS_INTEGER_LABEL="Integer (%s)"
 PLG_FIELDS_INTEGER_PARAMS_FIRST_DESC="This value is the lowest on the list."
 PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL="First"
 PLG_FIELDS_INTEGER_PARAMS_LAST_DESC="This value is the highest on the list."
@@ -14,4 +14,4 @@ PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_INTEGER_PARAMS_STEP_DESC="Each option will be the previous option incremented by this integer, starting with the first value until the last value is reached."
 PLG_FIELDS_INTEGER_PARAMS_STEP_LABEL="Step"
 PLG_FIELDS_INTEGER_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_INTEGER_XML_DESCRIPTION="This plugin lets create new fields of type 'Integer' in the extensions where custom fields are implemented."
+PLG_FIELDS_INTEGER_XML_DESCRIPTION="This plugin lets create new fields of type 'integer' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_integer.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_integer.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_INTEGER="Fields - Integer"
-PLG_FIELDS_INTEGER_XML_DESCRIPTION="This plugin lets create new fields of type 'Integer' in the extensions where custom fields are implemented."
+PLG_FIELDS_INTEGER_XML_DESCRIPTION="This plugin lets create new fields of type 'integer' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_list.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_list.ini
@@ -4,11 +4,11 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_LIST="Fields - List"
-PLG_FIELDS_LIST_LABEL="List"
+PLG_FIELDS_LIST_LABEL="List (%s)"
 PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_LIST_PARAMS_OPTIONS_DESC="The values of the list."
 PLG_FIELDS_LIST_PARAMS_OPTIONS_LABEL="List Values"
 PLG_FIELDS_LIST_PARAMS_OPTIONS_VALUE_LABEL="Value"
 PLG_FIELDS_LIST_PARAMS_OPTIONS_NAME_LABEL="Text"
-PLG_FIELDS_LIST_XML_DESCRIPTION="This plugin lets create new fields of type 'List' in the extensions where custom fields are implemented."
+PLG_FIELDS_LIST_XML_DESCRIPTION="This plugin lets create new fields of type 'list' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_list.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_list.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_LIST="Fields - List"
-PLG_FIELDS_LIST_XML_DESCRIPTION="This plugin lets create new fields of type 'List' in the extensions where custom fields are implemented."
+PLG_FIELDS_LIST_XML_DESCRIPTION="This plugin lets create new fields of type 'list' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_media.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_media.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_MEDIA="Fields - Media"
-PLG_FIELDS_MEDIA_LABEL="Media"
+PLG_FIELDS_MEDIA_LABEL="Media (%s)"
 PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed."
 PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_MEDIA_PARAMS_HOME_LABEL="Home Directory"
@@ -16,4 +16,4 @@ PLG_FIELDS_MEDIA_PARAMS_PREVIEW_INLINE="Inline"
 PLG_FIELDS_MEDIA_PARAMS_PREVIEW_LABEL="Preview"
 PLG_FIELDS_MEDIA_PARAMS_PREVIEW_TOOLTIP="Tooltip"
 PLG_FIELDS_MEDIA_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_MEDIA_XML_DESCRIPTION="This plugin lets create new fields of type 'Media' in the extensions where custom fields are implemented."
+PLG_FIELDS_MEDIA_XML_DESCRIPTION="This plugin lets create new fields of type 'media' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_media.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_media.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_MEDIA="Fields - Media"
-PLG_FIELDS_MEDIA_XML_DESCRIPTION="This plugin lets create new fields of type 'Media' in the extensions where custom fields are implemented."
+PLG_FIELDS_MEDIA_XML_DESCRIPTION="This plugin lets create new fields of type 'media' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_radio.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_radio.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_RADIO="Fields - Radio"
-PLG_FIELDS_RADIO_LABEL="Radio"
+PLG_FIELDS_RADIO_LABEL="Radio (%s)"
 PLG_FIELDS_RADIO_PARAMS_OPTIONS_DESC="The values of the radio list."
 PLG_FIELDS_RADIO_PARAMS_OPTIONS_NAME_LABEL="Text"
 PLG_FIELDS_RADIO_PARAMS_OPTIONS_LABEL="Radio Values"
 PLG_FIELDS_RADIO_PARAMS_OPTIONS_VALUE_LABEL="Value"
-PLG_FIELDS_RADIO_XML_DESCRIPTION="This plugin lets create new fields of type 'Radio' in the extensions where custom fields are implemented."
+PLG_FIELDS_RADIO_XML_DESCRIPTION="This plugin lets create new fields of type 'radio' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_radio.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_radio.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_RADIO="Fields - Radio"
-PLG_FIELDS_RADIO_XML_DESCRIPTION="This plugin lets create new fields of type 'Radio' in the extensions where custom fields are implemented."
+PLG_FIELDS_RADIO_XML_DESCRIPTION="This plugin lets create new fields of type 'radio' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_sql.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_sql.ini
@@ -4,10 +4,10 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_SQL="Fields - Sql"
-PLG_FIELDS_SQL_LABEL="Sql"
+PLG_FIELDS_SQL_LABEL="Sql (%s)"
 PLG_FIELDS_SQL_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_SQL_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_SQL_PARAMS_QUERY_DESC="The SQL query which will provide the data for the dropdown list. The query must return two columns; one called 'value' which will hold the values of the list items; the other called 'text' containing the text in the dropdown list."
 PLG_FIELDS_SQL_PARAMS_QUERY_LABEL="Query"
 PLG_FIELDS_SQL_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets create new fields of type 'Sql' in the extensions where custom fields are implemented."
+PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets create new fields of type 'sql' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_sql.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_sql.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_SQL="Fields - Sql"
-PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets create new fields of type 'Sql' in the extensions where custom fields are implemented."
+PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets create new fields of type 'sql' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_text.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_text.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_TEXT="Fields - Text"
-PLG_FIELDS_TEXT_LABEL="Text"
+PLG_FIELDS_TEXT_LABEL="Text (%s)"
 PLG_FIELDS_TEXT_PARAMS_FILTER_LABEL="Filter"
 PLG_FIELDS_TEXT_PARAMS_FILTER_DESC="Allow the system to save certain html tags or raw data."
 PLG_FIELDS_TEXT_PARAMS_FILTER_RAW="Raw"
 PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_TEXT_XML_DESCRIPTION="This plugin lets create new fields of type 'Text' in the extensions where custom fields are implemented."
+PLG_FIELDS_TEXT_XML_DESCRIPTION="This plugin lets create new fields of type 'text' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_text.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_text.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_TEXT="Fields - Text"
-PLG_FIELDS_TEXT_XML_DESCRIPTION="This plugin lets create new fields of type 'Text' in the extensions where custom fields are implemented."
+PLG_FIELDS_TEXT_XML_DESCRIPTION="This plugin lets create new fields of type 'text' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_textarea.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_textarea.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_TEXTAREA="Fields - Textarea"
-PLG_FIELDS_TEXTAREA_LABEL="Textarea"
+PLG_FIELDS_TEXTAREA_LABEL="Text Area (%s)"
 PLG_FIELDS_TEXTAREA_PARAMS_COLS_DESC="The number of columns of the field."
 PLG_FIELDS_TEXTAREA_PARAMS_COLS_LABEL="Columns"
 PLG_FIELDS_TEXTAREA_PARAMS_ROWS_DESC="The number of rows of the field."
 PLG_FIELDS_TEXTAREA_PARAMS_ROWS_LABEL="Rows"
-PLG_FIELDS_TEXTAREA_XML_DESCRIPTION="This plugin lets create new fields of type 'Textarea' in the extensions where custom fields are implemented."
+PLG_FIELDS_TEXTAREA_XML_DESCRIPTION="This plugin lets create new fields of type 'textarea' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_textarea.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_textarea.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_TEXTAREA="Fields - Textarea"
-PLG_FIELDS_TEXTAREA_XML_DESCRIPTION="This plugin lets create new fields of type 'Textarea' in the extensions where custom fields are implemented."
+PLG_FIELDS_TEXTAREA_XML_DESCRIPTION="This plugin lets create new fields of type 'textarea' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_url.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_url.ini
@@ -4,10 +4,10 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_URL="Fields - Url"
-PLG_FIELDS_URL_LABEL="Url"
+PLG_FIELDS_URL_LABEL="Url (%s)"
 PLG_FIELDS_URL_PARAMS_RELATIVE_DESC="Are relative URLs allowed."
 PLG_FIELDS_URL_PARAMS_RELATIVE_LABEL="Relative"
 PLG_FIELDS_URL_PARAMS_SCHEMES_DESC="The allowed schemes."
 PLG_FIELDS_URL_PARAMS_SCHEMES_LABEL="Schemes"
 PLG_FIELDS_URL_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_URL_XML_DESCRIPTION="This plugin lets create new fields of type 'Url' in the extensions where custom fields are implemented."
+PLG_FIELDS_URL_XML_DESCRIPTION="This plugin lets create new fields of type 'url' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_url.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_url.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_URL="Fields - Url"
-PLG_FIELDS_URL_XML_DESCRIPTION="This plugin lets create new fields of type 'Url' in the extensions where custom fields are implemented."
+PLG_FIELDS_URL_XML_DESCRIPTION="This plugin lets create new fields of type 'url' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -4,8 +4,5 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USER="Fields - User"
-PLG_FIELDS_USER_LABEL="User"
-PLG_FIELDS_USER_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
-PLG_FIELDS_USER_PARAMS_MULTIPLE_LABEL="Multiple"
-PLG_FIELDS_USER_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'User' in the extensions where custom fields are implemented."
+PLG_FIELDS_USER_LABEL="User (%s)"
+PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'user' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_user.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USER="Fields - User"
-PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'User' in the extensions where custom fields are implemented."
+PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'user' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USERGROUPLIST="Fields - Usergrouplist"
-PLG_FIELDS_USERGROUPLIST_LABEL="Usergrouplist"
+PLG_FIELDS_USERGROUPLIST_LABEL="User Groups (%s)"
 PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_USERGROUPLIST_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_USERGROUPLIST_PARAMS_USE_GLOBAL="Use From Plugin"
-PLG_FIELDS_USERGROUPLIST_XML_DESCRIPTION="This plugin lets create new fields of type 'Usergrouplist' in the extensions where custom fields are implemented."
+PLG_FIELDS_USERGROUPLIST_XML_DESCRIPTION="This plugin lets create new fields of type 'usergrouplist' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_usergrouplist.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USERGROUPLIST="Fields - Usergrouplist"
-PLG_FIELDS_USERGROUPLIST_XML_DESCRIPTION="This plugin lets create new fields of type 'Usergrouplist' in the extensions where custom fields are implemented."
+PLG_FIELDS_USERGROUPLIST_XML_DESCRIPTION="This plugin lets create new fields of type 'usergrouplist' in the extensions where custom fields are implemented."


### PR DESCRIPTION
See discussion here:
https://github.com/joomla/joomla-cms/pull/13659
and here
https://github.com/joomla/joomla-cms/pull/13666

This patch adds to the translation the type itself as it is used in the field.

We now should  get a dropdown like this when choosing a field type:
![screen shot 2017-01-23 at 16 55 40](https://cloud.githubusercontent.com/assets/869724/22211709/3dc4b130-e18e-11e6-87fa-d7776ef48d56.png)

In French we will get stuff like this ( did not change all ini yet)
![screen shot 2017-01-23 at 17 10 58](https://cloud.githubusercontent.com/assets/869724/22211915/000c8c22-e18f-11e6-84b1-858c4de92635.png)


