### PR TITLE
Move JLanguage* to namespace

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -57,3 +57,6 @@ JLoader::registerAlias('JRules',                       '\\Joomla\\Cms\\Access\\R
 JLoader::registerAlias('JAuthenticationHelper',        '\\Joomla\\Cms\\Authentication\\AuthenticationHelper', '4.0');
 
 JLoader::registerAlias('JHelp',                        '\\Joomla\\Cms\\Help\\Help', '4.0');
+
+JLoader::registerAlias('JLanguageAssociations',        '\\Joomla\\Cms\\Language\\Associations', '4.0');
+JLoader::registerAlias('JLanguageMultilang',           '\\Joomla\\Cms\\Language\\Multilanguage', '4.0');

--- a/libraries/src/Joomla/Cms/Language/Associations.php
+++ b/libraries/src/Joomla/Cms/Language/Associations.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * @package     Joomla.Libraries
- * @subpackage  Language
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
+
+namespace Joomla\Cms\Language;
 
 defined('JPATH_PLATFORM') or die;
 
@@ -16,7 +17,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.1
  */
-class JLanguageAssociations
+class Associations
 {
 	/**
 	 * Get the associations.
@@ -46,7 +47,7 @@ class JLanguageAssociations
 		{
 			$multilanguageAssociations[$queryKey] = array();
 
-			$db = JFactory::getDbo();
+			$db = \JFactory::getDbo();
 			$categoriesExtraSql = (($tablename === '#__categories') ? ' AND c2.extension = ' . $db->quote($extension) : '');
 			$query = $db->getQuery(true)
 				->select($db->quoteName('c2.language'))
@@ -100,9 +101,9 @@ class JLanguageAssociations
 			{
 				$items = $db->loadObjectList('language');
 			}
-			catch (RuntimeException $e)
+			catch (\RuntimeException $e)
 			{
-				throw new Exception($e->getMessage(), 500, $e);
+				throw new \Exception($e->getMessage(), 500, $e);
 			}
 
 			if ($items)
@@ -137,12 +138,12 @@ class JLanguageAssociations
 		// Status of language filter parameter.
 		static $enabled = false;
 
-		if (JLanguageMultilang::isEnabled())
+		if (Multilanguage::isEnabled())
 		{
 			// If already tested, don't test again.
 			if (!$tested)
 			{
-				$plugin = JPluginHelper::getPlugin('system', 'languagefilter');
+				$plugin = \JPluginHelper::getPlugin('system', 'languagefilter');
 
 				if (!empty($plugin))
 				{

--- a/libraries/src/Joomla/Cms/Language/Multilanguage.php
+++ b/libraries/src/Joomla/Cms/Language/Multilanguage.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * @package     Joomla.Libraries
- * @subpackage  Language
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
+
+namespace Joomla\Cms\Language;
 
 defined('JPATH_PLATFORM') or die;
 
@@ -14,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  2.5.4
  */
-class JLanguageMultilang
+class Multilanguage
 {
 	/**
 	 * Method to determine if the language filter plugin is enabled.
@@ -33,7 +34,7 @@ class JLanguageMultilang
 		static $enabled = false;
 
 		// Get application object.
-		$app = JFactory::getApplication();
+		$app = \JFactory::getApplication();
 
 		// If being called from the frontend, we can avoid the database query.
 		if ($app->isClient('site'))
@@ -47,7 +48,7 @@ class JLanguageMultilang
 		if (!$tested)
 		{
 			// Determine status of language filter plugin.
-			$db = JFactory::getDbo();
+			$db = \JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select('enabled')
 				->from($db->quoteName('#__extensions'))
@@ -69,13 +70,13 @@ class JLanguageMultilang
 	 * @return  array of language extension objects.
 	 *
 	 * @since   3.5
-	 * @deprecated   3.7.0  Use JLanguageHelper::getInstalledLanguages(0) instead.
+	 * @deprecated   3.7.0  Use \JLanguageHelper::getInstalledLanguages(0) instead.
 	 */
 	public static function getSiteLangs()
 	{
-		JLog::add(__METHOD__ . ' is deprecated. Use JLanguageHelper::getInstalledLanguages(0) instead.', JLog::WARNING, 'deprecated');
+		\JLog::add(__METHOD__ . ' is deprecated. Use \JLanguageHelper::getInstalledLanguages(0) instead.', \JLog::WARNING, 'deprecated');
 
-		return JLanguageHelper::getInstalledLanguages(0);
+		return \JLanguageHelper::getInstalledLanguages(0);
 	}
 
 	/**
@@ -93,7 +94,7 @@ class JLanguageMultilang
 		if (!isset($multilangSiteHomePages))
 		{
 			// Check for Home pages languages.
-			$db = JFactory::getDbo();
+			$db = \JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select('language')
 				->select('id')


### PR DESCRIPTION
Moves the classes JLanguageAssociations and JLanguageMultilang to namespace.

To ensure BC, it was tested with [lanternfish](https://extensions.joomla.org/extensions/extension/languages/multi-lingual-content/the-lanternfish/) to have a test with an existing extension. Lanternfish is overriding **JLanguageMultilang** on the site part of Joomla and that worked. So @wilsonge guess we have a working real world scenario.