### PR TITLE
[4.0] Extend JController from the Framework

### DIFF
--- a/administrator/components/com_config/controller/application/cancel.php
+++ b/administrator/components/com_config/controller/application/cancel.php
@@ -28,8 +28,8 @@ class ConfigControllerApplicationCancel extends ConfigControllerCanceladmin
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin', 'com_config'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		$this->context = 'com_config.config.global';

--- a/administrator/components/com_config/controller/application/removeroot.php
+++ b/administrator/components/com_config/controller/application/removeroot.php
@@ -35,15 +35,15 @@ class ConfigControllerApplicationRemoveroot extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken('get'))
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Initialise model.
@@ -57,12 +57,12 @@ class ConfigControllerApplicationRemoveroot extends JControllerBase
 		catch (RuntimeException $e)
 		{
 			// Save failed, go back to the screen and display a notice.
-			$this->app->enqueueMessage(JText::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'error');
-			$this->app->redirect(JRoute::_('index.php', false));
+			$this->getApplication()->enqueueMessage(JText::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'error');
+			$this->getApplication()->redirect(JRoute::_('index.php', false));
 		}
 
 		// Set the redirect based on the task.
-		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'));
-		$this->app->redirect(JRoute::_('index.php', false));
+		$this->getApplication()->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'));
+		$this->getApplication()->redirect(JRoute::_('index.php', false));
 	}
 }

--- a/administrator/components/com_config/controller/application/save.php
+++ b/administrator/components/com_config/controller/application/save.php
@@ -16,14 +16,6 @@ defined('_JEXEC') or die;
 class ConfigControllerApplicationSave extends JControllerBase
 {
 	/**
-	 * Application object - Redeclared for proper typehinting
-	 *
-	 * @var    JApplicationCms
-	 * @since  3.2
-	 */
-	protected $app;
-
-	/**
 	 * Method to save global configuration.
 	 *
 	 * @return  mixed  Calls $app->redirect() for all cases except JSON
@@ -35,22 +27,22 @@ class ConfigControllerApplicationSave extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Set FTP credentials, if given.
 		JClientHelper::setCredentialsFromRequest('ftp');
 
 		$model = new ConfigModelApplication;
-		$data  = $this->input->post->get('jform', array(), 'array');
+		$data  = $this->getInput()->post->get('jform', array(), 'array');
 
 		// Complete data array if needed
 		$oldData = $model->getData();
@@ -72,7 +64,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 		$return = $model->validate($form, $data);
 
 		// Save the posted data in the session.
-		$this->app->setUserState('com_config.config.global.data', $data);
+		$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 		// Check for validation errors.
 		if ($return === false)
@@ -82,7 +74,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 			 */
 
 			// Redirect back to the edit screen.
-			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
 		}
 
 		// Attempt to save the configuration.
@@ -90,7 +82,7 @@ class ConfigControllerApplicationSave extends JControllerBase
 		$return = $model->save($data);
 
 		// Save the validated data in the session.
-		$this->app->setUserState('com_config.config.global.data', $data);
+		$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 		// Check the return value.
 		if ($return === false)
@@ -100,22 +92,22 @@ class ConfigControllerApplicationSave extends JControllerBase
 			 */
 
 			// Save failed, go back to the screen and display a notice.
-			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.application', false));
 		}
 
 		// Set the success message.
-		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
+		$this->getApplication()->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])
 		{
 			case 'apply':
-				$this->app->redirect(JRoute::_('index.php?option=com_config', false));
+				$this->getApplication()->redirect(JRoute::_('index.php?option=com_config', false));
 				break;
 
 			case 'save':
 			default:
-				$this->app->redirect(JRoute::_('index.php', false));
+				$this->getApplication()->redirect(JRoute::_('index.php', false));
 				break;
 		}
 	}

--- a/administrator/components/com_config/controller/application/sendtestmail.php
+++ b/administrator/components/com_config/controller/application/sendtestmail.php
@@ -25,28 +25,28 @@ class ConfigControllerApplicationSendtestmail extends JControllerBase
 	public function execute()
 	{
 		// Send json mime type.
-		$this->app->mimeType = 'application/json';
-		$this->app->setHeader('Content-Type', $this->app->mimeType . '; charset=' . $this->app->charSet);
-		$this->app->sendHeaders();
+		$this->getApplication()->mimeType = 'application/json';
+		$this->getApplication()->setHeader('Content-Type', $this->getApplication()->mimeType . '; charset=' . $this->getApplication()->charSet);
+		$this->getApplication()->sendHeaders();
 
 		// Check if user token is valid.
 		if (!JSession::checkToken('get'))
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
 			echo new JResponseJson;
-			$this->app->close();
+			$this->getApplication()->close();
 		}
 
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 			echo new JResponseJson;
-			$this->app->close();
+			$this->getApplication()->close();
 		}
 
 		$model = new ConfigModelApplication;
 		echo new JResponseJson($model->sendTestMail());
-		$this->app->close();
+		$this->getApplication()->close();
 	}
 }

--- a/administrator/components/com_config/controller/application/store.php
+++ b/administrator/components/com_config/controller/application/store.php
@@ -25,20 +25,20 @@ class ConfigControllerApplicationStore extends JControllerBase
 	public function execute()
 	{
 		// Send json mime type.
-		$this->app->mimeType = 'application/json';
-		$this->app->setHeader('Content-Type', $this->app->mimeType . '; charset=' . $this->app->charSet);
-		$this->app->sendHeaders();
+		$this->getApplication()->mimeType = 'application/json';
+		$this->getApplication()->setHeader('Content-Type', $this->getApplication()->mimeType . '; charset=' . $this->getApplication()->charSet);
+		$this->getApplication()->sendHeaders();
 
 		// Check if user token is valid.
 		if (!JSession::checkToken('get'))
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
 			echo new JResponseJson;
-			$this->app->close();
+			$this->getApplication()->close();
 		}
 
 		$model = new ConfigModelApplication;
 		echo new JResponseJson($model->storePermissions());
