### PR TITLE
[4.0][RFC] Serialise inline scripts and inline styles

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -613,9 +613,9 @@ abstract class JHtml
 			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
 		}
 
-		if ($file === '' && isset($attribs['content']))
+		if ($file === '' && isset($options['inline']))
 		{
-			JFactory::getDocument()->addStyleDeclaration($attribs['content']);
+			JFactory::getDocument()->addStyleDeclaration($options['inline']);
 		}
 		else
 		{
@@ -694,9 +694,9 @@ abstract class JHtml
 			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
 		}
 
-		if ($file === '' && isset($attribs['content']))
+		if ($file === '' && isset($options['inline']))
 		{
-			JFactory::getDocument()->addScriptDeclaration($attribs['content']);
+			JFactory::getDocument()->addScriptDeclaration($options['inline']);
 		}
 		else
 		{

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -613,36 +613,43 @@ abstract class JHtml
 			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
 		}
 
-		$includes = static::includeRelativeFiles('css', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
-
-		// If only path is required
-		if ($options['pathOnly'])
+		if ($file === '' && isset($attribs['content']))
 		{
-			if (count($includes) === 0)
-			{
-				return;
-			}
-
-			if (count($includes) === 1)
-			{
-				return $includes[0];
-			}
-
-			return $includes;
+			JFactory::getDocument()->addStyleDeclaration($attribs['content']);
 		}
-
-		// If inclusion is required
-		$document = JFactory::getDocument();
-
-		foreach ($includes as $include)
+		else
 		{
-			// If there is already a version hash in the script reference (by using deprecated MD5SUM).
-			if ($pos = strpos($include, '?') !== false)
+			$includes = static::includeRelativeFiles('css', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
+
+			// If only path is required
+			if ($options['pathOnly'])
 			{
-				$options['version'] = substr($include, $pos + 1);
+				if (count($includes) === 0)
+				{
+					return;
+				}
+
+				if (count($includes) === 1)
+				{
+					return $includes[0];
+				}
+
+				return $includes;
 			}
 
-			$document->addStyleSheet($include, $options, $attribs);
+			// If inclusion is required
+			$document = JFactory::getDocument();
+
+			foreach ($includes as $include)
+			{
+				// If there is already a version hash in the script reference (by using deprecated MD5SUM).
+				if ($pos = strpos($include, '?') !== false)
+				{
+					$options['version'] = substr($include, $pos + 1);
+				}
+
+				$document->addStyleSheet($include, $options, $attribs);
+			}
 		}
 	}
 
@@ -687,42 +694,46 @@ abstract class JHtml
 			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
 		}
 
-		// Include MooTools framework
-		if ($options['framework'])
+		if ($file === '' && isset($attribs['content']))
 		{
-			static::_('behavior.framework');
+			JFactory::getDocument()->addScriptDeclaration($attribs['content']);
 		}
-
-		$includes = static::includeRelativeFiles('js', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
-
-		// If only path is required
-		if ($options['pathOnly'])
+		else
 		{
-			if (count($includes) === 0)
+			// Include MooTools framework
+			if ($options['framework'])
 			{
-				return;
+				static::_('behavior.framework');
 			}
 
-			if (count($includes) === 1)
+			$includes = static::includeRelativeFiles('js', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
+
+			// If only path is required
+			if ($options['pathOnly'])
 			{
-				return $includes[0];
+				if (count($includes) === 0)
+				{
+					return;
+				}
+
+				if (count($includes) === 1)
+				{
+					return $includes[0];
+				}
+
+				return $includes;
 			}
 
-			return $includes;
-		}
-
-		// If inclusion is required
-		$document = JFactory::getDocument();
-
-		foreach ($includes as $include)
-		{
-			// If there is already a version hash in the script reference (by using deprecated MD5SUM).
-			if ($pos = strpos($include, '?') !== false)
+			foreach ($includes as $include)
 			{
-				$options['version'] = substr($include, $pos + 1);
-			}
+				// If there is already a version hash in the script reference (by using deprecated MD5SUM).
+				if ($pos = strpos($include, '?') !== false)
+				{
+					$options['version'] = substr($include, $pos + 1);
+				}
 
-			$document->addScript($include, $options, $attribs);
+				JFactory::getDocument()->addScript($include, $options, $attribs);
+			}
 		}
 	}
 

--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -56,7 +56,7 @@ abstract class JHtmlJquery
 		// Check if we are loading in noConflict
 		if ($noConflict)
 		{
-			JHtml::_('script', 'system/jquery-noconflict.min.js', array('version' => 'auto', 'relative' => true));
+			JHtml::_('script', '', [], ['content' => 'jQuery.noConflict();']);
 		}
 
 		// Check if we are loading Migrate

