### PR TITLE
Add vscode to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .settings
 .DS_Store
 .idea
+.vscode
 
 # Local System Files (i.e. cache, logs, etc.) #
 /administrator/cache


### PR DESCRIPTION
### Summary of Changes

Add .vscode to global .gitignore same as we did for .idea (PHPStorm)

### Testing Instructions

Review

### Expected result

git ignores vscode files / folders

### Actual result

git does not ignore vscode files

### Documentation Changes Required

None