### PR TITLE
Proxy call for fields modal to backend files

### DIFF
--- a/components/com_fields/controller.php
+++ b/components/com_fields/controller.php
@@ -15,4 +15,29 @@ defined('_JEXEC') or die;
  */
 class FieldsController extends JControllerLegacy
 {
+	/**
+	 * Constructor.
+	 *
+	 * @param   array  $config  An optional associative array of configuration settings.
+	 *                          Recognized key values include 'name', 'default_task', 'model_path', and
+	 *                          'view_path' (this list is not meant to be comprehensive).
+	 *
+	 * @since   3.5
+	 */
+	public function __construct($config = array())
+	{
+		$this->input = JFactory::getApplication()->input;
+
+		// Frontpage Editor Fields Button proxying:
+		if ($this->input->get('view') === 'fields' && $this->input->get('layout') === 'modal')
+		{
+			// Load the backend language file.
+			$lang = JFactory::getLanguage();
+			$lang->load('com_fields', JPATH_ADMINISTRATOR);
+
+			$config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
+		}
+
+		parent::__construct($config);
+	}
 }

--- a/components/com_fields/controller.php
+++ b/components/com_fields/controller.php
@@ -22,7 +22,7 @@ class FieldsController extends JControllerLegacy
 	 *                          Recognized key values include 'name', 'default_task', 'model_path', and
 	 *                          'view_path' (this list is not meant to be comprehensive).
 	 *
-	 * @since   3.5
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct($config = array())
 	{

--- a/components/com_fields/models/forms/filter_fields.xml
+++ b/components/com_fields/models/forms/filter_fields.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fieldset name="group"
+		addfieldpath="/administrator/components/com_fields/models/fields">
+		<field
+			name="context"
+			type="fieldcontexts"
+			onchange="this.form.submit();"
+		/>
+	</fieldset>
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			label=""
+			hint="JSEARCH_FILTER"
+			class="js-stools-search-string"
+		/>
+
+		<field
+			name="state"
+			type="status"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+
+		<field
+			name="group_id"
+			type="fieldgroups"
+			state="0,1,2"
+			onchange="this.form.submit();"
+			>
+			<option value="">COM_FIELDS_VIEW_FIELDS_SELECT_GROUP</option>
+		</field>
+
+		<field
+			name="assigned_cat_ids"
+			type="category"
+			onchange="this.form.submit();"
+			>
+			<option value="">COM_FIELDS_VIEW_FIELDS_SELECT_CATEGORY</option>
+		</field>
+
+		<field
+			name="access"
+			type="accesslevel"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_ACCESS</option>
+		</field>
+
+		<field
+			name="language"
+			type="contentlanguage"
+			onchange="this.form.submit();"
+		>
+			<option value="">JOPTION_SELECT_LANGUAGE</option>
+		</field>
+	</fields>
+
+	<fields name="list">
+		<field
+			name="fullordering"
+			type="list"
+			label="JGLOBAL_SORT_BY"
+			statuses="*,0,1,2,-2"
+			description="JGLOBAL_SORT_BY"
+			onchange="this.form.submit();"
+			default="a.ordering ASC"
+		>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.state ASC">JSTATUS_ASC</option>
+			<option value="a.state DESC">JSTATUS_DESC</option>
+			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.type ASC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_ASC</option>
+			<option value="a.type DESC">COM_FIELDS_VIEW_FIELDS_SORT_TYPE_DESC</option>
+			<option value="category_title ASC">COM_FIELDS_FIELD_GROUP_LABEL</option>
+			<option value="category_title DESC">COM_FIELDS_FIELD_GROUP_LABEL</option>
+			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
+			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
+			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
+
+		<field
+			name="limit"
+			type="limitbox"
+			class="input-mini"
+			default="25"
+			label="COM_FIELDS_LIST_LIMIT" description="COM_FIELDS_LIST_LIMIT_DESC"
+			onchange="this.form.submit();"
+		/>
+	</fields>
+</form>

--- a/components/com_fields/models/forms/filter_fields.xml
+++ b/components/com_fields/models/forms/filter_fields.xml
@@ -30,7 +30,7 @@
 			type="fieldgroups"
 			state="0,1,2"
 			onchange="this.form.submit();"
-			>
+		>
 			<option value="">COM_FIELDS_VIEW_FIELDS_SELECT_GROUP</option>
 		</field>
 
@@ -38,7 +38,7 @@
 			name="assigned_cat_ids"
 			type="category"
 			onchange="this.form.submit();"
-			>
+		>
 			<option value="">COM_FIELDS_VIEW_FIELDS_SELECT_CATEGORY</option>
 		</field>
 
@@ -93,7 +93,8 @@
 			type="limitbox"
 			class="input-mini"
 			default="25"
-			label="COM_FIELDS_LIST_LIMIT" description="COM_FIELDS_LIST_LIMIT_DESC"
+			label="COM_FIELDS_LIST_LIMIT"
+			description="COM_FIELDS_LIST_LIMIT_DESC"
 			onchange="this.form.submit();"
 		/>
 	</fields>


### PR DESCRIPTION
Pull Request for Issue #13947.

### Summary of Changes
Adds a proxy for the fields modal that is used by the editor button

### Testing Instructions
Test the "Fields" editor button. If you get a modal and can insert a field or fieldgroup, then this works.

### Expected result
Button opens a modal with a list of fields

### Actual result
Button opens a modal with an error message

### Documentation Changes Required
None