### PR TITLE
Improve performance with assets

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -646,13 +646,21 @@ class ConfigModelApplication extends ConfigModelForm
 					$temp[$permission['action']][$permission['rule']] = array();
 				}
 
-				// Set the new permission.
-				$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
-
-				// Check if we have an inherited setting.
-				if (strlen($permission['value']) === 0)
+				if ($permission['value'] !== '')
 				{
+					// Set the new permission.
+					$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
+				}
+				else
+				{
+					// We have an inherited setting only.
 					unset($temp[$permission['action']][$permission['rule']]);
+				}
+
+				// Check if we have any inherited settings.
+				if (empty($temp[$permission['action']]))
+				{
+					unset($temp[$permission['action']]);
 				}
 			}
 			else
@@ -666,7 +674,7 @@ class ConfigModelApplication extends ConfigModelForm
 			{
 				$query->clear()
 					->update($this->db->quoteName('#__assets'))
-					->set($this->db->quoteName('rules') . ' = ' . $this->db->quote(json_encode($temp)))
+					->set($this->db->quoteName('rules') . ' = ' . $this->db->quote(json_encode($temp, JSON_FORCE_OBJECT)))
 					->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
 
 				$this->db->setQuery($query)->execute();

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -564,60 +564,86 @@ class ConfigModelApplication extends ConfigModelForm
 
 		try
 		{
-			// Load the current settings for this component.
-			$query = $this->db->getQuery(true)
-				->select($this->db->quoteName(array('name', 'rules')))
-				->from($this->db->quoteName('#__assets'))
-				->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
+			$asset  = JTable::getInstance('asset');
+			$result = $asset->loadByName($permission['component']);
 
-			$this->db->setQuery($query);
-
-			// Load the results as a list of stdClass objects (see later for more options on retrieving data).
-			$results = $this->db->loadAssocList();
-		}
-		catch (Exception $e)
-		{
-			$app->enqueueMessage($e->getMessage(), 'error');
-
-			return false;
-		}
-
-		// No record found, let's create one.
-		if (empty($results))
-		{
-			$data = array();
-			$data[$permission['action']] = array($permission['rule'] => $permission['value']);
-
-			$rules        = new JAccessRules($data);
-			$asset        = JTable::getInstance('asset');
-			$asset->rules = (string) $rules;
-			$asset->name  = (string) $permission['component'];
-			$asset->title = (string) $permission['title'];
-
-			// Get the parent asset id so we have a correct tree.
-			$parentAsset = JTable::getInstance('Asset');
-
-			if (strpos($asset->name, '.') !== false)
+			if ($result === false)
 			{
-				$assetParts = explode('.', $asset->name);
-				$parentAsset->loadByName($assetParts[0]);
-				$parentAssetId = $parentAsset->id;
+				$data = array($permission['action'] => array($permission['rule'] => $permission['value']));
+
+				$rules        = new JAccessRules($data);
+				$asset->rules = (string) $rules;
+				$asset->name  = (string) $permission['component'];
+				$asset->title = (string) $permission['title'];
+
+				// Get the parent asset id so we have a correct tree.
+				$parentAsset = JTable::getInstance('Asset');
+
+				if (strpos($asset->name, '.') !== false)
+				{
+					$assetParts = explode('.', $asset->name);
+					$parentAsset->loadByName($assetParts[0]);
+					$parentAssetId = $parentAsset->id;
+				}
+				else
+				{
+					$parentAssetId = $parentAsset->getRootId();
+				}
+
+				/**
+				 * @to do: incorrect ACL stored
+				 * When changing a permission of an item that doesn't have a row in the asset table the row a new row is created.
+				 * This works fine for item <-> component <-> global config scenario and component <-> global config scenario.
+				 * But doesn't work properly for item <-> section(s) <-> component <-> global config scenario,
+				 * because a wrong parent asset id (the component) is stored.
+				 * Happens when there is no row in the asset table (ex: deleted or not created on update).
+				 */
+
+				$asset->setLocation($parentAssetId, 'last-child');
 			}
 			else
 			{
-				$parentAssetId = $parentAsset->getRootId();
+				// Decode the rule settings.
+				$temp = json_decode($asset->rules, true);
+
+				// Check if a new value is to be set.
+				if (isset($permission['value']))
+				{
+					// Check if we already have an action entry.
+					if (!isset($temp[$permission['action']]))
+					{
+						$temp[$permission['action']] = array();
+					}
+
+					// Check if we already have a rule entry.
+					if (!isset($temp[$permission['action']][$permission['rule']]))
+					{
+						$temp[$permission['action']][$permission['rule']] = array();
+					}
+
+					// Set the new permission.
+					$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
+
+					// Check if we have an inherited setting.
+					if ($permission['value'] === '')
+					{
+						unset($temp[$permission['action']][$permission['rule']]);
+					}
+
+					// Check if we have any rules.
+					if (!$temp[$permission['action']])
+					{
+						unset($temp[$permission['action']]);
+					}
+				}
+				else
+				{
+					// There is no value so remove the action as it's not needed.
+					unset($temp[$permission['action']]);
+				}
+
+				$asset->rules = json_encode($temp, JSON_FORCE_OBJECT);
 			}
-
-			/**
-			 * @to do: incorrect ACL stored
-			 * When changing a permission of an item that doesn't have a row in the asset table the row a new row is created.
-			 * This works fine for item <-> component <-> global config scenario and component <-> global config scenario.
-			 * But doesn't work properly for item <-> section(s) <-> component <-> global config scenario,
-			 * because a wrong parent asset id (the component) is stored.
-			 * Happens when there is no row in the asset table (ex: deleted or not created on update).
-			 */
-
-			$asset->setLocation($parentAssetId, 'last-child');
 
 			if (!$asset->check() || !$asset->store())
 			{
@@ -626,66 +652,13 @@ class ConfigModelApplication extends ConfigModelForm
 				return false;
 			}
 		}
-		else
+		catch (Exception $e)
 		{
-			// Decode the rule settings.
-			$temp = json_decode($results[0]['rules'], true);
+			$app->enqueueMessage($e->getMessage(), 'error');
 
-			// Check if a new value is to be set.
-			if (isset($permission['value']))
-			{
-				// Check if we already have an action entry.
-				if (!isset($temp[$permission['action']]))
-				{
-					$temp[$permission['action']] = array();
-				}
-
-				// Check if we already have a rule entry.
-				if (!isset($temp[$permission['action']][$permission['rule']]))
-				{
-					$temp[$permission['action']][$permission['rule']] = array();
-				}
-
-				if ($permission['value'] !== '')
-				{
-					// Set the new permission.
-					$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
-				}
-				else
-				{
-					// We have an inherited setting only.
-					unset($temp[$permission['action']][$permission['rule']]);
-				}
-
-				// Check if we have any inherited settings.
-				if (empty($temp[$permission['action']]))
-				{
-					unset($temp[$permission['action']]);
-				}
-			}
-			else
-			{
-				// There is no value so remove the action as it's not needed.
-				unset($temp[$permission['action']]);
-			}
-
-			// Store the new permissions.
-			try
-			{
-				$query->clear()
-					->update($this->db->quoteName('#__assets'))
-					->set($this->db->quoteName('rules') . ' = ' . $this->db->quote(json_encode($temp, JSON_FORCE_OBJECT)))
-					->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
-
-				$this->db->setQuery($query)->execute();
-			}
-			catch (Exception $e)
-			{
-				$app->enqueueMessage($e->getMessage(), 'error');
-
-				return false;
-			}
+			return false;
 		}
+
 
 		// All checks done.
 		$result = array(
@@ -699,7 +672,7 @@ class ConfigModelApplication extends ConfigModelForm
 		try
 		{
 			// Get the asset id by the name of the component.
-			$query->clear()
+			$query = $this->db->getQuery(true)
 				->select($this->db->quoteName('id'))
 				->from($this->db->quoteName('#__assets'))
 				->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));

--- a/administrator/components/com_fields/tables/field.php
+++ b/administrator/components/com_fields/tables/field.php
@@ -18,14 +18,6 @@ use Joomla\Registry\Registry;
 class FieldsTableField extends JTable
 {
 	/**
-	 * Allow to refer to the parent asset instead of creating own fully inherits permissions.
-	 *
-	 * @var    boolean
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected $_allowForeignAsset = true;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param   JDatabaseDriver  $db  JDatabaseDriver object.

--- a/administrator/components/com_fields/tables/field.php
+++ b/administrator/components/com_fields/tables/field.php
@@ -18,6 +18,14 @@ use Joomla\Registry\Registry;
 class FieldsTableField extends JTable
 {
 	/**
+	 * Allow to refer to the parent asset instead of creating own fully inherits permissions.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_allowForeignAsset = true;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   JDatabaseDriver  $db  JDatabaseDriver object.

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -181,16 +181,15 @@ class ContentModelArticle extends JModelItem
 				if (!$user->get('guest'))
 				{
 					$userId = $user->get('id');
-					$asset = 'com_content.article.' . $data->id;
 
 					// Check general edit permission first.
-					if ($user->authorise('core.edit', $asset))
+					if ($user->authorise('core.edit', $data->asset_id))
 					{
 						$data->params->set('access-edit', true);
 					}
 
 					// Now check if edit.own is available.
-					elseif (!empty($userId) && $user->authorise('core.edit.own', $asset))
+					elseif (!empty($userId) && $user->authorise('core.edit.own', $data->asset_id))
 					{
 						// Check for a valid user and that they are the owner.
 						if ($userId == $data->created_by)

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -217,6 +217,7 @@ class ContentModelArticles extends JModelList
 			$query->select($this->getState('list.select', 'CASE WHEN badcats.id is not null THEN 0 ELSE a.state END AS state'));
 		}
 
+		$query->select('a.asset_id');
 		$query->from('#__content AS a');
 
 		$params = $this->getState('params');
@@ -650,16 +651,14 @@ class ContentModelArticles extends JModelList
 			// Technically guest could edit an article, but lets not check that to improve performance a little.
 			if (!$guest)
 			{
-				$asset = 'com_content.article.' . $item->id;
-
 				// Check general edit permission first.
-				if ($user->authorise('core.edit', $asset))
+				if ($user->authorise('core.edit', $item->asset_id))
 				{
 					$item->params->set('access-edit', true);
 				}
 
 				// Now check if edit.own is available.
-				elseif (!empty($userId) && $user->authorise('core.edit.own', $asset))
+				elseif (!empty($userId) && $user->authorise('core.edit.own', $item->asset_id))
 				{
 					// Check for a valid user and that they are the owner.
 					if ($userId == $item->created_by)

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -92,16 +92,15 @@ class ContentModelForm extends ContentModelArticle
 		// Compute selected asset permissions.
 		$user   = JFactory::getUser();
 		$userId = $user->get('id');
-		$asset  = 'com_content.article.' . $value->id;
 
 		// Check general edit permission first.
-		if ($user->authorise('core.edit', $asset))
+		if ($user->authorise('core.edit', $value->asset_id))
 		{
 			$value->params->set('access-edit', true);
 		}
 
 		// Now check if edit.own is available.
-		elseif (!empty($userId) && $user->authorise('core.edit.own', $asset))
+		elseif (!empty($userId) && $user->authorise('core.edit.own', $value->asset_id))
 		{
 			// Check for a valid user and that they are the owner.
 			if ($userId == $value->created_by)
@@ -114,7 +113,7 @@ class ContentModelForm extends ContentModelArticle
 		if ($itemId)
 		{
 			// Existing item
-			$value->params->set('access-change', $user->authorise('core.edit.state', $asset));
+			$value->params->set('access-change', $user->authorise('core.edit.state', $value->asset_id));
 		}
 		else
 		{

--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -388,7 +388,7 @@ abstract class JModuleHelper
 		$db = JFactory::getDbo();
 
 		$query = $db->getQuery(true)
-			->select('m.id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid')
+			->select('m.id, m.asset_id, m.title, m.module, m.position, m.content, m.showtitle, m.params, mm.menuid')
 			->from('#__modules AS m')
 			->join('LEFT', '#__modules_menu AS mm ON mm.moduleid = m.id')
 			->where('m.published = 1')

--- a/libraries/cms/table/corecontent.php
+++ b/libraries/cms/table/corecontent.php
@@ -21,6 +21,14 @@ use Joomla\Utilities\ArrayHelper;
 class JTableCorecontent extends JTable
 {
 	/**
+	 * Allow to refer to the parent asset instead of creating own fully inherits permissions.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_allowForeignAsset = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -785,6 +785,44 @@ class JAccess
 			}
 		}
 
+		// To support JTable::allowForeignAsset, try to find asset_id in direct table.
+		if (empty($loaded[$assetKey]))
+		{
+			$assetType = self::getAssetType($assetKey);
+
+			if ($assetType === 'com_content.article')
+			{
+				$table    = '#__content';
+				$table_pk = 'id';
+			}
+			elseif ($assetType === '#__ucm_content')
+			{
+				$table    = '#__ucm_content';
+				$table_pk = 'core_content_id';
+			}
+			elseif ($assetType === 'com_modules.module')
+			{
+				$table    = '#__modules';
+				$table_pk = 'id';
+			}
+			else
+			{
+				$table = false;
+			}
+
+			if ($table)
+			{
+				$db = JFactory::getDbo();
+
+				$query = $db->getQuery(true)
+					->select('asset_id')
+					->from($db->quoteName($table))
+					->where($db->quoteName($table_pk) . ' = ' . (int) substr($assetKey, strlen($assetType) + 1));
+
+				$loaded[$assetKey] = (int) $db->setQuery($query)->loadResult();
+			}
+		}
+
 		return (int) $loaded[$assetKey];
 	}
 

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -135,15 +135,22 @@ class JAccessRules
 	 */
 	public function mergeAction($action, $identities)
 	{
-		if (isset($this->data[$action]))
+		if ($identities)
 		{
-			// If exists, merge the action.
-			$this->data[$action]->mergeIdentities($identities);
+			if (isset($this->data[$action]))
+			{
+				// If exists, merge the action.
+				$this->data[$action]->mergeIdentities($identities);
+			}
+			else
+			{
+				// If new, add the action.
+				$this->data[$action] = new JAccessRule($identities);
+			}
 		}
 		else
 		{
-			// If new, add the action.
-			$this->data[$action] = new JAccessRule($identities);
+			unset($this->data[$action]);
 		}
 	}
 
@@ -214,6 +221,6 @@ class JAccessRules
 			$temp[$name] = json_decode((string) $rule);
 		}
 
-		return json_encode($temp);
+		return json_encode($temp, JSON_FORCE_OBJECT);
 	}
 }

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -135,22 +135,15 @@ class JAccessRules
 	 */
 	public function mergeAction($action, $identities)
 	{
-		if ($identities)
+		if (isset($this->data[$action]))
 		{
-			if (isset($this->data[$action]))
-			{
-				// If exists, merge the action.
-				$this->data[$action]->mergeIdentities($identities);
-			}
-			else
-			{
-				// If new, add the action.
-				$this->data[$action] = new JAccessRule($identities);
-			}
+			// If exists, merge the action.
+			$this->data[$action]->mergeIdentities($identities);
 		}
 		else
 		{
-			unset($this->data[$action]);
+			// If new, add the action.
+			$this->data[$action] = new JAccessRule($identities);
 		}
 	}
 
