### PR TITLE
Add expected and actual result headings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,8 @@ Pull Request for Issue # .
 
 ### Testing Instructions
 
+### Expected result
+
+### Actual result
+
 ### Documentation Changes Required


### PR DESCRIPTION
When we create a pull request, we have always to add the `### Expected result` and `### Actual result` part by hand. Would be comfortable to have them in the template.