### PR TITLE
Plugin System - Redirect - Display error 404 instead 500 when page does not exist [postgresql, sqlsrv]

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-02-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-02-15.sql
@@ -1,0 +1,2 @@
+-- Normalize redirect_links table default values.
+ALTER TABLE `#__redirect_links` MODIFY `comment` varchar(255) NOT NULL DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-02-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-02-15.sql
@@ -1,0 +1,2 @@
+-- Normalize redirect_links table default values.
+ALTER TABLE "#__redirect_links" ALTER COLUMN "comment" SET DEFAULT '';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-15.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-15.sql
@@ -1,0 +1,2 @@
+-- Normalize redirect_links table default values.
+ALTER TABLE [#__redirect_links] ADD DEFAULT ('') FOR [comment];

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1655,7 +1655,7 @@ CREATE TABLE IF NOT EXISTS `#__redirect_links` (
   `old_url` varchar(2048) NOT NULL,
   `new_url` varchar(2048),
   `referer` varchar(2048) NOT NULL,
-  `comment` varchar(255) NOT NULL,
+  `comment` varchar(255) NOT NULL DEFAULT '',
   `hits` int(10) unsigned NOT NULL DEFAULT 0,
   `published` tinyint(4) NOT NULL,
   `created_date` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1587,7 +1587,7 @@ CREATE TABLE "#__redirect_links" (
   "old_url" varchar(2048) NOT NULL,
   "new_url" varchar(2048),
   "referer" varchar(2048) NOT NULL,
-  "comment" varchar(255) NOT NULL,
+  "comment" varchar(255) NOT NULL DEFAULT '',
   "hits" bigint DEFAULT 0 NOT NULL,
   "published" smallint NOT NULL,
   "created_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -1587,7 +1587,7 @@ CREATE TABLE "#__redirect_links" (
   "old_url" varchar(2048) NOT NULL,
   "new_url" varchar(2048),
   "referer" varchar(2048) NOT NULL,
-  "comment" varchar(255) NOT NULL DEFAULT '',
+  "comment" varchar(255) DEFAULT '' NOT NULL,
   "hits" bigint DEFAULT 0 NOT NULL,
   "published" smallint NOT NULL,
   "created_date" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2665,7 +2665,7 @@ CREATE TABLE [#__redirect_links](
 	[old_url] [nvarchar](2048) NOT NULL,
 	[new_url] [nvarchar](2048),
 	[referer] [nvarchar](2048) NOT NULL,
-	[comment] [nvarchar](255) NOT NULL,
+	[comment] [nvarchar](255) NOT NULL DEFAULT '',
 	[hits] [bigint] NOT NULL DEFAULT 0,
 	[published] [smallint] NOT NULL,
 	[created_date] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/13262#issuecomment-279743085

### Summary of Changes
In table `#__redirect_links` column `comment` does not have a default value.

On J4 mysql error should be visible.
On postgresql and sqlsrv error exists. 

### Testing Instructions
Install fresh joomla staging on postgresql or sqlsrv database.
Enable System - Redirect plugin
Go to not exists page like "index.php?option=sdfsdf"

Before patch:
Error 500 PLG_SYSTEM_REDIRECT_ERROR_UPDATING_DATABASE 
After patch:
Error 404


### Expected result
ERROR 404

### Actual result
ERROR 500

### Documentation Changes Required
None
