### PR TITLE
New font for CodeMirror: Overpass Mono

### DIFF
--- a/plugins/editors/codemirror/fonts.json
+++ b/plugins/editors/codemirror/fonts.json
@@ -39,6 +39,11 @@
 		"url": "//fonts.googleapis.com/css?family=Nova+Mono",
 		"css": "'Nova Mono', monospace"
 	},
+	"overpass_mono": {
+		"name": "Overpass Mono",
+		"url": "//fonts.googleapis.com/css?family=Overpass+Mono",
+		"css": "'Overpass Mono', monospace"
+	},
 	"oxygen_mono": {
 		"name": "Oxygen Mono",
 		"url": "//fonts.googleapis.com/css?family=Oxygen+Mono",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
New font, y'all!

### Testing Instructions
Go to the plugin settings for CodeMirror, look in the Appearance tab and change the font. The new one is called "Overpass Mono". Save and it will be used in all instances of the CodeMirror editor. 

### Expected result

### Actual result

### Documentation Changes Required
