### PR TITLE
Reset Hits in batch copying if column exists

### DIFF
--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -409,6 +409,11 @@ abstract class JModelAdmin extends JModelForm
 				$this->table->state = 0;
 			}
 
+			if (isset($this->table->hits))
+			{
+				$this->table->hits = 0;
+			}
+
 			// New category ID
 			$this->table->catid = $categoryId;
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -409,9 +409,11 @@ abstract class JModelAdmin extends JModelForm
 				$this->table->state = 0;
 			}
 
-			if (isset($this->table->hits))
+			$hitsAlias = $this->table->getColumnAlias('hits');
+
+			if (isset($this->table->$hitsAlias))
 			{
-				$this->table->hits = 0;
+				$this->table->$hitsAlias = 0;
 			}
 
 			// New category ID


### PR DESCRIPTION
### Summary of Changes

When you batch copy items the hits counter (if there is one) is not reseted. This PR prevents overriding the method for just a one line code change.

### Testing Instructions

Test if after duplication the hits of duplicated items (which support hits and are not overriding the method!) are set to zero.

### Expected result

Hits are reset to zero after duplication

### Actual result

Hits are currently the same as the item copied from..

### Documentation Changes Required

None