### PR TITLE
Create an Exception for a missing component

### DIFF
--- a/libraries/cms/component/exception/missing.php
+++ b/libraries/cms/component/exception/missing.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Exception class defining an error for a missing component
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JComponentExceptionMissing extends InvalidArgumentException
+{
+}

--- a/libraries/cms/component/exception/missing.php
+++ b/libraries/cms/component/exception/missing.php
@@ -16,4 +16,17 @@ defined('JPATH_PLATFORM') or die;
  */
 class JComponentExceptionMissing extends InvalidArgumentException
 {
+	/**
+	 * Constructor
+	 *
+	 * @param   string     $message   The Exception message to throw.
+	 * @param   integer    $code      The Exception code.
+	 * @param   Exception  $previous  The previous exception used for the exception chaining.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($message = '', $code = 404, Exception $previous = null)
+	{
+		parent::__construct($message, $code, $previous);
+	}
 }

--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -310,7 +310,7 @@ class JComponentHelper
 	 * @return  string
 	 *
 	 * @since   1.5
-	 * @throws  Exception
+	 * @throws  JComponentExceptionMissing
 	 */
 	public static function renderComponent($option, $params = array())
 	{
@@ -324,7 +324,7 @@ class JComponentHelper
 
 		if (empty($option))
 		{
-			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
+			throw new JComponentExceptionMissing(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
 		if (JDEBUG)
@@ -363,7 +363,7 @@ class JComponentHelper
 		// If component is disabled throw error
 		if (!static::isEnabled($option) || !file_exists($path))
 		{
-			throw new Exception(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
+			throw new JComponentExceptionMissing(JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
 		}
 
 		// Load common and local language files.


### PR DESCRIPTION
### Summary of Changes

The base `Exception` class really shouldn't be thrown, it's too generic and gets caught by too many try/catch blocks.  Good practice is to use more specialized exceptions.

In `JComponentHelper::renderComponent()` an `Exception` is thrown if the component is missing (either the option parameter is empty, the component is disabled, or the entry point file doesn't exist in the filesystem).  I've created a new `JComponentExceptionMissing` class to represent this error state instead.

### Testing Instructions

A request for a non-existing or disabled component should result in a `JComponentExceptionMissing` object being thrown versus the base level `Exception`.

### Documentation Changes Required

N/A