### PR TITLE
Language strings should be uppercase (com_contact)

### DIFF
--- a/administrator/components/com_contact/contact.xml
+++ b/administrator/components/com_contact/contact.xml
@@ -35,16 +35,16 @@
 	</languages>
 
 	<administration>
-		<menu img="class:contact">com_contact</menu>
+		<menu img="class:contact">COM_CONTACT</menu>
 		<submenu>
 			<!--
 				Note that all & must be escaped to &amp; for the file to be valid
 				XML and be parsed by the installer
 			-->
 			<menu link="option=com_contact" img="class:contact"
-				alt="Contact/Contacts">com_contact_contacts</menu>
+				alt="Contact/Contacts">COM_CONTACT_CONTACTS</menu>
 			<menu link="option=com_categories&amp;extension=com_contact"
-				view="categories" img="class:contact-cat" alt="Contacts/Categories">com_contact_categories</menu>
+				view="categories" img="class:contact-cat" alt="Contacts/Categories">COM_CONTACT_CATEGORIES</menu>
 		</submenu>
 		<files folder="admin">
 			<filename>access.xml</filename>


### PR DESCRIPTION
### Summary of Changes

Language strings should be uppercase (com_contact)

### Testing Instructions

Review (as this file is not used in the CMS Install)

### Expected result

Uppercase language strings

### Actual result

lowercase language strings

### Documentation Changes Required

None.