### PR TITLE
[com_fields] SQL not Sql

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_sql.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_sql.ini
@@ -3,8 +3,8 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_SQL="Fields - Sql"
-PLG_FIELDS_SQL_LABEL="Sql (%s)"
+PLG_FIELDS_SQL="Fields - SQL"
+PLG_FIELDS_SQL_LABEL="SQL (%s)"
 PLG_FIELDS_SQL_PARAMS_MULTIPLE_DESC="Allow multiple values to be selected."
 PLG_FIELDS_SQL_PARAMS_MULTIPLE_LABEL="Multiple"
 PLG_FIELDS_SQL_PARAMS_QUERY_DESC="The SQL query which will provide the data for the dropdown list. The query must return two columns; one called 'value' which will hold the values of the list items; the other called 'text' containing the text in the dropdown list."

--- a/administrator/language/en-GB/en-GB.plg_fields_sql.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_sql.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_SQL="Fields - Sql"
+PLG_FIELDS_SQL="Fields - SQL"
 PLG_FIELDS_SQL_XML_DESCRIPTION="This plugin lets create new fields of type 'sql' in the extensions where custom fields are implemented."


### PR DESCRIPTION
Basically a typo. It's SQL not Sql

### Summary of Changes
Changes the name of the field type to SQL instead of Sql

### Testing Instructions
Verify the type name of the fieldtype is SQL when you create such a custom field

### Documentation Changes Required
None