### PR TITLE
Fixes issue with login message in incorrect language

### DIFF
--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -117,7 +117,7 @@ class JApplicationAdministrator extends JApplicationCms
 		$options    = array('language' => $login_lang ?: $this->getUserState('application.lang'));
 
 		// Initialise the application
-		$this->initialiseApp($option);
+		$this->initialiseApp($options);
 
 		// Test for magic quotes
 		if (get_magic_quotes_gpc())

--- a/libraries/cms/application/administrator.php
+++ b/libraries/cms/application/administrator.php
@@ -112,8 +112,12 @@ class JApplicationAdministrator extends JApplicationCms
 	 */
 	protected function doExecute()
 	{
+		// Get the language from the (login) form or user state
+		$login_lang = ($this->input->get('option') == 'com_login') ? $this->input->get('lang') : '';
+		$options    = array('language' => $login_lang ?: $this->getUserState('application.lang'));
+
 		// Initialise the application
-		$this->initialiseApp(array('language' => $this->getUserState('application.lang')));
+		$this->initialiseApp($option);
 
 		// Test for magic quotes
 		if (get_magic_quotes_gpc())


### PR DESCRIPTION
This fixes the issue with the login message not being displayed in selected language (admin).

You can easily test this by trying to log in (in the Administrator) on a multilingual site - using an incorrect password.
For instance, on a setup that has English (default) and Arabic installed.

After trying to log in with Arabic selected as login language, you will get a failed-login message in English.
If you then se the language selection to English and log in again with an incorrect password, you see the message in Arabic.
Not good!

This PR fixes this issue and sets the correct language (based ion what you have selected in the login form) before that error message is generated.