### PR TITLE
Multilingual associations: Display only site menu types in SearchTools

### DIFF
--- a/administrator/components/com_associations/models/forms/filter_associations.xml
+++ b/administrator/components/com_associations/models/forms/filter_associations.xml
@@ -58,6 +58,7 @@
 			type="menu"
 			label="COM_ASSOCIATIONS_FILTER_MENUTYPE_LABEL"
 			description="COM_ASSOCIATIONS_FILTER_MENUTYPE_DESC"
+			clientid="0"
 			onchange="this.form.submit();"
 		>
 			<option value="">COM_ASSOCIATIONS_SELECT_MENU</option>


### PR DESCRIPTION
As the new admin menus feature has been merged, com_associations SearchTools will display these in the Menu Type filter. This patch lets display only the Site Menutypes.

Test instructions:
Create a basic multilingual site from staging.
Create a custom admin menu:
![screen shot 2017-01-26 at 09 23 29](https://cloud.githubusercontent.com/assets/869724/22324366/28f079a2-e3a9-11e6-9d90-e83439f968b2.png)

Load Multilingual Associations.
Select Menu Items in Items Type field.
Select a language.
Then click on Search Tools

Before patch, when selecting Menu, you will get:
![screen shot 2017-01-26 at 09 27 43](https://cloud.githubusercontent.com/assets/869724/22324478/cf91458e-e3a9-11e6-8a96-9b3161952631.png)

Patch and test again. You should get

![screen shot 2017-01-26 at 09 29 25](https://cloud.githubusercontent.com/assets/869724/22324495/f684e470-e3a9-11e6-9494-da910fda1dc5.png)

@rdeutz @alikon 

