### PR TITLE
Use preg_match to ensure just a version check

### DIFF
--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -482,11 +482,9 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function testGetVersion()
 	{
 		$versionRow = self::$driver->setQuery('SELECT version();')->loadRow();
-		$versionArray = explode(' ', $versionRow[0]);
+		preg_match('/((\d+)\.)((\d+)\.)(\*|\d+)/', $versionRow[0], $versionArray);
 
-		$version = rtrim($versionArray[1], ',');
-
-		$this->assertGreaterThanOrEqual($version, self::$driver->getVersion());
+		$this->assertGreaterThanOrEqual($versionArray[0], self::$driver->getVersion());
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Unit test improvement
This method should be much less error prone due to the environment differences when getting the version from the `SELECT version();` query used in the unit test check of our method

### Testing Instructions
Code review

### Documentation Changes Required
none

### See also
https://github.com/joomla-framework/database/pull/77
