### PR TITLE
Fix some errors on User Profile Plugin

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -416,7 +416,7 @@ class PlgUserProfile extends JPlugin
 
 			foreach ($data['profile'] as $k => $v)
 			{
-				$tuples[] = '(' . $userId . ', ' . $db->quote('profile.' . $k) . ', ' . $db->quote(json_encode($v)) . ', ' . ($order++) . ')';
+				$tuples[] = $userId . ', ' . $db->quote('profile.' . $k) . ', ' . $db->quote(json_encode($v)) . ', ' . ($order++);
 			}
 
 			$query = $db->getQuery(true)
@@ -452,6 +452,7 @@ class PlgUserProfile extends JPlugin
 
 		if ($userId)
 		{
+			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->delete($db->qn('#__user_profiles'))
 				->where($db->qn('user_id') . ' = ' . $db->q((int) $userId))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes some errors on User Profile Plugin on 4.0-dev branch. I saw this error while reviewing the PR #14082

### Testing Instructions
1. Install Joomla 4.0
2. Enable User Profile Plugin
3. Edit a user account: Before Patch, you will receive an error **Save failed with the following error: Operand should contain 1 column(s)** . After patch, error is gone, profile data is being saved properly
4. Delete a user account. Before patch, you will receive an error **Call to a member function getQuery() on unknown**. After that, no error, user account is successfully deleted

You will need to apply the patch on PR #14082 before testing this PR

### Documentation Changes Required
None