### PR TITLE
[com_fields] Fields Content Plugin

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-31.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-31.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-31.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-31.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
@@ -1,6 +1,6 @@
 SET IDENTITY_INSERT #__extensions  ON;
 
 INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 458, '3.7.0-2016-08-06.sql', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 458, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
@@ -1,0 +1,6 @@
+SET IDENTITY_INSERT #__extensions  ON;
+
+INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 458, '3.7.0-2016-08-06.sql', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-31.sql
@@ -1,6 +1,6 @@
 SET IDENTITY_INSERT #__extensions  ON;
 
 INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
-SELECT 458, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 
 SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -225,6 +225,7 @@ class ContentHelper extends JHelperContent
 				case 'form':
 
 				// Category list view
+				case 'featured':
 				case 'category':
 					$section = 'article';
 			}

--- a/administrator/language/en-GB/en-GB.plg_content_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.ini
@@ -1,4 +1,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="Allows to include a custom field into the editor."
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to insert a custom field directly into the editor area."

--- a/administrator/language/en-GB/en-GB.plg_content_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.ini
@@ -1,0 +1,4 @@
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_FIELDS="Content - Fields"
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="Allows to include a custom field into the editor."

--- a/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
@@ -1,4 +1,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="Allows to include a custom field into the editor."
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to insert a custom field directly into the editor area."

--- a/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
@@ -1,0 +1,4 @@
+; Note : All ini files need to be saved as UTF-8
+
+PLG_CONTENT_FIELDS="Content - Fields"
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="Allows to include a custom field into the editor."

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -637,6 +637,7 @@ INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `elem
 (475, 0, 'plg_fields_url', 'plugin', 'url', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (476, 0, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (477, 0, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(478, 0, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (503, 0, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 0, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 0, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -639,6 +639,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (475, 'plg_fields_url', 'plugin', 'url', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -638,7 +638,7 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (474, 'plg_fields_textarea', 'plugin', 'textarea', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (475, 'plg_fields_url', 'plugin', 'url', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1056,6 +1056,8 @@ UNION ALL
 SELECT 476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
 SELECT 477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+UNION ALL
+SELECT 478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 -- Templates
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '1900-01-01 00:00:00', 0, 0

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1055,7 +1055,7 @@ SELECT 475, 'plg_fields_url', 'plugin', 'url', 'fields', 0, 1, 1, 0, '', '', '',
 UNION ALL
 SELECT 476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
 SELECT 478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 -- Templates

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -26,7 +26,7 @@ class PlgContentFields extends JPlugin
 	 * @param   int     $page     The 'page' number
 	 *
 	 * @return void
-
+	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function onContentPrepare($context, &$item, &$params, $page = 0)

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.Fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die();
+
+/**
+ * Plug-in to show a custom field in eg an article
+ * This uses the {fields ID} syntax
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgContentFields extends JPlugin
+{
+	/**
+	 * Plugin that shows a custom field
+	 *
+	 * @param   string $context  The context of the content being passed to the plugin.
+	 * @param   object &$item    The item object.  Note $article->text is also available
+	 * @param   object &$params  The article params
+	 * @param   int    $page     The 'page' number
+	 *
+	 * @return void
+
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function onContentPrepare($context, &$item, &$params, $page = 0)
+	{
+		// Don't run this plugin when the content is being indexed
+		if ($context == 'com_finder.indexer')
+		{
+			return;
+		}
+
+		// Don't run if there is no text property (in case of bad calls) or it is empty
+		if (empty($item->text))
+		{
+			return;
+		}
+
+		// Simple performance check to determine whether bot should process further
+		if (strpos($item->text, 'field') === false)
+		{
+			return;
+		}
+
+		// Expression to search for (positions)
+		$regex = '/{field\s+(.*?)}/i';
+
+		// Find all instances of plugin and put in $matches for "fields"
+		// $matches[0] is full pattern match, $matches[1] is the id
+		preg_match_all($regex, $item->text, $matches, PREG_SET_ORDER);
+
+		if ($matches)
+		{
+			$parts = FieldsHelper::extract($context);
+
+			if (count($parts) < 2)
+			{
+				return;
+			}
+
+			$context = $parts[0] . '.' . $parts[1];
+			$fields  = FieldsHelper::getFields($context, $item, true);
+			$tmp     = array();
+
+			foreach ($fields as $field)
+			{
+				$tmp[$field->id] = $field;
+			}
+
+			$fields = $tmp;
+
+			foreach ($matches as $i => $match)
+			{
+				$explode = explode(',', $match[1]);
+				$id      = (int) $explode[0];
+
+				if (!$id)
+				{
+					continue;
+				}
+
+				if (!isset($fields[$id]))
+				{
+					continue;
+				}
+
+				$output = FieldsHelper::render(
+					$context,
+					'field.render',
+					array(
+						'item'            => $item,
+						'context'         => $context,
+						'field'          => $fields[$id]
+					)
+				);
+
+				$item->text = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $item->text, 1);
+			}
+		}
+	}
+}

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -49,11 +49,8 @@ class PlgContentFields extends JPlugin
 			return;
 		}
 
-		// Expression to search for (positions)
-		$regex = '/{field\s+(.*?)}/i';
-
-		// Find all instances of plugin and put in $matches for "fields"
-		// $matches[0] is full pattern match, $matches[1] is the id
+		// Search for {field ID} or {fieldgroup ID} tags and put the results into $matches.
+		$regex = '/{(field|fieldgroup)\s+(.*?)}/i';
 		preg_match_all($regex, $item->text, $matches, PREG_SET_ORDER);
 
 		if ($matches)
@@ -78,10 +75,15 @@ class PlgContentFields extends JPlugin
 
 			foreach ($matches as $i => $match)
 			{
-				$explode = explode(',', $match[1]);
-				$id      = (int) $explode[0];
+				// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID
+				$id = (int) $match[2];
 
 				if (!$id)
+				{
+					continue;
+				}
+
+				if ($match[1] == 'field' && !isset($fields[$id]))
 				{
 					continue;
 				}

--- a/plugins/content/fields/fields.xml
+++ b/plugins/content/fields/fields.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.7.0" type="plugin" group="content" method="upgrade">
+	<name>plg_content_fields</name>
+	<author>Joomla! Project</author>
+	<creationDate>February 2017</creationDate>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.7.0</version>
+	<description>PLG_CONTENT_FIELDS_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="fields">fields.php</filename>
+	</files>
+	<config>
+		<fields name="params">
+			<fieldset name="basic">
+			</fieldset>
+		</fields>
+	</config>
+</extension>


### PR DESCRIPTION
Pull Request for Issue #13805 .

### Summary of Changes
This PR adds a new content plugin "fields" which will replace a plugin tag `{field 2}` into the rendered output for the field with the ID "2".
It also supports the tag {fieldgroup 3} which would give you all fields in the group with the ID "3".

### Testing Instructions
* Apply PR and discover and enable the plugin.
* Edit an article and enter the plugin tag as described above with the ID of an existing field.

### Expected result
The field(s) will be rendered at the place where the tag was set.

### Documentation Changes Required
Dunno. Maybe add documentation about this new plugin if other such plugins are documented.

### Remarks
Ideally there would be an accompagning editor button (could use help here as JS isn't my strenght)

**This is now ready for testing.**