### PR TITLE
Add container-fluid to com_template modals

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
@@ -9,15 +9,19 @@
 
 defined('_JEXEC') or die;
 ?>
-<div id="template-manager-copy" class="form-horizontal">
-	<div class="control-group">
-		<div class="control-label">
-			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL'); ?>
-			</label>
-		</div>
-		<div class="controls">
-			<input class="input-xlarge" type="text" id="new_name" name="new_name"  />
+<div id="template-manager-copy" class="container-fluid">
+	<div class="row-fluid">
+		<div class="form-horizontal">
+			<div class="control-group">
+				<div class="control-label">
+					<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL', 'COM_TEMPLATES_TEMPLATE_NEW_NAME_DESC'); ?>">
+						<?php echo JText::_('COM_TEMPLATES_TEMPLATE_NEW_NAME_LABEL'); ?>
+					</label>
+				</div>
+				<div class="controls">
+					<input class="input-xlarge" type="text" id="new_name" name="new_name"  />
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_body.php
@@ -9,4 +9,8 @@
 
 defined('_JEXEC') or die;
 ?>
-<p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>
+<div id="template-manager-delete" class="container-fluid">
+	<div class="row-fluid">
+        <p><?php echo JText::sprintf('COM_TEMPLATES_MODAL_FILE_DELETE', $this->fileName); ?></p>
+	</div>
+</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -11,58 +11,60 @@ defined('_JEXEC') or die;
 
 $input = JFactory::getApplication()->input;
 ?>
-<div id="#template-manager-file" class="row-fluid">
-	<div class="span12">
-		<div class="span6 column-right">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
-				<fieldset class="form-inline">
-					<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME'); ?></label>
-					<input type="text" name="name" required />
-					<select class="input-medium" data-chosen="true" name="type" required >
-						<option value="">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT'); ?> -</option>
-						<option value="css">css</option>
-						<option value="php">php</option>
-						<option value="js">js</option>
-						<option value="xml">xml</option>
-						<option value="ini">ini</option>
-						<option value="less">less</option>
-						<option value="sass">sass</option>
-						<option value="scss">scss</option>
-						<option value="txt">txt</option>
-					</select>
-					<input type="hidden" class="address" name="address" />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
-				</fieldset>
-			</form>
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
-				<fieldset class="form-inline">
-					<input type="hidden" class="address" name="address" />
-					<input type="file" name="files" required />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD'); ?>" class="btn btn-primary" /><br>
-					<?php $cMax    = $this->state->get('params')->get('upload_limit'); ?>
-					<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize($cMax . 'MB')); ?>
-					<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
-				</fieldset>
-			</form>
-			<?php if ($this->type != 'home') : ?>
-				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
+<div id="template-manager-file" class="container-fluid">
+	<div class="row-fluid">
+		<div class="span12">
+			<div class="span6 column-right">
+				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
 					<fieldset class="form-inline">
+						<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME'); ?></label>
+						<input type="text" name="name" required />
+						<select class="input-medium" data-chosen="true" name="type" required >
+							<option value="">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT'); ?> -</option>
+							<option value="css">css</option>
+							<option value="php">php</option>
+							<option value="js">js</option>
+							<option value="xml">xml</option>
+							<option value="ini">ini</option>
+							<option value="less">less</option>
+							<option value="sass">sass</option>
+							<option value="scss">scss</option>
+							<option value="txt">txt</option>
+						</select>
 						<input type="hidden" class="address" name="address" />
-						<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>">
-							<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?>
-						</label>
-						<input type="text" id="new_name" name="new_name" required />
 						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE'); ?>" class="btn btn-primary" />
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
 					</fieldset>
 				</form>
-			<?php endif; ?>
-		</div>
-		<div class="span6 column-left">
-			<?php echo $this->loadTemplate('folders'); ?>
-			<hr class="hr-condensed" />
+				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
+					<fieldset class="form-inline">
+						<input type="hidden" class="address" name="address" />
+						<input type="file" name="files" required />
+						<?php echo JHtml::_('form.token'); ?>
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD'); ?>" class="btn btn-primary" /><br>
+						<?php $cMax    = $this->state->get('params')->get('upload_limit'); ?>
+						<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize($cMax . 'MB')); ?>
+						<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
+					</fieldset>
+				</form>
+				<?php if ($this->type != 'home') : ?>
+					<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
+						<fieldset class="form-inline">
+							<input type="hidden" class="address" name="address" />
+							<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>">
+								<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?>
+							</label>
+							<input type="text" id="new_name" name="new_name" required />
+							<?php echo JHtml::_('form.token'); ?>
+							<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE'); ?>" class="btn btn-primary" />
+						</fieldset>
+					</form>
+				<?php endif; ?>
+			</div>
+			<div class="span6 column-left">
+				<?php echo $this->loadTemplate('folders'); ?>
+				<hr class="hr-condensed" />
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
@@ -11,22 +11,24 @@ defined('_JEXEC') or die;
 
 $input = JFactory::getApplication()->input;
 ?>
