### PR TITLE
Fieldset double translation

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -430,7 +430,7 @@ class FieldsHelper
 						$key = 'JGLOBAL_FIELDS';
 					}
 
-					$label = JText::_($key);
+					$label = $key;
 				}
 
 				if (!$description)
@@ -439,7 +439,7 @@ class FieldsHelper
 
 					if ($lang->hasKey($key))
 					{
-						$description = JText::_($key);
+						$description = $key;
 					}
 				}
 			}


### PR DESCRIPTION
Pull Request for Issue #14366

### Summary of Changes
Fieldsets label and description are automatically passed through JText.
No use to to add JText in the helpers


### Testing Instructions
Create an article field and do not assign it to a group.
Enable Language debug in Global Configuration.
Edit or create an article

Before patch the Fields Tab will display:
`??**Fields**??`

After patch
`**Fields**`
