### PR TITLE
[com_fields] Remove unneded properties for fields render layout

### DIFF
--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -52,25 +52,10 @@ if (!$fields)
 // Check if we have mail context in first element
 $isMail = (reset($fields)->context == 'com_contact.mail');
 
-// Load some output definitions
-$container = 'dl';
-
-if (key_exists('container', $displayData) && $displayData['container'])
-{
-	$container = $displayData['container'];
-}
-
-$class = 'contact-fields dl-horizontal';
-
-if (key_exists('container-class', $displayData) && $displayData['container-class'])
-{
-	$class = $displayData['container-class'];
-}
-
 if (!$isMail)
 {
 	// Print the container tag
-	echo '<' . $container . ' class="fields-container ' . $class . '">';
+	echo '<dl class="fields-container contact-fields dl-horizontal">';
 }
 
 // Loop through the fields and print them
@@ -88,5 +73,5 @@ foreach ($fields as $field)
 if (!$isMail)
 {
 	// Close the container
-	echo '</' . $container . '>';
+	echo '</dl>';
 }

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -49,23 +49,8 @@ if (!$fields)
 	return;
 }
 
-// Load some output definitions
-$container = 'dl';
-
-if (key_exists('container', $displayData) && $displayData['container'])
-{
-	$container = $displayData['container'];
-}
-
-$class = 'article-info muted';
-
-if (key_exists('container-class', $displayData) && $displayData['container-class'])
-{
-	$class = $displayData['container-class'];
-}
-
 // Print the container tag
-echo '<' . $container . ' class="fields-container ' . $class . '">';
+echo '<dl class="fields-container">';
 
 // Loop through the fields and print them
 foreach ($fields as $field)
@@ -80,4 +65,4 @@ foreach ($fields as $field)
 }
 
 // Close the container
-echo '</' . $container . '>';
+echo '</dl>';

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -436,9 +436,7 @@ class PlgSystemFields extends JPlugin
 				array(
 					'item'            => $item,
 					'context'         => $context,
-					'fields'          => $fields,
-					'container'       => $params->get('fields-container'),
-					'container-class' => $params->get('fields-container-class'),
+					'fields'          => $fields
 				)
 			);
 		}


### PR DESCRIPTION
Pull Request for Issue #13709.

### Summary of Changes
The actual com_fields auto generated output adds some article specific classes. This pr removes that functionality. It simplifyes the layout as there was too much of logic in there as well.

### Testing Instructions
Just create a couple of fields.

### Expected result
The fields don't have the muted class anymore:
![image](https://cloud.githubusercontent.com/assets/251072/22293309/612318f6-e30f-11e6-8171-206beaf012f4.png)

### Actual result
The fields do have the muted class:
![image](https://cloud.githubusercontent.com/assets/251072/22293349/85fd19ce-e30f-11e6-9f82-6ff1efac7f26.png)

