### PR TITLE
[J4.0] remove backslash from void tags (part 2)

### DIFF
--- a/administrator/components/com_admin/views/help/tmpl/default.php
+++ b/administrator/components/com_admin/views/help/tmpl/default.php
@@ -35,5 +35,5 @@ JHtml::_('bootstrap.tooltip');
 			<iframe name="helpFrame" height="2100px" src="<?php echo $this->page; ?>" class="helpFrame table table-bordered"></iframe>
 		</div>
 	</div>
-	<input class="textarea" type="hidden" name="option" value="com_admin" />
+	<input class="textarea" type="hidden" name="option" value="com_admin">
 </form>

--- a/administrator/components/com_admin/views/profile/tmpl/edit.php
+++ b/administrator/components/com_admin/views/profile/tmpl/edit.php
@@ -73,6 +73,6 @@ $fieldsets = $this->form->getFieldsets();
 	<?php endforeach; ?>
 
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_admin/views/sysinfo/tmpl/default.php
+++ b/administrator/components/com_admin/views/sysinfo/tmpl/default.php
@@ -43,7 +43,7 @@ JHtml::_('behavior.tabstate');
 
 			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 		</div>
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 		<?php // End Content ?>
 	</div>

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -81,7 +81,7 @@ class JFormFieldModalAssociation extends JFormField
  				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
  				. '</button>';
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '">';
 
 		// Select custom association modal
 		$html[] = JHtml::_(

--- a/administrator/components/com_associations/views/association/tmpl/edit.php
+++ b/administrator/components/com_associations/views/association/tmpl/edit.php
@@ -64,7 +64,7 @@ $options = array(
 
 	</div>
 
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="target-id" id="target-id" value="" />
+	<input type="hidden" name="task" value="">
+	<input type="hidden" name="target-id" id="target-id" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -166,7 +166,7 @@ JFactory::getDocument()->addScriptDeclaration('
 			</tbody>
 		</table>
 	<?php endif; ?>
-	<input type="hidden" name="task" value=""/>
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_associations/views/associations/tmpl/modal.php
+++ b/administrator/components/com_associations/views/associations/tmpl/modal.php
@@ -153,9 +153,9 @@ $app->getDocument()->addScriptDeclaration(
 
 	<?php endif; ?>
 
-		<input type="hidden" name="task" value=""/>
-		<input type="hidden" name="forcedItemType" value="<?php echo $app->input->get('forcedItemType', '', 'string'); ?>" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="forcedItemType" value="<?php echo $app->input->get('forcedItemType', '', 'string'); ?>">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_banners/models/fields/clicks.php
+++ b/administrator/components/com_banners/models/fields/clicks.php
@@ -36,7 +36,7 @@ class JFormFieldClicks extends JFormField
 		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
 
 		return '<div class="input-group"><input class="form-control type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" />'
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
 			. '<span class="input-group-btn"><a class="btn btn-secondary" ' . $onclick . '>'
 			. '<span class="icon-refresh"></span> ' . JText::_('COM_BANNERS_RESET_CLICKS') . '</a></span></div>';
 	}

--- a/administrator/components/com_banners/models/fields/impmade.php
+++ b/administrator/components/com_banners/models/fields/impmade.php
@@ -36,7 +36,7 @@ class JFormFieldImpMade extends JFormField
 		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
 
 		return '<div class="input-group"><input class="form-control" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" />'
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
 			. '<span class="input-group-btn"><a class="btn btn-secondary" ' . $onclick . '>'
 			. '<span class="icon-refresh"></span> ' . JText::_('COM_BANNERS_RESET_IMPMADE') . '</a></span></div>';
 	}

--- a/administrator/components/com_banners/models/fields/imptotal.php
+++ b/administrator/components/com_banners/models/fields/imptotal.php
@@ -42,8 +42,8 @@ class JFormFieldImpTotal extends JFormField
 		$checked  = empty($this->value) ? ' checked="checked"' : '';
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '" size="9" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8')
-			. '" ' . $class . $onchange . ' />'
-			. '<fieldset class="checkboxes impunlimited"><input id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . ' />'
+			. '" ' . $class . $onchange . '>'
+			. '<fieldset class="checkboxes impunlimited"><input id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . '>'
 			. '<label for="' . $this->id . '_unlimited" id="jform-imp" type="text">' . JText::_('COM_BANNERS_UNLIMITED') . '</label></fieldset>';
 	}
 }

--- a/administrator/components/com_banners/views/banner/tmpl/edit.php
+++ b/administrator/components/com_banners/views/banner/tmpl/edit.php
@@ -96,6 +96,6 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_banners/views/banners/tmpl/default.php
+++ b/administrator/components/com_banners/views/banners/tmpl/default.php
@@ -113,7 +113,7 @@ if ($saveOrder)
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
 											<input type="text" style="display:none" name="order[]" size="5"
-												value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+												value="<?php echo $item->ordering; ?>" class="width-20 text-area-order ">
 										<?php endif; ?>
 									</td>
 									<td class="text-center">
@@ -182,8 +182,8 @@ if ($saveOrder)
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_banners/views/client/tmpl/edit.php
+++ b/administrator/components/com_banners/views/client/tmpl/edit.php
@@ -57,6 +57,6 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_banners/views/clients/tmpl/default.php
+++ b/administrator/components/com_banners/views/clients/tmpl/default.php
@@ -151,8 +151,8 @@ $params     = (isset($this->state->params)) ? $this->state->params : new JObject
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_banners/views/tracks/tmpl/default.php
+++ b/administrator/components/com_banners/views/tracks/tmpl/default.php
@@ -99,8 +99,8 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								. JText::_('COM_BANNERS_TRACKS_EXPORT') . '</button>',
 					)
 				); ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -54,7 +54,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						foreach ($this->data as $folder => $item) : ?>
 							<tr class="row<?php echo $i % 2; ?>">
 								<td>
-									<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $item->group; ?>" onclick="Joomla.isChecked(this.checked);" />
+									<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $item->group; ?>" onclick="Joomla.isChecked(this.checked);">
 								</td>
 								<td>
 									<label for="cb<?php echo $i; ?>">
@@ -72,8 +72,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					</tbody>
 				</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_cache/views/purge/tmpl/default.php
+++ b/administrator/components/com_cache/views/purge/tmpl/default.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
 			<div id="j-main-container" class="j-main-container">
 				<div class="p-3">
 					<p class="m-0"><?php echo JText::_('COM_CACHE_PURGE_INSTRUCTIONS'); ?></p>
-					<input type="hidden" name="task" value="" />
+					<input type="hidden" name="task" value="">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -404,12 +404,12 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 				foreach ($this->value as $value)
 				{
-					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
+					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
 				}
 			}
 			else
 			{
-				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
+				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
 			}
 		}
 		else

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -128,7 +128,7 @@ class JFormFieldModal_Category extends JFormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -275,7 +275,7 @@ class JFormFieldModal_Category extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name . '"'
-			. '" data-text="' . htmlspecialchars(JText::_('COM_CATEGORIES_SELECT_A_CATEGORY', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_CATEGORIES_SELECT_A_CATEGORY', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
 
 		return $html;
 	}

--- a/administrator/components/com_categories/views/categories/tmpl/default.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default.php
@@ -179,7 +179,7 @@ if ($saveOrder)
 											<span class="icon-menu"></span>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
-											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>" />
+											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>">
 										<?php endif; ?>
 									</td>
 									<td class="text-center">
@@ -271,9 +271,9 @@ if ($saveOrder)
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="extension" value="<?php echo $extension; ?>">
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -128,10 +128,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="extension" value="<?php echo $extension; ?>" />
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<input type="hidden" name="extension" value="<?php echo $extension; ?>">
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_categories/views/category/tmpl/edit.php
+++ b/administrator/components/com_categories/views/category/tmpl/edit.php
@@ -102,8 +102,8 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
 		<?php echo $this->form->getInput('extension'); ?>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_checkin/views/checkin/tmpl/default.php
+++ b/administrator/components/com_checkin/views/checkin/tmpl/default.php
@@ -59,8 +59,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</tbody>
 					</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_config/model/field/filters.php
+++ b/administrator/components/com_config/model/field/filters.php
@@ -109,7 +109,7 @@ class JFormFieldFilters extends JFormField
 				. ' id="' . $this->id . $group->value . '_filter_tags" class="novalidate form-control"'
 				. ' title="' . JText::_('JGLOBAL_FILTER_TAGS_LABEL') . '"'
 				. ' value="' . $group_filter['filter_tags'] . '"'
-				. '/>';
+				. '>';
 			$html[] = '		</td>';
 			$html[] = '		<td>';
 			$html[] = '				<input'
@@ -118,7 +118,7 @@ class JFormFieldFilters extends JFormField
 				. ' id="' . $this->id . $group->value . '_filter_attributes" class="novalidate form-control"'
 				. ' title="' . JText::_('JGLOBAL_FILTER_ATTRIBUTES_LABEL') . '"'
 				. ' value="' . $group_filter['filter_attributes'] . '"'
-				. '/>';
+				. '>';
 			$html[] = '		</td>';
 			$html[] = '	</tr>';
 		}

--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -123,7 +123,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php echo $this->loadTemplate('permissions'); ?>
 					</div>
 				</div>
-				<input type="hidden" name="task" value="" />
+				<input type="hidden" name="task" value="">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_config/view/application/tmpl/default_ftplogin.php
+++ b/administrator/components/com_config/view/application/tmpl/default_ftplogin.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 			<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
 		</div>
 		<div class="controls">
-			<input type="text" id="username" name="username" class="form-control" size="70" value="" />
+			<input type="text" id="username" name="username" class="form-control" size="70" value="">
 		</div>
 	</div>
 	<div class="control-group">
@@ -28,7 +28,7 @@ defined('_JEXEC') or die;
 			<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
 		</div>
 		<div class="controls">
-			<input type="password" id="password" name="password" class="form-control" size="70" value="" />
+			<input type="password" id="password" name="password" class="form-control" size="70" value="">
 		</div>
 	</div>
 </fieldset>

--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -105,10 +105,10 @@ JFactory::getDocument()->addScriptDeclaration(
 
 		</div>
 
-		<input type="hidden" name="id" value="<?php echo $this->component->id; ?>" />
-		<input type="hidden" name="component" value="<?php echo $this->component->option; ?>" />
-		<input type="hidden" name="return" value="<?php echo $this->return; ?>" />
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="id" value="<?php echo $this->component->id; ?>">
+		<input type="hidden" name="component" value="<?php echo $this->component->option; ?>">
+		<input type="hidden" name="return" value="<?php echo $this->return; ?>">
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -117,7 +117,7 @@ class JFormFieldModal_Contact extends JFormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -270,7 +270,7 @@ class JFormFieldModal_Contact extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name . '"'
-			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTACT_SELECT_A_CONTACT', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTACT_SELECT_A_CONTACT', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
 
 		return $html;
 	}

--- a/administrator/components/com_contact/views/contact/tmpl/edit.php
+++ b/administrator/components/com_contact/views/contact/tmpl/edit.php
@@ -119,7 +119,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
+	<input type="hidden" name="task" value="">
+	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_contact/views/contacts/tmpl/default.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/default.php
@@ -112,7 +112,7 @@ if ($saveOrder)
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
 										<input type="text" style="display:none" name="order[]" size="5"
-											value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+											value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
@@ -183,8 +183,8 @@ if ($saveOrder)
 						); ?>
 					<?php endif; ?>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -134,8 +134,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -120,7 +120,7 @@ class JFormFieldModal_Article extends JFormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -267,7 +267,7 @@ class JFormFieldModal_Article extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_CONTENT_SELECT_AN_ARTICLE', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
 
 		return $html;
 	}

--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -167,9 +167,9 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="return" value="<?php echo $input->getCmd('return'); ?>">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_content/views/article/tmpl/pagebreak.php
+++ b/administrator/components/com_content/views/article/tmpl/pagebreak.php
@@ -38,7 +38,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 				<label for="title"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TITLE'); ?></label>
 			</div>
 			<div class="controls">
-				<input type="text" id="title" name="title" />
+				<input type="text" id="title" name="title">
 			</div>
 		</div>
 		<div class="control-group">
@@ -46,7 +46,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 				<label for="alias"><?php echo JText::_('COM_CONTENT_PAGEBREAK_TOC'); ?></label>
 			</div>
 			<div class="controls">
-				<input type="text" id="alt" name="alt" />
+				<input type="text" id="alt" name="alt">
 			</div>
 		</div>
 		<button onclick="insertPagebreak();" class="btn btn-primary"><?php echo JText::_('COM_CONTENT_PAGEBREAK_INSERT_BUTTON'); ?></button>

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -144,7 +144,7 @@ $assoc = JLanguageAssociations::isEnabled();
 										<span class="icon-menu"></span>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order ">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
@@ -251,8 +251,8 @@ $assoc = JLanguageAssociations::isEnabled();
 
 				<?php echo $this->pagination->getListFooter(); ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -132,9 +132,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -138,7 +138,7 @@ if ($saveOrder)
 									<span class="icon-menu"></span>
 								</span>
 									<?php if ($canChange && $saveOrder) : ?>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order " />
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order ">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
@@ -220,9 +220,9 @@ if ($saveOrder)
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="featured" value="1" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="featured" value="1">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -138,7 +138,7 @@ if ($saveOrder)
 									<span class="icon-menu"></span>
 								</span>
 									<?php if ($canChange && $saveOrder) : ?>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order ">
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">

--- a/administrator/components/com_contenthistory/views/history/tmpl/modal.php
+++ b/administrator/components/com_contenthistory/views/history/tmpl/modal.php
@@ -110,7 +110,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<thead>
 				<tr>
 					<th width="1%" class="text-center">
-						<input type="checkbox" name="checkall-toggle" value="" title="<?php echo JText::_('JGLOBAL_CHECK_ALL'); ?>" onclick="Joomla.checkAll(this)" />
+						<input type="checkbox" name="checkall-toggle" value="" title="<?php echo JText::_('JGLOBAL_CHECK_ALL'); ?>" onclick="Joomla.checkAll(this)">
 					</th>
 					<th width="15%">
 						<?php echo JText::_('JDATE'); ?>
@@ -182,8 +182,8 @@ JFactory::getDocument()->addScriptDeclaration("
 			</tbody>
 		</table>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_fields/models/fields/modal/field.php
+++ b/administrator/components/com_fields/models/fields/modal/field.php
@@ -132,7 +132,7 @@ class JFormFieldModal_Field extends JFormField
 
 		// The current field display field.
 		$html[] = '<span class="input-append">';
-		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35" />';
+		$html[] = '<input type="text" class="input-medium" id="' . $this->id . '_name" value="' . $title . '" disabled="disabled" size="35">';
 		$html[] = '<a href="#modalCategory-' . $this->id . '" class="btn hasTooltip" role="button"  data-toggle="modal"' . ' title="' .
 			JHtml::tooltipText('COM_FIELDS_CHANGE_FIELD') . '">' . '<span class="icon-file"></span> ' . JText::_('JSELECT') . '</a>';
 
@@ -175,7 +175,7 @@ class JFormFieldModal_Field extends JFormField
 			$class = ' class="required modal-value"';
 		}
 
-		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '" />';
+		$html[] = '<input type="hidden" id="' . $this->id . '_id"' . $class . ' name="' . $this->name . '" value="' . $value . '">';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -107,7 +107,7 @@ if ($saveOrder)
 											<span class="icon-menu"></span>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
-											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" />
+											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>">
 										<?php endif; ?>
 									</td>
 									<td class="text-center">

