### PR TITLE
Simplify catches for cache exceptions

### DIFF
--- a/administrator/components/com_login/models/login.php
+++ b/administrator/components/com_login/models/login.php
@@ -162,20 +162,7 @@ class LoginModelLogin extends JModelLegacy
 		{
 			return $clean = $cache->get($loader, array(), md5(serialize(array($clientId, $lang))));
 		}
-		catch (JCacheExceptionConnecting $cacheException)
-		{
-			try
-			{
-				return $loader();
-			}
-			catch (JDatabaseExceptionExecuting $databaseException)
-			{
-				JError::raiseWarning(500, JText::sprintf('JLIB_APPLICATION_ERROR_MODULE_LOAD', $databaseException->getMessage()));
-
-				return array();
-			}
-		}
-		catch (JCacheExceptionUnsupported $cacheException)
+		catch (JCacheException $cacheException)
 		{
 			try
 			{

--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -315,11 +315,7 @@ abstract class JPluginHelper
 		{
 			static::$plugins = $cache->get($loader, array(), md5($levels), false);
 		}
-		catch (JCacheExceptionConnecting $cacheException)
-		{
-			static::$plugins = $loader();
-		}
-		catch (JCacheExceptionUnsupported $cacheException)
+		catch (JCacheException $cacheException)
 		{
 			static::$plugins = $loader();
 		}


### PR DESCRIPTION
### Summary of Changes

Simplify the catches for a couple cache exception cases to catch the interface instead of each subclass.

### Testing Instructions

Review

### Documentation Changes Required

N/A