### PR TITLE
[Isis] Template menu assignment columns

### DIFF
--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -24,7 +24,7 @@ $user      = JFactory::getUser();
 	<ul class="menu-links">
 
 		<?php foreach ($menuTypes as &$type) : ?>
-			<li class="span3">
+			<li>
 				<div class="menu-links-block">
 					<button class="btn" type="button" class="jform-rightbtn" onclick="jQuery('.<?php echo $type->menutype; ?>').attr('checked', !jQuery('.<?php echo $type->menutype; ?>').attr('checked'));">
 						<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7517,12 +7517,6 @@ body .navbar-fixed-top {
 }
 #toolbar .btn-success {
 	width: 148px;
-	border-color: #2384d3;
-	border-color: rgba(0,0,0,0.2);
-	box-shadow: 0 1px 2px rgba(0,0,0,0.05);
-}
-#toolbar .btn-success {
-	width: 148px;
 }
 #toolbar .btn-primary [class^="icon-"],
 #toolbar .btn-primary [class*=" icon-"],
@@ -8925,8 +8919,26 @@ textarea.noResize {
 .hero-unit .lead {
 	font-weight: 400;
 }
+#menu-assignment {
+	position: relative;
+}
 #menu-assignment .menu-links {
+	margin-top: 15px;
 	margin-left: 0;
+	-webkit-column-count: 3;
+	-moz-column-count: 3;
+	column-count: 3;
+	-moz-column-gap: 15px;
+	-webkit-column-gap: 15px;
+	column-gap: 15px;
+}
+#menu-assignment .menu-links > li {
+	display: inline-block;
+	vertical-align: top;
+	margin-bottom: 15px;
+	width: 100%;
+	-webkit-column-break-inside: avoid;
+	-webkit-backface-visibility: hidden;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8937,6 +8937,7 @@ textarea.noResize {
 	vertical-align: top;
 	margin-bottom: 15px;
 	width: 100%;
+	list-style: none;
 	-webkit-column-break-inside: avoid;
 	-webkit-backface-visibility: hidden;
 }
@@ -8945,6 +8946,13 @@ textarea.noResize {
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+@media (max-width: 767px) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: auto;
+		-moz-column-count: auto;
+		column-count: auto;
+	}
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8919,8 +8919,26 @@ textarea.noResize {
 .hero-unit .lead {
 	font-weight: 400;
 }
+#menu-assignment {
+	position: relative;
+}
 #menu-assignment .menu-links {
+	margin-top: 15px;
 	margin-left: 0;
+	-webkit-column-count: 3;
+	-moz-column-count: 3;
+	column-count: 3;
+	-moz-column-gap: 15px;
+	-webkit-column-gap: 15px;
+	column-gap: 15px;
+}
+#menu-assignment .menu-links > li {
+	display: inline-block;
+	vertical-align: top;
+	margin-bottom: 15px;
+	width: 100%;
+	-webkit-column-break-inside: avoid;
+	-webkit-backface-visibility: hidden;
 }
 #menu-assignment .menu-links-block {
 	background-color: #fafafa;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8937,6 +8937,7 @@ textarea.noResize {
 	vertical-align: top;
 	margin-bottom: 15px;
 	width: 100%;
+	list-style: none;
 	-webkit-column-break-inside: avoid;
 	-webkit-backface-visibility: hidden;
 }
@@ -8945,6 +8946,13 @@ textarea.noResize {
 	border: 1px solid #ddd;
 	border-radius: 3px;
 	padding: 15px;
+}
+@media (max-width: 767px) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: auto;
+		-moz-column-count: auto;
+		column-count: auto;
+	}
 }
 .controls > .radio:first-child,
 .controls > .checkbox:first-child {

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1974,6 +1974,7 @@ textarea.noResize {
 			vertical-align: top;
 			margin-bottom: 15px;
 			width: 100%;
+			list-style: none;
 			-webkit-column-break-inside: avoid;
 			-webkit-backface-visibility: hidden;	
 		}
@@ -1983,6 +1984,13 @@ textarea.noResize {
 	    border: 1px solid #ddd;
 	    border-radius: 3px;
 	    padding: 15px;
+	}
+}
+@media (max-width: 767px) {
+	#menu-assignment .menu-links {
+		-webkit-column-count: auto;
+		-moz-column-count: auto;
+		column-count: auto;
 	}
 }
 

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1959,8 +1959,24 @@ textarea.noResize {
 
 /* Template Menu Assignment */
 #menu-assignment {
+	position: relative;
 	.menu-links {
+		margin-top: 15px;
 		margin-left: 0;
+		-webkit-column-count: 3;
+		-moz-column-count: 3;
+		column-count: 3;
+		-moz-column-gap: 15px;
+		-webkit-column-gap: 15px;
+		column-gap: 15px;
+		> li {
+			display: inline-block;
+			vertical-align: top;
+			margin-bottom: 15px;
+			width: 100%;
+			-webkit-column-break-inside: avoid;
+			-webkit-backface-visibility: hidden;	
+		}
 	}
 	.menu-links-block {
 		background-color: #fafafa;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The template styles menu assignment tab uses span3 for each block. As these blocks can exceed 4 spans, this can give unpredicable results. This PR proposes using column-count instead. For the 2.5% of browsers not supporting column-count, blocks will appear in a single column.

### Testing Instructions
Apply patch and navigate to the 'Menu Assignment' tab of a template style.

### Before PR
![menu-assign1](https://cloud.githubusercontent.com/assets/2803503/22739034/c9c65812-ee01-11e6-9288-28a84855f44c.png)

### After PR
![menu-assign2](https://cloud.githubusercontent.com/assets/2803503/22739040/cd85e4b8-ee01-11e6-9ee8-50963e669c0c.png)

### Documentation Changes Required
None