### PR TITLE
[4.0] Fix PHP errors in com_menu

### DIFF
--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -222,14 +222,14 @@ class JFormFieldModal_Menu extends JFormField
 
 		// The current menu item display field.
 		$html  = '';
-		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
+		if ($this->allowSelect || $this->allowNew || $this->allowEdit || $this->allowClear)
 		{
 			$html .= '<span class="input-group">';
 		}
 		
 		$html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
 
-		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
+		if ($this->allowSelect || $this->allowNew || $this->allowEdit || $this->allowClear)
 		{
 			$html .= '<span class="input-group-btn">';
 		}
@@ -288,7 +288,7 @@ class JFormFieldModal_Menu extends JFormField
 				. '</a>';
 		}
 
-		if ($allowSelect || $allowNew || $allowEdit || $allowClear)
+		if ($this->allowSelect || $this->allowNew || $this->allowEdit || $this->allowClear)
 		{
 			$html .= '</span></span>';
 		}


### PR DESCRIPTION
Pull Request for Issue #14434

### Summary of Changes

This fixes the PHP errors regarding undefined variables in `com_menu`


### Testing Instructions

- Apply PR
- Go to the Module Manager and open the "Menu" module
- Ensure there are no PHP errors
