### PR TITLE
Adjustments for JComponentHelper::load()

### DIFF
--- a/libraries/cms/component/helper.php
+++ b/libraries/cms/component/helper.php
@@ -424,9 +424,27 @@ class JComponentHelper
 	 * @return  boolean  True on success
 	 *
 	 * @since   3.2
+	 * @note    As of 4.0 this method will be restructured to only load the data into memory
 	 */
 	protected static function load($option)
 	{
+		try
+		{
+			JLog::add(
+				sprintf(
+					'Passing a parameter into %s() is deprecated and will be removed in 4.0. Read %s::$components directly after loading the data.',
+					__METHOD__,
+					__CLASS__
+				),
+				JLog::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $e)
+		{
+			// Informational log only
+		}
+
 		$loader = function ()
 		{
 			$db = JFactory::getDbo();
@@ -444,20 +462,7 @@ class JComponentHelper
 
 		try
 		{
-			$components = $cache->get($loader, array(), $option, false);
-
-			/**
-			 * Verify $components is an array, some cache handlers return an object even though
-			 * the original was a single object array.
-			 */
-			if (!is_array($components))
-			{
-				static::$components[$option] = $components;
-			}
-			else
-			{
-				static::$components = $components;
-			}
+			static::$components = $cache->get($loader, array(), __METHOD__);
 		}
 		catch (JCacheException $e)
 		{


### PR DESCRIPTION
### Summary of Changes

1) Deprecate passing the `$option` parameter into the method and making sure the extension is actually loaded; this turns the `load()` method's single responsibility into loading the data into memory and nothing more.  As of 4.0, the class internals (and if someone extended the class for any reason) should do its own validation the key exists in the static array versus relying on the loader to do it.
2) Changes the cache ID from the `$option` parameter to the result of `__METHOD__` to ensure a consistent cache ID for the loader versus something that is dynamic and probably results in extra calls to the cache due to the different IDs that result.

### Testing Instructions

1) Validate the query in the lambda function within `JComponentHelper::load()` runs one time and one time only for the request.
2) Validate that there is only a single cache object for this data.
3) Validate that everything still works normally otherwise.