### PR TITLE
Fixes: EXTRA_QUERY not added to update record

### DIFF
--- a/libraries/joomla/updater/updateadapter.php
+++ b/libraries/joomla/updater/updateadapter.php
@@ -48,7 +48,7 @@ abstract class JUpdateAdapter extends JAdapterInstance
 	 * @var    array
 	 * @since  12.1
 	 */
-	protected $updatecols = array('NAME', 'ELEMENT', 'TYPE', 'FOLDER', 'CLIENT', 'VERSION', 'DESCRIPTION', 'INFOURL');
+	protected $updatecols = array('NAME', 'ELEMENT', 'TYPE', 'FOLDER', 'CLIENT', 'VERSION', 'DESCRIPTION', 'INFOURL', 'EXTRA_QUERY');
 
 	/**
 	 * Should we try appending a .xml extension to the update site's URL?


### PR DESCRIPTION
You can have update sites with a value in the `extra_query` column in the `#__update_sites` table.
However, this is no longer added to the update url when trying to do an update.
In other words, the `extra_query` value from the `#__update_sites` table is not copied to the `extra_query` value in the `#__updates` table when doing a 'Find Updates'.

This PR fixes this issue.