### PR TITLE
[Improvement] Backend menu item edit form : Add Itemid to the alias link value

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -770,7 +770,7 @@ class MenusModelItem extends JModelAdmin
 			// Note that all request arguments become reserved parameter names.
 			$result->params = array_merge($result->params, $args);
 			// Add Itemid to the alias link value
-                        $result->link .= $result->id;
+			$result->link .= $result->id;
 		}
 
 		if ($table->type == 'url')

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -769,6 +769,8 @@ class MenusModelItem extends JModelAdmin
 		{
 			// Note that all request arguments become reserved parameter names.
 			$result->params = array_merge($result->params, $args);
+			// Add Itemid to the alias link value
+                        $result->link .= $result->id;
 		}
 
 		if ($table->type == 'url')

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -769,6 +769,7 @@ class MenusModelItem extends JModelAdmin
 		{
 			// Note that all request arguments become reserved parameter names.
 			$result->params = array_merge($result->params, $args);
+			
 			// Add Itemid to the alias link value
 			$result->link .= $result->id;
 		}


### PR DESCRIPTION
The link field of an alias menu item displays "index.php?Item=" without the actual item id.
![menus edit item stagging administration](https://cloud.githubusercontent.com/assets/1827776/22368755/8910967a-e488-11e6-9bc4-7f20c68006ae.png)

### Summary of Changes
I've added the menu item id to the link value in the MenusModelItem::getItem method.
### Testing Instructions
Create a menu alias and stay in the menu item edit form.
- Before the PR 
After save, you should see "index.php?Itemid=" in the link value readonly field.
- After the PR 
After save, you should see "index.php?Itemid=**XXX**" in the link field with **XXX** being the actual menu item id.
### Documentation Changes Required
No documentation changes required