### PR TITLE
Fix typo

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -449,7 +449,7 @@ class JControllerLegacy extends JObject
 		foreach ((array) $path as $dir)
 		{
 			// No surrounding spaces allowed!
-			$dir = rtrim(JPath::check($dir, '/'), '/') . '/';
+			$dir = rtrim(JPath::check($dir), '/') . '/';
 
 			// Add to the top of the search dirs
 			array_unshift($this->paths[$type], $dir);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The method JPath::check() https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/filesystem/path.php#L165 only has one parameter but we are passing two parameters in the method call and it is wrong.  This PR just fixes that typo.

### Testing Instructions
Code review

