### PR TITLE
Allow to pass the url parts without wrapping in an array

### DIFF
--- a/libraries/vendor/joomla/uri/src/AbstractUri.php
+++ b/libraries/vendor/joomla/uri/src/AbstractUri.php
@@ -110,14 +110,19 @@ abstract class AbstractUri implements UriInterface
 	/**
 	 * Returns full uri string.
 	 *
-	 * @param   array  $parts  An array specifying the parts to render.
+	 * @param   mixed   $parts  An array specifying the parts to render.
 	 *
 	 * @return  string  The rendered URI string.
 	 *
 	 * @since   1.0
 	 */
-	public function toString(array $parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'))
+	public function toString($parts = array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'))
 	{
+		if (is_string($parts))
+		{
+			$parts = func_get_args();
+		}
+
 		// Make sure the query is created
 		$query = $this->getQuery();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A) Stop type-hinting `AbstractUri::toString` so that array isn't required
B) Check if a string has been passed, if so get the `$parts` array from `func_get_args`

### Testing Instructions
Try this:
```
$uri->toString(array('path', 'query', 'fragment'));
```
Then try this:
```
$uri->toString('path', 'query', 'fragment');
```
Should be the same.

OK, how about this:
```
$parts = array(...); // Put whatever parts you want in here
$uri->toString($parts) === call_user_func_array(array($uri, 'toString'), $parts);
```
Should always be true.

### Documentation Changes Required
Probably not.

### Why?
OK, I like type-hinting too but, look, there's no reason to pass an array into this thing. Just pass the strings in any order and don't worry about it. Prefer an array? OK, still works. But, honestly, what's more readable?
```
$uri->toString(array('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment'));
```
or
```
$uri->toString('scheme', 'user', 'pass', 'host', 'port', 'path', 'query', 'fragment');
```
Not that you would ever write either of those since it's the default anyway... but you get the idea.