-		$this->app->close();
+		$this->getApplication()->close();
 	}
 }

--- a/administrator/components/com_config/controller/component/cancel.php
+++ b/administrator/components/com_config/controller/component/cancel.php
@@ -27,7 +27,7 @@ class ConfigControllerComponentCancel extends ConfigControllerCanceladmin
 	{
 		$this->context = 'com_config.config.global';
 
-		$this->component = $this->input->get('component');
+		$this->component = $this->getInput()->get('component');
 
 		$this->redirect = 'index.php?option=' . $this->component;
 

--- a/administrator/components/com_config/controller/component/save.php
+++ b/administrator/components/com_config/controller/component/save.php
@@ -36,8 +36,8 @@ class ConfigControllerComponentSave extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'), 'error');
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Set FTP credentials, if given.
@@ -45,16 +45,16 @@ class ConfigControllerComponentSave extends JControllerBase
 
 		$model  = new ConfigModelComponent;
 		$form   = $model->getForm();
-		$data   = $this->input->get('jform', array(), 'array');
-		$id     = $this->input->getInt('id');
-		$option = $this->input->get('component');
+		$data   = $this->getInput()->get('jform', array(), 'array');
+		$id     = $this->getInput()->getInt('id');
+		$option = $this->getInput()->get('component');
 		$user   = JFactory::getUser();
 
 		// Check if the user is authorised to do this.
 		if (!$user->authorise('core.admin', $option) && !$user->authorise('core.options', $option))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Remove the permissions rules data if user isn't allowed to edit them.
@@ -63,7 +63,7 @@ class ConfigControllerComponentSave extends JControllerBase
 			unset($data['params']['rules']);
 		}
 
-		$returnUri = $this->input->post->get('return', null, 'base64');
+		$returnUri = $this->getInput()->post->get('return', null, 'base64');
 
 		$redirect = '';
 
@@ -83,10 +83,10 @@ class ConfigControllerComponentSave extends JControllerBase
 			 */
 
 			// Save the data in the session.
-			$this->app->setUserState('com_config.config.global.data', $data);
+			$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 			// Redirect back to the edit screen.
-			$this->app->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
 		}
 
 		// Attempt to save the configuration.
@@ -103,19 +103,19 @@ class ConfigControllerComponentSave extends JControllerBase
 		catch (RuntimeException $e)
 		{
 			// Save the data in the session.
-			$this->app->setUserState('com_config.config.global.data', $data);
+			$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
-			$this->app->enqueueMessage(JText::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'error');
-			$this->app->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
+			$this->getApplication()->enqueueMessage(JText::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'error');
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
 		}
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])
 		{
 			case 'apply':
-				$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
-				$this->app->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
+				$this->getApplication()->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'), 'message');
+				$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false));
 
 				break;
 
@@ -134,7 +134,7 @@ class ConfigControllerComponentSave extends JControllerBase
 					$redirect = JUri::base();
 				}
 
-				$this->app->redirect(JRoute::_($redirect, false));
+				$this->getApplication()->redirect(JRoute::_($redirect, false));
 
 				break;
 		}

