### PR TITLE
[4.0] Change the field type of JDocumentFeed::$lastBuildDate and allow the build date to be customized

### DIFF
--- a/libraries/joomla/document/feed.php
+++ b/libraries/joomla/document/feed.php
@@ -59,9 +59,7 @@ class JDocumentFeed extends JDocument
 	/**
 	 * Lastbuild date feed element
 	 *
-	 * optional
-	 *
-	 * @var    string
+	 * @var    JDate
 	 * @since  11.1
 	 */
 	public $lastBuildDate = '';
@@ -175,6 +173,10 @@ class JDocumentFeed extends JDocument
 
 		// Set document type
 		$this->_type = 'feed';
+
+		// Gets and sets timezone offset from site configuration
+		$this->lastBuildDate = JFactory::getDate();
+		$this->lastBuildDate->setTimeZone(new DateTimeZone(JFactory::getApplication()->get('offset')));
 	}
 
 	/**

--- a/libraries/joomla/document/renderer/feed/rss.php
+++ b/libraries/joomla/document/renderer/feed/rss.php
@@ -43,12 +43,15 @@ class JDocumentRendererFeedRss extends JDocumentRenderer
 	{
 		$app = JFactory::getApplication();
 
-		// Gets and sets timezone offset from site configuration
-		$tz  = new DateTimeZone($app->get('offset'));
-		$now = JFactory::getDate();
-		$now->setTimeZone($tz);
-
 		$data = $this->_doc;
+
+		// If the last build date from the document isn't a JDate object, create one
+		if (!($data->lastBuildDate instanceof JDate))
+		{
+			// Gets and sets timezone offset from site configuration
+			$data->lastBuildDate = JFactory::getDate();
+			$data->lastBuildDate->setTimeZone(new DateTimeZone($app->get('offset')));
+		}
 
 		$url = JUri::getInstance()->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 		$syndicationURL = JRoute::_('&format=feed&type=rss');
@@ -78,7 +81,7 @@ class JDocumentRendererFeedRss extends JDocumentRenderer
 		$feed .= "		<title>" . $feed_title . "</title>\n";
 		$feed .= "		<description><![CDATA[" . $data->getDescription() . "]]></description>\n";
 		$feed .= "		<link>" . str_replace(' ', '%20', $url . $datalink) . "</link>\n";
-		$feed .= "		<lastBuildDate>" . htmlspecialchars($now->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
+		$feed .= "		<lastBuildDate>" . htmlspecialchars($data->lastBuildDate->toRFC822(true), ENT_COMPAT, 'UTF-8') . "</lastBuildDate>\n";
 		$feed .= "		<generator>" . $data->getGenerator() . "</generator>\n";
 		$feed .= "		<atom:link rel=\"self\" type=\"application/rss+xml\" href=\"" . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 


### PR DESCRIPTION
Pull Request for Issue #13008

### Summary of Changes

Within Joomla, the RSS feed's `lastBuildDate` element uses the current timestamp without a way for the timestamp to be set to a value which follows specification.  `JDocumentFeed::$lastBuildDate` can be used for this purpose.  However, right now the field is declared as a string and the renderer uses a `JDate` object.

This PR proposes a B/C break changing `JDocumentFeed::$lastBuildDate` to be a `JDate` object versus a string and changes the renderer to use this property instead of the hardcoded behavior that exists now.

### Testing Instructions

From a feed view, a developer should be able to set `JDocumentFeed::$lastBuildDate` to a `JDate` object with a timestamp of their choosing and the feed renderer use this value for the `lastBuildDate` element.

### Documentation Changes Required

Note the B/C breaking change with the `JDocumentFeed::$lastBuildDate` property.