### PR TITLE
this test fails to often and doesn’t makes sense

### DIFF
--- a/tests/unit/suites/libraries/joomla/session/JSessionTest.php
+++ b/tests/unit/suites/libraries/joomla/session/JSessionTest.php
@@ -196,27 +196,6 @@ class JSessionTest extends TestCase
 	}
 
 	/**
-	 * Test getFormToken
-	 *
-	 * @covers  JSession::getFormToken
-	 *
-	 * @return void
-	 */
-	public function testGetFormToken()
-	{
-		// Set the factory session object for getting the token
-		JFactory::$session = $this->object;
-
-		$user = JFactory::getUser();
-
-		$expected = md5($user->get('id', 0) . $this->object->getToken(false));
-
-		$object = $this->object;
-
-		$this->assertEquals($expected, $object::getFormToken(false), 'Form token should be calculated as above.');
-	}
-
-	/**
 	 * Test getName
 	 *
 	 * @covers  JSession::getName


### PR DESCRIPTION
### Summary of Changes

Removal of the testGetFormToken test. Main reasons are:
* we are testing here if "JUserHelper::genRandomPassword()" works, this should be tested in a test for the "JUserHelper" class and not here
* the test is not very stable, sometimes it fails and sometime not on the same codebase. 

### Testing Instructions

Code Review

### Expected result

Less failed tests