--- a/components/com_config/controller/cancel.php
+++ b/components/com_config/controller/cancel.php
@@ -17,14 +17,6 @@ defined('_JEXEC') or die;
 class ConfigControllerCancel extends JControllerBase
 {
 	/**
-	 * Application object - Redeclared for proper typehinting
-	 *
-	 * @var    JApplicationCms
-	 * @since  3.2
-	 */
-	protected $app;
-
-	/**
 	 * Method to handle cancel
 	 *
 	 * @return  boolean  True on success.
@@ -34,6 +26,6 @@ class ConfigControllerCancel extends JControllerBase
 	public function execute()
 	{
 		// Redirect back to home(base) page
-		$this->app->redirect(JUri::base());
+		$this->getApplication()->redirect(JUri::base());
 	}
 }

--- a/components/com_config/controller/canceladmin.php
+++ b/components/com_config/controller/canceladmin.php
@@ -53,8 +53,8 @@ class ConfigControllerCanceladmin extends ConfigControllerCancel
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		if (empty($this->context))
@@ -63,7 +63,7 @@ class ConfigControllerCanceladmin extends ConfigControllerCancel
 		}
 
 		// Redirect.
-		$this->app->setUserState($this->context . '.data', null);
+		$this->getApplication()->setUserState($this->context . '.data', null);
 
 		if (!empty($this->redirect))
 		{
@@ -73,7 +73,7 @@ class ConfigControllerCanceladmin extends ConfigControllerCancel
 				$this->redirect = JUri::base();
 			}
 
-			$this->app->redirect($this->redirect);
+			$this->getApplication()->redirect($this->redirect);
 		}
 		else
 		{

--- a/components/com_config/controller/cmsbase.php
+++ b/components/com_config/controller/cmsbase.php
@@ -37,11 +37,10 @@ class ConfigControllerCmsbase extends JControllerBase
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Get the application
-		$this->app = $this->getApplication();
-		$this->app->redirect('index.php?option=' . $this->input->get('option'));
+		$this->getApplication()->redirect('index.php?option=' . $this->getInput()->get('option'));
 
-		$this->componentFolder = $this->input->getWord('option', 'com_content');
-		$this->viewName        = $this->input->getWord('view');
+		$this->componentFolder = $this->getInput()->getWord('option', 'com_content');
+		$this->viewName        = $this->getInput()->getWord('view');
 
 		return $this;
 	}

--- a/components/com_config/controller/config/display.php
+++ b/components/com_config/controller/config/display.php
@@ -31,9 +31,9 @@ class ConfigControllerConfigDisplay extends ConfigControllerDisplay
 		// Get the document object.
 		$document     = JFactory::getDocument();
 
-		$viewName     = $this->input->getWord('view', 'config');
+		$viewName     = $this->getInput()->getWord('view', 'config');
 		$viewFormat   = $document->getType();
-		$layoutName   = $this->input->getWord('layout', 'default');
+		$layoutName   = $this->getInput()->getWord('layout', 'default');
 
 		// Access backend com_config
 		JLoader::registerPrefix(ucfirst($viewName), JPATH_ADMINISTRATOR . '/components/com_config');

--- a/components/com_config/controller/config/save.php
+++ b/components/com_config/controller/config/save.php
@@ -17,14 +17,6 @@ defined('_JEXEC') or die;
 class ConfigControllerConfigSave extends JControllerBase
 {
 	/**
-	 * Application object - Redeclared for proper typehinting
-	 *
-	 * @var    JApplicationCms
-	 * @since  3.2
-	 */
-	protected $app;
-
-	/**
 	 * Method to save global configuration.
 	 *
 	 * @return  boolean  True on success.
@@ -36,15 +28,15 @@ class ConfigControllerConfigSave extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Set FTP credentials, if given.
@@ -52,7 +44,7 @@ class ConfigControllerConfigSave extends JControllerBase
 
 		$model = new ConfigModelConfig;
 		$form  = $model->getForm();
-		$data  = $this->input->post->get('jform', array(), 'array');
+		$data  = $this->getInput()->post->get('jform', array(), 'array');
 
 		// Validate the posted data.
 		$return = $model->validate($form, $data);
@@ -65,10 +57,10 @@ class ConfigControllerConfigSave extends JControllerBase
 			 */
 
 			// Save the data in the session.
-			$this->app->setUserState('com_config.config.global.data', $data);
+			$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 			// Redirect back to the edit screen.
-			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
 		}
 
 		// Attempt to save the configuration.
@@ -98,15 +90,15 @@ class ConfigControllerConfigSave extends JControllerBase
 			 */
 
 			// Save the data in the session.
-			$this->app->setUserState('com_config.config.global.data', $data);
+			$this->getApplication()->setUserState('com_config.config.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
-			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
 		}
 
 		// Redirect back to com_config display
-		$this->app->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'));
-		$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
+		$this->getApplication()->enqueueMessage(JText::_('COM_CONFIG_SAVE_SUCCESS'));
+		$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.config', false));
 
 		return true;
 	}

--- a/components/com_config/controller/display.php
+++ b/components/com_config/controller/display.php
@@ -44,24 +44,24 @@ class ConfigControllerDisplay extends JControllerBase
 		// Get the document object.
 		$document = JFactory::getDocument();
 
-		$componentFolder = $this->input->getWord('option', 'com_config');
+		$componentFolder = $this->getInput()->getWord('option', 'com_config');
 
-		if ($this->app->isClient('administrator'))
+		if ($this->getApplication()->isClient('administrator'))
 		{
-			$viewName = $this->input->getWord('view', 'application');
+			$viewName = $this->getInput()->getWord('view', 'application');
 		}
 		else
 		{
-			$viewName = $this->input->getWord('view', 'config');
+			$viewName = $this->getInput()->getWord('view', 'config');
 		}
 
 		$viewFormat = $document->getType();
-		$layoutName = $this->input->getWord('layout', 'default');
+		$layoutName = $this->getInput()->getWord('layout', 'default');
 
 		// Register the layout paths for the view
 		$paths = new SplPriorityQueue;
 
-		if ($this->app->isClient('administrator'))
+		if ($this->getApplication()->isClient('administrator'))
 		{
 			$paths->insert(JPATH_ADMINISTRATOR . '/components/' . $componentFolder . '/view/' . $viewName . '/tmpl', 1);
 		}
@@ -82,7 +82,7 @@ class ConfigControllerDisplay extends JControllerBase
 			if (!JFactory::getUser()->authorise('core.admin', $component)
 				&& !JFactory::getUser()->authorise('core.options', $component))
 			{
-				$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+				$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
 
 				return;
 			}

--- a/components/com_config/controller/modules/cancel.php
+++ b/components/com_config/controller/modules/cancel.php
@@ -30,16 +30,16 @@ class ConfigControllerModulesCancel extends ConfigControllerCanceladmin
 		// Check if the user is authorized to do this.
 		$user = JFactory::getUser();
 
-		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id')))
+		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->getInput()->get('id')))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		$this->context = 'com_config.config.global';
 
 		// Get returnUri
-		$returnUri = $this->input->post->get('return', null, 'base64');
+		$returnUri = $this->getInput()->post->get('return', null, 'base64');
 
 		if (!empty($returnUri))
 		{
@@ -50,7 +50,7 @@ class ConfigControllerModulesCancel extends ConfigControllerCanceladmin
 			$this->redirect = JUri::base();
 		}
 
-		$id = $this->input->getInt('id');
+		$id = $this->getInput()->getInt('id');
 
 		// Access backend com_module
 		JLoader::register('ModulesControllerModule', JPATH_ADMINISTRATOR . '/components/com_modules/controllers/module.php');

--- a/components/com_config/controller/modules/display.php
+++ b/components/com_config/controller/modules/display.php
@@ -35,8 +35,8 @@ class ConfigControllerModulesDisplay extends ConfigControllerDisplay
 
 		$viewName     = 'modules';
 		$viewFormat   = $document->getType();
