### PR TITLE
Regression 3.7: last template style preview not working #1

### DIFF
--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -496,6 +496,9 @@ final class JApplicationSite extends JApplicationCms
 			$cache->store($templates, 'templates0' . $tag);
 		}
 
+		// Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid to edit the $templates array in the following assignment 
+		unset($template);
+		
 		if (isset($templates[$id]))
 		{
 			$template = $templates[$id];

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -497,6 +497,9 @@ final class JApplicationSite extends JApplicationCms
 				$template->params = new Registry($template->params);
 			}
 
+			// Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid editing it later
+			unset($template);
+
 			// Add home element, after loop to avoid double execution
 			if (isset($template_home))
 			{
@@ -507,8 +510,6 @@ final class JApplicationSite extends JApplicationCms
 			$cache->store($templates, $cacheId);
 		}
 
-		// Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid to edit the $templates array in the following assignment 
-		unset($template);
 		if (isset($templates[$id]))
 		{
 			$template = $templates[$id];

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -466,13 +466,7 @@ final class JApplicationSite extends JApplicationCms
 			$tag = '';
 		}
 
-		$cacheId = 'templates0' . $tag;
-
-		if ($cache->contains($cacheId))
-		{
-			$templates = $cache->get($cacheId);
-		}
-		else
+		if (!$templates = $cache->get('templates0' . $tag))
 		{
 			// Load styles
 			$db = JFactory::getDbo();
@@ -488,23 +482,18 @@ final class JApplicationSite extends JApplicationCms
 
 			foreach ($templates as &$template)
 			{
+				$registry = new Registry;
+				$registry->loadString($template->params);
+				$template->params = $registry;
+
 				// Create home element
-				if ($template->home == 1 && !isset($template_home) || $this->_language_filter && $template->home == $tag)
+				if ($template->home == 1 && !isset($templates[0]) || $this->_language_filter && $template->home == $tag)
 				{
-					$template_home = clone $template;
+					$templates[0] = clone $template;
 				}
-
-				$template->params = new Registry($template->params);
 			}
 
-			// Add home element, after loop to avoid double execution
-			if (isset($template_home))
-			{
-				$template_home->params = new Registry($template_home->params);
-				$templates[0] = $template_home;
-			}
-
-			$cache->store($templates, $cacheId);
+			$cache->store($templates, 'templates0' . $tag);
 		}
 
 		if (isset($templates[$id]))

--- a/libraries/cms/application/site.php
+++ b/libraries/cms/application/site.php
@@ -507,6 +507,8 @@ final class JApplicationSite extends JApplicationCms
 			$cache->store($templates, $cacheId);
 		}
 
+		// Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid to edit the $templates array in the following assignment 
+		unset($template);
 		if (isset($templates[$id]))
 		{
 			$template = $templates[$id];


### PR DESCRIPTION
Reference https://github.com/joomla/joomla-cms/issues/13637

### Steps to reproduce the issue
Install a new template on Joomla 3.7

Try to open the preview using the URL such as:
http://joomla37/?template=mytemplate


### Expected result
The frontend uses the latest installed template named 'mytemplate'


### Actual result
The default template is still used


### System information (as much as possible)
The code change in site.php included in the function 'getTemplate' caused the regression.

An additional line of code 510 must be added in order to unset the reference to the array before reassigning it:

// Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid to edit the $templates array in the following assignment 
unset($template);


### Additional comments