### PR TITLE
[Isis] Replace lessc row-fluid calculations

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -4854,158 +4854,158 @@ a.badge:focus {
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 		float: left;
-		margin-left: 2.7624309392265%;
-		*margin-left: 2.7092394498648%;
+		margin-left: 2.76243094%;
+		*margin-left: 2.70923945%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
 	}
 	.row-fluid .controls-row [class*="span"] + [class*="span"] {
-		margin-left: 2.7624309392265%;
+		margin-left: 2.76243094%;
 	}
 	.row-fluid .span12 {
 		width: 100%;
-		*width: 99.946808510638%;
+		*width: 99.94680851%;
 	}
 	.row-fluid .span11 {
-		width: 91.489361702128%;
-		*width: 91.436170212766%;
+		width: 91.43646409%;
+		*width: 91.3832726%;
 	}
 	.row-fluid .span10 {
-		width: 82.978723404255%;
-		*width: 82.925531914894%;
+		width: 82.87292818%;
+		*width: 82.81973669%;
 	}
 	.row-fluid .span9 {
-		width: 74.468085106383%;
-		*width: 74.414893617021%;
+		width: 74.30939227%;
+		*width: 74.25620078%;
 	}
 	.row-fluid .span8 {
-		width: 65.957446808511%;
-		*width: 65.904255319149%;
+		width: 65.74585635%;
+		*width: 65.69266486%;
 	}
 	.row-fluid .span7 {
-		width: 57.446808510638%;
-		*width: 57.393617021277%;
+		width: 57.18232044%;
+		*width: 57.12912895%;
 	}
 	.row-fluid .span6 {
-		width: 48.936170212766%;
-		*width: 48.882978723404%;
+		width: 48.61878453%;
+		*width: 48.56559304%;
 	}
 	.row-fluid .span5 {
-		width: 40.425531914894%;
-		*width: 40.372340425532%;
+		width: 40.05524862%;
+		*width: 40.00205713%;
 	}
 	.row-fluid .span4 {
-		width: 31.914893617021%;
-		*width: 31.86170212766%;
+		width: 31.49171271%;
+		*width: 31.43852122%;
 	}
 	.row-fluid .span3 {
-		width: 23.404255319149%;
-		*width: 23.351063829787%;
+		width: 22.9281768%;
+		*width: 22.87498531%;
 	}
 	.row-fluid .span2 {
-		width: 14.893617021277%;
-		*width: 14.840425531915%;
+		width: 14.36464088%;
+		*width: 14.31144939%;
 	}
 	.row-fluid .span1 {
-		width: 6.3829787234043%;
-		*width: 6.3297872340426%;
+		width: 5.80110497%;
+		*width: 5.74791348%;
 	}
 	.row-fluid .offset12 {
-		margin-left: 105.52486187845%;
-		*margin-left: 105.41847889973%;
+		margin-left: 105.52486188%;
+		*margin-left: 105.4184789%;
 	}
 	.row-fluid .offset12:first-child {
-		margin-left: 102.76243093923%;
-		*margin-left: 102.6560479605%;
+		margin-left: 102.76243094%;
+		*margin-left: 102.65604796%;
 	}
 	.row-fluid .offset11 {
-		margin-left: 95.744680851064%;
-		*margin-left: 95.63829787234%;
+		margin-left: 96.96132597%;
+		*margin-left: 96.85494299%;
 	}
 	.row-fluid .offset11:first-child {
-		margin-left: 93.617021276596%;
-		*margin-left: 93.510638297872%;
+		margin-left: 94.19889503%;
+		*margin-left: 94.09251205%;
 	}
 	.row-fluid .offset10 {
-		margin-left: 87.234042553191%;
-		*margin-left: 87.127659574468%;
+		margin-left: 88.39779006%;
+		*margin-left: 88.29140708%;
 	}
 	.row-fluid .offset10:first-child {
-		margin-left: 85.106382978723%;
-		*margin-left: 85%;
+		margin-left: 85.63535912%;
+		*margin-left: 85.52897614%;
 	}
 	.row-fluid .offset9 {
-		margin-left: 78.723404255319%;
-		*margin-left: 78.617021276596%;
+		margin-left: 79.83425414%;
+		*margin-left: 79.72787116%;
 	}
 	.row-fluid .offset9:first-child {
-		margin-left: 76.595744680851%;
-		*margin-left: 76.489361702128%;
+		margin-left: 77.0718232%;
+		*margin-left: 76.96544023%;
 	}
 	.row-fluid .offset8 {
-		margin-left: 70.212765957447%;
-		*margin-left: 70.106382978723%;
+		margin-left: 71.27071823%;
+		*margin-left: 71.16433525%;
 	}
 	.row-fluid .offset8:first-child {
-		margin-left: 68.085106382979%;
-		*margin-left: 67.978723404255%;
+		margin-left: 68.50828729%;
+		*margin-left: 68.40190431%;
 	}
 	.row-fluid .offset7 {
-		margin-left: 61.702127659574%;
-		*margin-left: 61.595744680851%;
+		margin-left: 62.70718232%;
+		*margin-left: 62.60079934%;
 	}
 	.row-fluid .offset7:first-child {
-		margin-left: 59.574468085106%;
-		*margin-left: 59.468085106383%;
+		margin-left: 59.94475138%;
+		*margin-left: 59.8383684%;
 	}
 	.row-fluid .offset6 {
-		margin-left: 53.191489361702%;
-		*margin-left: 53.085106382979%;
+		margin-left: 54.14364641%;
+		*margin-left: 54.03726343%;
 	}
 	.row-fluid .offset6:first-child {
-		margin-left: 51.063829787234%;
-		*margin-left: 50.957446808511%;
+		margin-left: 51.38121547%;
+		*margin-left: 51.27483249%;
 	}
 	.row-fluid .offset5 {
-		margin-left: 44.68085106383%;
-		*margin-left: 44.574468085106%;
+		margin-left: 45.5801105%;
+		*margin-left: 45.47372752%;
 	}
 	.row-fluid .offset5:first-child {
-		margin-left: 42.553191489362%;
-		*margin-left: 42.446808510638%;
+		margin-left: 42.81767956%;
+		*margin-left: 42.71129658%;
 	}
 	.row-fluid .offset4 {
-		margin-left: 36.170212765957%;
-		*margin-left: 36.063829787234%;
+		margin-left: 37.01657459%;
+		*margin-left: 36.91019161%;
 	}
 	.row-fluid .offset4:first-child {
-		margin-left: 34.042553191489%;
-		*margin-left: 33.936170212766%;
+		margin-left: 34.25414365%;
+		*margin-left: 34.14776067%;
 	}
 	.row-fluid .offset3 {
-		margin-left: 27.659574468085%;
-		*margin-left: 27.553191489362%;
+		margin-left: 28.45303867%;
+		*margin-left: 28.3466557%;
 	}
 	.row-fluid .offset3:first-child {
-		margin-left: 25.531914893617%;
-		*margin-left: 25.425531914894%;
+		margin-left: 25.69060773%;
+		*margin-left: 25.58422476%;
 	}
 	.row-fluid .offset2 {
-		margin-left: 19.148936170213%;
-		*margin-left: 19.042553191489%;
+		margin-left: 19.88950276%;
+		*margin-left: 19.78311978%;
 	}
 	.row-fluid .offset2:first-child {
-		margin-left: 17.021276595745%;
-		*margin-left: 16.914893617021%;
+		margin-left: 17.12707182%;
+		*margin-left: 17.02068884%;
 	}
 	.row-fluid .offset1 {
-		margin-left: 10.63829787234%;
-		*margin-left: 10.531914893617%;
+		margin-left: 11.32596685%;
+		*margin-left: 11.21958387%;
 	}
 	.row-fluid .offset1:first-child {
-		margin-left: 8.5106382978723%;
-		*margin-left: 8.4042553191489%;
+		margin-left: 8.56353591%;
+		*margin-left: 8.45715293%;
 	}
 	input,
 	textarea,
