### PR TITLE
Correct schemapath - sql updates files does not work on sqlsrv

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -15,7 +15,7 @@
 	<update>
 		<schemas>
 			<schemapath type="mysql">administrator/components/com_admin/sql/updates/mysql</schemapath>
-			<schemapath type="sqlsrv">administrator/components/com_admin/sql/updates/sqlsrv</schemapath>
+			<schemapath type="sqlsrv">administrator/components/com_admin/sql/updates/sqlazure</schemapath>
 			<schemapath type="sqlazure">administrator/components/com_admin/sql/updates/sqlazure</schemapath>
 			<schemapath type="postgresql">administrator/components/com_admin/sql/updates/postgresql</schemapath>
 		</schemas>


### PR DESCRIPTION
### Summary of Changes

Updates sql files does not work on sqlsrv driver because path does not exists.
This is simple fix which correct path only. 

More info you can find in `libraries/cms/installer/installer.php` in function `parseSchemaUpdates()`.

### Testing Instructions
Code review. 
