### PR TITLE
Core categories system shouldn't be mandatory to use core tags

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -592,8 +592,8 @@ class JHelperTags extends JHelper
 			)
 			->join('INNER', '#__content_types AS ct ON ct.type_alias = m.type_alias')
 
-			// Join over categoris for get only published
-			->join('INNER', '#__categories AS tc ON tc.id = c.core_catid AND tc.published = 1')
+			// Join over categories for get only tags from published categories
+			->join('LEFT', '#__categories AS tc ON tc.id = c.core_catid')
 
 			// Join over the users for the author and email
 			->select("CASE WHEN c.core_created_by_alias > ' ' THEN c.core_created_by_alias ELSE ua.name END AS author")
@@ -601,7 +601,8 @@ class JHelperTags extends JHelper
 
 			->join('LEFT', '#__users AS ua ON ua.id = c.core_created_user_id')
 
-			->where('m.tag_id IN (' . implode(',', $tagIds) . ')');
+			->where('m.tag_id IN (' . implode(',', $tagIds) . ')')
+			->where('(c.core_catid = 0 OR tc.published = 1)');
 
 		// Optionally filter on language
 		if (empty($language))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/12038 .

### Summary of Changes

https://github.com/joomla/joomla-cms/pull/10304 introduced a B/C issue with extensions that use core tag system without using core categories system. Making an inner join like:

```
->join('INNER', '#__categories AS tc ON tc.id = c.core_catid AND tc.published = 1')
```

That causes that 3rd part extensions are broken and tags used on them aren't shown in core tag views because `c.core_catid` is always `0`.

Patch changes the query to use something like:

```
LEFT JOIN boy8n_categories AS tc ON tc.id = c.core_catid
WHERE (c.core_catid = 0 OR tc.published = 1)
```

So that it only returns tags assigned to content not using the category system or using it and having the category published.

### Testing Instructions

1. Create a content category
2. Create a content item and assign it to category created in step 1. Also assign a sample tag on it.
3. Create a menu item of type `Tags` > `Compact list of tagged items` and in the `Tag` menu setting select the tag created in step 2.
4. In frontend go to menu item created in step 3 and check that you see the content item.
5. Unpublish category created in step 2. 
6. In frontend go to menu item created in step 3 and check that you DON'T see the content item.

Additional tests if you have a custom extension experiencing the issue ( see https://github.com/joomla/joomla-cms/issues/12038 ) also test this:

7. Publish category created in step 2. 
7. Create an item in your extension and assign the same tag assigned to the content item in step 2.
8. In frontend go to menu item created in step 3 and check that you see your extension item + core content item.
9. Unpublish category created in step 2. 
10. In frontend go to menu item created in step 3 and check that you see your extension item but you DON'T see core content item.



### Documentation Changes Required