@@ -5194,158 +5194,158 @@ a.badge:focus {
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 		float: left;
-		margin-left: 2.5641025641026%;
-		*margin-left: 2.5109110747409%;
+		margin-left: 2.76243094%;
+		*margin-left: 2.70923945%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
 	}
 	.row-fluid .controls-row [class*="span"] + [class*="span"] {
-		margin-left: 2.5641025641026%;
+		margin-left: 2.76243094%;
 	}
 	.row-fluid .span12 {
 		width: 100%;
-		*width: 99.946808510638%;
+		*width: 99.94680851%;
 	}
 	.row-fluid .span11 {
-		width: 91.436464088398%;
-		*width: 91.383272599036%;
+		width: 91.43646409%;
+		*width: 91.3832726%;
 	}
 	.row-fluid .span10 {
-		width: 82.872928176796%;
-		*width: 82.819736687434%;
+		width: 82.87292818%;
+		*width: 82.81973669%;
 	}
 	.row-fluid .span9 {
-		width: 74.309392265193%;
-		*width: 74.256200775832%;
+		width: 74.30939227%;
+		*width: 74.25620078%;
 	}
 	.row-fluid .span8 {
-		width: 65.745856353591%;
-		*width: 65.692664864229%;
+		width: 65.74585635%;
+		*width: 65.69266486%;
 	}
 	.row-fluid .span7 {
-		width: 57.182320441989%;
-		*width: 57.129128952627%;
+		width: 57.18232044%;
+		*width: 57.12912895%;
 	}
 	.row-fluid .span6 {
-		width: 48.618784530387%;
-		*width: 48.565593041025%;
+		width: 48.61878453%;
+		*width: 48.56559304%;
 	}
 	.row-fluid .span5 {
-		width: 40.055248618785%;
-		*width: 40.002057129423%;
+		width: 40.05524862%;
+		*width: 40.00205713%;
 	}
 	.row-fluid .span4 {
-		width: 31.491712707182%;
-		*width: 31.438521217821%;
+		width: 31.49171271%;
+		*width: 31.43852122%;
 	}
 	.row-fluid .span3 {
-		width: 22.92817679558%;
-		*width: 22.874985306218%;
+		width: 22.9281768%;
+		*width: 22.87498531%;
 	}
 	.row-fluid .span2 {
-		width: 14.364640883978%;
-		*width: 14.311449394616%;
+		width: 14.36464088%;
+		*width: 14.31144939%;
 	}
 	.row-fluid .span1 {
-		width: 5.8011049723757%;
-		*width: 5.747913483014%;
+		width: 5.80110497%;
+		*width: 5.74791348%;
 	}
 	.row-fluid .offset12 {
-		margin-left: 105.12820512821%;
-		*margin-left: 105.02182214948%;
+		margin-left: 105.52486188%;
+		*margin-left: 105.4184789%;
 	}
 	.row-fluid .offset12:first-child {
-		margin-left: 102.5641025641%;
-		*margin-left: 102.45771958538%;
+		margin-left: 102.76243094%;
+		*margin-left: 102.65604796%;
 	}
 	.row-fluid .offset11 {
-		margin-left: 96.961325966851%;
-		*margin-left: 96.854942988127%;
+		margin-left: 96.96132597%;
+		*margin-left: 96.85494299%;
 	}
 	.row-fluid .offset11:first-child {
-		margin-left: 94.198895027624%;
-		*margin-left: 94.092512048901%;
+		margin-left: 94.19889503%;
+		*margin-left: 94.09251205%;
 	}
 	.row-fluid .offset10 {
-		margin-left: 88.397790055249%;
-		*margin-left: 88.291407076525%;
+		margin-left: 88.39779006%;
+		*margin-left: 88.29140708%;
 	}
 	.row-fluid .offset10:first-child {
-		margin-left: 85.635359116022%;
-		*margin-left: 85.528976137299%;
+		margin-left: 85.63535912%;
+		*margin-left: 85.52897614%;
 	}
 	.row-fluid .offset9 {
-		margin-left: 79.834254143646%;
-		*margin-left: 79.727871164923%;
+		margin-left: 79.83425414%;
+		*margin-left: 79.72787116%;
 	}
 	.row-fluid .offset9:first-child {
-		margin-left: 77.07182320442%;
-		*margin-left: 76.965440225696%;
+		margin-left: 77.0718232%;
+		*margin-left: 76.96544023%;
 	}
 	.row-fluid .offset8 {
-		margin-left: 71.270718232044%;
-		*margin-left: 71.164335253321%;
+		margin-left: 71.27071823%;
+		*margin-left: 71.16433525%;
 	}
 	.row-fluid .offset8:first-child {
-		margin-left: 68.508287292818%;
-		*margin-left: 68.401904314094%;
+		margin-left: 68.50828729%;
+		*margin-left: 68.40190431%;
 	}
 	.row-fluid .offset7 {
-		margin-left: 62.707182320442%;
-		*margin-left: 62.600799341719%;
+		margin-left: 62.70718232%;
+		*margin-left: 62.60079934%;
 	}
 	.row-fluid .offset7:first-child {
-		margin-left: 59.944751381215%;
-		*margin-left: 59.838368402492%;
+		margin-left: 59.94475138%;
+		*margin-left: 59.8383684%;
 	}
 	.row-fluid .offset6 {
-		margin-left: 54.14364640884%;
-		*margin-left: 54.037263430116%;
+		margin-left: 54.14364641%;
+		*margin-left: 54.03726343%;
 	}
 	.row-fluid .offset6:first-child {
-		margin-left: 51.381215469613%;
-		*margin-left: 51.27483249089%;
+		margin-left: 51.38121547%;
+		*margin-left: 51.27483249%;
 	}
 	.row-fluid .offset5 {
-		margin-left: 45.580110497238%;
-		*margin-left: 45.473727518514%;
+		margin-left: 45.5801105%;
+		*margin-left: 45.47372752%;
 	}
 	.row-fluid .offset5:first-child {
-		margin-left: 42.817679558011%;
-		*margin-left: 42.711296579288%;
+		margin-left: 42.81767956%;
+		*margin-left: 42.71129658%;
 	}
 	.row-fluid .offset4 {
-		margin-left: 37.016574585635%;
-		*margin-left: 36.910191606912%;
+		margin-left: 37.01657459%;
+		*margin-left: 36.91019161%;
 	}
 	.row-fluid .offset4:first-child {
-		margin-left: 34.254143646409%;
-		*margin-left: 34.147760667685%;
+		margin-left: 34.25414365%;
+		*margin-left: 34.14776067%;
 	}
 	.row-fluid .offset3 {
-		margin-left: 28.453038674033%;
-		*margin-left: 28.34665569531%;
+		margin-left: 28.45303867%;
+		*margin-left: 28.3466557%;
 	}
 	.row-fluid .offset3:first-child {
-		margin-left: 25.690607734807%;
-		*margin-left: 25.584224756083%;
+		margin-left: 25.69060773%;
+		*margin-left: 25.58422476%;
 	}
 	.row-fluid .offset2 {
-		margin-left: 19.889502762431%;
-		*margin-left: 19.783119783708%;
+		margin-left: 19.88950276%;
+		*margin-left: 19.78311978%;
 	}
 	.row-fluid .offset2:first-child {
-		margin-left: 17.127071823204%;
-		*margin-left: 17.020688844481%;
+		margin-left: 17.12707182%;
+		*margin-left: 17.02068884%;
 	}
 	.row-fluid .offset1 {
-		margin-left: 11.325966850829%;
-		*margin-left: 11.219583872105%;
+		margin-left: 11.32596685%;
+		*margin-left: 11.21958387%;
 	}
 	.row-fluid .offset1:first-child {
-		margin-left: 8.5635359116022%;
-		*margin-left: 8.4571529328788%;
+		margin-left: 8.56353591%;
+		*margin-left: 8.45715293%;
 	}
 	input,
 	textarea,

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -4854,158 +4854,158 @@ a.badge:focus {
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 		float: left;
-		margin-left: 2.7624309392265%;
-		*margin-left: 2.7092394498648%;
+		margin-left: 2.76243094%;
+		*margin-left: 2.70923945%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
 	}
 	.row-fluid .controls-row [class*="span"] + [class*="span"] {
-		margin-left: 2.7624309392265%;
+		margin-left: 2.76243094%;
 	}
 	.row-fluid .span12 {
 		width: 100%;
-		*width: 99.946808510638%;
+		*width: 99.94680851%;
 	}
 	.row-fluid .span11 {
-		width: 91.489361702128%;
-		*width: 91.436170212766%;
+		width: 91.43646409%;
+		*width: 91.3832726%;
 	}
 	.row-fluid .span10 {
-		width: 82.978723404255%;
-		*width: 82.925531914894%;
+		width: 82.87292818%;
+		*width: 82.81973669%;
 	}
 	.row-fluid .span9 {
-		width: 74.468085106383%;
-		*width: 74.414893617021%;
+		width: 74.30939227%;
+		*width: 74.25620078%;
 	}
 	.row-fluid .span8 {
-		width: 65.957446808511%;
-		*width: 65.904255319149%;
+		width: 65.74585635%;
+		*width: 65.69266486%;
 	}
 	.row-fluid .span7 {
-		width: 57.446808510638%;
-		*width: 57.393617021277%;
+		width: 57.18232044%;
+		*width: 57.12912895%;
 	}
 	.row-fluid .span6 {
-		width: 48.936170212766%;
-		*width: 48.882978723404%;
+		width: 48.61878453%;
+		*width: 48.56559304%;
 	}
 	.row-fluid .span5 {
-		width: 40.425531914894%;
-		*width: 40.372340425532%;
+		width: 40.05524862%;
+		*width: 40.00205713%;
 	}
 	.row-fluid .span4 {
-		width: 31.914893617021%;
-		*width: 31.86170212766%;
+		width: 31.49171271%;
+		*width: 31.43852122%;
 	}
 	.row-fluid .span3 {
-		width: 23.404255319149%;
-		*width: 23.351063829787%;
+		width: 22.9281768%;
+		*width: 22.87498531%;
 	}
 	.row-fluid .span2 {
-		width: 14.893617021277%;
-		*width: 14.840425531915%;
+		width: 14.36464088%;
+		*width: 14.31144939%;
 	}
 	.row-fluid .span1 {
-		width: 6.3829787234043%;
-		*width: 6.3297872340426%;
+		width: 5.80110497%;
+		*width: 5.74791348%;
 	}
 	.row-fluid .offset12 {
-		margin-left: 105.52486187845%;
-		*margin-left: 105.41847889973%;
+		margin-left: 105.52486188%;
+		*margin-left: 105.4184789%;
 	}
 	.row-fluid .offset12:first-child {
-		margin-left: 102.76243093923%;
-		*margin-left: 102.6560479605%;
+		margin-left: 102.76243094%;
+		*margin-left: 102.65604796%;
 	}
 	.row-fluid .offset11 {
-		margin-left: 95.744680851064%;
-		*margin-left: 95.63829787234%;
+		margin-left: 96.96132597%;
+		*margin-left: 96.85494299%;
 	}
 	.row-fluid .offset11:first-child {
-		margin-left: 93.617021276596%;
-		*margin-left: 93.510638297872%;
+		margin-left: 94.19889503%;
+		*margin-left: 94.09251205%;
 	}
 	.row-fluid .offset10 {
-		margin-left: 87.234042553191%;
-		*margin-left: 87.127659574468%;
+		margin-left: 88.39779006%;
+		*margin-left: 88.29140708%;
 	}
 	.row-fluid .offset10:first-child {
-		margin-left: 85.106382978723%;
-		*margin-left: 85%;
+		margin-left: 85.63535912%;
+		*margin-left: 85.52897614%;
 	}
 	.row-fluid .offset9 {
-		margin-left: 78.723404255319%;
-		*margin-left: 78.617021276596%;
+		margin-left: 79.83425414%;
+		*margin-left: 79.72787116%;
 	}
 	.row-fluid .offset9:first-child {
-		margin-left: 76.595744680851%;
-		*margin-left: 76.489361702128%;
+		margin-left: 77.0718232%;
+		*margin-left: 76.96544023%;
 	}
 	.row-fluid .offset8 {
-		margin-left: 70.212765957447%;
-		*margin-left: 70.106382978723%;
+		margin-left: 71.27071823%;
+		*margin-left: 71.16433525%;
 	}
 	.row-fluid .offset8:first-child {
-		margin-left: 68.085106382979%;
-		*margin-left: 67.978723404255%;
+		margin-left: 68.50828729%;
+		*margin-left: 68.40190431%;
 	}
 	.row-fluid .offset7 {
-		margin-left: 61.702127659574%;
-		*margin-left: 61.595744680851%;
+		margin-left: 62.70718232%;
+		*margin-left: 62.60079934%;
 	}
 	.row-fluid .offset7:first-child {
-		margin-left: 59.574468085106%;
-		*margin-left: 59.468085106383%;
+		margin-left: 59.94475138%;
+		*margin-left: 59.8383684%;
 	}
 	.row-fluid .offset6 {
-		margin-left: 53.191489361702%;
-		*margin-left: 53.085106382979%;
+		margin-left: 54.14364641%;
+		*margin-left: 54.03726343%;
 	}
 	.row-fluid .offset6:first-child {
-		margin-left: 51.063829787234%;
-		*margin-left: 50.957446808511%;
+		margin-left: 51.38121547%;
+		*margin-left: 51.27483249%;
 	}
 	.row-fluid .offset5 {
-		margin-left: 44.68085106383%;
-		*margin-left: 44.574468085106%;
+		margin-left: 45.5801105%;
+		*margin-left: 45.47372752%;
 	}
 	.row-fluid .offset5:first-child {
-		margin-left: 42.553191489362%;
-		*margin-left: 42.446808510638%;
+		margin-left: 42.81767956%;
+		*margin-left: 42.71129658%;
 	}
 	.row-fluid .offset4 {
-		margin-left: 36.170212765957%;
-		*margin-left: 36.063829787234%;
+		margin-left: 37.01657459%;
+		*margin-left: 36.91019161%;
 	}
 	.row-fluid .offset4:first-child {
-		margin-left: 34.042553191489%;
-		*margin-left: 33.936170212766%;
+		margin-left: 34.25414365%;
+		*margin-left: 34.14776067%;
 	}
 	.row-fluid .offset3 {
-		margin-left: 27.659574468085%;
-		*margin-left: 27.553191489362%;
+		margin-left: 28.45303867%;
+		*margin-left: 28.3466557%;
 	}
 	.row-fluid .offset3:first-child {
-		margin-left: 25.531914893617%;
-		*margin-left: 25.425531914894%;
+		margin-left: 25.69060773%;
+		*margin-left: 25.58422476%;
 	}
 	.row-fluid .offset2 {
-		margin-left: 19.148936170213%;
-		*margin-left: 19.042553191489%;
+		margin-left: 19.88950276%;
+		*margin-left: 19.78311978%;
 	}
 	.row-fluid .offset2:first-child {
-		margin-left: 17.021276595745%;
-		*margin-left: 16.914893617021%;
+		margin-left: 17.12707182%;
+		*margin-left: 17.02068884%;
 	}
 	.row-fluid .offset1 {
-		margin-left: 10.63829787234%;
-		*margin-left: 10.531914893617%;
+		margin-left: 11.32596685%;
+		*margin-left: 11.21958387%;
 	}
 	.row-fluid .offset1:first-child {
-		margin-left: 8.5106382978723%;
-		*margin-left: 8.4042553191489%;
+		margin-left: 8.56353591%;
+		*margin-left: 8.45715293%;
 	}
 	input,
 	textarea,
