### PR TITLE
[admin_menus] Custom admin menus should not display as possible Menu Assignment when editing a template style

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 $menuTypes = MenusHelper::getMenuLinks();
 $user      = JFactory::getUser();
-//var_dump($menuTypes);
 ?>
 <label id="jform_menuselect-lbl" for="jform_menuselect"><?php echo JText::_('JGLOBAL_MENU_SELECTION'); ?></label>
 <div class="btn-toolbar">

--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 $menuTypes = MenusHelper::getMenuLinks();
 $user      = JFactory::getUser();
+//var_dump($menuTypes);
 ?>
 <label id="jform_menuselect-lbl" for="jform_menuselect"><?php echo JText::_('JGLOBAL_MENU_SELECTION'); ?></label>
 <div class="btn-toolbar">
@@ -22,25 +23,24 @@ $user      = JFactory::getUser();
 </div>
 <div id="menu-assignment">
 	<ul class="menu-links">
-
 		<?php foreach ($menuTypes as &$type) : ?>
-			<li class="span3">
-				<div class="menu-links-block">
-					<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery('.<?php echo $type->menutype; ?>').attr('checked', !jQuery('.<?php echo $type->menutype; ?>').attr('checked'));">
-						<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?>
-					</button>
-					<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
-	
-					<?php foreach ($type->links as $link) : ?>
-						<label class="checkbox small" for="link<?php echo (int) $link->value; ?>" >
-						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif; ?> />
-						<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
-						</label>
-					<?php endforeach; ?>
+			<?php if ($type->client_id == 0) : ?>
+				<li class="span3">
+					<div class="menu-links-block">
+						<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery('.<?php echo $type->menutype; ?>').attr('checked', !jQuery('.<?php echo $type->menutype; ?>').attr('checked'));">
+							<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?>
+						</button>
+						<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
 
-				</div>
-			</li>
+						<?php foreach ($type->links as $link) : ?>
+							<label class="checkbox small" for="link<?php echo (int) $link->value; ?>" >
+							<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif; ?> />
+							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
+							</label>
+						<?php endforeach; ?>
+					</div>
+				</li>
+			<?php endif; ?>
 		<?php endforeach; ?>
-
 	</ul>
 </div>


### PR DESCRIPTION
Pull Request for Issue # .
New issue
### Summary of Changes
Filter the possible menu assignment to display only site menu items
### Testing Instructions
Create a new admin menu and some menu items.
Edit a Site template style. Display the Menu Assignment tab.

Before patch, the admin menu is displayed.

![screen shot 2017-01-28 at 10 11 23](https://cloud.githubusercontent.com/assets/869724/22395557/7619ab78-e542-11e6-828f-9e7a2984a35c.png)

After patch, it is no more.

![screen shot 2017-01-28 at 10 10 48](https://cloud.githubusercontent.com/assets/869724/22395553/50f5554a-e542-11e6-9239-ca4cfdb0f553.png)


@izharaazmi 
