### PR TITLE
Correcting persian and dari calendar-locale "Close" string

### DIFF
--- a/media/system/js/fields/calendar-locales/fa-ir.js
+++ b/media/system/js/fields/calendar-locales/fa-ir.js
@@ -14,7 +14,7 @@ window.JoomlaCalLocale = {
 	dateType : "jalali",
 	minYear : 1268,
 	maxYear : 1458,
-	exit: "ستن",
+	exit: "بستن",
 	save: "پاک",
 	localLangNumbers: ["۰","۱","۲","۳","۴","۵","۶","۷","۸","۹"]
 };

--- a/media/system/js/fields/calendar-locales/prs-af.js
+++ b/media/system/js/fields/calendar-locales/prs-af.js
@@ -14,7 +14,7 @@ window.JoomlaCalLocale = {
 	dateType : "jalali",
 	minYear : 1268,
 	maxYear : 1458,
-	exit: "ستن",
+	exit: "بستن",
 	save: "پاک",
 	localLangNumbers: ["۰","۱","۲","۳","۴","۵","۶","۷","۸","۹"]
 };


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/14422#issuecomment-285172439

Close is `بستن` in Persian/Dari

Can be merged on Review.
@ghasemy50