### PR TITLE
Make JModelLegacy::cleanCache() resilient to cache errors

### DIFF
--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -578,11 +578,19 @@ abstract class JModelLegacy extends JObject
 		$options = array(
 			'defaultgroup' => ($group) ? $group : (isset($this->option) ? $this->option : JFactory::getApplication()->input->get('option')),
 			'cachebase' => ($client_id) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache'),
+			'result' => true,
 		);
 
-		/** @var JCacheControllerCallback $cache */
-		$cache = JCache::getInstance('callback', $options);
-		$cache->clean();
+		try
+		{
+			/** @var JCacheControllerCallback $cache */
+			$cache = JCache::getInstance('callback', $options);
+			$cache->clean();
+		}
+		catch (JCacheException $exception)
+		{
+			$options['result'] = false;
+		}
 
 		// Trigger the onContentCleanCache event.
 		JEventDispatcher::getInstance()->trigger($this->event_clean_cache, $options);


### PR DESCRIPTION
Partial Pull Request for Issue #13357

### Summary of Changes

Similar to #13524 this tries to make the `JModelLegacy` class resilient to cache related issues.

1. The call to clean the cache is now wrapped in a try/catch so a cache error doesn't result in something calling that method and catching exceptions treating the operation as a failure or an unhandled exception in general.

2. A new parameter is added to the arguments array for the cache clean event dispatched after this with a boolean flag indicating the result of the clean operation.

### Testing Instructions

If the cache store fails to connect or the cache configuration is bad, the exceptions thrown by the cache API should be caught and `JModelLegacy::cleanCache()` won't cause an uncaught exception from the cache API to bubble up the call stack.  When clearing the cache fails here, the event should be dispatched with the result flag being false.

### Documentation Changes Required

N/A