### PR TITLE
[Protostar] Equal field widths in mod_login

### DIFF
--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7281,8 +7281,7 @@ p {
 }
 .add-on + #modlgn-username,
 .add-on + #modlgn-passwd {
-	max-width: 132px;
-	width: 100%;
+	width: 132px;
 }
 .img_caption .left {
 	float: left;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7276,6 +7276,9 @@ p {
 .breadcrumb > .active {
 	color: #515151;
 }
+#login-form {
+	margin-top: 8px;
+}
 .add-on + #modlgn-username,
 .add-on + #modlgn-passwd {
 	max-width: 132px;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -7276,6 +7276,11 @@ p {
 .breadcrumb > .active {
 	color: #515151;
 }
+.add-on + #modlgn-username,
+.add-on + #modlgn-passwd {
+	max-width: 132px;
+	width: 100%;
+}
 .img_caption .left {
 	float: left;
 	margin-right: 1em;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -241,6 +241,13 @@ p {
 .breadcrumb > .active {
    color: #515151;
 }
+/* mod_login */
+.add-on {
+	+ #modlgn-username, + #modlgn-passwd {
+		max-width: 132px;
+		width: 100%;
+	}
+}
 /* Caption fixes */
 .img_caption .left {
 	float: left;

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -247,8 +247,7 @@ p {
 }
 .add-on {
 	+ #modlgn-username, + #modlgn-passwd {
-		max-width: 132px;
-		width: 100%;
+		width: 132px;
 	}
 }
 /* Caption fixes */

--- a/templates/protostar/less/template.less
+++ b/templates/protostar/less/template.less
@@ -242,6 +242,9 @@ p {
    color: #515151;
 }
 /* mod_login */
+#login-form {
+	margin-top: 8px;
+}
 .add-on {
 	+ #modlgn-username, + #modlgn-passwd {
 		max-width: 132px;


### PR DESCRIPTION
Pull Request for Issue  #14010 .

### Summary of Changes
Gives mod_login equal field widths (Display Labels: Icons).

### Testing Instructions
Enable 'secret key' field and check front end login module.

### Before PR
![mod-login1](https://cloud.githubusercontent.com/assets/2803503/22857101/95a76656-f096-11e6-9a90-fed47876e99d.png)

### After PR
![mod-login3](https://cloud.githubusercontent.com/assets/2803503/22857182/3aa22cb2-f098-11e6-98e2-15081622dbb4.png)

### Documentation Changes Required
None
