### PR TITLE
Fix Class 'JEventDispatcher' not found error

### DIFF
--- a/components/com_content/views/category/tmpl/blog.php
+++ b/components/com_content/views/category/tmpl/blog.php
@@ -13,19 +13,19 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 
 JHtml::_('behavior.caption');
 
-$dispatcher = JEventDispatcher::getInstance();
+$app = JFactory::getApplication();
 
 $this->category->text = $this->category->description;
-$dispatcher->trigger('onContentPrepare', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$app->triggerEvent('onContentPrepare', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
 $this->category->description = $this->category->text;
 
-$results = $dispatcher->trigger('onContentAfterTitle', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$results = $app->triggerEvent('onContentAfterTitle', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $dispatcher->trigger('onContentBeforeDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$results = $app->triggerEvent('onContentBeforeDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $dispatcher->trigger('onContentAfterDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
+$results = $app->triggerEvent('onContentAfterDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
 $afterDisplayContent = trim(implode("\n", $results));
 
 ?>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -19,19 +19,19 @@ $extension = $category->extension;
 $canEdit   = $params->get('access-edit');
 $className = substr($extension, 4);
 
-$dispatcher = JEventDispatcher::getInstance();
+$app = JFactory::getApplication();
 
 $category->text = $category->description;
-$dispatcher->trigger('onContentPrepare', array($extension . '.categories', &$category, &$params, 0));
+$app->triggerEvent('onContentPrepare', array($extension . '.categories', &$category, &$params, 0));
 $category->description = $category->text;
 
-$results = $dispatcher->trigger('onContentAfterTitle', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentAfterTitle', array($extension . '.categories', &$category, &$params, 0));
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $dispatcher->trigger('onContentBeforeDisplay', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentBeforeDisplay', array($extension . '.categories', &$category, &$params, 0));
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $dispatcher->trigger('onContentAfterDisplay', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentAfterDisplay', array($extension . '.categories', &$category, &$params, 0));
 $afterDisplayContent = trim(implode("\n", $results));
 
 /**
@@ -42,6 +42,7 @@ if (substr($className, -1) === 's')
 {
 	$className = rtrim($className, 's');
 }
+
 $tagsData = $category->tags->itemTags;
 ?>
 <div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes Class 'JEventDispatcher' not found on Joomla 4 when access to a category blog menu item

### Testing Instructions
1. Install Joomla 4
2. Create a menu item to link to category blog menu option
3. Before patch, you will see fatal error Class 'JEventDispatcher' not found
4. After that, error gone, the page display properly

### Documentation Changes Required
None
