### PR TITLE
Update tinymce.php

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1933,7 +1933,7 @@ class PlgEditorTinymce extends JPlugin
 		{
 			case 0: /* Simple mode*/
 				$scriptOptions['menubar']  = false;
-				$scriptOptions['toolbar1'] = 'bold italics underline strikethrough | undo redo | bullist numlist | code | ' . $toolbar5;
+				$scriptOptions['toolbar1'] = 'bold italic underline strikethrough | undo redo | bullist numlist | code | ' . $toolbar5;
 				$scriptOptions['plugins']  = $dragDropPlg . ' code';
 
 				break;


### PR DESCRIPTION
Pull Request for Issue #14131

### Summary of Changes

a typo in the code

in file:
\plugins\editors\tinymce\tinymce.php
1936:  $scriptOptions['toolbar1'] = 'bold italics underline strikethrough | undo redo | bullist numlist | code | ' . $toolbar5;

the word "italics" should be replaced by "italic"

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

