### PR TITLE
[com_tags] - remove warning from countTagItems()

### DIFF
--- a/administrator/components/com_tags/models/tags.php
+++ b/administrator/components/com_tags/models/tags.php
@@ -378,7 +378,7 @@ class TagsModelTags extends JModelList
 
 			if (class_exists($cName) && is_callable(array($cName, 'countTagItems')))
 			{
-				call_user_func(array($cName, 'countTagItems'), $items, $extension);
+				$cName::countTagItems($items, $extension);
 			}
 		}
 	}


### PR DESCRIPTION
### Testing Instructions
-  multilanguage 
- php 7.1.1
go to com_tags and click on search tools and filter for tag type (article for example)
### Expected result
no warning

### Actual result
![warining](https://cloud.githubusercontent.com/assets/181681/22856207/82680d6a-f08d-11e6-9143-c7c44bcaad71.PNG)

