### PR TITLE
JUserTest needs to clear JAccess stats for allowed test. ALso JAccessTe…

### DIFF
--- a/tests/unit/suites/libraries/joomla/access/JAccessTest.php
+++ b/tests/unit/suites/libraries/joomla/access/JAccessTest.php
@@ -300,10 +300,10 @@ class JAccessTest extends TestCaseDatabase
 	public function testGetGroupsByUser()
 	{
 		$array1 = array(0 => 1, 1 => 8);
-		$this->assertThat($array1, $this->equalTo(JAccess::getGroupsByUser(42, true)));
+		$this->assertThat(JAccess::getGroupsByUser(42, true), $this->equalTo($array1));
 
 		$array2 = array(0 => 8);
-		$this->assertThat($array2, $this->equalTo(JAccess::getGroupsByUser(42, false)));
+		$this->assertThat(JAccess::getGroupsByUser(42, false), $this->equalTo($array2));
 
 		$this->markTestSkipped('Test is now failing with full test suite.');
 

--- a/tests/unit/suites/libraries/joomla/user/JUserTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserTest.php
@@ -36,6 +36,9 @@ class JUserTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		// Clear JAccess static caches.
+		JAccess::clearStatics();
+
 		$this->saveFactoryState();
 
 		$this->object = new JUser('42');


### PR DESCRIPTION
…st::testGetGroupsByUser() has expected and actual reversed.

### Summary of Changes
JUserTest needs to clear JAccess stats for allowed test to make sure other tests are not messing it's results in testAuthorise .
JAccess::testGetGroupsByUser() has arguments passed to assertThat in wrong order.
### Testing Instructions

### Documentation Changes Required
