### PR TITLE
We have a Registry class to handle this.

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit.php
+++ b/administrator/components/com_content/views/article/tmpl/edit.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\Registry\Registry;
+
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
@@ -22,45 +24,13 @@ $this->hiddenFieldsets  = array('basic-limited');
 $this->ignore_fieldsets = array('jmetadata', 'item_associations');
 
 // Create shortcut to parameters.
-$params = $this->state->get('params');
+$params = clone($this->state->get('params'));
+$params->merge(new Registry($this->item->attribs));
 
 $app = JFactory::getApplication();
 $input = $app->input;
 
 $assoc = JLanguageAssociations::isEnabled();
-
-// This checks if the config options have ever been saved. If they haven't they will fall back to the original settings.
-$params = json_decode($params);
-$editoroptions = isset($params->show_publishing_options);
-
-if (!$editoroptions)
-{
-	$params->show_publishing_options = '1';
-	$params->show_article_options = '1';
-	$params->show_urls_images_backend = '0';
-	$params->show_urls_images_frontend = '0';
-}
-
-// Check if the article uses configuration settings besides global. If so, use them.
-if (isset($this->item->attribs['show_publishing_options']) && $this->item->attribs['show_publishing_options'] != '')
-{
-	$params->show_publishing_options = $this->item->attribs['show_publishing_options'];
-}
-
-if (isset($this->item->attribs['show_article_options']) && $this->item->attribs['show_article_options'] != '')
-{
-	$params->show_article_options = $this->item->attribs['show_article_options'];
-}
-
-if (isset($this->item->attribs['show_urls_images_frontend']) && $this->item->attribs['show_urls_images_frontend'] != '')
-{
-	$params->show_urls_images_frontend = $this->item->attribs['show_urls_images_frontend'];
-}
-
-if (isset($this->item->attribs['show_urls_images_backend']) && $this->item->attribs['show_urls_images_backend'] != '')
-{
-	$params->show_urls_images_backend = $this->item->attribs['show_urls_images_backend'];
-}
 
 JFactory::getDocument()->addScriptDeclaration('
 	Joomla.submitbutton = function(task)
@@ -107,7 +77,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 		<?php echo JHtml::_('bootstrap.endTab'); ?>
 
 		<?php // Do not show the images and links options if the edit form is configured not to. ?>
-		<?php if ($params->show_urls_images_backend == 1) : ?>
+		<?php if ($params->get('show_urls_images_backend') == 1) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'images', JText::_('COM_CONTENT_FIELDSET_URLS_AND_IMAGES')); ?>
 			<div class="row-fluid form-horizontal-desktop">
 				<div class="span6">
@@ -125,11 +95,11 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 		<?php endif; ?>
 
-		<?php $this->show_options = $params->show_article_options; ?>
+		<?php $this->show_options = $params->get('show_article_options', 1); ?>
 		<?php echo JLayoutHelper::render('joomla.edit.params', $this); ?>
 
 		<?php // Do not show the publishing options if the edit form is configured not to. ?>
-		<?php if ($params->show_publishing_options == 1) : ?>
+		<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'publishing', JText::_('COM_CONTENT_FIELDSET_PUBLISHING')); ?>
 			<div class="row-fluid form-horizontal-desktop">
 				<div class="span6">


### PR DESCRIPTION
The article edit form has some rather complex code just to override some display options based on item attributes. Our JRegistry class could handle that much more simpler.

### Summary of Changes
Replaces the rather complex code with proper Registry calls.


### Testing Instructions
* Make sure the article options in the "Configure Edit Screen" behave as expected. You can ignor ethe "Frontend Images and Links" one as that one isn't used in the backend form (for obvious reasons).


### Expected result
Setting one of the options to "No" should hide the respective tab even if global options are set to "Yes" and vice versa. Article settings take precedence over global settings.


### Actual result
Same behavior.


### Documentation Changes Required
None
