### PR TITLE
Mssql: Load class before call sqlsrv_fetch_object on windows platform

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -968,6 +968,9 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 	 */
 	protected function fetchObject($cursor = null, $class = 'stdClass')
 	{
+		// Class has to be loaded for sqlsrv on windows platform
+		class_exists($class);
+
 		return sqlsrv_fetch_object($cursor ? $cursor : $this->cursor, $class);
 	}
 


### PR DESCRIPTION
Pull Request for errors on front end mentioned at https://github.com/joomla/joomla-cms/pull/14102#issuecomment-280829604

### Summary of Changes
`sqlsrv_fetch_object($cursor, $class)` return null if Class from $class is not loaded.

To be sure that class is loaded I have added function `class_exists($class)` before calling `sqlsrv_fetch_object`.

Reason is not loaded class JMenuItem at:
https://github.com/joomla/joomla-cms/blob/staging/libraries/cms/menu/site.php#L88
 


### Testing Instructions

Install latest jooma 3.7 on database SQLSRV on **Windows** platform.
Go to front page.

### Expected result
Home page works.

### Actual result
Component not found. Error 404

### Documentation Changes Required
None
