### PR TITLE
[3.7] Remove default and mark query as required for the SQL field

### DIFF
--- a/plugins/fields/sql/params/sql.xml
+++ b/plugins/fields/sql/params/sql.xml
@@ -9,6 +9,7 @@
 				label="PLG_FIELDS_SQL_PARAMS_QUERY_LABEL"
 				description="PLG_FIELDS_SQL_PARAMS_QUERY_DESC"
 				rows="10"
+				required="true"
 			/>
 
 			<field

--- a/plugins/fields/sql/sql.php
+++ b/plugins/fields/sql/sql.php
@@ -43,11 +43,6 @@ class PlgFieldsSql extends FieldsListPlugin
 		$fieldNode->setAttribute('value_field', 'text');
 		$fieldNode->setAttribute('key_field', 'value');
 
-		if (! $fieldNode->getAttribute('query'))
-		{
-			$fieldNode->setAttribute('query', 'select id as value, name as text from #__users');
-		}
-
 		return $fieldNode;
 	}
 }

--- a/plugins/fields/sql/sql.xml
+++ b/plugins/fields/sql/sql.xml
@@ -25,10 +25,10 @@
 					name="query"
 					type="textarea"
 					filter="raw"
-					default="select id as value, name as text from #__users"
 					label="PLG_FIELDS_SQL_PARAMS_QUERY_LABEL"
 					description="PLG_FIELDS_SQL_PARAMS_QUERY_DESC"
 					rows="10"
+					required="true"
 				/>
 	
 				<field

--- a/plugins/fields/sql/tmpl/sql.php
+++ b/plugins/fields/sql/tmpl/sql.php
@@ -29,7 +29,7 @@ foreach ($value as $v)
 	$condition .= ', ' . $db->q($v);
 }
 
-$query = $fieldParams->get('query', 'select id as value, name as text from #__users');
+$query = $fieldParams->get('query', '');
 
 // Run the query with a having condition because it supports aliases
 $db->setQuery($query . ' having value in (' . trim($condition, ',') . ')');


### PR DESCRIPTION
Pull Request for Issue #14210

### Summary of Changes

Remove default and mark query as required for the SQL field

### Testing Instructions

- Set up a sql field with default values
- see the default is a dropdown of uses with id and name
- apply this patch
- notice that you now required to define a custom query else the result will be clear.

### Expected result

you now required to define a custom query else the result will be clear.

### Actual result

 see the default is a dropdown of uses with id and name

### Documentation Changes Required

None