### PR TITLE
Fixing URLs for orphaned articles

### DIFF
--- a/libraries/cms/component/router/rules/standard.php
+++ b/libraries/cms/component/router/rules/standard.php
@@ -279,7 +279,11 @@ class JComponentRouterRulesStandard implements JComponentRouterRulesInterface
 						$i--;
 						$found2 = false;
 					}
-					$found = true;
+
+					if (count($views[$view]->children))
+					{
+						$found = true;
+					}
 				}
 			}
 			unset($query[$views[$view]->parent_key]);


### PR DESCRIPTION
Pull Request for Issue #13978 .

### Summary of Changes
The issue is, that the home menu item is of type article and thus all orphaned articles are thought as being the homepage article. This is again because we are checking the path of views and even check the last view in the path. (the one without any further children) However, if we are at that point, we should be skipping that view, since we should either have matched that in the first step, where we match for the exactly matching menu item or not find a match at all.

### Testing Instructions
Please see the instructions in #13978 

### Expected result

### Actual result

### Documentation Changes Required
