### PR TITLE
A few improvements for assets

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -564,60 +564,86 @@ class ConfigModelApplication extends ConfigModelForm
 
 		try
 		{
-			// Load the current settings for this component.
-			$query = $this->db->getQuery(true)
-				->select($this->db->quoteName(array('name', 'rules')))
-				->from($this->db->quoteName('#__assets'))
-				->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
+			$asset  = JTable::getInstance('asset');
+			$result = $asset->loadByName($permission['component']);
 
-			$this->db->setQuery($query);
-
-			// Load the results as a list of stdClass objects (see later for more options on retrieving data).
-			$results = $this->db->loadAssocList();
-		}
-		catch (Exception $e)
-		{
-			$app->enqueueMessage($e->getMessage(), 'error');
-
-			return false;
-		}
-
-		// No record found, let's create one.
-		if (empty($results))
-		{
-			$data = array();
-			$data[$permission['action']] = array($permission['rule'] => $permission['value']);
-
-			$rules        = new JAccessRules($data);
-			$asset        = JTable::getInstance('asset');
-			$asset->rules = (string) $rules;
-			$asset->name  = (string) $permission['component'];
-			$asset->title = (string) $permission['title'];
-
-			// Get the parent asset id so we have a correct tree.
-			$parentAsset = JTable::getInstance('Asset');
-
-			if (strpos($asset->name, '.') !== false)
+			if ($result === false)
 			{
-				$assetParts = explode('.', $asset->name);
-				$parentAsset->loadByName($assetParts[0]);
-				$parentAssetId = $parentAsset->id;
+				$data = array($permission['action'] => array($permission['rule'] => $permission['value']));
+
+				$rules        = new JAccessRules($data);
+				$asset->rules = (string) $rules;
+				$asset->name  = (string) $permission['component'];
+				$asset->title = (string) $permission['title'];
+
+				// Get the parent asset id so we have a correct tree.
+				$parentAsset = JTable::getInstance('Asset');
+
+				if (strpos($asset->name, '.') !== false)
+				{
+					$assetParts = explode('.', $asset->name);
+					$parentAsset->loadByName($assetParts[0]);
+					$parentAssetId = $parentAsset->id;
+				}
+				else
+				{
+					$parentAssetId = $parentAsset->getRootId();
+				}
+
+				/**
+				 * @to do: incorrect ACL stored
+				 * When changing a permission of an item that doesn't have a row in the asset table the row a new row is created.
+				 * This works fine for item <-> component <-> global config scenario and component <-> global config scenario.
+				 * But doesn't work properly for item <-> section(s) <-> component <-> global config scenario,
+				 * because a wrong parent asset id (the component) is stored.
+				 * Happens when there is no row in the asset table (ex: deleted or not created on update).
+				 */
+
+				$asset->setLocation($parentAssetId, 'last-child');
 			}
 			else
 			{
-				$parentAssetId = $parentAsset->getRootId();
+				// Decode the rule settings.
+				$temp = json_decode($asset->rules, true);
+
+				// Check if a new value is to be set.
+				if (isset($permission['value']))
+				{
+					// Check if we already have an action entry.
+					if (!isset($temp[$permission['action']]))
+					{
+						$temp[$permission['action']] = array();
+					}
+
+					// Check if we already have a rule entry.
+					if (!isset($temp[$permission['action']][$permission['rule']]))
+					{
+						$temp[$permission['action']][$permission['rule']] = array();
+					}
+
+					// Set the new permission.
+					$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
+
+					// Check if we have an inherited setting.
+					if ($permission['value'] === '')
+					{
+						unset($temp[$permission['action']][$permission['rule']]);
+					}
+
+					// Check if we have any rules.
+					if (!$temp[$permission['action']])
+					{
+						unset($temp[$permission['action']]);
+					}
+				}
+				else
+				{
+					// There is no value so remove the action as it's not needed.
+					unset($temp[$permission['action']]);
+				}
+
+				$asset->rules = json_encode($temp, JSON_FORCE_OBJECT);
 			}
-
-			/**
-			 * @to do: incorrect ACL stored
-			 * When changing a permission of an item that doesn't have a row in the asset table the row a new row is created.
-			 * This works fine for item <-> component <-> global config scenario and component <-> global config scenario.
-			 * But doesn't work properly for item <-> section(s) <-> component <-> global config scenario,
-			 * because a wrong parent asset id (the component) is stored.
-			 * Happens when there is no row in the asset table (ex: deleted or not created on update).
-			 */
-
-			$asset->setLocation($parentAssetId, 'last-child');
 
 			if (!$asset->check() || !$asset->store())
 			{
@@ -626,58 +652,13 @@ class ConfigModelApplication extends ConfigModelForm
 				return false;
 			}
 		}
-		else
+		catch (Exception $e)
 		{
-			// Decode the rule settings.
-			$temp = json_decode($results[0]['rules'], true);
+			$app->enqueueMessage($e->getMessage(), 'error');
 
-			// Check if a new value is to be set.
-			if (isset($permission['value']))
-			{
-				// Check if we already have an action entry.
-				if (!isset($temp[$permission['action']]))
-				{
-					$temp[$permission['action']] = array();
-				}
-
-				// Check if we already have a rule entry.
-				if (!isset($temp[$permission['action']][$permission['rule']]))
-				{
-					$temp[$permission['action']][$permission['rule']] = array();
-				}
-
-				// Set the new permission.
-				$temp[$permission['action']][$permission['rule']] = (int) $permission['value'];
-
-				// Check if we have an inherited setting.
-				if (strlen($permission['value']) === 0)
-				{
-					unset($temp[$permission['action']][$permission['rule']]);
-				}
-			}
-			else
-			{
-				// There is no value so remove the action as it's not needed.
-				unset($temp[$permission['action']]);
-			}
-
-			// Store the new permissions.
-			try
-			{
-				$query->clear()
-					->update($this->db->quoteName('#__assets'))
-					->set($this->db->quoteName('rules') . ' = ' . $this->db->quote(json_encode($temp)))
-					->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));
-
-				$this->db->setQuery($query)->execute();
-			}
-			catch (Exception $e)
-			{
-				$app->enqueueMessage($e->getMessage(), 'error');
-
-				return false;
-			}
+			return false;
 		}
