### PR TITLE
Correcting articles manager title display

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -72,10 +72,10 @@ $assoc = JLanguageAssociations::isEnabled();
 						<th width="1%" class="center">
 							<?php echo JHtml::_('grid.checkall'); ?>
 						</th>
-						<th width="1%" style="min-width:55px" class="nowrap center">
+						<th width="1%" class="nowrap center">
 							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
 						</th>
-						<th>
+						<th style="min-width:100px" class="nowrap">
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="10%" class="nowrap hidden-phone">


### PR DESCRIPTION
Pull Request for Issue # .
New issue
### Summary of Changes
Adding min-width to the Title column
### Testing Instructions
Display Articles Manager before and after patch
### Documentation Changes Required
none

Before patch we get:

![css_articles](https://cloud.githubusercontent.com/assets/869724/22394845/1b01f116-e52c-11e6-9798-cbb6d54b52ff.gif)

After patch one should get

![css_articlesafter](https://cloud.githubusercontent.com/assets/869724/22394854/2fb3c224-e52c-11e6-837a-63c822483bd4.gif)
