### PR TITLE
[AppVeyor] Unit tests fix for file cache

### DIFF
--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -181,14 +181,15 @@ class JCacheStorageFile extends JCacheStorage
 
 		if ($_fileopen)
 		{
-			$result = @fwrite($_fileopen, $data, strlen($data));
+			$length = strlen($data);
+			$result = @fwrite($_fileopen, $data, $length);
 
 			if ($close)
 			{
 				@fclose($_fileopen);
 			}
 
-			return $result !== false;
+			return $result === $length;
 		}
 
 		return false;

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -146,7 +146,17 @@ class JCacheStorageFile extends JCacheStorage
 		// Prepend a die string
 		$data = $die . $data;
 
-		$_fileopen = @fopen($path, 'wb');
+		if (isset($this->_locked_files[$path]))
+		{
+			$_fileopen = $this->_locked_files[$path];
+
+			// Because lock method uses flag c+b we have to truncate it manually
+			ftruncate($_fileopen, 0);
+		}
+		else
+		{
+			$_fileopen = @fopen($path, 'wb');
+		}
 
 		if ($_fileopen)
 		{

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -160,13 +160,10 @@ class JCacheStorageFile extends JCacheStorage
 
 		if ($_fileopen)
 		{
-			$len = strlen($data);
-			@fwrite($_fileopen, $data, $len);
-			$written = true;
+			return @fwrite($_fileopen, $data, strlen($data)) !== false;
 		}
 
-		// Data integrity check
-		return $written && ($data == file_get_contents($path));
+		return false;
 	}
 
 	/**

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -75,23 +75,32 @@ class JCacheStorageFile extends JCacheStorage
 	 */
 	public function get($id, $group, $checkTime = true)
 	{
-		$data = false;
 		$path = $this->_getFilePath($id, $group);
 
 		if ($checkTime == false || ($checkTime == true && $this->_checkExpire($id, $group) === true))
 		{
 			if (file_exists($path))
 			{
-				$data = file_get_contents($path);
-
-				if ($data)
+				if (isset($this->_locked_files[$path]))
 				{
-					// Remove the initial die() statement
-					$data = str_replace('<?php die("Access Denied"); ?>#x#', '', $data);
+					$_fileopen = $this->_locked_files[$path];
+				}
+				else
+				{
+					$_fileopen = @fopen($path, 'rb');
+				}
+
+				if ($_fileopen)
+				{
+					$data = stream_get_contents($_fileopen);
+
+					if ($data !== false)
+					{
+						// Remove the initial die() statement
+						return str_replace('<?php die("Access Denied"); ?>#x#', '', $data);
+					}
 				}
 			}
-
-			return $data;
 		}
 
 		return false;

--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -173,7 +173,7 @@ abstract class TestCaseCache extends TestCase
 		$secondGroup = 'group2';
 
 		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
-		$this->assertTrue($this->handler->store($secondId, $data, $secondGroup), 'Initial Store Failed');
+		$this->assertTrue($this->handler->store($secondId, $secondGroup, $data), 'Initial Store Failed');
 		$this->assertTrue($this->handler->clean($this->group, 'notgroup'), 'Removal Failed');
 		$this->assertSame($this->handler->get($this->id, $this->group), $data, 'Data in the group specified in JCacheStorage::clean() should still exist');
 		$this->assertFalse($this->handler->get($secondId, $secondGroup), 'Data in the groups not specified in JCacheStorage::clean() should not exist');
@@ -193,12 +193,10 @@ abstract class TestCaseCache extends TestCase
 	 */
 	public function testCacheLock()
 	{
-		$returning             = new stdClass;
-		$returning->locklooped = false;
-		$returning->locked     = true;
-
-		$expected = $this->logicalOr($this->equalTo($returning), $this->isFalse());
-		$result   = $this->handler->lock($this->id, $this->group, 3);
+		$returning = (object) array('locklooped' => false, 'locked' => true);
+		$expected  = $this->logicalOr($this->equalTo($returning), $this->isFalse());
+		$result    = $this->handler->lock($this->id, $this->group, 3);
+		$data      = 'testData';
 
 		$this->assertThat($result, $expected, 'Initial Lock Failed');
 
@@ -213,6 +211,9 @@ abstract class TestCaseCache extends TestCase
 
 			$this->assertEquals($returning, $this->handler->lock($this->id, $this->group, 3), 'Re-attempt Lock Failed');
 		}
+
+		// Checks whether I can store the file locked by myself (see flock on Windows system)
+		$this->assertTrue($this->handler->store($this->id, $this->group, $data), 'Initial Store Failed');
 
 		if ($result === false)
 		{
@@ -230,5 +231,8 @@ abstract class TestCaseCache extends TestCase
 		}
 
 		$this->assertEquals($returning, $this->handler->lock($this->id, $this->group, 3), 'Second Lock Failed');
+
+		// Checks whether I can read the file locked by myself (see flock on Windows system)
+		$this->assertSame('testData', $this->handler->get($this->id, $this->group), 'Failed retrieving data from the cache store');
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Fix unit test in cache tests.
Change file cache handler methods `get` and `store` to work on Windows system too.

On Windows system `flock` works different. It locks other methods from read/write on the same file in the same process. 

Example:
```
$f = fopen('filename.txt', 'rb');
flock($f, LOCK_EX|LOCK_NB);
$content = stream_get_contents($f);
$content2 = file_get_contents('filename.txt'); // <- on Windows it will fail, but on linux it works
```

See http://php.net/manual/en/function.flock.php
> flock() uses mandatory locking instead of advisory locking on Windows.

### Testing Instructions
Code review 
or standard test to check whether joomla create cache files. 

Cache should works as before on linux system. 
On windows it start to work after patch applied.

### Expected result
App veyor success with cache tests

### Actual result
App veyor failed with cache tests

### Documentation Changes Required
No