### PR TITLE
[4.0] Ignore files when merging staging into 4.0-dev branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ administrator/templates/atum/scss/scss-lint-report.xml
 administrator/templates/isis
 administrator/templates/hathor
 templates/protostar
-generatecss.php
+build/generatecss.php
 media/editors/codemirror
 media/editors/tinymce
 media/jui/less

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ administrator/templates/atum/scss/scss-lint-report.xml
 # Removed in Joomla 4 #
 administrator/templates/isis
 administrator/templates/hathor
-templates/protostar
+templates/beez3
 build/generatecss.php
 media/editors/codemirror
 media/editors/tinymce

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,15 @@ node_modules/
 /build/assets_tmp
 administrator/templates/atum/scss/scss-lint-report.xml
 
+# Removed in Joomla 4 #
+administrator/templates/isis
+administrator/templates/hathor
+templates/protostar
+generatecss.php
+media/editors/codemirror
+media/editors/tinymce
+media/jui/less
+
 # CSS map files #
 .map
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the `.gitignore` file so that merging staging into the 4.0-dev branch is easier and doesn't show the bulk of old files.

### Testing Instructions

### Expected result

### Actual result

### Documentation Changes Required
