### PR TITLE
Fix JToolbarButton unit tests

### DIFF
--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -123,11 +123,11 @@ class JToolbarButtonTest extends TestCaseDatabase
 	{
 		$type = array('Standard', 'test');
 
-		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">" . PHP_EOL
-			. "\t<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { Joomla.submitbutton(''); }\" class=\"btn btn-small\">" . PHP_EOL
-			. "\t<span class=\"icon-test\"></span>" . PHP_EOL
-			. "\t</button>" . PHP_EOL
-			. "</div>" . PHP_EOL;
+		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">\n"
+			. "\t<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { Joomla.submitbutton(''); }\" class=\"btn btn-small\">\n"
+			. "\t<span class=\"icon-test\"></span>\n"
+			. "\t</button>\n"
+			. "</div>\n";
 
 		$this->assertEquals(
 			$expected,

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -92,9 +92,9 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-small\">" . PHP_EOL
-			. "\t<span class=\"icon-confirm-test\"></span>" . PHP_EOL
-			. "\tConfirm?</button>" . PHP_EOL;
+		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-small\">\n"
+			. "\t<span class=\"icon-confirm-test\"></span>\n"
+			. "\tConfirm?</button>\n";
 
 		$this->assertEquals(
 			$this->object->fetchButton('Confirm', 'Confirm action?', 'confirm-test', 'Confirm?', 'article.save'),

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
@@ -94,9 +94,9 @@ class JToolbarButtonHelpTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-small\">" . PHP_EOL
-			. "\t<span class=\"icon-question-sign\"></span>" . PHP_EOL
-			. "\tJTOOLBAR_HELP</button>" . PHP_EOL;
+		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-small\">\n"
+			. "\t<span class=\"icon-question-sign\"></span>\n"
+			. "\tJTOOLBAR_HELP</button>\n";
 
 		$this->assertEquals(
 			$this->object->fetchButton('Help', 'JHELP_CONTENT_ARTICLE_MANAGER'),


### PR DESCRIPTION
Pull Request for Issue #13790 .

### Summary of Changes
Should fix the windows unit tests failing in the windows unit tests due to use of `PHP_EOL` in HTML test output vs `\n` 

`\n` is the correct use for anything that is not file output or HTTP headers
