### PR TITLE
Select client_id as this is required for sorting objects

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -33,7 +33,7 @@ abstract class ModMenuHelper
 			->select('a.*, SUM(b.home) AS home')
 			->from('#__menu_types AS a')
 			->join('LEFT', '#__menu AS b ON b.menutype = a.menutype AND b.home != 0')
-			->select('b.language')
+			->select('b.language, b.client_id')
 			->join('LEFT', '#__languages AS l ON l.lang_code = language')
 			->select('l.image')
 			->select('l.sef')


### PR DESCRIPTION
### Summary of Changes
In the current staging after logging in the page is full of undefined property client_id. This change fixes that by loading the client_id. 

### Testing Instructions
1. Set error reporting to development ```public $error_reporting = 'development';```
2. Log in to the administrator section
3. You see a blue screen with notices of undefined property_client_id.
4. Apply patch
5. Reload page
6. Log out
7. Log in
8. Now you are logged in and see the control panel

### Expected result
To login and see the control panel
### Actual result
Page is full with notices
![image](https://cloud.githubusercontent.com/assets/359377/22861939/bfd241d8-f124-11e6-9dac-5ca2d5f68142.png)

### Documentation Changes Required
None