### PR TITLE
Use number field and not a text field for numbers

### DIFF
--- a/plugins/fields/integer/integer.xml
+++ b/plugins/fields/integer/integer.xml
@@ -35,7 +35,7 @@
 	
 				<field
 					name="first"
-					type="text"
+					type="number"
 					default="1"
 					label="PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL"
 					description="PLG_FIELDS_INTEGER_PARAMS_FIRST_DESC"
@@ -45,7 +45,7 @@
 	
 				<field
 					name="last"
-					type="text"
+					type="number"
 					default="100"
 					label="PLG_FIELDS_INTEGER_PARAMS_LAST_LABEL"
 					description="PLG_FIELDS_INTEGER_PARAMS_LAST_DESC"
@@ -55,7 +55,7 @@
 	
 				<field
 					name="step"
-					type="text"
+					type="number"
 					default="1"
 					label="PLG_FIELDS_INTEGER_PARAMS_STEP_LABEL"
 					description="PLG_FIELDS_INTEGER_PARAMS_STEP_DESC"

--- a/plugins/fields/integer/params/integer.xml
+++ b/plugins/fields/integer/params/integer.xml
@@ -15,7 +15,7 @@
 
 			<field
 				name="first"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL"
 				description="PLG_FIELDS_INTEGER_PARAMS_FIRST_DESC"
 				size="5"
@@ -23,7 +23,7 @@
 
 			<field
 				name="last"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_LAST_LABEL"
 				description="PLG_FIELDS_INTEGER_PARAMS_LAST_DESC"
 				size="5"
@@ -31,7 +31,7 @@
 
 			<field
 				name="step"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_STEP_LABEL"
 				description="PLG_FIELDS_INTEGER_PARAMS_STEP_DESC"
 				size="5"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Use the Number form field https://docs.joomla.org/Number_form_field_type and not the text form field for storing numbers in the integer field

### Testing Instructions

try to set up a integer form field before and after the patch

### Expected result

you can just enter numbers

### Actual result

you can enter everything.

### Documentation Changes Required

None