### PR TITLE
[fields] hide buttons

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_editor.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_editor.ini
@@ -5,11 +5,11 @@
 
 PLG_FIELDS_EDITOR="Fields - Editor"
 PLG_FIELDS_EDITOR_LABEL="Editor (%s)"
-PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC="Hide the buttons in the comma separated list."
+PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC="Comma separated list of editors-xtd plugin buttons to be hidden."
 PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL="Hide Buttons"
 PLG_FIELDS_EDITOR_PARAMS_HEIGHT_DESC="Defines the height (in pixels) of the WYSIWYG editor and defaults to 250px."
 PLG_FIELDS_EDITOR_PARAMS_HEIGHT_LABEL="Height"
-PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_DESC="Should the buttons be shown."
+PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_DESC="Should the editors-xtd plugin buttons be shown?"
 PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_LABEL="Show Buttons"
 PLG_FIELDS_EDITOR_PARAMS_USE_GLOBAL="Use From Plugin"
 PLG_FIELDS_EDITOR_PARAMS_WIDTH_DESC="Defines the width (in pixels) of the WYSIWYG editor and defaults to 100%."


### PR DESCRIPTION
clarify the tooltips related to how to hide editor-xtd plugin buttons from the editor field