### PR TITLE
[4.0] Remove state assignment as it is done already in the base class

### DIFF
--- a/administrator/components/com_installer/views/database/view.html.php
+++ b/administrator/components/com_installer/views/database/view.html.php
@@ -33,17 +33,16 @@ class InstallerViewDatabase extends InstallerViewDefault
 		$app = JFactory::getApplication();
 
 		// Get data from the model.
-		$this->state = $this->get('State');
-		$this->changeSet = $this->get('Items');
-		$this->errors = $this->changeSet->check();
-		$this->results = $this->changeSet->getStatus();
+		$this->changeSet     = $this->get('Items');
+		$this->errors        = $this->changeSet->check();
+		$this->results       = $this->changeSet->getStatus();
 		$this->schemaVersion = $this->get('SchemaVersion');
 		$this->updateVersion = $this->get('UpdateVersion');
 		$this->filterParams  = $this->get('DefaultTextFilters');
 		$this->schemaVersion = ($this->schemaVersion) ?  $this->schemaVersion : JText::_('JNONE');
 		$this->updateVersion = ($this->updateVersion) ?  $this->updateVersion : JText::_('JNONE');
-		$this->pagination = $this->get('Pagination');
-		$this->errorCount = count($this->errors);
+		$this->pagination    = $this->get('Pagination');
+		$this->errorCount    = count($this->errors);
 
 		if ($this->schemaVersion != $this->changeSet->getSchema())
 		{

--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -36,7 +36,6 @@ class InstallerViewDiscover extends InstallerViewDefault
 		}
 
 		// Get data from the model.
-		$this->state         = $this->get('State');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');
 		$this->filterForm    = $this->get('FilterForm');

--- a/administrator/components/com_installer/views/install/view.html.php
+++ b/administrator/components/com_installer/views/install/view.html.php
@@ -29,12 +29,10 @@ class InstallerViewInstall extends InstallerViewDefault
 	 */
 	public function display($tpl = null)
 	{
-		$paths = new stdClass;
+		$paths        = new stdClass;
 		$paths->first = '';
-		$state = $this->get('state');
 
-		$this->paths = &$paths;
-		$this->state = &$state;
+		$this->paths  = &$paths;
 
 		$this->showJedAndWebInstaller = JComponentHelper::getParams('com_installer')->get('show_jed_info', 1);
 

--- a/administrator/components/com_installer/views/languages/view.html.php
+++ b/administrator/components/com_installer/views/languages/view.html.php
@@ -29,11 +29,6 @@ class InstallerViewLanguages extends InstallerViewDefault
 	protected $pagination;
 
 	/**
-	 * @var object model state
-	 */
-	protected $state;
-
-	/**
 	 * Display the view.
 	 *
 	 * @param   null  $tpl  template to display
@@ -43,7 +38,6 @@ class InstallerViewLanguages extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state         = $this->get('State');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');
 		$this->filterForm    = $this->get('FilterForm');

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -24,8 +24,6 @@ class InstallerViewManage extends InstallerViewDefault
 
 	protected $form;
 
-	protected $state;
-
 	/**
 	 * Display the view.
 	 *
@@ -38,7 +36,6 @@ class InstallerViewManage extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state         = $this->get('State');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');
 		$this->filterForm    = $this->get('FilterForm');

--- a/administrator/components/com_installer/views/update/view.html.php
+++ b/administrator/components/com_installer/views/update/view.html.php
@@ -26,13 +26,6 @@ class InstallerViewUpdate extends InstallerViewDefault
 	protected $items;
 
 	/**
-	 * Model state object.
-	 *
-	 * @var  object
-	 */
-	public $state;
-
-	/**
 	 * List pagination.
 	 *
 	 * @var JPagination
@@ -51,13 +44,12 @@ class InstallerViewUpdate extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model.
-		$this->state         = $this->get('State');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 
-		$paths = new stdClass;
+		$paths        = new stdClass;
 		$paths->first = '';
 
 		$this->paths = &$paths;

--- a/administrator/components/com_installer/views/updatesites/view.html.php
+++ b/administrator/components/com_installer/views/updatesites/view.html.php
@@ -26,8 +26,6 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 
 	protected $form;
 
-	protected $state;
-
 	/**
 	 * Display the view
 	 *
@@ -42,7 +40,6 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 	public function display($tpl = null)
 	{
 		// Get data from the model
-		$this->state         = $this->get('State');
 		$this->items         = $this->get('Items');
 		$this->pagination    = $this->get('Pagination');
 		$this->filterForm    = $this->get('FilterForm');


### PR DESCRIPTION
As with PR #12173 the state variable is fetched in the base class it is not needed to do it again in the subclasses.
Additionally some code style is applied.