### PR TITLE
Use setDocumentTitle method of JViewLegacy to set document title

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -381,26 +381,13 @@ class ContactViewContact extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
+		
 		if (empty($title))
 		{
 			$title = $this->item->name;
 		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)
 		{

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -379,7 +379,7 @@ class ContactViewContact extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-		
+
 		if (empty($title))
 		{
 			$title = $this->item->name;

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -384,7 +384,7 @@ class ContactViewContact extends JViewLegacy
 		{
 			$title = $this->item->name;
 		}
-		
+
 		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -334,14 +334,12 @@ class ContactViewContact extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app     = JFactory::getApplication();
-		$menus   = $app->getMenu();
+		$app     = JFactory::getApplication();		
 		$pathway = $app->getPathway();
-		$title   = null;
-
+		
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -336,7 +336,7 @@ class ContactViewContact extends JViewLegacy
 	{
 		$app     = JFactory::getApplication();		
 		$pathway = $app->getPathway();
-		
+
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $app->getMenu()->getActive();

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -158,24 +158,9 @@ class ContactViewFeatured extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_CONTACT_DEFAULT_PAGE_TITLE'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($$this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -154,9 +154,9 @@ class ContactViewFeatured extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_CONTACT_DEFAULT_PAGE_TITLE'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -159,7 +159,7 @@ class ContactViewFeatured extends JViewLegacy
 			$this->params->def('page_heading', JText::_('COM_CONTACT_DEFAULT_PAGE_TITLE'));
 		}
 		
-		$this->setDocumentTitle($$this->params->get('page_title', ''));
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 		
 		if ($this->params->get('menu-meta_description'))
 		{

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -142,13 +142,9 @@ class ContactViewFeatured extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -151,7 +151,7 @@ class ContentViewArchive extends JViewLegacy
 	 * @return  void.
 	 */
 	protected function _prepareDocument()
-	{		
+	{
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = JFactory::getApplication()->getMenu()->getActive();

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -168,24 +168,9 @@ class ContentViewArchive extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('JGLOBAL_ARTICLES'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -151,14 +151,10 @@ class ContentViewArchive extends JViewLegacy
 	 * @return  void.
 	 */
 	protected function _prepareDocument()
-	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
+	{		
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -164,9 +164,9 @@ class ContentViewArchive extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('JGLOBAL_ARTICLES'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -214,7 +214,7 @@ class ContentViewArticle extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app     = JFactory::getApplication();		
+		$app     = JFactory::getApplication();
 		$pathway = $app->getPathway();
 
 		// Because the application sets a default page title,

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -256,7 +256,7 @@ class ContentViewArticle extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-		
+
 		if (empty($title))
 		{
 			$title = $this->item->title;

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -214,14 +214,12 @@ class ContentViewArticle extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app     = JFactory::getApplication();
-		$menus   = $app->getMenu();
+		$app     = JFactory::getApplication();		
 		$pathway = $app->getPathway();
-		$title   = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -261,7 +261,7 @@ class ContentViewArticle extends JViewLegacy
 		{
 			$title = $this->item->title;
 		}
-		
+
 		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -258,27 +258,13 @@ class ContentViewArticle extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-
-		// Check for empty title and add site name if param is set
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
+		
 		if (empty($title))
 		{
 			$title = $this->item->title;
 		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)
 		{

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -191,7 +191,7 @@ class ContentViewCategory extends JViewCategory
 		{
 			$title = $this->category->title;
 		}
-		
+
 		$this->setDocumentTitle($title);
 
 		if ($this->category->metadesc)

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -192,27 +192,13 @@ class ContentViewCategory extends JViewCategory
 		$title = $this->params->get('page_title', '');
 
 		$id = (int) @$menu->query['id'];
-
-		// Check for empty title and add site name if param is set
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
+		
 		if (empty($title))
 		{
 			$title = $this->category->title;
 		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($title);
 
 		if ($this->category->metadesc)
 		{

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -123,8 +123,8 @@ class ContentViewCategory extends JViewCategory
 		// Check for layout override only if this is not the active menu item
 		// If it is the active menu item, then the view and category id will match
 		$app     = JFactory::getApplication();
-		$active  = $app->getMenu()->getActive();						
-		
+		$active  = $app->getMenu()->getActive();
+
 		if ((!$active) || ((strpos($active->link, 'view=category') === false) || (strpos($active->link, '&id=' . (string) $this->category->id) === false)))
 		{
 			// Get the layout from the merged category params

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -123,11 +123,8 @@ class ContentViewCategory extends JViewCategory
 		// Check for layout override only if this is not the active menu item
 		// If it is the active menu item, then the view and category id will match
 		$app     = JFactory::getApplication();
-		$active  = $app->getMenu()->getActive();
-		$menus   = $app->getMenu();
-		$pathway = $app->getPathway();
-		$title   = null;
-
+		$active  = $app->getMenu()->getActive();						
+		
 		if ((!$active) || ((strpos($active->link, 'view=category') === false) || (strpos($active->link, '&id=' . (string) $this->category->id) === false)))
 		{
 			// Get the layout from the merged category params
@@ -182,16 +179,13 @@ class ContentViewCategory extends JViewCategory
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
-
-		if ($menu)
+		
+		if ($active)
 		{
-			$this->params->def('page_heading', $this->params->get('page_title', $menu->title));
+			$this->params->def('page_heading', $this->params->get('page_title', $active->title));
 		}
 
 		$title = $this->params->get('page_title', '');
-
-		$id = (int) @$menu->query['id'];
 		
 		if (empty($title))
 		{

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -183,24 +183,9 @@ class ContentViewFeatured extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('JGLOBAL_ARTICLES'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -179,9 +179,9 @@ class ContentViewFeatured extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('JGLOBAL_ARTICLES'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -167,13 +167,9 @@ class ContentViewFeatured extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -158,17 +158,8 @@ class ContentViewForm extends JViewLegacy
 		}
 
 		$title = $this->params->def('page_title', JText::_('COM_CONTENT_FORM_EDIT_ARTICLE'));
-
-		if ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($title);
 
 		$pathway = $app->getPathWay();
 		$pathway->addItem($title, '');

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -154,7 +154,7 @@ class ContentViewForm extends JViewLegacy
 		}
 
 		$title = $this->params->def('page_title', JText::_('COM_CONTENT_FORM_EDIT_ARTICLE'));
-		
+
 		$this->setDocumentTitle($title);
 
 		$pathway = $app->getPathWay();

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -140,13 +140,9 @@ class ContentViewForm extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -44,7 +44,6 @@ class FinderViewSearch extends JViewLegacy
 		$explained = JHtml::_('query.explained', $query);
 
 		// Set the document title.
-		
 		$this->setDocumentTitle($params->get('page_title', ''));
 
 		// Configure the document description.

--- a/components/com_finder/views/search/view.feed.php
+++ b/components/com_finder/views/search/view.feed.php
@@ -44,22 +44,8 @@ class FinderViewSearch extends JViewLegacy
 		$explained = JHtml::_('query.explained', $query);
 
 		// Set the document title.
-		$title = $params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		// Configure the document description.
 		if (!empty($explained))

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -196,23 +196,8 @@ class FinderViewSearch extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_FINDER_DEFAULT_PAGE_TITLE'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($layout = $this->params->get('article_layout'))
 		{

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -180,13 +180,9 @@ class FinderViewSearch extends JViewLegacy
 	 */
 	protected function prepareDocument($query)
 	{
-		$app = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -192,7 +192,7 @@ class FinderViewSearch extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_FINDER_DEFAULT_PAGE_TITLE'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($layout = $this->params->get('article_layout'))

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -264,7 +264,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-		
+
 		if (empty($title))
 		{
 			$title = $this->item->name;

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -269,7 +269,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		{
 			$title = $this->item->name;
 		}
-		
+
 		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Registry\Registry;
-
 /**
  * HTML View class for the Newsfeeds component
  *

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -219,7 +219,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 	{
 		$app     = JFactory::getApplication();		
 		$pathway = $app->getPathway();
-		
+
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
 		$menu = $app->getMenu()->getActive();

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -264,26 +264,13 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 				$pathway->addItem($item['title'], $item['link']);
 			}
 		}
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
+		
 		if (empty($title))
 		{
 			$title = $this->item->name;
 		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($title);
 
 		if ($this->item->metadesc)
 		{

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -217,14 +217,12 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 	 */
 	protected function _prepareDocument()
 	{
-		$app     = JFactory::getApplication();
-		$menus   = $app->getMenu();
+		$app     = JFactory::getApplication();		
 		$pathway = $app->getPathway();
-		$title   = null;
-
+		
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -59,19 +59,8 @@ class SearchViewSearch extends JViewLegacy
 		{
 			$params->set('page_title', JText::_('COM_SEARCH_SEARCH'));
 		}
-
-		$title = $params->get('page_title');
-
-		if ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($params->get('page_title'));
 
 		if ($params->get('menu-meta_description'))
 		{

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -42,10 +42,9 @@ class SearchViewSearch extends JViewLegacy
 		$areas      = $this->get('areas');
 		$state      = $this->get('state');
 		$searchWord = $state->get('keyword');
-		$params     = $app->getParams();
-
-		$menus = $app->getMenu();
-		$menu  = $menus->getActive();
+		$params     = $app->getParams();		
+		
+		$menu  = $app->getMenu()->getActive();
 
 		// Because the application sets a default page title, we need to get it right from the menu item itself
 		if (is_object($menu))

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -59,7 +59,7 @@ class SearchViewSearch extends JViewLegacy
 		{
 			$params->set('page_title', JText::_('COM_SEARCH_SEARCH'));
 		}
-		
+
 		$this->setDocumentTitle($params->get('page_title'));
 
 		if ($params->get('menu-meta_description'))

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -43,8 +43,7 @@ class SearchViewSearch extends JViewLegacy
 		$state      = $this->get('state');
 		$searchWord = $state->get('keyword');
 		$params     = $app->getParams();		
-		
-		$menu  = $app->getMenu()->getActive();
+		$menu       = $app->getMenu()->getActive();
 
 		// Because the application sets a default page title, we need to get it right from the menu item itself
 		if (is_object($menu))

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -224,9 +224,9 @@ class TagsViewTag extends JViewLegacy
 				$this->params->set('page_subheading', $menu->title);
 			}
 		}
-		
+
 		$this->setDocumentTitle($title);
-		
+
 		foreach ($this->item as $itemElement)
 		{
 			if ($itemElement->metadesc)

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -224,22 +224,9 @@ class TagsViewTag extends JViewLegacy
 				$this->params->set('page_subheading', $menu->title);
 			}
 		}
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($title);
+		
 		foreach ($this->item as $itemElement)
 		{
 			if ($itemElement->metadesc)

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -197,9 +197,7 @@ class TagsViewTag extends JViewLegacy
 	 * @return void
 	 */
 	protected function _prepareDocument()
-	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
+	{			
 		$title = null;
 
 		// Generate the tags title to use for page title, page heading and show tags title option
@@ -207,7 +205,7 @@ class TagsViewTag extends JViewLegacy
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($this->tags_title)
 		{

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -197,7 +197,7 @@ class TagsViewTag extends JViewLegacy
 	 * @return void
 	 */
 	protected function _prepareDocument()
-	{			
+	{
 		$title = null;
 
 		// Generate the tags title to use for page title, page heading and show tags title option

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -149,12 +149,10 @@ class TagsViewTags extends JViewLegacy
 	protected function _prepareDocument()
 	{
 		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -203,9 +203,9 @@ class TagsViewTags extends JViewLegacy
 					$title .= $itemElement->title;
 				}
 			}
-			
+
 			$this->setDocumentTitle($title);
-			
+
 			foreach ($this->item as $itemElement)
 			{
 				if ($itemElement->metadesc)

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -203,22 +203,9 @@ class TagsViewTags extends JViewLegacy
 					$title .= $itemElement->title;
 				}
 			}
-
-			if (empty($title))
-			{
-				$title = $app->get('sitename');
-			}
-			elseif ($app->get('sitename_pagetitles', 0) == 1)
-			{
-				$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-			}
-			elseif ($app->get('sitename_pagetitles', 0) == 2)
-			{
-				$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-			}
-
-			$this->document->setTitle($title);
-
+			
+			$this->setDocumentTitle($title);
+			
 			foreach ($this->item as $itemElement)
 			{
 				if ($itemElement->metadesc)

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -77,15 +77,12 @@ class UsersViewLogin extends JViewLegacy
 	 */
 	protected function prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
 		$user  = JFactory::getUser();
 		$login = $user->get('guest') ? true : false;
-		$title = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -95,9 +95,9 @@ class UsersViewLogin extends JViewLegacy
 		{
 			$this->params->def('page_heading', $login ? JText::_('JLOGIN') : JText::_('JLOGOUT'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -95,24 +95,9 @@ class UsersViewLogin extends JViewLegacy
 		{
 			$this->params->def('page_heading', $login ? JText::_('JLOGIN') : JText::_('JLOGOUT'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/profile/view.html.php
+++ b/components/com_users/views/profile/view.html.php
@@ -135,9 +135,9 @@ class UsersViewProfile extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_PROFILE'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/profile/view.html.php
+++ b/components/com_users/views/profile/view.html.php
@@ -135,24 +135,9 @@ class UsersViewProfile extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_PROFILE'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/profile/view.html.php
+++ b/components/com_users/views/profile/view.html.php
@@ -118,14 +118,11 @@ class UsersViewProfile extends JViewLegacy
 	 */
 	protected function prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
 		$user  = JFactory::getUser();
-		$title = null;
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -92,24 +92,9 @@ class UsersViewRegistration extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_REGISTRATION'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -76,13 +76,9 @@ class UsersViewRegistration extends JViewLegacy
 	 */
 	protected function prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -92,9 +92,9 @@ class UsersViewRegistration extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_REGISTRATION'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/components/com_users/views/remind/view.html.php
+++ b/components/com_users/views/remind/view.html.php
@@ -87,7 +87,7 @@ class UsersViewRemind extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_REMIND'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))

--- a/components/com_users/views/remind/view.html.php
+++ b/components/com_users/views/remind/view.html.php
@@ -71,13 +71,9 @@ class UsersViewRemind extends JViewLegacy
 	 */
 	protected function prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_users/views/remind/view.html.php
+++ b/components/com_users/views/remind/view.html.php
@@ -87,23 +87,8 @@ class UsersViewRemind extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_REMIND'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))
 		{

--- a/components/com_users/views/reset/view.html.php
+++ b/components/com_users/views/reset/view.html.php
@@ -97,7 +97,7 @@ class UsersViewReset extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_RESET'));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))

--- a/components/com_users/views/reset/view.html.php
+++ b/components/com_users/views/reset/view.html.php
@@ -97,23 +97,8 @@ class UsersViewReset extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_('COM_USERS_RESET'));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($this->params->get('menu-meta_description'))
 		{

--- a/components/com_users/views/reset/view.html.php
+++ b/components/com_users/views/reset/view.html.php
@@ -81,13 +81,9 @@ class UsersViewReset extends JViewLegacy
 	 */
 	protected function prepareDocument()
 	{
-		$app   = JFactory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
-
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = JFactory::getApplication()->getMenu()->getActive();
 
 		if ($menu)
 		{

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -31,7 +31,7 @@ class WrapperViewWrapper extends JViewLegacy
 		$params = $app->getParams();
 
 		// Because the application sets a default page title, we need to get it
-		// right from the menu item itself		
+		// right from the menu item itself
 		$this->setDocumentTitle($params->get('page_title', ''));
 
 		if ($params->get('menu-meta_description'))

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -31,23 +31,8 @@ class WrapperViewWrapper extends JViewLegacy
 		$params = $app->getParams();
 
 		// Because the application sets a default page title, we need to get it
-		// right from the menu item itself
-		$title = $params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		// right from the menu item itself		
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		if ($params->get('menu-meta_description'))
 		{

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -266,24 +266,9 @@ class JViewCategory extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_($this->defaultPageTitle));
 		}
-
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = JText::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
-
+		
+		$this->setDocumentTitle($this->params->get('page_title', ''));
+		
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -251,12 +251,10 @@ class JViewCategory extends JViewLegacy
 	protected function prepareDocument()
 	{
 		$app           = JFactory::getApplication();
-		$menus         = $app->getMenu();
 		$this->pathway = $app->getPathway();
-		$title         = null;
 
 		// Because the application sets a default page title, we need to get it from the menu item itself
-		$this->menu = $menus->getActive();
+		$this->menu = $app->getMenu()->getActive();
 
 		if ($this->menu)
 		{

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -266,9 +266,9 @@ class JViewCategory extends JViewLegacy
 		{
 			$this->params->def('page_heading', JText::_($this->defaultPageTitle));
 		}
-		
+
 		$this->setDocumentTitle($this->params->get('page_title', ''));
-		
+
 		if ($this->params->get('menu-meta_description'))
 		{
 			$this->document->setDescription($this->params->get('menu-meta_description'));

--- a/libraries/legacy/view/category.php
+++ b/libraries/legacy/view/category.php
@@ -113,7 +113,7 @@ class JViewCategory extends JViewLegacy
 		// Get some data from the models
 		$model       = $this->getModel();
 		$paramsModel = $model->getState('params');
-		
+
 		$paramsModel->set('check_access_rights', 0);
 		$model->setState('params', $paramsModel);
 
@@ -131,10 +131,10 @@ class JViewCategory extends JViewLegacy
 		{
 			return JError::raiseError(404, JText::_('JGLOBAL_CATEGORY_NOT_FOUND'));
 		}
-		
+
 		// Check whether category access level allows access.
 		$groups = $user->getAuthorisedViewLevels();
-		
+
 		if (!in_array($category->access, $groups))
 		{
 			return JError::raiseError(403, JText::_('JERROR_ALERTNOAUTHOR'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Since Joomla 3.6 , JViewLegacy has implemented the method setDocumentTitle https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/view/legacy.php#L854-L873 which is used to set document title base on site configuration. However, in many views in Joomla code base, we still use manual code, repeating code to set page title. This PR solves it

### Testing Instructions
A real test would be check all views changes by this PR and make sure the document title is not changed before and after patch. However, honestly, I don't think we can expect that kind of test here because it would take much time

So I hope developers can help reviewing the code of the PR and confirm that it is expected changes. If you review code, please help reviewing every file carefully.

### Documentation Changes Required
None