### PR TITLE
Don't display feed if category id missing or non existent

### DIFF
--- a/libraries/legacy/view/categoryfeed.php
+++ b/libraries/legacy/view/categoryfeed.php
@@ -67,6 +67,12 @@ class JViewCategoryfeed extends JViewLegacy
 		$items    = $this->get('Items');
 		$category = $this->get('Category');
 
+		// Don't display feed if category id missing or non existent
+		if ($category == false || $category->alias == "root")
+		{
+			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
+		}
+
 		foreach ($items as $item)
 		{
 			$this->reconcileNames($item);


### PR DESCRIPTION
Pull Request for Issue #13976 .

### Summary of Changes
Added an additional check to check if a valid category ID has been supplied.

### Testing Instructions
Open index.php?option=com_content&view=category&id=&format=feed on a Joomla site of your choice.

### Expected result
404 / error message because no category ID has been given in the URL, see the error message for format=html

### Actual result
A feed of all content items.