### PR TITLE
[3.8] Fix Fatal error on login

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -54,4 +54,4 @@ JLoader::registerAlias('JAccessExceptionNotallowed',   '\\Joomla\\Cms\\Access\\E
 JLoader::registerAlias('JRule',                        '\\Joomla\\Cms\\Access\\Rule', '4.0');
 JLoader::registerAlias('JRules',                       '\\Joomla\\Cms\\Access\\Rules', '4.0');
 
-JLoader::registerAlias('JAuthenticationHelper',        '\\Joomla\\Cms\\Access\\Authentication\\AuthenticationHelper', '4.0');
+JLoader::registerAlias('JAuthenticationHelper',        '\\Joomla\\Cms\\Authentication\\AuthenticationHelper', '4.0');


### PR DESCRIPTION
### Summary of Changes

Fix Fatal error on login about missing `JAuthenticationHelper`

### Testing Instructions

Install 3.8 and try to login into backend

### Expected result

works

### Actual result

error about missing `JAuthenticationHelper`

### Documentation Changes Required

None.