### PR TITLE
[admin-menus] Allows translation of menu items in parent and ordering dropdowns

### DIFF
--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -77,12 +77,12 @@ class JFormFieldMenuOrdering extends JFormFieldList
 			JError::raiseWarning(500, $e->getMessage());
 		}
 
-		// Allow translation of custom admin menus
+	// Allow translation of custom admin menus
 		foreach ($options as $i => &$option)
 		{
-			if ($options[$i]->clientId != 0)
+			if ($option->clientId != 0)
 			{
-				$options[$i]->text = JText::_($options[$i]->text);
+				$option->text = JText::_($option->text);
 			}
 		}
 

--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -77,7 +77,7 @@ class JFormFieldMenuOrdering extends JFormFieldList
 			JError::raiseWarning(500, $e->getMessage());
 		}
 
-	// Allow translation of custom admin menus
+		// Allow translation of custom admin menus
 		foreach ($options as &$option)
 		{
 			if ($option->clientId != 0)

--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -78,7 +78,7 @@ class JFormFieldMenuOrdering extends JFormFieldList
 		}
 
 	// Allow translation of custom admin menus
-		foreach ($options as $i => &$option)
+		foreach ($options as &$option)
 		{
 			if ($option->clientId != 0)
 			{

--- a/administrator/components/com_menus/models/fields/menuordering.php
+++ b/administrator/components/com_menus/models/fields/menuordering.php
@@ -48,7 +48,7 @@ class JFormFieldMenuOrdering extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text')
+			->select('a.id AS value, a.title AS text, a.client_id AS clientId')
 			->from('#__menu AS a')
 
 			->where('a.published >= 0')
@@ -75,6 +75,15 @@ class JFormFieldMenuOrdering extends JFormFieldList
 		catch (RuntimeException $e)
 		{
 			JError::raiseWarning(500, $e->getMessage());
+		}
+
+		// Allow translation of custom admin menus
+		foreach ($options as $i => &$option)
+		{
+			if ($options[$i]->clientId != 0)
+			{
+				$options[$i]->text = JText::_($options[$i]->text);
+			}
 		}
 
 		$options = array_merge(

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -87,7 +87,16 @@ class JFormFieldMenuParent extends JFormFieldList
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
-			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+			if ($clientId != 0)
+			{
+				// Allow translation of custom admin menus
+				$options[$i]->text = str_repeat('- ', $options[$i]->level) . JText::_($options[$i]->text);
+			}
+			else
+			{
+				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+			}
+
 		}
 
 		// Merge any additional options in the XML definition.


### PR DESCRIPTION
When creating custom admin menus, one can choose as title a language string constant.
For example
![screen shot 2017-02-03 at 08 24 37](https://cloud.githubusercontent.com/assets/869724/22582933/444799a0-e9ea-11e6-88e1-09603c11962b.png)

These constants (when they exist in core pack or overrides. I chose here some which are present in the sys.ini) will be translated in the menu items Manager as well as in the Menu itself

Menu items manager
![screen shot 2017-02-03 at 08 19 57](https://cloud.githubusercontent.com/assets/869724/22582852/c028fc2c-e9e9-11e6-8ce0-42a901c1cc39.png)

Menu itself
![screen shot 2017-02-03 at 10 41 36](https://cloud.githubusercontent.com/assets/869724/22586493/5fc75af4-e9fd-11e6-88ad-e28e4b082a37.png)

BUT, as you can see in the first screenshot, they are not translated in the "Parent Item" and "Ordering" dropdown.

This patch passes them through JText to get them translated there too.
After patch, one would get:

![screen shot 2017-02-03 at 10 31 06](https://cloud.githubusercontent.com/assets/869724/22586555/b5cb3312-e9fd-11e6-8e0e-8d4a3a9a1edd.png)
![screen shot 2017-02-03 at 10 30 56](https://cloud.githubusercontent.com/assets/869724/22586561/bdad3184-e9fd-11e6-9506-5f2773efcf4d.png)


To test, create some custom admin menu items with existing Constant (some examples can be seen above).
Edit one of these menu items.
Patch and edit again.

It is useful to set debug language ON in global Configuration to ease testing

@izharaazmi @franz-wohlkoenig @AlexRed 