### PR TITLE
Back to use require_once in JFormHelper

### DIFF
--- a/libraries/joomla/form/helper.php
+++ b/libraries/joomla/form/helper.php
@@ -212,7 +212,7 @@ class JFormHelper
 				continue;
 			}
 
-			JLoader::register($class, $file);
+			require_once $file;
 
 			if (class_exists($class))
 			{


### PR DESCRIPTION
Joomla3.7beta use JLoader instead directly require file in JFormHelper, but this will break all FormField file named `list.php` or same with existing core fields name.

For example, a field named `JFormFieldFoo_List` in `/models/fields/foo/list.php` will override the `JFormFieldList` class, so `JFormHelper::loadFieldClass('list')` will load `JFormFieldFoo_List` not `JFormFieldList`.

This will break many components.

See https://github.com/lyrasoft/quickicons/issues/45

### Summary of Changes

Back to use require_once in JFormHelper

### Testing Instructions

Create a field in `models/fields/foo/list.php` named `JFormFieldFoo_List` and include it in xml file, then try to load `JFormHelper::loadFieldClass('list');` in other fields file, Joomla will not able to load `JFormFieldList`

### Expected result

Should load `JFormFieldList`

### Actual result

`JFormFieldList` class not definded.

