### PR TITLE
keychain - don't need to load languages

### DIFF
--- a/bin/keychain.php
+++ b/bin/keychain.php
@@ -47,15 +47,6 @@ $config = new JConfig;
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-// Load Library language
-$lang = JFactory::getLanguage();
-
-// Try the finder_cli file in the current language (without allowing the loading of the file in the default language)
-$lang->load('finder_cli', JPATH_SITE, null, false, false)
-
-// Fallback to the finder_cli file in the default language
-|| $lang->load('finder_cli', JPATH_SITE, null, true);
-
 /**
  * Keychain Manager.
  *


### PR DESCRIPTION
Pull Request for Issue # .
don't need to load language from finder_cli

### Testing Instructions
code review


