### PR TITLE
Remove limit and change type of displayed error messages in com_contact

### DIFF
--- a/components/com_contact/controllers/contact.php
+++ b/components/com_contact/controllers/contact.php
@@ -87,30 +87,24 @@ class ContactControllerContact extends JControllerForm
 			return false;
 		}
 
-		$validate = $model->validate($form, $data);
-
-		if ($validate === false)
+		if (!$model->validate($form, $data))
 		{
-			// Get the validation messages.
 			$errors = $model->getErrors();
 
-			// Push up to three validation messages out to the user.
-			for ($i = 0, $n = count($errors); $i < $n && $i < 3; $i++)
+			foreach ($errors as $error)
 			{
-				if ($errors[$i] instanceof Exception)
+				$errorMessage = $error;
+
+				if ($error instanceof Exception)
 				{
-					$app->enqueueMessage($errors[$i]->getMessage(), 'warning');
+					$errorMessage = $error->getMessage();
 				}
-				else
-				{
-					$app->enqueueMessage($errors[$i], 'warning');
-				}
+
+				$app->enqueueMessage($errorMessage, 'error');
 			}
 
-			// Save the data in the session.
 			$app->setUserState('com_contact.contact.data', $data);
 
-			// Redirect back to the contact form.
 			$this->setRedirect(JRoute::_('index.php?option=com_contact&view=contact&id=' . $stub, false));
 
 			return false;


### PR DESCRIPTION
Remove limit and change type of displayed error messages for server side validation in com_contact.

While I was working on the PR #8085, I noticed a few odd things in the com_contact controller that I would like to address with a couple of PRs.

This one is about correcting or adjusting the error handling of the core functionality.

### Summary of Changes
The client side validation of com_contact will show an error message for every invalid field submitted. On the server side, the same messages are rendered as a warning and are limited to three messages per field / request.

### Testing Instructions
**Prerequisites**
While the changes should work on any 3.x version, you should test this PR against staging.

You can easily test this if you remove the class suffix "form-validate" from the form tag in /components/com_contact/views/contact/tmpl/default_form.php on line ~17 and add the **novalidate** attribute at the end to prevent the browser from validating the fields as well.

Create a contact item and add a link to that form. Don't forget to either add an email address or assign the item to an existing user, otherwise the form won't show.

Submit the empty form.

### Expected result
The browser should reload the page because we disabled the client side validation. The expeced result would be four **error** messages.

### Actual result
Given that you've tried to submit an empty form, before the patch you will see three **warnings** on top of the form. For the fun of it, fill in a name and submit the form a second time. The warning for the name field is now replaced by a warning for the message field at the buttom of that warning block.

Apply the patch and once more, submit the form. Now, depending on whether or not you cleared the name field, you should see all four **error** messages.
