### PR TITLE
Move PHPCS tests from travis to drone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_script:
   # JavaScript tests
   - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash build/travis/javascript-tests.sh $PWD; fi
   # Make sure all dev dependencies are installed
-  - if [[ $RUN_UNIT_TESTS == "yes" )]]; then bash build/travis/unit-tests.sh $PWD; fi
+  - if [[ $RUN_UNIT_TESTS == "yes" ]]; then bash build/travis/unit-tests.sh $PWD; fi
 
 script:
   - if [[ $RUN_UNIT_TESTS == "yes" ]]; then libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: php
 
 env:
   global:
-    - RUN_PHPCS="no"
     - RUN_UNIT_TESTS="yes"
     - RUN_JAVASCRIPT_TESTS="no"
     - INSTALL_MEMCACHE="yes"
@@ -15,8 +14,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env: RUN_PHPCS="yes" RUN_UNIT_TESTS="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
     - php: 5.3
       env: INSTALL_APC="yes"
     - php: 5.4
@@ -60,10 +57,9 @@ before_script:
   # JavaScript tests
   - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then export DISPLAY=:99.0; bash build/travis/javascript-tests.sh $PWD; fi
   # Make sure all dev dependencies are installed
-  - if [[ ( $RUN_UNIT_TESTS == "yes" ) || ( $RUN_PHPCS == "yes" ) ]]; then bash build/travis/unit-tests.sh $PWD; fi
+  - if [[ $RUN_UNIT_TESTS == "yes" )]]; then bash build/travis/unit-tests.sh $PWD; fi
 
 script:
-  - if [[ $RUN_PHPCS == "yes" ]]; then libraries/vendor/bin/phpcs --report=full --extensions=php -p --standard=build/phpcs/Joomla .; fi
   - if [[ $RUN_UNIT_TESTS == "yes" ]]; then libraries/vendor/bin/phpunit --configuration travisci-phpunit.xml; fi
   - if [[ $RUN_JAVASCRIPT_TESTS == "yes" ]]; then tests/javascript/node_modules/karma/bin/karma start karma.conf.js --single-run ; fi
 


### PR DESCRIPTION
### Summary of Changes

Move the PHPCS tests to drone. This gives us more resources on travis and drone is much faster with the result of the code style check

### Documentation Changes Required

People need to understand that our code style is now tested with drone and not with travis, biggest change here is that we don't say (in 9 fro 10 failures) "Make Travis happy" any time longer it will be "Make Drone happy" :-)
