### PR TITLE
Show the position where the error happens in the trace

### DIFF
--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -230,7 +230,7 @@ class JDocumentError extends JDocument
 			echo '	</tr>';
 
 			// Add the position of the actual file
-			array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine()));
+//			array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine(), 'function' => ''));
 
 			for ($i = count($backtrace) - 1; $i >= 0; $i--)
 			{

--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -230,7 +230,7 @@ class JDocumentError extends JDocument
 			echo '	</tr>';
 
 			// Add the position of the actual file
-//			array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine(), 'function' => ''));
+			array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine(), 'function' => ''));
 
 			for ($i = count($backtrace) - 1; $i >= 0; $i--)
 			{

--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -153,7 +153,7 @@ class JDocumentError extends JDocument
 		if (JFactory::$language)
 		{
 			$lang = JFactory::getLanguage();
-	
+
 			// 1.5 or core then 1.6
 			$lang->load('tpl_' . $template, JPATH_BASE, null, false, true)
 				|| $lang->load('tpl_' . $template, $directory . '/' . $template, null, false, true);
@@ -228,6 +228,9 @@ class JDocumentError extends JDocument
 			echo '		<td class="TD"><strong>Function</strong></td>';
 			echo '		<td class="TD"><strong>Location</strong></td>';
 			echo '	</tr>';
+
+			// Add the position of the actual file
+			array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine()));
 
 			for ($i = count($backtrace) - 1; $i >= 0; $i--)
 			{


### PR DESCRIPTION
### Summary of Changes
When debug mode is activated and an exception is thrown, then the stack trace is shown. This trace includes the call stack except the information where the actual error happened. This PR includes that information

### Testing Instructions
- Set debugging to yes in the global configuration 
![image](https://cloud.githubusercontent.com/assets/251072/23172860/8b69eb46-f857-11e6-853a-87ebd7971408.png)
- In the file /administrator/components/com_content/content.php after line 8 add the code `throw new Exception();`
- In the back end open Content -> Articles

### Expected result
A stack trace is shown where the last line is
> /administrator/components/com_content/content.php:9

### Actual result
A stack trace is shown where the last line is
> /libraries/cms/component/helper.php:399


### Documentation Changes Required

