### PR TITLE
[com_fields plugins] Clarifying some plugins descriptions

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_content_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to insert a custom field directly into the editor area."
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to render a custom field which has been entered by the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area."

--- a/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to insert a custom field directly into the editor area."
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to render a custom field which has been entered by the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.ini
@@ -5,4 +5,4 @@
 
 PLG_EDITORS-XTD_FIELDS="Button - Fields"
 PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD="Fields"
-PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a field into an item. Displays a popup allowing you to choose the field."
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."

--- a/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors-xtd_fields.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EDITORS-XTD_FIELDS="Button - Fields"
-PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a field into an item. Displays a popup allowing you to choose the field."
+PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."


### PR DESCRIPTION
While translating, I found that the new Content - Fields and editors-xtd_fields (Button - Fields) had unclear descriptions.

Changed the first one to:
`PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to render a custom field which has been entered by the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area."`

and the other one to:
`PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION="Displays a button to make it possible to insert a custom field into an editor area. Displays a popup allowing you to choose the field.<br/><strong>Warning!</strong>: the custom field will not be rendered if the <a href=\"index.php?option=com_plugins&view=plugins&filter[folder]=content\">Content - Fields</a> plugin is not enabled."`

@laoneo @Bakual 

