### PR TITLE
[4.0] Fix update progress bar

### DIFF
--- a/administrator/components/com_joomlaupdate/views/update/tmpl/default.php
+++ b/administrator/components/com_joomlaupdate/views/update/tmpl/default.php
@@ -40,8 +40,8 @@ JFactory::getDocument()->addScriptDeclaration(
 
 <div id="update-progress">
 	<div id="extprogress">
-		<div id="progress" class="progress progress-striped active">
-			<div id="progress-bar" class="bar bar-success" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+		<div id="progress" class="progress">
+			<div id="progress-bar" class="progress-bar progress-bar-striped progress-bar-animated" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
 		</div>
 		<div class="extprogrow">
 			<span class="extlabel"><?php echo JText::_('COM_JOOMLAUPDATE_VIEW_UPDATE_PERCENT'); ?></span>


### PR DESCRIPTION
Pull Request for Issue #14441

### Summary of Changes

This PR fixes the progress bar in com_joomlaupdate

### Testing Instructions

- Apply PR
- Joomla Update > Tab Upload & Update
- Upload a Joomla patch or some sort
- Progress bar should appear.


