### PR TITLE
Respect Error Reporting setting when MySQL is down

### DIFF
--- a/libraries/cms/error/page.php
+++ b/libraries/cms/error/page.php
@@ -149,14 +149,18 @@ class JErrorPage
 
 		if ($isException)
 		{
-			$message .= ': ';
-
-			if (isset($e))
+			// Make sure we do not display sensitive data in production environments
+			if (ini_get('display_errors'))
 			{
-				$message .= $e->getMessage() . ': ';
-			}
+				$message .= ': ';
 
-			$message .= $error->getMessage();
+				if (isset($e))
+				{
+					$message .= $e->getMessage() . ': ';
+				}
+
+				$message .= $error->getMessage();
+			}
 		}
 
 		echo $message;


### PR DESCRIPTION
This PR adds a simple but important check, to make sure we do not display sensitive data publicly in production environments.

## How to test
1. Go to the Joomla Global Configuration and set Error Reporting to "None". Save.
2. Take MySQL server down and make sure it stays down.
3. Visit the Joomla site and notice the error.
4. Apply this PR
5. Refresh the Joomla site. You now only get "Error displaying the error page".

Pull Request for Issue #14115 .

### Expected result
Blank page, nothing to show, similar to what would happen if there was a php error and Error Reporting option in Global Configuration was set to "None".


### Actual result
- Using the PDO driver we get the error:
`Error displaying the error page: Application Instantiation Error: Could not connect to PDO: SQLSTATE[HY000] [2002] Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)`
- Using the MySQL or MySQLi drivers, we get the error:
`Error displaying the error page: Application Instantiation Error: Could not connect to MySQL.`
