### PR TITLE
Speed up display articles by removing subquery of unpublished categories

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-03-09.sql
@@ -1,0 +1,15 @@
+UPDATE `#__categories` AS `c` INNER JOIN (
+	SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+	FROM `#__categories` AS `c2`
+	INNER JOIN `#__categories` AS `p` ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+	GROUP BY c2.id) c2
+ON c.id = c2.id
+SET published = c2.newPublished;
+
+UPDATE `#__menu` AS `c` INNER JOIN (
+	SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+	FROM `#__menu` AS `c2`
+	INNER JOIN `#__menu` AS `p` ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+	GROUP BY c2.id) c2
+ON c.id = c2.id
+SET published = c2.newPublished;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-09.sql
@@ -1,0 +1,17 @@
+UPDATE "#__categories" AS "c"
+SET published = c2.newPublished
+FROM (
+SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+FROM "#__categories" AS "c2"
+INNER JOIN "#__categories" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+GROUP BY c2.id) AS c2
+WHERE c2.id = c.id;
+
+UPDATE "#__menu" AS "c"
+SET published = c2.newPublished
+FROM (
+SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+FROM "#__menu" AS "c2"
+INNER JOIN "#__menu" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+GROUP BY c2.id) AS c2
+WHERE c2.id = c.id;

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-03-09.sql
@@ -1,0 +1,17 @@
+UPDATE "c"
+SET published = c2.newPublished
+FROM "#__categories" AS "c"
+INNER JOIN (
+SELECT c2.id,CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+FROM "#__categories" AS "c2"
+INNER JOIN "#__categories" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+GROUP BY c2.id) AS c2 ON c2.id = c.id;
+
+UPDATE "c"
+SET published = c2.newPublished
+FROM "#__menu" AS "c"
+INNER JOIN (
+SELECT c2.id,CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
+FROM "#__menu" AS "c2"
+INNER JOIN "#__menu" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
+GROUP BY c2.id) AS c2 ON c2.id = c.id;

--- a/components/com_contact/models/featured.php
+++ b/components/com_contact/models/featured.php
@@ -160,19 +160,8 @@ class ContactModelFeatured extends JModelList
 		}
 
 		// Change for sqlsrv... aliased c.published to cat_published
-		// Join to check for category published state in parent categories up the tree
-		$query->select('c.published as cat_published, CASE WHEN badcats.id is null THEN c.published ELSE 0 END AS parents_published');
-		$subquery = 'SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ';
-		$subquery .= 'ON cat.lft BETWEEN parent.lft AND parent.rgt ';
-		$subquery .= 'WHERE parent.extension = ' . $db->quote('com_contact');
-
-		// Find any up-path categories that are not published
-		// If all categories are published, badcats.id will be null, and we just use the contact state
-		$subquery .= ' AND parent.published != 1 GROUP BY cat.id ';
-
-		// Select state to unpublished if up-path category is unpublished
-		$publishedWhere = 'CASE WHEN badcats.id is null THEN a.published ELSE 0 END';
-		$query->join('LEFT OUTER', '(' . $subquery . ') AS badcats ON badcats.id = c.id');
+		$query->select('c.published as cat_published, c.published AS parents_published')
+			->where('c.published = 1');
 
 		// Filter by state
 		$state = $this->getState('filter.published');
@@ -185,8 +174,7 @@ class ContactModelFeatured extends JModelList
 			$date = JFactory::getDate();
 			$nowDate = $db->quote($date->toSql());
 			$query->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
