### PR TITLE
Alpha order the language strings

### DIFF
--- a/administrator/language/en-GB/en-GB.com_categories.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_categories.sys.ini
@@ -4,11 +4,10 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CATEGORIES="Categories"
-COM_CATEGORIES_XML_DESCRIPTION="This component manages categories."
-
 COM_CATEGORIES_CATEGORIES_VIEW_DEFAULT_DESC="Shows a List of All categories in the selected component."
 COM_CATEGORIES_CATEGORIES_VIEW_DEFAULT_TITLE="List All Categories"
 COM_CATEGORIES_CATEGORY_VIEW_EDIT_DESC="Create a new Category in the selected component."
 COM_CATEGORIES_CATEGORY_VIEW_EDIT_TITLE="Create New Category"
 COM_CATEGORIES_CHOOSE_COMPONENT_DESC="Select a component to which this category should be linked. <br />If a component using categories is not proposed in the list, please create at least one category for it using the default regular menu."
 COM_CATEGORIES_CHOOSE_COMPONENT_LABEL="Choose a Component"
+COM_CATEGORIES_XML_DESCRIPTION="This component manages categories."


### PR DESCRIPTION
### Summary of Changes

This just alpha order the new language strings in `administrator/language/en-GB/en-GB.com_categories.sys.ini`

### Testing Instructions

review

### Expected result

alpha orderd strings

### Actual result

none alpha orderd string

### Documentation Changes Required

None.