### PR TITLE
[4.0] Fix PHP Notice in authentication library

### DIFF
--- a/libraries/joomla/authentication/authentication.php
+++ b/libraries/joomla/authentication/authentication.php
@@ -134,6 +134,9 @@ class JAuthentication extends JObject
 		JLoader::register('JAuthenticationResponse', __DIR__ . '/response.php');
 		$response = new JAuthenticationResponse;
 
+		// Get the dispatcher
+		$dispatcher = $this->getDispatcher();
+
 		/*
 		 * Loop through the plugins and check if the credentials can be used to authenticate
 		 * the user
@@ -147,7 +150,7 @@ class JAuthentication extends JObject
 
 			if (class_exists($className))
 			{
-				$plugin = new $className($this->getDispatcher(), (array) $plugin);
+				$plugin = new $className($dispatcher, (array) $plugin);
 			}
 			else
 			{


### PR DESCRIPTION
Pull Request for Issue #14147 

### Summary of Changes

This PR fixes the following error:

>PHP Notice: Only variables should be passed by reference in ROOT/libraries/joomla/authentication/authentication.php on line 150

So rather than passing `$this->getDispatcher()` directly as a constructor argument, we make it a variable: 

`$dispatcher = $this->getDispatcher()`

### Testing Instructions

Not sure what they are as they were't provided in the issue.

