### PR TITLE
[com_fields] Remove from global option for the display functionality

### DIFF
--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -291,13 +291,12 @@
 				type="list"
 				label="COM_FIELDS_FIELD_DISPLAY_LABEL"
 				description="COM_FIELDS_FIELD_DISPLAY_DESC"
-				default="-1"
+				default="2"
 			>
 				<option value="1">COM_FIELDS_FIELD_DISPLAY_AFTER_TITLE</option>
 				<option value="2">COM_FIELDS_FIELD_DISPLAY_BEFORE_DISPLAY</option>
 				<option value="3">COM_FIELDS_FIELD_DISPLAY_AFTER_DISPLAY</option>
 				<option value="0">JNO</option>
-				<option value="-1">JGLOBAL_USE_GLOBAL</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/administrator/language/en-GB/en-GB.plg_system_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_fields.ini
@@ -4,9 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_FIELDS="System - Fields"
-PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_AFTER_DISPLAY="After Display"
-PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_AFTER_TITLE="After Title"
-PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_BEFORE_DISPLAY="Before Display"
-PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_DESC="Joomla offers several content events which are triggered during the content creation process. Here you can define how the custom fields should be integrated into content."
-PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_LABEL="Automatic Display"
 PLG_SYSTEM_FIELDS_XML_DESCRIPTION="The system fields plugin lets you display the custom fields."

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -412,12 +412,7 @@ class PlgSystemFields extends JPlugin
 		{
 			foreach ($fields as $key => $field)
 			{
-				$fieldDisplayType = $field->params->get('display', '-1');
-
-				if ($fieldDisplayType == '-1')
-				{
-					$fieldDisplayType = $this->params->get('display', '2');
-				}
+				$fieldDisplayType = $field->params->get('display', '2');
 
 				if ($fieldDisplayType == $displayType)
 				{

--- a/plugins/system/fields/fields.xml
+++ b/plugins/system/fields/fields.xml
@@ -16,22 +16,4 @@
 		<language tag="en-GB">en-GB.plg_system_fields.ini</language>
 		<language tag="en-GB">en-GB.plg_system_fields.sys.ini</language>
 	</languages>
-	<config>
-		<fields name="params">
-			<fieldset name="basic">
-				<field
-					name="display"
-					type="list"
-					label="PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_LABEL"
-					description="PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_DESC"
-					default="2"
-					>
-					<option value="1">PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_AFTER_TITLE</option>
-					<option value="2">PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_BEFORE_DISPLAY</option>
-					<option value="3">PLG_SYSTEM_FIELDS_CONFIG_DISPLAY_AFTER_DISPLAY</option>
-					<option value="0">JNO</option>
-				</field>
-			</fieldset>
-		</fields>
-	</config>
 </extension>


### PR DESCRIPTION
Pull Request for Issue #13350.

### Summary of Changes
The automatic display functionality offers to inherit from global. The current implementation inherits the settings from the system plugin. This workde well for DPFields, but for the core it confuses more than it solves. This PR removes that option.

![image](https://cloud.githubusercontent.com/assets/251072/22365865/150d5bb8-e47a-11e6-86cc-c218b7875669.png)

### Testing Instructions
- Create a new custom field
- Open the options tab

### Expected result
Automatic display shows "Before display".

### Actual result
Automatic display shows "Use Global".
