### PR TITLE
Catch SQL exception in SQL form field

### DIFF
--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -275,7 +275,16 @@ class JFormFieldSQL extends JFormFieldList
 
 		// Set the query and get the result list.
 		$db->setQuery($this->query);
-		$items = $db->loadObjectlist();
+
+		$items = array();
+		try
+		{
+			$items = $db->loadObjectlist();
+		}
+		catch (Exception $e)
+		{
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+		}
 
 		// Add header.
 		if (!empty($header))

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -277,6 +277,7 @@ class JFormFieldSQL extends JFormFieldList
 		$db->setQuery($this->query);
 
 		$items = array();
+
 		try
 		{
 			$items = $db->loadObjectlist();


### PR DESCRIPTION
Pull Request for Issue #13867.

### Summary of Changes
The SQL form field should handle SQL errors and not crash the page. Actually it enqueus the error message to the application, don't know if there is a better way to handle exceptions in form fields. @mbabker and @Bakual any clue?

### Testing Instructions
- Create a SQL form field with an invalid query like "An invalid query". ![image](https://cloud.githubusercontent.com/assets/251072/22582107/f9b46076-e9e4-11e6-996d-27ae0410d2e2.png)
- Adit an article.

### Expected result
An error message should be shown on the top of the page.

### Actual result
The site crashes.
### Documentation Changes Required
