### PR TITLE
Remove redundant rule-set from template.less

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8902,14 +8902,6 @@ textarea.noResize {
 		padding-right: 10px;
 	}
 }
-@media (max-width: 979px) {
-	.com_fields .row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-	}
-	.com_fields .row-fluid [class*="span"]:first-of-type {
-		margin-left: 0;
-	}
-}
 .popover-content {
 	min-height: 33px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8902,14 +8902,6 @@ textarea.noResize {
 		padding-right: 10px;
 	}
 }
-@media (max-width: 979px) {
-	.com_fields .row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-	}
-	.com_fields .row-fluid [class*="span"]:first-of-type {
-		margin-left: 0;
-	}
-}
 .popover-content {
 	min-height: 33px;
 }

--- a/administrator/templates/isis/less/template.less
+++ b/administrator/templates/isis/less/template.less
@@ -1937,15 +1937,6 @@ textarea.noResize {
 		}
 	}
 }
-// Following can be removed if a solution is found for #13768
-@media (max-width: 979px) {
-	.com_fields .row-fluid [class*="span"] {
-		margin-left: 2.12766%;
-		&:first-of-type {
-			margin-left: 0;
-		}
-	} 
-}
 
 /* Popover minimum height - overwrite bootstrap default */
 .popover-content {


### PR DESCRIPTION
Pull Request for Issue .

### Summary of Changes
Since #13845 the following can be removed from the Isis template.less

```
// Following can be removed if a solution is found for #13768
@media (max-width: 979px) {
	.com_fields .row-fluid [class*="span"] {
		margin-left: 2.12766%;
		&:first-of-type {
			margin-left: 0;
		}
	} 
}
```

### Testing Instructions
Apply patch and check that merged #13769 still tests correctly

### Documentation Changes Required
None