-<div id="#template-manager-folder" class="row-fluid">
-	<div class="span12">
-		<div class="span6 column-right">
-			<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
-				<fieldset class="form-inline">
-					<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME'); ?></label>
-					<input type="text" name="name" required />
-					<input type="hidden" class="address" name="address" />
-					<?php echo JHtml::_('form.token'); ?>
-					<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
-				</fieldset>
-			</form>
-		</div>
-		<div class="span6 column-left">
-			<?php echo $this->loadTemplate('folders'); ?>
-			<hr class="hr-condensed" />
+<div id="template-manager-folder" class="container-fluid">
+	<div class="row-fluid">
+		<div class="span12">
+			<div class="span6 column-right">
+				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
+					<fieldset class="form-inline">
+						<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME'); ?></label>
+						<input type="text" name="name" required />
+						<input type="hidden" class="address" name="address" />
+						<?php echo JHtml::_('form.token'); ?>
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
+					</fieldset>
+				</form>
+			</div>
+			<div class="span6 column-left">
+				<?php echo $this->loadTemplate('folders'); ?>
+				<hr class="hr-condensed" />
+			</div>
 		</div>
 	</div>
 </div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -10,17 +10,21 @@
 defined('_JEXEC') or die;
 
 ?>
-<div id="template-manager-rename" class="form-horizontal">
-	<div class="control-group">
-		<div class="control-label">
-			<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>">
-				<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?>
-			</label>
-		</div>
-		<div class="controls">
-			<div class="input-append">
-				<input class="input-xlarge" type="text" name="new_name" required />
-				<span class="add-on">.<?php echo JFile::getExt($this->fileName); ?></span>
+<div id="template-manager-rename" class="container-fluid">
+	<div class="row-fluid">
+		<div class="form-horizontal">
+			<div class="control-group">
+				<div class="control-label">
+					<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', JText::_('COM_TEMPLATES_NEW_FILE_NAME')); ?>">
+						<?php echo JText::_('COM_TEMPLATES_NEW_FILE_NAME')?>
+					</label>
+				</div>
+				<div class="controls">
+					<div class="input-append">
+						<input class="input-xlarge" type="text" name="new_name" required />
+						<span class="add-on">.<?php echo JFile::getExt($this->fileName); ?></span>
+					</div>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
@@ -9,25 +9,27 @@
 
 defined('_JEXEC') or die;
 ?>
-<div id="template-manager-resize" class="form-horizontal">
-	<div class="control-group">
-		<div class="control-label">
-			<label for="height" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_IMAGE_HEIGHT'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT')?>
-			</label>
+<div id="template-manager-resize" class="container-fluid">
+	<div class="row-fluid">
+		<div class="control-group">
+			<div class="control-label">
+				<label for="height" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_IMAGE_HEIGHT'); ?>">
+					<?php echo JText::_('COM_TEMPLATES_IMAGE_HEIGHT')?>
+				</label>
+			</div>
+			<div class="controls">
+				<input class="input-xlarge" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required />
+			</div>
 		</div>
-		<div class="controls">
-			<input class="input-xlarge" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required />
-		</div>
-	</div>
-	<div class="control-group">
-		<div class="control-label">
-			<label for="width" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_IMAGE_WIDTH'); ?>">
-				<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH')?>
-			</label>
-		</div>
-		<div class="controls">
-			<input class="input-xlarge" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required />
+		<div class="control-group">
+			<div class="control-label">
+				<label for="width" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_IMAGE_WIDTH'); ?>">
+					<?php echo JText::_('COM_TEMPLATES_IMAGE_WIDTH')?>
+				</label>
+			</div>
+			<div class="controls">
+				<input class="input-xlarge" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required />
+			</div>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
Pull Request for Issue  #14016 .

### Summary of Changes
Adds container-fluid to the com_template modals

### Testing Instructions
Navigate to Extensions -> Templates -> Templates -> {Protostar] and open file. Check each buttons modals window.

### Before PR
![template-modal1](https://cloud.githubusercontent.com/assets/2803503/22857140/58bdb190-f097-11e6-9bae-3aa141865b1e.png)

### After PR
![template-modal2](https://cloud.githubusercontent.com/assets/2803503/22857141/5ce57b36-f097-11e6-9654-acb0a7dc3c19.png)

### Documentation Changes Required
None