### PR TITLE
[com_associations] moved "checked out" check to a helper function

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -481,6 +481,44 @@ class AssociationsHelper extends JHelperContent
 	}
 
 	/**
+	 * Check if an item is checked out
+	 *
+	 * @param   string  $extensionName  The extension name with com_
+	 * @param   string  $typeName       The item type
+	 * @param   int     $itemId         The id of item for which we need the associated items
+	 *
+	 * @return  boolean  True if item is checked out.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isCheckoutItem($extensionName, $typeName, $itemId)
+	{
+		if (!self::hasSupport($extensionName))
+		{
+			return false;
+		}
+
+		if (!self::typeSupportsCheckout($extensionName, $typeName))
+		{
+			return false;
+		}
+
+		// Get the extension specific helper method
+		$helper = self::getExtensionHelper($extensionName);
+
+		if (method_exists($helper, 'isCheckoutItem'))
+		{
+			return $helper->isCheckoutItem($typeName, $itemId);
+		}
+
+		$item = self::getItem($extensionName, $typeName, $itemId);
+
+		$checkedOutFieldName = $helper->getTypeFieldName($typeName, 'checked_out');
+
+		return $item->{$checkedOutFieldName} != 0;
+	}
+
+	/**
 	 * Check if user can checkin an item.
 	 *
 	 * @param   string  $extensionName  The extension name with com_

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -212,10 +212,13 @@ class AssociationsHelper extends JHelperContent
 					$additional = '<br/>' . JText::_('COM_ASSOCIATIONS_HEADING_MENUTYPE') . ': ' . $items[$langCode]['menu_title'];
 				}
 
-				$additional .= $addLink ? '<br/><br/>' . JText::_('COM_ASSOCIATIONS_EDIT_ASSOCIATION') : '';
 				$labelClass  = 'label';
 				$target      = $langCode . ':' . $items[$langCode]['id'] . ':edit';
-				$allow       = $canEditReference && self::allowEdit($extensionName, $typeName, $items[$langCode]['id']);
+				$allow       = $canEditReference
+								&& self::allowEdit($extensionName, $typeName, $items[$langCode]['id'])
+								&& self::canCheckinItem($extensionName, $typeName, $items[$langCode]['id']);
+
+				$additional .= $addLink && $allow ? '<br/><br/>' . JText::_('COM_ASSOCIATIONS_EDIT_ASSOCIATION') : '';
 			}
 			else
 			{
@@ -475,6 +478,46 @@ class AssociationsHelper extends JHelperContent
 		}
 
 		return JFactory::getUser()->authorise('core.create', $extensionName);
+	}
+
+	/**
+	 * Check if user can checkin an item.
+	 *
+	 * @param   string  $extensionName  The extension name with com_
+	 * @param   string  $typeName       The item type
+	 * @param   int     $itemId         The id of item for which we need the associated items
+	 *
+	 * @return  boolean  True on allowed.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function canCheckinItem($extensionName, $typeName, $itemId)
+	{
+		if (!self::hasSupport($extensionName))
+		{
+			return false;
+		}
+
+		if (!self::typeSupportsCheckout($extensionName, $typeName))
+		{
+			return true;
+		}
+
+		// Get the extension specific helper method
+		$helper = self::getExtensionHelper($extensionName);
+
+		if (method_exists($helper, 'canCheckinItem'))
+		{
+			return $helper->canCheckinItem($typeName, $itemId);
+		}
+
+		$item = self::getItem($extensionName, $typeName, $itemId);
+
+		$checkedOutFieldName = $helper->getTypeFieldName($typeName, 'checked_out');
+
+		$userId = JFactory::getUser()->id;
+
+		return ($item->{$checkedOutFieldName} == $userId || $item->{$checkedOutFieldName} == 0);
 	}
 
 	/**

--- a/administrator/components/com_associations/models/fields/itemlanguage.php
+++ b/administrator/components/com_associations/models/fields/itemlanguage.php
@@ -42,22 +42,10 @@ class JFormFieldItemLanguage extends JFormFieldList
 
 		list($extensionName, $typeName) = explode('.', $input->get('itemtype'));
 
-		$extension = AssociationsHelper::getSupportedExtension($extensionName);
-		$types     = $extension->get('types');
+		// Get the extension specific helper method
+		$helper = AssociationsHelper::getExtensionHelper($extensionName);
 
-		if (array_key_exists($typeName, $types))
-		{
-			$type = $types[$typeName];
-		}
-
-		$details = $type->get('details');
-
-		if (array_key_exists('fields', $details))
-		{
-			$fields = $details['fields'];
-		}
-
-		$languageField = substr($fields['language'], 2);
+		$languageField = $helper->getTypeFieldName($typeName, 'language');
 		$referenceId   = $input->get('id', 0, 'int');
 		$reference     = ArrayHelper::fromObject(AssociationsHelper::getItem($extensionName, $typeName, $referenceId));
 		$referenceLang = $reference[$languageField];
@@ -94,8 +82,8 @@ class JFormFieldItemLanguage extends JFormFieldList
 				 // Check if user does have permission to edit the associated item.
 				$canEdit = AssociationsHelper::allowEdit($extensionName, $typeName, $itemId);
 
-				// ToDo: Do an additional check to check if user can edit a checked out item (if component item type supports it).
-				$canCheckout = true;
+				// Check if item can be checked out
+				$canCheckout = AssociationsHelper::canCheckinItem($extensionName, $typeName, $itemId);
 
 				// Disable language if user is not allowed to edit the item associated to it.
 				$options[$langCode]->disable = !($canEdit && $canCheckout);

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -110,6 +110,7 @@ JFactory::getDocument()->addScriptDeclaration('
 				$canCheckin = true;
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
 				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
+				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<?php if (!empty($this->typeSupports['state'])) : ?>
@@ -121,10 +122,10 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 						<?php endif; ?>
-						<?php if (isset($item->checked_out) && $item->checked_out) : ?>
+						<?php if ($canCheckin && $isCheckout) : ?>
 							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.', $canCheckin); ?>
 						<?php endif; ?>
-						<?php if ($canEdit) : ?>
+						<?php if ($canEdit && !$isCheckout) : ?>
 							<a href="<?php echo JRoute::_($this->editUri . '&id=' . (int) $item->id); ?>">
 							<?php echo $this->escape($item->title); ?></a>
 						<?php else : ?>
@@ -145,7 +146,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php echo $item->language_title ? JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, array('title' => $item->language_title), true) . '&nbsp;' . $this->escape($item->language_title) : JText::_('JUNDEFINED'); ?>
 					</td>
 					<td>
-						<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language); ?>
+						<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, !$isCheckout); ?>
 					</td>
 					<?php if (!empty($this->typeFields['menutype'])) : ?>
 						<td class="small">

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -109,7 +109,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			<?php foreach ($this->items as $i => $item) :
 				$canCheckin = true;
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
-				$canCheckin = $canManageCheckin || AssociationsHelper::typeSupportsCheckout($this->extensionName, $this->typeName);
+				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<?php if (!empty($this->typeSupports['state'])) : ?>


### PR DESCRIPTION
### Summary of Changes
This PR moves the check if an item is checked out to the helper function and used this function when creating links to items

### Testing Instructions
* install latest staging with 2 or more languages 
* create a 2nd user
* open 2 browsers and log in with both users
* browser A: open Multilingual Associations extension
* browser A: chose article and a language
* browser B: open an article (edit)

You will see that you can access an checked out article, this end with an error message but that's not nice.

**Apply the patch**

Now you can see that articles have the locked sign and also the associated items don't have a link to open it.
