### PR TITLE
Create a value object for a component record

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -21,7 +21,7 @@ class JComponentHelper
 	/**
 	 * The component list cache
 	 *
-	 * @var    array
+	 * @var    JComponentRecord[]
 	 * @since  1.6
 	 */
 	protected static $components = array();
@@ -32,7 +32,7 @@ class JComponentHelper
 	 * @param   string   $option  The component option.
 	 * @param   boolean  $strict  If set and the component does not exist, the enabled attribute will be set to false.
 	 *
-	 * @return  stdClass   An object with the information for the component.
+	 * @return  JComponentRecord  An object with the information for the component.
 	 *
 	 * @since   1.5
 	 */
@@ -46,19 +46,14 @@ class JComponentHelper
 			}
 			else
 			{
-				$result = new stdClass;
+				$result = new JComponentRecord;
 				$result->enabled = $strict ? false : true;
-				$result->params = new Registry;
+				$result->setParams(new Registry);
 			}
 		}
 		else
 		{
 			$result = static::$components[$option];
-		}
-
-		if (is_string($result->params))
-		{
-			static::$components[$option]->params = new Registry(static::$components[$option]->params);
 		}
 
 		return $result;
@@ -436,7 +431,7 @@ class JComponentHelper
 				->where($db->quoteName('type') . ' = ' . $db->quote('component'));
 			$db->setQuery($query);
 
-			return $db->loadObjectList('option');
+			return $db->loadObjectList('option', 'JComponentRecord');
 		};
 
 		/** @var JCacheControllerCallback $cache */
@@ -493,7 +488,7 @@ class JComponentHelper
 	/**
 	 * Get installed components
 	 *
-	 * @return  array  The components property
+	 * @return  JComponentRecord[]  The components property
 	 *
 	 * @since   3.6.3
 	 */

--- a/libraries/cms/component/record.php
+++ b/libraries/cms/component/record.php
@@ -54,7 +54,7 @@ class JComponentRecord extends JObject
 	/**
 	 * Class constructor
 	 *
-	 * @param   array  $data  The menu item data to load
+	 * @param   array  $data  The component record data to load
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/libraries/cms/component/record.php
+++ b/libraries/cms/component/record.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Component
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Object representing a component extension record
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JComponentRecord extends JObject
+{
+	/**
+	 * Primary key
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $id;
+
+	/**
+	 * The component name
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $option;
+
+	/**
+	 * The component parameters
+	 *
+	 * @var    string|Registry
+	 * @since  __DEPLOY_VERSION__
+	 * @note   This field is protected to require reading this field to proxy through the getter to convert the params to a Registry instance
+	 */
+	protected $params;
+
+	/**
+	 * Indicates if this component is enabled
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $enabled;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param   array  $data  The menu item data to load
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($data = array())
+	{
+		foreach ((array) $data as $key => $value)
+		{
+			$this->$key = $value;
+		}
+	}
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to the the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  4.0  Access the item parameters through the `getParams()` method
+	 */
+	public function __get($name)
+	{
+		if ($name === 'params')
+		{
+			return $this->getParams();
+		}
+
+		return $this->get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to the the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  4.0  Set the item parameters through the `setParams()` method
+	 */
+	public function __set($name, $value)
+	{
+		if ($name === 'params')
+		{
+			$this->setParams($value);
+
+			return;
+		}
+
+		$this->set($name, $value);
+	}
+
+	/**
+	 * Returns the menu item parameters
+	 *
+	 * @return  Registry
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getParams()
+	{
+		if (!($this->params instanceof Registry))
+		{
+			$this->params = new Registry($this->params);
+		}
+
+		return $this->params;
+	}
+
+	/**
+	 * Sets the menu item parameters
+	 *
+	 * @param   Registry|string  $params  The data to be stored as the parameters
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setParams($params)
+	{
+		$this->params = $params;
+	}
+}

--- a/libraries/cms/component/record.php
+++ b/libraries/cms/component/record.php
@@ -15,6 +15,7 @@ use Joomla\Registry\Registry;
  * Object representing a component extension record
  *
  * @since  __DEPLOY_VERSION__
+ * @note   As of 4.0 this class will no longer extend JObject
  */
 class JComponentRecord extends JObject
 {

--- a/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
+++ b/tests/unit/suites/libraries/cms/component/JComponentHelperTest.php
@@ -45,9 +45,8 @@ class JComponentHelperTest extends TestCaseDatabase
 		$component = JComponentHelper::getComponent('com_content');
 
 		$this->assertEquals(22, $component->id,	'com_content is extension ID 22');
-		$this->assertInstanceOf('JRegistry', $component->params, 'Parameters need to be of type JRegistry');
+		$this->assertInstanceOf('Joomla\\Registry\\Registry', $component->params, 'Parameters need to be a Registry instance');
 		$this->assertEquals('1', $component->params->get('show_title'), 'The show_title parameter of com_content should be set to 1');
-		$this->assertObjectHasAttribute('enabled', $component, 'The component data needs to have an enabled field');
 		$this->assertSame($component, JComponentHelper::getComponent('com_content'), 'The object returned must always be the same');
 	}
 
@@ -62,10 +61,9 @@ class JComponentHelperTest extends TestCaseDatabase
 	public function testGetComponent_falseComponent()
 	{
 		$component = JComponentHelper::getComponent('com_false');
-		$this->assertObjectNotHasAttribute('id', $component, 'Anonymous component does not have an ID');
-		$this->assertInstanceOf('JRegistry', $component->params, 'Parameters need to be of type JRegistry');
+		$this->assertEmpty($component->id,	'Anonymous component has no extension ID');
+		$this->assertInstanceOf('Joomla\\Registry\\Registry', $component->params, 'Parameters need to be a Registry instance');
 		$this->assertEquals(0, $component->params->count(), 'Anonymous component does not have any set parameters');
-		$this->assertObjectHasAttribute('enabled', $component, 'The component data needs to have an enabled field');
 		$this->assertTrue($component->enabled, 'The anonymous component has to be enabled by default if not strict');
 	}
 
@@ -78,7 +76,7 @@ class JComponentHelperTest extends TestCaseDatabase
 	 * @covers  JComponentHelper::getComponent
 	 */
 	public function testGetComponent_falseComponent_strict()
-	{		
+	{
 		$component = JComponentHelper::getComponent('com_false', true);
 		$this->assertFalse($component->enabled, 'The anonymous component has to be disabled by default if strict');
 	}


### PR DESCRIPTION
### Summary of Changes

Create a new `JComponentRecord` value object representing the object loaded by `JComponentHelper::load()` for a component.  Shift the logic for converting the record's parameters to a `Registry` object to the point where the parameters are first accessed (this removes a needless conversion if calling `JComponentHelper::isEnabled()` and that is the only interaction with a component's record).

The value object extends `JObject` as a bridge to help with the transition.  At 4.0, this class extension should be dropped as well as the magic getter/setter methods.

### Testing Instructions

The CMS still functions as intended.  Component parameters are lazy loaded when needed.

### Documentation Changes Required

Document the new class and scheduled deprecations.