### PR TITLE
[namespace] Namespace JFactory correctly in Admin model

### DIFF
--- a/libraries/src/Cms/Model/Admin.php
+++ b/libraries/src/Cms/Model/Admin.php
@@ -753,7 +753,7 @@ abstract class Admin extends Form
 					$context = $this->option . '.' . $this->name;
 
 					// Trigger the before delete event.
-					$result = JFactory::getApplication()->triggerEvent($this->event_before_delete, array($context, $table));
+					$result = \JFactory::getApplication()->triggerEvent($this->event_before_delete, array($context, $table));
 
 					if (in_array(false, $result, true))
 					{
@@ -802,7 +802,7 @@ abstract class Admin extends Form
 					}
 
 					// Trigger the after event.
-					JFactory::getApplication()->triggerEvent($this->event_after_delete, array($context, $table));
+					\JFactory::getApplication()->triggerEvent($this->event_after_delete, array($context, $table));
 				}
 				else
 				{
@@ -1155,7 +1155,7 @@ abstract class Admin extends Form
 			}
 
 			// Trigger the before save event.
-			$result = JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, $table, $isNew));
+			$result = \JFactory::getApplication()->triggerEvent($this->event_before_save, array($context, $table, $isNew));
 
 			if (in_array(false, $result, true))
 			{
@@ -1176,7 +1176,7 @@ abstract class Admin extends Form
 			$this->cleanCache();
 
 			// Trigger the after save event.
-			JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, $table, $isNew));
+			\JFactory::getApplication()->triggerEvent($this->event_after_save, array($context, $table, $isNew));
 		}
 		catch (\Exception $e)
 		{


### PR DESCRIPTION
Pull Request for Issue #13839.

### Summary of Changes
Fixes the missing root namespace declaration for JFactory.

### Testing Instructions
- Fresh installation of the 4.0-dev branch
- Go to create a new field
- Attempt to save

### Expected result
Field should get saved.

### Actual result
Error `Fatal error: Class 'Joomla\Cms\Model\JFactory' not found in \libraries\src\Cms\Model\Admin.php on line 1158` is thrown.

### Documentation Changes Required
