### PR TITLE
Mod Latest Articles - Admin

### DIFF
--- a/administrator/modules/mod_latest/helper.php
+++ b/administrator/modules/mod_latest/helper.php
@@ -34,7 +34,7 @@ abstract class ModLatestHelper
 
 		// Set List SELECT
 		$model->setState('list.select', 'a.id, a.title, a.checked_out, a.checked_out_time, ' .
-			' a.access, a.created, a.created_by, a.created_by_alias, a.featured, a.state');
+			' a.access, a.created, a.created_by, a.created_by_alias, a.featured, a.state, a.publish_up, a.publish_down');
 
 		// Set Ordering filter
 		switch ($params->get('ordering'))

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php foreach ($list as $i => $item) : ?>
 			<div class="row-fluid">
 				<div class="span8">
-					<?php echo JHtml::_('jgrid.published', $item->state, $i, '', false); ?>
+					<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
 					<?php if ($item->checked_out) : ?>
 						<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 		<?php foreach ($list as $i => $item) : ?>
 			<div class="row-fluid">
 				<div class="span8">
-					<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', $canChange, 'cb', $item->publish_up, $item->publish_down); ?>
+					<?php echo JHtml::_('jgrid.published', $item->state, $i, 'articles.', false, 'cb', $item->publish_up, $item->publish_down); ?>
 					<?php if ($item->checked_out) : ?>
 						<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
+$canChange = false;
 ?>
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.tooltip');
-$canChange = false;
 ?>
 <div class="row-striped">
 	<?php foreach ($users as $user) : ?>


### PR DESCRIPTION
the admin module mod_latest displays a list of the most rrecent articles added to the site but it only shows if the article is published or not. It doesnt display if the article is pending or expired.

this PR resolves that and the module will now correctly display if the article is
published, unpublished, pending or expired

### Test Instructions
Create 4 articles
1. Published
2. Unpublished
3. Published but Pending (published in the future)
4. Published but Expired (published but now after the end date)

Before the PR the admin module on the control panel will just display published/unpublished

After the PR the admin module will display the correct icons (the ones you see in the article manager)

### Before

<img width="465" alt="screenshotr09-58-43" src="https://cloud.githubusercontent.com/assets/1296369/23790778/78505f62-0578-11e7-8426-6285aed65bfb.png">

### After

<img width="494" alt="screenshotr10-00-05" src="https://cloud.githubusercontent.com/assets/1296369/23790773/74e00738-0578-11e7-9c16-4693eed3e1b6.png">