-				->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')')
-				->where($publishedWhere . ' = ' . (int) $state);
+				->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 		}
 
 		// Filter by language

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -88,10 +88,7 @@ class ContentModelArticle extends JModelItem
 					->select(
 						$this->getState(
 							'item.select', 'a.id, a.asset_id, a.title, a.alias, a.introtext, a.fulltext, ' .
-							// If badcats is not null, this means that the article is inside an unpublished category
-							// In this case, the state is set to 0 to indicate Unpublished (even if the article state is Published)
-							'CASE WHEN badcats.id is null THEN a.state ELSE 0 END AS state, ' .
-							'a.catid, a.created, a.created_by, a.created_by_alias, ' .
+							'a.state, a.catid, a.created, a.created_by, a.created_by_alias, ' .
 							// Use created if modified is 0
 							'CASE WHEN a.modified = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.modified END as modified, ' .
 							'a.modified_by, a.checked_out, a.checked_out_time, a.publish_up, a.publish_down, ' .
@@ -99,11 +96,13 @@ class ContentModelArticle extends JModelItem
 							'a.metakey, a.metadesc, a.access, a.hits, a.metadata, a.featured, a.language, a.xreference'
 						)
 					);
-				$query->from('#__content AS a');
+				$query->from('#__content AS a')
+					->where('a.id = ' . (int) $pk);
 
 				// Join on category table.
 				$query->select('c.title AS category_title, c.alias AS category_alias, c.access AS category_access')
-					->join('LEFT', '#__categories AS c on c.id = a.catid');
+					->innerJoin('#__categories AS c on c.id = a.catid')
+					->where('c.published > 0');
 
 				// Join on user table.
 				$query->select('u.name AS author')
@@ -121,9 +120,7 @@ class ContentModelArticle extends JModelItem
 
 				// Join on voting table
 				$query->select('ROUND(v.rating_sum / v.rating_count, 0) AS rating, v.rating_count as rating_count')
-					->join('LEFT', '#__content_rating AS v ON a.id = v.content_id')
-
-					->where('a.id = ' . (int) $pk);
+					->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 
 				if ((!$user->authorise('core.edit.state', 'com_content')) && (!$user->authorise('core.edit', 'com_content')))
 				{
@@ -136,14 +133,6 @@ class ContentModelArticle extends JModelItem
 					$query->where('(a.publish_up = ' . $nullDate . ' OR a.publish_up <= ' . $nowDate . ')')
 						->where('(a.publish_down = ' . $nullDate . ' OR a.publish_down >= ' . $nowDate . ')');
 				}
-
-				// Join to check for category published state in parent categories up the tree
-				// If all categories are published, badcats.id will be null, and we just use the article state
-				$subquery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ';
-				$subquery .= 'ON cat.lft BETWEEN parent.lft AND parent.rgt ';
-				$subquery .= 'WHERE parent.extension = ' . $db->quote('com_content');
-				$subquery .= ' AND parent.published <= 0 GROUP BY cat.id)';
-				$query->join('LEFT OUTER', $subquery . ' AS badcats ON badcats.id = c.id');
 
 				// Filter by published state.
 				$published = $this->getState('filter.published');

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -190,6 +190,9 @@ class ContentModelArticles extends JModelList
 				'a.id, a.title, a.alias, a.introtext, a.fulltext, ' .
 					'a.checked_out, a.checked_out_time, ' .
 					'a.catid, a.created, a.created_by, a.created_by_alias, ' .
+					// Published/archived article in archive category is treats as archive article
+					// If category is not published then force 0
+					'CASE WHEN c.published = 2 AND a.state > 0 THEN 2 WHEN c.published != 1 THEN 0 ELSE a.state END as state,' .
 					// Use created if modified is 0
 					'CASE WHEN a.modified = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.modified END as modified, ' .
 					'a.modified_by, uam.name as modified_by_name,' .
@@ -199,23 +202,6 @@ class ContentModelArticles extends JModelList
 					'a.hits, a.xreference, a.featured, a.language, ' . ' ' . $query->length('a.fulltext') . ' AS readmore'
 			)
 		);
