### PR TITLE
Support for link target in admin menu links

### DIFF
--- a/administrator/components/com_menus/models/forms/itemadmin.xml
+++ b/administrator/components/com_menus/models/forms/itemadmin.xml
@@ -124,7 +124,6 @@
 		>
 			<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>
 			<option value="1">COM_MENUS_FIELD_VALUE_NEW_WITH_NAV</option>
-			<option value="2">COM_MENUS_FIELD_VALUE_NEW_WITHOUT_NAV</option>
 		</field>
 
 		<field

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -499,7 +499,9 @@ class JAdminCssMenu
 			}
 			else
 			{
-				$this->addChild(new JMenuNode($item->text, $item->link, $item->parent_id == 1 ? null : 'class:'), true);
+				$target = $item->browserNav ? '_blank' : null;
+
+				$this->addChild(new JMenuNode($item->text, $item->link, $item->parent_id == 1 ? null : 'class:', false, $target), true);
 				$this->loadItems($item->submenu);
 				$this->getParent();
 			}


### PR DESCRIPTION
Support for link target in admin menu links

### Summary of Changes
We have an option to define link target for menu links but it is currently not being honoured in admin menus. 

### Testing Instructions
Create a menu item in a custom admin menu. Set its link target to "New Window..."

### Expected result
It should open in new tab/window when clicked.

### Actual result
Opens in same tab/window (before patch)
Opens in new tab/window (after patch)

### Documentation Changes Required
None
