### PR TITLE
[bug] Fix localPath in gallery plugin. Closes #14056

### DIFF
--- a/plugins/fields/gallery/tmpl/gallery.php
+++ b/plugins/fields/gallery/tmpl/gallery.php
@@ -68,7 +68,7 @@ foreach ($value as $path)
 		$properties = JImage::getImageFileProperties($file);
 
 		// Relative path
-		$localPath    = str_replace(JPATH_ROOT . '/' . $root . '/', '', $file);
+		$localPath    = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . $root . DIRECTORY_SEPARATOR, '', $file);
 		$webImagePath = $root . '/' . $localPath;
 
 		if (($maxImageWidth && $properties->width > $maxImageWidth) || ($maxImageHeight && $properties->height > $maxImageHeight))

--- a/plugins/fields/gallery/tmpl/gallery.php
+++ b/plugins/fields/gallery/tmpl/gallery.php
@@ -68,7 +68,7 @@ foreach ($value as $path)
 		$properties = JImage::getImageFileProperties($file);
 
 		// Relative path
-		$localPath    = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . $root . DIRECTORY_SEPARATOR, '', $file);
+		$localPath    = str_replace(JPath::clean(JPATH_ROOT . '/' . $root . '/'), '', $file);
 		$webImagePath = $root . '/' . $localPath;
 
 		if (($maxImageWidth && $properties->width > $maxImageWidth) || ($maxImageHeight && $properties->height > $maxImageHeight))


### PR DESCRIPTION
Pull Request for Issue #14056.

### Summary of Changes

Replace '/' by DIRECTORY_SEPARATOR for wamp support.

### Testing Instructions

!! Testing must be made on Windows Systems

1.Create article.
2.Create custom field type gallery
3.On article gallery field select one folder to show the images, for example sampledata
4.Open article on frontend

### Expected result

Article with photo gallery

### Actual result

Warning message without gallery

### Documentation Changes Required
No.
