### PR TITLE
[imp] multilangstatus module: adding a warning

### DIFF
--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -233,7 +233,7 @@ abstract class MultilangstatusHelper
 	 *
 	 * @return  boolean True if the module is published, false otherwise.
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getDefaultHomeModule()
 	{
@@ -289,7 +289,7 @@ abstract class MultilangstatusHelper
 	 *
 	 * @return  stdClass  The Module object
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getModule($moduleName, $instanceTitle = null)
 	{

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -242,10 +242,10 @@ abstract class MultilangstatusHelper
 		$query = $db->getQuery(true)
 			->select($db->qn('menutype'))
 			->from($db->qn('#__menu'))
-			->where($db->qn('home') . ' = ' . $db->quote('1'))
-			->where($db->qn('published') . ' = ' . $db->quote('1'))
-			->where($db->qn('client_id') . ' = ' . $db->quote('0'))
-			->where($db->qn('language') . ' = ' . $db->quote('*'));
+			->where($db->qn('home') . ' = ' . $db->q('1'))
+			->where($db->qn('published') . ' = ' . $db->q('1'))
+			->where($db->qn('client_id') . ' = ' . $db->q('0'))
+			->where($db->qn('language') . ' = ' . $db->q('*'));
 
 		$db->setQuery($query);
 
@@ -255,9 +255,9 @@ abstract class MultilangstatusHelper
 		$query->clear()
 			->select($db->qn('title'))
 			->from($db->qn('#__modules'))
-			->where($db->qn('module') . ' = ' . $db->quote('mod_menu'))
-			->where($db->qn('published') . ' = ' . $db->quote('1'))
-			->where($db->qn('client_id') . ' = ' . $db->quote('0'));
+			->where($db->qn('module') . ' = ' . $db->q('mod_menu'))
+			->where($db->qn('published') . ' = ' . $db->q('1'))
+			->where($db->qn('client_id') . ' = ' . $db->q('0'));
 
 		$db->setQuery($query);
 
@@ -274,10 +274,8 @@ abstract class MultilangstatusHelper
 			{
 				continue;
 			}
-			else
-			{
-				return true;
-			}
+
+			return true;
 		}
 	}
 
@@ -298,13 +296,13 @@ abstract class MultilangstatusHelper
 		$query = $db->getQuery(true)
 			->select('id, title, module, position, content, showtitle, params')
 			->from($db->qn('#__modules'))
-			->where($db->qn('module') . ' = ' . $db->quote($moduleName))
-			->where($db->qn('published') . ' = ' . $db->quote('1'))
-			->where($db->qn('client_id') . ' = ' . $db->quote('0'));
+			->where($db->qn('module') . ' = ' . $db->q($moduleName))
+			->where($db->qn('published') . ' = ' . $db->q('1'))
+			->where($db->qn('client_id') . ' = ' . $db->q('0'));
 
 		if ($instanceTitle)
 		{
-			$query->where($db->qn('title') . ' = ' . $db->quote($instanceTitle));
+			$query->where($db->qn('title') . ' = ' . $db->q($instanceTitle));
 		}
 
 		$db->setQuery($query);

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -242,10 +242,10 @@ abstract class MultilangstatusHelper
 		$query = $db->getQuery(true)
 			->select($db->qn('menutype'))
 			->from($db->qn('#__menu'))
-			->where($db->qn('home') . ' = '. $db->quote('1'))
-			->where($db->qn('published') . ' = '. $db->quote('1'))
-			->where($db->qn('client_id') . ' = '. $db->quote('0'))
-			->where($db->qn('language') . ' = '. $db->quote('*'));
+			->where($db->qn('home') . ' = ' . $db->quote('1'))
+			->where($db->qn('published') . ' = ' . $db->quote('1'))
+			->where($db->qn('client_id') . ' = ' . $db->quote('0'))
+			->where($db->qn('language') . ' = ' . $db->quote('*'));
 
 		$db->setQuery($query);
 
@@ -256,8 +256,8 @@ abstract class MultilangstatusHelper
 			->select($db->qn('title'))
 			->from($db->qn('#__modules'))
 			->where($db->qn('module') . ' = ' . $db->quote('mod_menu'))
