### PR TITLE
fix typo in test comments

### DIFF
--- a/tests/unit/suites/libraries/joomla/JFactoryTest.php
+++ b/tests/unit/suites/libraries/joomla/JFactoryTest.php
@@ -70,7 +70,7 @@ class JFactoryTest extends TestCaseDatabase
 	}
 
 	/**
-	 * Tests the JFactory::getLangauge method.
+	 * Tests the JFactory::getLanguage method.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
If we are going to describe methods in the doc blocks then they should be correct