@@ -216,9 +209,10 @@ class JAccessRules
 
 		foreach ($this->data as $name => $rule)
 		{
-			// Convert the action to JSON, then back into an array otherwise
-			// re-encoding will quote the JSON for the identities in the action.
-			$temp[$name] = json_decode((string) $rule);
+			if ($data = $rule->getData())
+			{
+				$temp[$name] = $data;
+			}
 		}
 
 		return json_encode($temp, JSON_FORCE_OBJECT);

--- a/libraries/joomla/document/renderer/html/modules.php
+++ b/libraries/joomla/document/renderer/html/modules.php
@@ -41,7 +41,7 @@ class JDocumentRendererHtmlModules extends JDocumentRenderer
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+			if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', $mod->asset_id))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				JLayoutHelper::render('joomla.edit.frontediting_modules', $displayData);

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -184,7 +184,7 @@ class JFormFieldRules extends JFormField
 		$newItem       = empty($assetId) && $isGlobalConfig === false && $section !== 'component';
 		$parentAssetId = null;
 
-		if (!empty($assetId))
+		if (!$isGlobalConfig && $section !== 'component' && !empty($assetId))
 		{
 			$namePrefix = $component . '.' . $section . '.';
 

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -180,7 +180,7 @@ class JFormFieldRules extends JFormField
 
 		// Get the asset id.
 		// Note that for global configuration, com_config injects asset_id = 1 into the form.
-		$assetId       = $this->form->getValue($assetField);
+		$assetId       = (int) $this->form->getValue($assetField);
 		$newItem       = empty($assetId) && $isGlobalConfig === false && $section !== 'component';
 		$parentAssetId = null;
 
@@ -195,12 +195,11 @@ class JFormFieldRules extends JFormField
 			{
 				// This is not own asset.
 				$parentAssetId = $assetId;
-				$assetId = null;
 			}
 		}
 
 		// If the asset id is empty (component or new item).
