### PR TITLE
Allow og metas through $doc->setMetaData()

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -413,33 +413,77 @@ class JDocument
 	/**
 	 * Sets or alters a meta tag.
 	 *
-	 * @param   string  $name       Name of the meta HTML tag
-	 * @param   string  $content    Value of the meta HTML tag
-	 * @param   string  $attribute  Attribute to use in the meta HTML tag
+	 * @param   string  $name       Name of the meta HTML tag or Array
+	 * @param   string  $content    Value of the meta HTML tag @deprecated 4.0
+	 * @param   string  $attribute  Attribute to use in the meta HTML tag @deprecated 4.0
 	 *
 	 * @return  JDocument instance of $this to allow chaining
 	 *
+	 *  The $content and $attribute are deprecated and will be remove in 4.0
+	 *  use the new syntax:
+	 *  setMetaData(array(
+	 *            "name" => "viewport",
+	 *            "content" => "width=device-width, initial-scale=1.0"
+	 *           )
+	 *  )
 	 * @since   11.1
 	 */
 	public function setMetaData($name, $content, $attribute = 'name')
 	{
-		// B/C old http_equiv parameter.
-		if (!is_string($attribute))
+		if (!is_array($name))
 		{
-			$attribute = $attribute == true ? 'http-equiv' : 'name';
-		}
+			// B/C old http_equiv parameter.
+			if (!is_string($attribute))
+			{
+				$attribute = $attribute == true ? 'http-equiv' : 'name';
+			}
 
-		if ($name == 'generator')
-		{
-			$this->setGenerator($content);
-		}
-		elseif ($name == 'description')
-		{
-			$this->setDescription($content);
+			if ($name == 'generator')
+			{
+				$this->setGenerator($content);
+			}
+			elseif ($name == 'description')
+			{
+				$this->setDescription($content);
+			}
+			else
+			{
+				$this->_metaTags[$attribute][$name] = $content;
+			}
 		}
 		else
 		{
-			$this->_metaTags[$attribute][$name] = $content;
+			$attrib = 'name';
+
+			foreach ($name as $title => $val)
+			{
+				if ($title === 'property' && $title !== 'content')
+				{
+					$attrib = 'property';
+					$namedProp = $val;
+				}
+				elseif ($title === 'http-equiv' && $title !== 'content')
+				{
+					$attrib = 'http-equiv';
+					$namedProp = $val;
+				}
+				elseif ($title === 'generator' && $title !== 'content')
+				{
+					$this->setGenerator($content);
+					return;
+				}
+				elseif ($title === 'description' && $title !== 'content')
+				{
+					$this->setDescription($content);
+					return;
+				}
+				elseif ($title === 'name' && $title !== 'content')
+				{
+					$attrib = 'name';
+					$namedProp = $val;
+				}
+			}
+			$this->_metaTags[$attrib][$namedProp] = $name['content'];
 		}
 
 		return $this;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Enhance public function setMetaData() to allow setting og metas
For infos on og metas check: http://ogp.me

### Testing Instructions
Apply the patch with patch tester
edit index.php on isis template and add
```php
$this->setMetaData(
	array(
		"property" => "og:title",
		"content" => "The Rock"
	), '', ''
);
$this->setMetaData(
	array(
		"property" => "og:type",
		"content" => "video.movie"
	), '', ''
);

$this->setMetaData(
	array(
		"property" => "og:url",
		"content" => "http://www.imdb.com/title/tt0117500/"
	), '', ''
);
```
just before 
```
?>
<!DOCTYPE html>
```

Inspect the rendered page through your browsers developers tools

#### Preview
![screen shot 2017-02-09 at 19 45 36](https://cloud.githubusercontent.com/assets/3889375/22795729/645127c8-ef00-11e6-9594-2cc780709210.png)

### Documentation Changes Required

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/joomla/joomla-cms/14001)
<!-- Reviewable:end -->
