### PR TITLE
com_finder outputs empty p tag with no description

### DIFF
--- a/components/com_finder/views/search/tmpl/default_result.php
+++ b/components/com_finder/views/search/tmpl/default_result.php
@@ -53,7 +53,7 @@ if (!empty($this->query->highlight)
 	<h4 class="result-title <?php echo $mime; ?>">
 		<a href="<?php echo JRoute::_($route); ?>"><?php echo $this->result->title; ?></a>
 	</h4>
-	<?php if ($show_description) : ?>
+	<?php if ($show_description && $description !== '') : ?>
 		<p class="result-text<?php echo $this->pageclass_sfx; ?>">
 			<?php echo $description; ?>
 		</p>


### PR DESCRIPTION
### Steps to reproduce the issue
Set description on article or anything other item to nothing. In my scenario it was using Docman where they are just documents with no content.

### Expected result
html not to be rendered if there isn't a description to render

### Actual result
Renders a < p > html tag with no content, causes excess padding and just a mess on most sites.


### System information (as much as possible)
J3.6.5 / J3.7.0Alpha2.

### Additional comments

this is just a simple change to make the output of search results which have no description inside them to not render excess html.

Pull Request for Issue # .

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
