### PR TITLE
[4.0] Set breakpoint for global config columns

### DIFF
--- a/administrator/components/com_config/view/application/tmpl/default.php
+++ b/administrator/components/com_config/view/application/tmpl/default.php
@@ -70,11 +70,11 @@ JFactory::getDocument()->addScriptDeclaration('
 			<div id="config-document" class="tab-content">
 				<div id="page-site" class="tab-pane active">
 					<div class="row">
-						<div class="col-md-6">
+						<div class="col-lg-12 col-xl-6">
 							<?php echo $this->loadTemplate('site'); ?>
 							<?php echo $this->loadTemplate('metadata'); ?>
 						</div>
-						<div class="col-md-6">
+						<div class="col-lg-12 col-xl-6">
 							<?php echo $this->loadTemplate('seo'); ?>
 							<?php echo $this->loadTemplate('cookie'); ?>
 						</div>
@@ -92,13 +92,13 @@ JFactory::getDocument()->addScriptDeclaration('
 				</div>
 				<div id="page-server" class="tab-pane">
 					<div class="row">
-						<div class="col-md-6">
+						<div class="col-lg-12 col-xl-6">
 							<?php echo $this->loadTemplate('server'); ?>
 							<?php echo $this->loadTemplate('locale'); ?>
 							<?php echo $this->loadTemplate('ftp'); ?>
 							<?php echo $this->loadTemplate('proxy'); ?>
 						</div>
-						<div class="col-md-6">
+						<div class="col-lg-12 col-xl-6">
 							<?php echo $this->loadTemplate('database'); ?>
 							<?php echo $this->loadTemplate('mail'); ?>
 						</div>


### PR DESCRIPTION
Pull Request for Issue #14487 (Step 2 of 2) .

### Summary of Changes
Sets col-lg-12 for 2 column layouts within global config

### Testing Instructions
Apply patch and navigate to Global Config. Resize browser window. 'Site' and 'Server' tabs should switch to single column layouts below 1200px

