### PR TITLE
Fixes incorrect background colour of icons in coloured toolbar buttons

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7521,11 +7521,21 @@ body .navbar-fixed-top {
 	border-color: rgba(0,0,0,0.2);
 	box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
-#toolbar .btn-success:hover {
-	background-color: #378137;
+#toolbar .btn-success {
+	width: 148px;
 }
+#toolbar .btn-primary [class^="icon-"],
+#toolbar .btn-primary [class*=" icon-"],
+#toolbar .btn-warning [class^="icon-"],
+#toolbar .btn-warning [class*=" icon-"],
+#toolbar .btn-danger [class^="icon-"],
+#toolbar .btn-danger [class*=" icon-"],
 #toolbar .btn-success [class^="icon-"],
-#toolbar .btn-success [class*=" icon-"] {
+#toolbar .btn-success [class*=" icon-"],
+#toolbar .btn-info [class^="icon-"],
+#toolbar .btn-info [class*=" icon-"],
+#toolbar .btn-inverse [class^="icon-"],
+#toolbar .btn-inverse [class*=" icon-"] {
 	background-color: transparent;
 	border-right: 0;
 	border-left: 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7517,15 +7517,19 @@ body .navbar-fixed-top {
 }
 #toolbar .btn-success {
 	width: 148px;
-	border-color: #2384d3;
-	border-color: rgba(0,0,0,0.2);
-	box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
-#toolbar .btn-success:hover {
-	background-color: #378137;
-}
+#toolbar .btn-primary [class^="icon-"],
+#toolbar .btn-primary [class*=" icon-"],
+#toolbar .btn-warning [class^="icon-"],
+#toolbar .btn-warning [class*=" icon-"],
+#toolbar .btn-danger [class^="icon-"],
+#toolbar .btn-danger [class*=" icon-"],
 #toolbar .btn-success [class^="icon-"],
-#toolbar .btn-success [class*=" icon-"] {
+#toolbar .btn-success [class*=" icon-"],
+#toolbar .btn-info [class^="icon-"],
+#toolbar .btn-info [class*=" icon-"],
+#toolbar .btn-inverse [class^="icon-"],
+#toolbar .btn-inverse [class*=" icon-"] {
 	background-color: transparent;
 	border-right: 0;
 	border-left: 0;

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -489,12 +489,13 @@ body .navbar-fixed-top {
 	}
 	.btn-success {
 		width: 148px;
-		border-color: @btnPrimaryBackground;
-		border-color: rgba(0, 0, 0, 0.2);
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-		&:hover {
-			background-color: #378137;
-		}
+	}
+	.btn-primary,
+	.btn-warning,
+	.btn-danger,
+	.btn-success,
+	.btn-info,
+	.btn-inverse {
 		[class^="icon-"], [class*=" icon-"] {
 			background-color: transparent;
 			border-right: 0;


### PR DESCRIPTION
This fixes the faulty grey background colour of coloured buttons in the toolbar.

For instance if you have a button with class `btn-primary`:

Before:
![](http://regl.io/i/vrtwe.png)

After:
![](http://regl.io/i/6qubl.png)
