### PR TITLE
Fixing missing alias in URLs

### DIFF
--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -71,20 +71,18 @@ class ContactRouter extends JComponentRouterView
 
 		if ($category)
 		{
+			$path = array_reverse($category->getPath(), true);
+			$path[0] = '1:root';
+
 			if ($this->noIDs)
 			{
-				$path = array_reverse($category->getPath(), true);
 				foreach ($path as &$segment)
 				{
 					list($id, $segment) = explode(':', $segment, 2);
 				}
+			}
 
-				return $path;
-			}
-			else
-			{
-				return array_reverse($category->getPath(), true);
-			}
+			return $path;
 		}
 
 		return array();

--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -113,25 +113,23 @@ class ContactRouter extends JComponentRouterView
 	 */
 	public function getContactSegment($id, $query)
 	{
+		if (!strpos($id, ':'))
+		{
+			$db = JFactory::getDbo();
+			$dbquery = $db->getQuery(true);
+			$dbquery->select($dbquery->qn('alias'))
+				->from($dbquery->qn('#__contact_details'))
+				->where('id = ' . $dbquery->q((int) $id));
+			$db->setQuery($dbquery);
+
+			$id .= ':' . $db->loadResult();
+		}
+
 		if ($this->noIDs)
 		{
-			if (strpos($id, ':'))
-			{
-				list($void, $segment) = explode(':', $id, 2);
+			list($void, $segment) = explode(':', $id, 2);
 
-				return array($void => $segment);
-			}
-			else
-			{
-				$db = JFactory::getDbo();
-				$dbquery = $db->getQuery(true);
-				$dbquery->select($dbquery->qn('alias'))
-					->from($dbquery->qn('#__contact_details'))
-					->where('id = ' . $dbquery->q((int) $id));
-				$db->setQuery($dbquery);
-
-				return array($id => $id . ':' . $db->loadResult());
-			}
+			return array($void => $segment);
 		}
 
 		return array((int) $id => $id);

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -73,20 +73,18 @@ class ContentRouter extends JComponentRouterView
 
 		if ($category)
 		{
+			$path = array_reverse($category->getPath(), true);
+			$path[0] = '1:root';
+
 			if ($this->noIDs)
 			{
-				$path = array_reverse($category->getPath(), true);
 				foreach ($path as &$segment)
 				{
 					list($id, $segment) = explode(':', $segment, 2);
 				}
+			}
 
-				return $path;
-			}
-			else
-			{
-				return array_reverse($category->getPath(), true);
-			}
+			return $path;
 		}
 
 		return array();

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -115,25 +115,23 @@ class ContentRouter extends JComponentRouterView
 	 */
 	public function getArticleSegment($id, $query)
 	{
+		if (!strpos($id, ':'))
+		{
+			$db = JFactory::getDbo();
+			$dbquery = $db->getQuery(true);
+			$dbquery->select($dbquery->qn('alias'))
+				->from($dbquery->qn('#__content'))
+				->where('id = ' . $dbquery->q($id));
+			$db->setQuery($dbquery);
+
+			$id .= ':' . $db->loadResult();
+		}
+
 		if ($this->noIDs)
 		{
-			if (strpos($id, ':'))
-			{
-				list($void, $segment) = explode(':', $id, 2);
+			list($void, $segment) = explode(':', $id, 2);
 
-				return array($void => $segment);
-			}
-			else
-			{
-				$db = JFactory::getDbo();
-				$dbquery = $db->getQuery(true);
-				$dbquery->select($dbquery->qn('alias'))
-					->from($dbquery->qn('#__content'))
-					->where('id = ' . $dbquery->q($id));
-				$db->setQuery($dbquery);
-
-				return array($id => $id . ':' . $db->loadResult());
-			}
+			return array($void => $segment);
 		}
 
 		return array((int) $id => $id);

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -111,25 +111,23 @@ class NewsfeedsRouter extends JComponentRouterView
 	 */
 	public function getNewsfeedSegment($id, $query)
 	{
+		if (!strpos($id, ':'))
+		{
+			$db = JFactory::getDbo();
+			$dbquery = $db->getQuery(true);
+			$dbquery->select($dbquery->qn('alias'))
+				->from($dbquery->qn('#__newsfeeds'))
+				->where('id = ' . $dbquery->q((int) $id));
+			$db->setQuery($dbquery);
+
+			$id .= ':' . $db->loadResult();
+		}
+
 		if ($this->noIDs)
 		{
-			if (strpos($id, ':'))
-			{
-				list($void, $segment) = explode(':', $id, 2);
+			list($void, $segment) = explode(':', $id, 2);
 
-				return array($void => $segment);
-			}
-			else
-			{
-				$db = JFactory::getDbo();
-				$dbquery = $db->getQuery(true);
-				$dbquery->select($dbquery->qn('alias'))
-					->from($dbquery->qn('#__newsfeeds'))
-					->where('id = ' . $dbquery->q((int) $id));
-				$db->setQuery($dbquery);
-
-				return array($id => $id . ':' . $db->loadResult());
-			}
+			return array($void => $segment);
 		}
 
 		return array((int) $id => $id);

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -69,20 +69,18 @@ class NewsfeedsRouter extends JComponentRouterView
 		$category = JCategories::getInstance($this->getName())->get($id);
 		if ($category)
 		{
+			$path = array_reverse($category->getPath(), true);
+			$path[0] = '1:root';
+
 			if ($this->noIDs)
 			{
-				$path = array_reverse($category->getPath(), true);
 				foreach ($path as &$segment)
 				{
 					list($id, $segment) = explode(':', $segment, 2);
 				}
+			}
 
-				return $path;
-			}
-			else
-			{
-				return array_reverse($category->getPath(), true);
-			}
+			return $path;
 		}
 
 		return array();


### PR DESCRIPTION
Pull Request for Issue #9698.

### Summary of Changes
The modern router currently has a slightly broken behavior regarding malformed router input. If a URL given to the router does not contain a complete slug, it will either create a URL without an alias (when it is supposed to create them with IDs), or it will create a URL with a proper alias, but also with an ID, even though removing IDs is enabled. This fixes that.

### Testing Instructions
1. Enable modern routing
2. Create an article with links to another article, a contact and a newsfeed and, disabling the editor, edit all three URLs to only contain &id=<number> instead of &id=<number>:<alias>.
3. Check in the frontend that the URL looks right except for the last segment, which is only the ID.
4. Enable "Remove IDs from URL" for all three components and check again and see that now all three links have an alias, but also still contain the ID.
5. Apply these changes
6. Check again in the frontend and see that all three links are now correctly formed, containing just an alias and no ID.
7. Disable the "Remove IDs from URL" for all three components and now see that all three URLs contain an ID and an alias.

### Documentation Changes Required
No doc changes required.
