### PR TITLE
Fixing contact fields

### DIFF
--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -181,14 +181,15 @@ class ContactHelper extends JHelperContent
 	 * is returned.
 	 *
 	 * @param   string  $section  The section to get the mapping for
+	 * @param   object  $item     optional item object
 	 *
 	 * @return  string|null  The new section
 	 *
 	 * @since   3.7.0
 	 */
-	public static function validateSection($section)
+	public static function validateSection($section, $item)
 	{
-		if (JFactory::getApplication()->isClient('site') && $section == 'contact')
+		if (JFactory::getApplication()->isClient('site') && $section == 'contact' && $item instanceof JForm)
 		{
 			// The contact form needs to be the mail section
 			$section = 'mail';

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -28,7 +28,8 @@ class FieldsHelper
 	 * @param   string  $contextString  contextString
 	 * @param   object  $item           optional item object
 	 *
-	 * @return array|null
+	 * @return  array|null
+	 *
 	 * @since   3.7.0
 	 */
 	public static function extract($contextString, $item = null)

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -26,12 +26,12 @@ class FieldsHelper
 	 * be in the format component.context.
 	 *
 	 * @param   string  $contextString  contextString
+	 * @param   object  $item           optional item object
 	 *
-	 * @return  array|null
-	 *
+	 * @return array|null
 	 * @since   3.7.0
 	 */
-	public static function extract($contextString)
+	public static function extract($contextString, $item = null)
 	{
 		$parts = explode('.', $contextString, 2);
 
@@ -53,7 +53,7 @@ class FieldsHelper
 
 			if (class_exists($cName) && is_callable(array($cName, 'validateSection')))
 			{
-				$section = call_user_func_array(array($cName, 'validateSection'), array($parts[1]));
+				$section = call_user_func_array(array($cName, 'validateSection'), array($parts[1], $item));
 
 				if ($section)
 				{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -52,7 +52,7 @@ class PlgSystemFields extends JPlugin
 			$context = $item->extension . '.categories';
 		}
 
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{
@@ -109,7 +109,7 @@ class PlgSystemFields extends JPlugin
 		}
 
 		$fieldsData = $data['params'];
-		$parts      = FieldsHelper::extract($context);
+		$parts      = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{
@@ -206,7 +206,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentAfterDelete($context, $item)
 	{
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{
@@ -263,7 +263,7 @@ class PlgSystemFields extends JPlugin
 			$context = str_replace('com_categories.category', '', $context) . '.categories';
 		}
 
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $form);
 
 		if (!$parts)
 		{
@@ -302,7 +302,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentPrepareData($context, $data)
 	{
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $data);
 
 		if (!$parts)
 		{
@@ -380,7 +380,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	private function display($context, $item, $params, $displayType)
 	{
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{
@@ -439,7 +439,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentPrepare($context, $item)
 	{
-		$parts = FieldsHelper::extract($context);
+		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{


### PR DESCRIPTION
Pull Request for Issue #14004 .

### Summary of Changes
This PR adds the object to the FieldsHelper::extract method as an optional argument. This way extensions can determine in their helper if the context is the proper one for the current object.
It adds a check to the com_contact helper so it can give the correct context (mail or contact) back based on the passed object (item or form).

### Testing Instructions
* Assign some custom fields to a contact as well as its mail form and add some values.
* Check the contact in frontend, the fields should show up as expected and form needs to additional fields.

### Expected result
Fields show up as expected both in contact and form.

### Actual result
Only the added fields for the contact form show up.

### Documentation Changes Required
None

### Comment
We need this because in com_contact (and maybe 3rd party extensions) the context doesn't differentiate between the contact itself and the contact form. It's always "com_contact.contact". So we need a way to differentiate that, which we can do by looking at the object.
With 4.0, we can change the context for the contact form to "com_contact.mail". The question is if we then should remove the optional argument again (and deprecate it right away now) or if we want to leave it for 4.x. Imho, it wouldn't really hurt to pass it and it *may* be helpful for 3rd parties.