--- a/libraries/cms/html/jquery.php
+++ b/libraries/cms/html/jquery.php
@@ -56,7 +56,7 @@ abstract class JHtmlJquery
 		// Check if we are loading in noConflict
 		if ($noConflict)
 		{
-			JHtml::_('script', '', [], ['content' => 'jQuery.noConflict();']);
+			JHtml::_('script', '', ['inline' => 'jQuery.noConflict();']);
 		}
 
 		// Check if we are loading Migrate

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -133,15 +133,7 @@ class JDocument
 	 * @var    array
 	 * @since  11.1
 	 */
-	public $_scripts = array();
-
-	/**
-	 * Array of scripts placed in the header
-	 *
-	 * @var    array
-	 * @since  11.1
-	 */
-	public $_script = array();
+	public $scripts = array();
 
 	/**
 	 * Array of scripts options
@@ -151,20 +143,12 @@ class JDocument
 	protected $scriptOptions = array();
 
 	/**
-	 * Array of linked style sheets
+	 * Array of style sheets and inline styles
 	 *
 	 * @var    array
 	 * @since  11.1
 	 */
-	public $_styleSheets = array();
-
-	/**
-	 * Array of included style declarations
-	 *
-	 * @var    array
-	 * @since  11.1
-	 */
-	public $_style = array();
+	public $styleSheets = array();
 
 	/**
 	 * Array of meta tags
@@ -213,6 +197,22 @@ class JDocument
 	 * @since  3.2
 	 */
 	protected $mediaVersion = null;
+
+	/**
+	 * Pointer for the inline script
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERION__
+	 */
+	protected $inlineScriptsEnum = 0;
+
+	/**
+	 * Pointer for the inline stylesheet
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERION__
+	 */
+	protected $inlineStyleSheetsEnum = 0;
 
 	/**
 	 * Class constructor.
@@ -503,8 +503,8 @@ class JDocument
 			$attribs['type'] = 'text/javascript';
 		}
 
-		$this->_scripts[$url]            = isset($this->_scripts[$url]) ? array_replace($this->_scripts[$url], $attribs) : $attribs;
-		$this->_scripts[$url]['options'] = isset($this->_scripts[$url]['options']) ? array_replace($this->_scripts[$url]['options'], $options) : $options;
+		$this->scripts[$url]            = isset($this->scripts[$url]) ? array_replace($this->scripts[$url], $attribs) : $attribs;
+		$this->scripts[$url]['options'] = isset($this->scripts[$url]['options']) ? array_replace($this->scripts[$url]['options'], $options) : $options;
 
 		return $this;
 	}
@@ -573,16 +573,10 @@ class JDocument
 	 *
 	 * @since   11.1
 	 */
-	public function addScriptDeclaration($content, $type = 'text/javascript')
+	public function addScriptDeclaration($content)
 	{
-		if (!isset($this->_script[strtolower($type)]))
-		{
-			$this->_script[strtolower($type)] = $content;
-		}
-		else
-		{
-			$this->_script[strtolower($type)] .= chr(13) . $content;
-		}
+		$this->scripts['inlineScript_' . $this->inlineScriptsEnum]['content'] = $content;
+		$this->inlineScriptsEnum = $this->inlineScriptsEnum + 1;
 
 		return $this;
 	}
@@ -686,15 +680,15 @@ class JDocument
 			$attribs['type'] = 'text/css';
 		}
 
-		$this->_styleSheets[$url] = isset($this->_styleSheets[$url]) ? array_replace($this->_styleSheets[$url], $attribs) : $attribs;
+		$this->styleSheets[$url] = isset($this->styleSheets[$url]) ? array_replace($this->styleSheets[$url], $attribs) : $attribs;
 
-		if (isset($this->_styleSheets[$url]['options']))
+		if (isset($this->styleSheets[$url]['options']))
 		{
-			$this->_styleSheets[$url]['options'] = array_replace($this->_styleSheets[$url]['options'], $options);
+			$this->styleSheets[$url]['options'] = array_replace($this->styleSheets[$url]['options'], $options);
 		}
 		else
 		{
-			$this->_styleSheets[$url]['options'] = $options;
+			$this->styleSheets[$url]['options'] = $options;
 		}
 
 		return $this;
@@ -766,14 +760,8 @@ class JDocument
 	 */
 	public function addStyleDeclaration($content, $type = 'text/css')
 	{
-		if (!isset($this->_style[strtolower($type)]))
-		{
-			$this->_style[strtolower($type)] = $content;
-		}
-		else
-		{
-			$this->_style[strtolower($type)] .= chr(13) . $content;
-		}
+		$this->styleSheets['inlineStyles_' . $this->inlineStyleSheetsEnum]['content'] = $content;
+		$this->inlineStyleSheetsEnum = $this->inlineStyleSheetsEnum + 1;
 
 		return $this;
 	}

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -133,10 +133,8 @@ class JDocumentHtml extends JDocument
 		$data['link']        = $this->link;
 		$data['metaTags']    = $this->_metaTags;
 		$data['links']       = $this->_links;
