### PR TITLE
Fix typo in Dispatcher class

### DIFF
--- a/libraries/src/Cms/Dispatcher/Dispatcher.php
+++ b/libraries/src/Cms/Dispatcher/Dispatcher.php
@@ -53,7 +53,7 @@ abstract class Dispatcher implements DispatcherInterface
 	public function dispatch()
 	{
 		// Check the user has permission to access this component if in the backend
-		if ($this->app->isClient('admin') && !$this->app->getIdentity()->authorise('core.manage', $this->app->scope))
+		if ($this->app->isClient('administrator') && !$this->app->getIdentity()->authorise('core.manage', $this->app->scope))
 		{
 			throw new \JAccessExceptionNotallowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR just fixed a type in Dispatcher. JApplicationAdministrator has $name = 'administrator', so **admin** in this line of code need to be replaced by **administrator**.

### Testing Instructions
Code review

### Documentation Changes Required

None.

