### PR TITLE
fix for a failing install after PR #13621

### DIFF
--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -895,7 +895,7 @@ class InstallationModelDatabase extends JModelBase
 			'#__contact_details'     => array('publish_up', 'publish_down', 'created', 'modified'),
 			'#__content'             => array('publish_up', 'publish_down', 'created', 'modified'),
 			'#__contentitem_tag_map' => array('tag_date'),
-			'#__fields'              => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
+			'#__fields'              => array('created_time', 'modified_time'),
 			'#__finder_filters'      => array('created', 'modified'),
 			'#__finder_links'        => array('indexdate', 'publish_start_date', 'publish_end_date', 'start_date', 'end_date'),
 			'#__messages'            => array('date_time'),


### PR DESCRIPTION
### Summary of Changes
PR #13621 removed database columns but this columns have to be deleted in the installation model

### Testing Instructions
* checkout staging
* try installation (without test data)

This should fail with:

![joomla -webinstallation](https://cloud.githubusercontent.com/assets/467356/22222774/7016178a-e1b8-11e6-8411-20514adcb3df.png)

* apply patch
* remove all DB tables 
* try install (without test data)

Should work