### PR TITLE
Multilanguage: Displaying the contact correct articles

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -316,10 +316,7 @@ class ContactModelContact extends JModelForm
 			// Filter per language if plugin published
 			if (JLanguageMultilang::isEnabled())
 			{
-				$query->where(
-					('a.created_by = ' . (int) $contact->user_id) . ' AND ' .
-					('a.language=' . $db->quote(JFactory::getLanguage()->getTag()) . ' OR a.language=' . $db->quote('*'))
-				);
+				$query->where('a.language IN (' . $db->quote(JFactory::getLanguage()->getTag()) . ',' . $db->quote('*') . ')');
 			}
 
 			if (is_numeric($published))


### PR DESCRIPTION
In a multilangual site, when displaying a Contact's articles, should only be displayed the articles created by the user linked to the contact in the language of the UI + the articles created by the same user and set to ALL languages.

To test, create a multingual site (with 2 languages is OK) from a clean staging.
Create another user than the superuser, for example an administrator.

Create an article category set to ALL languages (just for better structure of the site).
Create 2 articles in that category, both articles set to ALL languages and set as featured. One of this article with Created user set to Super User, the other set to the new administrator user.

![screen shot 2017-02-22 at 17 12 43](https://cloud.githubusercontent.com/assets/869724/23220415/3d5a92e0-f922-11e6-97e4-d72a765af6c8.png)

Now create one contact for each user, make sure that Show Articles is set in the Contact Component Options and in the Contacts themselves. Tag these Contacts to ALL languages as we do not need here to have one contact per lang.
![screen shot 2017-02-22 at 17 13 55_2](https://cloud.githubusercontent.com/assets/869724/23220512/8c8b7b36-f922-11e6-8709-342b41ee1f89.png)

In the Featured Articles menu items which are automatically created as Home for each language, make sure Show Author and Link to Author are set to yes.

Display frontend.
3 articles will show
![screen shot 2017-02-22 at 17 05 03](https://cloud.githubusercontent.com/assets/869724/23220106/2b59a622-f921-11e6-97de-a7972c347799.png)

Click on the authors link in the new articles set to ALL.
The contact will display for the author chosen.
Display the Articles for that author.

before patch, the article set to ALL languages BUT created by the other user will also display.
![screen shot 2017-02-22 at 17 09 24](https://cloud.githubusercontent.com/assets/869724/23220262/b0330582-f921-11e6-8794-17d5e965aec6.png)

After patch, the articles listed will righfully display the articles created by this user and this user only
![screen shot 2017-02-22 at 17 10 19](https://cloud.githubusercontent.com/assets/869724/23220336/f5b80f9e-f921-11e6-87b9-3ca925c00507.png)


