### PR TITLE
Fixes initial com_fields sql update file for mysql.

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -1,12 +1,12 @@
 CREATE TABLE IF NOT EXISTS `#__fields` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `asset_id` int(10) NOT NULL DEFAULT 0,
-  `context` varchar(255) NOT NULL DEFAULT '',
+  `context` varchar(255) CHAR SET utf8 NOT NULL DEFAULT '',
   `group_id` int(10) NOT NULL DEFAULT 0,
   `title` varchar(255) NOT NULL DEFAULT '',
   `alias` varchar(255) NOT NULL DEFAULT '',
   `label` varchar(255) NOT NULL DEFAULT '',
-  `default_value` text NOT NULL DEFAULT '',
+  `default_value` text NOT NULL,
   `type` varchar(255) NOT NULL DEFAULT 'text',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
@@ -41,7 +41,7 @@ CREATE TABLE `#__fields_categories` (
 CREATE TABLE IF NOT EXISTS `#__fields_groups` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `asset_id` int(10) NOT NULL DEFAULT 0,
-  `context` varchar(255) NOT NULL DEFAULT '',
+  `context` varchar(255) CHAR SET utf8 NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
@@ -66,9 +66,9 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
 
 CREATE TABLE IF NOT EXISTS `#__fields_values` (
   `field_id` int(10) unsigned NOT NULL,
-  `context` varchar(255) NOT NULL,
+  `context` varchar(255) CHAR SET utf8 NOT NULL DEFAULT '',
   `item_id` varchar(255) NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
-  `value` text NOT NULL DEFAULT '',
+  `value` text NOT NULL,
   KEY (`field_id`),
   KEY (`context`),
   KEY (`item_id`)

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -67,7 +67,7 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
 CREATE TABLE IF NOT EXISTS `#__fields_values` (
   `field_id` int(10) unsigned NOT NULL,
   `context` varchar(255) CHAR SET utf8 NOT NULL DEFAULT '',
-  `item_id` varchar(255) NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
+  `item_id` varchar(255) CHAR SET utf8 NOT NULL COMMENT 'Allow references to items which have strings as ids, eg. none db systems.',
   `value` text NOT NULL,
   KEY (`field_id`),
   KEY (`context`),


### PR DESCRIPTION
### Summary of Changes
Fixed two issues with the initial com_fields sql update file for MySQL (I don't have PostgreSQL or MSSQL, so someone should probably look at possible constraints of those, too).

1. Due to the length of the `context` field, combined with the utf8mb4 unicode default for the table, it will not create the index. That is, because it would surpass the max length of 767 bytes for MySQL.
I changed the specific fields to utf8, so the max length of 767 bytes is not surpassed.

2. TEXT/BLOBS cannot have a default
Removed defaults for those in this specific file.

### Testing Instructions
Run the sql file before the patch, notice the errors.
Run the sql file after  the patch, notice the errors missing.


### Documentation Changes Required
The issue with the max key length (for mysql and maybe others), should probably be noted in the docs.