-		$layoutName   = $this->input->getWord('layout', 'default');
-		$returnUri    = $this->input->get->get('return', null, 'base64');
+		$layoutName   = $this->getInput()->getWord('layout', 'default');
+		$returnUri    = $this->getInput()->get->get('return', null, 'base64');
 
 		// Construct redirect URI
 		if (!empty($returnUri))
@@ -54,7 +54,7 @@ class ConfigControllerModulesDisplay extends ConfigControllerDisplay
 			$redirect = JUri::base();
 		}
 
-		$moduleData = (new \Joomla\Component\Modules\Administrator\Model\Module)->getItem($this->input->getInt('id'));
+		$moduleData = (new \Joomla\Component\Modules\Administrator\Model\Module)->getItem($this->getInput()->getInt('id'));
 
 		if (!$moduleData)
 		{

--- a/components/com_config/controller/modules/save.php
+++ b/components/com_config/controller/modules/save.php
@@ -30,28 +30,28 @@ class ConfigControllerModulesSave extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			$this->app->enqueueMessage(JText::_('JINVALID_TOKEN'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JINVALID_TOKEN'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Check if the user is authorized to do this.
 		$user = JFactory::getUser();
 
-		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id'))
+		if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->getInput()->get('id'))
 			&& !$user->authorise('module.edit.frontend', 'com_modules'))
 		{
-			$this->app->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
-			$this->app->redirect('index.php');
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php');
 		}
 
 		// Set FTP credentials, if given.
 		JClientHelper::setCredentialsFromRequest('ftp');
 
 		// Get sumitted module id
-		$moduleId = '&id=' . $this->input->get('id');
+		$moduleId = '&id=' . $this->getInput()->get('id');
 
 		// Get returnUri
-		$returnUri = $this->input->post->get('return', null, 'base64');
+		$returnUri = $this->getInput()->post->get('return', null, 'base64');
 		$redirect = '';
 
 		if (!empty($returnUri))
@@ -62,8 +62,8 @@ class ConfigControllerModulesSave extends JControllerBase
 		JLoader::register('ModulesDispatcher', JPATH_ADMINISTRATOR . '/components/com_modules/dispatcher.php');
 
 		$app = \Joomla\CMS\Application\CmsApplication::getInstance('administrator');
-		$app->loadLanguage($this->app->getLanguage());
-		$dispatcher      = new ModulesDispatcher($app, $this->input);
+		$app->loadLanguage($this->getApplication()->getLanguage());
+		$dispatcher      = new ModulesDispatcher($app, $this->getInput());
 
 		$controllerClass = $dispatcher->getController('Module');
 
@@ -86,18 +86,18 @@ class ConfigControllerModulesSave extends JControllerBase
 			$app->setUserState('com_config.modules.global.data', $data);
 
 			// Save failed, go back to the screen and display a notice.
-			$this->app->enqueueMessage(JText::_('JERROR_SAVE_FAILED'));
-			$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.modules' . $moduleId . $redirect, false));
+			$this->getApplication()->enqueueMessage(JText::_('JERROR_SAVE_FAILED'));
+			$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.modules' . $moduleId . $redirect, false));
 		}
 
 		// Redirect back to com_config display
-		$this->app->enqueueMessage(JText::_('COM_CONFIG_MODULES_SAVE_SUCCESS'));
+		$this->getApplication()->enqueueMessage(JText::_('COM_CONFIG_MODULES_SAVE_SUCCESS'));
 
 		// Set the redirect based on the task.
 		switch ($this->options[3])
 		{
 			case 'apply':
-				$this->app->redirect(JRoute::_('index.php?option=com_config&controller=config.display.modules' . $moduleId . $redirect, false));
+				$this->getApplication()->redirect(JRoute::_('index.php?option=com_config&controller=config.display.modules' . $moduleId . $redirect, false));
 				break;
 
 			case 'save':
@@ -117,7 +117,7 @@ class ConfigControllerModulesSave extends JControllerBase
 				{
 					$redirect = JUri::base();
 				}
-				$this->app->redirect($redirect);
+				$this->getApplication()->redirect($redirect);
 				break;
 		}
 	}

--- a/components/com_config/controller/templates/display.php
+++ b/components/com_config/controller/templates/display.php
@@ -31,9 +31,9 @@ class ConfigControllerTemplatesDisplay extends ConfigControllerDisplay
 		// Get the document object.
 		$document     = JFactory::getDocument();
 
-		$viewName     = $this->input->getWord('view', 'templates');
+		$viewName     = $this->getInput()->getWord('view', 'templates');
 		$viewFormat   = $document->getType();
-		$layoutName   = $this->input->getWord('layout', 'default');
+		$layoutName   = $this->getInput()->getWord('layout', 'default');
 
 		// Access backend com_config
 		JLoader::register('TemplatesController', JPATH_ADMINISTRATOR . '/components/com_templates/controller.php');
@@ -44,14 +44,14 @@ class ConfigControllerTemplatesDisplay extends ConfigControllerDisplay
 
 		// Set backend required params
 		$document->setType('json');
-		$this->input->set('id', $app->getTemplate('template')->id);
+		$this->getInput()->set('id', $app->getTemplate('template')->id);
 
 		// Execute backend controller
 		$serviceData = json_decode($displayClass->display(), true);
 
 		// Reset params back after requesting from service
 		$document->setType('html');
-		$this->input->set('view', $viewName);
+		$this->getInput()->set('view', $viewName);
 
 		// Register the layout paths for the view
 		$paths = new SplPriorityQueue;

