### PR TITLE
Make JControllerLegacy::display() resilient to cache errors

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -634,9 +634,6 @@ class JControllerLegacy extends JObject
 		{
 			$option = $this->input->get('option');
 
-			/** @var JCacheControllerView $cache */
-			$cache = JFactory::getCache($option, 'view');
-
 			if (is_array($urlparams))
 			{
 				$app = JFactory::getApplication();
@@ -659,7 +656,16 @@ class JControllerLegacy extends JObject
 				$app->registeredurlparams = $registeredurlparams;
 			}
 
-			$cache->get($view, 'display');
+			try
+			{
+				/** @var JCacheControllerView $cache */
+				$cache = JFactory::getCache($option, 'view');
+				$cache->get($view, 'display');
+			}
+			catch (JCacheException $exception)
+			{
+				$view->display();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Partial Pull Request for Issue #13357

### Summary of Changes

Similar to #13524 this tries to make the `JControllerLegacy` class resilient to cache related issues.

1. The call to display the component is wrapped in a try/catch so a cache error doesn't result in an error displaying the page, on a cache exception the view will directly be called similar to if caching isn't enabled.

### Testing Instructions

If the cache store fails to connect or the cache configuration is bad, the exceptions thrown by the cache API should be caught and `JControllerLegacy::display()` won't cause an uncaught exception from the cache API to bubble up the call stack.  When processing from the cache fails here, the view should still attempt to be displayed.

### Documentation Changes Required

N/A