### PR TITLE
Fix FolderList field type (on Windows)

### DIFF
--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -11,7 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.filesystem.folder');
 jimport('joomla.filesystem.file');
-jimport('joomla.filesystem.patch');
+jimport('joomla.filesystem.path');
 
 JFormHelper::loadFieldClass('list');
 

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -11,6 +11,7 @@ defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.filesystem.folder');
 jimport('joomla.filesystem.file');
+jimport('joomla.filesystem.patch');
 
 JFormHelper::loadFieldClass('list');
 
@@ -193,6 +194,8 @@ class JFormFieldFileList extends JFormFieldList
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}
+		
+		$path = JPath::clean($path);
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -10,6 +10,7 @@
 defined('JPATH_PLATFORM') or die;
 
 jimport('joomla.filesystem.folder');
+jimport('joomla.filesystem.path');
 
 JFormHelper::loadFieldClass('list');
 
@@ -189,6 +190,8 @@ class JFormFieldFolderList extends JFormFieldList
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}
+		
+		$path = JPath::clean($path);
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)


### PR DESCRIPTION
Pull Request for Issue #14075 .

### Summary of Changes
The FolderList field type (https://docs.joomla.org/Folderlist_form_field_type) provides a drop down list of folders (relative path) from a specified directory. Due to a bug in the code, the dropdown list contains full path of the folders on Windows instead of just the relative path. It causes an issue with Imagelist field type as described in issue #14075 

### Testing Instructions
1.Create article
2.Create custom field type "List of images"
3.Select images Directory, for example banners
4.On frontend try to edit this article
5. On frontend you get no list of images and if you try to edit article you get warning message
6. Apply patch
7. Edit the custom field, select a folder in **Directory** parameter again (so that the parameter is saved with correct relative path)
8. Edit the article in frontend again, confirm that the issue fixed.

### Documentation Changes Required
None
