### PR TITLE
Lazyload the pathway

### DIFF
--- a/libraries/cms/pathway/pathway.php
+++ b/libraries/cms/pathway/pathway.php
@@ -110,6 +110,11 @@ class JPathway
 	 */
 	public function getPathway()
 	{
+		if (empty($this->_pathway))
+		{
+			$this->loadPathway();
+		}
+
 		$pw = $this->_pathway;
 
 		// Use array_values to reset the array keys numerically
@@ -144,6 +149,11 @@ class JPathway
 	 */
 	public function getPathwayNames()
 	{
+		if (empty($this->_pathway))
+		{
+			$this->loadPathway();
+		}
+
 		$names = array();
 
 		// Build the names array using just the names of each pathway item
@@ -200,6 +210,18 @@ class JPathway
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Load the pathway for this instance.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadPathway()
+	{
+		// There is nothing to do for the default implementation
 	}
 
 	/**

--- a/libraries/cms/pathway/site.php
+++ b/libraries/cms/pathway/site.php
@@ -17,13 +17,13 @@ defined('JPATH_PLATFORM') or die;
 class JPathwaySite extends JPathway
 {
 	/**
-	 * Class constructor.
+	 * Load the pathway for this instance.
 	 *
-	 * @param   array  $options  The class options.
+	 * @return  void
 	 *
-	 * @since   1.5
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct($options = array())
+	protected function loadPathway()
 	{
 		$this->_pathway = array();
 


### PR DESCRIPTION
### Summary of Changes

The `JPathwaySite` constructor attempts to arbitrarily build the pathway for each instantiated object.  Instead of this being a constructor behavior that happens on every load, let's make this a lazy load behavior that is only set up when the data is read.

### Testing Instructions

The pathway should still be loaded correctly when it is interacted with.

### Documentation Changes Required

N/A