### PR TITLE
[fields] Fix deprecated JUser::getParameters()

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -178,7 +178,6 @@ class PlgSystemFields extends JPlugin
 		}
 
 		$user = JFactory::getUser($userData['id']);
-		$user->params = (string) $user->getParam();
 
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -178,7 +178,7 @@ class PlgSystemFields extends JPlugin
 		}
 
 		$user = JFactory::getUser($userData['id']);
-		$user->params = (string) $user->getParameters();
+		$user->params = (string) $user->getParam();
 
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);


### PR DESCRIPTION
Pull Request for Issue #14072

### Summary of Changes

In Joomla 4.0, when trying to save a user in the backend, the following error will appear:

> Fatal error: Call to undefined method JUser::getParameters() in C:\dev\joomla4\plugins\system\fields\fields.php on line 181

because `JUser::getParameters()` was removed.

### Testing Instructions

**Joomla 3.x AND Joomla 4.0**
- Apply patch
- Try to save a user in the backend