--- a/components/com_config/controller/templates/save.php
+++ b/components/com_config/controller/templates/save.php
@@ -28,13 +28,13 @@ class ConfigControllerTemplatesSave extends JControllerBase
 		// Check for request forgeries.
 		if (!JSession::checkToken())
 		{
-			JFactory::getApplication()->redirect('index.php', JText::_('JINVALID_TOKEN'));
+			$this->getApplication()->redirect('index.php', JText::_('JINVALID_TOKEN'));
 		}
 
 		// Check if the user is authorized to do this.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			JFactory::getApplication()->redirect('index.php', JText::_('JERROR_ALERTNOAUTHOR'));
+			$this->getApplication()->redirect('index.php', JText::_('JERROR_ALERTNOAUTHOR'));
 
 			return;
 		}
@@ -42,7 +42,7 @@ class ConfigControllerTemplatesSave extends JControllerBase
 		// Set FTP credentials, if given.
 		JClientHelper::setCredentialsFromRequest('ftp');
 
-		$app = JFactory::getApplication();
+		$app = $this->getApplication();
 
 		// Access backend com_templates
 		JLoader::register('TemplatesControllerStyle', JPATH_ADMINISTRATOR . '/components/com_templates/controllers/style.php');
@@ -55,7 +55,7 @@ class ConfigControllerTemplatesSave extends JControllerBase
 
 		// Set backend required params
 		$document->setType('json');
