### PR TITLE
Catch date format errors

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1298,7 +1298,16 @@ class JForm
 					$offset = JFactory::getConfig()->get('offset');
 
 					// Return an SQL formatted datetime string in UTC.
-					$return = JFactory::getDate($value, $offset)->toSql();
+					try
+					{
+						$return = JFactory::getDate($value, $offset)->toSql();
+					}
+					catch (Exception $e)
+					{
+						JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', JText::_((string) $element['label'])), 'warning');
+
+						$return = '';
+					}
 				}
 				else
 				{
@@ -1331,7 +1340,16 @@ class JForm
 					$offset = JFactory::getUser()->getParam('timezone', JFactory::getConfig()->get('offset'));
 
 					// Return a MySQL formatted datetime string in UTC.
-					$return = JFactory::getDate($value, $offset)->toSql();
+					try
+					{
+						$return = JFactory::getDate($value, $offset)->toSql();
+					}
+					catch (Exception $e)
+					{
+						JFactory::getApplication()->enqueueMessage(JText::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', JText::_((string) $element['label'])), 'warning');
+
+						$return = '';
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Pull Request for Issue #13962.

This is only a partial solution for the issue raised.

### Summary of Changes
This PR catches the exception which may be thrown by `JFactory::getDate` when the value isn't a proper date. If catched, it will show a generic message "Invalid Field: Fieldname".

This is just to prevent a big error page. Ideally we would have a formfield rule which will stop the saving process and show the fautly field. This PR doesn't do that, it just makes sure the filtering doesn't generate a big errror when it fails.

### Testing Instructions
Edit an article and enter into a calendar filed (eg "Created Date") a date with wrong value. Eg use  "1.5.1975" which will trigger the error.

### Expected result
Should show a warning that the date is wrong but keep the page functional.
![warning](https://cloud.githubusercontent.com/assets/1018684/22746499/2c993f46-ee24-11e6-8941-ae57bea5f8a7.PNG)

### Actual result
Will show a big error
![error](https://cloud.githubusercontent.com/assets/1018684/22746395/dd559880-ee23-11e6-845e-0adf8bd87274.PNG)

### Documentation Changes Required
None