### PR TITLE
Add a reset head data function to JDocument

### DIFF
--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -146,6 +146,76 @@ class JDocumentHtml extends JDocument
 	}
 
 	/**
+	 * Reset the HTML document head data
+	 *
+	 * @param   mixed  $types  type or types of the heads elements to reset
+	 *
+	 * @return  JDocumentHTML  instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function resetHeadData($types = null)
+	{
+		if (is_null($types))
+		{
+			$this->title        = '';
+			$this->description  = '';
+			$this->link         = '';
+			$this->_metaTags    = array();
+			$this->_links       = array();
+			$this->_styleSheets = array();
+			$this->_style       = array();
+			$this->_scripts     = array();
+			$this->_script      = array();
+			$this->_custom      = array();
+		}
+
+		if (is_array($types))
+		{
+			foreach ($types as $type)
+			{
+				$this->resetHeadDatum($type);
+			}
+		}
+
+		if (is_string($types))
+		{
+			$this->resetHeadDatum($types);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Reset a part the HTML document head data
+	 *
+	 * @param   string  $type  type of the heads elements to reset
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function resetHeadDatum($type)
+	{
+		switch ($type)
+		{
+			case 'title':
+			case 'description':
+			case 'link':
+				$this->{$type} = '';
+
+			case '_metaTags':
+			case '_links':
+			case '_styleSheets':
+			case '_style':
+			case '_scripts':
+			case '_script':
+			case '_custom':
+				$this->{$type} = array();
+		}
+	}
+
+	/**
 	 * Set the HTML document head data
 	 *
 	 * @param   array  $data  The document head data in array form

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -204,14 +204,15 @@ class JDocumentHtml extends JDocument
 			case 'link':
 				$this->{$type} = '';
 
-			case '_metaTags':
-			case '_links':
-			case '_styleSheets':
-			case '_style':
-			case '_scripts':
-			case '_script':
-			case '_custom':
-				$this->{$type} = array();
+			case 'metaTags':
+			case 'links':
+			case 'styleSheets':
+			case 'style':
+			case 'scripts':
+			case 'script':
+			case 'custom':
+				$realType = '_' . $type;
+				$this->{$realType} = array();
 		}
 	}
 

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -203,6 +203,7 @@ class JDocumentHtml extends JDocument
 			case 'description':
 			case 'link':
 				$this->{$type} = '';
+				break;
 
 			case 'metaTags':
 			case 'links':
@@ -213,6 +214,7 @@ class JDocumentHtml extends JDocument
 			case 'custom':
 				$realType = '_' . $type;
 				$this->{$realType} = array();
+				break;
 		}
 	}
 


### PR DESCRIPTION
### Summary of Changes

If you are using another framework/version as the joomla core is using, it is sometimes needed to change the head data or set them to empty. In such situations people often  accessing the private property of the JDocument Object (its not really a private property it just starts with a "_" what **means** it is private). This PR adds a function to reset certain parts of the head data.
 
### Testing Instructions

You can use that in your template (Hello Templates clubs :-))

Add a JFactory::getDocument()->resetHeadData('scripts');

### Expected result

All Javascript loaded before should now not be loaded

### Documentation Changes Required

API and release notes