### PR TITLE
[com_fields] Custom fields for categories

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -549,7 +549,7 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		// Trigger the before save event.
-		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew, $data));
 
 		if (in_array(false, $result, true))
 		{
@@ -664,7 +664,7 @@ class CategoriesModelCategory extends JModelAdmin
 		}
 
 		// Trigger the after save event.
-		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew, $data));
 
 		// Rebuild the path for the category:
 		if (!$table->rebuildPath($table->id))

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -215,8 +215,9 @@ class ContactHelper extends JHelperContent
 		JFactory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
 		$contexts = array(
-			'com_contact.contact' => JText::_('COM_CONTACT_FIELDS_CONTEXT_CONTACT'),
-			'com_contact.mail' => JText::_('COM_CONTACT_FIELDS_CONTEXT_MAIL'),
+			'com_contact.contact'    => JText::_('COM_CONTACT_FIELDS_CONTEXT_CONTACT'),
+			'com_contact.mail'       => JText::_('COM_CONTACT_FIELDS_CONTEXT_MAIL'),
+			'com_contact.categories' => JText::_('JCATEGORY')
 		);
 
 		return $contexts;

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -251,7 +251,8 @@ class ContentHelper extends JHelperContent
 		JFactory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
 		$contexts = array(
-			'com_content.article' => JText::_('COM_CONTENT'),
+			'com_content.article'    => JText::_('COM_CONTENT'),
+			'com_content.categories' => JText::_('JCATEGORY')
 		);
 
 		return $contexts;

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -141,9 +141,7 @@ class FieldsHelper
 		{
 			if (self::$fieldCache === null)
 			{
-				self::$fieldCache = JModelLegacy::getInstance('Field', 'FieldsModel', array(
-					'ignore_request' => true)
-				);
+				self::$fieldCache = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
 			}
 
 			$new = array();

--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -12,6 +12,22 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 JHtml::_('behavior.caption');
+
+$dispatcher = JEventDispatcher::getInstance();
+
+$this->category->text = $this->category->description;
+$dispatcher->trigger('onContentPrepare', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$this->category->description = $this->category->text;
+
+$results = $dispatcher->trigger('onContentAfterTitle', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$afterDisplayTitle = trim(implode("\n", $results));
+
+$results = $dispatcher->trigger('onContentBeforeDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$beforeDisplayContent = trim(implode("\n", $results));
+
+$results = $dispatcher->trigger('onContentAfterDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$afterDisplayContent = trim(implode("\n", $results));
+
 ?>
 <div class="blog<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Blog">
 	<?php if ($this->params->get('show_page_heading')) : ?>
@@ -27,20 +43,23 @@ JHtml::_('behavior.caption');
 			<?php endif; ?>
 		</h2>
 	<?php endif; ?>
+	<?php echo $afterDisplayTitle; ?>
 
 	<?php if ($this->params->get('show_cat_tags', 1) && !empty($this->category->tags->itemTags)) : ?>
 		<?php $this->category->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->category->tagLayout->render($this->category->tags->itemTags); ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_description', 1) || $this->params->def('show_description_image', 1)) : ?>
+	<?php if ($beforeDisplayContent || $afterDisplayContent || $this->params->get('show_description', 1) || $this->params->def('show_description_image', 1)) : ?>
 		<div class="category-desc clearfix">
 			<?php if ($this->params->get('show_description_image') && $this->category->getParams()->get('image')) : ?>
 				<img src="<?php echo $this->category->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($this->category->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>"/>
 			<?php endif; ?>
+			<?php echo $beforeDisplayContent; ?>
 			<?php if ($this->params->get('show_description') && $this->category->description) : ?>
 				<?php echo JHtml::_('content.prepare', $this->category->description, '', 'com_content.category'); ?>
 			<?php endif; ?>
+			<?php echo $afterDisplayContent; ?>
 		</div>
 	<?php endif; ?>
 

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -14,9 +14,25 @@ defined('JPATH_BASE') or die;
  * layout you need to close this div either by overriding this file or in your main layout.
  */
 $params    = $displayData->params;
-$extension = $displayData->get('category')->extension;
+$category  = $displayData->get('category');
+$extension = $category->extension;
 $canEdit   = $params->get('access-edit');
 $className = substr($extension, 4);
+
+$dispatcher = JEventDispatcher::getInstance();
+
+$category->text = $category->description;
+$dispatcher->trigger('onContentPrepare', array($extension . '.categories', &$category, &$params, 0));
+$category->description = $category->text;
+
+$results = $dispatcher->trigger('onContentAfterTitle', array($extension . '.categories', &$category, &$params, 0));
+$afterDisplayTitle = trim(implode("\n", $results));
+
+$results = $dispatcher->trigger('onContentBeforeDisplay', array($extension . '.categories', &$category, &$params, 0));
+$beforeDisplayContent = trim(implode("\n", $results));
+
+$results = $dispatcher->trigger('onContentAfterDisplay', array($extension . '.categories', &$category, &$params, 0));
+$afterDisplayContent = trim(implode("\n", $results));
 
 /**
  * This will work for the core components but not necessarily for other components
@@ -26,7 +42,7 @@ if (substr($className, -1) === 's')
 {
 	$className = rtrim($className, 's');
 }
-$tagsData = $displayData->get('category')->tags->itemTags;
+$tagsData = $category->tags->itemTags;
 ?>
 <div>
 	<div class="<?php echo $className .'-category' . $displayData->pageclass_sfx; ?>">
@@ -38,22 +54,25 @@ $tagsData = $displayData->get('category')->tags->itemTags;
 
 		<?php if ($params->get('show_category_title', 1)) : ?>
 			<h2>
-				<?php echo JHtml::_('content.prepare', $displayData->get('category')->title, '', $extension . '.category.title'); ?>
+				<?php echo JHtml::_('content.prepare', $category->title, '', $extension . '.category.title'); ?>
 			</h2>
 		<?php endif; ?>
+		<?php echo $afterDisplayTitle; ?>
 
 		<?php if ($params->get('show_cat_tags', 1)) : ?>
 			<?php echo JLayoutHelper::render('joomla.content.tags', $tagsData); ?>
 		<?php endif; ?>
 
-		<?php if ($params->get('show_description', 1) || $params->def('show_description_image', 1)) : ?>
+		<?php if ($beforeDisplayContent || $afterDisplayContent || $params->get('show_description', 1) || $params->def('show_description_image', 1)) : ?>
 			<div class="category-desc">
-				<?php if ($params->get('show_description_image') && $displayData->get('category')->getParams()->get('image')) : ?>
-					<img src="<?php echo $displayData->get('category')->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($displayData->get('category')->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>"/>
+				<?php if ($params->get('show_description_image') && $category->getParams()->get('image')) : ?>
+					<img src="<?php echo $category->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($category->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>"/>
 				<?php endif; ?>
-				<?php if ($params->get('show_description') && $displayData->get('category')->description) : ?>
-					<?php echo JHtml::_('content.prepare', $displayData->get('category')->description, '', $extension . '.category.description'); ?>
+				<?php echo $beforeDisplayContent; ?>
+				<?php if ($params->get('show_description') && $category->description) : ?>
+					<?php echo JHtml::_('content.prepare', $category->description, '', $extension . '.category.description'); ?>
 				<?php endif; ?>
+				<?php echo $afterDisplayContent; ?>
 				<div class="clr"></div>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #13107.

### Summary of Changes
Adds custom fields support for categories in contacts and articles.

![image](https://cloud.githubusercontent.com/assets/251072/22498193/1d219a86-e857-11e6-9db9-a5db492a9186.png)

![image](https://cloud.githubusercontent.com/assets/251072/22498213/3ab52630-e857-11e6-92f8-8ca3ee78a3f1.png)

![image](https://cloud.githubusercontent.com/assets/251072/22498379/4cd63ede-e858-11e6-8391-93226c66d910.png)

### Testing Instructions
- In the back end go to Content -> Fields
- Change the contex to Category (first image above)
- Click on New
- Define a title
- Click Save
- Go to Content -> Categories
- Edit the _Uncategorised_ category
- In the tab _Fields_ set a value for the new created field
- Create a new menu item _Articles -> Category List_ and select the _Uncategorised_ category
- Create a new menu item _Articles -> Category Blog_ and select the _Uncategorised_ category
- On the front end, open the new menu item
 
### Expected result
The _Fields_ tab appears when editing a category. On the front end, the fields will be displayed in the list menu item.

### Actual result

### Documentation Changes Required
