### PR TITLE
Made reference to fulltext alt instead of introtext alt

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -105,7 +105,7 @@ JFactory::getDocument()->addScriptDeclaration("
 						<?php if ($images->image_intro_caption) : ?>
 							<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
 						<?php endif; ?>
-						src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+						src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 				</div>
 			<?php endif; ?>
 			</span>


### PR DESCRIPTION
It seems that this makes reference to the image_fulltext_alt but the rest of the code seems to be targeting the intro text.  Shoot me down if I'm wrong, I only noticed this because I was trying to merge a conflict.

I would also question (and I really don't know the pros/cons) as to whether this could use a JLayout instead.  The pro in my eyes would be code maintainability and standardisation.  There may be an argument against this I really am not skilled enough to know.

Pull Request for Issue # .

### Summary of Changes

It referenced the intro text instead of the full text.  Fill in both items differently so you can test.

### Testing Instructions

Set up an article with different intro text and full text (I suggest the text "introtext" and "fulltext").  

Make sure intro image is set up with an image.  Make sure intro image is set to show.

Go to a tag view ensuring the article is showing.  View the source of the image and ensure there is an alt text.  

### Expected result
1. Alt Text Shows.
2. Alt text matches intro image.

### Actual result
article full image alt text shows

### Documentation Changes Required
n/a
