### PR TITLE
[Protostar] Media modal image select

### DIFF
--- a/media/media/css/popup-imagelist.css
+++ b/media/media/css/popup-imagelist.css
@@ -62,3 +62,162 @@ html>body .item img {
 	background-color: #eee;
 	color: #095197;
 }
+
+.thumbnails.thumbnails-media {
+	margin-left: 0;
+}
+.thumbnails-media .thumbnail {
+	background-color: #f4f4f4;
+	border-radius: 3px;
+	border: 0;
+	box-shadow: 0 0 0 1px rgba(0,0,0,0.05) inset;
+	padding: 0px;
+	height: 100px;
+	width: 100px;
+	margin: 8px 16px;
+	margin-left: 0 !important;
+	position: relative;
+	text-align: center;
+	overflow: hidden;
+}
+.thumbnails-media .thumbnail .close {
+	background-color: #ccc;
+	border-left: 1px solid rgba(0,0,0,0.1);
+	height: 22px;
+	line-height: 22px;
+	opacity: 0.3;
+	text-align: center;
+	width: 22px;
+	top: 0;
+	right: 0;
+}
+.thumbnails-media .thumbnail .close:hover {
+	background-color: #bbb;
+}
+.thumbnails-media .thumbnail *,
+.thumbnails-media .thumbnail *:before {
+	-webkit-transition: all 0.2s ease;
+	transition: all 0.2s ease;
+	-webkit-background-clip: padding-box;
+	background-clip: padding-box;
+	-webkit-box-sizing: border-box;
+	box-sizing: border-box;
+}
+.thumbnails-media .thumbnail input[type="radio"],
+.thumbnails-media .thumbnail input[type="checkbox"] {
+	margin: 0;
+	opacity: 0.55;
+	position: absolute;
+	top: 5px;
+	left: 5px;
+}
+.thumbnails-media .thumbnail .controls,
+.thumbnails-media .thumbnail .imginfoBorder {
+	display: none;
+}
+.thumbnails-media .imgThumb {
+	position: relative;
+	z-index: 1;
+	width: 100%;
+	display: inline-block;
+}
+.thumbnails-media .imgThumb input {
+	display: none;
+}
+.thumbnails-media .imgThumb label,
+.thumbnails-media .imgThumb .imgThumbInside {
+	display: block;
+	line-height: 100px;
+	position: relative;
+	width: 100%;
+	border-radius: 3px;
+	overflow: hidden;
+}
+.thumbnails-media .imgThumb label:before,
+.thumbnails-media .imgThumb .imgThumbInside:before {
+	font-family: "IcoMoon";
+	font-style: normal;
+	content: 'G';
+	position: absolute;
+	top: 0;
+	right: 0;
+	background-color: #46a546;
+	color: #fff;
+	line-height: 26px;
+	width: 26px;
+	-webkit-transform: scale(0.5);
+	transform: scale(0.5);
+	opacity: 0;
+	border-color: rgba(0,0,0,0.2);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+	border-radius: 0 3px;
+}
+.thumbnails-media .imgThumb img {
+	width: auto;
+}
+.thumbnails-media .selected :checked + label,
+.thumbnails-media .selected .imgThumbInside,
+.thumbnails-media .imgInput :checked + label,
+.thumbnails-media .imgInput .imgThumbInside {
+	background-color: #ddd;
+}
+.thumbnails-media .selected :checked + label:before,
+.thumbnails-media .selected .imgThumbInside:before,
+.thumbnails-media .imgInput :checked + label:before,
+.thumbnails-media .imgInput .imgThumbInside:before {
+	-webkit-transform: scale(1);
+	transform: scale(1);
+	opacity: 1;
+}
+.thumbnails-media .selected :checked + label:after,
+.thumbnails-media .selected .imgThumbInside:after,
+.thumbnails-media .imgInput :checked + label:after,
+.thumbnails-media .imgInput .imgThumbInside:after {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	content: '';
+	border: 3px solid #46a546;
+	border-radius: 5px;
+}
+.thumbnails-media .imgPreview a {
+	padding: 0;
+	position: absolute;
+	left: 0;
+	z-index: 1;
+	height: 26px;
+	width: 26px;
+}
+.thumbnails-media .imgPreview a,
+.thumbnails-media .imgDetails {
+	position: absolute;
+	left: 0;
+	background-color: #fff;
+	border-color: rgba(0,0,0,0.2);
+	bottom: 0;
+	line-height: 26px;
+	border: 1px solid rgba(0,0,0,0.1);
+	border-width: 1px 1px 0 0;
+	border-radius: 0 3px 0 0;
+	z-index: 1;
+}
+.thumbnails-media .imgPreview a:hover,
+.thumbnails-media .imgDetails:hover {
+	background-color: #eee;
+}
+.thumbnails-media .imgDetails {
+	padding: 0 5px;
+	line-height: 20px;
+	color: #555;
+}
+.thumbnails-media .imgFolder span {
+	line-height: 90px;
+	font-size: 38px;
+	margin: 0;
+	width: auto;
+}
+.thumbnails-media .imgFolder + .imgDetails {
+	color: inherit;
+}

