### PR TITLE
Don't return admin menus

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -204,6 +204,7 @@ class MenusHelper
 		}
 
 		$query->where('a.published != -2');
+		$query->where('a.client_id = 0');
 		$query->order('a.lft ASC');
 
 		// Get the options.
@@ -227,6 +228,7 @@ class MenusHelper
 				->select('*')
 				->from('#__menu_types')
 				->where('menutype <> ' . $db->quote(''))
+				->where('client_id = 0')
 				->order('title, menutype');
 			$db->setQuery($query);
 


### PR DESCRIPTION
Pull Request for Issue #13783.
Replaces #13788 and #13787

### Summary of Changes
Adding `client_id` checks to `MenusHelper::getMenuLinks()` so it returns only menus from frontend.
This method is used in core to fetch the menu items for the module and template "menu assignment" and by the `JFormFieldMenuitem` to get the menu item list.

### Testing Instructions
* Create a custom admin menu
* Edit a module and a template and check the menu assignment tab. The custom admin menu should not appear in the list of menu items
* Edit the "System - Page Cache" plugin and check that the custom admin menu doesn't appear in the "Exclude Menu Items" list.

### Documentation Changes Required
None