### PR TITLE
[com_fields] Responsive subform.repeatable-table

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8873,6 +8873,11 @@ textarea.noResize {
 		padding-right: 10px;
 	}
 }
+@media (max-width: 979px) {
+	.com_fields .row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
+}
 .popover-content {
 	min-height: 33px;
 }
@@ -8904,11 +8909,6 @@ textarea.noResize {
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
-}
-@media (max-width: 979px) {
-	.row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-	}
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8905,8 +8905,10 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
-.row-fluid [class*="span"] {
-	margin-left: 2.12766%;
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8821,6 +8821,10 @@ textarea.noResize {
 	.subform-table-layout .subform-repeatable {
 		padding-right: 0;
 	}
+	.subform-table-layout .subform-repeatable tbody td:last-of-type {
+		text-align: right;
+		padding-bottom: 15px;
+	}
 	.subform-table-layout table,
 	.subform-table-layout thead,
 	.subform-table-layout tbody,
@@ -8860,10 +8864,6 @@ textarea.noResize {
 	}
 	.subform-table-layout tbody td:first-of-type:before {
 		top: 18px;
-	}
-	.subform-table-layout tbody td:last-of-type {
-		text-align: right;
-		padding-bottom: 15px;
 	}
 	.subform-table-layout td:before {
 		content: attr(data-column);
@@ -9833,4 +9833,20 @@ a.grid_true {
 	border-width: 1px 0 0 1px;
 	left: auto;
 	right: 0;
+}
+.subform-table-layout td {
+	padding-left: 10px;
+}
+.subform-table-layout td::before {
+	content: attr(data-column);
+	left: auto;
+	right: 10px;
+	padding-left: 10px;
+	padding-right: 0;
+}
+.subform-table-layout .subform-repeatable tbody td:last-of-type {
+	text-align: left;
+}
+.subform-table-layout .form-horizontal .controls {
+	margin-top: 0;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8877,6 +8877,9 @@ textarea.noResize {
 	.com_fields .row-fluid [class*="span"] {
 		margin-left: 2.12766%;
 	}
+	.com_fields .row-fluid [class*="span"]:first-of-type {
+		margin-left: 0;
+	}
 }
 .popover-content {
 	min-height: 33px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8803,6 +8803,76 @@ textarea.noResize {
 		margin-bottom: 10px;
 	}
 }
+.subform-table-layout .control-group,
+.subform-table-layout .control-group:last-of-type {
+	margin-bottom: 0;
+}
+.subform-table-layout .controls {
+	padding-right: 20px;
+}
+.subform-table-layout input {
+	width: 100%;
+	max-width: 206px;
+}
+.subform-table-layout table .btn-group {
+	margin: 0 7px;
+}
+@media (max-width: 1024px) {
+	.subform-table-layout .subform-repeatable {
+		padding-right: 0;
+	}
+	.subform-table-layout table,
+	.subform-table-layout thead,
+	.subform-table-layout tbody,
+	.subform-table-layout th,
+	.subform-table-layout td,
+	.subform-table-layout tr {
+		display: block;
+	}
+	.subform-table-layout table {
+		border: 1px solid #ddd;
+	}
+	.subform-table-layout thead th {
+		position: absolute;
+		top: -9999px;
+		left: -9999px;
+	}
+	.subform-table-layout thead th:last-of-type {
+		position: static;
+		width: 100% !important;
+		text-align: right;
+		box-sizing: border-box;
+		border-left: 0;
+	}
+	.subform-table-layout tr {
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+	.subform-table-layout td {
+		border: none;
+		position: relative;
+		padding-left: 50%;
+	}
+	.subform-table-layout tbody td:first-of-type {
+		padding-top: 15px;
+		border-top: 1px solid #ddd;
+	}
+	.subform-table-layout tbody td:first-of-type:before {
+		top: 18px;
+	}
+	.subform-table-layout tbody td:last-of-type {
+		text-align: right;
+		padding-bottom: 15px;
+	}
+	.subform-table-layout td:before {
+		content: attr(data-column);
+		position: absolute;
+		top: 13px;
+		left: 10px;
+		padding-right: 10px;
+	}
+}
 .popover-content {
 	min-height: 33px;
 }
@@ -8834,6 +8904,9 @@ textarea.noResize {
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
+}
+.row-fluid [class*="span"] {
+	margin-left: 2.12766%;
 }
 .pull-right {
 	float: left;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8905,6 +8905,8 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
-.row-fluid [class*="span"] {
-	margin-left: 2.12766%;
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8803,6 +8803,76 @@ textarea.noResize {
 		margin-bottom: 10px;
 	}
 }
+.subform-table-layout .control-group,
+.subform-table-layout .control-group:last-of-type {
+	margin-bottom: 0;
+}
+.subform-table-layout .controls {
+	padding-right: 20px;
+}
+.subform-table-layout input {
+	width: 100%;
+	max-width: 206px;
+}
+.subform-table-layout table .btn-group {
+	margin: 0 7px;
+}
+@media (max-width: 1024px) {
+	.subform-table-layout .subform-repeatable {
+		padding-right: 0;
+	}
+	.subform-table-layout table,
+	.subform-table-layout thead,
+	.subform-table-layout tbody,
+	.subform-table-layout th,
+	.subform-table-layout td,
+	.subform-table-layout tr {
+		display: block;
+	}
+	.subform-table-layout table {
+		border: 1px solid #ddd;
+	}
+	.subform-table-layout thead th {
+		position: absolute;
+		top: -9999px;
+		left: -9999px;
+	}
+	.subform-table-layout thead th:last-of-type {
+		position: static;
+		width: 100% !important;
+		text-align: right;
+		box-sizing: border-box;
+		border-left: 0;
+	}
+	.subform-table-layout tr {
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+	.subform-table-layout td {
+		border: none;
+		position: relative;
+		padding-left: 50%;
+	}
+	.subform-table-layout tbody td:first-of-type {
+		padding-top: 15px;
+		border-top: 1px solid #ddd;
+	}
+	.subform-table-layout tbody td:first-of-type:before {
+		top: 18px;
+	}
+	.subform-table-layout tbody td:last-of-type {
+		text-align: right;
+		padding-bottom: 15px;
+	}
+	.subform-table-layout td:before {
+		content: attr(data-column);
+		position: absolute;
+		top: 13px;
+		left: 10px;
+		padding-right: 10px;
+	}
+}
 .popover-content {
 	min-height: 33px;
 }
@@ -8834,4 +8904,7 @@ textarea.noResize {
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
+}
+.row-fluid [class*="span"] {
+	margin-left: 2.12766%;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8873,6 +8873,11 @@ textarea.noResize {
 		padding-right: 10px;
 	}
 }
+@media (max-width: 979px) {
+	.com_fields .row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	}
+}
 .popover-content {
 	min-height: 33px;
 }
@@ -8904,9 +8909,4 @@ textarea.noResize {
 }
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
-}
-@media (max-width: 979px) {
-	.row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-	}
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8821,6 +8821,10 @@ textarea.noResize {
 	.subform-table-layout .subform-repeatable {
 		padding-right: 0;
 	}
+	.subform-table-layout .subform-repeatable tbody td:last-of-type {
+		text-align: right;
+		padding-bottom: 15px;
+	}
 	.subform-table-layout table,
 	.subform-table-layout thead,
 	.subform-table-layout tbody,
@@ -8860,10 +8864,6 @@ textarea.noResize {
 	}
 	.subform-table-layout tbody td:first-of-type:before {
 		top: 18px;
-	}
-	.subform-table-layout tbody td:last-of-type {
-		text-align: right;
-		padding-bottom: 15px;
 	}
 	.subform-table-layout td:before {
 		content: attr(data-column);

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8877,6 +8877,9 @@ textarea.noResize {
 	.com_fields .row-fluid [class*="span"] {
 		margin-left: 2.12766%;
 	}
+	.com_fields .row-fluid [class*="span"]:first-of-type {
+		margin-left: 0;
+	}
 }
 .popover-content {
 	min-height: 33px;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -385,3 +385,23 @@ a.grid_true {
     left: auto;
     right: 0;
 }
+
+/* SubForms (Table) */
+.subform-table-layout {
+	td {
+		padding-left: 10px;
+		&::before {
+			content: attr(data-column);
+			left: auto;
+			right: 10px;
+			padding-left: 10px;
+			padding-right: 0;
+		}
+	}
+	.subform-repeatable tbody td:last-of-type {
+		text-align: left;
+	}
+	.form-horizontal .controls {
+		margin-top: 0;
+	}
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1836,6 +1836,82 @@ textarea.noResize {
 	}
 }
 
+.subform-table-layout {
+	.control-group, .control-group:last-of-type {
+		margin-bottom: 0;
+	}
+	.controls {
+		padding-right: 20px;
+	}
+	.btn-group {
+
+	}
+	input {
+		width: 100%;
+		max-width: 206px;
+	}
+	table .btn-group {
+		margin: 0 7px;
+	}
+}
+@media (max-width: 1024px) {
+	.subform-table-layout {
+		.subform-repeatable {
+			padding-right: 0;
+		}
+		table, thead, tbody, th, td, tr { 
+			display: block; 
+		}
+		table {
+			border: 1px solid #ddd;
+		}
+		thead {
+			
+			th { 
+				position: absolute;
+				top: -9999px;
+				left: -9999px;
+				&:last-of-type {
+					position: static;
+					width: 100% !important;
+					text-align: right;
+					box-sizing: border-box;
+					border-left: 0;
+				}
+			}
+		}
+		tr { 
+			margin: 0;
+    		padding: 0;
+			border: 0;
+		}
+		td { 
+			border: none;
+			position: relative;
+			padding-left: 50%; 
+		}
+		tbody {
+			td:first-of-type {
+				padding-top: 15px;
+				border-top: 1px solid #ddd;
+				&:before {top:18px;}
+			}
+			td:last-of-type {
+				text-align: right;
+				padding-bottom: 15px;
+			}
+		}
+		
+		td:before { 
+			content: attr(data-column);
+			position: absolute;
+			top: 13px;
+			left: 10px;
+			padding-right: 10px; 
+		}
+	}
+}
+
 /* Popover minimum height - overwrite bootstrap default */
 .popover-content {
     min-height: 33px;
@@ -1878,3 +1954,8 @@ textarea.noResize {
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
 }
+
+// Bootsrap revert of override to default 
+.row-fluid [class*="span"] {
+    margin-left: 2.12766%;
+} 

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1858,6 +1858,10 @@ textarea.noResize {
 	.subform-table-layout {
 		.subform-repeatable {
 			padding-right: 0;
+			tbody td:last-of-type {
+				text-align: right;
+				padding-bottom: 15px;
+			}
 		}
 		table, thead, tbody, th, td, tr { 
 			display: block; 
@@ -1895,10 +1899,6 @@ textarea.noResize {
 				padding-top: 15px;
 				border-top: 1px solid #ddd;
 				&:before {top:18px;}
-			}
-			td:last-of-type {
-				text-align: right;
-				padding-bottom: 15px;
 			}
 		}
 		

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1911,6 +1911,12 @@ textarea.noResize {
 		}
 	}
 }
+// Following can be removed if a solution is found for #13768
+@media (max-width: 979px) {
+	.com_fields .row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	} 
+}
 
 /* Popover minimum height - overwrite bootstrap default */
 .popover-content {
@@ -1953,11 +1959,4 @@ textarea.noResize {
 /* Align btn-group-yesno to label */
 .form-horizontal .controls > .radio.btn-group-yesno:first-child {
 	padding-top: 2px;
-}
-
-// Bootsrap revert of override to default 
-@media (max-width: 979px) {
-	.row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-	} 
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1915,6 +1915,9 @@ textarea.noResize {
 @media (max-width: 979px) {
 	.com_fields .row-fluid [class*="span"] {
 		margin-left: 2.12766%;
+		&:first-of-type {
+			margin-left: 0;
+		}
 	} 
 }
 

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1956,6 +1956,8 @@ textarea.noResize {
 }
 
 // Bootsrap revert of override to default 
-.row-fluid [class*="span"] {
-    margin-left: 2.12766%;
-} 
+@media (max-width: 979px) {
+	.row-fluid [class*="span"] {
+		margin-left: 2.12766%;
+	} 
+}

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -23,7 +23,7 @@ extract($displayData);
 
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">
 	<?php foreach ($form->getGroup('') as $field) : ?>
-	<td>
+	<td data-column="<?php echo strip_tags($field->label); ?>">
 		<?php echo $field->renderField(array('hiddenLabel' => true)); ?>
 	</td>
 	<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes subform tables responsive, switching from column to row views on smaller screens. This form is used in com_fields however applies to all subform tables

### Testing Instructions
Navigate to Content -> Fields -> New. Set 'Type' to 'Checkbox', add a number of values and resize the browser window.

@laoneo This resolves the issue we discussed at the sprint regarding using subform.repeatable-table and smaller screens.

### Before Patch
![subform1](https://cloud.githubusercontent.com/assets/2803503/22336278/8b7bf8f0-e3d9-11e6-9247-884176e1591a.gif)

### After Patch
![subform2](https://cloud.githubusercontent.com/assets/2803503/22336339/cea4c1ca-e3d9-11e6-8fb0-2a4824d86cff.gif)


### Documentation Changes Required
None
