### PR TITLE
[4.0] Fix login autofocus in Firefox

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -45,9 +45,10 @@ if ($spacing > 0)
 				id="mod-login-username"
 				type="text"
 				class="form-control input-full"
+				tabindex="1"
 				placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>"
-				size="15"
-				autofocus="true">
+				autofocus
+			>
 		</div>
 
 		<div class="form-group">
@@ -57,7 +58,7 @@ if ($spacing > 0)
 				type="password"
 				class="form-control input-full"
 				placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>"
-				size="15">
+			>
 		</div>
 
 		<?php if (count($twofactormethods) > 1): ?>
@@ -69,7 +70,7 @@ if ($spacing > 0)
 					type="text"
 					class="form-control input-full"
 					placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>"
-					size="15">
+				>
 			</div>
 		<?php endif; ?>
 

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -56,6 +56,9 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 <head>
 	<jdoc:include type="head" />
 	<style>
+		.login-initial {
+			display: none;
+		}
 		<?php // Check if debug is on ?>
 		<?php if ($app->get('debug_lang', 1) || $app->get('debug', 1)) : ?>
 		.view-login .container {
@@ -92,6 +95,7 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 			<?php // End Content ?>
 		</div>
 	</div>
+
 	<nav class="navbar fixed-bottom hidden-xs-down">
 		<ul class="nav nav-fill">
 			<li class="nav-item">
@@ -105,6 +109,17 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 			</li>
 		</ul>
 	</nav>
+
 	<jdoc:include type="modules" name="debug" style="none" />
+
+	<script>
+		document.addEventListener('DOMContentLoaded', function() {
+			var formTmp = document.querySelector('.login-initial');
+			if (formTmp) {
+				formTmp.style.display = 'block';
+				document.getElementById('mod-login-username').focus();
+			}
+		});
+	</script>
 </body>
 </html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -56,9 +56,6 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 <head>
 	<jdoc:include type="head" />
 	<style>
-		.login-initial {
-			display: none;
-		}
 		<?php // Check if debug is on ?>
 		<?php if ($app->get('debug_lang', 1) || $app->get('debug', 1)) : ?>
 		.view-login .container {
@@ -109,11 +106,5 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 		</ul>
 	</nav>
 	<jdoc:include type="modules" name="debug" style="none" />
-	<script>
-		document.addEventListener('DOMContentLoaded', function() {
-			var formTmp = document.querySelector('.login-initial');
-			if (formTmp) formTmp.style.display = 'block';
-		});
-	</script>
 </body>
 </html>


### PR DESCRIPTION
Pull Request for Issue #14071

### Summary of Changes

In Firefox, the backend login form would autofocus because the form was being set to `display:block` using Javascript. This PR removes that JS as there's no reason to hide the login form.


### Testing Instructions

- Apply patch
- Go to the admin login page
- It shoudl autofocus on the "Username" input
