### PR TITLE
Editor Plugin to insert the new {field ID} and {fieldgroup ID} tags

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -505,6 +505,7 @@ class JoomlaInstallerScript
 			array('plugin', 'user', 'fields', 0),
 			array('plugin', 'usergrouplist', 'fields', 0),
 			array('plugin', 'fields', 'content', 0),
+			array('plugin', 'fields', 'editors-xtd', 0),
 
 			// Templates
 			array('template', 'beez3', '', 0),

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-02-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-02-02.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(479, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-02-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-02-02.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+(479, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-02.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-02.sql
@@ -1,0 +1,6 @@
+SET IDENTITY_INSERT #__extensions  ON;
+
+INSERT INTO #__extensions ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
+SELECT 479, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+
+SET IDENTITY_INSERT #__extensions  OFF;

--- a/administrator/components/com_fields/views/fields/tmpl/modal.php
+++ b/administrator/components/com_fields/views/fields/tmpl/modal.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_modules
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+if (JFactory::getApplication()->isClient('site'))
+{
+	JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
+}
+
+JHtml::_('behavior.core');
+JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('formbehavior.chosen', 'select');
+
+// Special case for the search field tooltip.
+$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
+JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
+
+$listOrder = $this->escape($this->state->get('list.ordering'));
+$listDirn  = $this->escape($this->state->get('list.direction'));
+$editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
+
+JFactory::getDocument()->addScriptDeclaration('
+fieldIns = function(id) {
+	window.parent.jInsertEditorText("{field " + id + "}", "' . $editor . '");
+	window.parent.jModalClose();
+};
+fieldgroupIns = function(id) {
+	window.parent.jInsertEditorText("{fieldgroup " + id + "}", "' . $editor . '");
+	window.parent.jModalClose();
+};');
+?>
+<div class="container-popup">
+
+	<form action="<?php echo JRoute::_('index.php?option=com_fields&view=fields&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm">
+
+		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
+			<table class="table table-striped" id="moduleList">
+				<thead>
+					<tr>
+						<th width="1%" class="nowrap center">
+							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'a.state', $listDirn, $listOrder); ?>
+						</th>
+						<th class="title">
+							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="15%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'COM_FIELDS_FIELD_GROUP_LABEL', 'group_title', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'COM_FIELDS_FIELD_TYPE_LABEL', 'a.type', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
+						</th>
+						<th width="10%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+						</th>
+						<th width="1%" class="nowrap hidden-phone">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+						</th>
+					</tr>
+				</thead>
+				<tfoot>
+					<tr>
+						<td colspan="8">
+							<?php echo $this->pagination->getListFooter(); ?>
+						</td>
+					</tr>
+				</tfoot>
+				<tbody>
+					<?php
+					$iconStates = array(
+						-2 => 'icon-trash',
+						0  => 'icon-unpublish',
+						1  => 'icon-publish',
+						2  => 'icon-archive',
+					);
+					foreach ($this->items as $i => $item) :
+					?>
+					<tr class="row<?php echo $i % 2; ?>">
+						<td class="center">
+							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
+						</td>
+						<td class="has-context">
+							<a class="btn btn-small btn-block btn-success" href="#" onclick="fieldIns('<?php echo $this->escape($item->id); ?>');"><?php echo $this->escape($item->title); ?></a>
+						</td>
+						<td class="small hidden-phone">
+							<a class="btn btn-small btn-block btn-warning" href="#" onclick="fieldgroupIns('<?php echo $this->escape($item->group_id); ?>');"><?php echo $item->group_id ? $this->escape($item->group_title) : JText::_('JNONE'); ?></a>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $item->type; ?>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo $this->escape($item->access_level); ?>
+						</td>
+						<td class="small hidden-phone">
+							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+						</td>
+						<td class="hidden-phone">
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+
+		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="boxchecked" value="0" />
+		<?php echo JHtml::_('form.token'); ?>
+
+	</form>
+</div>

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -90,7 +90,11 @@ class FieldsViewFields extends JViewLegacy
 			JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_FIELDS_SYSTEM_PLUGIN_NOT_ENABLED', $link), 'warning');
 		}
 
-		$this->addToolbar();
+		// Only add toolbar when not in modal window.
+		if ($this->getLayout() !== 'modal')
+		{
+			$this->addToolbar();
+		}
 
 		FieldsHelper::addSubmenu($this->state->get('filter.context'), 'fields');
 		$this->sidebar = JHtmlSidebar::render();

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EDITORS-XTD_FIELDS="Button - Fields"
+PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD="Fields"
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a field into an item. Displays a popup allowing you to choose the field."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
@@ -1,0 +1,7 @@
+; Joomla! Project
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
+; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
+; Note : All ini files need to be saved as UTF-8
+
+PLG_EDITORS-XTD_FIELDS="Button - Fields"
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a field into an item. Displays a popup allowing you to choose the field."

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -147,6 +147,8 @@
 		<filename>en-GB.plg_editors-xtd_article.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_contact.ini</filename>
 		<filename>en-GB.plg_editors-xtd_contact.sys.ini</filename>
+		<filename>en-GB.plg_editors-xtd_fields.ini</filename>
+		<filename>en-GB.plg_editors-xtd_fields.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_image.ini</filename>
 		<filename>en-GB.plg_editors-xtd_image.sys.ini</filename>
 		<filename>en-GB.plg_editors-xtd_menu.ini</filename>

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -638,6 +638,7 @@ INSERT INTO `#__extensions` (`extension_id`, `package_id`, `name`, `type`, `elem
 (476, 0, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (477, 0, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (478, 0, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(479, 0, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (503, 0, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (504, 0, 'hathor', 'template', 'hathor', '', 1, 1, 1, 0, '', '{"showSiteName":"0","colourChoice":"0","boldText":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
 (506, 0, 'protostar', 'template', 'protostar', '', 0, 1, 1, 0, '', '{"templateColor":"","logoFile":"","googleFont":"1","googleFontName":"Open+Sans","fluidContainer":"0"}', '', '', 0, '0000-00-00 00:00:00', 0, 0),

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -639,7 +639,8 @@ INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder"
 (475, 'plg_fields_url', 'plugin', 'url', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
 (477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
-(478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
+(478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0),
+(479, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 -- Templates
 INSERT INTO "#__extensions" ("extension_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "system_data", "checked_out", "checked_out_time", "ordering", "state") VALUES

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -1057,7 +1057,9 @@ SELECT 476, 'plg_fields_user', 'plugin', 'user', 'fields', 0, 1, 1, 0, '', '', '
 UNION ALL
 SELECT 477, 'plg_fields_usergrouplist', 'plugin', 'usergrouplist', 'fields', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 UNION ALL
-SELECT 478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
+SELECT 478, 'plg_content_fields', 'plugin', 'fields', 'content', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
+UNION ALL
+SELECT 479, 'plg_editors-xtd_fields', 'plugin', 'fields', 'editors-xtd', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0;
 -- Templates
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 503, 'beez3', 'template', 'beez3', '', 0, 1, 1, 0, '', '{"wrapperSmall":"53","wrapperLarge":"72","sitetitle":"","sitedescription":"","navposition":"center","templatecolor":"nature"}', '', '', 0, '1900-01-01 00:00:00', 0, 0

--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+/**
+ * Editor Fields button
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PlgButtonFields extends JPlugin
+{
+	/**
+	 * Load the language file on instantiation.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $autoloadLanguage = true;
+
+	/**
+	 * Display the button
+	 *
+	 * @param   string  $name  The name of the button to add
+	 *
+	 * @return  JObject  The button options as JObject
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function onDisplay($name)
+	{
+		// Register FieldsHelper
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
+		// Guess the field context based on view.
+		$jinput = JFactory::getApplication()->input;
+		$context = $jinput->get('option') . '.' . $jinput->get('view');
+
+		// Validate context.
+		$context = implode('.', FieldsHelper::extract($context));
+		if (!FieldsHelper::getFields($context))
+		{
+			return;
+		}
+
+		$link = 'index.php?option=com_fields&amp;view=fields&amp;layout=modal&amp;tmpl=component&amp;context='
+			. $context . '&amp;editor=' . $name . '&amp;' . JSession::getFormToken() . '=1';
+
+		$button          = new JObject;
+		$button->modal   = true;
+		$button->class   = 'btn';
+		$button->link    = $link;
+		$button->text    = JText::_('PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD');
+		$button->name    = 'puzzle';
+		$button->options = "{handler: 'iframe', size: {x: 800, y: 500}}";
+
+		return $button;
+	}
+}

--- a/plugins/editors-xtd/fields/fields.xml
+++ b/plugins/editors-xtd/fields/fields.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension version="3.7" type="plugin" group="editors-xtd" method="upgrade">
+	<name>plg_editors-xtd_fields</name>
+	<author>Joomla! Project</author>
+	<creationDate>February 2017</creationDate>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>3.7.0</version>
+	<description>PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION</description>
+	<files>
+		<filename plugin="fields">fields.php</filename>
+	</files>
+	<languages>
+		<language tag="en-GB">en-GB.plg_editors-xtd_fields.ini</language>
+		<language tag="en-GB">en-GB.plg_editors-xtd_fields.sys.ini</language>
+	</languages>
+</extension>


### PR DESCRIPTION
### Summary of Changes
Adds a new plugin to help inserting the new {field ID} and {fieldgroup ID} tags.
It's based on the loadmodule editor plugin.
**The button only shows if there are any fields which could be inserted.**

### Testing Instructions
* Discover and enable the new "Button - Fields" plugin.
* Go to eg an article and see the new editor button
![button](https://cloud.githubusercontent.com/assets/1018684/22570526/ff36d5f4-e99b-11e6-8a0c-16471729f420.PNG)
* Click the button which opens the modal
![modal](https://cloud.githubusercontent.com/assets/1018684/22570533/0794ae10-e99c-11e6-881d-6e979316e86a.PNG)
* Select either a field or the group and check that the correct tag is entered into the editor

### Documentation Changes Required
Don't know

### Notes
The button only shows if there are any fields which could be inserted. If there are none for a given context, then the button isn't shown. The context is guessed based on the active component (option) and view and the validated using the FieldHelper.