### PR TITLE
[Installation] Move the warning about internet to download languages to a info message

### DIFF
--- a/installation/view/complete/tmpl/default.php
+++ b/installation/view/complete/tmpl/default.php
@@ -27,7 +27,7 @@ defined('_JEXEC') or die;
 				<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC'); ?></p>
 				<p><a href="#" class="btn btn-primary" id="instLangs" onclick="return Install.goToPage('languages');"><span class="icon-arrow-right icon-white"></span> <?php echo JText::_('INSTL_COMPLETE_INSTALL_LANGUAGES'); ?></a></p>
 			</div>
-			<div class="alert span6">
+			<div class="alert alert-info span6">
 				<p><?php echo JText::_('INSTL_COMPLETE_LANGUAGE_DESC2'); ?></p>
 			</div>
 		</div>


### PR DESCRIPTION
### Summary of Changes

Move the warning about internet to download languages to a info message

Thanks to @widmann-it for the idea. #jc17de

### Testing Instructions

- Download: https://github.com/zero-24/joomla-cms/archive/install_alert.zip
- Install as clean joomla
- see on the complete view the changes between expected result and actual result 

### Expected result

![afterpatch](https://cloud.githubusercontent.com/assets/2596554/22618631/940ff70a-eae1-11e6-8028-20fce2e3c530.png)

### Actual result

![actual](https://cloud.githubusercontent.com/assets/2596554/22618633/99f33420-eae1-11e6-9ea3-936d60403f69.png)

### Documentation Changes Required

None