### PR TITLE
[com_fields] Show field group description when opening a user profile

### DIFF
--- a/components/com_users/views/profile/tmpl/default_custom.php
+++ b/components/com_users/views/profile/tmpl/default_custom.php
@@ -39,6 +39,9 @@ foreach ($tmp as $customField)
 			<?php if (isset($fieldset->label) && strlen($legend = trim(JText::_($fieldset->label)))) : ?>
 				<legend><?php echo $legend; ?></legend>
 			<?php endif; ?>
+			<?php if (isset($fieldset->description) && trim($fieldset->description)) : ?>
+				<p><?php echo $this->escape(JText::_($fieldset->description)); ?></p>
+			<?php endif; ?>
 			<dl class="dl-horizontal">
 				<?php foreach ($fields as $field) : ?>
 					<?php if (!$field->hidden && $field->type !== 'Spacer') : ?>


### PR DESCRIPTION
Pull Request for Issue #14372.

### Summary of Changes
Shows the field group description when opening a user profile.

![image](https://cloud.githubusercontent.com/assets/251072/23659147/7a391aec-0345-11e7-8e34-82717834e9f2.png)

![image](https://cloud.githubusercontent.com/assets/251072/23659125/6c2c3a7e-0345-11e7-8854-588197c76418.png)


### Testing Instructions
- Create a user field group Demo1 with a description text _Some field group description_
- Create a user custom field and assign it to the group Demo1
- Create a User -> Profile menu item


### Expected result
On the front should the description _Some field group description_ be visible below the field group name.


### Actual result
The description _Some field group description_ is not shown.