### PR TITLE
Remove max-width on login lang field

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7212,6 +7212,7 @@ a:focus {
 }
 .view-login #lang_chzn {
 	width: 233px !important;
+	max-width: none;
 }
 .view-login #lang_chzn .chzn-single div {
 	width: 43px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7212,6 +7212,7 @@ a:focus {
 }
 .view-login #lang_chzn {
 	width: 233px !important;
+	max-width: none;
 }
 .view-login #lang_chzn .chzn-single div {
 	width: 43px;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -145,6 +145,7 @@ a:focus {
 	}
 	#lang_chzn {
 		width: 233px !important;
+		max-width: none;
 		.chzn-single div {
 			width:43px;
 		}


### PR DESCRIPTION
Pull Request for Issue #13693  .

### Summary of Changes
Sets all fields in Isis admin login to the same width

### Testing Instructions
Open login...

![login-lang](https://cloud.githubusercontent.com/assets/2803503/22254659/27f842f8-e24d-11e6-98ad-15fcfe133000.png)


### Documentation Changes Required
