### PR TITLE
Deprecate OAuth client classes

### DIFF
--- a/libraries/joomla/oauth1/client.php
+++ b/libraries/joomla/oauth1/client.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for interacting with an OAuth 1.0 and 1.0a server.
  *
- * @since  13.1
+ * @since       13.1
+ * @deprecated  4.0  Use the `joomla/oauth1` package via Composer instead
  */
 abstract class JOAuth1Client
 {

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -14,7 +14,8 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Platform class for interacting with an OAuth 2.0 server.
  *
- * @since  12.3
+ * @since       12.3
+ * @deprecated  4.0  Use the `joomla/oauth2` package via Composer instead
  */
 class JOAuth2Client
 {


### PR DESCRIPTION
### Summary of Changes

With the social packages being deprecated in favor of the Framework counterparts, the `JOAuth*Client` classes no longer have a use in core.  Similarly, the 4.0 branch is now in a state where the client class dependencies can be fulfilled by CMS classes.  So, I'd like to propose deprecating these client classes in favor of consuming the Framework counterparts, similar to what has been happening with many other classes.

### Testing Instructions

Maintainer decision.

### Documentation Changes Required

The deprecation should be documented.