### PR TITLE
Update item.php

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -602,7 +602,7 @@ class MenusModelItem extends JModelAdmin
 			$filters = JFactory::getApplication()->getUserState('com_menus.items.filter');
 			$data['published'] = (isset($filters['published']) ? $filters['published'] : null);
 			$data['language'] = (isset($filters['language']) ? $filters['language'] : null);
-			$data['access'] = (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'));
+			$data['access'] = (!empty($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'));
 		}
 
 		if (isset($data['menutype']) && !$this->getState('item.menutypeid'))


### PR DESCRIPTION
Pull Request for Issue #14253 

### Summary of Changes
Line 605 changed from isset to !empty for $filters['access'] 


### Steps to reproduce the issue
Set the global setting of default access level to any other View Level than the Public and click to create a new menu item. The new menu item won't use your default View Level as per the global setting. Likely it will still use the Public level. 


### Expected result
Creating new menu item should have access level preselected as defined in Global config.


### Actual result
Creating new menu item won't have that access level.


### System information (as much as possible)
Joomla 3.6.5


### Additional comments
The problem is inside the loadFormData() method -(administrator/com_menus/models/item.php) ~ line #596 
`$data['access'] = (isset($filters['access']) ? $filters['access'] : JFactory::getConfig()->get('access'));`

It currently checks if $filters['access'] is set - which it seems it is no matter what, so it always return true.
!empty should be used instead, to check if the access element has a value.

There is an issue with new menu items that won't obey to the global setting of default access level.
Currently they will use a default access level, if there is a filter previously in the menu items list, but otherwise they will default to the first menu item by viewlevel id.

*A small update:*  
What I haven't test though, is if the checking of the other $filters that this method deals, would also need to be against a non empty value, instead of the var being set. But as far I recall, the case with the others filters is that there is not a global default that they need to retrieve anyways.

### Documentation Changes Required

none