### PR TITLE
Add AppVeyor CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,6 +72,10 @@ install:
     - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
+    - ps: >-
+        If ($env:php_ver_target -eq "5.6") {
+          If ($env:PHP -eq "1") {
+            echo extension=php_mysql.dll >> php.ini}}
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd C:\projects\joomla-cms

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,10 +72,7 @@ install:
     - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
-    - ps: >-
-        If ($env:php_ver_target -eq "5.6") {
-          If ($env:PHP -eq "1") {
-            echo extension=php_mysql.dll >> php.ini}}
+    - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd C:\projects\joomla-cms

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,101 @@
+build: false
+shallow_clone: true
+platform:
+  - x64
+clone_folder: C:\projects\joomla-cms
+## Build matrix for lowest and highest possible targets
+environment:
+  matrix:
+  - dependencies: current
+    php_ver_target: 5.6
+  - dependencies: current
+    php_ver_target: 7.0
+  - dependencies: current
+    php_ver_target: 7.1
+
+init:
+  - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1
+  - SET ANSICON=121x90 (121x90)
+services:
+  - mssql2014
+  - mysql
+  - postgresql94
+  - iis
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+    - IF EXIST C:\tools\php (SET PHP=0)
+    - ps: >-
+        If ($env:php_ver_target -eq "5.6") {
+        appveyor-retry cinst --ignore-checksums -y --forcex86 php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')
+        } Else {
+        appveyor-retry cinst --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $Env:php_ver_target | Select-Object -first 1) -replace '[php|]','')}
+    - cinst -y sqlite
+    - cd C:\tools\php
+    - ps: >-
+        If ($env:php_ver_target -eq "5.6") {
+          If ($env:PHP -eq "1") {
+            appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
+            7z x php-sqlsrv.zip > $null
+            copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
+            copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll
+            Remove-Item C:\tools\php\* -include .zip}}
+    - ps: >-
+        If ($env:php_ver_target -eq "7.0") {
+          If ($env:PHP -eq "1") {
+            appveyor DownloadFile https://github.com/Microsoft/msphpsql/releases/download/4.1.5-Windows/7.0.zip
+            7z x 7.0.zip > $null
+            copy 7.0\x64\php_pdo_sqlsrv_7_nts.dll ext\php_pdo_sqlsrv_nts.dll
+            copy 7.0\x64\php_sqlsrv_7_nts.dll ext\php_sqlsrv_nts.dll
+            Remove-Item C:\tools\php\* -include .zip}}
+    - ps: >-
+        If ($env:php_ver_target -eq "7.1") {
+          If ($env:PHP -eq "1") {
+            appveyor DownloadFile https://github.com/Microsoft/msphpsql/releases/download/4.1.5-Windows/7.1.zip
+            7z x 7.1.zip > $null
+            copy 7.1\x64\php_pdo_sqlsrv_71_nts.dll ext\php_pdo_sqlsrv_nts.dll
+            copy 7.1\x64\php_sqlsrv_71_nts.dll ext\php_sqlsrv_nts.dll
+            Remove-Item C:\tools\php\* -include .zip}}
+    - IF %PHP%==1 copy php.ini-production php.ini /Y
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pdo_sqlsrv_nts.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_sqlsrv_nts.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+    - cd C:\projects\joomla-cms
+    - appveyor-retry composer install --no-progress --profile
+
+before_test:
+#  Database setup for MySQL via PowerShell tools
+  - >
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql" -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS joomla_ut;"
+  - >
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql" -u root -p"Password12!" joomla_ut < tests\unit\schema\mysql.sql
+
+#  Database setup for PostgreSQL
+  - SET PGUSER=postgres
+  - SET PGPASSWORD=Password12!
+  - PATH=C:\Program Files\PostgreSQL\9.4\bin\;%PATH%
+  - createdb joomla_ut
+  - psql -d joomla_ut -a -f tests\unit\schema\postgresql.sql
+
+# Database setup for SQL Server
+  - ps: $sqlInstance = "(local)\SQL2014"
+  - ps: sqlcmd -b -E -S "$sqlInstance" -Q "CREATE DATABASE joomla_ut"
+  - ps: sqlcmd -S "$sqlInstance" -U "sa" -P "Password12!" -i $env:APPVEYOR_BUILD_FOLDER\tests\unit\schema\sqlsrv.sql
+
+test_script:
+  - cd C:\projects\joomla-cms
+  - libraries/vendor/bin/phpunit -c appveyor-phpunit.xml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cm
 Build Status
 ---------------------
 Travis-CI: [![Build Status](https://travis-ci.org/joomla/joomla-cms.svg?branch=staging)](https://travis-ci.org/joomla/joomla-cms)
+AppVeyor: [![Build status](https://ci.appveyor.com/api/projects/status/bpcxulw6nnxlv8kb?svg=true)](https://ci.appveyor.com/project/joomla/joomla-cms)
 Jenkins: [![Build Status](http://build.joomla.org/job/cms/badge/icon)](http://build.joomla.org/job/cms/)
 
 What is this?

--- a/appveyor-phpunit.xml
+++ b/appveyor-phpunit.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/unit/bootstrap.php" colors="true">
+	<php>
+		<const name="JTEST_DATABASE_MYSQL_DSN" value="host=127.0.0.1;dbname=joomla_ut;user=root;pass=Password12!" />
+		<const name="JTEST_DATABASE_MYSQLI_DSN" value="host=127.0.0.1;dbname=joomla_ut;user=root;pass=Password12!" />
+		<const name="JTEST_DATABASE_PDO_MYSQL_DSN" value="host=127.0.0.1;dbname=joomla_ut;user=root;pass=Password12!" />
+		<const name="JTEST_DATABASE_POSTGRESQL_DSN" value="host=127.0.0.1;port=5432;dbname=joomla_ut;user=postgres;pass=Password12!" />
+		<const name="JTEST_DATABASE_SQLSRV_DSN" value="host=(local)\SQL2014;dbname=joomla_ut;user=sa;pass=Password12!" />
+		<!-- <const name="JTEST_HTTP_STUB" value="http://localhost/tests/unit/stubs/jhttp_stub.php" /> -->
+	</php>
+
+	<testsuites>
+		<testsuite name="libraries-cms">
+			<directory>tests/unit/suites/libraries/cms</directory>
+		</testsuite>
+		<testsuite name="libraries-platform">
+			<directory>tests/unit/suites/libraries/joomla</directory>
+		</testsuite>
+		<testsuite name="libraries-legacy">
+			<directory>tests/unit/suites/libraries/legacy</directory>
+		</testsuite>
+		<testsuite name="database">
+			<directory>tests/unit/suites/database</directory>
+		</testsuite>
+		<testsuite name="administrator">
+			<directory>tests/unit/suites/administrator</directory>
+		</testsuite>
+		<testsuite name="FinderIndexer">
+			<directory>tests/unit/suites/finderIndexer</directory>
+		</testsuite>
+		<testsuite name="plugins">
+			<directory>tests/unit/suites/plugins</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/build/build.php
+++ b/build/build.php
@@ -99,12 +99,14 @@ $filesArray = array(
  * These paths are from the repository root without the leading slash
  */
 $doNotPackage = array(
+	'.appveyor.yml',
 	'.drone.yml',
 	'.github',
 	'.gitignore',
 	'.php_cs',
 	'.travis.yml',
 	'README.md',
+	'appveyor-phpunit.xml',
 	'build',
 	'build.xml',
 	'composer.json',

--- a/tests/unit/core/case/database/mysql.php
+++ b/tests/unit/core/case/database/mysql.php
@@ -118,7 +118,12 @@ abstract class TestCaseDatabaseMysql extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/core/case/database/mysqli.php
+++ b/tests/unit/core/case/database/mysqli.php
@@ -113,7 +113,12 @@ abstract class TestCaseDatabaseMysqli extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/core/case/database/oracle.php
+++ b/tests/unit/core/case/database/oracle.php
@@ -128,7 +128,12 @@ abstract class TestCaseDatabaseOracle extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		self::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/core/case/database/pdomysql.php
+++ b/tests/unit/core/case/database/pdomysql.php
@@ -137,6 +137,6 @@ abstract class TestCaseDatabasePdomysql extends TestCaseDatabase
 
 		static::$driver->connect();
 
-		return $this->createDefaultDBConnection(static::$driver->getConnection(), self::$options['database']);
+		return $this->createDefaultDBConnection(static::$driver->getConnection(), self::$_options['database']);
 	}
 }

--- a/tests/unit/core/case/database/pdomysql.php
+++ b/tests/unit/core/case/database/pdomysql.php
@@ -130,12 +130,13 @@ abstract class TestCaseDatabasePdomysql extends TestCaseDatabase
 	 */
 	protected function getConnection()
 	{
-		// Compile the connection DSN.
-		$dsn = 'mysql:host=' . self::$_options['host'] . ';dbname=' . self::$_options['database'];
+		if (static::$driver === null)
+		{
+			static::fail('Could not fetch a database driver to establish the connection.');
+		}
 
-		// Create the PDO object from the DSN and options.
-		$pdo = new PDO($dsn, self::$_options['user'], self::$_options['password']);
+		static::$driver->connect();
 
-		return $this->createDefaultDBConnection($pdo, self::$_options['database']);
+		return $this->createDefaultDBConnection(static::$driver->getConnection(), self::$options['database']);
 	}
 }

--- a/tests/unit/core/case/database/pdomysql.php
+++ b/tests/unit/core/case/database/pdomysql.php
@@ -113,7 +113,12 @@ abstract class TestCaseDatabasePdomysql extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -116,7 +116,12 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$_stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/core/case/database/sqlsrv.php
+++ b/tests/unit/core/case/database/sqlsrv.php
@@ -130,6 +130,7 @@ abstract class TestCaseDatabaseSqlsrv extends TestCaseDatabase
 
 		// Create the PDO object from the DSN and options.
 		$pdo = new PDO($dsn, self::$options['user'], self::$options['password']);
+		$pdo->exec('create table [jos_dbtest]([id] [int] IDENTITY(1,1) NOT NULL, [title] [nvarchar](50) NOT NULL, [start_date] [datetime] NOT NULL, [description] [nvarchar](max) NOT NULL, CONSTRAINT [PK_jos_dbtest_id] PRIMARY KEY CLUSTERED ([id] ASC) WITH (STATISTICS_NORECOMPUTE  = OFF, IGNORE_DUP_KEY = OFF))');
 
 		return $this->createDefaultDBConnection($pdo, self::$options['database']);
 	}

--- a/tests/unit/core/case/database/sqlsrv.php
+++ b/tests/unit/core/case/database/sqlsrv.php
@@ -113,7 +113,12 @@ abstract class TestCaseDatabaseSqlsrv extends TestCaseDatabase
 	public static function tearDownAfterClass()
 	{
 		JFactory::$database = self::$stash;
-		static::$driver = null;
+
+		if (static::$driver !== null)
+		{
+			static::$driver->disconnect();
+			static::$driver = null;
+		}
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -252,7 +252,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testGetCollation()
 	{
-		$this->assertContains('UTF-8', self::$driver->getCollation());
+		$this->assertNotEmpty(self::$driver->getCollation());
 	}
 
 	/**
@@ -484,7 +484,9 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
 		$versionArray = explode(' ', $versionRow[0]);
 
-		$this->assertGreaterThanOrEqual($versionArray[1], self::$driver->getVersion());
+		$version = rtrim($versionArray[1], ',');
+
+		$this->assertGreaterThanOrEqual($version, self::$driver->getVersion());
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #13690

### Summary of Changes

Adds AppVeyor CI support for the repository.  This adds an additional test build to pull requests running in a Windows environment with the following configuration:

- PHP 5.6, 7.0, and 7.1
- MySQL 5.7
- PostgreSQL 9.4
- SQL Server 2014

The AppVeyor build will run PHPUnit, hence incorporating automated test coverage from a Windows environment into the development process.

### Testing Instructions

Merge once the build is green

### Documentation Changes Required

N/A