### PR TITLE
Debug cancel buttons

### DIFF
--- a/administrator/components/com_users/views/debuggroup/view.html.php
+++ b/administrator/components/com_users/views/debuggroup/view.html.php
@@ -92,6 +92,7 @@ class UsersViewDebuggroup extends JViewLegacy
 	protected function addToolbar()
 	{
 		JToolbarHelper::title(JText::sprintf('COM_USERS_VIEW_DEBUG_GROUP_TITLE', $this->group->id, $this->group->title), 'users groups');
+		JToolbarHelper::cancel('group.cancel', 'JTOOLBAR_CLOSE');
 
 		JToolbarHelper::help('JHELP_USERS_DEBUG_GROUPS');
 	}

--- a/administrator/components/com_users/views/debuguser/view.html.php
+++ b/administrator/components/com_users/views/debuguser/view.html.php
@@ -92,6 +92,7 @@ class UsersViewDebuguser extends JViewLegacy
 	protected function addToolbar()
 	{
 		JToolbarHelper::title(JText::sprintf('COM_USERS_VIEW_DEBUG_USER_TITLE', $this->user->id, $this->user->name), 'users user');
+		JToolbarHelper::cancel('user.cancel', 'JTOOLBAR_CLOSE');
 
 		JToolbarHelper::help('JHELP_USERS_DEBUG_USERS');
 	}


### PR DESCRIPTION
This PR adds a "Close" button to the user and usergroup debug views which allows to get back to the regular manager.

### Summary of Changes
Adds said button


### Testing Instructions
* Enable "Debug System" in the Joomla Global Configuration (System tab).
* Go to User (or User Groups) Manager and click on the "Debug Permissions Report" link next to the user (or user group)
![debug](https://cloud.githubusercontent.com/assets/1018684/23615372/74abf6f4-0286-11e7-80d0-e393c5ce3e78.PNG)


### Expected result
With this PR you have a "Close" button which brings you back to the manager view.
![close](https://cloud.githubusercontent.com/assets/1018684/23615374/797bbade-0286-11e7-956e-4a5798057fc8.PNG)



### Actual result
No such button. You need to use the menu to get back to the manager.


### Documentation Changes Required
Maybe tutorials may need new screenshots.

#### Disclaimer
Work is done by @brianteeman 