### PR TITLE
MSSQL Replace datetime to datetime2(0) type for all joomla columns.

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-16.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-02-16.sql
@@ -1,0 +1,329 @@
+-- Replace datetime to datetime2(0) type for all columns.
+DROP INDEX [idx_track_date] ON [#__banner_tracks];
+ALTER TABLE [#__banner_tracks] DROP CONSTRAINT [PK_#__banner_tracks_track_date];
+ALTER TABLE [#__banner_tracks] ALTER COLUMN [track_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banner_tracks] ADD CONSTRAINT [PK_#__banner_tracks_track_date_type_id] PRIMARY KEY CLUSTERED
+(
+	[track_date] ASC,
+	[track_type] ASC,
+	[banner_id] ASC
+) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY];
+CREATE NONCLUSTERED INDEX [idx_track_date2] ON [#__banner_tracks]
+(
+	[track_date] ASC
+) WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+CREATE PROCEDURE "#removeDefault"
+(
+	@table NVARCHAR(100),
+	@column NVARCHAR(100)
+)
+AS
+BEGIN
+	DECLARE @constraintName AS nvarchar(100)
+	DECLARE @constraintQuery AS nvarchar(1000)
+	SELECT @constraintName = name FROM sys.default_constraints
+		WHERE parent_object_id = object_id(@table)
+		AND parent_column_id = columnproperty(object_id(@table), @column, 'ColumnId')
+	SET @constraintQuery = 'ALTER TABLE [' + @table + '] DROP CONSTRAINT [' + @constraintName + ']'
+	EXECUTE sp_executesql @constraintQuery
+END;
+
+EXECUTE "#removeDefault" "#__banner_clients", 'checked_out_time';
+ALTER TABLE [#__banner_clients] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banner_clients] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__banners", 'checked_out_time';
+ALTER TABLE [#__banners] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__banners", 'publish_up';
+ALTER TABLE [#__banners] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__banners", 'publish_down';
+ALTER TABLE [#__banners] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__banners", 'reset';
+ALTER TABLE [#__banners] ALTER COLUMN [reset] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [reset];
+
+EXECUTE "#removeDefault" "#__banners", 'created';
+ALTER TABLE [#__banners] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__banners", 'modified';
+ALTER TABLE [#__banners] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__banners] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+DROP INDEX [idx_checked_out_time] ON [#__categories];
+EXECUTE "#removeDefault" "#__categories", 'checked_out_time';
+ALTER TABLE [#__categories] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__categories] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+CREATE NONCLUSTERED INDEX [idx_checked_out_time2] ON [#__categories](
+	[checked_out_time] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+EXECUTE "#removeDefault" "#__categories", 'created_time';
+ALTER TABLE [#__categories] ALTER COLUMN [created_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__categories] ADD DEFAULT '1900-01-01 00:00:00' FOR [created_time];
+
+EXECUTE "#removeDefault" "#__categories", 'modified_time';
+ALTER TABLE [#__categories] ALTER COLUMN [modified_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__categories] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified_time];
+
+EXECUTE "#removeDefault" "#__contact_details", 'checked_out_time';
+ALTER TABLE [#__contact_details] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contact_details] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__contact_details", 'created';
+ALTER TABLE [#__contact_details] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contact_details] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__contact_details", 'modified';
+ALTER TABLE [#__contact_details] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contact_details] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+EXECUTE "#removeDefault" "#__contact_details", 'publish_up';
+ALTER TABLE [#__contact_details] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contact_details] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__contact_details", 'publish_down';
+ALTER TABLE [#__contact_details] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contact_details] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__content", 'created';
+ALTER TABLE [#__content] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__content] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__content", 'modified';
+ALTER TABLE [#__content] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__content] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+EXECUTE "#removeDefault" "#__content", 'checked_out_time';
+ALTER TABLE [#__content] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__content] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__content", 'publish_up';
+ALTER TABLE [#__content] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__content] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__content", 'publish_down';
+ALTER TABLE [#__content] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__content] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+DROP INDEX [idx_date_id] ON [#__contentitem_tag_map];
+EXECUTE "#removeDefault" "#__contentitem_tag_map", 'tag_date';
+ALTER TABLE [#__contentitem_tag_map] ALTER COLUMN [tag_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__contentitem_tag_map] ADD DEFAULT '1900-01-01 00:00:00' FOR [tag_date];
+CREATE NONCLUSTERED INDEX [idx_date_id2] ON [#__contentitem_tag_map](
+	[tag_date] ASC,
+	[tag_id] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+EXECUTE "#removeDefault" "#__extensions", 'checked_out_time';
+ALTER TABLE [#__extensions] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__extensions] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__fields", 'checked_out_time';
+ALTER TABLE [#__fields] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__fields", 'created_time';
+ALTER TABLE [#__fields] ALTER COLUMN [created_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields] ADD DEFAULT '1900-01-01 00:00:00' FOR [created_time];
+
+EXECUTE "#removeDefault" "#__fields", 'modified_time';
+ALTER TABLE [#__fields] ALTER COLUMN [modified_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified_time];
+
+EXECUTE "#removeDefault" "#__fields_groups", 'checked_out_time';
+ALTER TABLE [#__fields_groups] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields_groups] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__fields_groups", 'created';
+ALTER TABLE [#__fields_groups] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields_groups] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__fields_groups", 'modified';
+ALTER TABLE [#__fields_groups] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__fields_groups] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+EXECUTE "#removeDefault" "#__finder_filters", 'created';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_filters] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__finder_filters", 'modified';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_filters] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+EXECUTE "#removeDefault" "#__finder_filters", 'checked_out_time';
+ALTER TABLE [#__finder_filters] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_filters] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__finder_links", 'indexdate';
+ALTER TABLE [#__finder_links] ALTER COLUMN [indexdate] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [indexdate];
+
+EXECUTE "#removeDefault" "#__finder_links", 'publish_start_date';
+ALTER TABLE [#__finder_links] ALTER COLUMN [publish_start_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_start_date];
+
+EXECUTE "#removeDefault" "#__finder_links", 'publish_end_date';
+ALTER TABLE [#__finder_links] ALTER COLUMN [publish_end_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_end_date];
+
+EXECUTE "#removeDefault" "#__finder_links", 'start_date';
+ALTER TABLE [#__finder_links] ALTER COLUMN [start_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [start_date];
+
+EXECUTE "#removeDefault" "#__finder_links", 'end_date';
+ALTER TABLE [#__finder_links] ALTER COLUMN [end_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__finder_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [end_date];
+
+EXECUTE "#removeDefault" "#__menu", 'checked_out_time';
+ALTER TABLE [#__menu] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__menu] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__messages", 'date_time';
+ALTER TABLE [#__messages] ALTER COLUMN [date_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__messages] ADD DEFAULT '1900-01-01 00:00:00' FOR [date_time];
+
+EXECUTE "#removeDefault" "#__modules", 'checked_out_time';
+ALTER TABLE [#__modules] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__modules] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__modules", 'publish_up';
+ALTER TABLE [#__modules] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__modules] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__modules", 'publish_down';
+ALTER TABLE [#__modules] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__modules] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__newsfeeds", 'checked_out_time';
+ALTER TABLE [#__newsfeeds] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__newsfeeds] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__newsfeeds", 'created';
+ALTER TABLE [#__newsfeeds] ALTER COLUMN [created] [datetime2](0) NOT NULL;
+ALTER TABLE [#__newsfeeds] ADD DEFAULT '1900-01-01 00:00:00' FOR [created];
+
+EXECUTE "#removeDefault" "#__newsfeeds", 'modified';
+ALTER TABLE [#__newsfeeds] ALTER COLUMN [modified] [datetime2](0) NOT NULL;
+ALTER TABLE [#__newsfeeds] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified];
+
+EXECUTE "#removeDefault" "#__newsfeeds", 'publish_up';
+ALTER TABLE [#__newsfeeds] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__newsfeeds] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__newsfeeds", 'publish_down';
+ALTER TABLE [#__newsfeeds] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__newsfeeds] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__redirect_links", 'created_date';
+ALTER TABLE [#__redirect_links] ALTER COLUMN [created_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__redirect_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [created_date];
+
+DROP INDEX [idx_link_modifed] ON [#__redirect_links];
+EXECUTE "#removeDefault" "#__redirect_links", 'modified_date';
+ALTER TABLE [#__redirect_links] ALTER COLUMN [modified_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__redirect_links] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified_date];
+CREATE NONCLUSTERED INDEX [idx_link_modifed2] ON [#__redirect_links](
+	[modified_date] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+EXECUTE "#removeDefault" "#__tags", 'checked_out_time';
+ALTER TABLE [#__tags] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__tags] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__tags", 'created_time';
+ALTER TABLE [#__tags] ALTER COLUMN [created_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__tags] ADD DEFAULT '1900-01-01 00:00:00' FOR [created_time];
+
+EXECUTE "#removeDefault" "#__tags", 'modified_time';
+ALTER TABLE [#__tags] ALTER COLUMN [modified_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__tags] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified_time];
+
+EXECUTE "#removeDefault" "#__tags", 'publish_up';
+ALTER TABLE [#__tags] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__tags] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__tags", 'publish_down';
+ALTER TABLE [#__tags] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__tags] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__ucm_content", 'core_checked_out_time';
+ALTER TABLE [#__ucm_content] ALTER COLUMN [core_checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_content] ADD DEFAULT '1900-01-01 00:00:00' FOR [core_checked_out_time];
+
+DROP INDEX [idx_created_time] ON [#__ucm_content];
+EXECUTE "#removeDefault" "#__ucm_content", 'core_created_time';
+ALTER TABLE [#__ucm_content] ALTER COLUMN [core_created_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_content] ADD DEFAULT '1900-01-01 00:00:00' FOR [core_created_time];
+CREATE NONCLUSTERED INDEX [idx_created_time2] ON [#__ucm_content](
+	[core_created_time] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+DROP INDEX [idx_modified_time] ON [#__ucm_content];
+EXECUTE "#removeDefault" "#__ucm_content", 'core_modified_time';
+ALTER TABLE [#__ucm_content] ALTER COLUMN [core_modified_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_content] ADD DEFAULT '1900-01-01 00:00:00' FOR [core_modified_time];
+CREATE NONCLUSTERED INDEX [idx_modified_time2] ON [#__ucm_content](
+	[core_modified_time] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+EXECUTE "#removeDefault" "#__ucm_content", 'core_publish_up';
+ALTER TABLE [#__ucm_content] ALTER COLUMN [core_publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_content] ADD DEFAULT '1900-01-01 00:00:00' FOR [core_publish_up];
+
+EXECUTE "#removeDefault" "#__ucm_content", 'core_publish_down';
+ALTER TABLE [#__ucm_content] ALTER COLUMN [core_publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_content] ADD DEFAULT '1900-01-01 00:00:00' FOR [core_publish_down];
+
+DROP INDEX [idx_save_date] ON [#__ucm_history];
+EXECUTE "#removeDefault" "#__ucm_history", 'save_date';
+ALTER TABLE [#__ucm_history] ALTER COLUMN [save_date] [datetime2](0) NOT NULL;
+ALTER TABLE [#__ucm_history] ADD DEFAULT '1900-01-01 00:00:00' FOR [save_date];
+CREATE NONCLUSTERED INDEX [idx_save_date2] ON [#__ucm_history](
+	[save_date] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
+
+EXECUTE "#removeDefault" "#__user_notes", 'checked_out_time';
+ALTER TABLE [#__user_notes] ALTER COLUMN [checked_out_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [checked_out_time];
+
+EXECUTE "#removeDefault" "#__user_notes", 'created_time';
+ALTER TABLE [#__user_notes] ALTER COLUMN [created_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [created_time];
+
+EXECUTE "#removeDefault" "#__user_notes", 'modified_time';
+ALTER TABLE [#__user_notes] ALTER COLUMN [modified_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [modified_time];
+
+EXECUTE "#removeDefault" "#__user_notes", 'review_time';
+ALTER TABLE [#__user_notes] ALTER COLUMN [review_time] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [review_time];
+
+EXECUTE "#removeDefault" "#__user_notes", 'publish_up';
+ALTER TABLE [#__user_notes] ALTER COLUMN [publish_up] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_up];
+
+EXECUTE "#removeDefault" "#__user_notes", 'publish_down';
+ALTER TABLE [#__user_notes] ALTER COLUMN [publish_down] [datetime2](0) NOT NULL;
+ALTER TABLE [#__user_notes] ADD DEFAULT '1900-01-01 00:00:00' FOR [publish_down];
+
+EXECUTE "#removeDefault" "#__users", 'registerDate';
+ALTER TABLE [#__users] ALTER COLUMN [registerDate] [datetime2](0) NOT NULL;
+ALTER TABLE [#__users] ADD DEFAULT '1900-01-01 00:00:00' FOR [registerDate];
+
+EXECUTE "#removeDefault" "#__users", 'lastvisitDate';
+ALTER TABLE [#__users] ALTER COLUMN [lastvisitDate] [datetime2](0) NOT NULL;
+ALTER TABLE [#__users] ADD DEFAULT '1900-01-01 00:00:00' FOR [lastvisitDate];
+
+EXECUTE "#removeDefault" "#__users", 'lastResetTime';
+ALTER TABLE [#__users] ALTER COLUMN [lastResetTime] [datetime2](0) NOT NULL;
+ALTER TABLE [#__users] ADD DEFAULT '1900-01-01 00:00:00' FOR [lastResetTime];
+
+DROP PROCEDURE "#removeDefault";

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -15,7 +15,7 @@
 	<update>
 		<schemas>
 			<schemapath type="mysql">administrator/components/com_admin/sql/updates/mysql</schemapath>
-			<schemapath type="sqlsrv">administrator/components/com_admin/sql/updates/sqlsrv</schemapath>
+			<schemapath type="sqlsrv">administrator/components/com_admin/sql/updates/sqlazure</schemapath>
 			<schemapath type="sqlazure">administrator/components/com_admin/sql/updates/sqlazure</schemapath>
 			<schemapath type="postgresql">administrator/components/com_admin/sql/updates/postgresql</schemapath>
 		</schemas>

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -165,7 +165,7 @@ CREATE TABLE [#__banner_clients](
 	[extrainfo] [nvarchar](max) NOT NULL,
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[metakey] [nvarchar](max) NOT NULL DEFAULT 0,
 	[own_prefix] [smallint] NOT NULL DEFAULT 0,
 	[metakey_prefix] [nvarchar](255) NOT NULL DEFAULT '',
@@ -192,11 +192,11 @@ CREATE NONCLUSTERED INDEX [idx_own_prefix] ON [#__banner_clients]
 SET QUOTED_IDENTIFIER ON;
 
 CREATE TABLE [#__banner_tracks](
-	[track_date] [datetime] NOT NULL,
+	[track_date] [datetime2](0) NOT NULL,
 	[track_type] [bigint] NOT NULL,
 	[banner_id] [bigint] NOT NULL,
 	[count] [bigint] NOT NULL DEFAULT 0,
- CONSTRAINT [PK_#__banner_tracks_track_date] PRIMARY KEY CLUSTERED
+ CONSTRAINT [PK_#__banner_tracks_track_date_type_id] PRIMARY KEY CLUSTERED
 (
 	[track_date] ASC,
 	[track_type] ASC,
@@ -209,7 +209,7 @@ CREATE NONCLUSTERED INDEX [idx_banner_id] ON [#__banner_tracks]
 	[banner_id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_track_date] ON [#__banner_tracks]
+CREATE NONCLUSTERED INDEX [idx_track_date2] ON [#__banner_tracks]
 (
 	[track_date] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
@@ -246,15 +246,15 @@ CREATE TABLE [#__banners](
 	[track_clicks] [smallint] NOT NULL DEFAULT -1,
 	[track_impressions] [smallint] NOT NULL DEFAULT -1,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[reset] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[created] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[reset] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[language] [nvarchar](7) NOT NULL DEFAULT '',
 	[created_by] [bigint] NOT NULL DEFAULT 0,
 	[created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
-	[modified] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[version] [bigint] NOT NULL DEFAULT 1,
  CONSTRAINT [PK_#__banners_id] PRIMARY KEY CLUSTERED
@@ -311,16 +311,16 @@ CREATE TABLE [#__categories](
 	[description] [nvarchar](max) NOT NULL DEFAULT '',
 	[published] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[access] [int] NOT NULL DEFAULT 0,
 	[params] [nvarchar](max) NOT NULL DEFAULT '',
 	[metadesc] [nvarchar](1024) NOT NULL DEFAULT '',
 	[metakey] [nvarchar](1024) NOT NULL DEFAULT '',
 	[metadata] [nvarchar](2048) NOT NULL DEFAULT '',
 	[created_user_id] [bigint] NOT NULL DEFAULT 0,
-	[created_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_user_id] [bigint] NOT NULL DEFAULT 0,
-	[modified_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[hits] [bigint] NOT NULL DEFAULT 0,
 	[language] [nvarchar](7) NOT NULL DEFAULT '',
 	[version] [bigint] NOT NULL DEFAULT 1,
@@ -373,7 +373,7 @@ CREATE NONCLUSTERED INDEX [idx_created_user_id] ON [#__categories]
 	[created_user_id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_checked_out_time] ON [#__categories]
+CREATE NONCLUSTERED INDEX [idx_checked_out_time2] ON [#__categories]
 (
 	[checked_out_time] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
@@ -421,7 +421,7 @@ CREATE TABLE [#__contact_details](
 	[default_con] [tinyint] NOT NULL DEFAULT 0,
 	[published] [smallint] NOT NULL,
 	[checked_out] [int] NOT NULL,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[ordering] [int] NOT NULL DEFAULT 0,
 	[params] [nvarchar](max) NOT NULL,
 	[user_id] [int] NOT NULL DEFAULT 0,
@@ -433,18 +433,18 @@ CREATE TABLE [#__contact_details](
 	[sortname2] [nvarchar](255) NOT NULL,
 	[sortname3] [nvarchar](255) NOT NULL,
 	[language] [nvarchar](7) NOT NULL,
-	[created] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by] [bigint] NOT NULL DEFAULT 0,
 	[created_by_alias] [nvarchar](255) NOT NULL,
-	[modified] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[metakey] [nvarchar](max) NOT NULL,
 	[metadesc] [nvarchar](max) NOT NULL,
 	[metadata] [nvarchar](max) NOT NULL,
 	[featured] [tinyint] NOT NULL DEFAULT 0,
 	[xreference] [nvarchar](50) NOT NULL,
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[version] [bigint] NOT NULL DEFAULT 1,
 	[hits] [bigint] NOT NULL DEFAULT 0,
  CONSTRAINT [PK_#__contact_details_id] PRIMARY KEY CLUSTERED
@@ -506,15 +506,15 @@ CREATE TABLE [#__content](
 	[fulltext] [nvarchar](max) NOT NULL,
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[catid] [bigint] NOT NULL DEFAULT 0,
-	[created] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by] [bigint] NOT NULL DEFAULT 0,
 	[created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
-	[modified] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[images] [nvarchar](max) NOT NULL,
 	[urls] [nvarchar](max) NOT NULL,
 	[attribs] [nvarchar](max) NOT NULL,
@@ -663,7 +663,7 @@ CREATE TABLE [#__contentitem_tag_map](
 	[core_content_id] [bigint] NOT NULL,
 	[content_item_id] [int] NOT NULL,
 	[tag_id] [bigint] NOT NULL,
-	[tag_date] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[tag_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[type_id] [int] NOT NULL,
  CONSTRAINT [#__contentitem_tag_map$uc_ItemnameTagid] UNIQUE NONCLUSTERED
 (
@@ -673,7 +673,7 @@ CREATE TABLE [#__contentitem_tag_map](
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
 ) ON [PRIMARY];
 
-CREATE NONCLUSTERED INDEX [idx_date_id] ON [#__contentitem_tag_map]
+CREATE NONCLUSTERED INDEX [idx_date_id2] ON [#__contentitem_tag_map]
 (
 	[tag_date] ASC,
 	[tag_id] ASC
@@ -711,7 +711,7 @@ CREATE TABLE [#__extensions](
 	[custom_data] [nvarchar](max) NOT NULL,
 	[system_data] [nvarchar](max) NOT NULL DEFAULT '',
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[ordering] [int] NULL DEFAULT 0,
 	[state] [int] NULL DEFAULT 0,
  CONSTRAINT [PK_#__extensions_extension_id] PRIMARY KEY CLUSTERED
@@ -1105,14 +1105,14 @@ CREATE TABLE [#__fields] (
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[required] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[ordering] [int] NOT NULL DEFAULT 0,
 	[params] [nvarchar](max) NOT NULL DEFAULT '',
 	[fieldparams] [nvarchar](max) NOT NULL DEFAULT '',
 	[language] [nvarchar](7) NOT NULL DEFAULT '',
-	[created_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_user_id] [bigint] NOT NULL DEFAULT 0,
-	[modified_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[access] [int] NOT NULL DEFAULT 1,
 CONSTRAINT [PK_#__fields_id] PRIMARY KEY CLUSTERED(
@@ -1166,12 +1166,12 @@ CREATE TABLE [#__fields_groups] (
 	[description] [nvarchar](max) NOT NULL DEFAULT '',
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[ordering] [int] NOT NULL DEFAULT 0,
 	[language] [nvarchar](7) NOT NULL DEFAULT '',
-	[created] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by] [bigint] NOT NULL DEFAULT 0,
-	[modified] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[access] [int] NOT NULL DEFAULT 1,
 CONSTRAINT [PK_#__fields_groups_id] PRIMARY KEY CLUSTERED(
@@ -1234,13 +1234,13 @@ CREATE TABLE [#__finder_filters](
 	[title] [nvarchar](255) NOT NULL,
 	[alias] [nvarchar](255) NOT NULL,
 	[state] [smallint] NOT NULL DEFAULT 1,
-	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by] [bigint] NOT NULL,
 	[created_by_alias] [nvarchar](255) NOT NULL,
-	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[map_count] [bigint] NOT NULL DEFAULT 0,
 	[data] [nvarchar](max) NOT NULL,
 	[params] [nvarchar](max) NULL,
@@ -1260,16 +1260,16 @@ CREATE TABLE [#__finder_links](
 	[route] [nvarchar](255) NOT NULL,
 	[title] [nvarchar](255) NULL,
 	[description] [nvarchar](max) NULL,
-	[indexdate] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[indexdate] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[md5sum] [nvarchar](32) NULL,
 	[published] [smallint] NOT NULL DEFAULT 1,
 	[state] [int] NULL DEFAULT 1,
 	[access] [int] NULL DEFAULT 0,
 	[language] [nvarchar](8) NOT NULL,
-	[publish_start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[publish_start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[start_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[end_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[list_price] [float] NOT NULL DEFAULT 0,
 	[sale_price] [float] NOT NULL DEFAULT 0,
 	[type_id] [int] NOT NULL,
@@ -2219,7 +2219,7 @@ CREATE TABLE [#__menu](
 	[level] [bigint] NOT NULL DEFAULT 0,
 	[component_id] [bigint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[browserNav] [smallint] NOT NULL DEFAULT 0,
 	[access] [int] NOT NULL DEFAULT 0,
 	[img] [nvarchar](255) NOT NULL,
@@ -2375,7 +2375,7 @@ CREATE TABLE [#__messages](
 	[user_id_from] [bigint] NOT NULL DEFAULT 0,
 	[user_id_to] [bigint] NOT NULL DEFAULT 0,
 	[folder_id] [tinyint] NOT NULL DEFAULT 0,
-	[date_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[date_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[priority] [tinyint] NOT NULL,
 	[subject] [nvarchar](255) NOT NULL DEFAULT '',
@@ -2418,9 +2418,9 @@ CREATE TABLE [#__modules](
 	[ordering] [int] NOT NULL DEFAULT 0,
 	[position] [nvarchar](50) NULL DEFAULT '',
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[published] [smallint] NOT NULL DEFAULT 0,
 	[module] [nvarchar](50) NULL,
 	[access] [bigint] NOT NULL DEFAULT 0,
@@ -2547,23 +2547,23 @@ CREATE TABLE [#__newsfeeds](
 	[numarticles] [bigint] NOT NULL DEFAULT 1,
 	[cache_time] [bigint] NOT NULL DEFAULT 3600,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[ordering] [int] NOT NULL DEFAULT 0,
 	[rtl] [smallint] NOT NULL DEFAULT 0,
 	[access] [bigint] NOT NULL DEFAULT 0,
 	[language] [nvarchar](7) NOT NULL,
 	[params] [nvarchar](max) NOT NULL,
-	[created] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by] [bigint] NOT NULL DEFAULT 0,
 	[created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
-	[modified] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_by] [bigint] NOT NULL DEFAULT 0,
 	[metakey] [nvarchar](max) NOT NULL,
 	[metadesc] [nvarchar](max) NOT NULL,
 	[metadata] [nvarchar](max) NOT NULL,
 	[xreference] [nvarchar](50) NOT NULL,
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[description] [nvarchar](max) NOT NULL,
 	[version] [bigint] NOT NULL DEFAULT 1,
 	[hits] [bigint] NOT NULL DEFAULT 0,
@@ -2668,8 +2668,8 @@ CREATE TABLE [#__redirect_links](
 	[comment] [nvarchar](255) NOT NULL,
 	[hits] [bigint] NOT NULL DEFAULT 0,
 	[published] [smallint] NOT NULL,
-	[created_date] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[modified_date] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[modified_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[header] [smallint] NOT NULL DEFAULT 301,
  CONSTRAINT [PK_#__redirect_links_id] PRIMARY KEY CLUSTERED
 (
@@ -2682,7 +2682,7 @@ CREATE NONCLUSTERED INDEX [idx_old_url] ON [#__redirect_links]
 	[old_url] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_link_modifed] ON [#__redirect_links]
+CREATE NONCLUSTERED INDEX [idx_link_modifed2] ON [#__redirect_links]
 (
 	[modified_date] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
@@ -2743,24 +2743,24 @@ CREATE TABLE [#__tags](
 	[description] [nvarchar](max) NOT NULL,
 	[published] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[access] [bigint] NOT NULL DEFAULT 0,
 	[params] [nvarchar](max) NOT NULL,
 	[metadesc] [nvarchar](1024) NOT NULL,
 	[metakey] [nvarchar](1024) NOT NULL,
 	[metadata] [nvarchar](2048) NOT NULL,
 	[created_user_id] [bigint] NOT NULL DEFAULT 0,
-	[created_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[modified_user_id] [bigint] NOT NULL DEFAULT 0,
-	[modified_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[images] [nvarchar](max) NOT NULL,
 	[urls] [nvarchar](max) NOT NULL,
 	[hits] [bigint] NOT NULL DEFAULT 0,
 	[language] [nvarchar](7) NOT NULL,
 	[version] [bigint] NOT NULL DEFAULT 1,
-	[publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
  CONSTRAINT [PK_#__tags_id] PRIMARY KEY CLUSTERED
 (
 	[id] ASC
@@ -2889,7 +2889,7 @@ CREATE TABLE [#__ucm_content](
 	[core_alias] [nvarchar](255) NOT NULL DEFAULT '',
 	[core_body] [nvarchar](max) NOT NULL DEFAULT '',
 	[core_state] [smallint] NOT NULL DEFAULT 0,
-	[core_checked_out_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[core_checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[core_checked_out_user_id] [bigint] NOT NULL DEFAULT 0,
 	[core_access] [bigint] NOT NULL DEFAULT 0,
 	[core_params] [nvarchar](max) NOT NULL DEFAULT '',
@@ -2897,12 +2897,12 @@ CREATE TABLE [#__ucm_content](
 	[core_metadata] [nvarchar](2048) NOT NULL DEFAULT '',
 	[core_created_user_id] [bigint] NOT NULL DEFAULT 0,
 	[core_created_by_alias] [nvarchar](255) NOT NULL DEFAULT '',
-	[core_created_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[core_created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[core_modified_user_id] [bigint] NOT NULL DEFAULT 0,
-	[core_modified_time] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[core_modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[core_language] [nvarchar](7) NOT NULL DEFAULT '',
-	[core_publish_up] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[core_publish_down] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[core_publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[core_publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[core_content_item_id] [bigint] NOT NULL DEFAULT 0,
 	[asset_id] [bigint] NOT NULL DEFAULT 0,
 	[core_images] [nvarchar](max) NOT NULL DEFAULT '',
@@ -2952,12 +2952,12 @@ CREATE NONCLUSTERED INDEX [idx_title] ON [#__ucm_content]
 	[core_title] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_modified_time] ON [#__ucm_content]
+CREATE NONCLUSTERED INDEX [idx_modified_time2] ON [#__ucm_content]
 (
 	[core_modified_time] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_created_time] ON [#__ucm_content]
+CREATE NONCLUSTERED INDEX [idx_created_time2] ON [#__ucm_content]
 (
 	[core_created_time] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
@@ -2995,7 +2995,7 @@ CREATE TABLE [#__ucm_history](
 	[ucm_item_id] [bigint] NOT NULL,
 	[ucm_type_id] [bigint] NOT NULL,
 	[version_note] [nvarchar](255) NOT NULL DEFAULT '',
-	[save_date] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[save_date] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[editor_user_id] [bigint] NOT NULL DEFAULT 0,
 	[character_count] [bigint] NOT NULL DEFAULT 0,
 	[sha1_hash] [nvarchar](50) NOT NULL DEFAULT '',
@@ -3013,7 +3013,7 @@ CREATE NONCLUSTERED INDEX [idx_ucm_item_id] ON [#__ucm_history]
 	[ucm_item_id] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-CREATE NONCLUSTERED INDEX [idx_save_date] ON [#__ucm_history]
+CREATE NONCLUSTERED INDEX [idx_save_date2] ON [#__ucm_history]
 (
 	[save_date] ASC
 )WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
@@ -3135,14 +3135,14 @@ CREATE TABLE [#__user_notes](
 	[body] [nvarchar](max) NOT NULL,
 	[state] [smallint] NOT NULL DEFAULT 0,
 	[checked_out] [bigint] NOT NULL DEFAULT 0,
-	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[checked_out_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[created_user_id] [bigint] NOT NULL,
-	[created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[created_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[modified_user_id] [bigint] NOT NULL,
-	[modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[review_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[modified_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[review_time] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_up] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[publish_down] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
  CONSTRAINT [PK_#__user_notes_id] PRIMARY KEY CLUSTERED
 (
 	[id] ASC
@@ -3257,11 +3257,11 @@ CREATE TABLE [#__users](
 	[password] [nvarchar](100) NOT NULL DEFAULT '',
 	[block] [smallint] NOT NULL DEFAULT 0,
 	[sendEmail] [smallint] NULL DEFAULT 0,
-	[registerDate] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
-	[lastvisitDate] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[registerDate] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
+	[lastvisitDate] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[activation] [nvarchar](100) NOT NULL DEFAULT '',
 	[params] [nvarchar](max) NOT NULL,
-	[lastResetTime] [datetime] NOT NULL DEFAULT '1900-01-01T00:00:00.000',
+	[lastResetTime] [datetime2](0) NOT NULL DEFAULT '1900-01-01 00:00:00',
 	[resetCount] [int] NOT NULL DEFAULT 0,
 	[otpKey] [nvarchar](1000) NOT NULL DEFAULT '',
 	[otep] [nvarchar](1000) NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for Issue #11277

### Summary of Changes

Change type for 69 columns from type datetime to datetime2(0).
A few indexes change name. 
Sql updates files recreated indexes after change type.

I did a real test for "sql update files" from joomla 3.5 and upgrade to currrent PR (with PR #14102).

### Testing Instructions
* Install joomla with applied patch (no sample data).
* Create a few articles without date on publish down. 
* Check on back end or home page if they are expired or not.
Before patch they are expired, after patch it is correct.

### Expected result
Published articles  without publish_down date appears as not expired.

### Actual result
Published articles  without publish_down date appears as expired.

### Documentation Changes Required
None