### PR TITLE
Make JComponentHelper resilient to cache errors

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -430,18 +430,24 @@ class JComponentHelper
 	 */
 	protected static function load($option)
 	{
-		$db = JFactory::getDbo();
-		$query = $db->getQuery(true)
-			->select($db->quoteName(array('extension_id', 'element', 'params', 'enabled'), array('id', 'option', null, null)))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('type') . ' = ' . $db->quote('component'));
-		$db->setQuery($query);
+		$loader = function ()
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName(array('extension_id', 'element', 'params', 'enabled'), array('id', 'option', null, null)))
+				->from($db->quoteName('#__extensions'))
+				->where($db->quoteName('type') . ' = ' . $db->quote('component'));
+			$db->setQuery($query);
 
+			return $db->loadObjectList('option');
+		};
+
+		/** @var JCacheControllerCallback $cache */
 		$cache = JFactory::getCache('_system', 'callback');
 
 		try
 		{
-			$components = $cache->get(array($db, 'loadObjectList'), array('option'), $option, false);
+			$components = $cache->get($loader, array(), $option, false);
 
 			/**
 			 * Verify $components is an array, some cache handlers return an object even though
@@ -456,27 +462,9 @@ class JComponentHelper
 				static::$components = $components;
 			}
 		}
-		catch (RuntimeException $e)
+		catch (JCacheException $e)
 		{
-			/*
-			 * Fatal error
-			 *
-			 * It is possible for this error to be reached before the global JLanguage instance has been loaded so we check for its presence
-			 * before logging the error to ensure a human friendly message is always given
-			 */
-
-			if (JFactory::$language)
-			{
-				$msg = JText::sprintf('JLIB_APPLICATION_ERROR_COMPONENT_NOT_LOADING', $option, $e->getMessage());
-			}
-			else
-			{
-				$msg = sprintf('Error loading component: %1$s, %2$s', $option, $e->getMessage());
-			}
-
-			JLog::add($msg, JLog::WARNING, 'jerror');
-
-			return false;
+			static::$components = $loader();
 		}
 
 		if (empty(static::$components[$option]))


### PR DESCRIPTION
Partial Pull Request for Issue #13357

### Summary of Changes

Similar to #13524 this tries to make the `JComponentHelper` class resilient to cache related issues.

1. The database query is now fully stored and executed in a lambda function, this lambda function is passed to the cache controller instead of only instructing it to run `JDatabaseDriver::loadObjectList()`

2. Cache exceptions are caught and the lambda function will attempt to be run directly instead.

3. On a database failure, we're out of luck; sorry.

### Testing Instructions

If the cache store fails to connect or the cache configuration is bad, the exceptions thrown by the cache API should be caught and `JComponentHelper::load()` try to manually execute the lambda function to load the data.  The method currently catches all thrown `RuntimeException` objects but will now only catch `JCacheException` objects; in the case of a database error (all the database exceptions extend `RuntimeException`), we've got a bigger issue and this method shouldn't try to act as an error handler for that type of failure and let the application keep running.

### Documentation Changes Required

N/A