### PR TITLE
Use controller's input instead of application's input in ControllerAdmin

### DIFF
--- a/libraries/legacy/controller/admin.php
+++ b/libraries/legacy/controller/admin.php
@@ -113,7 +113,7 @@ class JControllerAdmin extends JControllerLegacy
 		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
 
 		// Get items to remove from the request.
-		$cid = JFactory::getApplication()->input->get('cid', array(), 'array');
+		$cid = $this->input->get('cid', array(), 'array');
 
 		if (!is_array($cid) || count($cid) < 1)
 		{
@@ -187,7 +187,7 @@ class JControllerAdmin extends JControllerLegacy
 		JSession::checkToken() or die(JText::_('JINVALID_TOKEN'));
 
 		// Get items to publish from the request.
-		$cid = JFactory::getApplication()->input->get('cid', array(), 'array');
+		$cid = $this->input->get('cid', array(), 'array');
 		$data = array('publish' => 1, 'unpublish' => 0, 'archive' => 2, 'trash' => -2, 'report' => -3);
 		$task = $this->getTask();
 		$value = ArrayHelper::getValue($data, $task, 0, 'int');
@@ -263,7 +263,7 @@ class JControllerAdmin extends JControllerLegacy
 		// Check for request forgeries.
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$ids = JFactory::getApplication()->input->post->get('cid', array(), 'array');
+		$ids = $this->input->post->get('cid', array(), 'array');
 		$inc = ($this->getTask() == 'orderup') ? -1 : 1;
 
 		$model = $this->getModel();
@@ -343,7 +343,7 @@ class JControllerAdmin extends JControllerLegacy
 		// Check for request forgeries.
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$ids = JFactory::getApplication()->input->post->get('cid', array(), 'array');
+		$ids = $this->input->post->get('cid', array(), 'array');
 
 		$model = $this->getModel();
 		$return = $model->checkin($ids);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In some methods of ContrllerAdmin class, we are getting input data from application input instead of from controller input object. This is not really correct, this small PR just correct it.

### Testing Instructions
Code review

### Documentation Changes Required
None

