### PR TITLE
[com_fields] Load language files from components

### DIFF
--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -95,7 +95,7 @@ class FieldsViewField extends JViewLegacy
 		// Load component language file
 		$lang = JFactory::getLanguage();
 		$lang->load($component, JPATH_ADMINISTRATOR)
-		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
+		|| $lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component));
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_FIELD_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -93,7 +93,9 @@ class FieldsViewField extends JViewLegacy
 		}
 
 		// Load component language file
-		JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR);
+		$lang = JFactory::getLanguage();
+		$lang->load($component, JPATH_ADMINISTRATOR)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_FIELD_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -124,7 +124,7 @@ class FieldsViewFields extends JViewLegacy
 		// Load extension language file
 		$lang = JFactory::getLanguage();
 		$lang->load($component, JPATH_ADMINISTRATOR)
-		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
+		|| $lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component));
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_FIELDS_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -122,7 +122,9 @@ class FieldsViewFields extends JViewLegacy
 		}
 
 		// Load extension language file
-		JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR);
+		$lang = JFactory::getLanguage();
+		$lang->load($component, JPATH_ADMINISTRATOR)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_FIELDS_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/group/view.html.php
+++ b/administrator/components/com_fields/views/group/view.html.php
@@ -119,7 +119,7 @@ class FieldsViewGroup extends JViewLegacy
 		// Load component language file
 		$lang = JFactory::getLanguage();
 		$lang->load($component, JPATH_ADMINISTRATOR)
-		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
+		|| $lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component));
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_GROUP_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/group/view.html.php
+++ b/administrator/components/com_fields/views/group/view.html.php
@@ -117,7 +117,9 @@ class FieldsViewGroup extends JViewLegacy
 		}
 
 		// Load component language file
-		JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR);
+		$lang = JFactory::getLanguage();
+		$lang->load($component, JPATH_ADMINISTRATOR)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_GROUP_' . ($isNew ? 'ADD' : 'EDIT') . '_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/groups/view.html.php
+++ b/administrator/components/com_fields/views/groups/view.html.php
@@ -128,7 +128,9 @@ class FieldsViewGroups extends JViewLegacy
 		}
 
 		// Load component language file
-		JFactory::getLanguage()->load($component, JPATH_ADMINISTRATOR);
+		$lang = JFactory::getLanguage();
+		$lang->load($component, JPATH_ADMINISTRATOR)
+		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_GROUPS_TITLE', JText::_(strtoupper($component)));
 

--- a/administrator/components/com_fields/views/groups/view.html.php
+++ b/administrator/components/com_fields/views/groups/view.html.php
@@ -130,7 +130,7 @@ class FieldsViewGroups extends JViewLegacy
 		// Load component language file
 		$lang = JFactory::getLanguage();
 		$lang->load($component, JPATH_ADMINISTRATOR)
-		|| $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
+		|| $lang->load($component, JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component));
 
 		$title = JText::sprintf('COM_FIELDS_VIEW_GROUPS_TITLE', JText::_(strtoupper($component)));
 


### PR DESCRIPTION
Currently, in the com_fields views the language files for the components are only loaded from the global language folder. However the components may also have them in their own language folder.

### Summary of Changes
Adjusts the loading of language files to also have a look in the components language folder.

### Testing Instructions
* Install an extension which supports fields already. You may use my SermonSpeaker component (GitHub branch with fields support is https://github.com/Bakual/SermonSpeaker/tree/SermonSpeaker5.6. Just zip the "com_sermonspeaker" folder and install it)
* Go to the field and field group manager and the respective edit forms in SermonSpeaker and watch the header of the page. You'll see an untranslated string there. After applying the PR the strings will be translated.

### Documentation Changes Required
None