### PR TITLE
Remove useless format parameter from custom calendar field plugin

### DIFF
--- a/plugins/fields/calendar/calendar.xml
+++ b/plugins/fields/calendar/calendar.xml
@@ -18,19 +18,4 @@
 		<language tag="en-GB">en-GB.plg_fields_calendar.ini</language>
 		<language tag="en-GB">en-GB.plg_fields_calendar.sys.ini</language>
 	</languages>
-	<config>
-		<fields name="params">
-			<fieldset name="basic">
-				<field
-					name="format"
-					type="text"
-					default="%Y-%m-%d"
-					class="input-xxlarge"
-					label="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_LABEL"
-					description="PLG_FIELDS_CALENDAR_PARAMS_FORMAT_DESC"
-					size="20"
-				/>
-			</fieldset>
-		</fields>
-	</config>
 </extension>


### PR DESCRIPTION
Pull Request for Issue #14339 and  #14340.

### Summary of Changes
Removing the unused format parameter from the calendar plugin


### Testing Instructions
Not much to test actually since the parameter isn't used.
Test that it doesn't appear anymore in the plugin settings for the fields - calendar plugin

### Documentation Changes Required
None