### PR TITLE
Stop using globals

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -54,10 +54,10 @@ class MediaControllerFile extends JControllerLegacy
 		// Instantiate the media helper
 		$mediaHelper = new JHelperMedia;
 
-		if ($_SERVER['CONTENT_LENGTH'] > ($params->get('upload_maxsize', 0) * 1024 * 1024)
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('upload_max_filesize'))
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('post_max_size'))
-			|| $_SERVER['CONTENT_LENGTH'] > $mediaHelper->toBytes(ini_get('memory_limit')))
+		if ($this->input->server->get('CONTENT_LENGTH') > ($params->get('upload_maxsize', 0) * 1024 * 1024)
+			|| $this->input->server->get('CONTENT_LENGTH') > $mediaHelper->toBytes(ini_get('upload_max_filesize'))
+			|| $this->input->server->get('CONTENT_LENGTH') > $mediaHelper->toBytes(ini_get('post_max_size'))
+			|| $this->input->server->get('CONTENT_LENGTH') > $mediaHelper->toBytes(ini_get('memory_limit')))
 		{
 			$response = array(
 				'status'  => '0',


### PR DESCRIPTION
### Summary of Changes
We should use `JInput` instead of superglobals in our codebase

### Testing Instructions
Try uploading a file via the ajax upload in com_media

### Documentation Changes Required
n/a