### PR TITLE
Update phpass to 0.4

### DIFF
--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -2,7 +2,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.3 / genuine.
+# Version 0.4 / genuine.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.
@@ -48,7 +48,7 @@ class PasswordHash {
 	function get_random_bytes($count)
 	{
 		$output = '';
-		if (is_readable('/dev/urandom') &&
+		if (@is_readable('/dev/urandom') &&
 		    ($fh = @fopen('/dev/urandom', 'rb'))) {
 			$output = fread($fh, $count);
 			fclose($fh);


### PR DESCRIPTION
Pull Request for Update phpass to 0.4

most recent version found on http://cvsweb.openwall.com/cgi/cvsweb.cgi/projects/phpass/PasswordHash.php

- Prefixed is_readable() with "@" to suppress warning when open_basedir restriction is in effect.  WordPress did the same:
  - http://core.trac.wordpress.org/changeset/13429
  - http://code.google.com/p/textpattern/issues/detail?id=107

### Summary of Changes
a direct copy of phpass 0.4
Note: this does not fix the php4 constructor issue

### Testing Instructions
merge by code review / tests pass

### Documentation Changes Required
none
