### PR TITLE
Fix issue with callback cache controller hashing Closures

### DIFF
--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -212,6 +212,14 @@ class JCacheControllerCallback extends JCacheController
 			$callback[0] = $vars;
 		}
 
+		// A Closure can't be serialized, so to generate the ID we'll need to get its hash
+		if (is_a($callback, 'closure'))
+		{
+			$hash = spl_object_hash($callback);
+
+			return md5($hash . serialize($args));
+		}
+
 		return md5(serialize(array($callback, $args)));
 	}
 }

--- a/libraries/joomla/cache/controller/callback.php
+++ b/libraries/joomla/cache/controller/callback.php
@@ -217,7 +217,7 @@ class JCacheControllerCallback extends JCacheController
 		{
 			$hash = spl_object_hash($callback);
 
-			return md5($hash . serialize($args));
+			return md5($hash . serialize(array($args)));
 		}
 
 		return md5(serialize(array($callback, $args)));


### PR DESCRIPTION
### Summary of Changes

When using a Closure with the cache's callback controller, generating the ID will fail because it attempts to serialize a Closure which isn't allowed.  Change the code to use an object hash for the Closure instead.

### Testing Instructions

Probably should be easily triggered just by turning on caching for core because there are a few places where Closures are used now.  Failing that, I guess something like this should work as a test case:

```php
JFactory::getCache('_system', 'callback')->get(function () { echo 'Hello World!'; });
```

### Expected result

Page displays correctly

### Actual result

Page errors out due to attempted serialization of a Closure

### Documentation Changes Required

N/A