### PR TITLE
[4.0] Fix 'Joomla\Cms\Model\JFactory' not found

### DIFF
--- a/libraries/src/Cms/Model/Model.php
+++ b/libraries/src/Cms/Model/Model.php
@@ -199,9 +199,9 @@ abstract class Model extends \JObject
 		}
 
 		// Check for a possible service from the container otherwise manually instantiate the class
-		if (JFactory::getContainer()->exists($modelClass))
+		if (\JFactory::getContainer()->exists($modelClass))
 		{
-			return JFactory::getContainer()->get($modelClass);
+			return \JFactory::getContainer()->get($modelClass);
 		}
 
 		return new $modelClass($config);


### PR DESCRIPTION
Pull Request for Issue #13725

### Summary of Changes

Fixes the error:

```
Class 'Joomla\Cms\Model\JFactory' not found
```

### Testing Instructions