@@ -5194,158 +5194,158 @@ a.badge:focus {
 		-moz-box-sizing: border-box;
 		box-sizing: border-box;
 		float: left;
-		margin-left: 2.5641025641026%;
-		*margin-left: 2.5109110747409%;
+		margin-left: 2.76243094%;
+		*margin-left: 2.70923945%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
 	}
 	.row-fluid .controls-row [class*="span"] + [class*="span"] {
-		margin-left: 2.5641025641026%;
+		margin-left: 2.76243094%;
 	}
 	.row-fluid .span12 {
 		width: 100%;
-		*width: 99.946808510638%;
+		*width: 99.94680851%;
 	}
 	.row-fluid .span11 {
-		width: 91.436464088398%;
-		*width: 91.383272599036%;
+		width: 91.43646409%;
+		*width: 91.3832726%;
 	}
 	.row-fluid .span10 {
-		width: 82.872928176796%;
-		*width: 82.819736687434%;
+		width: 82.87292818%;
+		*width: 82.81973669%;
 	}
 	.row-fluid .span9 {
-		width: 74.309392265193%;
-		*width: 74.256200775832%;
+		width: 74.30939227%;
+		*width: 74.25620078%;
 	}
 	.row-fluid .span8 {
-		width: 65.745856353591%;
-		*width: 65.692664864229%;
+		width: 65.74585635%;
+		*width: 65.69266486%;
 	}
 	.row-fluid .span7 {
-		width: 57.182320441989%;
-		*width: 57.129128952627%;
+		width: 57.18232044%;
+		*width: 57.12912895%;
 	}
 	.row-fluid .span6 {
-		width: 48.618784530387%;
-		*width: 48.565593041025%;
+		width: 48.61878453%;
+		*width: 48.56559304%;
 	}
 	.row-fluid .span5 {
-		width: 40.055248618785%;
-		*width: 40.002057129423%;
+		width: 40.05524862%;
+		*width: 40.00205713%;
 	}
 	.row-fluid .span4 {
-		width: 31.491712707182%;
-		*width: 31.438521217821%;
+		width: 31.49171271%;
+		*width: 31.43852122%;
 	}
 	.row-fluid .span3 {
-		width: 22.92817679558%;
-		*width: 22.874985306218%;
+		width: 22.9281768%;
+		*width: 22.87498531%;
 	}
 	.row-fluid .span2 {
-		width: 14.364640883978%;
-		*width: 14.311449394616%;
+		width: 14.36464088%;
+		*width: 14.31144939%;
 	}
 	.row-fluid .span1 {
-		width: 5.8011049723757%;
-		*width: 5.747913483014%;
+		width: 5.80110497%;
+		*width: 5.74791348%;
 	}
 	.row-fluid .offset12 {
-		margin-left: 105.12820512821%;
-		*margin-left: 105.02182214948%;
+		margin-left: 105.52486188%;
+		*margin-left: 105.4184789%;
 	}
 	.row-fluid .offset12:first-child {
-		margin-left: 102.5641025641%;
-		*margin-left: 102.45771958538%;
+		margin-left: 102.76243094%;
+		*margin-left: 102.65604796%;
 	}
 	.row-fluid .offset11 {
-		margin-left: 96.961325966851%;
-		*margin-left: 96.854942988127%;
+		margin-left: 96.96132597%;
+		*margin-left: 96.85494299%;
 	}
 	.row-fluid .offset11:first-child {
-		margin-left: 94.198895027624%;
-		*margin-left: 94.092512048901%;
+		margin-left: 94.19889503%;
+		*margin-left: 94.09251205%;
 	}
 	.row-fluid .offset10 {
-		margin-left: 88.397790055249%;
-		*margin-left: 88.291407076525%;
+		margin-left: 88.39779006%;
+		*margin-left: 88.29140708%;
 	}
 	.row-fluid .offset10:first-child {
-		margin-left: 85.635359116022%;
-		*margin-left: 85.528976137299%;
+		margin-left: 85.63535912%;
+		*margin-left: 85.52897614%;
 	}
 	.row-fluid .offset9 {
-		margin-left: 79.834254143646%;
-		*margin-left: 79.727871164923%;
+		margin-left: 79.83425414%;
+		*margin-left: 79.72787116%;
 	}
 	.row-fluid .offset9:first-child {
-		margin-left: 77.07182320442%;
-		*margin-left: 76.965440225696%;
+		margin-left: 77.0718232%;
+		*margin-left: 76.96544023%;
 	}
 	.row-fluid .offset8 {
-		margin-left: 71.270718232044%;
-		*margin-left: 71.164335253321%;
+		margin-left: 71.27071823%;
+		*margin-left: 71.16433525%;
 	}
 	.row-fluid .offset8:first-child {
-		margin-left: 68.508287292818%;
-		*margin-left: 68.401904314094%;
+		margin-left: 68.50828729%;
+		*margin-left: 68.40190431%;
 	}
 	.row-fluid .offset7 {
-		margin-left: 62.707182320442%;
-		*margin-left: 62.600799341719%;
+		margin-left: 62.70718232%;
+		*margin-left: 62.60079934%;
 	}
 	.row-fluid .offset7:first-child {
-		margin-left: 59.944751381215%;
-		*margin-left: 59.838368402492%;
+		margin-left: 59.94475138%;
+		*margin-left: 59.8383684%;
 	}
 	.row-fluid .offset6 {
-		margin-left: 54.14364640884%;
-		*margin-left: 54.037263430116%;
+		margin-left: 54.14364641%;
+		*margin-left: 54.03726343%;
 	}
 	.row-fluid .offset6:first-child {
-		margin-left: 51.381215469613%;
-		*margin-left: 51.27483249089%;
+		margin-left: 51.38121547%;
+		*margin-left: 51.27483249%;
 	}
 	.row-fluid .offset5 {
-		margin-left: 45.580110497238%;
-		*margin-left: 45.473727518514%;
+		margin-left: 45.5801105%;
+		*margin-left: 45.47372752%;
 	}
 	.row-fluid .offset5:first-child {
-		margin-left: 42.817679558011%;
-		*margin-left: 42.711296579288%;
+		margin-left: 42.81767956%;
+		*margin-left: 42.71129658%;
 	}
 	.row-fluid .offset4 {
-		margin-left: 37.016574585635%;
-		*margin-left: 36.910191606912%;
+		margin-left: 37.01657459%;
+		*margin-left: 36.91019161%;
 	}
 	.row-fluid .offset4:first-child {
-		margin-left: 34.254143646409%;
-		*margin-left: 34.147760667685%;
+		margin-left: 34.25414365%;
+		*margin-left: 34.14776067%;
 	}
 	.row-fluid .offset3 {
-		margin-left: 28.453038674033%;
-		*margin-left: 28.34665569531%;
+		margin-left: 28.45303867%;
+		*margin-left: 28.3466557%;
 	}
 	.row-fluid .offset3:first-child {
-		margin-left: 25.690607734807%;
-		*margin-left: 25.584224756083%;
+		margin-left: 25.69060773%;
+		*margin-left: 25.58422476%;
 	}
 	.row-fluid .offset2 {
-		margin-left: 19.889502762431%;
-		*margin-left: 19.783119783708%;
+		margin-left: 19.88950276%;
+		*margin-left: 19.78311978%;
 	}
 	.row-fluid .offset2:first-child {
-		margin-left: 17.127071823204%;
-		*margin-left: 17.020688844481%;
+		margin-left: 17.12707182%;
+		*margin-left: 17.02068884%;
 	}
 	.row-fluid .offset1 {
-		margin-left: 11.325966850829%;
-		*margin-left: 11.219583872105%;
+		margin-left: 11.32596685%;
+		*margin-left: 11.21958387%;
 	}
 	.row-fluid .offset1:first-child {
-		margin-left: 8.5635359116022%;
-		*margin-left: 8.4571529328788%;
+		margin-left: 8.56353591%;
+		*margin-left: 8.45715293%;
 	}
 	input,
 	textarea,

