### PR TITLE
Fixes the issue which causes custom menu items to be lost on component update

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -311,7 +311,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 		// Make sure that menu items pointing to the component have correct component id assigned to them.
 		// Prevents message "Component 'com_extension' does not exist." after uninstalling / re-installing component.
-		if (!$this->_updateSiteMenus($this->extension->extension_id))
+		if (!$this->_updateMenus($this->extension->extension_id))
 		{
 			JLog::add(JText::_('JLIB_INSTALLER_ABORT_COMP_UPDATESITEMENUS_FAILED'), JLog::WARNING, 'jerror');
 		}
@@ -887,13 +887,14 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 		$option = $this->get('element');
 
-		// If a component exists with this option in the table then we don't need to add menus
+		// If a component exists with this option in the table within the protected menutype 'main' then we don't need to add menus
 		$query = $db->getQuery(true)
 					->select('m.id, e.extension_id')
 					->from('#__menu AS m')
 					->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
 					->where('m.parent_id = 1')
 					->where('m.client_id = 1')
+					->where('m.menutype = ' . $db->quote('main'))
 					->where('e.element = ' . $db->quote($option));
 
 		$db->setQuery($query);
@@ -1103,6 +1104,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 					->select('id')
 					->from('#__menu')
 					->where($db->quoteName('client_id') . ' = 1')
+					->where($db->quoteName('menutype') . ' = ' . $db->q('main'))
 					->where($db->quoteName('component_id') . ' = ' . (int) $id);
 
 		$db->setQuery($query);
@@ -1134,6 +1136,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 
 	/**
 	 * Method to update menu database entries for a component in case if the component has been uninstalled before.
+	 * NOTE: This will not update admin menus. Use _updateMenus() instead to update admin menus ase well.
 	 *
 	 * @param   int|null  $component_id  The component ID.
 	 *
@@ -1142,6 +1145,21 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 	 * @since   3.4.2
 	 */
 	protected function _updateSiteMenus($component_id = null)
+	{
+		return $this->_updateMenus($component_id, 0);
+	}
+
+	/**
+	 * Method to update menu database entries for a component in case if the component has been uninstalled before.
+	 *
+	 * @param   int|null  $component_id  The component ID.
+	 * @param   int       $clientId      The client id
+	 *
+	 * @return  boolean  True if successful
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _updateMenus($component_id, $clientId = null)
 	{
 		$db     = $this->parent->getDbo();
 		$option = $this->get('element');
@@ -1152,9 +1170,15 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 					->update('#__menu')
 					->set('component_id = ' . $db->quote($component_id))
 					->where('type = ' . $db->quote('component'))
-					->where('client_id = 0')
-					->where('link LIKE ' . $db->quote('index.php?option=' . $option)
-							. " OR link LIKE '" . $db->escape('index.php?option=' . $option . '&') . "%'");
+					->where('(' .
+						'link LIKE ' . $db->quote('index.php?option=' . $option) . ' OR ' .
+						'link LIKE ' . $db->q($db->escape('index.php?option=' . $option . '&') . '%', false) .
+					')');
+
+		if (isset($clientId))
+		{
+			$query->where('client_id = ' . (int) $clientId);
+		}
 
 		$db->setQuery($query);
 

--- a/libraries/fof/utils/installscript/installscript.php
+++ b/libraries/fof/utils/installscript/installscript.php
@@ -1622,13 +1622,14 @@ abstract class FOFUtilsInstallscript
 		$table = JTable::getInstance('menu');
 		$option = $parent->get('element');
 
-		// If a component exists with this option in the table then we don't need to add menus
+		// If a component exists with this option in the table then we don't need to add menus - check only 'main' menutype
 		$query = $db->getQuery(true)
 			->select('m.id, e.extension_id')
 			->from('#__menu AS m')
 			->join('LEFT', '#__extensions AS e ON m.component_id = e.extension_id')
 			->where('m.parent_id = 1')
 			->where('m.client_id = 1')
+			->where('m.menutype = ' . $db->q('main'))
 			->where($db->qn('e') . '.' . $db->qn('type') . ' = ' . $db->q('component'))
 			->where('e.element = ' . $db->quote($option));
 
@@ -1947,6 +1948,7 @@ abstract class FOFUtilsInstallscript
 			->set($db->qn('published') . ' = ' . $db->q(1))
 			->where('m.parent_id = 1')
 			->where('m.client_id = 1')
+			->where('m.menutype = ' . $db->quote('main'))
 			->where('e.type = ' . $db->quote('component'))
 			->where('e.element = ' . $db->quote($option));
 


### PR DESCRIPTION
Pull Request for Issue #13642.

### Summary of Changes
1. Changed `\JInstallerAdapterComponent::_removeAdminMenus` to remove only the protected menu items, i.e. - `menutype == 'main'` and leave alone other menutypes.
2. Replicated `\JInstallerAdapterComponent::_updateSiteMenus` as `\JInstallerAdapterComponent::_updateMenus`   to update the admin menus as well.

### Testing Instructions
1. Create a custom admin menu.
2. Install any extension.
3. Create a menu link for the component in your custom menu.
4. Reinstall/update your component.

Extra: Uninstall your component. The menu item should still exist in your custom admin menu, though orphaned.

### Expected result
The custom menu item in step 3 above, should still point to the same component.

### Actual result
Without this patch The custom menu item in step 3 above is removed. After this patch, we get the expected result.

### Documentation Changes Required
None

Pinging @rdeutz @infograf768 @Bakual 