--- a/templates/protostar/html/com_media/imageslist/default_folder.php
+++ b/templates/protostar/html/com_media/imageslist/default_folder.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$input = JFactory::getApplication()->input;
+?>
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a href="index.php?option=com_media&amp;view=imagesList&amp;tmpl=component&amp;folder=<?php echo $this->_tmp_folder->path_relative; ?>&amp;asset=<?php echo $input->getCmd('asset');?>&amp;author=<?php echo $input->getCmd('author');?>" target="imageframe">
+		<div class="imgFolder">
+			<span class="icon-folder-2"></span>
+		</div>
+		<div class="small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_folder->name, 10, false); ?>
+		</div>
+	</a>
+</li>

--- a/templates/protostar/html/com_media/imageslist/default_image.php
+++ b/templates/protostar/html/com_media/imageslist/default_image.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_media
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
+
+$params     = new Registry;
+$dispatcher = JEventDispatcher::getInstance();
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+?>
+
+<li class="imgOutline thumbnail height-80 width-80 center">
+	<a class="img-preview" href="javascript:ImageManager.populateFields('<?php echo $this->_tmp_img->path_relative; ?>')" title="<?php echo $this->_tmp_img->name; ?>" >
+		<div class="imgThumb">
+			<div class="imgThumbInside">
+			<?php echo JHtml::_('image', $this->baseURL . '/' . $this->_tmp_img->path_relative, JText::sprintf('COM_MEDIA_IMAGE_TITLE', $this->_tmp_img->title, JHtml::_('number.bytes', $this->_tmp_img->size)), array('width' => $this->_tmp_img->width_60, 'height' => $this->_tmp_img->height_60)); ?>
+			</div>
+		</div>
+		<div class="imgDetails small">
+			<?php echo JHtml::_('string.truncate', $this->_tmp_img->name, 10, false); ?>
+		</div>
+	</a>
+</li>
+<?php
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));


### PR DESCRIPTION
Pull Request for Issue #14397 .

### Summary of Changes
Applies #12643 to Protostar

### Testing Instructions
Apply patch. In Article: Options set 'Frontend Images and Links' ('Editing Layout' tab) to Yes.

Select a Intro- or Full-Article-Image at Frontend

### Before Patch
![image-frontend1](https://cloud.githubusercontent.com/assets/2803503/23650129/f4850eaa-0318-11e7-802f-3ce37031fab2.JPG)

### After Patch
![image-frontend3](https://cloud.githubusercontent.com/assets/2803503/23650180/25214ef2-0319-11e7-89dd-cee5dbfcabbc.jpg)

### Documentation Changes Required
None
