### PR TITLE
Add `input-medium` class in mod_search to get similar output as for mod_finder

### DIFF
--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -29,7 +29,7 @@ else
 	<form action="<?php echo JRoute::_('index.php'); ?>" method="post" class="form-inline">
 		<?php
 			$output = '<label for="mod-search-searchword' . $module->id . '" class="element-invisible">' . $label . '</label> ';
-			$output .= '<input name="searchword" id="mod-search-searchword' . $module->id . '" maxlength="' . $maxlength . '"  class="inputbox search-query" type="search"' . $width;
+			$output .= '<input name="searchword" id="mod-search-searchword' . $module->id . '" maxlength="' . $maxlength . '"  class="inputbox search-query input-medium" type="search"' . $width;
 			$output .= ' placeholder="' . $text . '" />';
 
 			if ($button) :

--- a/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
+++ b/tests/unit/suites/libraries/joomla/document/renderer/JDocumentRendererHtmlModulesTest.php
@@ -101,7 +101,7 @@ class JDocumentRendererHtmlModulesTest extends TestCaseDatabase
 			. '<form action="index.php" method="post" class="form-inline">'
 			. '<label for="mod-search-searchword63" class="element-invisible">Search ...</label>'
 			. '<input name="searchword" id="mod-search-searchword63" maxlength="200"  '
-			. 'class="inputbox search-query" type="search" size="20" placeholder="Search ..." />'
+			. 'class="inputbox search-query input-medium" type="search" size="20" placeholder="Search ..." />'
 			. '<input type="hidden" name="task" value="search" /><input type="hidden" name="option" value="com_search" />'
 			. '<input type="hidden" name="Itemid" value="" /></form></div></div>';
 		$this->assertEquals($html, $htmlClean, 'render output does not match expected content');


### PR DESCRIPTION
### Summary of Changes
Adding `input-medium` class for input field to get the same output as for mod_finder. We have had this issue for the joomla.org templates for example, where the output is different if using mod_search instead of mod_finder.

### Testing Instructions
Before patch the `input-medium` class is not in the output for mod_search, after applying patch the output should be changed and `input-medium` is one of the classes.