-		$data['styleSheets'] = $this->_styleSheets;
-		$data['style']       = $this->_style;
-		$data['scripts']     = $this->_scripts;
-		$data['script']      = $this->_script;
+		$data['styleSheets'] = $this->styleSheets;
+		$data['scripts']     = $this->scripts;
 		$data['custom']      = $this->_custom;
 		$data['scriptText']  = JText::script();
 
@@ -164,10 +162,8 @@ class JDocumentHtml extends JDocument
 		$this->link         = (isset($data['link']) && !empty($data['link'])) ? $data['link'] : $this->link;
 		$this->_metaTags    = (isset($data['metaTags']) && !empty($data['metaTags'])) ? $data['metaTags'] : $this->_metaTags;
 		$this->_links       = (isset($data['links']) && !empty($data['links'])) ? $data['links'] : $this->_links;
-		$this->_styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets'])) ? $data['styleSheets'] : $this->_styleSheets;
-		$this->_style       = (isset($data['style']) && !empty($data['style'])) ? $data['style'] : $this->_style;
-		$this->_scripts     = (isset($data['scripts']) && !empty($data['scripts'])) ? $data['scripts'] : $this->_scripts;
-		$this->_script      = (isset($data['script']) && !empty($data['script'])) ? $data['script'] : $this->_script;
+		$this->styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets'])) ? $data['styleSheets'] : $this->styleSheets;
+		$this->scripts     = (isset($data['scripts']) && !empty($data['scripts'])) ? $data['scripts'] : $this->scripts;
 		$this->_custom      = (isset($data['custom']) && !empty($data['custom'])) ? $data['custom'] : $this->_custom;
 
 		if (isset($data['scriptText']) && !empty($data['scriptText']))
@@ -221,35 +217,13 @@ class JDocumentHtml extends JDocument
 		$this->_links = (isset($data['links']) && !empty($data['links']) && is_array($data['links']))
 			? array_unique(array_merge($this->_links, $data['links']), SORT_REGULAR)
 			: $this->_links;
-		$this->_styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets']) && is_array($data['styleSheets']))
-			? array_merge($this->_styleSheets, $data['styleSheets'])
-			: $this->_styleSheets;
+		$this->styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets']) && is_array($data['styleSheets']))
+			? array_merge($this->styleSheets, $data['styleSheets'])
+			: $this->styleSheets;
 
-		if (isset($data['style']))
-		{
-			foreach ($data['style'] as $type => $stdata)
-			{
-				if (!isset($this->_style[strtolower($type)]) || !stristr($this->_style[strtolower($type)], $stdata))
-				{
-					$this->addStyleDeclaration($stdata, $type);
-				}
-			}
-		}
-
-		$this->_scripts = (isset($data['scripts']) && !empty($data['scripts']) && is_array($data['scripts']))
-			? array_merge($this->_scripts, $data['scripts'])
-			: $this->_scripts;
-
-		if (isset($data['script']))
-		{
-			foreach ($data['script'] as $type => $sdata)
-			{
-				if (!isset($this->_script[strtolower($type)]) || !stristr($this->_script[strtolower($type)], $sdata))
-				{
-					$this->addScriptDeclaration($sdata, $type);
-				}
-			}
-		}
+		$this->scripts = (isset($data['scripts']) && !empty($data['scripts']) && is_array($data['scripts']))
+			? array_merge($this->scripts, $data['scripts'])
+			: $this->scripts;
 
 		$this->_custom = (isset($data['custom']) && !empty($data['custom']) && is_array($data['custom']))
 			? array_unique(array_merge($this->_custom, $data['custom']))

--- a/media/system/js/jquery-noconflict.js
+++ b/media/system/js/jquery-noconflict.js
@@ -1,1 +1,0 @@
-jQuery.noConflict();

--- a/media/system/js/jquery-noconflict.min.js
+++ b/media/system/js/jquery-noconflict.min.js
@@ -1,1 +1,0 @@
-jQuery.noConflict();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Drop the separate arrays for inline scripts and styles
- The data will be merged in the relative scrips and styleSheets arrays (can we remove the underscore???)
- Make `JHTML` compatible with these changes

### Testing Instructions
Apply patch and observe the produced head, inline scripts should be between script tags with src, same for the styles
Also the `jQuery.noConflict();` should be inline and not a file... 


### Update to JHtml
for inline script:
```php
JHtml::_('script', '', ['inline' => ‘content for inline script’]);
```
For inline style:
```php
JHtml::_('stylesheet', '', ['inline' => ‘content for inline script’]);
```

### Actual result
Check the structure of the head:
![screen shot 2017-02-24 at 23 56 37](https://cloud.githubusercontent.com/assets/3889375/23322496/eb2dfdc8-faec-11e6-9b4a-75ea79a61df4.png)

### Documentation Changes Required
YUP!

@wilsonge @mbabker @yvesh 