### PR TITLE
Escape NULL byte in mssql driver

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -234,6 +234,9 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	{
 		$result = str_replace("'", "''", $text);
 
+		// SQL Server does not accept NULL byte in query string
+		$result = str_replace("\0", "' + CHAR(0) + N'", $result);
+
 		// Fix for SQL Sever escape sequence, see https://support.microsoft.com/en-us/kb/164291
 		$result = str_replace(
 			array("\\\n",     "\\\r",     "\\\\\r\r\n"),

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
@@ -27,6 +27,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		return array(
 			array("'%_abc123[]", false, "''%_abc123[]"),
 			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
+			array("binary\000data", false, "binary' + CHAR(0) + N'data"),
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13262#issuecomment-279690569

### Summary of Changes

MSSQL cut query string on NULL byte.
There not exists any escape sequence like `\\\0` to escape NULL byte.

This PR use function CHAR(0) and concatenation to workaround it.

"... 'text\0suffix' ..." will be replace to 
"... 'text' + CHAR(0) + 'suffix' ..."

### Testing Instructions
Be sure that you have enabled plugin `Smart Search - Categories`.
Go to Smart Search component and click Index button:

before patch you should see error:
`[Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Unclosed quotation mark after the character string 'O:19:"FinderIndexerResult":19:{s:11:"'.`

after patch you should see:
`[Microsoft][ODBC Driver 13 for SQL Server][SQL Server]Cannot insert the value NULL into column 'term_id', table 'joomla.dbo.#__finder_tokens_aggregate'; column does not allow nulls. INSERT fails.`


### Expected result
Query is valid but database table row has wrong value (unrelated issue).

### Actual result
Query is corrupted.

### Documentation Changes Required
None
