### PR TITLE
[J4.0] Add treeprefix to fix access level styling

### DIFF
--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  HTML
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_BASE') or die;
+
+/**
+ * Layout variables
+ * ---------------------
+ *
+ * @var  integer  $level  The level of the item in the tree like structure.
+ *
+ * @since  3.6.0
+ */
+
+extract($displayData);
+
+if ($level > 1)
+{
+	echo '<span class="text-muted">' . str_repeat('&#8942;&nbsp;&nbsp;&nbsp;', (int) $level - 2) . '</span>&ndash;&nbsp;';
+}


### PR DESCRIPTION
Pull Request for Issue #13914 

### Summary of Changes

This re-adds the treeprefix layout so fix the access levels edit view, that contains a tree list.

### Testing Instructions

- Apply patch on J4.0
- Go to **Users** >> **Access Levels** >> **Edit**
- Indentation should be as per J3.x

### Before patch:

<img width="1440" alt="64ce5d58-ead5-11e6-8c3b-25c655bb834b" src="https://cloud.githubusercontent.com/assets/2019801/22824476/07d06e8e-ef80-11e6-8fe7-ab6cf2e943c9.png">

### After patch:

![tree](https://cloud.githubusercontent.com/assets/2019801/22824483/0cac126e-ef80-11e6-95fe-46a0f2250309.png)

