### PR TITLE
[com_fields] User group field does work on the front end

### DIFF
--- a/plugins/fields/usergrouplist/usergrouplist.php
+++ b/plugins/fields/usergrouplist/usergrouplist.php
@@ -18,28 +18,4 @@ JLoader::import('components.com_fields.libraries.fieldsplugin', JPATH_ADMINISTRA
  */
 class PlgFieldsUsergrouplist extends FieldsPlugin
 {
-
-	/**
-	 * Transforms the field into an XML element and appends it as child on the given parent. This
-	 * is the default implementation of a field. Form fields which do support to be transformed into
-	 * an XML Element must implement the JFormDomfieldinterface.
-	 *
-	 * @param   stdClass    $field   The field.
-	 * @param   DOMElement  $parent  The field node parent.
-	 * @param   JForm       $form    The form.
-	 *
-	 * @return  DOMElement
-	 *
-	 * @since   3.7.0
-	 */
-	public function onCustomFieldsPrepareDom($field, DOMElement $parent, JForm $form)
-	{
-		if (JFactory::getApplication()->isClient('site'))
-		{
-			// The user field is not working on the front end
-			return;
-		}
-
-		return parent::onCustomFieldsPrepareDom($field, $parent, $form);
-	}
 }


### PR DESCRIPTION
Pull Request for Issue #13874.

### Summary of Changes
Enables the usergroup field for the front end editing.


### Testing Instructions
- Create a "User Groups" field
- Edit an article on the front end


### Expected result
Field is displayed.


### Actual result
Field is not displayed


### Documentation Changes Required

