### PR TITLE
[imp] Validate the default value against the field type validation rule

### DIFF
--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldpath="/administrator/components/com_categories/models/fields" >
+	<fieldset addfieldpath="/administrator/components/com_categories/models/fields" addrulepath="/administrator/components/com_fields/models/rules">
 		<field
 			name="id"
 			type="text"
@@ -88,6 +88,7 @@
 			filter="raw"
 			label="COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL"
 			description="COM_FIELDS_FIELD_DEFAULT_VALUE_DESC"
+                        validate="default"
 		/>
 	
 		<field

--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -88,7 +88,7 @@
 			filter="raw"
 			label="COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL"
 			description="COM_FIELDS_FIELD_DEFAULT_VALUE_DESC"
-                        validate="default"
+			validate="default"
 		/>
 	
 		<field

--- a/administrator/components/com_fields/models/rules/default.php
+++ b/administrator/components/com_fields/models/rules/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 /**
  * JFormRuleDefault for com_fields to make sure the default value is valid.
  *
- * @since  1.6
+ * @since  __DEPLOY_VERSION__
  */
 class JFormRuleDefault extends JFormRule
 {
@@ -27,6 +27,8 @@ class JFormRuleDefault extends JFormRule
 	 * @param   JForm             $form     The form object for which the field is being tested.
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
 	{

--- a/administrator/components/com_fields/models/rules/default.php
+++ b/administrator/components/com_fields/models/rules/default.php
@@ -8,6 +8,11 @@
  */
 defined('_JEXEC') or die;
 
+/**
+ * JFormRuleDefault for com_fields to make sure the default value is valid.
+ *
+ * @since  1.6
+ */
 class JFormRuleDefault extends JFormRule
 {
 	/**
@@ -24,13 +29,13 @@ class JFormRuleDefault extends JFormRule
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
-    {
+	{
 		// Skip validation if empty
-		if(empty($value))
+		if (empty($value))
 		{
 			return true;
 		}
-		
+
 		// Load the JFormRule object for the field.
 		$type = $form->getValue('type');
 		$rule = JFormHelper::loadRuleType($type);
@@ -72,5 +77,5 @@ class JFormRuleDefault extends JFormRule
 		}
 
 		return true;
-    }
+	}
 }

--- a/administrator/components/com_fields/models/rules/default.php
+++ b/administrator/components/com_fields/models/rules/default.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+class JFormRuleDefault extends JFormRule
+{
+	/**
+	 * Method to test the default value against the field type validation rule
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the <field /> tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 */
+	public function test(SimpleXMLElement $element, $value, $group = null, JRegistry $input = null, JForm $form = null)
+    {
+		// Skip validation if empty
+		if(empty($value))
+		{
+			return true;
+		}
+		
+		// Load the JFormRule object for the field.
+		$type = $form->getValue('type');
+		$rule = JFormHelper::loadRuleType($type);
+
+		// If the object could not be loaded abort validation.
+		if ($rule === false)
+		{
+			return true;
+		}
+
+		// Run the field validation rule test.
+		$valid = $rule->test($element, $value, $group, $input, $form);
+
+		// Check for an error in the validation test.
+		if ($valid instanceof Exception)
+		{
+			return $valid;
+		}
+
+		// Check if the field is valid.
+		if ($valid === false)
+		{
+			// Does the field have a defined error message?
+			$message = (string) $element['message'];
+
+			if ($message)
+			{
+				$message = JText::_($element['message']);
+
+				return new UnexpectedValueException($message);
+			}
+			else
+			{
+				$message = JText::_($element['label']);
+				$message = JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $message);
+
+				return new UnexpectedValueException($message);
+			}
+		}
+
+		return true;
+    }
+}


### PR DESCRIPTION
Pull Request for Issue #13869.

### Summary of Changes
Added a JFormRule in com_fields to make sure default value is validated against the field type.

### Testing Instructions
1. Create a field (url, color, .. ) 
2. Set an invalid value  in default value field.
3. Submit and you should get a validation message.
4. Repeat with a valid default value and no validation message should appear.
### Expected result
Displays a validation message.
### Actual result
Does not validate the default value against the field type.
### Documentation Changes Required
No.