-
-		// Process an Archived Article layout
-		if ($this->getState('filter.published') == 2)
-		{
-			// If badcats is not null, this means that the article is inside an archived category
-			// In this case, the state is set to 2 to indicate Archived (even if the article state is Published)
-			$query->select($this->getState('list.select', 'CASE WHEN badcats.id is null THEN a.state ELSE 2 END AS state'));
-		}
-		else
-		{
-			/*
-			Process non-archived layout
-			If badcats is not null, this means that the article is inside an unpublished category
-			In this case, the state is set to 0 to indicate Unpublished (even if the article state is Published)
-			*/
-			$query->select($this->getState('list.select', 'CASE WHEN badcats.id is not null THEN 0 ELSE a.state END AS state'));
-		}
 
 		$query->from('#__content AS a');
 
@@ -241,6 +227,7 @@ class ContentModelArticles extends JModelList
 
 		// Join over the categories.
 		$query->select('c.title AS category_title, c.path AS category_route, c.access AS category_access, c.alias AS category_alias')
+			->select('c.published, c.published AS parents_published')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the users for the author and modified_by names.
@@ -262,33 +249,6 @@ class ContentModelArticles extends JModelList
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 		}
 
-		// Join to check for category published state in parent categories up the tree
-		$query->select('c.published, CASE WHEN badcats.id is null THEN c.published ELSE 0 END AS parents_published');
-		$subquery = 'SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ';
-		$subquery .= 'ON cat.lft BETWEEN parent.lft AND parent.rgt ';
-		$subquery .= 'WHERE parent.extension = ' . $db->quote('com_content');
-
-		if ($this->getState('filter.published') == 2)
-		{
-			// Find any up-path categories that are archived
-			// If any up-path categories are archived, include all children in archived layout
-			$subquery .= ' AND parent.published = 2 GROUP BY cat.id ';
-
-			// Set effective state to archived if up-path category is archived
-			$publishedWhere = 'CASE WHEN badcats.id is null THEN a.state ELSE 2 END';
-		}
-		else
-		{
-			// Find any up-path categories that are not published
-			// If all categories are published, badcats.id will be null, and we just use the article state
-			$subquery .= ' AND parent.published != 1 GROUP BY cat.id ';
-
-			// Select state to unpublished if up-path category is unpublished
-			$publishedWhere = 'CASE WHEN badcats.id is null THEN a.state ELSE 0 END';
-		}
-
-		$query->join('LEFT OUTER', '(' . $subquery . ') AS badcats ON badcats.id = c.id');
-
 		// Filter by access level.
 		if ($access = $this->getState('filter.access'))
 		{
@@ -300,18 +260,24 @@ class ContentModelArticles extends JModelList
 		// Filter by published state
 		$published = $this->getState('filter.published');
 
-		if (is_numeric($published))
+		if (is_numeric($published) && $published == 2)
 		{
-			// Use article state if badcats.id is null, otherwise, force 0 for unpublished
-			$query->where($publishedWhere . ' = ' . (int) $published);
+			// If category is archived then article has to be published or archived.
+			// If categogy is published then article has to be archived.
+			$query->where('(c.published = 2 AND a.state > 0) OR (c.published = 1 AND a.state = 2)');
+		}
+		elseif (is_numeric($published))
+		{
+			// Category has to be published
+			$query->where('c.published = 1 AND a.state = ' . (int) $published);
 		}
 		elseif (is_array($published))
 		{
 			$published = ArrayHelper::toInteger($published);
 			$published = implode(',', $published);
 
-			// Use article state if badcats.id is null, otherwise, force 0 for unpublished
-			$query->where($publishedWhere . ' IN (' . $published . ')');
+			// Category has to be published
+			$query->where('c.published = 1 AND a.state IN (' . $published . ')');
 		}
 
 		// Filter by featured state

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -193,7 +193,13 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 					{
 						$joinElem = $join->getElements();
 
-						$joinArray = preg_split('/\sON\s/i', $joinElem[0], 2);
+						$joinArray = preg_split('/\sON\s/i', $joinElem[0]);
+
+						if (count($joinArray) > 2)
+						{
+							$condition = array_pop($joinArray);
+							$joinArray = array(implode(' ON ', $joinArray), $condition);
+						}
 
 						$this->from($joinArray[0]);
 

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -332,9 +332,12 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 					$table = $this->update->getElements();
 					$table = $table[0];
 
+					$tableName = explode(' ', $table);
+					$tableName = $tableName[0];
+
 					if ($this->columns === null)
 					{
-						$fields = $this->db->getTableColumns($table);
+						$fields = $this->db->getTableColumns($tableName);
 
 						foreach ($fields as $key => $value)
 						{
@@ -367,7 +370,7 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 					$select->join  = $this->join;
 					$select->where = $this->where;
 
-					return 'INSERT OR REPLACE INTO ' . $table
+					return 'INSERT OR REPLACE INTO ' . $tableName
 						. ' (' . implode(',', array_keys($fields)) . ')'
 						. (string) $select;
 				}

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -295,16 +295,17 @@ class JTableNested extends JTable
 	/**
 	 * Method to move a node and its children to a new location in the tree.
 	 *
-	 * @param   integer  $referenceId  The primary key of the node to reference new location by.
-	 * @param   string   $position     Location type string. ['before', 'after', 'first-child', 'last-child']
-	 * @param   integer  $pk           The primary key of the node to move.
+	 * @param   integer  $referenceId      The primary key of the node to reference new location by.
+	 * @param   string   $position         Location type string. ['before', 'after', 'first-child', 'last-child']
+	 * @param   integer  $pk               The primary key of the node to move.
+	 * @param   boolean  $updatePublished  Flag indicate that method updatePublishedColumn should be call.
 	 *
 	 * @return  boolean  True on success.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException on database error.
 	 */
-	public function moveByReference($referenceId, $position = 'after', $pk = null)
+	public function moveByReference($referenceId, $position = 'after', $pk = null, $updatePublished = true)
 	{
 		// @codeCoverageIgnoreStart
 		if ($this->_debug)
@@ -502,6 +503,11 @@ class JTableNested extends JTable
 			$this->_db->setQuery($query);
 
 			$this->_runQuery($query, 'JLIB_DATABASE_ERROR_MOVE_FAILED');
+
+			if ($updatePublished)
+			{
+				$this->updatePublishedColumn($node->$k);
+			}
 		}
 
 		// Unlock the table for writing.
@@ -685,7 +691,7 @@ class JTableNested extends JTable
 			}
 
 			$query = $this->_db->getQuery(true)
-				->select('COUNT(' . $this->_tbl_key . ')')
+				->select('1')
 				->from($this->_tbl)
 				->where($this->_tbl_key . ' = ' . $this->parent_id);
 
@@ -833,7 +839,8 @@ class JTableNested extends JTable
 			// If the location has been set, move the node to its new location.
 			if ($this->_location_id > 0)
 			{
-				if (!$this->moveByReference($this->_location_id, $this->_location, $this->$k))
+				// Skip updatePublishedColumn method, it will be called later.
+				if (!$this->moveByReference($this->_location_id, $this->_location, $this->$k, false))
 				{
 					// Error message set in move method.
 					return false;
@@ -876,6 +883,11 @@ class JTableNested extends JTable
 			// @codeCoverageIgnoreEnd
 		}
 
+		if (property_exists($this, 'published'))
+		{
+			$this->updatePublishedColumn($this->$k);
+		}
+
 		// Unlock the table for writing.
 		$this->_unlock();
 
@@ -909,12 +921,16 @@ class JTableNested extends JTable
 	public function publish($pks = null, $state = 1, $userId = 0)
 	{
 		$k = $this->_tbl_key;
-		$query = $this->_db->getQuery(true);
+
+		$query     = $this->_db->getQuery(true);
+		$table     = $this->_db->quoteName($this->_tbl);
+		$published = $this->_db->quoteName($this->getColumnAlias('published'));
+		$key       = $this->_db->quoteName($k);
 
 		// Sanitize input.
-		$pks = ArrayHelper::toInteger($pks);
+		$pks    = ArrayHelper::toInteger($pks);
 		$userId = (int) $userId;
-		$state = (int) $state;
+		$state  = (int) $state;
 
 		// If $state > 1, then we allow state changes even if an ancestor has lower state
 		// (for example, can change a child state to Archived (2) if an ancestor is Published (1)
@@ -978,19 +994,17 @@ class JTableNested extends JTable
 			{
 				// Get any ancestor nodes that have a lower publishing state.
 				$query->clear()
-					->select('n.' . $k)
-					->from($this->_db->quoteName($this->_tbl) . ' AS n')
-					->where('n.lft < ' . (int) $node->lft)
-					->where('n.rgt > ' . (int) $node->rgt)
-					->where('n.parent_id > 0')
-					->where($this->_db->qn('n.' . $this->getColumnAlias('published')) . ' < ' . (int) $compareState);
+					->select('1')
+					->from($table)
+					->where('lft < ' . (int) $node->lft)
+					->where('rgt > ' . (int) $node->rgt)
+					->where('parent_id > 0')
+					->where($published . ' < ' . (int) $compareState);
 
 				// Just fetch one row (one is one too many).
 				$this->_db->setQuery($query, 0, 1);
 
-				$rows = $this->_db->loadColumn();
-
-				if (!empty($rows))
+				if ($this->_db->loadResult())
 				{
 					$e = new UnexpectedValueException(
 						sprintf('%s::publish(%s, %d, %d) ancestors have lower state.', get_class($this), $pks[0], $state, $userId)
@@ -1001,12 +1015,7 @@ class JTableNested extends JTable
 				}
 			}
 
-			// Update and cascade the publishing state.
-			$query->clear()
-				->update($this->_db->quoteName($this->_tbl))
-				->set($this->_db->qn($this->getColumnAlias('published')) . ' = ' . (int) $state)
-				->where('(lft > ' . (int) $node->lft . ' AND rgt < ' . (int) $node->rgt . ') OR ' . $k . ' = ' . (int) $pk);
-			$this->_db->setQuery($query)->execute();
+			$this->updatePublishedColumn($pk, $state);
 
 			// If checkout support exists for the object, check the row in.
 			if ($checkoutSupport)
@@ -1486,6 +1495,83 @@ class JTableNested extends JTable
 			$this->_unlock();
 			throw $e;
 		}
+	}
+
+	/**
+	 * Method to recursive update published column for children rows.
+	 *
+	 * @param   integer  $pk        Id number of row which published column was changed.
+	 * @param   integer  $newState  An optional value for published column of row identified by $pk.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  RuntimeException on database error.
+	 */
+	protected function updatePublishedColumn($pk, $newState = null)
+	{
+		$query     = $this->_db->getQuery(true);
+		$table     = $this->_db->quoteName($this->_tbl);
+		$key       = $this->_db->quoteName($this->_tbl_key);
+		$published = $this->_db->quoteName($this->getColumnAlias('published'));
+
+		if ($newState !== null)
+		{
+			// Use a new published state in changed row.
+			$newState = "(CASE WHEN p2.$key = " . (int) $pk . " THEN " . (int) $newState . " ELSE p2.$published END)";
+		}
+		else
+		{
+			$newState = "p2.$published";
+		}
+
+		/**
+		 * We have to calculate the correct value for c2.published
+		 * based on p2.published and own c2.published column,
+		 * where (p2) is parent category is and (c2) current category
+		 *
+		 * p2.published <= c2.published AND p2.published > 0 THEN c2.published
+		 *            2 <=  2 THEN  2 (If archived in archived then archived)
+		 *            1 <=  2 THEN  2 (If archived in published then archived)
+		 *            1 <=  1 THEN  1 (If published in published then published)
+		 *
+		 * p2.published >  c2.published AND c2.published > 0 THEN p2.published
+		 *            2 >   1 THEN  2 (If published in archived then archived)
+		 *
+		 * p2.published >  c2.published THEN c2.published ELSE p2.published
+		 *            2 >  -2 THEN -2 (If trashed in archived then trashed)
+		 *            2 >   0 THEN  0 (If unpublished in archived then unpublished)
+		 *            1 >   0 THEN  0 (If unpublished in published then unpublished)
+		 *            0 >  -2 THEN -2 (If trashed in unpublished then trashed)
+		 * ELSE
+		 *            0 <=  2 THEN  0 (If archived in unpublished then unpublished)
+		 *            0 <=  1 THEN  0 (If published in unpublished then unpublished)
+		 *            0 <=  0 THEN  0 (If unpublished in unpublished then unpublished)
+		 *           -2 <= -2 THEN -2 (If trashed in trashed then trashed)
+		 *           -2 <=  0 THEN -2 (If unpublished in trashed then trashed)
+		 *           -2 <=  1 THEN -2 (If published in trashed then trashed)
+		 *           -2 <=  2 THEN -2 (If archived in trashed then trashed)
+		 */
+
+		// Prepare a list of correct published states.
+		$subquery = (string) $query->clear()
+			->select("c2.$key")
+			->select("CASE WHEN MIN($newState) > 0 THEN MAX($newState) ELSE MIN($newState) END AS newPublished")
+			->from("$table AS c2")
+			->innerJoin("$table AS p2 ON (p2.lft <= c2.lft AND c2.rgt <= p2.rgt)")
+			->group("c2.$key");
+
+		// Update and cascade the publishing state.
+		$query->clear()
+			->update("$table AS c")
+			->innerJoin("$table AS node ON node.lft <= c.lft AND c.rgt <= node.rgt")
+			->innerJoin("($subquery) AS c2 ON c2.$key = c.$key")
+			->set("$published = c2.newPublished")
+			->where("node.$key = " . (int) $pk);
+
+		$this->_runQuery($query, 'JLIB_DATABASE_ERROR_STORE_FAILED');
+
+		return true;
 	}
 
 	/**

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1555,19 +1555,19 @@ class JTableNested extends JTable
 
 		// Prepare a list of correct published states.
 		$subquery = (string) $query->clear()
-			->select("c2.$key")
+			->select("c2.$key AS newId")
 			->select("CASE WHEN MIN($newState) > 0 THEN MAX($newState) ELSE MIN($newState) END AS newPublished")
-			->from("$table AS c2")
-			->innerJoin("$table AS p2 ON (p2.lft <= c2.lft AND c2.rgt <= p2.rgt)")
+			->from("$table AS node")
+			->innerJoin("$table AS c2 ON node.lft <= c2.lft AND c2.rgt <= node.rgt")
+			->innerJoin("$table AS p2 ON p2.lft <= c2.lft AND c2.rgt <= p2.rgt")
+			->where("node.$key = " . (int) $pk)
 			->group("c2.$key");
 
 		// Update and cascade the publishing state.
 		$query->clear()
 			->update("$table AS c")
-			->innerJoin("$table AS node ON node.lft <= c.lft AND c.rgt <= node.rgt")
-			->innerJoin("($subquery) AS c2 ON c2.$key = c.$key")
-			->set("$published = c2.newPublished")
-			->where("node.$key = " . (int) $pk);
+			->innerJoin("($subquery) AS c2 ON c2.newId = c.$key")
+			->set("$published = c2.newPublished");
 
 		$this->_runQuery($query, 'JLIB_DATABASE_ERROR_STORE_FAILED');
 

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -241,12 +241,6 @@ class JCategories
 		if ($this->_options['published'] == 1)
 		{
 			$query->where('c.published = 1');
-
-			$subQuery = ' (SELECT cat.id as id FROM #__categories AS cat JOIN #__categories AS parent ' .
-				'ON cat.lft BETWEEN parent.lft AND parent.rgt WHERE parent.extension = ' . $db->quote($extension) .
-				' AND parent.published != 1 GROUP BY cat.id) ';
-			$query->join('LEFT', $subQuery . 'AS badcats ON badcats.id = c.id')
-				->where('badcats.id is null');
 		}
 
 		$query->order('c.lft');

--- a/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
@@ -410,6 +410,19 @@ class JTableNestedTest extends TestCaseDatabase
 		self::$driver->setQuery('UPDATE #__categories SET published = 0')
 			->execute();
 
+		// This query won't change any column because root.1 is unpublished.
+		$this->assertTrue($this->class->publish(array(101, 102), 1));
+
+		$nodes = self::$driver->setQuery('SELECT id, published FROM #__categories')->loadObjectList('id');
+
+		$this->assertEquals(0, $nodes[101]->published, 'Checks node 101.');
+		$this->assertEquals(0, $nodes[102]->published, 'Checks node 102.');
+		$this->assertEquals(0, $nodes[103]->published, 'Checks node 103.');
+
+		// Set root.1 as published
+		self::$driver->setQuery('UPDATE #__categories SET published = CASE WHEN id = 1 THEN 1 ELSE 0 END')
+			->execute();
+
 		$this->assertTrue($this->class->publish(array(101, 102), 1));
 
 		$nodes = self::$driver->setQuery('SELECT id, published FROM #__categories')->loadObjectList('id');


### PR DESCRIPTION
Pull Request for Issue # .

Related to #5544

### Summary of Changes

**Main Improvement:**
* remove subquery with "badcats" from frontend queries.
* recursive update column published for children items, column `published` is re-calculated on every save, change state, move or copy for `#__categories` and `#__menu` (in general for subclasses of JTableNested).

In order to not display unpublished categories on front end old installation has to call additional query.
That query re-calculates `published` column for whole tree.

After apply patch on exists installation you have to run 2 queries from:
[Chose your database]
```
* administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-03-09.sql
* administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-09.sql
* administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-03-09.sql
```

### A new Rules for nested tables like (category, menu):
* If parent will be published then there is no action or restrictions for children
* If parent will be archived then all published children will be set as archived
* If parent will be unpublished then all published/archived will be set as unpublished
* If parent will be trashed then all children will be trashed

__Old behaviour:__
* On save, move or copy category (or menu)  then is no exists any recursion for published column. There could be published subcategory in non published category.
* On publish/unpiblish/archive/trash category/menu all children has been recursive update to the same state.
* You can create published category on unpublished parent.
* On frontend query (related to articles), the query has to check ("badcats") if all category parents has the correct state (ex. published = 1) 

__New bevaviour__
* On all action like save/move/copy/change state recursion is call and change children state.
* `published` column of children items is changed based on the rules.
* If you create a new category (as published) on unpublished parent, then the new category also be unpiblished.
* Frontend queries does not need to include subquery with "badcats" because last child has calculated state of published column. 

### Testing Instructions
Test categories, menus and articles on front end and on back end.

[UPDATED]
* Create a new category/menu as published on non published category, result: non published
* Change state on category with children, see recursive
* Move some (sub tree of) category to other ex. unpublished category.
* Changing published state at edit form of category/menu give the same result as in categories/menu list by click [Publish/Archive...]. **There should be no difference where you change the published state.**

All above points should follow the rules. 

### Expected result
Joomla should work as before but faster on frontend views: featured/blog/list/archived/article and on others which use model from `components/com_content/models/articles.php` like `mod_articles...`

### Actual result
On front end with lots of categories and articles Joomla works slow. 


### Documentation Changes Required
I do not know.
Special subquery (badcats) for nested tables are now not required.
The new rules in `JTableNested` which change published state for children.