-			->where($db->qn('published') . ' = '. $db->quote('1'))
-			->where($db->qn('client_id') . ' = '. $db->quote('0'));
+			->where($db->qn('published') . ' = ' . $db->quote('1'))
+			->where($db->qn('client_id') . ' = ' . $db->quote('0'));
 
 		$db->setQuery($query);
 
@@ -284,8 +284,8 @@ abstract class MultilangstatusHelper
 	/**
 	 * Get module by name
 	 *
-	 * @param   string  $name   The name of the module
-	 * @param   string  $title  The title of the module, optional
+	 * @param   string  $moduleName     The name of the module
+	 * @param   string  $instanceTitle  The title of the module, optional
 	 *
 	 * @return  stdClass  The Module object
 	 *

--- a/administrator/components/com_languages/helpers/multilangstatus.php
+++ b/administrator/components/com_languages/helpers/multilangstatus.php
@@ -8,6 +8,7 @@
  */
 
 defined('_JEXEC') or die;
+use Joomla\Registry\Registry;
 
 /**
  * Multilang status helper.
@@ -225,5 +226,98 @@ abstract class MultilangstatusHelper
 		}
 
 		return $warnings;
+	}
+
+	/**
+	 * Method to get the status of the module displaying the menutype of the default Home page set to All languages.
+	 *
+	 * @return  boolean True if the module is published, false otherwise.
+	 *
+	 * @since   3.7.0
+	 */
+	public static function getDefaultHomeModule()
+	{
+		// Find Default Home menutype.
+		$db = JFactory::getDbo();
+		$query = $db->getQuery(true)
+			->select($db->qn('menutype'))
+			->from($db->qn('#__menu'))
+			->where($db->qn('home') . ' = '. $db->quote('1'))
+			->where($db->qn('published') . ' = '. $db->quote('1'))
+			->where($db->qn('client_id') . ' = '. $db->quote('0'))
+			->where($db->qn('language') . ' = '. $db->quote('*'));
+
+		$db->setQuery($query);
+
+		$menutype = $db->loadResult();
+
+		// Get published site menu modules titles.
+		$query->clear()
+			->select($db->qn('title'))
+			->from($db->qn('#__modules'))
+			->where($db->qn('module') . ' = ' . $db->quote('mod_menu'))
+			->where($db->qn('published') . ' = '. $db->quote('1'))
+			->where($db->qn('client_id') . ' = '. $db->quote('0'));
+
+		$db->setQuery($query);
+
+		$menutitles = $db->loadColumn();
+
+		// Do we have a published menu module displaying the default Home menu item set to all languages?
+		foreach ($menutitles as $menutitle)
+		{
+			$module       = self::getModule('mod_menu', $menutitle);
+			$moduleParams = new JRegistry($module->params);
+			$param        = $moduleParams->get('menutype', '');
+
+			if ($param && $param != $menutype)
+			{
+				continue;
+			}
+			else
+			{
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Get module by name
+	 *
+	 * @param   string  $name   The name of the module
+	 * @param   string  $title  The title of the module, optional
+	 *
+	 * @return  stdClass  The Module object
+	 *
+	 * @since   3.7.0
+	 */
+	public static function getModule($moduleName, $instanceTitle = null)
+	{
+		$db = JFactory::getDbo();
+
+		$query = $db->getQuery(true)
+			->select('id, title, module, position, content, showtitle, params')
+			->from($db->qn('#__modules'))
+			->where($db->qn('module') . ' = ' . $db->quote($moduleName))
+			->where($db->qn('published') . ' = ' . $db->quote('1'))
+			->where($db->qn('client_id') . ' = ' . $db->quote('0'));
+
+		if ($instanceTitle)
+		{
+			$query->where($db->qn('title') . ' = ' . $db->quote($instanceTitle));
+		}
+
+		$db->setQuery($query);
+
+		try
+		{
+			$modules = $db->loadObject();
+		}
+		catch (RuntimeException $e)
+		{
+			JLog::add(JText::sprintf('JLIB_APPLICATION_ERROR_MODULE_LOAD', $e->getMessage()), JLog::WARNING, 'jerror');
+		}
+
+		return $modules;
 	}
 }

--- a/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
@@ -23,6 +23,16 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 	<?php else : ?>
 	<table class="table table-striped table-condensed">
 		<tbody>
+		<?php if ($this->defaultHome == true) : ?>
+			<tr class="warning">
+				<td>
+					<span class="icon-pending"></span>
+				</td>
+				<td>
+					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_DEFAULT_HOME_MODULE_PUBLISHED'); ?>
+				</td>
+			</tr>
+		<?php endif; ?>
 		<?php if ($notice_homes) : ?>
 			<tr class="warning">
 				<td>

--- a/administrator/components/com_languages/views/multilangstatus/view.html.php
+++ b/administrator/components/com_languages/views/multilangstatus/view.html.php
@@ -35,6 +35,7 @@ class LanguagesViewMultilangstatus extends JViewLegacy
 		$this->site_langs      = JLanguageHelper::getInstalledLanguages(0);
 		$this->statuses        = MultilangstatusHelper::getStatus();
 		$this->homepages       = JLanguageMultilang::getSiteHomePages();
+		$this->defaultHome     = MultilangstatusHelper::getDefaultHomeModule();
 
 		parent::display($tpl);
 	}

--- a/administrator/language/en-GB/en-GB.com_languages.ini
+++ b/administrator/language/en-GB/en-GB.com_languages.ini
@@ -88,6 +88,7 @@ COM_LANGUAGES_MSG_SWITCH_ADMIN_LANGUAGE_SUCCESS="The Administrator Language has 
 COM_LANGUAGES_MULTILANGSTATUS_CONTACTS_ERROR="Some of the contacts linked to the user <strong>%s</strong> are incorrect."
 COM_LANGUAGES_MULTILANGSTATUS_CONTACTS_ERROR_TIP="Warning! A user/author should have only one contact to which is assigned language 'All' OR one contact for each published Content Language."
 COM_LANGUAGES_MULTILANGSTATUS_CONTENT_LANGUAGE_PUBLISHED="Published Content Languages"
+COM_LANGUAGES_MULTILANGSTATUS_DEFAULT_HOME_MODULE_PUBLISHED="This site is set as a multilingual site. The menu module displaying the Home menu item set to language &quot;All&quot; should not be published."
 COM_LANGUAGES_MULTILANGSTATUS_ERROR_CONTENT_LANGUAGE="A Default Home page is assigned to the <strong>%s</strong> Content Language although a Site Language for this Content Language is not installed or published AND/OR the Content Language is not published."
 COM_LANGUAGES_MULTILANGSTATUS_ERROR_LANGUAGE_TAG="The Content Language tag <strong>%s</strong> does not match the Site Language tag. Check that the Site Language is installed and published and the correct language tag is used for the Content Language. Example: for English (en-GB) both tags should be 'en-GB'."
 COM_LANGUAGES_MULTILANGSTATUS_HOMES_MISSING="This site is set as a multilingual site. One or more of the Default Home pages for the published Content languages are missing although the Language Filter plugin is enabled AND/OR one or more Language Switcher modules are published."


### PR DESCRIPTION
We have remarked in the forums that, when creating a multilingual site, users often forget to unpublish (or delete) the menu module to which is assigned the menutype containing the default Home menu item tagged to ALL languages.
That menu item is compulsory, but the menu module itself should at least be unpublished.

This patch will display a Warning in case that menu module exists and is published.

To test, create a multilingual site, make sure you have a menu module to which is assigned the menutype containing the default Home menu item tagged to ALL languages.
Make sure it is published.

Also, go to Modules->Administrator and make sure the Multilanguage Status module is published.
Then click on that module link in the status bar to get the modal popup.

If the menu module is published, you should get

![screen shot 2017-02-15 at 11 40 24](https://cloud.githubusercontent.com/assets/869724/22970751/9801614c-f373-11e6-9c92-ad93d3d82ea3.png)

If it is not published, there will not be any message in the pop-up.
 