### PR TITLE
Fix contact creator plugin

### DIFF
--- a/administrator/components/com_contact/tables/contact.php
+++ b/administrator/components/com_contact/tables/contact.php
@@ -212,6 +212,10 @@ class ContactTableContact extends JTable
 			// Put array back together delimited by ", "
 			$this->metakey = implode(', ', $cleanKeys);
 		}
+		else
+		{
+			$this->metakey = '';
+		}
 
 		// Clean up description -- eliminate quotes and <> brackets
 		if (!empty($this->metadesc))
@@ -219,6 +223,20 @@ class ContactTableContact extends JTable
 			// Only process if not empty
 			$badCharacters = array("\"", '<', '>');
 			$this->metadesc = StringHelper::str_ireplace($badCharacters, '', $this->metadesc);
+		}
+		else
+		{
+			$this->metadesc = '';
+		}
+
+		if (empty($this->params))
+		{
+			$this->params = '{}';
+		}
+
+		if (empty($this->metadata))
+		{
+			$this->metadata = '{}';
 		}
 
 		return true;

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -92,9 +92,6 @@ class PlgUserContactCreator extends JPlugin
 			$contact->access   = (int) JFactory::getConfig()->get('access');
 			$contact->language = '*';
 			$contact->generateAlias();
-			$contact->sortname1= '';
-			$contact->sortname2= '';
-			$contact->sortname3= '';
 
 			// Check if the contact already exists to generate new name & alias if required
 			if ($contact->id == 0)

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -38,7 +38,7 @@ class PlgUserContactCreator extends JPlugin
 	 * @param   boolean  $success  True if user was succesfully stored in the database.
 	 * @param   string   $msg      Message.
 	 *
-	 * @return  void
+	 * @return  boolean
 	 *
 	 * @since   1.6
 	 */
@@ -92,6 +92,9 @@ class PlgUserContactCreator extends JPlugin
 			$contact->access   = (int) JFactory::getConfig()->get('access');
 			$contact->language = '*';
 			$contact->generateAlias();
+			$contact->sortname1= '';
+			$contact->sortname2= '';
+			$contact->sortname3= '';
 
 			// Check if the contact already exists to generate new name & alias if required
 			if ($contact->id == 0)


### PR DESCRIPTION
Pull Request for Issue #14090 .

### Summary of Changes
Fixes the contact creation plugin

### Testing Instructions
Test contact creation now works (note you may have to apply https://github.com/joomla/joomla-cms/pull/13956 to fix a fields related problem on saving a user)

### Expected result
Contact now saves

@alikon or @csthomas - Should some of these fields (like `sortname1`) be optional default null fields instead of some of this??

### Documentation Changes Required
N/A