### PR TITLE
Add the option to filter extensions on core or third party

### DIFF
--- a/administrator/components/com_installer/models/forms/filter_manage.xml
+++ b/administrator/components/com_installer/models/forms/filter_manage.xml
@@ -40,6 +40,15 @@
 			>
 			<option value="">COM_INSTALLER_VALUE_FOLDER_SELECT</option>
 		</field>
+		<field
+			name="core"
+			type="list"
+			onchange="this.form.submit();"
+		>
+			<option value="">COM_INSTALLER_VALUE_CORE_SELECT</option>
+			<option value="1">COM_INSTALLER_VALUE_CORE_YES</option>
+			<option value="0">COM_INSTALLER_VALUE_CORE_NO</option>
+		</field>
 	</fields>
 	<fields name="list">
 		<field

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -39,6 +39,7 @@ class InstallerModelManage extends InstallerModel
 				'folder', 'folder_translated',
 				'package_id',
 				'extension_id',
+				'core',
 			);
 		}
 
@@ -67,6 +68,7 @@ class InstallerModelManage extends InstallerModel
 		$this->setState('filter.status', $this->getUserStateFromRequest($this->context . '.filter.status', 'filter_status', '', 'string'));
 		$this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
 		$this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
+		$this->setState('filter.core', $this->getUserStateFromRequest($this->context . '.filter.core', 'filter_core', '', 'string'));
 
 		$this->setState('message', $app->getUserState('com_installer.message'));
 		$this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
@@ -284,14 +286,15 @@ class InstallerModelManage extends InstallerModel
 		$type     = $this->getState('filter.type');
 		$clientId = $this->getState('filter.client_id');
 		$folder   = $this->getState('filter.folder');
+		$core     = $this->getState('filter.core');
 
 		if ($status != '')
 		{
-			if ($status == '2')
+			if ($status === '2')
 			{
 				$query->where('protected = 1');
 			}
-			elseif ($status == '3')
+			elseif ($status === '3')
 			{
 				$query->where('protected = 0');
 			}
@@ -307,14 +310,26 @@ class InstallerModelManage extends InstallerModel
 			$query->where('type = ' . $this->_db->quote($type));
 		}
 
-		if ($clientId != '')
+		if ($clientId !== '')
 		{
 			$query->where('client_id = ' . (int) $clientId);
 		}
 
-		if ($folder != '')
+		if ($folder !== '')
 		{
 			$query->where('folder = ' . $this->_db->quote($folder == '*' ? '' : $folder));
+		}
+
+		if ($core !== '')
+		{
+			if ($core === '0')
+			{
+				$query->where($this->getDbo()->quoteName('extension_id') . ' >= 10000');
+			}
+			elseif ($core === '1')
+			{
+				$query->where($this->getDbo()->quoteName('extension_id') . ' < 10000');
+			}
 		}
 
 		// Process search filter (extension id).

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -273,3 +273,6 @@ COM_INSTALLER_WEBINSTALLER_INSTALL_WEB_LOADING_ERROR="Can't connect to the Jooml
 COM_INSTALLER_WEBINSTALLER_LOAD_APPS="Select to load extensions browser"
 COM_INSTALLER_XML_DESCRIPTION="Installer component for adding, removing and upgrading extensions"
 JLIB_RULES_SETTING_NOTES="Changes apply to this component only.<br /><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br /><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br /><em><strong>Allowed</strong></em> will enable the action for this component unless it is overruled by a Global Configuration setting."
+COM_INSTALLER_VALUE_CORE_SELECT=" - Select Core - "
+COM_INSTALLER_VALUE_CORE_YES="Show core extensions"
+COM_INSTALLER_VALUE_CORE_NO="Show third party extensions"


### PR DESCRIPTION
### Summary of Changes
This change adds an extra filter on the Extensions -> Manage page to filter extensions on whether they are core or 3rd party extensions.

<img width="1165" alt="image" src="https://cloud.githubusercontent.com/assets/359377/22403486/b8e070dc-e618-11e6-8179-5baeab65b5c0.png">

### Testing Instructions
1. Apply path
2. Go to Extensions -> Manage
3. Click on Search Tools
4. There is now a filter on the end called **- Select Core -**
5. Filter on **Show core extensions**
6. The list now only shows core extensions
7. Filter on **Show third party extensions**
8. The list now only shows third party extensions
9. Filter on **- Select Core -**
10. All extensions show in the list

### Documentation Changes Required
Don't know

Any feedback on the language strings is appreciated.