### PR TITLE
Multilanguage: Frontend field tags filtering

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -111,6 +111,8 @@ class JFormFieldTag extends JFormFieldList
 	protected function getOptions()
 	{
 		$published = $this->element['published']?: array(0, 1);
+		$app       = JFactory::getApplication();
+		$tag       = $app->getLanguage()->getTag();
 
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true)
@@ -118,8 +120,18 @@ class JFormFieldTag extends JFormFieldList
 			->from('#__tags AS a')
 			->join('LEFT', $db->qn('#__tags') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
 
+		// Limit Options in multilanguage
+		if ($app->isClient('site') && JLanguageMultilang::isEnabled())
+		{
+			$lang = JComponentHelper::getParams('com_tags')->get('tag_list_language_filter');
+
+			if ($lang == 'current_language')
+			{
+				$query->where('a.language in (' . $db->quote($tag) . ',' . $db->quote('*') . ')');
+			}
+		}
 		// Filter language
-		if (!empty($this->element['language']))
+		elseif (!empty($this->element['language']))
 		{
 			if (strpos($this->element['language'], ',') !== false)
 			{


### PR DESCRIPTION
Pull Request for Issue #13996

### Summary of Changes
On a multilingual site, when Tags Language Filter is set to "current", display only tags set to the Current language and to All languages in the tags field when editing an article.
### Testing Instructions
Install a basic multilingual site.
Create some tags and set them to each language used, and at least one set to ALL languages.

![screen shot 2017-02-10 at 09 01 20](https://cloud.githubusercontent.com/assets/869724/22818834/913eccc6-ef6f-11e6-8540-7b6b2796025a.png)
Make sure Tags component filter language option is set to `current`.
![screen shot 2017-02-10 at 08 40 04](https://cloud.githubusercontent.com/assets/869724/22818848/9f23ba40-ef6f-11e6-8d3f-7bcb3629fe45.png)
Edit or create an article IN FRONTEND
### Before patch
All tags display in the dropdown

![screen shot 2017-02-10 at 09 04 34](https://cloud.githubusercontent.com/assets/869724/22818939/07d5c1be-ef70-11e6-869c-a51351141627.png)
### After patch
Only tags assigned to the current language and to All languages display
![screen shot 2017-02-10 at 08 41 36](https://cloud.githubusercontent.com/assets/869724/22818874/b71c830c-ef6f-11e6-9d1d-dd8457a52d0e.png)


### Documentation Changes Required
NOne

@pulsarinformatique @franz-wohlkoenig @alikon 