### PR TITLE
Module publish up, down and checkout out time should always have a null date if not set

### DIFF
--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -184,11 +184,6 @@ class JTableModule extends JTable
 			$this->publish_down = $this->_db->getNullDate();
 		}
 
-		if (!$this->checked_out_time)
-		{
-			$this->checked_out_time = $this->_db->getNullDate();
-		}
-
 		return parent::store($updateNulls);
 	}
 }

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -161,4 +161,34 @@ class JTableModule extends JTable
 
 		return parent::bind($array, $ignore);
 	}
+
+	/**
+	 * Stores a contact.
+	 *
+	 * @param   boolean  $updateNulls  True to update fields even if they are null.
+	 *
+	 * @return  boolean  True on success, false on failure.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function store($updateNulls = false)
+	{
+		// Set publish_up, publish_down and checked_out_time to null date if not set
+		if (!$this->publish_up)
+		{
+			$this->publish_up = $this->_db->getNullDate();
+		}
+
+		if (!$this->publish_down)
+		{
+			$this->publish_down = $this->_db->getNullDate();
+		}
+
+		if (!$this->checked_out_time)
+		{
+			$this->checked_out_time = $this->_db->getNullDate();
+		}
+
+		return parent::store($updateNulls);
+	}
 }

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -163,7 +163,7 @@ class JTableModule extends JTable
 	}
 
 	/**
-	 * Stores a contact.
+	 * Stores a module.
 	 *
 	 * @param   boolean  $updateNulls  True to update fields even if they are null.
 	 *


### PR DESCRIPTION
Pull Request for Issue #13031 .

### Summary of Changes
This a fix aimed towards the Joomla 4.x branch that ought to be in the 3.x branch too. Currently we don't always set this value (but with `STRICT_TRANS_TABLES` disabled it automatically has a null date applied). In the 4.x branch we've enabled this parameter causing modules to fail to save.

We are doing this same check in com_contact for example hence why I'm making this PR at the staging branch rather than 4.x even if the results aren't obvious to test in this branch

### Testing Instructions
Check modules continue to save in the 3.x branch with a null date if any of publish up, publish down or the checked out time isn't set

### Documentation Changes Required
None