### PR TITLE
[4.0] Fix the fatal errors after the install

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -54,4 +54,4 @@ JLoader::registerAlias('JAccessExceptionNotallowed',   '\\Joomla\\Cms\\Access\\E
 JLoader::registerAlias('JRule',                        '\\Joomla\\Cms\\Access\\Rule', '4.0');
 JLoader::registerAlias('JRules',                       '\\Joomla\\Cms\\Access\\Rules', '4.0');
 
-JLoader::registerAlias('JAuthenticationHelper',        '\\Joomla\\Cms\\Access\\Authentication\\AuthenticationHelper', '4.0');
+JLoader::registerAlias('JAuthenticationHelper',        '\\Joomla\\Cms\\Authentication\\AuthenticationHelper', '4.0');

--- a/libraries/src/Cms/Authentication/AuthenticationHelper.php
+++ b/libraries/src/Cms/Authentication/AuthenticationHelper.php
@@ -30,7 +30,7 @@ abstract class AuthenticationHelper
 		\JPluginHelper::importPlugin('twofactorauth');
 
 		// Trigger onUserTwofactorIdentify event and return the two factor enabled plugins.
-		$identities = JFactory::getApplication()->triggerEvent('onUserTwofactorIdentify', array());
+		$identities = \JFactory::getApplication()->triggerEvent('onUserTwofactorIdentify', array());
 
 		// Generate array with two factor auth methods.
 		$options = array(


### PR DESCRIPTION
### Summary of Changes

fix the fatal errors after the install

### Testing Instructions

Install 3.8 and try to login into backend

### Expected result

works

### Actual result

error about missing `JAuthenticationHelper` and about a non namespaces version of JFactory

### Documentation Changes Required

None