### PR TITLE
Tag model should respect published state and ACL

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -280,12 +280,17 @@ class TagsModelTag extends JModelList
 					$table->load($id);
 
 					// Check published state.
-					if ($published = $this->getState('filter.published'))
+					if ($published = $this->getState('tag.state'))
 					{
 						if ($table->published != $published)
 						{
-							return $this->item;
+							continue;
 						}
+					}
+
+					if (!in_array($table->access, JFactory::getUser()->getAuthorisedViewLevels()))
+					{
+						continue;
 					}
 
 					// Convert the JTable to a clean JObject.
@@ -299,6 +304,11 @@ class TagsModelTag extends JModelList
 					return false;
 				}
 			}
+		}
+
+		if (!$this->item)
+		{
+			return JError::raiseError(404, JText::_('COM_TAGS_TAG_NOT_FOUND'));
 		}
 
 		return $this->item;


### PR DESCRIPTION
Pull Request for Issue #14222.

### Summary of Changes
Properly check published state of tag and check against view levels

### Testing Instructions
* Assign a tag to an article.
* Visit the article in frontend and click on the tag so you get tot he tag view. Make sure you're not logged in with a user.
* Unpublish the tag in backend.
* Reload the tag view -> Should create an error but instead still shows fine.
* Publish the tag again and change the access level to "Registered".
* Reload the tag view again -> Should create an error but instead still shows fine.

### Expected result
Both reloads should create an error since we don't have access to that tag.

### Actual result
View shows fine, ignoring access and published state.

### Documentation Changes Required
None

### Disclaimer
Given which component we are talking about, I fully expect additional related issues. This PR doesn't try to solve everything :smile: 