### PR TITLE
[com_fields] Default the gallery directory when empty

### DIFF
--- a/plugins/fields/gallery/gallery.php
+++ b/plugins/fields/gallery/gallery.php
@@ -18,4 +18,38 @@ JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRA
  */
 class PlgFieldsGallery extends FieldsPlugin
 {
+	/**
+	 * Transforms the field into an XML element and appends it as child on the given parent. This
+	 * is the default implementation of a field. Form fields which do support to be transformed into
+	 * an XML Element mut implemet the JFormDomfieldinterface.
+	 *
+	 * @param   stdClass    $field   The field.
+	 * @param   DOMElement  $parent  The field node parent.
+	 * @param   JForm       $form    The form.
+	 *
+	 * @return  DOMElement
+	 *
+	 * @since   3.7.0
+	 */
+	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
+	{
+		$fieldNode = parent::onCustomFieldsPrepareDom($field, $parent, $form);
+
+		if (!$fieldNode)
+		{
+			return $fieldNode;
+		}
+
+		$directory = $fieldNode->getAttribute('directory');
+
+		// Can be empty when the plugin doesn't get saved.
+		if (!$directory)
+		{
+			$directory = 'images';
+		}
+
+		$fieldNode->setAttribute('directory', $directory);
+
+		return $fieldNode;
+	}
 }

--- a/plugins/fields/gallery/gallery.php
+++ b/plugins/fields/gallery/gallery.php
@@ -21,7 +21,7 @@ class PlgFieldsGallery extends FieldsPlugin
 	/**
 	 * Transforms the field into an XML element and appends it as child on the given parent. This
 	 * is the default implementation of a field. Form fields which do support to be transformed into
-	 * an XML Element mut implemet the JFormDomfieldinterface.
+	 * an XML Element must implement the JFormDomfieldinterface.
 	 *
 	 * @param   stdClass    $field   The field.
 	 * @param   DOMElement  $parent  The field node parent.


### PR DESCRIPTION
Pull Request for Issue #13744.

### Summary of Changes
On a fresh installation, when the plugin params didn't get saved, the default directory is empty. This PR handles this situation.

### Testing Instructions
- Fresh installation of Joomla staging.
- Gallery plugin doesn't have to be saved.
- Create a gallery field for articles and don't put a value in the directory parameter.
- Edit an article.

### Expected result
Only the subfolders of /images should be shown.

### Actual result
The whole directory of the Joomla installation is shown.
