### PR TITLE
Use folder list and not text for the directory param

### DIFF
--- a/plugins/fields/media/media.xml
+++ b/plugins/fields/media/media.xml
@@ -23,7 +23,10 @@
 			<fieldset name="basic">
 				<field
 					name="directory"
-					type="text"
+					type="folderlist"
+					directory="images"
+					hide_none="true"
+					recursive="true"
 					label="PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_LABEL"
 					description="PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_DESC"
 				/>

--- a/plugins/fields/media/params/media.xml
+++ b/plugins/fields/media/params/media.xml
@@ -4,7 +4,10 @@
 		<fieldset name="fieldparams">
 			<field
 				name="directory"
-				type="text"
+				type="folderlist"
+				directory="images"
+				hide_none="true"
+				recursive="true"
 				label="PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_LABEL"
 				description="PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_DESC"
 			/>


### PR DESCRIPTION
Pull Request for Issue #14076

### Summary of Changes

use folderlist and not text field

### Testing Instructions

- Try to setup a media field.
- confirm you can only select valid folders and only under the images folder for the media field

### Expected result

you can only select valid folders and only under the images folder for the gallery

### Actual result

You can insert every path you want.

### Documentation Changes Required

none