--- a/administrator/components/com_fields/views/fields/tmpl/modal.php
+++ b/administrator/components/com_fields/views/fields/tmpl/modal.php
@@ -116,8 +116,8 @@ fieldgroupIns = function(id) {
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -109,7 +109,7 @@ if ($saveOrder)
 											<span class="icon-menu"></span>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
-											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" />
+											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>">
 										<?php endif; ?>
 									</td>
 									<td class="text-center">

--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -98,7 +98,7 @@ JFactory::getDocument()->addStyleDeclaration('
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd'); ?>" />
+	<input type="hidden" name="task" value="">
+	<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', '', 'cmd'); ?>">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_finder/views/filters/tmpl/default.php
+++ b/administrator/components/com_finder/views/filters/tmpl/default.php
@@ -126,8 +126,8 @@ JFactory::getDocument()->addScriptDeclaration('
 					</tbody>
 				</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -127,8 +127,8 @@ JFactory::getDocument()->addScriptDeclaration('
 						<?php endforeach; ?>
 					</tbody>
 				</table>
-				<input type="hidden" name="task" value="display" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="display">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_finder/views/indexer/tmpl/default.php
+++ b/administrator/components/com_finder/views/indexer/tmpl/default.php
@@ -22,5 +22,5 @@ JFactory::getDocument()->addScriptDeclaration('var msg = "' . JText::_('COM_FIND
 	<div id="progress" class="progress progress-striped active">
 		<div id="progress-bar" class="bar bar-success" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 	</div>
-	<input id="finder-indexer-token" type="hidden" name="<?php echo JFactory::getSession()->getFormToken(); ?>" value="1" />
+	<input id="finder-indexer-token" type="hidden" name="<?php echo JFactory::getSession()->getFormToken(); ?>" value="1">
 </div>

--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -149,8 +149,8 @@ JFactory::getDocument()->addScriptDeclaration('
 				<?php endif; ?>
 			</div>
 
-			<input type="hidden" name="task" value="display" />
-			<input type="hidden" name="boxchecked" value="0" />
+			<input type="hidden" name="task" value="display">
+			<input type="hidden" name="boxchecked" value="0">
 			<?php echo JHtml::_('form.token'); ?>
 		</div>
 	</div>

--- a/administrator/components/com_installer/views/database/tmpl/default.php
+++ b/administrator/components/com_installer/views/database/tmpl/default.php
@@ -66,8 +66,8 @@ defined('_JEXEC') or die;
 						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/default/tmpl/default_ftp.php
+++ b/administrator/components/com_installer/views/default/tmpl/default_ftp.php
@@ -25,7 +25,7 @@ defined('_JEXEC') or die;
 					<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
 				</td>
 				<td>
-					<input type="text" id="username" name="username" class="form-control" size="70" value="" />
+					<input type="text" id="username" name="username" class="form-control" size="70" value="">
 				</td>
 			</tr>
 			<tr>
@@ -33,7 +33,7 @@ defined('_JEXEC') or die;
 					<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
 				</td>
 				<td>
-					<input type="password" id="password" name="password" class="form-control" size="70" value="" />
+					<input type="password" id="password" name="password" class="form-control" size="70" value="">
 				</td>
 			</tr>
 		</tbody>

--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -113,8 +113,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					</table>
 					<?php endif; ?>
 					<div><?php echo JText::_('COM_INSTALLER_MSG_DISCOVER_DESCRIPTION'); ?></div>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/discover/tmpl/default_item.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default_item.php
@@ -11,8 +11,8 @@ defined('_JEXEC') or die;
 ?>
 <tr class="<?php echo 'row' . $this->item->index % 2; ?>" <?php echo $this->item->style; ?>>
 	<td>
-			<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />
-<!--		<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?> />-->
+			<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?>>
+<!--		<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?>>-->
 		<span class="bold"><?php echo $this->item->name; ?></span>
 	</td>
 	<td>

--- a/administrator/components/com_installer/views/discover/tmpl/default_item.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default_item.php
@@ -11,8 +11,7 @@ defined('_JEXEC') or die;
 ?>
 <tr class="<?php echo 'row' . $this->item->index % 2; ?>" <?php echo $this->item->style; ?>>
 	<td>
-			<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?>>
-<!--		<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?>>-->
+		<input type="checkbox" id="cb<?php echo $this->item->index; ?>" name="eid[]" value="<?php echo $this->item->extension_id; ?>" onclick="Joomla.isChecked(this.checked);" <?php echo $this->item->cbd; ?>>
 		<span class="bold"><?php echo $this->item->name; ?></span>
 	</td>
 	<td>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -108,7 +108,7 @@ JFactory::getDocument()->addStyleDeclaration(
 								<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_TOS'); ?></p>
 							<input class="btn btn-primary" type="button"
 								value="<?php echo JText::_('COM_INSTALLER_INSTALL_FROM_WEB_ADD_TAB'); ?>"
-								onclick="Joomla.submitbuttonInstallWebInstaller()"/>
+								onclick="Joomla.submitbuttonInstallWebInstaller()">
 						</div>
 					<?php endif; ?>
 					<?php echo JHtml::_('bootstrap.startTabSet', 'myTab'); ?>
@@ -136,8 +136,8 @@ JFactory::getDocument()->addStyleDeclaration(
 						<?php echo JHtml::_('bootstrap.endTab'); ?>
 					<?php endif; ?>
 
-					<input type="hidden" name="installtype" value=""/>
-					<input type="hidden" name="task" value="install.install"/>
+					<input type="hidden" name="installtype" value="">
+					<input type="hidden" name="task" value="install.install">
 					<?php echo JHtml::_('form.token'); ?>
 
 					<?php echo JHtml::_('bootstrap.endTabSet'); ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -67,7 +67,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<td>
 									<?php $buttonText = (isset($this->installedLang[0][$language->code]) || isset($this->installedLang[1][$language->code])) ? 'REINSTALL' : 'INSTALL'; ?>
 									<?php $onclick = 'document.getElementById(\'install_url\').value = \'' . $language->detailsurl . '\'; Joomla.submitbutton(\'install.install\');'; ?>
-									<input type="button" class="btn btn-secondary btn-sm" value="<?php echo JText::_('COM_INSTALLER_' . $buttonText . '_BUTTON'); ?>" onclick="<?php echo $onclick; ?>" />
+									<input type="button" class="btn btn-secondary btn-sm" value="<?php echo JText::_('COM_INSTALLER_' . $buttonText . '_BUTTON'); ?>" onclick="<?php echo $onclick; ?>">
 								</td>
 								<td>
 									<label for="cb<?php echo $i; ?>">
@@ -94,11 +94,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</tbody>
 					</table>
 					<?php endif; ?>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="return" value="<?php echo base64_encode('index.php?option=com_installer&view=languages') ?>" />
-					<input type="hidden" id="install_url" name="install_url" />
-					<input type="hidden" name="installtype" value="url" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="return" value="<?php echo base64_encode('index.php?option=com_installer&view=languages') ?>">
+					<input type="hidden" id="install_url" name="install_url">
+					<input type="hidden" name="installtype" value="url">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -131,8 +131,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</tbody>
 					</table>
 					<?php endif; ?>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -127,8 +127,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</tbody>
 						</table>
 					<?php endif; ?>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -110,8 +110,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</tbody>
 					</table>
 					<?php endif; ?>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_installer/views/warnings/tmpl/default.php
+++ b/administrator/components/com_installer/views/warnings/tmpl/default.php
@@ -31,7 +31,7 @@ defined('_JEXEC') or die;
 						<?php echo JHtml::_('bootstrap.endAccordion'); ?>
 					<?php endif; ?>
 					<div>
-						<input type="hidden" name="boxchecked" value="0" />
+						<input type="hidden" name="boxchecked" value="0">
 						<?php echo JHtml::_('form.token'); ?>
 					</div>
 				</div>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php
@@ -19,6 +19,6 @@ defined('_JEXEC') or die;
 	</p>
 </fieldset>
 <form action="<?php echo JRoute::_('index.php?option=com_joomlaupdate'); ?>" method="post" id="adminForm">
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default.php
@@ -56,8 +56,8 @@ jQuery(document).ready(function($) {
 			<?php endif; ?>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="update.download" />
-		<input type="hidden" name="option" value="com_joomlaupdate" />
+		<input type="hidden" name="task" value="update.download">
+		<input type="hidden" name="option" value="com_joomlaupdate">
 
 		<?php echo JHtml::_('form.token'); ?>
 	</form>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_reinstall.php
@@ -58,7 +58,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME'); ?>
 				</td>
 				<td>
-					<input class="form-control" class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>" />
+					<input class="form-control" class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>">
 				</td>
 			</tr>
 			<tr id="row_ftp_port" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -66,7 +66,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>" />
+					<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>">
 				</td>
 			</tr>
 			<tr id="row_ftp_username" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -74,7 +74,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>" />
+					<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>">
 				</td>
 			</tr>
 			<tr id="row_ftp_password" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -82,7 +82,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>" />
+					<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>">
 				</td>
 			</tr>
 			<tr id="row_ftp_directory" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -90,7 +90,7 @@ defined('_JEXEC') or die;
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>" />
+					<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>">
 				</td>
 			</tr>
 			</tbody>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -73,7 +73,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME'); ?>
 			</td>
 			<td>
-				<input class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>" />
+				<input class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>">
 			</td>
 		</tr>
 		<tr id="row_ftp_port" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -81,7 +81,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT'); ?>
 			</td>
 			<td>
-				<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>" />
+				<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>">
 			</td>
 		</tr>
 		<tr id="row_ftp_username" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -89,7 +89,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME'); ?>
 			</td>
 			<td>
-				<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>" />
+				<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>">
 			</td>
 		</tr>
 		<tr id="row_ftp_password" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -97,7 +97,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD'); ?>
 			</td>
 			<td>
-				<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>" />
+				<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>">
 			</td>
 		</tr>
 		<tr id="row_ftp_directory" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -105,7 +105,7 @@ defined('_JEXEC') or die;
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY'); ?>
 			</td>
 			<td>
-				<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>" />
+				<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>">
 			</td>
 		</tr>
 		</tbody>

--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_upload.php
@@ -96,7 +96,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPLOAD_PACKAGE_FILE'); ?>
 				</td>
 				<td>
-					<input class="form-control" id="install_package" name="install_package" type="file" size="57" />
+					<input class="form-control" id="install_package" name="install_package" type="file" size="57">
 					<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize()); ?>
 					<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
 				</td>
@@ -114,7 +114,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_HOSTNAME'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>" />
+					<input class="form-control" type="text" name="ftp_host" value="<?php echo $this->ftp['host']; ?>">
 				</td>
 			</tr>
 			<tr id="upload_ftp_port" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -122,7 +122,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PORT'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>" />
+					<input class="form-control" type="text" name="ftp_port" value="<?php echo $this->ftp['port']; ?>">
 				</td>
 			</tr>
 			<tr id="upload_ftp_username" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -130,7 +130,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_USERNAME'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>" />
+					<input class="form-control" type="text" name="ftp_user" value="<?php echo $this->ftp['username']; ?>">
 				</td>
 			</tr>
 			<tr id="upload_ftp_password" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -138,7 +138,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_PASSWORD'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>" />
+					<input class="form-control" type="password" name="ftp_pass" value="<?php echo $this->ftp['password']; ?>">
 				</td>
 			</tr>
 			<tr id="upload_ftp_directory" <?php echo $this->ftpFieldsDisplay; ?>>
@@ -146,7 +146,7 @@ JFactory::getDocument()->addStyleDeclaration($css);
 					<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_FTP_DIRECTORY'); ?>
 				</td>
 				<td>
-					<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>" />
+					<input class="form-control" type="text" name="ftp_root" value="<?php echo $this->ftp['directory']; ?>">
 				</td>
 			</tr>
 			</tbody>
@@ -161,8 +161,8 @@ JFactory::getDocument()->addStyleDeclaration($css);
 		</table>
 	</fieldset>
 
-	<input type="hidden" name="task" value="update.upload" />
-	<input type="hidden" name="option" value="com_joomlaupdate" />
+	<input type="hidden" name="task" value="update.upload">
+	<input type="hidden" name="option" value="com_joomlaupdate">
 	<?php echo JHtml::_('form.token'); ?>
 
 </form>

--- a/administrator/components/com_joomlaupdate/views/update/tmpl/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/views/update/tmpl/finaliseconfirm.php
@@ -38,7 +38,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 							<?php echo JText::_('JGLOBAL_USERNAME'); ?>
 						</label>
 					</span>
-					<input name="username" tabindex="1" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true" />
+					<input name="username" tabindex="1" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
 				</div>
 			</div>
 		</div>
@@ -51,7 +51,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 							<?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 						</label>
 					</span>
-					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"/>
+					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15">
 				</div>
 			</div>
 		</div>
@@ -65,7 +65,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 								<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15">
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
@@ -86,8 +86,8 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 			</div>
 		</div>
 
-		<input type="hidden" name="option" value="com_joomlaupdate"/>
-		<input type="hidden" name="task" value="update.finaliseconfirm" />
+		<input type="hidden" name="option" value="com_joomlaupdate">
+		<input type="hidden" name="task" value="update.finaliseconfirm">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
+++ b/administrator/components/com_joomlaupdate/views/upload/tmpl/captive.php
@@ -37,7 +37,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 							<?php echo JText::_('JGLOBAL_USERNAME'); ?>
 						</label>
 					</span>
-					<input name="username" tabindex="1" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true" />
+					<input name="username" tabindex="1" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
 				</div>
 			</div>
 		</div>
@@ -50,7 +50,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 							<?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 						</label>
 					</span>
-					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15"/>
+					<input name="passwd" tabindex="2" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" size="15">
 				</div>
 			</div>
 		</div>
@@ -64,7 +64,7 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 								<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15"/>
+						<input name="secretkey" autocomplete="off" tabindex="3" id="mod-login-secretkey" type="text" class="form-control" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" size="15">
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
@@ -85,8 +85,8 @@ $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 			</div>
 		</div>
 
-		<input type="hidden" name="option" value="com_joomlaupdate"/>
-		<input type="hidden" name="task" value="update.confirm"/>
+		<input type="hidden" name="option" value="com_joomlaupdate">
+		<input type="hidden" name="task" value="update.confirm">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/components/com_languages/helpers/html/languages.php
+++ b/administrator/components/com_languages/helpers/html/languages.php
@@ -50,7 +50,7 @@ abstract class JHtmlLanguages
 			. ' value="' . htmlspecialchars($language, ENT_COMPAT, 'UTF-8') . '"'
 			. ' onclick="Joomla.isChecked(this.checked);"'
 			. ' title="' . ($rowNum + 1) . '"'
-			. '/>';
+			. '>';
 	}
 
 	/**

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -126,8 +126,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					</tbody>
 				</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_languages/views/language/tmpl/edit.php
+++ b/administrator/components/com_languages/views/language/tmpl/edit.php
@@ -81,6 +81,6 @@ JFactory::getDocument()->addScriptDeclaration(
 
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_languages/views/languages/tmpl/default.php
+++ b/administrator/components/com_languages/views/languages/tmpl/default.php
@@ -104,7 +104,7 @@ if ($saveOrder)
 										<span class="sortable-handler hasTooltip <?php echo $disableClassName; ?>" title="<?php echo $disabledLabel; ?>">
 											<span class="icon-menu"></span>
 										</span>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 									<?php else : ?>
 										<span class="sortable-handler inactive">
 											<span class="icon-menu"></span>
@@ -156,8 +156,8 @@ if ($saveOrder)
 						</tbody>
 					</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_languages/views/override/tmpl/edit.php
+++ b/administrator/components/com_languages/views/override/tmpl/edit.php
@@ -147,8 +147,8 @@ JFactory::getDocument()->addScriptDeclaration('
 				</span>
 			</fieldset>
 
-			<input type="hidden" name="task" value="" />
-			<input type="hidden" name="id" value="<?php echo $this->item->key; ?>" />
+			<input type="hidden" name="task" value="">
+			<input type="hidden" name="id" value="<?php echo $this->item->key; ?>">
 
 			<?php echo JHtml::_('form.token'); ?>
 		</div>

--- a/administrator/components/com_languages/views/overrides/tmpl/default.php
+++ b/administrator/components/com_languages/views/overrides/tmpl/default.php
@@ -34,7 +34,7 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 				<div id="filter-bar" class="btn-toolbar clearfix">
 					<div class="filter-search btn-group float-left">
 						<div class="input-group">
-							<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="form-control hasTooltip" title="<?php echo JHtml::tooltipText('COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC'); ?>" />
+							<input type="text" name="filter_search" id="filter_search" placeholder="<?php echo JText::_('JSEARCH_FILTER'); ?>" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" class="form-control hasTooltip" title="<?php echo JHtml::tooltipText('COM_LANGUAGES_VIEW_OVERRIDES_FILTER_SEARCH_DESC'); ?>">
 							<div class="input-group-btn">
 								<button type="submit" class="btn btn-secondary hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>"><span class="icon-search"></span></button>
 								<button type="button" class="btn btn-secondary hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_CLEAR'); ?>" onclick="document.getElementById('filter_search').value='';this.form.submit();"><span class="icon-remove"></span></button>
@@ -115,10 +115,10 @@ $opposite_strings  = LanguagesHelper::parseFile($opposite_filename);
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
-				<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-				<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
+				<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>">
+				<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_media/views/images/tmpl/default.php
+++ b/administrator/components/com_media/views/images/tmpl/default.php
@@ -93,7 +93,7 @@ else // XTD Image plugin
 						<label for="f_url"><?php echo JText::_('COM_MEDIA_IMAGE_URL'); ?></label>
 					</div>
 					<div class="controls">
-						<input type="text" id="f_url" value="" />
+						<input type="text" id="f_url" value="">
 					</div>
 				</div>
 				<?php if (!$this->state->get('field.id')): ?>
@@ -119,7 +119,7 @@ else // XTD Image plugin
 							<label for="f_alt"><?php echo JText::_('COM_MEDIA_IMAGE_DESCRIPTION'); ?></label>
 						</div>
 						<div class="controls">
-							<input type="text" id="f_alt" value="" />
+							<input type="text" id="f_alt" value="">
 						</div>
 					</div>
 					<div class="col-md-6 control-group">
@@ -127,7 +127,7 @@ else // XTD Image plugin
 							<label for="f_title"><?php echo JText::_('COM_MEDIA_TITLE'); ?></label>
 						</div>
 						<div class="controls">
-							<input type="text" id="f_title" value="" />
+							<input type="text" id="f_title" value="">
 						</div>
 					</div>
 				</div>
@@ -137,7 +137,7 @@ else // XTD Image plugin
 							<label for="f_caption"><?php echo JText::_('COM_MEDIA_CAPTION'); ?></label>
 						</div>
 						<div class="controls">
-							<input type="text" id="f_caption" value="" />
+							<input type="text" id="f_caption" value="">
 						</div>
 					</div>
 					<div class="col-md-6 control-group">
@@ -145,7 +145,7 @@ else // XTD Image plugin
 							<label title="<?php echo JText::_('COM_MEDIA_CAPTION_CLASS_DESC'); ?>" class="noHtmlTip" for="f_caption_class"><?php echo JText::_('COM_MEDIA_CAPTION_CLASS_LABEL'); ?></label>
 						</div>
 						<div class="controls">
-							<input type="text" list="d_caption_class" id="f_caption_class" value="" />
+							<input type="text" list="d_caption_class" id="f_caption_class" value="">
 							<datalist id="d_caption_class">
 								<option value="text-left">
 								<option value="text-center">
@@ -156,9 +156,9 @@ else // XTD Image plugin
 				</div>
 			<?php endif; ?>
 
-			<input type="hidden" id="dirPath" name="dirPath" />
-			<input type="hidden" id="f_file" name="f_file" />
-			<input type="hidden" id="tmpl" name="component" />
+			<input type="hidden" id="dirPath" name="dirPath">
+			<input type="hidden" id="f_file" name="f_file">
+			<input type="hidden" id="tmpl" name="component">
 
 		</div>
 	</form>
@@ -172,7 +172,7 @@ else // XTD Image plugin
 							<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
 						</div>
 						<div class="controls">
-							<input required type="file" id="upload-file" name="Filedata[]" multiple /><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
+							<input required type="file" id="upload-file" name="Filedata[]" multiple><button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
 							<p class="help-block">
 								<?php $cMax    = (int) $this->config->get('upload_maxsize'); ?>
 								<?php $maxSize = JUtility::getMaxUploadSize($cMax . 'MB'); ?>

--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -64,18 +64,18 @@ if ($lang->isRtl())
 					<legend><?php echo JText::_('COM_MEDIA_DESCFTPTITLE'); ?></legend>
 					<?php echo JText::_('COM_MEDIA_DESCFTP'); ?>
 					<label for="username"><?php echo JText::_('JGLOBAL_USERNAME'); ?></label>
-					<input type="text" id="username" name="username" size="70" value="" />
+					<input type="text" id="username" name="username" size="70" value="">
 
 					<label for="password"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-					<input type="password" id="password" name="password" size="70" value="" />
+					<input type="password" id="password" name="password" size="70" value="">
 				</fieldset>
 			</form>
 		<?php endif; ?>
 
 		<form action="index.php?option=com_media" name="adminForm" id="mediamanager-form" method="post" enctype="multipart/form-data">
-			<input type="hidden" name="task" value="" />
-			<input type="hidden" name="cb1" id="cb1" value="0" />
-			<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>" />
+			<input type="hidden" name="task" value="">
+			<input type="hidden" name="cb1" id="cb1" value="0">
+			<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>">
 		</form>
 
 		<?php if ($user->authorise('core.create', 'com_media')) : ?>
@@ -85,7 +85,7 @@ if ($lang->isRtl())
 				<div id="uploadform">
 					<fieldset id="upload-noflash" class="actions">
 						<label for="upload-file" class="control-label"><?php echo JText::_('COM_MEDIA_UPLOAD_FILE'); ?></label>
-						<input required type="file" id="upload-file" name="Filedata[]" multiple />
+						<input required type="file" id="upload-file" name="Filedata[]" multiple>
 						<button class="btn btn-primary" id="upload-submit"><span class="icon-upload icon-white"></span> <?php echo JText::_('COM_MEDIA_START_UPLOAD'); ?></button>
 						<p class="help-block">
 							<?php $cMax    = (int) $this->config->get('upload_maxsize'); ?>
@@ -93,7 +93,7 @@ if ($lang->isRtl())
 							<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', JHtml::_('number.bytes', $maxSize)); ?>
 						</p>
 					</fieldset>
-					<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>" />
+					<input class="update-folder" type="hidden" name="folder" id="folder" value="<?php echo $this->state->folder; ?>">
 					<?php JFactory::getSession()->set('com_media.return_url', 'index.php?option=com_media'); ?>
 				</div>
 			</form>
@@ -101,9 +101,9 @@ if ($lang->isRtl())
 		<div id="collapseFolder" class="collapse">
 			<form action="index.php?option=com_media&amp;task=folder.create&amp;tmpl=<?php echo $input->getCmd('tmpl', 'index'); ?>" name="folderForm" id="folderForm" class="form-inline" method="post">
 				<div class="path">
-					<input type="text" id="folderpath" readonly="readonly" class="form-control update-folder" />
-					<input required type="text" class="form-control" id="foldername" name="foldername" />
-					<input class="form-control update-folder" type="hidden" name="folderbase" id="folderbase" value="<?php echo $this->state->folder; ?>" />
+					<input type="text" id="folderpath" readonly="readonly" class="form-control update-folder">
+					<input required type="text" class="form-control" id="foldername" name="foldername">
+					<input class="form-control update-folder" type="hidden" name="folderbase" id="folderbase" value="<?php echo $this->state->folder; ?>">
 					<button type="submit" class="btn btn-secondary"><span class="icon-folder-open"></span> <?php echo JText::_('COM_MEDIA_CREATE_FOLDER'); ?></button>
 				</div>
 				<?php echo JHtml::_('form.token'); ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -126,9 +126,9 @@ $doc->addScriptDeclaration(
 		</table>
 	</div>
 
-	<input type="hidden" name="task" value="list" />
-	<input type="hidden" name="username" value="" />
-	<input type="hidden" name="password" value="" />
-	<input type="hidden" name="boxchecked" value="" />
+	<input type="hidden" name="task" value="list">
+	<input type="hidden" name="username" value="">
+	<input type="hidden" name="password" value="">
+	<input type="hidden" name="boxchecked" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_media/views/medialist/tmpl/details_doc.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_doc.php
@@ -35,7 +35,7 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 <?php if ($user->authorise('core.delete', 'com_media')):?>
 	<td>
 		<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $this->_tmp_doc->name; ?>" rel="<?php echo $this->_tmp_doc->name; ?>"><span class="icon-remove hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JACTION_DELETE');?>"></span></a>
-		<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_doc->name; ?>" />
+		<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_doc->name; ?>">
 	</td>
 <?php endif;?>
 </tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_folder.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_folder.php
@@ -29,7 +29,7 @@ JHtml::_('bootstrap.tooltip');
 	<?php if ($user->authorise('core.delete', 'com_media')):?>
 		<td>
 			<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=folder.delete&amp;tmpl=index&amp;folder=<?php echo $this->state->folder; ?>&amp;<?php echo JSession::getFormToken(); ?>=1&amp;rm[]=<?php echo $this->_tmp_folder->name; ?>" rel="<?php echo $this->_tmp_folder->name; ?>' :: <?php echo $this->_tmp_folder->files + $this->_tmp_folder->folders; ?>"><span class="icon-remove hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JACTION_DELETE');?>"></span></a>
-			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_folder->name; ?>" />
+			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_folder->name; ?>">
 		</td>
 	<?php endif;?>
 </tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_img.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_img.php
@@ -35,7 +35,7 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	<?php if ($user->authorise('core.delete', 'com_media')):?>
 		<td>
 			<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $this->_tmp_img->name; ?>" rel="<?php echo $this->_tmp_img->name; ?>"><span class="icon-remove hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JACTION_DELETE');?>"></span></a>
-			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_img->name; ?>" />
+			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_img->name; ?>">
 		</td>
 	<?php endif;?>
 </tr>

--- a/administrator/components/com_media/views/medialist/tmpl/details_video.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_video.php
@@ -45,7 +45,7 @@ jQuery(document).ready(function($){
 	<?php if ($user->authorise('core.delete', 'com_media')):?>
 		<td>
 			<a class="delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $this->_tmp_video->name; ?>" rel="<?php echo $this->_tmp_video->name; ?>"><span class="icon-remove hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JACTION_DELETE');?>"></span></a>
-			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_video->name; ?>" />
+			<input type="checkbox" name="rm[]" value="<?php echo $this->_tmp_video->name; ?>">
 		</td>
 	<?php endif;?>
 </tr>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs.php
@@ -109,10 +109,10 @@ $doc->addScriptDeclaration(
 				$this->loadTemplate('imgs');
 		?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="username" value="" />
-		<input type="hidden" name="password" value="" />
-		<input type="hidden" name="boxchecked" value="" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="username" value="">
+		<input type="hidden" name="password" value="">
+		<input type="hidden" name="boxchecked" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</ul>
 </form>

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -93,7 +93,7 @@ class JFormFieldMenutype extends JFormFieldList
 
 		$link = JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
-			. '" value="' . $value . '"' . $size . $class . ' />';
+			. '" value="' . $value . '"' . $size . $class . '>';
 		$html[] = '<span class="input-group-btn"><a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="'
 			. JText::_('JSELECT') . '">' . '<span class="icon-list icon-white"></span> '
 			. JText::_('JSELECT') . '</a></span></span>';
@@ -112,7 +112,7 @@ class JFormFieldMenutype extends JFormFieldList
 			)
 		);
 		$html[] = '<input type="hidden" name="' . $this->name . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" />';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
 
 		return implode("\n", $html);
 	}

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -227,7 +227,7 @@ class JFormFieldModal_Menu extends JFormField
 			$html .= '<span class="input-group">';
 		}
 		
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -374,7 +374,7 @@ class JFormFieldModal_Menu extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-			. '" data-text="' . htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
 
 		return $html;
 	}

--- a/administrator/components/com_menus/views/item/tmpl/edit.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit.php
@@ -182,9 +182,9 @@ $clientId = $this->state->get('item.client_id', 0);
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
+	<input type="hidden" name="task" value="">
+	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 	<?php echo $this->form->getInput('component_id'); ?>
 	<?php echo JHtml::_('form.token'); ?>
-	<input type="hidden" id="fieldtype" name="fieldtype" value="" />
+	<input type="hidden" id="fieldtype" name="fieldtype" value="">
 </form>

--- a/administrator/components/com_menus/views/item/tmpl/edit_container.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_container.php
@@ -114,7 +114,7 @@ JFactory::getDocument()->addStyleDeclaration($style);
 								<div class="treeselect-item pull-left">
 									<input type="checkbox" <?php echo $link->value > 1 ? ' name="jform[params][hideitems][]" ' : ''; ?>
 										   id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>" class="novalidate checkbox-toggle"
-										<?php echo $selected ? ' checked="checked"' : ''; ?> />
+										<?php echo $selected ? ' checked="checked"' : ''; ?>>
 
 									<?php if ($link->value == 1): ?>
 										<label for="<?php echo $id . $link->value; ?>" class="btn btn-mini btn-info pull-left"><?php echo JText::_('JALL') ?></label>

--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -158,7 +158,7 @@ if ($menuType == '')
 											<span class="icon-menu"></span>
 										</span>
 										<?php if ($canChange && $saveOrder) : ?>
-											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>" />
+											<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>">
 										<?php endif; ?>
 									</td>
 								<?php endif; ?>
@@ -267,8 +267,8 @@ if ($menuType == '')
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -170,10 +170,10 @@ jQuery(document).ready(function($) {
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="function" value="<?php echo $function; ?>" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="function" value="<?php echo $function; ?>">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_menus/views/menu/tmpl/edit.php
+++ b/administrator/components/com_menus/views/menu/tmpl/edit.php
@@ -70,7 +70,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php endif; ?>
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -232,8 +232,8 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_messages/views/config/tmpl/default.php
+++ b/administrator/components/com_messages/views/config/tmpl/default.php
@@ -37,7 +37,7 @@ JFactory::getDocument()->addScriptDeclaration(
 		</fieldset>
 		<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitform('config.save', this.form);"></button>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 </div>

--- a/administrator/components/com_messages/views/message/tmpl/default.php
+++ b/administrator/components/com_messages/views/message/tmpl/default.php
@@ -45,8 +45,8 @@ JHtml::_('behavior.core');
 				<?php echo $this->item->message; ?>
 			</div>
 		</div>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="reply_id" value="<?php echo $this->item->message_id; ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="reply_id" value="<?php echo $this->item->message_id; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/components/com_messages/views/message/tmpl/edit.php
+++ b/administrator/components/com_messages/views/message/tmpl/edit.php
@@ -52,6 +52,6 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		</div>
 	</fieldset>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_messages/views/messages/tmpl/default.php
+++ b/administrator/components/com_messages/views/messages/tmpl/default.php
@@ -94,8 +94,8 @@ JFactory::getDocument()->addStyleDeclaration(
 			</table>
 		<?php endif; ?>
 		<div>
-			<input type="hidden" name="task" value="" />
-			<input type="hidden" name="boxchecked" value="0" />
+			<input type="hidden" name="task" value="">
+			<input type="hidden" name="boxchecked" value="0">
 			<?php echo JHtml::_('form.token'); ?>
 		</div>
 	</div>

--- a/administrator/components/com_modules/views/module/tmpl/edit.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit.php
@@ -293,7 +293,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 		<?php echo $this->form->getInput('module'); ?>
 		<?php echo $this->form->getInput('client_id'); ?>

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -107,7 +107,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 									<?php
 									$uselessMenuItem = (in_array($link->type, array('separator', 'heading', 'alias', 'url')));
 									?>
-									<input type="checkbox" class="float-left novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?> />
+									<input type="checkbox" class="float-left novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?>>
 									<label for="<?php echo $id . $link->value; ?>" class="float-left">
 										<?php echo $link->text; ?> <span class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($link->alias)); ?></span>
 										<?php if (JLanguageMultilang::isEnabled() && $link->language != '' && $link->language != '*') : ?>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -98,7 +98,7 @@ $colSpan = $clientId === 1 ? 9 : 10;
 								<span class="icon-menu"></span>
 							</span>
 							<?php if ($canChange && $saveOrder) : ?>
-								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 							<?php endif; ?>
 						</td>
 						<td class="text-center">
@@ -184,8 +184,8 @@ $colSpan = $clientId === 1 ? 9 : 10;
 				$this->loadTemplate('batch_body')
 			); ?>
 		<?php endif; ?>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -123,8 +123,8 @@ modulePosIns = function(position) {
 		</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_modules/views/positions/tmpl/modal.php
+++ b/administrator/components/com_modules/views/positions/tmpl/modal.php
@@ -28,7 +28,7 @@ $type      = $this->state->get('filter.type');
 			<label for="filter_search">
 				<?php echo JText::_('JSEARCH_FILTER_LABEL'); ?>
 			</label>
-			<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_MODULES_FILTER_SEARCH_DESC'); ?>" />
+			<input type="text" name="filter_search" id="filter_search" value="<?php echo $this->escape($this->state->get('filter.search')); ?>" size="30" title="<?php echo JText::_('COM_MODULES_FILTER_SEARCH_DESC'); ?>">
 
 			<button type="submit">
 				<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
@@ -95,10 +95,10 @@ $type      = $this->state->get('filter.type');
 	</table>
 
 	<div>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="filter_order" value="<?php echo $ordering; ?>" />
-		<input type="hidden" name="filter_order_Dir" value="<?php echo $direction; ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="filter_order" value="<?php echo $ordering; ?>">
+		<input type="hidden" name="filter_order_Dir" value="<?php echo $direction; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -117,7 +117,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 			$html .= '<span class="input-group">';
 		}
 
-		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35" />';
+		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
 		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
 		{
@@ -270,7 +270,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 		$class = $this->required ? ' class="required modal-value"' : '';
 
 		$html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name . '"'
-			. '" data-text="' . htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars(JText::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
 
 		return $html;
 	}

--- a/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/tmpl/edit.php
@@ -106,7 +106,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
-	<input type="hidden" name="task" value="" />
-	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>" />
+	<input type="hidden" name="task" value="">
+	<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/default.php
@@ -111,7 +111,7 @@ if ($saveOrder)
 										<span class="icon-menu"></span>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
@@ -182,8 +182,8 @@ if ($saveOrder)
 						); ?>
 					<?php endif; ?>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -120,9 +120,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -150,6 +150,6 @@ JFactory::getDocument()->addScriptDeclaration("
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</div>
 
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_plugins/views/plugins/tmpl/default.php
+++ b/administrator/components/com_plugins/views/plugins/tmpl/default.php
@@ -95,7 +95,7 @@ if ($saveOrder)
 								<span class="icon-menu"></span>
 							</span>
 							<?php if ($canChange && $saveOrder) : ?>
-								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+								<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 							<?php endif; ?>
 						</td>
 						<td class="text-center">
@@ -133,8 +133,8 @@ if ($saveOrder)
 			</table>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_redirect/views/link/tmpl/edit.php
+++ b/administrator/components/com_redirect/views/link/tmpl/edit.php
@@ -45,7 +45,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -130,8 +130,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				); ?>
 			<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_redirect/views/links/tmpl/default_addform.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_addform.php
@@ -23,13 +23,13 @@ defined('_JEXEC') or die;
 					<div class="control-group">
 						<label for="new_url" class="control-label"><?php echo JText::_('COM_REDIRECT_FIELD_NEW_URL_LABEL'); ?></label>
 						<div class="controls">
-							<input type="text" name="new_url" id="new_url" value="" size="50" title="<?php echo JText::_('COM_REDIRECT_FIELD_NEW_URL_DESC'); ?>" />
+							<input type="text" name="new_url" id="new_url" value="" size="50" title="<?php echo JText::_('COM_REDIRECT_FIELD_NEW_URL_DESC'); ?>">
 						</div>
 					</div>
 					<div class="control-group">
 						<label for="comment" class="control-label"><?php echo JText::_('COM_REDIRECT_FIELD_COMMENT_LABEL'); ?></label>
 						<div class="controls">
-							<input type="text" name="comment" id="comment" value="" size="50" title="<?php echo JText::_('COM_REDIRECT_FIELD_COMMENT_DESC'); ?>" />
+							<input type="text" name="comment" id="comment" value="" size="50" title="<?php echo JText::_('COM_REDIRECT_FIELD_COMMENT_DESC'); ?>">
 						</div>
 					</div>
 					<button class="btn btn-primary" type="button" onclick="this.form.task.value='links.duplicateUrls';this.form.submit();"><?php echo JText::_('COM_REDIRECT_BUTTON_UPDATE_LINKS'); ?></button>

--- a/administrator/components/com_search/views/searches/tmpl/default.php
+++ b/administrator/components/com_search/views/searches/tmpl/default.php
@@ -71,8 +71,8 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 			</tbody>
 		</table>
 		<?php endif; ?>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_tags/views/tag/tmpl/edit.php
+++ b/administrator/components/com_tags/views/tag/tmpl/edit.php
@@ -63,6 +63,6 @@ $this->ignore_fieldsets = array('jmetadata');
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 	</div>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_tags/views/tags/tmpl/default.php
+++ b/administrator/components/com_tags/views/tags/tmpl/default.php
@@ -177,7 +177,7 @@ if ($saveOrder)
 									<span class="icon-menu"></span>
 								</span>
 								<?php if ($canChange && $saveOrder) : ?>
-									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>" />
+									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $orderkey + 1; ?>">
 								<?php endif; ?>
 							</td>
 							<td class="text-center">
@@ -262,8 +262,8 @@ if ($saveOrder)
 			<?php endif; ?>
 		<?php endif; ?>
 
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_templates/views/style/tmpl/edit.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit.php
@@ -102,7 +102,7 @@ JFactory::getDocument()->addScriptDeclaration("
 
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
+++ b/administrator/components/com_templates/views/style/tmpl/edit_assignment.php
@@ -31,7 +31,7 @@ $user      = JFactory::getUser();
 					<h5><?php echo $type->title ? $type->title : $type->menutype; ?></h5>
 					<?php foreach ($type->links as $link) : ?>
 						<label class="checkbox small" for="link<?php echo (int) $link->value; ?>" >
-						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif; ?> />
+						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink <?php echo $type->menutype; ?>"<?php endif; ?>>
 						<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
 						</label>
 					<?php endforeach; ?>

--- a/administrator/components/com_templates/views/styles/tmpl/default.php
+++ b/administrator/components/com_templates/views/styles/tmpl/default.php
@@ -137,8 +137,8 @@ $colSpan = $clientId === 1 ? 5 : 6;
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -187,7 +187,7 @@ if ($this->type == 'font')
 	<div class="col-md-9">
 		<?php if ($this->type == 'home') : ?>
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
-				<input type="hidden" name="task" value="" />
+				<input type="hidden" name="task" value="">
 				<?php echo JHtml::_('form.token'); ?>
 				<h2><?php echo JText::_('COM_TEMPLATES_HOME_HEADING'); ?></h2>
 				<p><?php echo JText::_('COM_TEMPLATES_HOME_TEXT'); ?></p>
@@ -224,7 +224,7 @@ if ($this->type == 'font')
 						</li>
 					<?php endforeach; ?>
 				</ul>
-				<input type="hidden" name="task" value="" />
+				<input type="hidden" name="task" value="">
 				<?php echo JHtml::_('form.token'); ?>
 			</form>
 		<?php endif; ?>
@@ -232,11 +232,11 @@ if ($this->type == 'font')
 			<img id="image-crop" src="<?php echo $this->image['address'] . '?' . time(); ?>" />
 			<form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
 				<fieldset class="adminform">
-					<input type ="hidden" id="x" name="x" />
-					<input type ="hidden" id="y" name="y" />
-					<input type ="hidden" id="h" name="h" />
-					<input type ="hidden" id="w" name="w" />
-					<input type="hidden" name="task" value="" />
+					<input type ="hidden" id="x" name="x">
+					<input type ="hidden" id="y" name="y">
+					<input type ="hidden" id="h" name="h">
+					<input type ="hidden" id="w" name="w">
+					<input type="hidden" name="task" value="">
 					<?php echo JHtml::_('form.token'); ?>
 				</fieldset>
 			</form>
@@ -289,7 +289,7 @@ if ($this->type == 'font')
 								</ul>
 							</li>
 						</ol>
-						<input type="hidden" name="task" value="" />
+						<input type="hidden" name="task" value="">
 						<?php echo JHtml::_('form.token'); ?>
 					</fieldset>
 				</form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_copy_body.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
 					</label>
 				</div>
 				<div class="controls">
-					<input class="form-control" type="text" id="new_name" name="new_name"  />
+					<input class="form-control" type="text" id="new_name" name="new_name">
 				</div>
 			</div>
 		</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_delete_footer.php
@@ -12,10 +12,10 @@ defined('_JEXEC') or die;
 $input = JFactory::getApplication()->input;
 ?>
 <form method="post" action="">
-	<input type="hidden" name="option" value="com_templates" />
-	<input type="hidden" name="task" value="template.delete" />
-	<input type="hidden" name="id" value="<?php echo $input->getInt('id'); ?>" />
-	<input type="hidden" name="file" value="<?php echo $this->file; ?>" />
+	<input type="hidden" name="option" value="com_templates">
+	<input type="hidden" name="task" value="template.delete">
+	<input type="hidden" name="id" value="<?php echo $input->getInt('id'); ?>">
+	<input type="hidden" name="file" value="<?php echo $this->file; ?>">
 	<?php echo JHtml::_('form.token'); ?>
 	<a href="#" class="btn btn-secondary" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
 	<button type="submit" class="btn btn-danger"><?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE'); ?></button>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_file_body.php
@@ -18,7 +18,7 @@ $input = JFactory::getApplication()->input;
 				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
 					<fieldset class="form-inline">
 						<label><?php echo JText::_('COM_TEMPLATES_FILE_NAME'); ?></label>
-						<input type="text" name="name" required />
+						<input type="text" name="name" required>
 						<select class="input-medium" data-chosen="true" name="type" required >
 							<option value="">- <?php echo JText::_('COM_TEMPLATES_NEW_FILE_SELECT'); ?> -</option>
 							<option value="css">css</option>
@@ -31,17 +31,17 @@ $input = JFactory::getApplication()->input;
 							<option value="scss">scss</option>
 							<option value="txt">txt</option>
 						</select>
-						<input type="hidden" class="address" name="address" />
+						<input type="hidden" class="address" name="address">
 						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary">
 					</fieldset>
 				</form>
 				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.uploadFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
 					<fieldset class="form-inline">
-						<input type="hidden" class="address" name="address" />
-						<input type="file" name="files" required />
+						<input type="hidden" class="address" name="address">
+						<input type="file" name="files" required>
 						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD'); ?>" class="btn btn-primary" /><br>
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_UPLOAD'); ?>" class="btn btn-primary"><br>
 						<?php $cMax    = $this->state->get('params')->get('upload_limit'); ?>
 						<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize($cMax . 'MB')); ?>
 						<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
@@ -50,13 +50,13 @@ $input = JFactory::getApplication()->input;
 				<?php if ($this->type != 'home') : ?>
 					<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.copyFile&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well" enctype="multipart/form-data">
 						<fieldset class="form-inline">
-							<input type="hidden" class="address" name="address" />
+							<input type="hidden" class="address" name="address">
 							<label for="new_name" class="modalTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_TEMPLATES_FILE_NEW_NAME_DESC'); ?>">
 								<?php echo JText::_('COM_TEMPLATES_FILE_NEW_NAME_LABEL')?>
 							</label>
-							<input type="text" id="new_name" name="new_name" required />
+							<input type="text" id="new_name" name="new_name" required>
 							<?php echo JHtml::_('form.token'); ?>
-							<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE'); ?>" class="btn btn-primary" />
+							<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_COPY_FILE'); ?>" class="btn btn-primary">
 						</fieldset>
 					</form>
 				<?php endif; ?>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_body.php
@@ -18,10 +18,10 @@ $input = JFactory::getApplication()->input;
 				<form method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.createFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" class="well">
 					<fieldset class="form-inline">
 						<label><?php echo JText::_('COM_TEMPLATES_FOLDER_NAME'); ?></label>
-						<input type="text" name="name" required />
-						<input type="hidden" class="address" name="address" />
+						<input type="text" name="name" required>
+						<input type="hidden" class="address" name="address">
 						<?php echo JHtml::_('form.token'); ?>
-						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary" />
+						<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_CREATE'); ?>" class="btn btn-primary">
 					</fieldset>
 				</form>
 			</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_folder_footer.php
@@ -14,8 +14,8 @@ $input = JFactory::getApplication()->input;
 <form id="deleteFolder" method="post" action="<?php echo JRoute::_('index.php?option=com_templates&task=template.deleteFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>">
 	<fieldset>
 		<a href="#" class="btn btn-secondary" data-dismiss="modal"><?php echo JText::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></a>
-		<input type="hidden" class="address" name="address" />
+		<input type="hidden" class="address" name="address">
 		<?php echo JHtml::_('form.token'); ?>
-		<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE'); ?>" class="btn btn-danger" />
+		<input type="submit" value="<?php echo JText::_('COM_TEMPLATES_BUTTON_DELETE'); ?>" class="btn btn-danger">
 	</fieldset>
 </form>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_rename_body.php
@@ -21,7 +21,7 @@ defined('_JEXEC') or die;
 				</div>
 				<div class="controls">
 					<div class="input-group">
-						<input class="form-control" type="text" name="new_name" required />
+						<input class="form-control" type="text" name="new_name" required>
 						<div class="input-group-addon">.<?php echo JFile::getExt($this->fileName); ?></div>
 					</div>
 				</div>

--- a/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
+++ b/administrator/components/com_templates/views/template/tmpl/default_modal_resize_body.php
@@ -19,7 +19,7 @@ defined('_JEXEC') or die;
 					</label>
 				</div>
 				<div class="controls">
-					<input class="form-control" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required />
+					<input class="form-control" type="number" name="height" placeholder="<?php echo $this->image['height']; ?> px" required>
 				</div>
 			</div>
 			<div class="control-group">
@@ -29,7 +29,7 @@ defined('_JEXEC') or die;
 					</label>
 				</div>
 				<div class="controls">
-					<input class="form-control" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required />
+					<input class="form-control" type="number" name="width" placeholder="<?php echo $this->image['width']; ?> px" required>
 				</div>
 			</div>
 		</div>

--- a/administrator/components/com_templates/views/template/tmpl/readonly.php
+++ b/administrator/components/com_templates/views/template/tmpl/readonly.php
@@ -22,6 +22,6 @@ $input = JFactory::getApplication()->input;
 			<?php echo $this->loadTemplate('description'); ?>
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 	<?php echo JHtml::_('bootstrap.endTabSet'); ?>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -104,8 +104,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -93,8 +93,8 @@ $colSpan   = 4 + count($this->actions);
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 		<div>
 			<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -93,8 +93,8 @@ $colSpan   = 4 + count($this->actions);
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="boxchecked" value="0" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="boxchecked" value="0">
 		<?php echo JHtml::_('form.token'); ?>
 		<div>
 			<?php echo JText::_('COM_USERS_DEBUG_LEGEND'); ?>

--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -49,6 +49,6 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		</div>
 	</fieldset>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -131,8 +131,8 @@ JFactory::getDocument()->addScriptDeclaration('
 					</table>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -42,6 +42,6 @@ JFactory::getDocument()->addScriptDeclaration("
 		<legend><?php echo JText::_('COM_USERS_USER_GROUPS_HAVING_ACCESS'); ?></legend>
 		<?php echo JHtml::_('access.usergroups', 'jform[rules]', $this->item->rules); ?>
 	</fieldset>
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -94,7 +94,7 @@ if ($saveOrder)
 										<span class="icon-menu"></span>
 									</span>
 									<?php if ($canChange && $saveOrder) : ?>
-										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+										<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order">
 									<?php endif; ?>
 								</td>
 								<td class="text-center">
@@ -119,8 +119,8 @@ if ($saveOrder)
 						</tbody>
 					</table>
 				<?php endif; ?>
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_users/views/mail/tmpl/default.php
+++ b/administrator/components/com_users/views/mail/tmpl/default.php
@@ -48,7 +48,7 @@ JFactory::getDocument()->addScriptDeclaration($script);
 						<?php echo JComponentHelper::getParams('com_users')->get('mailBodySuffix'); ?></div>
 				</div>
 			</fieldset>
-			<input type="hidden" name="task" value="" />
+			<input type="hidden" name="task" value="">
 			<?php echo JHtml::_('form.token'); ?>
 		</div>
 		<div class="col-md-3">

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -83,7 +83,7 @@ jQuery(document).ready(function() {
 			</div>
 		</div>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -111,8 +111,8 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 				<?php endif; ?>
 
 				<div>
-					<input type="hidden" name="task" value="" />
-					<input type="hidden" name="boxchecked" value="0" />
+					<input type="hidden" name="task" value="">
+					<input type="hidden" name="boxchecked" value="0">
 					<?php echo JHtml::_('form.token'); ?>
 				</div>
 			</div>

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -125,6 +125,6 @@ $settings = array();
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	</fieldset>
 
-	<input type="hidden" name="task" value="" />
+	<input type="hidden" name="task" value="">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -178,8 +178,8 @@ $loggeduser = JFactory::getUser();
 					<?php endif; ?>
 				<?php endif; ?>
 
-				<input type="hidden" name="task" value="" />
-				<input type="hidden" name="boxchecked" value="0" />
+				<input type="hidden" name="task" value="">
+				<input type="hidden" name="boxchecked" value="0">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -117,11 +117,11 @@ if ($isMoo)
 			</tbody>
 		</table>
 		<?php endif; ?>
-		<input type="hidden" name="task" value="" />
-		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>" />
-		<input type="hidden" name="boxchecked" value="0" />
-		<input type="hidden" name="required" value="<?php echo $userRequired; ?>" />
-		<input type="hidden" name="ismoo" value="<?php echo $isMoo; ?>" />
+		<input type="hidden" name="task" value="">
+		<input type="hidden" name="field" value="<?php echo $this->escape($field); ?>">
+		<input type="hidden" name="boxchecked" value="0">
+		<input type="hidden" name="required" value="<?php echo $userRequired; ?>">
+		<input type="hidden" name="ismoo" value="<?php echo $isMoo; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</form>
 </div>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -90,9 +90,9 @@ if ($spacing > 0)
 			<div><a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>"><?php echo JText::_('MOD_LOGIN_RESET'); ?></a></div>
 		</div>
 
-		<input type="hidden" name="option" value="com_login"/>
-		<input type="hidden" name="task" value="login"/>
-		<input type="hidden" name="return" value="<?php echo $return; ?>"/>
+		<input type="hidden" name="option" value="com_login">
+		<input type="hidden" name="task" value="login">
+		<input type="hidden" name="return" value="<?php echo $return; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</fieldset>
 </form>

--- a/administrator/templates/atum/html/pagination.php
+++ b/administrator/templates/atum/html/pagination.php
@@ -71,7 +71,7 @@ defined('_JEXEC') or die;
 function pagination_list_footer($list)
 {
 	$html = $list['pageslinks'];
-	$html .= "\n<input type=\"hidden\" name=\"" . $list['prefix'] . "limitstart\" value=\"" . $list['limitstart'] . "\" />";
+	$html .= "\n<input type=\"hidden\" name=\"" . $list['prefix'] . "limitstart\" value=\"" . $list['limitstart'] . "\">";
 
 	return $html;
 }

--- a/components/com_config/view/config/tmpl/default.php
+++ b/components/com_config/view/config/tmpl/default.php
@@ -52,7 +52,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		</div>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 
 		<!-- End Content -->

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -187,9 +187,9 @@ JFactory::getDocument()->addScriptDeclaration("
 					</fieldset>
 				</div>
 
-				<input type="hidden" name="id" value="<?php echo $this->item['id']; ?>" />
-				<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', null, 'base64'); ?>" />
-				<input type="hidden" name="task" value="" />
+				<input type="hidden" name="id" value="<?php echo $this->item['id']; ?>">
+				<input type="hidden" name="return" value="<?php echo JFactory::getApplication()->input->get('return', null, 'base64'); ?>">
+				<input type="hidden" name="task" value="">
 				<?php echo JHtml::_('form.token'); ?>
 
 			</div>

--- a/components/com_config/view/templates/tmpl/default.php
+++ b/components/com_config/view/templates/tmpl/default.php
@@ -51,7 +51,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		</div>
 
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 
 		<!-- End Content -->

--- a/components/com_contact/views/category/tmpl/default_items.php
+++ b/components/com_contact/views/category/tmpl/default_items.php
@@ -24,7 +24,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php if ($this->params->get('filter_field')) : ?>
 			<div class="btn-group">
 				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_CONTACT_FILTER_LABEL') . '&#160;'; ?></label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" />
+				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>">
 			</div>
 		<?php endif; ?>
 
@@ -121,8 +121,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		</div>
 		<?php endif; ?>
 		<div>
-			<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-			<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
+			<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>">
+			<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>">
 		</div>
 </form>
 <?php endif; ?>

--- a/components/com_contact/views/contact/tmpl/default_form.php
+++ b/components/com_contact/views/contact/tmpl/default_form.php
@@ -34,10 +34,10 @@ JHtml::_('behavior.formvalidator');
 		<div class="control-group">
 			<div class="controls">
 				<button class="btn btn-primary validate" type="submit"><?php echo JText::_('COM_CONTACT_CONTACT_SEND'); ?></button>
-				<input type="hidden" name="option" value="com_contact" />
-				<input type="hidden" name="task" value="contact.submit" />
-				<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
-				<input type="hidden" name="id" value="<?php echo $this->contact->slug; ?>" />
+				<input type="hidden" name="option" value="com_contact">
+				<input type="hidden" name="task" value="contact.submit">
+				<input type="hidden" name="return" value="<?php echo $this->return_page; ?>">
+				<input type="hidden" name="id" value="<?php echo $this->contact->slug; ?>">
 				<?php echo JHtml::_('form.token'); ?>
 			</div>
 		</div>

--- a/components/com_contact/views/featured/tmpl/default_items.php
+++ b/components/com_contact/views/featured/tmpl/default_items.php
@@ -30,8 +30,8 @@ $params = &$this->item->params;
 			<?php echo $this->pagination->getLimitBox(); ?>
 		</div>
 	<?php endif; ?>
-	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>" />
-		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>" />
+	<input type="hidden" name="filter_order" value="<?php echo $listOrder; ?>">
+		<input type="hidden" name="filter_order_Dir" value="<?php echo $listDirn; ?>">
 	</fieldset>
 
 	<table class="category">

--- a/components/com_content/views/archive/tmpl/default.php
+++ b/components/com_content/views/archive/tmpl/default.php
@@ -26,7 +26,7 @@ JHtml::_('behavior.caption');
 	<div class="filter-search">
 		<?php if ($this->params->get('filter_field') !== 'hide') : ?>
 		<label class="filter-search-lbl element-invisible" for="filter-search"><?php echo JText::_('COM_CONTENT_TITLE_FILTER_LABEL') . '&#160;'; ?></label>
-		<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->filter); ?>" class="inputbox span2" onchange="document.getElementById('adminForm').submit();" placeholder="<?php echo JText::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>" />
+		<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->filter); ?>" class="inputbox span2" onchange="document.getElementById('adminForm').submit();" placeholder="<?php echo JText::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>">
 		<?php endif; ?>
 
 		<?php echo $this->form->monthField; ?>
@@ -34,9 +34,9 @@ JHtml::_('behavior.caption');
 		<?php echo $this->form->limitField; ?>
 
 		<button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo JText::_('JGLOBAL_FILTER_BUTTON'); ?></button>
-		<input type="hidden" name="view" value="archive" />
-		<input type="hidden" name="option" value="com_content" />
-		<input type="hidden" name="limitstart" value="0" />
+		<input type="hidden" name="view" value="archive">
+		<input type="hidden" name="option" value="com_content">
+		<input type="hidden" name="limitstart" value="0">
 	</div>
 	<br />
 	</fieldset>

--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -51,7 +51,7 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 					<label class="filter-search-lbl element-invisible" for="filter-search">
 						<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL') . '&#160;'; ?>
 					</label>
-					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>" />
+					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_CONTENT_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>">
 				<?php else : ?>
 					<select name="filter_tag" id="filter_tag" onchange="document.adminForm.submit();" >
 						<option value=""><?php echo JText::_('JOPTION_SELECT_TAG'); ?></option>
@@ -69,10 +69,10 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 			</div>
 		<?php endif; ?>
 
-		<input type="hidden" name="filter_order" value="" />
-		<input type="hidden" name="filter_order_Dir" value="" />
-		<input type="hidden" name="limitstart" value="" />
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="filter_order" value="">
+		<input type="hidden" name="filter_order_Dir" value="">
+		<input type="hidden" name="limitstart" value="">
+		<input type="hidden" name="task" value="">
 	</fieldset>
 
 	<div class="control-group hide pull-right">

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -144,8 +144,8 @@ JFactory::getDocument()->addScriptDeclaration("
 
 			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 
-			<input type="hidden" name="task" value="" />
-			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>" />
+			<input type="hidden" name="task" value="">
+			<input type="hidden" name="return" value="<?php echo $this->return_page; ?>">
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 		<div class="btn-toolbar">

--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -188,7 +188,7 @@ abstract class JHtmlFilter
 				$html .= '<label class="checkbox" tax-'
 					. $bk . '>';
 				$html .= '<input type="checkbox" class="selector filter-node' . $classSuffix . '" value="' . $nk . '" name="t[]" id="tax-'
-					. $bk . '"' . $checked . ' />';
+					. $bk . '"' . $checked . '>';
 				$html .= $nv->title;
 				$html .= '</label>';
 				$html .= '</div>';

--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -27,14 +27,14 @@ if ($this->params->get('show_autosuggest', 1))
 	 * DISABLED UNTIL WEIRD VALUES CAN BE TRACKED DOWN.
 	 */
 	if (false && $this->state->get('list.ordering') !== 'relevance_dsc') : ?>
-		<input type="hidden" name="o" value="<?php echo $this->escape($this->state->get('list.ordering')); ?>" />
+		<input type="hidden" name="o" value="<?php echo $this->escape($this->state->get('list.ordering')); ?>">
 	<?php endif; ?>
 
 	<fieldset class="word">
 		<label for="q">
 			<?php echo JText::_('COM_FINDER_SEARCH_TERMS'); ?>
 		</label>
-		<input type="text" name="q" class="js-finder-search-query inputbox" size="30" value="<?php echo $this->escape($this->query->input); ?>" />
+		<input type="text" name="q" class="js-finder-search-query inputbox" size="30" value="<?php echo $this->escape($this->query->input); ?>">
 		<?php if ($this->escape($this->query->input) != '' || $this->params->get('allow_empty_search')) : ?>
 			<button name="Search" type="submit" class="btn btn-primary"><span class="icon-search icon-white"></span> <?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 		<?php else : ?>

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -208,7 +208,7 @@ class FinderViewSearch extends JViewLegacy
 		{
 			if (is_scalar($v))
 			{
-				$fields .= '<input type="hidden" name="' . $n . '" value="' . $v . '" />';
+				$fields .= '<input type="hidden" name="' . $n . '" value="' . $v . '">';
 			}
 		}
 

--- a/components/com_mailto/views/mailto/tmpl/default.php
+++ b/components/com_mailto/views/mailto/tmpl/default.php
@@ -41,22 +41,22 @@ JFactory::getDocument()->addScriptDeclaration("
 	<form action="<?php echo JUri::base() ?>index.php" id="mailtoForm" method="post">
 		<div class="formelm">
 			<label for="mailto_field"><?php echo JText::_('COM_MAILTO_EMAIL_TO'); ?></label>
-			<input type="text" id="mailto_field" name="mailto" class="inputbox" size="25" value="<?php echo $this->escape($data->mailto); ?>"/>
+			<input type="text" id="mailto_field" name="mailto" class="inputbox" size="25" value="<?php echo $this->escape($data->mailto); ?>">
 		</div>
 		<div class="formelm">
 			<label for="sender_field">
 			<?php echo JText::_('COM_MAILTO_SENDER'); ?></label>
-			<input type="text" id="sender_field" name="sender" class="inputbox" value="<?php echo $this->escape($data->sender); ?>" size="25" />
+			<input type="text" id="sender_field" name="sender" class="inputbox" value="<?php echo $this->escape($data->sender); ?>" size="25">
 		</div>
 		<div class="formelm">
 			<label for="from_field">
 			<?php echo JText::_('COM_MAILTO_YOUR_EMAIL'); ?></label>
-			<input type="text" id="from_field" name="from" class="inputbox" value="<?php echo $this->escape($data->from); ?>" size="25" />
+			<input type="text" id="from_field" name="from" class="inputbox" value="<?php echo $this->escape($data->from); ?>" size="25">
 		</div>
 		<div class="formelm">
 			<label for="subject_field">
 			<?php echo JText::_('COM_MAILTO_SUBJECT'); ?></label>
-			<input type="text" id="subject_field" name="subject" class="inputbox" value="<?php echo $this->escape($data->subject); ?>" size="25" />
+			<input type="text" id="subject_field" name="subject" class="inputbox" value="<?php echo $this->escape($data->subject); ?>" size="25">
 		</div>
 		<p>
 			<button class="button" onclick="return Joomla.submitbutton('send');">
@@ -66,11 +66,11 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo JText::_('COM_MAILTO_CANCEL'); ?>
 			</button>
 		</p>
-		<input type="hidden" name="layout" value="<?php echo htmlspecialchars($this->getLayout(), ENT_COMPAT, 'UTF-8'); ?>" />
-		<input type="hidden" name="option" value="com_mailto" />
-		<input type="hidden" name="task" value="send" />
-		<input type="hidden" name="tmpl" value="component" />
-		<input type="hidden" name="link" value="<?php echo $data->link; ?>" />
+		<input type="hidden" name="layout" value="<?php echo htmlspecialchars($this->getLayout(), ENT_COMPAT, 'UTF-8'); ?>">
+		<input type="hidden" name="option" value="com_mailto">
+		<input type="hidden" name="task" value="send">
+		<input type="hidden" name="tmpl" value="component">
+		<input type="hidden" name="link" value="<?php echo $data->link; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 
 	</form>

--- a/components/com_newsfeeds/views/category/tmpl/default_items.php
+++ b/components/com_newsfeeds/views/category/tmpl/default_items.php
@@ -25,7 +25,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 		<?php if (($this->params->get('filter_field') != 'hide') && ($this->params->get('filter_field') == '1')) : ?>
 			<div class="btn-group">
 				<label class="filter-search-lbl element-invisible" for="filter-search"><span class="label label-warning"><?php echo JText::_('JUNPUBLISHED'); ?></span><?php echo JText::_('COM_NEWSFEEDS_FILTER_LABEL') . '&#160;'; ?></label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>" />
+				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>">
 			</div>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_pagination_limit')) : ?>

--- a/components/com_search/views/search/tmpl/default_form.php
+++ b/components/com_search/views/search/tmpl/default_form.php
@@ -18,12 +18,12 @@ $upper_limit = $lang->getUpperLimitSearchWord();
 
 	<div class="btn-toolbar">
 		<div class="btn-group pull-left">
-			<input type="text" name="searchword" placeholder="<?php echo JText::_('COM_SEARCH_SEARCH_KEYWORD'); ?>" id="search-searchword" size="30" maxlength="<?php echo $upper_limit; ?>" value="<?php echo $this->escape($this->origkeyword); ?>" class="inputbox" />
+			<input type="text" name="searchword" placeholder="<?php echo JText::_('COM_SEARCH_SEARCH_KEYWORD'); ?>" id="search-searchword" size="30" maxlength="<?php echo $upper_limit; ?>" value="<?php echo $this->escape($this->origkeyword); ?>" class="inputbox">
 		</div>
 		<div class="btn-group pull-left">
 			<button name="Search" onclick="this.form.submit()" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'COM_SEARCH_SEARCH');?>"><span class="icon-search"></span><?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 		</div>
-		<input type="hidden" name="task" value="search" />
+		<input type="hidden" name="task" value="search">
 		<div class="clearfix"></div>
 	</div>
 
@@ -56,7 +56,7 @@ $upper_limit = $lang->getUpperLimitSearchWord();
 				$checked = is_array($this->searchareas['active']) && in_array($val, $this->searchareas['active']) ? 'checked="checked"' : '';
 			?>
 			<label for="area-<?php echo $val; ?>" class="checkbox">
-				<input type="checkbox" name="areas[]" value="<?php echo $val; ?>" id="area-<?php echo $val; ?>" <?php echo $checked; ?> >
+				<input type="checkbox" name="areas[]" value="<?php echo $val; ?>" id="area-<?php echo $val; ?>" <?php echo $checked; ?>>
 				<?php echo JText::_($txt); ?>
 			</label>
 			<?php endforeach; ?>

--- a/components/com_tags/views/tag/tmpl/default_items.php
+++ b/components/com_tags/views/tag/tmpl/default_items.php
@@ -38,7 +38,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				<label class="filter-search-lbl element-invisible" for="filter-search">
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 				<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 					<span class="icon-search"></span>
 				</button>
@@ -56,10 +56,10 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		<?php endif; ?>
 
-		<input type="hidden" name="filter_order" value="" />
-		<input type="hidden" name="filter_order_Dir" value="" />
-		<input type="hidden" name="limitstart" value="" />
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="filter_order" value="">
+		<input type="hidden" name="filter_order_Dir" value="">
+		<input type="hidden" name="limitstart" value="">
+		<input type="hidden" name="task" value="">
 		<div class="clearfix"></div>
 	</fieldset>
 	<?php endif; ?>

--- a/components/com_tags/views/tag/tmpl/list_items.php
+++ b/components/com_tags/views/tag/tmpl/list_items.php
@@ -30,7 +30,7 @@ JFactory::getDocument()->addScriptDeclaration("
 				<label class="filter-search-lbl element-invisible" for="filter-search">
 					<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 				</label>
-				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+				<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 				<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 					<span class="icon-search"></span>
 				</button>
@@ -48,10 +48,10 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 		<?php endif; ?>
 
-		<input type="hidden" name="filter_order" value="" />
-		<input type="hidden" name="filter_order_Dir" value="" />
-		<input type="hidden" name="limitstart" value="" />
-		<input type="hidden" name="task" value="" />
+		<input type="hidden" name="filter_order" value="">
+		<input type="hidden" name="filter_order_Dir" value="">
+		<input type="hidden" name="limitstart" value="">
+		<input type="hidden" name="task" value="">
 		<div class="clearfix"></div>
 	</fieldset>
 	<?php endif; ?>

--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -54,7 +54,7 @@ JFactory::getDocument()->addScriptDeclaration("
 					<label class="filter-search-lbl element-invisible" for="filter-search">
 						<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL') . '&#160;'; ?>
 					</label>
-					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>" />
+					<input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" title="<?php echo JText::_('COM_TAGS_FILTER_SEARCH_DESC'); ?>" placeholder="<?php echo JText::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>">
 					<button type="button" name="filter-search-button" title="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>" onclick="document.adminForm.submit();" class="btn">
 						<span class="icon-search"></span>
 					</button>
@@ -72,10 +72,10 @@ JFactory::getDocument()->addScriptDeclaration("
 				</div>
 			<?php endif; ?>
 
-			<input type="hidden" name="filter_order" value="" />
-			<input type="hidden" name="filter_order_Dir" value="" />
-			<input type="hidden" name="limitstart" value="" />
-			<input type="hidden" name="task" value="" />
+			<input type="hidden" name="filter_order" value="">
+			<input type="hidden" name="filter_order_Dir" value="">
+			<input type="hidden" name="limitstart" value="">
+			<input type="hidden" name="task" value="">
 			<div class="clearfix"></div>
 		</fieldset>
 	<?php endif; ?>

--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -67,7 +67,7 @@ JHtml::_('behavior.formvalidator');
 			<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
 			<div  class="control-group">
 				<div class="control-label"><label><?php echo JText::_('COM_USERS_LOGIN_REMEMBER_ME') ?></label></div>
-				<div class="controls"><input id="remember" type="checkbox" name="remember" class="inputbox" value="yes"/></div>
+				<div class="controls"><input id="remember" type="checkbox" name="remember" class="inputbox" value="yes"></div>
 			</div>
 			<?php endif; ?>
 
@@ -80,7 +80,7 @@ JHtml::_('behavior.formvalidator');
 			</div>
 
 			<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem'))); ?>
-			<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>" />
+			<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>">
 			<?php echo JHtml::_('form.token'); ?>
 		</fieldset>
 	</form>

--- a/components/com_users/views/login/tmpl/default_logout.php
+++ b/components/com_users/views/login/tmpl/default_logout.php
@@ -41,9 +41,9 @@ defined('_JEXEC') or die;
 			</div>
 		</div>
 		<?php if ($this->params->get('logout_redirect_url')) : ?>
-			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return'))); ?>" />
+			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return'))); ?>">
 		<?php else : ?>
-			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_menuitem', $this->form->getValue('return'))); ?>" />
+			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_menuitem', $this->form->getValue('return'))); ?>">
 		<?php endif; ?>
 		<?php echo JHtml::_('form.token'); ?>
 	</form>

--- a/components/com_users/views/profile/tmpl/edit.php
+++ b/components/com_users/views/profile/tmpl/edit.php
@@ -135,8 +135,8 @@ $lang->load('plg_user_profile', JPATH_ADMINISTRATOR);
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate"><span><?php echo JText::_('JSUBMIT'); ?></span></button>
 				<a class="btn" href="<?php echo JRoute::_('index.php?option=com_users&view=profile'); ?>" title="<?php echo JText::_('JCANCEL'); ?>"><?php echo JText::_('JCANCEL'); ?></a>
-				<input type="hidden" name="option" value="com_users" />
-				<input type="hidden" name="task" value="profile.save" />
+				<input type="hidden" name="option" value="com_users">
+				<input type="hidden" name="task" value="profile.save">
 			</div>
 		</div>
 		<?php echo JHtml::_('form.token'); ?>

--- a/components/com_users/views/registration/tmpl/default.php
+++ b/components/com_users/views/registration/tmpl/default.php
@@ -55,8 +55,8 @@ JHtml::_('behavior.formvalidator');
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate"><?php echo JText::_('JREGISTER'); ?></button>
 				<a class="btn" href="<?php echo JRoute::_(''); ?>" title="<?php echo JText::_('JCANCEL'); ?>"><?php echo JText::_('JCANCEL'); ?></a>
-				<input type="hidden" name="option" value="com_users" />
-				<input type="hidden" name="task" value="registration.register" />
+				<input type="hidden" name="option" value="com_users">
+				<input type="hidden" name="task" value="registration.register">
 			</div>
 		</div>
 		<?php echo JHtml::_('form.token'); ?>

--- a/installation/form/field/prefix.php
+++ b/installation/form/field/prefix.php
@@ -81,6 +81,6 @@ class InstallationFormFieldPrefix extends JFormField
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '"' .
 				' value="' . htmlspecialchars($prefix, ENT_COMPAT, 'UTF-8') . '"' .
-				$class . $disabled . $readonly . $onchange . $maxLength . '/>';
+				$class . $disabled . $readonly . $onchange . $maxLength . '>';
 	}
 }

--- a/installation/view/complete/tmpl/default.php
+++ b/installation/view/complete/tmpl/default.php
@@ -39,7 +39,7 @@ defined('_JEXEC') or die;
 		<div class="row">
 			<div class="alert alert-info">
 				<p><?php echo JText::_('INSTL_COMPLETE_REMOVE_INSTALLATION'); ?></p>
-				<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>" />
+				<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>">
 			</div>
 		</div>
 		<div class="row">

--- a/installation/view/database/tmpl/default.php
+++ b/installation/view/database/tmpl/default.php
@@ -69,7 +69,7 @@ defined('_JEXEC') or die;
 			<a  class="btn btn-primary" href="#" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNEXT'); ?>"><span class="fa fa-arrow-right icon-white"></span> <?php echo JText::_('JNEXT'); ?></a>
 		</div>
 	</div>
-	<input type="hidden" name="task" value="database" />
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="task" value="database">
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/installation/view/defaultlanguage/tmpl/default.php
+++ b/installation/view/defaultlanguage/tmpl/default.php
@@ -95,7 +95,7 @@ JS
 						name="administratorlang"
 						value="<?php echo $lang->language; ?>"
 						<?php if ($lang->published) echo 'checked="checked"'; ?>
-					/>
+					>
 				</td>
 				<td align="text-center">
 					<label for="admin-language-cb<?php echo $i; ?>">
@@ -136,7 +136,7 @@ JS
 						name="frontendlang"
 						value="<?php echo $lang->language; ?>"
 						<?php if ($lang->published) echo 'checked="checked"'; ?>
-					/>
+					>
 				</td>
 				<td align="text-center">
 					<label for="site-language-cb<?php echo $i; ?>">
@@ -175,7 +175,7 @@ JS
 			<?php endif; ?>
 		</div>
 	</div>
-	<input type="hidden" name="task" value="setdefaultlanguage" />
+	<input type="hidden" name="task" value="setdefaultlanguage">
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 

--- a/installation/view/ftp/tmpl/default.php
+++ b/installation/view/ftp/tmpl/default.php
@@ -57,7 +57,7 @@ defined('_JEXEC') or die;
 			<a class="btn btn-primary" href="#" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNEXT'); ?>"><span class="fa fa-arrow-right icon-white"></span> <?php echo JText::_('JNEXT'); ?></a>
 		</div>
 	</div>
-	<input type="hidden" name="task" value="ftp" />
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="task" value="ftp">
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/installation/view/install/tmpl/default.php
+++ b/installation/view/install/tmpl/default.php
@@ -44,7 +44,7 @@ defined('_JEXEC') or die;
 			</tr>
 		</tfoot>
 	</table>
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -92,7 +92,7 @@ $version = new JVersion;
 					<?php $language->code = $element[1]; ?>
 					<tr>
 						<td>
-							<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $language->update_id; ?>" />
+							<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $language->update_id; ?>">
 						</td>
 						<td>
 							<label for="cb<?php echo $i; ?>"><?php echo $language->name; ?></label>
@@ -112,7 +112,7 @@ $version = new JVersion;
 				<?php endforeach; ?>
 			</tbody>
 		</table>
-		<input type="hidden" name="task" value="InstallLanguages" />
+		<input type="hidden" name="task" value="InstallLanguages">
 		<?php echo JHtml::_('form.token'); ?>
 	<?php endif; ?>
 	<div class="btn-toolbar justify-content-end">

--- a/installation/view/preinstall/tmpl/default.php
+++ b/installation/view/preinstall/tmpl/default.php
@@ -21,8 +21,8 @@ var_dump('TEST');
 		<label for="jform_language" class="control-label"><?php echo JText::_('INSTL_SELECT_LANGUAGE_TITLE'); ?></label>
 		<?php echo $this->form->getInput('language'); ?>
 	</div>
-	<input type="hidden" name="view" value="preinstall" />
-	<input type="hidden" name="task" value="setlanguage" />
+	<input type="hidden" name="view" value="preinstall">
+	<input type="hidden" name="task" value="setlanguage">
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 <form action="index.php" method="post" id="adminForm">
@@ -108,6 +108,6 @@ var_dump('TEST');
 			<a href="#" class="btn btn-primary" onclick="Install.submitform();" title="<?php echo JText::_('JCHECK_AGAIN'); ?>"><span class="icon-refresh icon-white"></span> <?php echo JText::_('JCHECK_AGAIN'); ?></a>
 		</div>
 	</div>
-	<input type="hidden" name="task" value="preinstall" />
+	<input type="hidden" name="task" value="preinstall">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/installation/view/remove/tmpl/default.php
+++ b/installation/view/remove/tmpl/default.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 	</div>
 	<div class="alert alert-info">
 		<p><?php echo JText::_('INSTL_COMPLETE_REMOVE_INSTALLATION'); ?></p>
-		<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>" />
+		<input type="button" class="btn btn-warning" name="instDefault" onclick="Install.removeFolder(this);" value="<?php echo JText::_('INSTL_COMPLETE_REMOVE_FOLDER'); ?>">
 	</div>
 	<div>
 		<div class="btn-group">

--- a/installation/view/site/tmpl/default.php
+++ b/installation/view/site/tmpl/default.php
@@ -22,8 +22,8 @@ defined('_JEXEC') or die;
 		<label for="jform_language"><?php echo JText::_('INSTL_SELECT_LANGUAGE_TITLE'); ?></label>
 		<?php echo $this->form->getInput('language'); ?>
 	</div>
-	<input type="hidden" name="task" value="setlanguage" />
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="task" value="setlanguage">
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
@@ -76,7 +76,7 @@ defined('_JEXEC') or die;
 			<a href="#" class="btn btn-primary" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNEXT'); ?>"><span class="fa fa-arrow-right icon-white"></span> <?php echo JText::_('JNEXT'); ?></a>
 		</div>
 	</div>
-	<input type="hidden" name="task" value="site" />
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="task" value="site">
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -346,8 +346,8 @@ $prev = $useftp ? 'ftp' : 'database';
 		</div>
 	</div>
 
-	<input type="hidden" name="task" value="summary" />
-	<input type="hidden" name="format" value="json" />
+	<input type="hidden" name="task" value="summary">
+	<input type="hidden" name="format" value="json">
 	<?php echo JHtml::_('form.token'); ?>
 </form>
 

--- a/layouts/joomla/edit/details.php
+++ b/layouts/joomla/edit/details.php
@@ -47,7 +47,7 @@ $saveHistory = $displayData->get('state')->get('params')->get('save_history', 0)
 		<?php if (JLanguageMultilang::isEnabled()) : ?>
 			<?php echo $displayData->getForm()->renderField('language'); ?>
 		<?php else : ?>
-			<input type="hidden" id="jform_language" name="jform[language]" value="<?php echo $displayData->getForm()->getValue('language'); ?>" />
+			<input type="hidden" id="jform_language" name="jform[language]" value="<?php echo $displayData->getForm()->getValue('language'); ?>">
 		<?php endif; ?>
 		
 		<?php echo $displayData->getForm()->renderField('tags'); ?>

--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -49,7 +49,7 @@ extract($displayData);
  *     %3 - value
  *     %4 = any other attributes
  */
-$format = '<input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s />';
+$format = '<input type="checkbox" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 
 // The alt option for JText::alt
 $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -91,4 +91,4 @@ JHtml::_('script', 'system/fields/color-field-adv-init.min.js', array('version' 
 	<?php echo $format; ?>
 	<?php echo $keywords; ?>
 	<?php echo $direction; ?>
-	<?php echo $validate; ?>/>
+	<?php echo $validate; ?>>

--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -68,4 +68,4 @@ $attributes = array(
 	<?php echo !empty($class) ? ' class="form-control validate-email ' . $class . '"' : ' class="form-control validate-email"'; ?>
 	id="<?php echo $id; ?>"
 	value="<?php echo htmlspecialchars(JStringPunycode::emailToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>"
-	<?php echo implode(' ', $attributes); ?> />
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -57,5 +57,5 @@ $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize());
 	<?php echo $disabled ? ' disabled' : ''; ?>
 	<?php echo $autofocus ? ' autofocus' : ''; ?>
 	<?php echo !empty($onchange) ? ' onchange="' . $onchange . '"' : ''; ?>
-	<?php echo $required ? ' required aria-required="true"' : ''; ?> /><br>
+	<?php echo $required ? ' required aria-required="true"' : ''; ?>><br>
 	<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>

--- a/layouts/joomla/form/field/hidden.php
+++ b/layouts/joomla/form/field/hidden.php
@@ -48,7 +48,9 @@ $class    = !empty($class) ? ' class="' . $class . '"' : '';
 $disabled = $disabled ? ' disabled' : '';
 $onchange = $onchange ? ' onchange="' . $onchange . '"' : '';
 ?>
-<input type="hidden" name="<?php
-echo $name; ?>" id="<?php
-echo $id; ?>" value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"<?php echo $class, $disabled, $onchange; ?> />
+<input
+	type="hidden"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo $class, $disabled, $onchange; ?>>

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -131,7 +131,7 @@ $url    = ($readonly ? ''
 				<i class="icon-eye"></i>
 			</div>
 		<?php endif; ?>
-		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" readonly="readonly"<?php echo $attr; ?> />
+		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" readonly="readonly"<?php echo $attr; ?>>
 		<?php if ($disabled != true) : ?>
 			<div class="input-group-btn">
 				<a class="btn btn-secondary button-select"><?php echo JText::_("JLIB_FORM_BUTTON_SELECT"); ?></a>

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -78,4 +78,4 @@ else
 	name="<?php echo $name; ?>"
 	id="<?php echo $id; ?>"
 	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
-	<?php echo implode(' ', $attributes); ?> />
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -79,8 +79,9 @@ $attributes = array(
 );
 
 ?>
-<input type="password" name="<?php
-echo $name; ?>" id="<?php
-echo $id; ?>" value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php
-echo implode(' ', $attributes); ?> />
+<input
+	type="password"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/radio.php
+++ b/layouts/joomla/form/field/radio.php
@@ -47,7 +47,7 @@ extract($displayData);
  *     %3 - value
  *     %4 = any other attributes
  */
-$format     = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s />';
+$format     = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $alt        = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);	
 $dataToggle = (strpos(trim($class), 'btn-group') !== false) ? ' data-toggle="buttons"' : '';
 

--- a/layouts/joomla/form/field/radiobasic.php
+++ b/layouts/joomla/form/field/radiobasic.php
@@ -50,7 +50,7 @@ JHtml::_('jquery.framework');
  *     %3 - value
  *     %4 = any other attributes
  */
-$format = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s />';
+$format = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 $alt    = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 ?>
 <fieldset id="<?php echo $id; ?>" class="<?php echo trim($class . ' radio'); ?>"

--- a/layouts/joomla/form/field/range.php
+++ b/layouts/joomla/form/field/range.php
@@ -60,8 +60,9 @@ $value = (float) $value;
 $value = empty($value) ? $min : $value;
 
 ?>
-<input type="range" name="<?php
-echo $name; ?>" id="<?php
-echo $id; ?>" value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php
-echo implode(' ', $attributes); ?> />
+<input
+	type="range"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -71,4 +71,4 @@ $attributes = array(
 	<?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?>
 	id="<?php echo $id; ?>"
 	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
-	<?php echo implode(' ', $attributes); ?> />
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -78,7 +78,7 @@ $attributes = array(
 echo $name; ?>" id="<?php
 echo $id; ?>" <?php
 echo $dirname; ?> value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo implode(' ', $attributes); ?> />
+echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo implode(' ', $attributes); ?>>
 <?php if ($options) : ?>
 	<datalist id="<?php echo $id; ?>_datalist">
 		<?php foreach ($options as $option) : ?>

--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -60,10 +60,10 @@ $attributes = array(
 	$required ? ' required aria-required="true"' : '',
 );
 ?>
-<input <?php
-echo $inputType; ?> name="<?php
-echo $name; ?>" <?php
-echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?> id="<?php
-echo $id; ?>" value="<?php
-echo htmlspecialchars(JStringPunycode::urlToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>" <?php
-echo implode(' ', $attributes); ?> />
+<input
+	<?php echo $inputType; ?>
+	name="<?php echo $name; ?>"
+	<?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?>
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars(JStringPunycode::urlToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo implode(' ', $attributes); ?>>

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -103,7 +103,7 @@ if (!$readonly)
 	data-input-name=".field-user-input-name"
 	data-button-select=".button-select">
 	<div class="input-group">
-		<input <?php echo ArrayHelper::toString($inputAttributes); ?> readonly />
+		<input <?php echo ArrayHelper::toString($inputAttributes); ?> readonly>
 			<?php if (!$readonly) : ?>
 				<span class="input-group-btn">
 					<a class="btn btn-primary button-select" title="<?php echo JText::_('JLIB_FORM_CHANGE_USER') ?>"><span class="icon-user icon-white"></span></a>
@@ -127,5 +127,5 @@ if (!$readonly)
 	<?php // Create the real field, hidden, that stored the user id. ?>
 	<input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo (int) $value; ?>"
 		class="field-user-input <?php echo $class ? (string) $class : ''?>"
-		data-onchange="<?php echo $this->escape($onchange); ?>"/>
+		data-onchange="<?php echo $this->escape($onchange); ?>">
 </div>

--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -80,7 +80,7 @@ if ($currentPage >= $step)
 	<?php endif; ?>
 
 	<?php if ($showLimitStart) : ?>
-		<input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>" />
+		<input type="hidden" name="<?php echo $list['prefix']; ?>limitstart" value="<?php echo $list['limitstart']; ?>">
 	<?php endif; ?>
 
 </div>

--- a/libraries/cms/form/field/ordering.php
+++ b/libraries/cms/form/field/ordering.php
@@ -129,7 +129,7 @@ class JFormFieldOrdering extends JFormField
 		if ($this->readonly)
 		{
 			$html[] = JHtml::_('list.ordering', '', $query, trim($attr), $this->value, $itemId ? 0 : 1);
-			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '"/>';
+			$html[] = '<input type="hidden" name="' . $this->name . '" value="' . $this->value . '">';
 		}
 		else
 		{

--- a/libraries/cms/html/access.php
+++ b/libraries/cms/html/access.php
@@ -157,7 +157,7 @@ abstract class JHtmlAccess
 				$html[] = '		<div class="controls">';
 				$html[] = '			<label class="checkbox" for="' . $eid . '">';
 				$html[] = '			<input type="checkbox" name="' . $name . '[]" value="' . $item->id . '" id="' . $eid . '"';
-				$html[] = '					' . $checked . $rel . ' />';
+				$html[] = '					' . $checked . $rel . '>';
 				$html[] = '			' . JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $item->title;
 				$html[] = '			</label>';
 				$html[] = '		</div>';
@@ -206,7 +206,7 @@ abstract class JHtmlAccess
 			// Build the HTML for the item.
 			$html[] = '	<li>';
 			$html[] = '		<input type="checkbox" name="' . $name . '[]" value="' . $item->id . '" id="' . $eid . '"';
-			$html[] = '			' . $checked . ' />';
+			$html[] = '			' . $checked . '>';
 			$html[] = '		<label for="' . $eid . '">';
 			$html[] = '			' . JText::_($item->title);
 			$html[] = '		</label>';

--- a/libraries/cms/html/form.php
+++ b/libraries/cms/html/form.php
@@ -28,6 +28,6 @@ abstract class JHtmlForm
 	 */
 	public static function token()
 	{
-		return '<input type="hidden" name="' . JSession::getFormToken() . '" value="1" />';
+		return '<input type="hidden" name="' . JSession::getFormToken() . '" value="1">';
 	}
 }

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -127,7 +127,7 @@ abstract class JHtmlGrid
 		JHtml::_('bootstrap.tooltip');
 
 		return '<input type="checkbox" name="' . $name . '" value="" class="hasTooltip" title="' . JHtml::_('tooltipText', $tip)
-			. '" onclick="' . $action . '" />';
+			. '" onclick="' . $action . '">';
 	}
 
 	/**
@@ -146,7 +146,7 @@ abstract class JHtmlGrid
 	public static function id($rowNum, $recId, $checkedOut = false, $name = 'cid', $stub = 'cb')
 	{
 		return $checkedOut ? '' : '<input type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
-			. '" onclick="Joomla.isChecked(this.checked);" />';
+			. '" onclick="Joomla.isChecked(this.checked);">';
 	}
 
 	/**

--- a/libraries/cms/html/list.php
+++ b/libraries/cms/html/list.php
@@ -160,7 +160,7 @@ abstract class JHtmlList
 				$text = JText::_('JGLOBAL_NEWITEMSFIRST_DESC');
 			}
 
-			$html = '<input type="hidden" name="' . $name . '" value="' . (int) $selected . '" /><span class="readonly">' . $text . '</span>';
+			$html = '<input type="hidden" name="' . $name . '" value="' . (int) $selected . '"><span class="readonly">' . $text . '</span>';
 		}
 
 		return $html;

--- a/libraries/cms/html/menu.php
+++ b/libraries/cms/html/menu.php
@@ -236,7 +236,7 @@ abstract class JHtmlMenu
 		}
 		else
 		{
-			$ordering = '<input type="hidden" name="ordering" value="' . $row->ordering . '" />' . JText::_('JGLOBAL_NEWITEMSLAST_DESC');
+			$ordering = '<input type="hidden" name="ordering" value="' . $row->ordering . '">' . JText::_('JGLOBAL_NEWITEMSLAST_DESC');
 		}
 
 		return $ordering;

--- a/libraries/cms/html/select.php
+++ b/libraries/cms/html/select.php
@@ -715,7 +715,7 @@ abstract class JHtmlSelect
 
 			$html .= "\n\t" . '<label for="' . $id . '" id="' . $id . '-lbl" class="radio">';
 			$html .= "\n\t\n\t" . '<input type="radio" name="' . $name . '" id="' . $id . '" value="' . $k . '" ' . $extra
-				. $attribs . ' />' . $t;
+				. $attribs . '>' . $t;
 			$html .= "\n\t" . '</label>';
 		}
 

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -673,7 +673,7 @@ class JPagination
 		$html .= $list['pageslinks'];
 		$html .= "\n<div class=\"counter\">" . $list['pagescounter'] . "</div>";
 
-		$html .= "\n<input type=\"hidden\" name=\"" . $list['prefix'] . "limitstart\" value=\"" . $list['limitstart'] . "\" />";
+		$html .= "\n<input type=\"hidden\" name=\"" . $list['prefix'] . "limitstart\" value=\"" . $list['limitstart'] . "\">";
 		$html .= "\n</div>";
 
 		return $html;

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -525,8 +525,8 @@ class JCache
 		if (isset($data['body']))
 		{
 			$token       = JSession::getFormToken();
-			$search      = '#<input type="hidden" name="[0-9a-f]{32}" value="1" />#';
-			$replacement = '<input type="hidden" name="' . $token . '" value="1" />';
+			$search      = '#<input type="hidden" name="[0-9a-f]{32}" value="1">#';
+			$replacement = '<input type="hidden" name="' . $token . '" value="1">';
 
 			$data['body'] = preg_replace($search, $replacement, $data['body']);
 			$body         = $data['body'];

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -145,7 +145,7 @@ class JFormFieldCheckbox extends JFormField
 		$html .= '<label class="form-check-label">';
 		$html .= '<input type="checkbox" name="' . $this->name . '" id="' . $this->id . '" value="'
 				. htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"' . $class . $checked . $disabled . $onclick . $onchange
-				. $required . $autofocus . ' />';		
+				. $required . $autofocus . '>';		
 		$html .= '</label>';
 		$html .= '</div>';
 		

--- a/libraries/joomla/form/fields/combo.php
+++ b/libraries/joomla/form/fields/combo.php
@@ -63,7 +63,7 @@ class JFormFieldCombo extends JFormFieldList
 
 		// Build the input for the combo box.
 		$html[] = '<input type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
-			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $attr . ' data-list="' . implode(', ', $val) . '" />';
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"' . $attr . ' data-list="' . implode(', ', $val) . '">';
 
 		return implode($html);
 	}

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -182,12 +182,12 @@ class JFormFieldGroupedList extends JFormField
 
 				foreach ($this->value as $value)
 				{
-					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
+					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
 				}
 			}
 			else
 			{
-				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
+				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
 			}
 		}
 

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -72,12 +72,12 @@ class JFormFieldList extends JFormField
 
 				foreach ($this->value as $value)
 				{
-					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '"/>';
+					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
 				}
 			}
 			else
 			{
-				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '"/>';
+				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
 			}
 		}
 		else

--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -295,7 +295,7 @@ class JFormFieldSubform extends JFormField
 		// for allow to submit an empty value
 		if ($this->multiple)
 		{
-			$html = '<input name="' . $this->name . '" type="hidden" value="" />' . $html;
+			$html = '<input name="' . $this->name . '" type="hidden" value="">' . $html;
 		}
 
 		return $html;

--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -43,14 +43,14 @@ class ModFinderHelper
 		// Create hidden input elements for each part of the URI.
 		foreach ($uri->getQuery(true) as $n => $v)
 		{
-			$fields[] = '<input type="hidden" name="' . $n . '" value="' . $v . '" />';
+			$fields[] = '<input type="hidden" name="' . $n . '" value="' . $v . '">';
 		}
 
 		// Add a field for Itemid if we need one.
 		if ($needId)
 		{
 			$id       = $paramItem ?: JFactory::getApplication()->input->get('Itemid', '0', 'int');
-			$fields[] = '<input type="hidden" name="Itemid" value="' . $id . '" />';
+			$fields[] = '<input type="hidden" name="Itemid" value="' . $id . '">';
 		}
 
 		return implode('', $fields);

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -20,7 +20,7 @@ $lang->load('com_finder', JPATH_SITE);
 $suffix = $params->get('moduleclass_sfx');
 $output = '<input type="text" name="q" class="js-finder-search-query input-medium" size="'
 	. $params->get('field_size', 20) . '" value="' . htmlspecialchars(JFactory::getApplication()->input->get('q', '', 'string'), ENT_COMPAT, 'UTF-8') . '"'
-	. ' placeholder="' . JText::_('MOD_FINDER_SEARCH_VALUE') . '"/>';
+	. ' placeholder="' . JText::_('MOD_FINDER_SEARCH_VALUE') . '">';
 
 $showLabel  = $params->get('show_label', 1);
 $labelClass = (!$showLabel ? 'element-invisible ' : '') . 'finder' . $suffix;

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -30,11 +30,11 @@ JHtml::_('bootstrap.tooltip');
 							<span class="icon-user hasTooltip" title="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>"></span>
 							<label for="modlgn-username" class="element-invisible"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 						</span>
-						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
+						<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
 					</div>
 				<?php else : ?>
 					<label for="modlgn-username"><?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
-					<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>" />
+					<input id="modlgn-username" type="text" name="username" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
 				<?php endif; ?>
 			</div>
 		</div>
@@ -48,11 +48,11 @@ JHtml::_('bootstrap.tooltip');
 								<label for="modlgn-passwd" class="element-invisible"><?php echo JText::_('JGLOBAL_PASSWORD'); ?>
 							</label>
 						</span>
-						<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+						<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>">
 					</div>
 				<?php else : ?>
 					<label for="modlgn-passwd"><?php echo JText::_('JGLOBAL_PASSWORD'); ?></label>
-					<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>" />
+					<input id="modlgn-passwd" type="password" name="password" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_PASSWORD'); ?>">
 				<?php endif; ?>
 			</div>
 		</div>
@@ -67,14 +67,14 @@ JHtml::_('bootstrap.tooltip');
 								<label for="modlgn-secretkey" class="element-invisible"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?>
 							</label>
 						</span>
-						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+						<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>">
 						<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 							<span class="icon-help"></span>
 						</span>
 				</div>
 				<?php else : ?>
 					<label for="modlgn-secretkey"><?php echo JText::_('JGLOBAL_SECRETKEY'); ?></label>
-					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>" />
+					<input id="modlgn-secretkey" autocomplete="off" type="text" name="secretkey" class="input-small" tabindex="0" size="18" placeholder="<?php echo JText::_('JGLOBAL_SECRETKEY'); ?>">
 					<span class="btn width-auto hasTooltip" title="<?php echo JText::_('JGLOBAL_SECRETKEY_HELP'); ?>">
 						<span class="icon-help"></span>
 					</span>
@@ -85,7 +85,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php endif; ?>
 		<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
 		<div id="form-login-remember" class="control-group checkbox">
-			<label for="modlgn-remember" class="control-label"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME'); ?></label> <input id="modlgn-remember" type="checkbox" name="remember" class="inputbox" value="yes"/>
+			<label for="modlgn-remember" class="control-label"><?php echo JText::_('MOD_LOGIN_REMEMBER_ME'); ?></label> <input id="modlgn-remember" type="checkbox" name="remember" class="inputbox" value="yes">
 		</div>
 		<?php endif; ?>
 		<div id="form-login-submit" class="control-group">
@@ -111,9 +111,9 @@ JHtml::_('bootstrap.tooltip');
 					<?php echo JText::_('MOD_LOGIN_FORGOT_YOUR_PASSWORD'); ?></a>
 				</li>
 			</ul>
-		<input type="hidden" name="option" value="com_users" />
-		<input type="hidden" name="task" value="user.login" />
-		<input type="hidden" name="return" value="<?php echo $return; ?>" />
+		<input type="hidden" name="option" value="com_users">
+		<input type="hidden" name="task" value="user.login">
+		<input type="hidden" name="return" value="<?php echo $return; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 	<?php if ($params->get('posttext')) : ?>

--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -30,10 +30,10 @@ JHtml::_('behavior.keepalive');
 	</ul>
 <?php endif; ?>
 	<div class="logout-button">
-		<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGOUT'); ?>" />
-		<input type="hidden" name="option" value="com_users" />
-		<input type="hidden" name="task" value="user.logout" />
-		<input type="hidden" name="return" value="<?php echo $return; ?>" />
+		<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo JText::_('JLOGOUT'); ?>">
+		<input type="hidden" name="option" value="com_users">
+		<input type="hidden" name="task" value="user.logout">
+		<input type="hidden" name="return" value="<?php echo $return; ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -26,11 +26,11 @@ else
 		<?php
 			$output = '<label for="mod-search-searchword' . $module->id . '" class="element-invisible">' . $label . '</label> ';
 			$output .= '<input name="searchword" id="mod-search-searchword' . $module->id . '" maxlength="' . $maxlength . '"  class="inputbox search-query" type="search"' . $width;
-			$output .= ' placeholder="' . $text . '" />';
+			$output .= ' placeholder="' . $text . '">';
 
 			if ($button) :
 				if ($imagebutton) :
-					$btn_output = ' <input type="image" alt="' . $button_text . '" class="button" src="' . $img . '" onclick="this.form.searchword.focus();"/>';
+					$btn_output = ' <input type="image" alt="' . $button_text . '" class="button" src="' . $img . '" onclick="this.form.searchword.focus();">';
 				else :
 					$btn_output = ' <button class="button btn btn-primary" onclick="this.form.searchword.focus();">' . $button_text . '</button>';
 				endif;
@@ -57,8 +57,8 @@ else
 
 			echo $output;
 		?>
-		<input type="hidden" name="task" value="search" />
-		<input type="hidden" name="option" value="com_search" />
-		<input type="hidden" name="Itemid" value="<?php echo $mitemid; ?>" />
+		<input type="hidden" name="task" value="search">
+		<input type="hidden" name="option" value="com_search">
+		<input type="hidden" name="Itemid" value="<?php echo $mitemid; ?>">
 	</form>
 </div>

--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -36,10 +36,10 @@ for ($i = 1; $i < 6; $i++)
 	<span class="content_vote">
 		<label class="unseen element-invisible" for="content_vote_'<?php echo (int) $row->id; ?>"><?php echo JText::_('PLG_VOTE_LABEL'); ?></label>
 		<?php echo JHtml::_('select.genericlist', $options, 'user_rating', null, 'value', 'text', '5', 'content_vote_' . (int) $row->id); ?>
-		&#160;<input class="btn btn-mini" type="submit" name="submit_vote" value="<?php echo JText::_('PLG_VOTE_RATE'); ?>" />
-		<input type="hidden" name="task" value="article.vote" />
-		<input type="hidden" name="hitcount" value="0" />
-		<input type="hidden" name="url" value="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" />
+		&#160;<input class="btn btn-mini" type="submit" name="submit_vote" value="<?php echo JText::_('PLG_VOTE_RATE'); ?>">
+		<input type="hidden" name="task" value="article.vote">
+		<input type="hidden" name="hitcount" value="0">
+		<input type="hidden" name="url" value="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>">
 		<?php echo JHtml::_('form.token'); ?>
 	</span>
 </form>

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -39,12 +39,12 @@ JFactory::getDocument()->addScriptDeclaration('
 	</label>
 	<div class="controls">
 		<input type="text" id="install_directory" name="install_directory" class="form-control"
-			value="<?php echo $app->input->get('install_directory', $app->get('tmp_path')); ?>" />
+			value="<?php echo $app->input->get('install_directory', $app->get('tmp_path')); ?>">
 	</div>
 </div>
 <div class="control-group">
 	<div class="controls">
 		<input type="button" class="btn btn-primary" id="installbutton_directory"
-			value="<?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonfolder()" />
+			value="<?php echo JText::_('PLG_INSTALLER_FOLDERINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonfolder()">
 	</div>
 </div>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -34,7 +34,7 @@ JFactory::getDocument()->addScriptDeclaration('
 <div class="control-group">
 	<label for="install_package" class="control-label"><?php echo JText::_('PLG_INSTALLER_PACKAGEINSTALLER_EXTENSION_PACKAGE_FILE'); ?></label>
 	<div class="controls">
-		<input class="form-control" id="install_package" name="install_package" type="file" />
+		<input class="form-control" id="install_package" name="install_package" type="file">
 		<?php $maxSize = JHtml::_('number.bytes', JUtility::getMaxUploadSize()); ?>
 		<?php echo JText::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?>
 	</div>

--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -35,12 +35,12 @@ JFactory::getDocument()->addScriptDeclaration('
 		<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?>
 	</label>
 	<div class="controls">
-		<input type="text" id="install_url" name="install_url" class="form-control" placeholder="https://"/>
+		<input type="text" id="install_url" name="install_url" class="form-control" placeholder="https://">
 	</div>
 </div>
 <div class="control-group">
 	<div class="controls">
 		<input type="button" class="btn btn-primary" id="installbutton_url"
-			value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonurl()" />
+			value="<?php echo JText::_('PLG_INSTALLER_URLINSTALLER_BUTTON'); ?>" onclick="Joomla.submitbuttonurl()">
 	</div>
 </div>

--- a/plugins/system/stats/layouts/field/uniqueid.php
+++ b/plugins/system/stats/layouts/field/uniqueid.php
@@ -40,7 +40,7 @@ extract($displayData);
  * @var   array    $options         Options available for this field.
  */
 ?>
-<input type="hidden" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" />
+<input type="hidden" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>">
 <a class="btn" onclick="document.getElementById('<?php echo $id; ?>').value='';Joomla.submitbutton('plugin.apply');">
 	<span class="icon-refresh"></span> <?php echo JText::_('PLG_SYSTEM_STATS_RESET_UNIQUE_ID'); ?>
 </a>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<input type="hidden" name="jform[twofactor][totp][key]" value="<?php echo $secret ?>" />
+<input type="hidden" name="jform[twofactor][totp][key]" value="<?php echo $secret ?>">
 
 <div class="well">
 	<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_INTRO') ?>

--- a/tests/unit/suites/libraries/cms/html/JHtmlFormTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlFormTest.php
@@ -79,7 +79,7 @@ class JHtmlFormTest extends TestCase
 
 		$this->assertThat(
 			JHtmlForm::token(),
-			$this->equalTo('<input type="hidden" name="' . $token . '" value="1" />')
+			$this->equalTo('<input type="hidden" name="' . $token . '" value="1">')
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
@@ -97,13 +97,13 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 			array(
 				"<div class=\"controls\">\n\t" .
 				"<label for=\"yesId\" id=\"yesId-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\">Yes\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\" >Yes\n\t" .
 				"</label>\n\t" .
 				"<label for=\"myRadioListName0\" id=\"myRadioListName0-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\">No\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\" >No\n\t" .
 				"</label>\n\t" .
 				"<label for=\"myRadioListName-1\" id=\"myRadioListName-1-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\">Maybe\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\" >Maybe\n\t" .
 				"</label>\n" .
 				"</div>\n",
 				array(

--- a/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlSelectTest.php
@@ -97,13 +97,13 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 			array(
 				"<div class=\"controls\">\n\t" .
 				"<label for=\"yesId\" id=\"yesId-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\"  />Yes\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\">Yes\n\t" .
 				"</label>\n\t" .
 				"<label for=\"myRadioListName0\" id=\"myRadioListName0-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\"  />No\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\">No\n\t" .
 				"</label>\n\t" .
 				"<label for=\"myRadioListName-1\" id=\"myRadioListName-1-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\"  />Maybe\n\t" .
+				"<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\">Maybe\n\t" .
 				"</label>\n" .
 				"</div>\n",
 				array(
@@ -126,10 +126,10 @@ class JHtmlSelectTest extends PHPUnit_Framework_TestCase
 			array(
 				"<div class=\"controls\">\n\t" .
 				"<label for=\"fooId\" id=\"fooId-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\" />FOO\n\t" .
+				"<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\">FOO\n\t" .
 				"</label>\n\t" .
 				"<label for=\"myFooBarListNamebar\" id=\"myFooBarListNamebar-lbl\" class=\"radio\">\n\t\n\t" .
-				"<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\" />BAR\n\t" .
+				"<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\">BAR\n\t" .
 				"</label>\n" .
 				"</div>\n",
 				array(

--- a/tests/unit/suites/libraries/cms/html/TestHelpers/JHtmlSelect-helper-dataset.php
+++ b/tests/unit/suites/libraries/cms/html/TestHelpers/JHtmlSelect-helper-dataset.php
@@ -79,15 +79,15 @@ class JHtmlSelectTest_DataSet
 			"<div class=\"controls\">
 	<label for=\"yesId\" id=\"yesId-lbl\" class=\"radio\">
 	
-	<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\"  >Yes
+	<input type=\"radio\" name=\"myRadioListName\" id=\"yesId\" value=\"1\">Yes
 	</label>
 	<label for=\"myRadioListName0\" id=\"myRadioListName0-lbl\" class=\"radio\">
 	
-	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\"  >No
+	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName0\" value=\"0\">No
 	</label>
 	<label for=\"myRadioListName-1\" id=\"myRadioListName-1-lbl\" class=\"radio\">
 	
-	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\"  >Maybe
+	<input type=\"radio\" name=\"myRadioListName\" id=\"myRadioListName-1\" value=\"-1\">Maybe
 	</label>
 </div>
 ",
@@ -112,11 +112,11 @@ class JHtmlSelectTest_DataSet
 			"<div class=\"controls\">
 	<label for=\"fooId\" id=\"fooId-lbl\" class=\"radio\">
 	
-	<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\" >FOO
+	<input type=\"radio\" name=\"myFooBarListName\" id=\"fooId\" value=\"foo\" class=\"i am radio\" onchange=\"jsfunc();\">FOO
 	</label>
 	<label for=\"myFooBarListNamebar\" id=\"myFooBarListNamebar-lbl\" class=\"radio\">
 	
-	<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\" >BAR
+	<input type=\"radio\" name=\"myFooBarListName\" id=\"myFooBarListNamebar\" value=\"bar\" class=\"i am radio\" onchange=\"jsfunc();\">BAR
 	</label>
 </div>
 ",

--- a/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
+++ b/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
@@ -96,9 +96,9 @@ class JDocumentRendererHtmlModulesTest extends TestCaseDatabase
 			. '<form action="index.php" method="post" class="form-inline">'
 			. '<label for="mod-search-searchword63" class="element-invisible">Search ...</label>'
 			. '<input name="searchword" id="mod-search-searchword63" maxlength="200"  '
-			. 'class="inputbox search-query" type="search" size="20" placeholder="Search ..." />'
-			. '<input type="hidden" name="task" value="search" /><input type="hidden" name="option" value="com_search" />'
-			. '<input type="hidden" name="Itemid" value="" /></form></div></div>';
+			. 'class="inputbox search-query" type="search" size="20" placeholder="Search ...">'
+			. '<input type="hidden" name="task" value="search"><input type="hidden" name="option" value="com_search">'
+			. '<input type="hidden" name="Itemid" value=""></form></div></div>';
 		$this->assertEquals($html, $htmlClean, 'render output does not match expected content');
 	}
 

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldCheckboxesTest.php
@@ -117,7 +117,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red"> was missing.'
 		);
 
 		// Test that the 'blue' option exists
@@ -133,7 +133,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 
 		// Test that no option is checked
@@ -214,7 +214,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" checked /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red" checked> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is not checked
@@ -231,7 +231,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 	}
 
@@ -299,7 +299,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" checked /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red" checked> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is not checked
@@ -316,7 +316,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 	}
 
@@ -376,7 +376,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red"> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is checked
@@ -393,7 +393,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" checked /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue" checked> was missing.'
 		);
 	}
 
@@ -455,7 +455,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red"> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is not checked
@@ -472,7 +472,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 	}
 
@@ -534,7 +534,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" checked /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red" checked> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is not checked
@@ -551,7 +551,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 	}
 
@@ -612,7 +612,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="red" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="red"> was missing.'
 		);
 
 		// Test that the 'blue' option exists and is not checked
@@ -629,7 +629,7 @@ class JFormFieldCheckboxesTest extends TestCaseDatabase
 		$this->assertTag(
 			$matcher,
 			$result,
-			'A descendant tag like <input type="checkbox" name="color" value="blue" /> was missing.'
+			'A descendant tag like <input type="checkbox" name="color" value="blue"> was missing.'
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldCheckbox-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldCheckbox-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input"></label></div>',
 		),
 
 		'ValueNoChecked' => array(
@@ -32,7 +32,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'default' => 'red',
 				'value' => 'red',
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="red" class="form-check-input" checked /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="red" class="form-check-input" checked></label></div>',
 		),
 
 		'NoValueChecked' => array(
@@ -42,7 +42,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'default' => 'red',
 				'checked' => true,
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="red" class="form-check-input" checked /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="red" class="form-check-input" checked></label></div>',
 		),
 
 		'Disabled' => array(
@@ -51,7 +51,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" disabled /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" disabled></label></div>',
 		),
 
 		'Class' => array(
@@ -60,7 +60,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input foo bar" /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input foo bar"></label></div>',
 		),
 
 		'Autofocus' => array(
@@ -69,7 +69,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" autofocus /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" autofocus></label></div>',
 		),
 
 		'OnchangeOnclick' => array(
@@ -79,7 +79,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'onchange' => 'bar();',
 				'onclick' => 'foo();',
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" onclick="foo();" onchange="bar();" /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" onclick="foo();" onchange="bar();"></label></div>',
 		),
 
 		'Required' => array(
@@ -88,7 +88,7 @@ class JHtmlFieldCheckboxTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" required aria-required="true" /></label></div>',
+			'<div class="form-check"><label class="form-check-label"><input type="checkbox" name="myTestName" id="myTestId" value="1" class="form-check-input" required aria-required="true"></label></div>',
 		),
 
 	);

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldEmail-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldEmail-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldEmailTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'foo@bar.com',
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="foo@bar.com" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="foo@bar.com">',
 		),
 
 		'Class' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email foo bar" id="myTestId" value="" />',
+			'<input type="email" name="myTestName" class="form-control validate-email foo bar" id="myTestId" value="">',
 		),
 
 		'Size' => array(
@@ -49,7 +49,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'size' => 60,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" size="60" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" size="60">',
 		),
 
 		'Disabled' => array(
@@ -58,7 +58,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" disabled />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" disabled>',
 		),
 
 		'Readonly' => array(
@@ -67,7 +67,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" readonly />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" readonly>',
 		),
 
 		'Hint' => array(
@@ -76,7 +76,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'hint' => 'Type any email.',
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" placeholder="Type any email." />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" placeholder="Type any email.">',
 		),
 
 		'Autocomplete' => array(
@@ -85,7 +85,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'autocomplete' => false,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" autocomplete="off" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" autocomplete="off">',
 		),
 
 		'Autofocus' => array(
@@ -94,7 +94,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" autofocus />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" autofocus>',
 		),
 
 		'Spellcheck' => array(
@@ -103,7 +103,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'spellcheck' => false,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" spellcheck="false" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" spellcheck="false">',
 		),
 
 		'Onchange' => array(
@@ -112,7 +112,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" onchange="foobar();" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" onchange="foobar();">',
 		),
 
 		'Maxlength' => array(
@@ -121,7 +121,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'maxlength' => 250,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" maxlength="250" />',
+			'<input type="email" name="myTestName" class="form-control validate-email" id="myTestId" value="" maxlength="250">',
 		),
 
 		'Required' => array(
@@ -130,7 +130,7 @@ class JHtmlFieldEmailTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<input type="email" name="myTestName" class="form-control validate-email required" id="myTestId" value="" required aria-required="true" />',
+			'<input type="email" name="myTestName" class="form-control validate-email required" id="myTestId" value="" required aria-required="true">',
 		),
 
 	);

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldNumber-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldNumber-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldNumberTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'value' => 2,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="2" class="form-control" />',
+			'<input type="number" name="myTestName" id="myTestId" value="2" class="form-control">',
 		),
 
 		'Min' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'min' => 2,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" min="2" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" min="2">',
 		),
 
 		'MinRequired' => array(
@@ -50,7 +50,7 @@ class JHtmlFieldNumberTest_DataSet
 				'required' => 'true',
 				'min' => 2,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="2" class="form-control" min="2" required aria-required="true" />',
+			'<input type="number" name="myTestName" id="myTestId" value="2" class="form-control" min="2" required aria-required="true">',
 		),
 
 		'Max' => array(
@@ -59,7 +59,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'max' => 200,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" max="200" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" max="200">',
 		),
 
 		'Step' => array(
@@ -68,7 +68,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'step' => 5,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" step="5" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" step="5">',
 		),
 
 		'Class' => array(
@@ -77,7 +77,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control foo bar" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control foo bar">',
 		),
 
 		'Disabled' => array(
@@ -86,7 +86,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" disabled />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" disabled>',
 		),
 
 		'Readonly' => array(
@@ -95,7 +95,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" readonly />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" readonly>',
 		),
 
 		'Autofocus' => array(
@@ -104,7 +104,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" autofocus />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" autofocus>',
 		),
 
 		'Onchange' => array(
@@ -113,7 +113,7 @@ class JHtmlFieldNumberTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" onchange="foobar();" />',
+			'<input type="number" name="myTestName" id="myTestId" value="" class="form-control" onchange="foobar();">',
 		),
 	);
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldPassword-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldPassword-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'foobar',
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="foobar" class="form-control" />',
+			'<input type="password" name="myTestName" id="myTestId" value="foobar" class="form-control">',
 		),
 
 		'Class' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control foo bar" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control foo bar">',
 		),
 
 		'Size' => array(
@@ -49,7 +49,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'size' => 60,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" size="60" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" size="60">',
 		),
 
 		'Disabled' => array(
@@ -58,7 +58,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" disabled />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" disabled>',
 		),
 
 		'Readonly' => array(
@@ -67,7 +67,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" readonly />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" readonly>',
 		),
 
 		'Hint' => array(
@@ -76,7 +76,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'hint' => 'Type any password.',
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" placeholder="Type any password." class="form-control" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" placeholder="Type any password." class="form-control">',
 		),
 
 		'Autocomplete' => array(
@@ -85,7 +85,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'autocomplete' => false,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" autocomplete="off" class="form-control" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" autocomplete="off" class="form-control">',
 		),
 
 		'Autofocus' => array(
@@ -94,7 +94,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" autofocus />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" autofocus>',
 		),
 
 		'Maxlength' => array(
@@ -103,7 +103,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'maxLength' => 250,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" maxlength="250" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" maxlength="250">',
 		),
 
 		'Required' => array(
@@ -112,7 +112,7 @@ class JHtmlFieldPasswordTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" required aria-required="true" />',
+			'<input type="password" name="myTestName" id="myTestId" value="" class="form-control" required aria-required="true">',
 		),
 
 	);

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
@@ -18,7 +18,7 @@ class JHtmlFieldRadioTest_DataSet
 {
 	public static $getInputTest = array(
 		'NoOptions' => array(
-			'<field name="myTestId" type="radio">',
+			'<field name="myTestId" type="radio" />',
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRadio-helper-dataset.php
@@ -18,7 +18,7 @@ class JHtmlFieldRadioTest_DataSet
 {
 	public static $getInputTest = array(
 		'NoOptions' => array(
-			'<field name="myTestId" type="radio" />',
+			'<field name="myTestId" type="radio">',
 			array(
 				'id' => 'myTestId',
 				'name' => 'myTestName',
@@ -35,7 +35,7 @@ class JHtmlFieldRadioTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" />No</label></fieldset>'
+			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1">Yes</label><label class="radio"><input type="radio" name="myTestName" value="0">No</label></fieldset>'
 		),
 
 		'FieldClass' => array(
@@ -57,7 +57,7 @@ class JHtmlFieldRadioTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<fieldset id="myTestId" class="radio" ><label class="radio foo"><input type="radio" name="myTestName" value="1" />Yes</label><label class="radio bar"><input type="radio" name="myTestName" value="0" />No</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" ><label class="radio foo"><input type="radio" name="myTestName" value="1">Yes</label><label class="radio bar"><input type="radio" name="myTestName" value="0">No</label></fieldset>',
 		),
 
 		'FieldDisabled' => array(
@@ -70,7 +70,7 @@ class JHtmlFieldRadioTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<fieldset id="myTestId" class="radio" disabled ><label class="radio"><input type="radio" name="myTestName" value="1" />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" />No</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" disabled ><label class="radio"><input type="radio" name="myTestName" value="1">Yes</label><label class="radio"><input type="radio" name="myTestName" value="0">No</label></fieldset>',
 		),
 
 		'OptionDisabled' => array(
@@ -82,7 +82,7 @@ class JHtmlFieldRadioTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" disabled />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" />No</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" disabled />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0">No</label></fieldset>',
 		),
 
 		'ReadonlyChecked' => array(
@@ -97,7 +97,7 @@ class JHtmlFieldRadioTest_DataSet
 				'readonly' => true,
 				'value' => '0',
 			),
-			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" disabled />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" checked="checked" />No</label><label class="radio"><input type="radio" name="myTestName" value="-1" disabled />None</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" disabled />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" checked="checked">No</label><label class="radio"><input type="radio" name="myTestName" value="-1" disabled />None</label></fieldset>',
 		),
 
 		'Autofocus' => array(
@@ -119,7 +119,7 @@ class JHtmlFieldRadioTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" onclick="foo();" />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" onchange="bar();" />No</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" ><label class="radio"><input type="radio" name="myTestName" value="1" onclick="foo();">Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" onchange="bar();">No</label></fieldset>',
 		),
 
 		'Required' => array(
@@ -132,7 +132,7 @@ class JHtmlFieldRadioTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<fieldset id="myTestId" class="radio" required aria-required="true" ><label class="radio"><input type="radio" name="myTestName" value="1" required aria-required="true" />Yes</label><label class="radio"><input type="radio" name="myTestName" value="0" />No</label></fieldset>',
+			'<fieldset id="myTestId" class="radio" required aria-required="true" ><label class="radio"><input type="radio" name="myTestName" value="1" required aria-required="true">Yes</label><label class="radio"><input type="radio" name="myTestName" value="0">No</label></fieldset>',
 		),
 	);
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRange-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldRange-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldRangeTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" />',
+			'<input type="range" name="myTestName" id="myTestId" value="0">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'value' => 2,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="2" />',
+			'<input type="range" name="myTestName" id="myTestId" value="2">',
 		),
 
 		'Min' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'min' => 2,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="2" min="2" />',
+			'<input type="range" name="myTestName" id="myTestId" value="2" min="2">',
 		),
 
 		'Max' => array(
@@ -49,7 +49,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'max' => 200,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" max="200" />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" max="200">',
 		),
 
 		'Step' => array(
@@ -58,7 +58,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'step' => 5,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" step="5" />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" step="5">',
 		),
 
 		'Class' => array(
@@ -67,7 +67,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" class="foo bar" />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" class="foo bar">',
 		),
 
 		'Disabled' => array(
@@ -76,7 +76,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" disabled />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" disabled>',
 		),
 
 		'Readonly' => array(
@@ -85,7 +85,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" readonly />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" readonly>',
 		),
 
 		'Autofocus' => array(
@@ -94,7 +94,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" autofocus />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" autofocus>',
 		),
 
 		'Onchange' => array(
@@ -103,7 +103,7 @@ class JHtmlFieldRangeTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="range" name="myTestName" id="myTestId" value="0" onchange="foobar();" />',
+			'<input type="range" name="myTestName" id="myTestId" value="0" onchange="foobar();">',
 		),
 	);
 }

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldTel-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldTel-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldTelTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'foobar',
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="foobar" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="foobar">',
 		),
 
 		'Class' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="tel" name="myTestName" class="form-control foo bar" id="myTestId" value="" />',
+			'<input type="tel" name="myTestName" class="form-control foo bar" id="myTestId" value="">',
 		),
 
 		'Size' => array(
@@ -49,7 +49,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'size' => 60,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" size="60" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" size="60">',
 		),
 
 		'Disabled' => array(
@@ -58,7 +58,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" disabled />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" disabled>',
 		),
 
 		'Readonly' => array(
@@ -67,7 +67,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" readonly />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" readonly>',
 		),
 
 		'Hint' => array(
@@ -76,7 +76,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'hint' => 'Type any tel.',
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" placeholder="Type any tel." />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" placeholder="Type any tel.">',
 		),
 
 		'Autocomplete' => array(
@@ -85,7 +85,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'autocomplete' => false,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" autocomplete="off" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" autocomplete="off">',
 		),
 
 		'Autofocus' => array(
@@ -94,7 +94,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" autofocus />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" autofocus>',
 		),
 
 		'Spellcheck' => array(
@@ -103,7 +103,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'spellcheck' => false,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" spellcheck="false" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" spellcheck="false">',
 		),
 
 		'Onchange' => array(
@@ -112,7 +112,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" onchange="foobar();" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" onchange="foobar();">',
 		),
 
 		'Maxlength' => array(
@@ -121,7 +121,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'maxLength' => 250,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" maxlength="250" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" maxlength="250">',
 		),
 
 		'Required' => array(
@@ -130,7 +130,7 @@ class JHtmlFieldTelTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" required aria-required="true" />',
+			'<input type="tel" name="myTestName" class="form-control" id="myTestId" value="" required aria-required="true">',
 		),
 
 	);

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldText-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldText-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldTextTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'foobar',
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="foobar" class="form-control" />',
+			'<input type="text" name="myTestName" id="myTestId" value="foobar" class="form-control">',
 		),
 
 		'Class' => array(
@@ -40,7 +40,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control foo bar" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control foo bar">',
 		),
 
 		'Size' => array(
@@ -49,7 +49,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'size' => 60,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" size="60" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" size="60">',
 		),
 
 		'Disabled' => array(
@@ -58,7 +58,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" disabled />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" disabled>',
 		),
 
 		'Readonly' => array(
@@ -67,7 +67,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" readonly />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" readonly>',
 		),
 
 		'Hint' => array(
@@ -76,7 +76,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'hint' => 'Type any text.',
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" placeholder="Type any text." />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" placeholder="Type any text.">',
 		),
 
 		'Autocomplete' => array(
@@ -85,7 +85,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'autocomplete' => false,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" autocomplete="off" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" autocomplete="off">',
 		),
 
 		'Autofocus' => array(
@@ -94,7 +94,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" autofocus />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" autofocus>',
 		),
 
 		'Spellcheck' => array(
@@ -103,7 +103,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'spellcheck' => false,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" spellcheck="false" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" spellcheck="false">',
 		),
 
 		'Onchange' => array(
@@ -112,7 +112,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" onchange="foobar();" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" onchange="foobar();">',
 		),
 
 		'Maxlength' => array(
@@ -121,7 +121,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'maxLength' => 250,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" maxlength="250" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" maxlength="250">',
 		),
 
 		'Required' => array(
@@ -130,7 +130,7 @@ class JHtmlFieldTextTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" required aria-required="true" />',
+			'<input type="text" name="myTestName" id="myTestId" value="" class="form-control" required aria-required="true">',
 		),
 
 	);

