### PR TITLE
[com_fields] Change the default value text of the user field

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -3,9 +3,10 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_USER="Fields - User"
-PLG_FIELDS_USER_LABEL="User (%s)"
-PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'user' in the extensions where custom fields are implemented."
 
 COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL="Default Users"
 COM_FIELDS_FIELD_DEFAULT_VALUE_DESC="A comma separated list of user ids."
+
+PLG_FIELDS_USER="Fields - User"
+PLG_FIELDS_USER_LABEL="User (%s)"
+PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'user' in the extensions where custom fields are implemented."

--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -6,3 +6,6 @@
 PLG_FIELDS_USER="Fields - User"
 PLG_FIELDS_USER_LABEL="User (%s)"
 PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets create new fields of type 'user' in the extensions where custom fields are implemented."
+
+COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL="Default Users"
+COM_FIELDS_FIELD_DEFAULT_VALUE_DESC="A comma separated list of user ids."


### PR DESCRIPTION
Pull Request for Issue #14362.

### Summary of Changes
Changes the default text of the user custom field.


### Testing Instructions
Create a user custom field.


### Expected result
The following default text should be shown:
> Default Users

With the tooltip:
> A comma separated list of user ids.


### Actual result
The standard text of com_fields is shown.


### Documentation Changes Required

