### PR TITLE
[com_fields] Disable the option to show the user field on the front

### DIFF
--- a/plugins/fields/user/params/user.xml
+++ b/plugins/fields/user/params/user.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
+		<fieldset name="basic">
+			<field
+				name="show_on"
+				type="hidden"
+				filter="unset"
+			/>
+		</fieldset>
+	</fields>
+</form>


### PR DESCRIPTION
Pull Request for Issue #13873.

### Summary of Changes
The user form field doesn't work on the front. Why is not part of this pr. This pr removes the option to define where the field to display.
![image](https://cloud.githubusercontent.com/assets/251072/23826436/4b6cc678-069c-11e7-86c3-41a6b5b9c8c5.png)



### Testing Instructions
- Create a new user field.
- Open the options tab.

### Expected result
The "Show On" setting should not being displayed.


### Actual result
The "Show On" setting is displayed.


### Documentation Changes Required