-		$this->input->set('id', $app->getTemplate('template')->id);
+		$this->getInput()->set('id', $app->getTemplate('template')->id);
 
 		// Execute backend controller
 		$return = $controllerClass->save();

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
             "php": "5.5.9"
         },
         "preferred-install": {
+            "joomla/application": "dist",
+            "joomla/controller": "dist",
             "joomla/crypt": "dist",
             "joomla/event": "dist",
             "joomla/http": "dist",
@@ -31,6 +33,7 @@
     "require": {
         "php": ">=5.5.9",
         "joomla/application": "~2.0@dev",
+        "joomla/controller": "~2.0@dev",
         "joomla/crypt": "~2.0@dev",
         "joomla/data": "~1.2",
         "joomla/di": "~1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4857162408ea82b596fb66fcf9444a31",
+    "content-hash": "0811b09a52a0563cd302c35abf1c7cf9",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -259,6 +259,57 @@
                 "joomla"
             ],
             "time": "2015-02-24T00:21:06+00:00"
+        },
+        {
+            "name": "joomla/controller",
+            "version": "dev-2.0-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/joomla-framework/controller.git",
+                "reference": "441b110abd0c088fef356dd8dcb60cecd93e1f60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/joomla-framework/controller/zipball/441b110abd0c088fef356dd8dcb60cecd93e1f60",
+                "reference": "441b110abd0c088fef356dd8dcb60cecd93e1f60",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|~7.0"
+            },
+            "require-dev": {
+                "joomla/application": "~1.0|~2.0",
+                "joomla/input": "~1.0|~2.0",
+                "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "suggest": {
+                "joomla/application": "The joomla/application package is required to use Joomla\\Controller\\AbstractController",
+                "joomla/input": "The joomla/input package is required to use Joomla\\Controller\\AbstractController"
+            },
+            "type": "joomla-package",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.0-dev": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Joomla\\Controller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Joomla Controller Package",
+            "homepage": "https://github.com/joomla-framework/controller",
+            "keywords": [
+                "controller",
+                "framework",
+                "joomla"
+            ],
+            "time": "2017-02-19T22:01:31+00:00"
         },
         {
             "name": "joomla/crypt",
@@ -3164,6 +3215,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "joomla/application": 20,
+        "joomla/controller": 20,
         "joomla/crypt": 20,
         "joomla/event": 20,
         "joomla/http": 20,

--- a/libraries/joomla/controller/base.php
+++ b/libraries/joomla/controller/base.php
@@ -10,128 +10,66 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\AbstractApplication;
+use Joomla\Controller\AbstractController;
+use Joomla\Input\Input;
 
 /**
  * Joomla Platform Base Controller Class
  *
  * @since  12.1
  */
-abstract class JControllerBase implements JController
+abstract class JControllerBase extends AbstractController implements JController
 {
-	/**
-	 * The application object.
-	 *
-	 * @var    AbstractApplication
-	 * @since  12.1
-	 */
-	protected $app;
-
-	/**
-	 * The input object.
-	 *
-	 * @var    JInput
-	 * @since  12.1
-	 */
-	protected $input;
-
 	/**
 	 * Instantiate the controller.
 	 *
-	 * @param   JInput               $input  The input object.
+	 * @param   Input                $input  The input object.
 	 * @param   AbstractApplication  $app    The application object.
 	 *
 	 * @since  12.1
 	 */
-	public function __construct(JInput $input = null, AbstractApplication $app = null)
+	public function __construct(Input $input = null, AbstractApplication $app = null)
 	{
-		// Setup dependencies.
-		$this->app = isset($app) ? $app : $this->loadApplication();
-		$this->input = isset($input) ? $input : $this->loadInput();
-	}
-
-	/**
-	 * Get the application object.
-	 *
-	 * @return  AbstractApplication  The application object.
-	 *
-	 * @since   12.1
-	 */
-	public function getApplication()
-	{
-		return $this->app;
-	}
-
-	/**
-	 * Get the input object.
-	 *
-	 * @return  JInput  The input object.
-	 *
-	 * @since   12.1
-	 */
-	public function getInput()
-	{
-		return $this->input;
-	}
-
-	/**
-	 * Serialize the controller.
-	 *
-	 * @return  string  The serialized controller.
-	 *
-	 * @since   12.1
-	 */
-	public function serialize()
-	{
-		return serialize($this->input);
-	}
-
-	/**
-	 * Unserialize the controller.
-	 *
-	 * @param   string  $input  The serialized controller.
-	 *
-	 * @return  JController  Supports chaining.
-	 *
-	 * @since   12.1
-	 * @throws  UnexpectedValueException if input is not the right class.
-	 */
-	public function unserialize($input)
-	{
-		// Setup dependencies.
-		$this->app = $this->loadApplication();
-
-		// Unserialize the input.
-		$this->input = unserialize($input);
-
-		if (!($this->input instanceof JInput))
+		if ($app)
 		{
-			throw new UnexpectedValueException(sprintf('%s::unserialize would not accept a `%s`.', get_class($this), gettype($this->input)));
+			$this->setApplication($app);
+		}
+		else
+		{
+			$this->loadApplication();
 		}
 
-		return $this;
+		if ($input)
+		{
+			$this->setInput($input);
+		}
+		else
+		{
+			$this->loadInput();
+		}
 	}
 
 	/**
 	 * Load the application object.
 	 *
-	 * @return  AbstractApplication  The application object.
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
 	protected function loadApplication()
 	{
-		return JFactory::getApplication();
+		$this->setApplication(JFactory::getApplication());
 	}
 
 	/**
 	 * Load the input object.
 	 *
-	 * @return  JInput  The input object.
+	 * @return  void
 	 *
 	 * @since   12.1
 	 */
 	protected function loadInput()
 	{
-		return $this->app->input;
+		$this->setInput($this->getApplication()->input);
 	}
 }

--- a/libraries/joomla/controller/controller.php
+++ b/libraries/joomla/controller/controller.php
@@ -10,27 +10,17 @@
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\AbstractApplication;
+use Joomla\Controller\ControllerInterface;
+use Joomla\Input\Input;
 
 /**
  * Joomla Platform Controller Interface
  *
- * @since  12.1
+ * @since       12.1
+ * @deprecated  5.0  Implement Joomla\Controller\ControllerInterface instead
  */
-interface JController extends Serializable
+interface JController extends ControllerInterface
 {
-	/**
-	 * Execute the controller.
-	 *
-	 * @return  boolean  True if controller finished execution, false if the controller did not
-	 *                   finish execution. A controller might return false if some precondition for
-	 *                   the controller to run has not been satisfied.
-	 *
-	 * @since   12.1
-	 * @throws  LogicException
-	 * @throws  RuntimeException
-	 */
-	public function execute();
-
 	/**
 	 * Get the application object.
 	 *
@@ -43,7 +33,7 @@ interface JController extends Serializable
 	/**
 	 * Get the input object.
 	 *
-	 * @return  JInput  The input object.
+	 * @return  Input  The input object.
 	 *
 	 * @since   12.1
 	 */

--- a/libraries/vendor/composer/autoload_psr4.php
+++ b/libraries/vendor/composer/autoload_psr4.php
@@ -33,6 +33,7 @@ return array(
     'Joomla\\DI\\Tests\\' => array($vendorDir . '/joomla/di/Tests'),
     'Joomla\\DI\\' => array($vendorDir . '/joomla/di/src'),
     'Joomla\\Crypt\\' => array($vendorDir . '/joomla/crypt/src'),
+    'Joomla\\Controller\\' => array($vendorDir . '/joomla/controller/src'),
     'Joomla\\Application\\' => array($vendorDir . '/joomla/application/src'),
     'Joomla\\' => array($baseDir . '/libraries/src'),
     'Composer\\CaBundle\\' => array($vendorDir . '/composer/ca-bundle/src'),

--- a/libraries/vendor/composer/autoload_static.php
+++ b/libraries/vendor/composer/autoload_static.php
@@ -67,6 +67,7 @@ class ComposerStaticInitf349050c508061257f7f25c9c2eeb293
             'Joomla\\DI\\Tests\\' => 16,
             'Joomla\\DI\\' => 10,
             'Joomla\\Crypt\\' => 13,
+            'Joomla\\Controller\\' => 18,
             'Joomla\\Application\\' => 19,
             'Joomla\\' => 7,
         ),
@@ -184,6 +185,10 @@ class ComposerStaticInitf349050c508061257f7f25c9c2eeb293
         'Joomla\\Crypt\\' => 
         array (
             0 => __DIR__ . '/..' . '/joomla/crypt/src',
+        ),
+        'Joomla\\Controller\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/joomla/controller/src',
         ),
         'Joomla\\Application\\' => 
         array (

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -1467,5 +1467,58 @@
             "framework",
             "joomla"
         ]
+    },
+    {
+        "name": "joomla/controller",
+        "version": "dev-2.0-dev",
+        "version_normalized": "dev-2.0-dev",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/joomla-framework/controller.git",
+            "reference": "441b110abd0c088fef356dd8dcb60cecd93e1f60"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/joomla-framework/controller/zipball/441b110abd0c088fef356dd8dcb60cecd93e1f60",
+            "reference": "441b110abd0c088fef356dd8dcb60cecd93e1f60",
+            "shasum": ""
+        },
+        "require": {
+            "php": "^5.5.9|~7.0"
+        },
+        "require-dev": {
+            "joomla/application": "~1.0|~2.0",
+            "joomla/input": "~1.0|~2.0",
+            "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0",
+            "squizlabs/php_codesniffer": "1.*"
+        },
+        "suggest": {
+            "joomla/application": "The joomla/application package is required to use Joomla\\Controller\\AbstractController",
+            "joomla/input": "The joomla/input package is required to use Joomla\\Controller\\AbstractController"
+        },
+        "time": "2017-02-19T22:01:31+00:00",
+        "type": "joomla-package",
+        "extra": {
+            "branch-alias": {
+                "dev-2.0-dev": "2.0-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Joomla\\Controller\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "GPL-2.0+"
+        ],
+        "description": "Joomla Controller Package",
+        "homepage": "https://github.com/joomla-framework/controller",
+        "keywords": [
+            "controller",
+            "framework",
+            "joomla"
+        ]
     }
 ]

