### PR TITLE
Mssql file - replace 2 byte unicode whitespace to ascii 1 byte

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2016-08-29.sql
@@ -1,4 +1,4 @@
-/****** Object:  Table [#__fields] ******/
+/****** Object:  Table [#__fields] ******/
 
 SET QUOTED_IDENTIFIER ON;
 
@@ -52,15 +52,15 @@ CREATE NONCLUSTERED INDEX [idx_language] ON [#__fields](
 	[language] ASC)
 WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-/****** Object:  Table [#__fields_categories] ******/
+/****** Object:  Table [#__fields_categories] ******/
 
 SET QUOTED_IDENTIFIER ON;
 
-CREATE TABLE [#__fields_categories] ( 
-	[field_id] [int] NOT NULL DEFAULT 0,   
-	[category_id] [int] NOT NULL DEFAULT 0,   
+CREATE TABLE [#__fields_categories] (
+	[field_id] [int] NOT NULL DEFAULT 0,
+	[category_id] [int] NOT NULL DEFAULT 0,
 CONSTRAINT [PK_#__fields_categories_id] PRIMARY KEY CLUSTERED(
-	[field_id] ASC, 
+	[field_id] ASC,
 	[category_id] ASC)
 WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON
 ) ON [PRIMARY]) ON [PRIMARY];
@@ -115,7 +115,7 @@ CREATE NONCLUSTERED INDEX [idx_language] ON [#__fields_groups](
 	[language] ASC)
 WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-/****** Object:  Table [#__fields_values] ******/
+/****** Object:  Table [#__fields_values] ******/
 
 SET QUOTED_IDENTIFIER ON;
 
@@ -138,7 +138,7 @@ CREATE NONCLUSTERED INDEX [idx_item_id] ON [#__fields_values](
 	[item_id] ASC)
 WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF);
 
-SET IDENTITY_INSERT [#__extensions] ON;
+SET IDENTITY_INSERT [#__extensions] ON;
 
 INSERT INTO [#__extensions] ([extension_id], [name], [type], [element], [folder], [client_id], [enabled], [access], [protected], [manifest_cache], [params], [custom_data], [system_data], [checked_out], [checked_out_time], [ordering], [state])
 SELECT 33, 'com_fields', 'component', 'com_fields', '', 1, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
@@ -146,4 +146,4 @@ UNION ALL
 SELECT 461, 'plg_system_fields', 'plugin', 'fields', 'system', 0, 1, 1, 0, '', '', '', '', 0, '1900-01-01 00:00:00', 0, 0
 
 
-SET IDENTITY_INSERT [#__extensions] OFF; 
+SET IDENTITY_INSERT [#__extensions] OFF;


### PR DESCRIPTION
### Summary of Changes
The changed file contained 2 byte utf-8  char which geneated error on my virtualbox windows 7 with sqlsrv.

```
CREATE TABLE [j37_fields_categories] (┬á
        [field_id] [int] NOT NULL DEFAULT 0,┬á ┬á
        [category_id] [int] NOT NULL DEFAULT 0,┬á ┬á
CONSTRAINT [PK_j37_fields_categories_id] PRIMARY KEY CLUSTERED(
        [field_id] ASC,┬á
        [category_id] ASC)
WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW
_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON
) ON [PRIMARY]) ON [PRIMARY];

[Microsoft][ODBC Driver 11 for SQL Server][SQL Server]Incorrect syntax near '┬á'
```

This PR replace 2-byte white space char to 1 byte white space.

### Testing Instructions
Merge by code review.
