### PR TITLE
'STRICT_TRANS_TABLES' on MySQL 5.7

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -94,7 +94,6 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
-			'STRICT_TRANS_TABLES',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -186,7 +186,6 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
-			'STRICT_TRANS_TABLES',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -154,7 +154,6 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		// Set sql_mode to MySql 5.7.8+ default strict mode.
 		$sqlModes = array(
 			'ONLY_FULL_GROUP_BY',
-			'STRICT_TRANS_TABLES',
 			'ERROR_FOR_DIVISION_BY_ZERO',
 			'NO_AUTO_CREATE_USER',
 			'NO_ENGINE_SUBSTITUTION',


### PR DESCRIPTION
With this parameter 'STRICT_TRANS_TABLES' on MySQL 5.7.16:

When I try to save a module I get an error:
Save failed with the following error: Incorrect datetime value: '' for column 'publish_up' at row 1

When I try to save the content language I get an error:
Save failed with the following error: Field 'asset_id' doesn't have a default value