### PR TITLE
[mssql] Simpler workaround for query with limit and offset

### DIFF
--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -334,29 +334,21 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 	 */
 	public function processLimit($query, $limit, $offset = 0)
 	{
-		if ($limit == 0 && $offset == 0)
+		if ($limit)
+		{
+			$total = $offset + $limit;
+			$query = substr_replace($query, 'SELECT TOP ' . (int) $total, stripos($query, 'SELECT'), 6);
+		}
+
+		if (!$offset)
 		{
 			return $query;
 		}
 
-		$start = $offset + 1;
-		$end   = $offset + $limit;
-
-		$orderBy = stristr($query, 'ORDER BY');
-
-		if (is_null($orderBy) || empty($orderBy))
-		{
-			$orderBy = 'ORDER BY (select 0)';
-		}
-
-		$query = str_ireplace($orderBy, '', $query);
-
-		$rowNumberText = ', ROW_NUMBER() OVER (' . $orderBy . ') AS RowNumber FROM ';
-
-		$query = preg_replace('/\sFROM\s/i', $rowNumberText, $query, 1);
-		$query = 'SELECT * FROM (' . $query . ') A WHERE A.RowNumber BETWEEN ' . $start . ' AND ' . $end;
-
-		return $query;
+		return PHP_EOL
+			. 'SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber FROM ('
+			. $query
+			. PHP_EOL . ') AS A) AS A WHERE RowNumber > ' . (int) $offset;
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
@@ -52,8 +52,8 @@ class JDatabaseIteratorSqlsrvTest extends TestCaseDatabaseSqlsrv
 				2,
 				0,
 				array(
-					(object) array('title' => 'Testing', 'RowNumber' => '1'),
-					(object) array('title' => 'Testing2', 'RowNumber' => '2')
+					(object) array('title' => 'Testing'),
+					(object) array('title' => 'Testing2')
 				),
 				null
 			),

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -151,6 +151,44 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	}
 
 	/**
+	 * Test for the JDatabaseQuerySqlsrv::__processLimit method.
+	 *
+	 * @return  JDatabaseQuerySqlsrv
+	 *
+	 * @since   3.7.0
+	 */
+	public function test__processLimit()
+	{
+		$this->_instance
+			->select('id, COUNT(*) AS count')
+			->from('a')
+			->where('id = 1');
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1',
+			$this->_instance->processLimit((string) $this->_instance, 0)
+		);
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT TOP 30 id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1',
+			$this->_instance->processLimit((string) $this->_instance, 30)
+		);
+
+		$this->assertEquals(
+			PHP_EOL . 'SELECT * FROM (SELECT *, ROW_NUMBER() OVER (ORDER BY (SELECT 0)) AS RowNumber FROM (' .
+			PHP_EOL . 'SELECT TOP 4 id,COUNT(*) AS count' .
+			PHP_EOL . 'FROM a' .
+			PHP_EOL . 'WHERE id = 1' .
+			PHP_EOL . ') AS A) AS A WHERE RowNumber > 3',
+			$this->_instance->processLimit((string) $this->_instance, 1, 3)
+		);
+	}
+
+	/**
 	 * Test for the JDatabaseQuery::__string method for a 'update' case.
 	 *
 	 * @return  void


### PR DESCRIPTION
It is a part of the other more complicated PR #13262

### Summary of Changes

Better workaround for sql query with `offset` and `limit`.
* do not create sub query if there is only `limit` applied, use `SELECT TOP`

### Testing Instructions
Apply patch on installed joomla (on mssql db) with sample data.
Go to article list on backend and check whether pagination works.

### Expected result
Works as before,
* start to work in conjunction with PR #13854  at administrator/index.php?option=com_finder&view=maps

### Actual result
* sql error at administrator/index.php?option=com_finder&view=maps
* and does not work in conjunction with PR #13854   

### Documentation Changes Required
No