### PR TITLE
Use folderlist and not text field

### DIFF
--- a/plugins/fields/gallery/gallery.xml
+++ b/plugins/fields/gallery/gallery.xml
@@ -70,8 +70,10 @@
 	
 				<field
 					name="directory"
-					type="text"
-					default="images"
+					type="folderlist"
+					directory="images"
+					hide_none="true"
+					recursive="true"
 					label="PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_LABEL"
 					description="PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_DESC"
 				/>

--- a/plugins/fields/gallery/params/gallery.xml
+++ b/plugins/fields/gallery/params/gallery.xml
@@ -50,7 +50,10 @@
 
 			<field
 				name="directory"
-				type="text"
+				type="folderlist"
+				directory="images"
+				hide_none="true"
+				recursive="true"
 				label="PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_LABEL"
 				description="PLG_FIELDS_GALLERY_PARAMS_DIRECTORY_DESC"
 			/>


### PR DESCRIPTION
Pull Request for Issue #14207

### Summary of Changes

use folderlist and not text field

### Testing Instructions

- Try to setup a field.
- confirm you can only select valid folders and only under the images folder for the gallery

### Expected result

you can only select valid folders and only under the images folder for the gallery

### Actual result

You can insert every path you want.

### Documentation Changes Required

none