### PR TITLE
[com_fields] Define the buttons to hide as list

### DIFF
--- a/plugins/fields/editor/editor.php
+++ b/plugins/fields/editor/editor.php
@@ -41,6 +41,7 @@ class PlgFieldsEditor extends FieldsPlugin
 		}
 
 		$fieldNode->setAttribute('buttons', $field->fieldparams->get('buttons', 0) ? 'true' : 'false');
+		$fieldNode->setAttribute('hide', implode(',', $field->fieldparams->get('hide', array())));
 		$fieldNode->setAttribute('filter', 'JComponentHelper::filterText');
 
 		return $fieldNode;

--- a/plugins/fields/editor/editor.xml
+++ b/plugins/fields/editor/editor.xml
@@ -32,15 +32,16 @@
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 				</field>
-	
+
 				<field
 					name="hide"
-					type="text"
-					default="pagebreak,readmore"
+					type="plugins"
+					folder="editors-xtd"
+					multiple="true"
 					label="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL"
 					description="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC"
 				/>
-	
+
 				<field
 					name="width"
 					type="text"
@@ -49,7 +50,7 @@
 					description="PLG_FIELDS_EDITOR_PARAMS_WIDTH_DESC"
 					size="5"
 				/>
-	
+
 				<field
 					name="height"
 					type="text"

--- a/plugins/fields/editor/params/editor.xml
+++ b/plugins/fields/editor/params/editor.xml
@@ -15,7 +15,9 @@
 
 			<field
 				name="hide"
-				type="text"
+				type="plugins"
+				folder="editors-xtd"
+				multiple="true"
 				label="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL"
 				description="PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC"
 			/>


### PR DESCRIPTION
Pull Request for Issue #14342.

### Summary of Changes
Changes the buttons to hide in the editor custom field to a list of button plugins. This does NOT work with Tynimce, probably a bug or what do you think @dgt41?

### Testing Instructions
- In the global configuration select any editor except Tynimce as default editor.
- Create a new Editor custom field.
- Select in the buttons to hide list "Button Module" and "Button Article".
- Save the field.
- Open an article

### Expected result
The buttons "Module" and "Article" are not visible on the editor field.

### Actual result
The buttons "Module" and "Article" are not visible on the editor field.