### PR TITLE
Fix showing user fields in a contact

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -177,8 +177,8 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
-		$user = JFactory::getUser($userData['id']);
-		$user->params = (string) $user->getParameters();
+		$userData['params'] = json_decode($userData['params'], true);
+		$user               = JFactory::getUser($userData['id']);
 
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);


### PR DESCRIPTION
Currently, fields specified in a user don't show up in the contact if the user is assigned to that contact. The Fieldgroup sliders appear, but no fields within it.

### Summary of Changes
This PR changes the `$userData['params']` from a JSON string to the array we expect in the onContentAfterSave method.

### Testing Instructions
* Create some user fields and save some values into it.
* Create a contact and assign the user with the save fields to it.
* Check out the contact in frontend.

### Expected result
Get the sliders for each fieldgroup filled with the saved fields.

### Actual result
Only get the sliders without any fields in it.

### Documentation Changes Required
None