### PR TITLE
[admin_menus] Taking off useless columns in menu items manager

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -71,22 +71,26 @@ if ($menuType == '')
 						<th class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_MENU', 'menutype_title', $listDirn, $listOrder); ?>
 						</th>
-						<?php if ($this->state->get('filter.client_id') == 0): ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<th width="5%" class="center nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_HOME', 'a.home', $listDirn, $listOrder); ?>
 						</th>
 						<?php endif; ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
+						<?php endif; ?>
 						<?php if ($assoc) : ?>
 							<th width="5%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 							</th>
 						<?php endif; ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<th width="15%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
 						</th>
+						<?php endif; ?>
 						<th width="1%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -203,7 +207,7 @@ if ($menuType == '')
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->menutype_title ?: ucwords($item->menutype)); ?>
 						</td>
-						<?php if ($this->state->get('filter.client_id') == 0): ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<td class="center hidden-phone">
 							<?php if ($item->type == 'component') : ?>
 								<?php if ($item->language == '*' || $item->home == '0') : ?>
@@ -226,9 +230,11 @@ if ($menuType == '')
 							<?php endif; ?>
 						</td>
 						<?php endif; ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
+						<?php endif; ?>
 						<?php if ($assoc) : ?>
 							<td class="small hidden-phone">
 								<?php if ($item->association) : ?>
@@ -236,9 +242,11 @@ if ($menuType == '')
 								<?php endif; ?>
 							</td>
 						<?php endif; ?>
+						<?php if ($this->state->get('filter.client_id') == 0) : ?>
 						<td class="small hidden-phone">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>
+						<?php endif; ?>
 						<td class="hidden-phone">
 							<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 								<?php echo (int) $item->id; ?>


### PR DESCRIPTION
Custom admin menus do not need Access or Language (These can be implemented in 4.0 if judged necessary).
This PR takes the related columns out of the menu items Manager

After patch, one should get:
![screen shot 2017-02-03 at 08 19 57](https://cloud.githubusercontent.com/assets/869724/22582852/c028fc2c-e9e9-11e6-8ce0-42a901c1cc39.png)

SIDE NOTE: _Hidden Feature: one can save an admin menu item title as a lang string constant which is why the capture above shows these as translated. Useful when multiple languages are used in back-end._
![screen shot 2017-02-03 at 08 24 37](https://cloud.githubusercontent.com/assets/869724/22582933/444799a0-e9ea-11e6-88e1-09603c11962b.png)


@izharaazmi @franz-wohlkoenig