### PR TITLE
[com_fields] Show categories when a category is available in fields list

### DIFF
--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -147,9 +147,10 @@ if ($saveOrder)
 									<div class="small">
 										<?php if ($category) : ?>
 											<?php echo JText::_('JCATEGORY') . ': '; ?>
-											<?php if ($categories = FieldsHelper::getAssignedCategoriesTitles($item->id)) : ?>
+											<?php $categories = FieldsHelper::getAssignedCategoriesTitles($item->id); ?>
+											<?php if ($categories) : ?>
 												<?php echo implode(', ', $categories); ?>
-											<?php else: ?>
+											<?php else : ?>
 												<?php echo JText::_('JALL'); ?>
 											<?php endif; ?>
 										<?php endif; ?>

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -25,6 +25,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.ordering');
 $saveOrder = ($listOrder == 'a.ordering' && strtolower($listDirn) == 'asc');
 
+// The category object of the component
+$category = JCategories::getInstance(str_replace('com_', '', $component));
+
 if ($saveOrder)
 {
 	$saveOrderingUrl = 'index.php?option=com_fields&task=fields.saveOrderAjax&tmpl=component';
@@ -142,11 +145,13 @@ if ($saveOrder)
 										<?php endif; ?>
 									</span>
 									<div class="small">
-										<?php echo JText::_('JCATEGORY') . ': '; ?>
-										<?php if ($categories = FieldsHelper::getAssignedCategoriesTitles($item->id)) : ?>
-											<?php echo implode(', ', $categories); ?>
-										<?php else: ?>
-											<?php echo JText::_('JALL'); ?>
+										<?php if ($category) : ?>
+											<?php echo JText::_('JCATEGORY') . ': '; ?>
+											<?php if ($categories = FieldsHelper::getAssignedCategoriesTitles($item->id)) : ?>
+												<?php echo implode(', ', $categories); ?>
+											<?php else: ?>
+												<?php echo JText::_('JALL'); ?>
+											<?php endif; ?>
 										<?php endif; ?>
 									</div>
 								</div>


### PR DESCRIPTION
Pull Request for Issue #14373.

### Summary of Changes
Don't show the category information in the fields list, when the component doesn't use categories.


### Testing Instructions
- Log in on the back end
- Go to Users -> Fields
- Create a new custom field

### Expected result
Below the custom field title is no label "Category: All" shown.


### Actual result
"Category: All" label is shown below the field title.