### PR TITLE
duplicated code

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -19,8 +19,6 @@ class FieldsHelper
 {
 	private static $fieldsCache = null;
 
-	private static $fieldCache = null;
-
 	/**
 	 * Extracts the component and section from the context string which has to
 	 * be in the format component.context.


### PR DESCRIPTION
private static $fieldsCache = null; was written twice, surely there is no need?

Pull Request for Issue # .

### Summary of Changes
Removed a duplicated line.

### Testing Instructions
It is to do with field cache.  I'm not enough of a coder to know exactly what this does so someone else would be better off writing this description.  

### Documentation Changes Required
none
