### PR TITLE
Stop spans from wrapping on smaller screens

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8835,8 +8835,10 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
-.row-fluid [class*="span"] {
-	margin-left: 2.12766%;
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8835,6 +8835,9 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
+.row-fluid [class*="span"] {
+	margin-left: 2.12766%;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8840,6 +8840,11 @@ textarea.noResize {
 		margin-left: 2.12766%;
 	}
 }
+@media (max-width: 767px) {
+	.row-fluid [class*="span"] {
+		margin-left: 0;
+	}
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8835,6 +8835,8 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
-.row-fluid [class*="span"] {
-	margin-left: 2.12766%;
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8840,3 +8840,8 @@ textarea.noResize {
 		margin-left: 2.12766%;
 	}
 }
+@media (max-width: 767px) {
+	.row-fluid [class*="span"] {
+		margin-left: 0;
+	}
+}

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8835,3 +8835,6 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
+.row-fluid [class*="span"] {
+	margin-left: 2.12766%;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1885,3 +1885,8 @@ textarea.noResize {
 		margin-left: 2.12766%;
 	} 
 }
+@media (max-width: 767px) {
+	.row-fluid [class*="span"] {
+		margin-left: 0;
+	} 
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1879,7 +1879,9 @@ textarea.noResize {
 	padding-top: 2px;
 }
 
-// Bootsrap revert of override to default 
-.row-fluid [class*="span"] {
-    margin-left: 2.12766%;
-} 
+// Stop spans from wrapping on smaller screens
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	} 
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1878,3 +1878,8 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
+
+// Bootsrap revert of override to default 
+.row-fluid [class*="span"] {
+    margin-left: 2.12766%;
+} 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Stop spans from wrapping on smaller screens

### Testing Instructions
Apply patch. Navigate to article edit and resize the browser window...

**Before Patch**

![grid1](https://cloud.githubusercontent.com/assets/2803503/22294447/4b45647a-e30b-11e6-83c1-12d88b23770f.gif)

**After Patch**

![grid2](https://cloud.githubusercontent.com/assets/2803503/22294541/8d803b6c-e30b-11e6-841f-b017a97e5063.gif)


### Documentation Changes Required
None