### PR TITLE
Allow to clear messages after receiving them

### DIFF
--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -453,7 +453,7 @@ class JApplicationCms extends JApplicationWeb
 	/**
 	 * Get the system message queue.
 	 *
-	 * @param   boolean  $clear     Clear the messages currently attached to the application object
+	 * @param   boolean  $clear  Clear the messages currently attached to the application object
 	 *
 	 * @return  array  The system message queue.
 	 *

--- a/libraries/cms/application/cms.php
+++ b/libraries/cms/application/cms.php
@@ -453,11 +453,13 @@ class JApplicationCms extends JApplicationWeb
 	/**
 	 * Get the system message queue.
 	 *
+	 * @param   boolean  $clear     Clear the messages currently attached to the application object
+	 *
 	 * @return  array  The system message queue.
 	 *
 	 * @since   3.2
 	 */
-	public function getMessageQueue()
+	public function getMessageQueue($clear = false)
 	{
 		// For empty queue, if messages exists in the session, enqueue them.
 		if (!count($this->_messageQueue))
@@ -471,8 +473,15 @@ class JApplicationCms extends JApplicationWeb
 				$session->set('application.queue', null);
 			}
 		}
+		
+		$messageQueue = $this->_messageQueue;
+		
+		if ($clear)
+		{
+			$this->_messageQueue = array();
+		}
 
-		return $this->_messageQueue;
+		return $messageQueue;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
At the moment, the JApplicationCms class allows us to retrive all messages attached to the object via ```$app->getMessageQueue()```. This method clears the messages from the session, so we'll get no duplicates (what is great), but the methods also attach/keeps the messages itself. So after a redirect all the messages will be outputted again. (https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/application/cms.php#L1052).

This is very unhandy, if you want to change the error messages, like (as easy example):

```
$app = JFactory::getApplication();

$messages = $app->getMessageQueue();

foreach ($messages as $message)
{
    $app->enqueueMessage('Prefix: ' . $message['message'], $message['type']);
}
```
The complex picture where this could appear is:

- You have an profile plugin with an ```onUserBeforeSave``` and an ```onContentPrepareForm``` event.
- The ```onContentPrepareForm``` extends the user profile form with a image upload
- The ```onUserBeforeSave``` validates the file with the JMediaHelper class

The problem is now: if an error raises in the JHelperMedia class (https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/helper/media.php), it will use ```$app->enqueMessage(...)``` to "communicate" this errors (e.g. https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/helper/media.php#L59). The profile saving method looks for errors in the user model and attach a prefix (https://github.com/joomla/joomla-cms/blob/staging/components/com_users/controllers/profile.php#L162), so any plugin has to raise/throw it's own errors to interact with this call (https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/user/user.php#L786).

So the way is:
1. Let JHelperMedia validate the file
2. Check ```$app->getMessageQueue()```  for existing errors and throw them
3. The user object catchs them and gives them to the model/controller, which attach it as prefix
4. The error will be outputted (what is OK)
5. the "old" error will also be outputted (what is very annoying)

Solution: see this patch. An additional parameter which clears the application message queue and prevent double output.

### Testing Instructions
Call somewhere
```
$app = JFactory::getApplication();
$app->enqueueMessage('Foo', 'notice');
$app->getMessageQueue(true);
$app->redirect(JRoute::_('index.php'));
```

### Expected result (After patch)
The message does not appear

### Actual result (Before patch)
The message appears
### Documentation Changes Required
