### PR TITLE
com_cache : Missing lang strings values

### DIFF
--- a/administrator/language/en-GB/en-GB.com_cache.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_cache.sys.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
-COM_CACHE_CACHE_VIEW_DEFAULT_DESC="Clear Cache"
+COM_CACHE_CACHE_VIEW_DEFAULT_DESC="Clear Cache Manager"
 COM_CACHE_CACHE_VIEW_DEFAULT_TITLE="Clear Cache"
-COM_CACHE_PURGE_VIEW_DEFAULT_DESC="Clear Expired Cache"
+COM_CACHE_PURGE_VIEW_DEFAULT_DESC="Clear Expired Cache Manager"
 COM_CACHE_PURGE_VIEW_DEFAULT_TITLE="Clear Expired Cache"
 COM_CACHE_XML_DESCRIPTION="Component for cache management."

--- a/administrator/language/en-GB/en-GB.com_cache.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_cache.sys.ini
@@ -4,9 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
-COM_CACHE_XML_DESCRIPTION="Component for cache management."
-
-COM_CACHE_CACHE_VIEW_DEFAULT_DESC=""
+COM_CACHE_CACHE_VIEW_DEFAULT_DESC="Clear Cache"
 COM_CACHE_CACHE_VIEW_DEFAULT_TITLE="Clear Cache"
-COM_CACHE_PURGE_VIEW_DEFAULT_DESC=""
+COM_CACHE_PURGE_VIEW_DEFAULT_DESC="Clear Expired Cache"
 COM_CACHE_PURGE_VIEW_DEFAULT_TITLE="Clear Expired Cache"
+COM_CACHE_XML_DESCRIPTION="Component for cache management."


### PR DESCRIPTION
2 strings used in CDATA were empty in com_cache.sys.ini
I also alpha ordered the strings

These strings are used in the modal which lets choose admin menus.
After patch, the description is displayed.

![screen shot 2017-02-02 at 08 42 17](https://cloud.githubusercontent.com/assets/869724/22540954/92461568-e923-11e6-9166-26d317cb04be.png)

@Bakual @izharaazmi 
