### PR TITLE
Improvements for JLibraryHelper

### DIFF
--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -38,27 +38,22 @@ class JLibraryHelper
 	 */
 	public static function getLibrary($element, $strict = false)
 	{
-		// Is already cached ?
-		if (isset(static::$libraries[$element]))
-		{
-			return static::$libraries[$element];
-		}
-
-		if (static::_load($element))
+		// Is already cached?
+		if (isset(static::$libraries[$element]) || static::_load($element))
 		{
 			$result = static::$libraries[$element];
+
+			// Convert the params to an object.
+			if (is_string($result->params))
+			{
+				$result->params = new Registry($result->params);
+			}
 		}
 		else
 		{
 			$result = new stdClass;
 			$result->enabled = $strict ? false : true;
 			$result->params = new Registry;
-		}
-
-		// Convert the params to an object.
-		if (is_string($result->params))
-		{
-			$result->params = new Registry($result->params);
 		}
 
 		return $result;

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -187,7 +187,7 @@ class JLibraryHelper
 
 		try
 		{
-			static::$libraries = $cache->get($loader);
+			static::$libraries = $cache->get($loader, array(), __METHOD__);
 		}
 		catch (JCacheException $e)
 		{

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -46,12 +46,6 @@ class JLibraryHelper
 
 		if (static::_load($element))
 		{
-			// Convert the params to an object.
-			if (is_string(static::$libraries[$element]->params))
-			{
-				static::$libraries[$element]->params = new Registry(static::$libraries[$element]->params);
-			}
-
 			$result = static::$libraries[$element];
 		}
 		else
@@ -59,6 +53,12 @@ class JLibraryHelper
 			$result = new stdClass;
 			$result->enabled = $strict ? false : true;
 			$result->params = new Registry;
+		}
+
+		// Convert the params to an object.
+		if (is_string($result->params))
+		{
+			$result->params = new Registry($result->params);
 		}
 
 		return $result;

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -144,14 +144,32 @@ class JLibraryHelper
 	/**
 	 * Load the installed libraries into the libraries property.
 	 *
-	 * @param   string  $element  The element value for the extension
+	 * @param   string  $element  The element value for the extension [deprecated]
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @note    As of 4.0 this method will be restructured to only load the data into memory
 	 */
 	protected static function load($element)
 	{
+		try
+		{
+			JLog::add(
+				sprintf(
+					'Passing a parameter into %s() is deprecated and will be removed in 4.0. Read %s::$libraries directly after loading the data.',
+					__METHOD__,
+					__CLASS__
+				),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $e)
+		{
+			// Informational log only
+		}
+
 		$loader = function ()
 		{
 			$db = JFactory::getDbo();
@@ -169,20 +187,7 @@ class JLibraryHelper
 
 		try
 		{
-			$libraries = $cache->get($loader, array(), $element, false);
-
-			/**
-			 * Verify $libraries is an array, some cache handlers return an object even though
-			 * the original was a single object array.
-			 */
-			if (!is_array($libraries))
-			{
-				static::$libraries[$element] = $libraries;
-			}
-			else
-			{
-				static::$libraries = $libraries;
-			}
+			static::$libraries = $cache->get($loader);
 		}
 		catch (JCacheException $e)
 		{

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -134,8 +134,23 @@ class JLibraryHelper
 	 * @return  boolean  True on success
 	 *
 	 * @since   3.2
+	 * @deprecated  4.0  Use JLibraryHelper::load() instead
 	 */
 	protected static function _load($element)
+	{
+		return static::load($element);
+	}
+
+	/**
+	 * Load the installed libraries into the libraries property.
+	 *
+	 * @param   string  $element  The element value for the extension
+	 *
+	 * @return  boolean  True on success
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected static function load($element)
 	{
 		$loader = function ()
 		{

--- a/libraries/cms/library/helper.php
+++ b/libraries/cms/library/helper.php
@@ -46,6 +46,12 @@ class JLibraryHelper
 
 		if (static::_load($element))
 		{
+			// Convert the params to an object.
+			if (is_string(static::$libraries[$element]->params))
+			{
+				static::$libraries[$element]->params = new Registry(static::$libraries[$element]->params);
+			}
+
 			$result = static::$libraries[$element];
 		}
 		else
@@ -201,12 +207,6 @@ class JLibraryHelper
 			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_LIBRARY_NOT_LOADING', $element, $error), JLog::WARNING, 'jerror');
 
 			return false;
-		}
-
-		// Convert the params to an object.
-		if (is_string(static::$libraries[$element]->params))
-		{
-			static::$libraries[$element]->params = new Registry(static::$libraries[$element]->params);
 		}
 
 		return true;


### PR DESCRIPTION
### Summary of Changes

This PR makes several small tweaks to the `JLibraryHelper` class, including:

1) Deprecating `JLibraryHelper::_load()` in favor of `JLibraryHelper::load()` for code style reasons (no underscore methods)
2) Changing `JLibraryHelper::load()` to issue only a single database query for all libraries versus a query per library, similar to the other helper loaders
3) Making `JLibraryHelper::load()` resilient to a cache engine failure and no longer catching a database failure

### Testing Instructions

Interaction with the library helper still works as normal.  This PR mainly requires ensuring the Joomla library parameters still load OK (if you have a query string on your media URLs and don't get a "error loading library" message, you're good.

### Documentation Changes Required

Document the deprecation.