### PR TITLE
Workaround for missing SORT_NATURAL flag on php 5.3

### DIFF
--- a/administrator/components/com_associations/models/fields/itemtype.php
+++ b/administrator/components/com_associations/models/fields/itemtype.php
@@ -54,7 +54,7 @@ class JFormFieldItemType extends JFormFieldGroupedList
 		}
 
 		// Sort by alpha order.
-		ksort($options, SORT_NATURAL);
+		uksort($options, 'strnatcmp');
 
 		// Add options to parent array.
 		return array_merge(parent::getGroups(), $options);


### PR DESCRIPTION
Pull Request for Issue #14063

### Summary of Changes
`Replace ksort($options, SORT_NATURAL);` which does not work on php 5.3
to working equivalent `uksort($options, 'strnatcmp');`

Links:
* http://stackoverflow.com/questions/14096277/sorting-an-array-by-key-numerically
* http://stackoverflow.com/questions/12846030/keys-in-php-array-are-not-sorted-numerically
* http://stackoverflow.com/questions/15930583/array-keys-being-sorted-incorrectly-by-uksort-function


### Testing Instructions
Core review or 
create your own php test script to check `uksort` vs `ksort` or
real test on php 5.3 for component Multilingual Associations (take a look at #14063)


### Expected result
No warning on php 5.3 and works for all other php versions.


### Actual result
Warning on php 5.3 


### Documentation Changes Required
None