--- a/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldUrl-helper-dataset.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/TestHelpers/JHtmlFieldUrl-helper-dataset.php
@@ -22,7 +22,7 @@ class JHtmlFieldUrlTest_DataSet
 				'id' => 'myTestId',
 				'name' => 'myTestName',
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="">',
 		),
 
 		'Value' => array(
@@ -31,7 +31,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'http://foobar.com',
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="http://foobar.com" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="http://foobar.com">',
 		),
 
 		// Stript always illegal characters that may be used in XSS.
@@ -41,7 +41,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'value' => 'http://<>"foobar.com',
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="http://&lt;&gt;&quot;foobar.com" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="http://&lt;&gt;&quot;foobar.com">',
 		),
 
 		'Class' => array(
@@ -50,7 +50,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'class' => 'foo bar',
 			),
-			'<input type="url" name="myTestName" class="form-control foo bar" id="myTestId" value="" />',
+			'<input type="url" name="myTestName" class="form-control foo bar" id="myTestId" value="">',
 		),
 
 		'Size' => array(
@@ -59,7 +59,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'size' => 60,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" size="60" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" size="60">',
 		),
 
 		'Disabled' => array(
@@ -68,7 +68,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'disabled' => true,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" disabled />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" disabled>',
 		),
 
 		'Readonly' => array(
@@ -77,7 +77,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'readonly' => true,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" readonly />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" readonly>',
 		),
 
 		'Hint' => array(
@@ -86,7 +86,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'hint' => 'Type any url.',
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" placeholder="Type any url." />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" placeholder="Type any url.">',
 		),
 
 		'Autocomplete' => array(
@@ -95,7 +95,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'autocomplete' => false,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" autocomplete="off" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" autocomplete="off">',
 		),
 
 		'Autofocus' => array(
@@ -104,7 +104,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'autofocus' => true,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" autofocus />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" autofocus>',
 		),
 
 		'Spellcheck' => array(
@@ -113,7 +113,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'spellcheck' => false,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" spellcheck="false" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" spellcheck="false">',
 		),
 
 		'Onchange' => array(
@@ -122,7 +122,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'onchange' => 'foobar();',
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" onchange="foobar();" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" onchange="foobar();">',
 		),
 
 		'Maxlength' => array(
@@ -131,7 +131,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'maxlength' => 250,
 			),
-			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" maxlength="250" />',
+			'<input type="url" name="myTestName" class="form-control" id="myTestId" value="" maxlength="250">',
 		),
 
 		'Required' => array(
@@ -140,7 +140,7 @@ class JHtmlFieldUrlTest_DataSet
 				'name' => 'myTestName',
 				'required' => true,
 			),
-			'<input type="url" name="myTestName" class="form-control required" id="myTestId" value="" required aria-required="true" />',
+			'<input type="url" name="myTestName" class="form-control required" id="myTestId" value="" required aria-required="true">',
 		),
 	);
 }


### PR DESCRIPTION
Pull Request for Issue # .

This PR is part 2 of https://github.com/joomla/joomla-cms/pull/14000

In HTML5, the backslash is not required on void elements, so this PR remove them from all `<input>` elements.

### Testing instructions

Will need to be code review