### PR TITLE
Remove the content fields plugintag if ID is invalid

### DIFF
--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -80,24 +80,23 @@ class PlgContentFields extends JPlugin
 			foreach ($matches as $i => $match)
 			{
 				// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID
-				$id = (int) $match[2];
+				$id     = (int) $match[2];
+				$output = '';
 
 				if ($match[1] == 'field' && $id)
 				{
-					if (!isset($fieldsById[$id]))
+					if (isset($fieldsById[$id]))
 					{
-						continue;
+						$output = FieldsHelper::render(
+							$context,
+							'field.render',
+							array(
+								'item'    => $item,
+								'context' => $context,
+								'field'   => $fieldsById[$id]
+							)
+						);
 					}
-
-					$output = FieldsHelper::render(
-						$context,
-						'field.render',
-						array(
-							'item'    => $item,
-							'context' => $context,
-							'field'   => $fieldsById[$id]
-						)
-					);
 				}
 				else
 				{
@@ -108,25 +107,21 @@ class PlgContentFields extends JPlugin
 					}
 					else
 					{
-						if (!isset($groups[$id]))
-						{
-							continue;
-						}
-						else
-						{
-							$renderFields = $groups[$id];
-						}
+						$renderFields = isset($groups[$id]) ? $groups[$id] : '';
 					}
 
-					$output = FieldsHelper::render(
-						$context,
-						'fields.render',
-						array(
-							'item'    => $item,
-							'context' => $context,
-							'fields'  => $renderFields
-						)
-					);
+					if ($renderFields)
+					{
+						$output = FieldsHelper::render(
+							$context,
+							'fields.render',
+							array(
+								'item'    => $item,
+								'context' => $context,
+								'fields'  => $renderFields
+							)
+						);
+					}
 				}
 
 				$item->text = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $item->text, 1);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13875#issuecomment-277275327.

### Summary of Changes
When the plugin tag {field ID} or {fieldgroup ID} is used with a non-existant ID (eg {field 12345}), then the tag currently shows up in the article.
This PR changes this behavior so the plugin tag gets removed always.

### Testing Instructions
* Use a plugin tag like {field 12345} in an article and see that it disappears after applying this PR.
* Test with an existing ID and verify that the field still shows up as expected.

### Documentation Changes Required
None