### PR TITLE
[J4.0] Add meta theme colour for Android chrome

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -59,6 +59,7 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 </head>
 

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -59,6 +59,7 @@ $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<?php // TO-DO: sync with _variables.scss ?>
 	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 </head>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -53,14 +53,15 @@ $hidden      = $app->input->get('hidemainmenu');
 $logoLg      = $this->baseurl . '/templates/' . $this->template . '/images/logo.svg';
 $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-icon.svg';
 
+// Set some meta data
+$doc->setMetaData('viewport', 'width=device-width, initial-scale=1');
+// @TODO sync with _variables.scss
+$doc->setMetaData('theme-color', '#1c3d5c');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<?php // TO-DO: sync with _variables.scss ?>
-	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 </head>
 

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -51,6 +51,7 @@ $sitename = $app->get('sitename');
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<?php // TO-DO: sync with _variables.scss ?>
 	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 	<style>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -45,14 +45,15 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
+// Set some meta data
+$doc->setMetaData('viewport', 'width=device-width, initial-scale=1');
+// @TODO sync with _variables.scss
+$doc->setMetaData('theme-color', '#1c3d5c');
+
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<?php // TO-DO: sync with _variables.scss ?>
-	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 	<style>
 		.login-initial {

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -51,6 +51,7 @@ $sitename = $app->get('sitename');
 <head>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="theme-color" content="#1c3d5c" />
 	<jdoc:include type="head" />
 	<style>
 		.login-initial {

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -87,7 +87,7 @@ $sitename = $app->get('sitename');
 			</noscript>
 			<?php // Begin Content ?>
 			<div id="element-box" class="login card card-block">
-				<h2 class="text-center m-t-1 m-b-2"><?php echo JText::_('MOD_LOGIN_LOGIN'); ?></h2>
+				<h2 class="text-center mt-1 mb-2"><?php echo JText::_('MOD_LOGIN_LOGIN'); ?></h2>
 				<jdoc:include type="message" />
 				<jdoc:include type="component" />
 			</div>


### PR DESCRIPTION
### Summary of Changes

Just a small but nice addition that adds a theme colour to the Atum template on Chrome (Android)

### Testing Instructions

- apply patch
- visit site in Chrome on an Android device
- Ensure the theme colour is blue (`#1c3d5c`)

### Expected result

This is just sample image of what is would look like

![theme-color](https://cloud.githubusercontent.com/assets/2019801/22785910/2901c830-eece-11e6-8ab9-821f0eb359b9.png)

