### PR TITLE
Fix JFormFieldCaptcha

### DIFF
--- a/libraries/cms/form/field/captcha.php
+++ b/libraries/cms/form/field/captcha.php
@@ -14,7 +14,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  2.5
  */
-class JFormFieldCaptcha extends JFormField implements JFormDomfieldinterface
+class JFormFieldCaptcha extends JFormField
 {
 	/**
 	 * The field type.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
See https://github.com/joomla/joomla-cms/issues/14467 for issue description. Look at JFormFieldCaptcha, the intention is **implements JFormDomfieldinterface** . However, that interface is not defined anywhere in our codebase (both Joomla 3 and Joomla 4). Since @laoneo said that the interface was abandon long time ago and this is the only Form Field has this implements JFormDomfieldinterface, I think we just need to remove the implements JFormDomfieldinterface from class definition

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/14467 and confirm the issue. Apply patch and confirm the issue fixed

