### PR TITLE
[com_fields] Calendar Field Plugin options, Language string is missing

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_calendar.ini
@@ -5,6 +5,7 @@
 
 PLG_FIELDS_CALENDAR="Fields - Calendar"
 PLG_FIELDS_CALENDAR_LABEL="Calendar (%s)"
+PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL="Format"
 PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_DESC="If enabled, the calendar field expects a date and time and will also display the time. The formats are localised using the regular language strings."
 PLG_FIELDS_CALENDAR_PARAMS_SHOWTIME_LABEL="Show Time"
 PLG_FIELDS_CALENDAR_XML_DESCRIPTION="This plugin lets create new fields of type 'Calendar' in the extensions where custom fields are implemented."


### PR DESCRIPTION
Pull Request for Issue #14339

### Summary of Changes

Add missing language string PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL

### Testing Instructions

Go to the Plugin settings of the calender fields.

### Expected result

language string is translated

### Actual result

![image](https://cloud.githubusercontent.com/assets/828371/23582411/d807a558-0129-11e7-9c76-aedb486a2a21.png)

### Documentation Changes Required

None