### PR TITLE
Mark Event and Session classes deprecated

### DIFF
--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -15,8 +15,9 @@ defined('JPATH_PLATFORM') or die;
  * This is the Observable part of the Observer design pattern
  * for the event architecture.
  *
- * @see    JPlugin
- * @since  12.1
+ * @see         JPlugin
+ * @since       12.1
+ * @deprecated  4.0  The CMS' Event classes will be replaced with the `joomla/event` package
  */
 class JEventDispatcher extends JObject
 {

--- a/libraries/joomla/event/event.php
+++ b/libraries/joomla/event/event.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * JEvent Class
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Event classes will be replaced with the `joomla/event` package
  */
 abstract class JEvent extends JObject
 {

--- a/libraries/joomla/session/exception/unsupported.php
+++ b/libraries/joomla/session/exception/unsupported.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Exception class defining an unsupported session storage object
  *
- * @since  3.6.3
+ * @since       3.6.3
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionExceptionUnsupported extends RuntimeException
 {

--- a/libraries/joomla/session/handler/interface.php
+++ b/libraries/joomla/session/handler/interface.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Interface for managing HTTP sessions
  *
- * @since  3.5
+ * @since       3.5
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 interface JSessionHandlerInterface
 {

--- a/libraries/joomla/session/handler/joomla.php
+++ b/libraries/joomla/session/handler/joomla.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Interface for managing HTTP sessions
  *
- * @since  3.5
+ * @since       3.5
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionHandlerJoomla extends JSessionHandlerNative
 {

--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Interface for managing HTTP sessions
  *
- * @since  3.5
+ * @since       3.5
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionHandlerNative implements JSessionHandlerInterface
 {

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -12,9 +12,9 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Custom session storage handler for PHP
  *
- * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
- * @todo   When dropping compatibility with PHP 5.3 use the SessionHandlerInterface and the SessionHandler class
- * @since  11.1
+ * @see         https://secure.php.net/manual/en/function.session-set-save-handler.php
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 abstract class JSessionStorage
 {

--- a/libraries/joomla/session/storage/apc.php
+++ b/libraries/joomla/session/storage/apc.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die;
 /**
  * APC session storage handler for PHP
  *
- * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
- * @since  11.1
+ * @see         https://secure.php.net/manual/en/function.session-set-save-handler.php
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageApc extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/database.php
+++ b/libraries/joomla/session/storage/database.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Database session storage handler for PHP
  *
- * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
- * @since  11.1
+ * @see         https://secure.php.net/manual/en/function.session-set-save-handler.php
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageDatabase extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Memcache session storage handler for PHP
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageMemcache extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/memcached.php
+++ b/libraries/joomla/session/storage/memcached.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Memcached session storage handler for PHP
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageMemcached extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/none.php
+++ b/libraries/joomla/session/storage/none.php
@@ -12,8 +12,9 @@ defined('JPATH_PLATFORM') or die;
 /**
  * File session handler for PHP
  *
- * @see    https://secure.php.net/manual/en/function.session-set-save-handler.php
- * @since  11.1
+ * @see         https://secure.php.net/manual/en/function.session-set-save-handler.php
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageNone extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/wincache.php
+++ b/libraries/joomla/session/storage/wincache.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * WINCACHE session storage handler for PHP
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageWincache extends JSessionStorage
 {

--- a/libraries/joomla/session/storage/xcache.php
+++ b/libraries/joomla/session/storage/xcache.php
@@ -12,7 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * XCache session storage handler
  *
- * @since  11.1
+ * @since       11.1
+ * @deprecated  4.0  The CMS' Session classes will be replaced with the `joomla/session` package
  */
 class JSessionStorageXcache extends JSessionStorage
 {


### PR DESCRIPTION
### Summary of Changes

These classes have been replaced in the 4.0 branch however are not yet deprecated.  Corrects that.

### Testing Instructions

Review