### PR TITLE
Adds inline style to hide label

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -26,7 +26,8 @@ $output = '<input type="text" name="q" id="mod-finder-searchword' . $module->id 
 
 $showLabel  = $params->get('show_label', 1);
 $labelClass = (!$showLabel ? 'element-invisible ' : '') . 'finder' . $suffix;
-$label      = '<label for="mod-finder-searchword' . $module->id . '" class="' . $labelClass . '">' . $params->get('alt_label', JText::_('JSEARCH_FILTER_SUBMIT')) . '</label>';
+$style	    = (!$showLabel ? 'style="display:none;" ' : '');
+$label      = '<label for="mod-finder-searchword' . $module->id . '" class="' . $labelClass . '" ' . $style . '>' . $params->get('alt_label', JText::_('JSEARCH_FILTER_SUBMIT')) . '</label>';
 
 switch ($params->get('label_pos', 'left'))
 {


### PR DESCRIPTION
As per Georges comment we always need to render the label for Accessibility reasons regardless of the show/hide setting. This pull just adds some inline CSS to hide the label and respect the config option within the module.

Leaving behind the original classing incase it is being used already in the users template.

Pull Request for Issue # .

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
