### PR TITLE
Convert the system Redirect plugin to use lowercase urls at all times…

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -213,7 +213,7 @@ class PlgSystemRedirect extends JPlugin
 			{
 				$data = (object) array(
 					'id' => 0,
-					'old_url' => strtolower($url),
+					'old_url' => $url,
 					'referer' => $app->input->server->getString('HTTP_REFERER', ''),
 					'hits' => 1,
 					'published' => 0,

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -118,11 +118,11 @@ class PlgSystemRedirect extends JPlugin
 
 		$uri = JUri::getInstance();
 
-		$url = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment')));
-		$urlRel = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
+		$url = strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
+		$urlRel = strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
 
-		$urlWithoutQuery = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment')));
-		$urlRelWithoutQuery = rawurldecode($uri->toString(array('path', 'fragment')));
+		$urlWithoutQuery = strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
+		$urlRelWithoutQuery = strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
 
 		// Why is this (still) here?
 		if ((strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http://') !== false))
@@ -213,7 +213,7 @@ class PlgSystemRedirect extends JPlugin
 			{
 				$data = (object) array(
 					'id' => 0,
-					'old_url' => $url,
+					'old_url' => strtolower($url),
 					'referer' => $app->input->server->getString('HTTP_REFERER', ''),
 					'hits' => 1,
 					'published' => 0,

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\String\StringHelper;
 
 /**
  * Plugin class for redirect handling.
@@ -118,11 +119,11 @@ class PlgSystemRedirect extends JPlugin
 
 		$uri = JUri::getInstance();
 
-		$url = strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
-		$urlRel = strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
+		$url = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
+		$urlRel = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
 
-		$urlWithoutQuery = strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
-		$urlRelWithoutQuery = strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
+		$urlWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
+		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
 
 		// Why is this (still) here?
 		if ((strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http://') !== false))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Converted the Redirect System Plugin to store in lowercase and match redirect on lowercase. I've gone for strtolower since it's url based. But we could replace it with mb_strtolower for UTF-8 standards if you think it is needed but it is slower.

### Testing Instructions
Create an article on your website say: my-article and access it in the frontend. Perfect. remove e from it so change the url to say: mywebsite.com/inde.php/my-articl and now you get a 404, next change it to mywebsite.com/inde.php/My-articl and you get a 404. But you now have two redirects to do in the redirects component. 
 
### Expected result
upper and lowercase 404 urls show be equal since J! stores menu item aliases in lowercase.
### Actual result
both lowercase and uppercase 404's are stored and matched independently. 
### Documentation Changes Required

Resolves #12666 