### PR TITLE
Escape quotes in $db->quoteName

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1929,11 +1929,11 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 			if (strlen($q) == 1)
 			{
-				$parts[] = $q . $part . $q;
+				$parts[] = $q . str_replace($q, $q . $q, $part) . $q;
 			}
 			else
 			{
-				$parts[] = $q{0} . $part . $q{1};
+				$parts[] = $q{0} . str_replace($q{1}, $q{1} . $q{1}, $part) . $q{1};
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Escape quote char in `$db->quoteName()` method.

~~It can be considered as a little security fix, 
but joomla (with correct sanitise aliases/columns) is secure also without this patch.~~

### I based on:
* https://github.com/doctrine/dbal/commit/925b25877b3d4da503094869919f1bf9b53db1c4
* https://github.com/doctrine/dbal/issues/1304
* https://github.com/zendframework/zend-db/blob/master/src/Adapter/Platform/AbstractPlatform.php#L74
* https://github.com/zendframework/zend-db/blob/master/src/Adapter/Platform/Mysql.php#L27

### Testing Instructions
Code review or
Create and execute each query for specified database type:
```
$db = JFactory::getDbo();
$q1 = $db->getQuery(true)->select($db->quoteName('title', 'protected`title'))->from('#__content')->where('id=1');

// Without patch it generate error on mysql but it works on other databases
$db->setQuery($q1)->loadAssoc();
```

```
$db = JFactory::getDbo();
$q2 = $db->getQuery(true)->select($db->quoteName('title', 'protected"title'))->from('#__content')->where('id=1');

// Without patch it generate error on postgresql but it works on other databases
$db->setQuery($q2)->loadAssoc();
```

```
$db = JFactory::getDbo();
$q3 = $db->getQuery(true)->select($db->quoteName('title', 'protected]title'))->from('#__content')->where('id=1');

// Without patch it generate error on mssql but it works on other databases
$db->setQuery($q3)->loadAssoc();
```

### Expected result - valid queries
* on MySQL
    - ```SELECT title AS `protected``title` FROM #__content where id=1```
* on postgreSQL
    - `SELECT title AS "protected""title" FROM #__content where id=1`
* on MSSQL
    - `SELECT title AS [protected]]title] FROM #__content where id=1`

### Actual result - invalid queries

* on MySQL
    - ```SELECT title AS `protected`title` FROM #__content where id=1```
* on postgreSQL
    - `SELECT title AS "protected"title" FROM #__content where id=1`
* on MSSQL
    - `SELECT title AS [protected]title] FROM #__content where id=1`

### Documentation Changes Required
No