--- a/administrator/templates/isis/less/bootstrap/responsive-1200px-min.less
+++ b/administrator/templates/isis/less/bootstrap/responsive-1200px-min.less
@@ -1,0 +1,201 @@
+//
+// Responsive: Large desktop and up
+// --------------------------------------------------
+
+
+@media (min-width: 1200px) {
+
+  // Fixed grid
+  #grid > .core(@gridColumnWidth1200, @gridGutterWidth1200);
+
+  // Fluid grid
+   .row-fluid {
+    width: 100%;
+    *zoom: 1;
+  }
+  .row-fluid:before,
+  .row-fluid:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row-fluid:after {
+    clear: both;
+  }
+  .row-fluid [class*="span"] {
+    display: block;
+    width: 100%;
+    min-height: 28px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    float: left;
+    margin-left: 2.76243094%;
+    *margin-left: 2.70923945%;
+  }
+  .row-fluid [class*="span"]:first-child {
+    margin-left: 0;
+  }
+  .row-fluid .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 2.76243094%;
+  }
+  .row-fluid .span12 {
+    width: 100%;
+    *width: 99.94680851%;
+  }
+  .row-fluid .span11 {
+    width: 91.43646409%;
+    *width: 91.3832726%;
+  }
+  .row-fluid .span10 {
+    width: 82.87292818%;
+    *width: 82.81973669%;
+  }
+  .row-fluid .span9 {
+    width: 74.30939227%;
+    *width: 74.25620078%;
+  }
+  .row-fluid .span8 {
+    width: 65.74585635%;
+    *width: 65.69266486%;
+  }
+  .row-fluid .span7 {
+    width: 57.18232044%;
+    *width: 57.12912895%;
+  }
+  .row-fluid .span6 {
+    width: 48.61878453%;
+    *width: 48.56559304%;
+  }
+  .row-fluid .span5 {
+    width: 40.05524862%;
+    *width: 40.00205713%;
+  }
+  .row-fluid .span4 {
+    width: 31.49171271%;
+    *width: 31.43852122%;
+  }
+  .row-fluid .span3 {
+    width: 22.9281768%;
+    *width: 22.87498531%;
+  }
+  .row-fluid .span2 {
+    width: 14.36464088%;
+    *width: 14.31144939%;
+  }
+  .row-fluid .span1 {
+    width: 5.80110497%;
+    *width: 5.74791348%;
+  }
+  .row-fluid .offset12 {
+    margin-left: 105.52486188%;
+    *margin-left: 105.4184789%;
+  }
+  .row-fluid .offset12:first-child {
+    margin-left: 102.76243094%;
+    *margin-left: 102.65604796%;
+  }
+  .row-fluid .offset11 {
+    margin-left: 96.96132597%;
+    *margin-left: 96.85494299%;
+  }
+  .row-fluid .offset11:first-child {
+    margin-left: 94.19889503%;
+    *margin-left: 94.09251205%;
+  }
+  .row-fluid .offset10 {
+    margin-left: 88.39779006%;
+    *margin-left: 88.29140708%;
+  }
+  .row-fluid .offset10:first-child {
+    margin-left: 85.63535912%;
+    *margin-left: 85.52897614%;
+  }
+  .row-fluid .offset9 {
+    margin-left: 79.83425414%;
+    *margin-left: 79.72787116%;
+  }
+  .row-fluid .offset9:first-child {
+    margin-left: 77.0718232%;
+    *margin-left: 76.96544023%;
+  }
+  .row-fluid .offset8 {
+    margin-left: 71.27071823%;
+    *margin-left: 71.16433525%;
+  }
+  .row-fluid .offset8:first-child {
+    margin-left: 68.50828729%;
+    *margin-left: 68.40190431%;
+  }
+  .row-fluid .offset7 {
+    margin-left: 62.70718232%;
+    *margin-left: 62.60079934%;
+  }
+  .row-fluid .offset7:first-child {
+    margin-left: 59.94475138%;
+    *margin-left: 59.8383684%;
+  }
+  .row-fluid .offset6 {
+    margin-left: 54.14364641%;
+    *margin-left: 54.03726343%;
+  }
+  .row-fluid .offset6:first-child {
+    margin-left: 51.38121547%;
+    *margin-left: 51.27483249%;
+  }
+  .row-fluid .offset5 {
+    margin-left: 45.5801105%;
+    *margin-left: 45.47372752%;
+  }
+  .row-fluid .offset5:first-child {
+    margin-left: 42.81767956%;
+    *margin-left: 42.71129658%;
+  }
+  .row-fluid .offset4 {
+    margin-left: 37.01657459%;
+    *margin-left: 36.91019161%;
+  }
+  .row-fluid .offset4:first-child {
+    margin-left: 34.25414365%;
+    *margin-left: 34.14776067%;
+  }
+  .row-fluid .offset3 {
+    margin-left: 28.45303867%;
+    *margin-left: 28.3466557%;
+  }
+  .row-fluid .offset3:first-child {
+    margin-left: 25.69060773%;
+    *margin-left: 25.58422476%;
+  }
+  .row-fluid .offset2 {
+    margin-left: 19.88950276%;
+    *margin-left: 19.78311978%;
+  }
+  .row-fluid .offset2:first-child {
+    margin-left: 17.12707182%;
+    *margin-left: 17.02068884%;
+  }
+  .row-fluid .offset1 {
+    margin-left: 11.32596685%;
+    *margin-left: 11.21958387%;
+  }
+  .row-fluid .offset1:first-child {
+    margin-left: 8.56353591%;
+    *margin-left: 8.45715293%;
+  }
+
+  // Input grid
+  #grid > .input(@gridColumnWidth1200, @gridGutterWidth1200);
+
+  // Thumbnails
+  .thumbnails {
+    margin-left: -@gridGutterWidth1200;
+  }
+  .thumbnails > li {
+    margin-left: @gridGutterWidth1200;
+  }
+  .row-fluid .thumbnails {
+    margin-left: 0;
+  }
+
+}