--- a/libraries/vendor/joomla/controller/LICENSE
+++ b/libraries/vendor/joomla/controller/LICENSE
@@ -1,0 +1,340 @@
+GNU GENERAL PUBLIC LICENSE
+				Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+				Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+			GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+	a) You must cause the modified files to carry prominent notices
+	stating that you changed the files and the date of any change.
+
+	b) You must cause any work that you distribute or publish, that in
+	whole or in part contains or is derived from the Program or any
+	part thereof, to be licensed as a whole at no charge to all third
+	parties under the terms of this License.
+
+	c) If the modified program normally reads commands interactively
+	when run, you must cause it, when started running for such
+	interactive use in the most ordinary way, to print or display an
+	announcement including an appropriate copyright notice and a
+	notice that there is no warranty (or else, saying that you provide
+	a warranty) and that users may redistribute the program under
+	these conditions, and telling the user how to view a copy of this
+	License.  (Exception: if the Program itself is interactive but
+	does not normally print such an announcement, your work based on
+	the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+	a) Accompany it with the complete corresponding machine-readable
+	source code, which must be distributed under the terms of Sections
+	1 and 2 above on a medium customarily used for software interchange; or,
+
+	b) Accompany it with a written offer, valid for at least three
+	years, to give any third party, for a charge no more than your
+	cost of physically performing source distribution, a complete
+	machine-readable copy of the corresponding source code, to be
+	distributed under the terms of Sections 1 and 2 above on a medium
+	customarily used for software interchange; or,
+
+	c) Accompany it with the information you received as to the offer
+	to distribute corresponding source code.  (This alternative is
+	allowed only for noncommercial distribution and only if you
+	received the program in object code or executable form with such
+	an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+				NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+			 END OF TERMS AND CONDITIONS
+
+		How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+	<one line to give the program's name and a brief idea of what it does.>
+	Copyright (C) <year>  <name of author>
+
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation; either version 2 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+	Gnomovision version 69, Copyright (C) year name of author
+	Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+	This is free software, and you are welcome to redistribute it
+	under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.

--- a/libraries/vendor/joomla/controller/src/AbstractController.php
+++ b/libraries/vendor/joomla/controller/src/AbstractController.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Part of the Joomla Framework Controller Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Controller;
+
+use Joomla\Input\Input;
+use Joomla\Application\AbstractApplication;
+
+/**
+ * Joomla Framework Base Controller Class
+ *
+ * @since  1.0
+ */
+abstract class AbstractController implements ControllerInterface
+{
+	/**
+	 * The application object.
+	 *
+	 * @var    AbstractApplication
+	 * @since  1.0
+	 */
+	private $app;
+
+	/**
+	 * The input object.
+	 *
+	 * @var    Input
+	 * @since  1.0
+	 */
+	private $input;
+
+	/**
+	 * Instantiate the controller.
+	 *
+	 * @param   Input                $input  The input object.
+	 * @param   AbstractApplication  $app    The application object.
+	 *
+	 * @since  1.0
+	 */
+	public function __construct(Input $input = null, AbstractApplication $app = null)
+	{
+		$this->input = $input;
+		$this->app   = $app;
+	}
+
+	/**
+	 * Get the application object.
+	 *
+	 * @return  AbstractApplication  The application object.
+	 *
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException if the application has not been set.
+	 */
+	public function getApplication()
+	{
+		if ($this->app)
+		{
+			return $this->app;
+		}
+
+		throw new \UnexpectedValueException('Application not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Get the input object.
+	 *
+	 * @return  Input  The input object.
+	 *
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException
+	 */
+	public function getInput()
+	{
+		if ($this->input)
+		{
+			return $this->input;
+		}
+
+		throw new \UnexpectedValueException('Input not set in ' . __CLASS__);
+	}
+
+	/**
+	 * Serialize the controller.
+	 *
+	 * @return  string  The serialized controller.
+	 *
+	 * @since   1.0
+	 */
+	public function serialize()
+	{
+		return serialize($this->getInput());
+	}
+
+	/**
+	 * Set the application object.
+	 *
+	 * @param   AbstractApplication  $app  The application object.
+	 *
+	 * @return  AbstractController  Returns itself to support chaining.
+	 *
+	 * @since   1.0
+	 */
+	public function setApplication(AbstractApplication $app)
+	{
+		$this->app = $app;
+
+		return $this;
+	}
+
+	/**
+	 * Set the input object.
+	 *
+	 * @param   Input  $input  The input object.
+	 *
+	 * @return  AbstractController  Returns itself to support chaining.
+	 *
+	 * @since   1.0
+	 */
+	public function setInput(Input $input)
+	{
+		$this->input = $input;
+
+		return $this;
+	}
+
+	/**
+	 * Unserialize the controller.
+	 *
+	 * @param   string  $input  The serialized controller.
+	 *
+	 * @return  AbstractController  Returns itself to support chaining.
+	 *
+	 * @since   1.0
+	 * @throws  \UnexpectedValueException if input is not the right class.
+	 */
+	public function unserialize($input)
+	{
+		$input = unserialize($input);
+
+		if (!($input instanceof Input))
+		{
+			throw new \UnexpectedValueException(sprintf('%s would not accept a `%s`.', __METHOD__, gettype($this->input)));
+		}
+
+		$this->setInput($input);
+
+		return $this;
+	}
+}

--- a/libraries/vendor/joomla/controller/src/ControllerInterface.php
+++ b/libraries/vendor/joomla/controller/src/ControllerInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Part of the Joomla Framework Controller Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Controller;
+
+/**
+ * Joomla Framework Controller Interface
+ *
+ * @since  1.0
+ */
+interface ControllerInterface extends \Serializable
+{
+	/**
+	 * Execute the controller.
+	 *
+	 * @return  boolean  True if controller finished execution, false if the controller did not
+	 *                   finish execution. A controller might return false if some precondition for
+	 *                   the controller to run has not been satisfied.
+	 *
+	 * @since   1.0
+	 * @throws  \LogicException
+	 * @throws  \RuntimeException
+	 */
+	public function execute();
+}

--- a/tests/unit/suites/libraries/joomla/controller/JControllerBaseTest.php
+++ b/tests/unit/suites/libraries/joomla/controller/JControllerBaseTest.php
@@ -34,82 +34,15 @@ class JControllerBaseTest extends TestCase
 	public function test__construct()
 	{
 		// New controller with no dependencies.
-		$this->assertEquals('default', TestReflection::getValue($this->_instance, 'app')->input, 'Checks the mock application came from the factory.');
-		$this->assertAttributeEquals('default', 'input', $this->_instance, 'Checks the input came from the application.');
+		$this->assertAttributeSame(JFactory::$application, 'app', $this->_instance, 'Checks the mock application came from the factory.');
 
 		// New controller with dependencies
-		$app = TestMockApplicationWeb::create($this);
-		$app->test = 'ok';
+		$app   = $this->getMockWeb();
+		$input = new JInput;
 
-		$class = new BaseController(new JInputCookie, $app);
-		$this->assertAttributeInstanceOf('JInputCookie', 'input', $class, 'Checks the type of the injected input.');
+		$class = new BaseController($input, $app);
+		$this->assertAttributeSame($input, 'input', $class, 'Checks the injected input.');
 		$this->assertAttributeSame($app, 'app', $class, 'Checks the injected application.');
-	}
-
-	/**
-	 * Tests the getApplication method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function testGetApplication()
-	{
-		TestReflection::setValue($this->_instance, 'app', 'application');
-		$this->assertEquals('application', $this->_instance->getApplication());
-	}
-
-	/**
-	 * Tests the getInput method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function testGetInput()
-	{
-		TestReflection::setValue($this->_instance, 'input', 'input');
-		$this->assertEquals('input', $this->_instance->getInput());
-	}
-
-	/**
-	 * Tests the serialize method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function testSerialise()
-	{
-		$this->assertEquals('s:7:"default";', $this->_instance->serialize());
-	}
-
-	/**
-	 * Tests the unserialize method.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 */
-	public function testUnserialise()
-	{
-		$input = serialize(new JInput);
-
-		$this->assertSame($this->_instance, $this->_instance->unserialize($input), 'Checks chaining and target method.');
-		$this->assertInstanceOf('JInput', $this->_instance->getInput());
-	}
-
-	/**
-	 * Tests the unserialize method for an expected exception.
-	 *
-	 * @return  void
-	 *
-	 * @since   12.1
-	 * @expectedException  UnexpectedValueException
-	 */
-	public function testUnserialise_exception()
-	{
-		$this->_instance->unserialize('s:7:"default";');
 	}
 
 	/**
@@ -121,8 +54,11 @@ class JControllerBaseTest extends TestCase
 	 */
 	public function testLoadApplication()
 	{
-		JFactory::$application = 'application';
-		$this->assertEquals('application', TestReflection::invoke($this->_instance, 'loadApplication'));
+		JFactory::$application = $this->getMockCmsApp();
+
+		TestReflection::invoke($this->_instance, 'loadApplication');
+
+		$this->assertAttributeSame(JFactory::$application, 'app', $this->_instance);
 	}
 
 	/**
@@ -134,10 +70,11 @@ class JControllerBaseTest extends TestCase
 	 */
 	public function testLoadInput()
 	{
-		// Reset the input property so we know it changes based on the mock application.
-		TestReflection::setValue($this->_instance, 'input', null);
+		JFactory::$application->input = $this->getMockBuilder('JInput')->disableOriginalConstructor()->getMock();
 
-		$this->assertEquals('default', TestReflection::invoke($this->_instance, 'loadInput'));
+		TestReflection::invoke($this->_instance, 'loadInput');
+
+		$this->assertAttributeSame(JFactory::$application->input, 'input', $this->_instance);
 	}
 
 	/**
@@ -153,8 +90,7 @@ class JControllerBaseTest extends TestCase
 
 		$this->saveFactoryState();
 
-		$app = TestMockApplicationWeb::create($this);
-		$app->input = 'default';
+		$app = $this->getMockWeb();
 
 		JFactory::$application = $app;
 


### PR DESCRIPTION
### Summary of Changes

The web application routers were removed in the 4.0 branch in favor of using the Framework's Router package.  1.x of this package requires a `Joomla\Controller\ControllerInterface` implementation, of which it is impossible to do with existing CMS code.  This PR therefore makes the "no MVC" controller base class and interface compatible with the Framework's Controller package.

### Testing Instructions

Code review

### Documentation Changes Required

The `$app` and `$input` properties will now be private, requiring the use of the appropriate getters to retrieve this objects in subclasses.

If merged this will be added to https://docs.joomla.org/Potential_backward_compatibility_issues_in_Joomla_4