### PR TITLE
[com_media] Styling change for folder tree

### DIFF
--- a/administrator/components/com_media/views/media/tmpl/default.php
+++ b/administrator/components/com_media/views/media/tmpl/default.php
@@ -50,7 +50,7 @@ if ($lang->isRtl())
 		<h3 style="padding-left: 10px;"><?php echo JText::_('COM_MEDIA_FOLDERS'); ?> </h3>
 		</div>
 		<div id="treeview" class="sidebar">
-			<div id="media-tree_tree" class="sidebar-nav">
+			<div id="media-tree_tree" class="tree-holder">
 				<?php echo $this->loadTemplate('folders'); ?>
 			</div>
 		</div>

--- a/administrator/components/com_media/views/media/tmpl/default_folders.php
+++ b/administrator/components/com_media/views/media/tmpl/default_folders.php
@@ -13,14 +13,14 @@ defined('_JEXEC') or die;
 $ulTarget = str_replace('/', '-', $this->folders['data']->relative);
 
 ?>
-<ul class="nav nav-list collapse in" id="collapseFolder-<?php echo $ulTarget; ?>">
+<ul class="nav nav-list" id="collapseFolder-<?php echo $ulTarget; ?>">
 <?php if (isset($this->folders['children'])) :
 	foreach ($this->folders['children'] as $folder) :
 	// Get a sanitised name for the target
 	$target = str_replace('/', '-', $folder['data']->relative); ?>
-	<li id="<?php echo $target; ?>">
-		<a href="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $folder['data']->relative; ?>" target="folderframe">
-			<span class="icon-folder-2 pull-left"></span>
+	<li id="<?php echo $target; ?>" class="folder">
+		<a href="index.php?option=com_media&amp;view=mediaList&amp;tmpl=component&amp;folder=<?php echo $folder['data']->relative; ?>" target="folderframe" class="folder-url" >
+			<span class="icon-folder"></span>
 			<?php echo $folder['data']->name; ?>
 		</a>
 		<?php echo $this->getFolderLevel($folder); ?>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -9019,6 +9019,9 @@ textarea.noResize {
 	box-shadow: -3px 0 0 #3071a9;
 	border-left: 0;
 }
+.com_media .tree-holder {
+	padding: 0 10px;
+}
 .pull-right {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -9019,3 +9019,6 @@ textarea.noResize {
 	box-shadow: -3px 0 0 #3071a9;
 	border-left: 0;
 }
+.com_media .tree-holder {
+	padding: 0 10px;
+}

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -2035,7 +2035,7 @@ textarea.noResize {
 	}
 }
 
-/* com_templates */
+/* Folder/File Tree */
 .tree-holder {
 	.folder-url, .file {
 		position: relative;
@@ -2069,5 +2069,11 @@ textarea.noResize {
 				border-left: 0;
 			}
 		}
+	}
+}
+
+.com_media {
+	.tree-holder {
+		padding: 0 10px;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR applies the changes on https://github.com/joomla/joomla-cms/pull/14052 to the com_media folder tree

### Testing Instructions
Apply patch and navigate to Content -> Media

### Before Patch
![media-tree1](https://cloud.githubusercontent.com/assets/2803503/23586121/d2417876-0186-11e7-95ee-58413d4320ec.png)
### After Patch
![media-tree2](https://cloud.githubusercontent.com/assets/2803503/23586122/d4b7dc80-0186-11e7-8cc3-9eb5a3e1f3a1.png)

### Documentation Changes Required
Possibly screenshots
