### PR TITLE
[com_fields] Migrate category view show_user_custom_fields to fieldgroups

### DIFF
--- a/components/com_contact/models/forms/form.xml
+++ b/components/com_contact/models/forms/form.xml
@@ -464,9 +464,9 @@
 			
 		<field
 			name="show_user_custom_fields"
-			type="category"
+			type="fieldgroups"
 			multiple="true"
-			extension="com_users.user.fields"
+			context="com_users.user"
 			label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 			description="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_DESC"
 			>

--- a/components/com_contact/views/category/tmpl/default.xml
+++ b/components/com_contact/views/category/tmpl/default.xml
@@ -33,8 +33,8 @@
 
 
 	<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
+	<fields name="params">
+		<fieldset name="basic" label="JGLOBAL_CATEGORY_OPTIONS">
 
 			<field name="spacer1" type="spacer" class="text"
 					label="JGLOBAL_SUBSLIDER_DRILL_CATEGORIES_LABEL"
@@ -108,9 +108,9 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-</fieldset>
+		</fieldset>
 
-<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
+		<fieldset name="advanced" label="JGLOBAL_LIST_LAYOUT_OPTIONS">
 
 			<field name="spacer2" type="spacer" class="text"
 					label="JGLOBAL_SUBSLIDER_DRILL_CATEGORIES_LABEL"
@@ -263,9 +263,10 @@
 				<option value="sortname">COM_CONTACT_FIELD_VALUE_SORT_NAME</option>
 				<option value="ordering">COM_CONTACT_FIELD_VALUE_ORDERING</option>
 			</field>
-</fieldset>
+		</fieldset>
 
-<fieldset name="contact" label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL">
+		<fieldset name="contact" label="COM_CONTACT_BASIC_OPTIONS_FIELDSET_LABEL"
+			addfieldpath="/administrator/components/com_fields/models/fields">
 			<field name="presentation_style"
 				type="list"
 				description="COM_CONTACT_FIELD_PRESENTATION_DESC"
@@ -512,12 +513,12 @@
 				<option value="0">JHIDE</option>
 				<option value="1">JSHOW</option>
 			</field>
-
+			
 			<field
 				name="show_user_custom_fields"
-				type="category"
+				type="fieldgroups"
 				multiple="true"
-				extension="com_users.user.fields"
+				context="com_users.user"
 				label="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_LABEL"
 				description="COM_CONTACT_FIELD_USER_CUSTOM_FIELDS_SHOW_DESC"
 				>
@@ -563,10 +564,9 @@
 				size="30"
 				useglobal="true"
 			/>
-</fieldset>
+		</fieldset>
 		<!-- Form options. -->
-		<fieldset name="Contact_Form" label="COM_CONTACT_MAIL_FIELDSET_LABEL"
-		>
+		<fieldset name="Contact_Form" label="COM_CONTACT_MAIL_FIELDSET_LABEL">
 
 			<field name="show_email_form" type="list"
 				description="COM_CONTACT_FIELD_EMAIL_SHOW_FORM_DESC"
@@ -633,8 +633,7 @@
 			/>
 		</fieldset>
 
-		<fieldset name="integration"
-		>
+		<fieldset name="integration">
 
 			<field name="show_feed_link" type="list"
 				description="JGLOBAL_Show_Feed_Link_Desc"
@@ -646,5 +645,5 @@
 			</field>
 
 		</fieldset>
-</fields>
+	</fields>
 </metadata>


### PR DESCRIPTION
### Summary of Changes
As with the move to fieldgroups in PR #13019 the _show_user_custom_fields_ value in the category view  was forgotten to migrate in PR #13103.

Additionally some indentation is fixe in the XML file.

### Testing Instructions
- Go to Users -> Field Groups
- Create two Groups with the name Demo1 and Demo2
- Go to Users -> Fields
- Create a field with the Title Demo Field 1 and assign it to the field group Demo1
- Create a field with the Title Demo Field 2 and assign it to the field group Demo2
- Create a field with the Title Demo Field and assign it to no field group
- Edit the super admin user and set some custom fields values
- Create a menu item "Contacts -> List Contacts in a Category"
- Open the the tab "Contact Display Options" and select Demo1 in the parameter "Show User Custom Fields"
- Create a new contact and link it to the super admin user
- On the front open the new contact category menu item
- Click on the contact

### Expected result
Only the values from the fields "Demo Field 1" should be shown on the contact.

### Actual result
The select box doesn't show the user field groups in the contact menu item.