--- a/administrator/templates/isis/less/bootstrap/responsive-768px-979px.less
+++ b/administrator/templates/isis/less/bootstrap/responsive-768px-979px.less
@@ -1,0 +1,192 @@
+//
+// Responsive: Tablet to desktop
+// --------------------------------------------------
+
+
+@media (min-width: 768px) and (max-width: 979px) {
+
+  // Fixed grid
+  #grid > .core(@gridColumnWidth768, @gridGutterWidth768);
+
+  // Fluid grid
+   .row-fluid {
+    width: 100%;
+    *zoom: 1;
+  }
+  .row-fluid:before,
+  .row-fluid:after {
+    display: table;
+    content: "";
+    line-height: 0;
+  }
+  .row-fluid:after {
+    clear: both;
+  }
+  .row-fluid [class*="span"] {
+    display: block;
+    width: 100%;
+    min-height: 28px;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    float: left;
+    margin-left: 2.76243094%;
+    *margin-left: 2.70923945%;
+  }
+  .row-fluid [class*="span"]:first-child {
+    margin-left: 0;
+  }
+  .row-fluid .controls-row [class*="span"] + [class*="span"] {
+    margin-left: 2.76243094%;
+  }
+  .row-fluid .span12 {
+    width: 100%;
+    *width: 99.94680851%;
+  }
+  .row-fluid .span11 {
+    width: 91.43646409%;
+    *width: 91.3832726%;
+  }
+  .row-fluid .span10 {
+    width: 82.87292818%;
+    *width: 82.81973669%;
+  }
+  .row-fluid .span9 {
+    width: 74.30939227%;
+    *width: 74.25620078%;
+  }
+  .row-fluid .span8 {
+    width: 65.74585635%;
+    *width: 65.69266486%;
+  }
+  .row-fluid .span7 {
+    width: 57.18232044%;
+    *width: 57.12912895%;
+  }
+  .row-fluid .span6 {
+    width: 48.61878453%;
+    *width: 48.56559304%;
+  }
+  .row-fluid .span5 {
+    width: 40.05524862%;
+    *width: 40.00205713%;
+  }
+  .row-fluid .span4 {
+    width: 31.49171271%;
+    *width: 31.43852122%;
+  }
+  .row-fluid .span3 {
+    width: 22.9281768%;
+    *width: 22.87498531%;
+  }
+  .row-fluid .span2 {
+    width: 14.36464088%;
+    *width: 14.31144939%;
+  }
+  .row-fluid .span1 {
+    width: 5.80110497%;
+    *width: 5.74791348%;
+  }
+  .row-fluid .offset12 {
+    margin-left: 105.52486188%;
+    *margin-left: 105.4184789%;
+  }
+  .row-fluid .offset12:first-child {
+    margin-left: 102.76243094%;
+    *margin-left: 102.65604796%;
+  }
+  .row-fluid .offset11 {
+    margin-left: 96.96132597%;
+    *margin-left: 96.85494299%;
+  }
+  .row-fluid .offset11:first-child {
+    margin-left: 94.19889503%;
+    *margin-left: 94.09251205%;
+  }
+  .row-fluid .offset10 {
+    margin-left: 88.39779006%;
+    *margin-left: 88.29140708%;
+  }
+  .row-fluid .offset10:first-child {
+    margin-left: 85.63535912%;
+    *margin-left: 85.52897614%;
+  }
+  .row-fluid .offset9 {
+    margin-left: 79.83425414%;
+    *margin-left: 79.72787116%;
+  }
+  .row-fluid .offset9:first-child {
+    margin-left: 77.0718232%;
+    *margin-left: 76.96544023%;
+  }
+  .row-fluid .offset8 {
+    margin-left: 71.27071823%;
+    *margin-left: 71.16433525%;
+  }
+  .row-fluid .offset8:first-child {
+    margin-left: 68.50828729%;
+    *margin-left: 68.40190431%;
+  }
+  .row-fluid .offset7 {
+    margin-left: 62.70718232%;
+    *margin-left: 62.60079934%;
+  }
+  .row-fluid .offset7:first-child {
+    margin-left: 59.94475138%;
+    *margin-left: 59.8383684%;
+  }
+  .row-fluid .offset6 {
+    margin-left: 54.14364641%;
+    *margin-left: 54.03726343%;
+  }
+  .row-fluid .offset6:first-child {
+    margin-left: 51.38121547%;
+    *margin-left: 51.27483249%;
+  }
+  .row-fluid .offset5 {
+    margin-left: 45.5801105%;
+    *margin-left: 45.47372752%;
+  }
+  .row-fluid .offset5:first-child {
+    margin-left: 42.81767956%;
+    *margin-left: 42.71129658%;
+  }
+  .row-fluid .offset4 {
+    margin-left: 37.01657459%;
+    *margin-left: 36.91019161%;
+  }
+  .row-fluid .offset4:first-child {
+    margin-left: 34.25414365%;
+    *margin-left: 34.14776067%;
+  }
+  .row-fluid .offset3 {
+    margin-left: 28.45303867%;
+    *margin-left: 28.3466557%;
+  }
+  .row-fluid .offset3:first-child {
+    margin-left: 25.69060773%;
+    *margin-left: 25.58422476%;
+  }
+  .row-fluid .offset2 {
+    margin-left: 19.88950276%;
+    *margin-left: 19.78311978%;
+  }
+  .row-fluid .offset2:first-child {
+    margin-left: 17.12707182%;
+    *margin-left: 17.02068884%;
+  }
+  .row-fluid .offset1 {
+    margin-left: 11.32596685%;
+    *margin-left: 11.21958387%;
+  }
+  .row-fluid .offset1:first-child {
+    margin-left: 8.56353591%;
+    *margin-left: 8.45715293%;
+  }
+
+  // Input grid
+  #grid > .input(@gridColumnWidth768, @gridGutterWidth768);
+
+  // No need to reset .thumbnails here since it's the same @gridGutterWidth
+
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -59,9 +59,9 @@
 // Phones to portrait tablets and narrow desktops
 @import "../../../../media/jui/less/responsive-767px-max.less";
 // Tablets to regular desktops
-@import "../../../../media/jui/less/responsive-768px-979px.less";
+@import "bootstrap/responsive-768px-979px.less";
 // Large desktops
-@import "../../../../media/jui/less/responsive-1200px-min.less";
+@import "bootstrap/responsive-1200px-min.less";
 // RESPONSIVE NAVBAR
 // ------------------
 // From 979px and below, show a button to toggle navbar contents


### PR DESCRIPTION
Pull Request for Issue #13820 & #13768 .

### Summary of Changes
The Joomla LESS compiler returns incorrect values for the row-fluid Bootstrap grid. This PR replaces these with the correct values within the Isis admin template.

I realise that the ideal solution is to fix the compiler however I don't think this option is available and replacing the compiler is unlikely until 4.0.

### Testing Instructions
Apply patch. Navigate to article edit and resize the browser window...

### Before Patch
![grid1](https://cloud.githubusercontent.com/assets/2803503/22510811/39603b42-e88b-11e6-921e-d111ba4da737.gif)

### After Patch
![grid2](https://cloud.githubusercontent.com/assets/2803503/22510851/741e9b0c-e88b-11e6-9be9-67b7ee7b2e4d.gif)

### Documentation Changes Required
None