-		if (empty($assetId) && !$parentAssetId)
+		if (empty($assetId))
 		{
 			// Get the component asset id as fallback.
 			$db = JFactory::getDbo();
@@ -239,7 +238,7 @@ class JFormFieldRules extends JFormField
 
 		// Full width format.
 
-		if ($assetId)
+		if ($assetId && $assetId !== $parentAssetId)
 		{
 			// Get the rules for just this asset (non-recursive).
 			$assetRules = JAccess::getAssetRules($assetId, false, false);

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -106,22 +106,18 @@ class JTableAsset extends JTableNested
 		{
 			// Get the JDatabaseQuery object
 			$query = $this->_db->getQuery(true)
-				->select('COUNT(id)')
+				->select('1')
 				->from($this->_db->quoteName($this->_tbl))
 				->where($this->_db->quoteName('id') . ' = ' . $this->parent_id);
-			$this->_db->setQuery($query);
 
-			if ($this->_db->loadResult())
+			if ($this->_db->setQuery($query, 0, 1)->loadResult())
 			{
 				return true;
 			}
-			else
-			{
-				$this->setError('Invalid Parent ID');
 
-				return false;
+			$this->setError('Invalid Parent ID');
 
-			}
+			return false;
 		}
 
 		return true;

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -101,6 +101,7 @@ class JTableAsset extends JTableNested
 		{
 			$this->rules = '{}';
 		}
+
 		// JTableNested does not allow parent_id = 0, override this.
 		if ($this->parent_id > 0)
 		{

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -834,45 +834,95 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 
 				return false;
 			}
+
+			// Specify how a new or moved node asset is inserted into the tree.
+			if (empty($this->asset_id) || $asset->parent_id != $parentId)
+			{
+				$asset->setLocation($parentId, 'last-child');
+			}
+
+			// Prepare the asset to be stored.
+			$asset->parent_id = $parentId;
+			$asset->name      = $name;
+			$asset->title     = $title;
+
+			if ($this->_rules instanceof JAccessRules)
+			{
+				$asset->rules = (string) $this->_rules;
+			}
+
+			/*
+			* There is some limitation when joomla can use that shortcut.
+			* It should be used only for leafs.
+			*/
+			$useDirectParentAsset = is_subclass_of($this, 'JTableNested') === false && substr_count($name, '.') > 1;
+
+			if ($useDirectParentAsset && (empty($asset->rules) || $asset->rules === '{}'))
+			{
+				if (!empty($asset->id))
+				{
+					// To be sure to not delete parent of other asset.
+					$query = $this->_db->getQuery(true)
+						->select('1')
+						->from($this->_db->quoteName('#__assets'))
+						->where('parent_id = ' . (int) $asset->id);
+
+					if ($this->_db->setQuery($query, 0, 1)->loadResult())
+					{
+						// Current asset is not a leaf.
+						$useDirectParentAsset = false;
+					}
+				}
+			}
 			else
 			{
-				// Specify how a new or moved node asset is inserted into the tree.
-				if (empty($this->asset_id) || $asset->parent_id != $parentId)
+				$useDirectParentAsset = false;
+			}
+
+			if ($useDirectParentAsset)
+			{
+				// Use a parent asset if current asset full inherits its parent
+				$parentAsset = self::getInstance('Asset', 'JTable', array('dbo' => $this->getDbo()));
+
+				if ($parentAsset->load($parentId))
 				{
-					$asset->setLocation($parentId, 'last-child');
-				}
+					// Remove old asset.
+					if (!empty($asset->id))
+					{
+						$asset->delete();
+					}
 
-				// Prepare the asset to be stored.
-				$asset->parent_id = $parentId;
-				$asset->name      = $name;
-				$asset->title     = $title;
+					// Use already saved parent asset.
+					$asset = $parentAsset;
 
-				if ($this->_rules instanceof JAccessRules)
-				{
-					$asset->rules = (string) $this->_rules;
-				}
-
-				if (!$asset->check() || !$asset->store($updateNulls))
-				{
-					$this->setError($asset->getError());
-
-					return false;
+					// Re-inject the asset id.
+					$this->asset_id = $asset->id;
 				}
 				else
 				{
-					// Create an asset_id or heal one that is corrupted.
-					if (empty($this->asset_id) || ($currentAssetId != $this->asset_id && !empty($this->asset_id)))
-					{
-						// Update the asset_id field in this table.
-						$this->asset_id = (int) $asset->id;
+					$this->setError('Invalid Parent ID');
 
-						$query = $this->_db->getQuery(true)
-							->update($this->_db->quoteName($this->_tbl))
-							->set('asset_id = ' . (int) $this->asset_id);
-						$this->appendPrimaryKeys($query);
-						$this->_db->setQuery($query)->execute();
-					}
+					return false;
 				}
+			}
+			elseif (!$asset->check() || !$asset->store($updateNulls))
+			{
+				$this->setError($asset->getError());
+
+				return false;
+			}
+
+			// Create an asset_id or heal one that is corrupted.
+			if (empty($this->asset_id) || ($currentAssetId != $this->asset_id && !empty($this->asset_id)))
+			{
+				// Update the asset_id field in this table.
+				$this->asset_id = (int) $asset->id;
+
+				$query = $this->_db->getQuery(true)
+					->update($this->_db->quoteName($this->_tbl))
+					->set('asset_id = ' . (int) $this->asset_id);
+				$this->appendPrimaryKeys($query);
+				$this->_db->setQuery($query)->execute();
 			}
 		}
 

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -231,13 +231,6 @@ class JTableContent extends JTable
 			{
 				$this->metadata = '{}';
 			}
-
-			// If we don't have any access rules set at this point just use an empty JAccessRules class
-			if (!$this->getRules())
-			{
-				$rules = $this->getDefaultAssetValues('com_content');
-				$this->setRules($rules);
-			}
 		}
 
 		// Check the publish down date is not earlier than publish up.

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -21,6 +21,14 @@ use Joomla\String\StringHelper;
 class JTableContent extends JTable
 {
 	/**
+	 * Allow to refer to the parent asset instead of creating own fully inherits permissions.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_allowForeignAsset = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   JDatabaseDriver  $db  A database connector object

--- a/libraries/legacy/table/module.php
+++ b/libraries/legacy/table/module.php
@@ -19,6 +19,14 @@ use Joomla\Registry\Registry;
 class JTableModule extends JTable
 {
 	/**
+	 * Allow to refer to the parent asset instead of creating own fully inherits permissions.
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_allowForeignAsset = true;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   JDatabaseDriver  $db  Database driver object.

--- a/tests/unit/schema/ddl.sql
+++ b/tests/unit/schema/ddl.sql
@@ -327,6 +327,7 @@ CREATE TABLE `jos_menu_types` (
 
 CREATE TABLE `jos_modules` (
   `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `asset_id` INTEGER NOT NULL DEFAULT '0',
   `title` TEXT NOT NULL DEFAULT '',
   `note` TEXT NOT NULL DEFAULT '',
   `content` TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
### Summary of Changes
1. Do not add default values from com_content component asset to new assets, better use inheritance `{}`.

2. Leaf asset (last-child, ex: com_content.article.1) can be replaced by parent asset if leaf asset does not change any permission.

If article, module or ucm_content table has reference to leaf asset which has rules as `{}` (means inherits all rules from parent asset) then this table may reference to parent asset instead.

Example for `com_content`:
- 1000 articles in 10 categories have 1011 assets = 1000 (com_content.article.xxxx) + 10 (com_content.category.xx) + 1 (com_content)

After current PR com_content assets may be reduced to:
- 1000 articles in 10 categories will have 11 assets = 10 (com_content.category.xx) + 1 (com_content)

Notice: If user won't set article permissions as `inherit` for all then there won't be any benefits. (old behaviour)

It seems that lots of users do not use too often article permission tab or change its value so
this PR would improve performance a lot.

Current problem:
- before this PR joomla does not use (on creating article) inherit value by default. 
That means that exist articles won't be automatically improved.
But every new article with all permission inherited from parent won't create a new row for `#__assets` table.

How to fix old articles?
Re-save each one or use a few sql queries to fix that.
[I may add it later]  

### Testing Instructions

* Install joomla with some contents, like sample - testing data
* Change article permissions few times, set all to inherit. (always save article after changes)
* On phpmyadmin you can see that on changed article (with set all as inherit), means rules = `{}` 
article refers to category asset and recreate own asset if you change at least one permission to not `inherit`.
* Set permission rules to categories, articles and check whether values are preserved after saved.
* Check if permission is correct on frontend for modules and articles. 

### Documentation Changes Required
Maybe add some notes about reference to parent assets when article/module... use full inherited permissions.