+
 
 		// All checks done.
 		$result = array(
@@ -691,7 +672,7 @@ class ConfigModelApplication extends ConfigModelForm
 		try
 		{
 			// Get the asset id by the name of the component.
-			$query->clear()
+			$query = $this->db->getQuery(true)
 				->select($this->db->quoteName('id'))
 				->from($this->db->quoteName('#__assets'))
 				->where($this->db->quoteName('name') . ' = ' . $this->db->quote($permission['component']));

--- a/libraries/joomla/access/rules.php
+++ b/libraries/joomla/access/rules.php
@@ -209,11 +209,12 @@ class JAccessRules
 
 		foreach ($this->data as $name => $rule)
 		{
-			// Convert the action to JSON, then back into an array otherwise
-			// re-encoding will quote the JSON for the identities in the action.
-			$temp[$name] = json_decode((string) $rule);
+			if ($data = $rule->getData())
+			{
+				$temp[$name] = $data;
+			}
 		}
 
-		return json_encode($temp);
+		return json_encode($temp, JSON_FORCE_OBJECT);
 	}
 }

--- a/libraries/joomla/table/asset.php
+++ b/libraries/joomla/table/asset.php
@@ -101,27 +101,24 @@ class JTableAsset extends JTableNested
 		{
 			$this->rules = '{}';
 		}
+
 		// JTableNested does not allow parent_id = 0, override this.
 		if ($this->parent_id > 0)
 		{
 			// Get the JDatabaseQuery object
 			$query = $this->_db->getQuery(true)
-				->select('COUNT(id)')
+				->select('1')
 				->from($this->_db->quoteName($this->_tbl))
 				->where($this->_db->quoteName('id') . ' = ' . $this->parent_id);
-			$this->_db->setQuery($query);
 
-			if ($this->_db->loadResult())
+			if ($this->_db->setQuery($query, 0, 1)->loadResult())
 			{
 				return true;
 			}
-			else
-			{
-				$this->setError('Invalid Parent ID');
 
-				return false;
+			$this->setError('Invalid Parent ID');
 
-			}
+			return false;
 		}
 
 		return true;

--- a/libraries/legacy/table/content.php
+++ b/libraries/legacy/table/content.php
@@ -231,13 +231,6 @@ class JTableContent extends JTable
 			{
 				$this->metadata = '{}';
 			}
-
-			// If we don't have any access rules set at this point just use an empty JAccessRules class
-			if (!$this->getRules())
-			{
-				$rules = $this->getDefaultAssetValues('com_content');
-				$this->setRules($rules);
-			}
 		}
 
 		// Check the publish down date is not earlier than publish up.

--- a/tests/unit/schema/ddl.sql
+++ b/tests/unit/schema/ddl.sql
@@ -327,6 +327,7 @@ CREATE TABLE `jos_menu_types` (
 
 CREATE TABLE `jos_modules` (
   `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `asset_id` INTEGER NOT NULL DEFAULT '0',
   `title` TEXT NOT NULL DEFAULT '',
   `note` TEXT NOT NULL DEFAULT '',
   `content` TEXT NOT NULL DEFAULT '',


### PR DESCRIPTION
Pull Request for a few fixes from my previous non B/C PR #14279  

### Summary of Changes
* Do not force to set rules from com_content component to every new article. 
  Use inheritance (simple '{}') as in other extensions.
* Clean empty actions from rules: `{'core.edit': {}, 'core.delete: {}'}` __to__ `{}`
* Use faster `JAccessRules::getData()` instead of `json_decode()` and `json_encode()` in method `JAccessRules::__toString()`
* Add missing column `asset_id` in `tests/unit/schema/ddl.sql`


### Testing Instructions
1. Install joomla (I have installed with sample - Test English)
2. Go to backend Content -> Articles -> click on button Options -> select Tab Permissions
3. Change permissions for `Manager` from 'Inherit' to 'Allowed' for `Create`, `Edit`, `Delete`:
![samplea1](https://cloud.githubusercontent.com/assets/9054379/23606561/94a807f6-0261-11e7-9006-863e9b5d4ba8.jpeg)
4. Save and Close.
5. Create a new Article, in permission tab as above(for Manager) permission are set as 'Inherit' - it is OK.
6. Save and check again - **Now a few permissions has been changed from 'Inherit' to 'Allowed'** - it is not OK.
7. Apply patch
8. Back to point 5 (create a new article)
9. After save, permissions for Manager stay 'Inherit'. - that is now OK.
10. Change permission for Manager for `Edit` action from 'Inherit' to 'Allowed' and `Save`.
11. Change tab to user group 'Editor':
![samplea1](https://cloud.githubusercontent.com/assets/9054379/23607636/e8058988-0265-11e7-8dc9-81c88323b224.jpeg)
12. Action `Edit` is as 'Allowed'. Change it to 'Inherit' and `Save`.
13. Back to permissions for `Manager` and check if `Edit` action has **not** been reset and still has selected 'Allowed'.

### Expected result
A new article by default inherit permissions from parent category (after stored).

### Actual result
A new article after save always has copy of permissions from com_content asset.

### Documentation Changes Required
None
