### PR TITLE
If no container is defined in the active admin menu, force default container

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -354,6 +354,33 @@ class JAdminCssMenu
 			$authMenus   = $me->authorise('core.manage', 'com_menus');
 			$authModules = $me->authorise('core.manage', 'com_modules');
 
+			$types = ArrayHelper::getColumn($items, 'type');
+
+			if (!in_array('container', $types))
+			{
+				$container = array(
+					'id'                => 0,
+					'menutype'          => $menutype,
+					'title'             => JText::_('MOD_MENU_COMPONENTS'),
+					'link'              => '',
+					'type'              => 'container',
+					'published'         => '1',
+					'parent_id'         => '1',
+					'level'             => '1',
+					'component_id'      => '0',
+					'browserNav'        => '0',
+					'access'            => '0',
+					'img'               => ' ',
+					'template_style_id' => '0',
+					'params'            => new Registry(array('menu_text' => 1, 'menu_show' => 1)),
+					'home'              => '0',
+					'language'          => '*',
+					'client_id'         => '1',
+					'element'           => null,
+				);
+				$items[]   = (object) $container;
+			}
+
 			if ($enabled && $params->get('check') && ($authMenus || $authModules))
 			{
 				$elements = ArrayHelper::getColumn($items, 'element');


### PR DESCRIPTION
### Summary of Changes
If no container is defined in the active admin menu, force default container

### Testing Instructions
* Create a custom admin menu
* Set it as your active menu in menu module settings.
* It should show a container menu item with all components similar to that of "Components" menu in the default Joomla admin menu. 
* Create a new menu item of type "System Links > Components Menu Container" in your custom menu.
* The default container should disappear and your custom container should show up.

### Documentation Changes Required
None

Pinging @infograf768 