### PR TITLE
[Fields] multiple

### DIFF
--- a/plugins/fields/integer/integer.xml
+++ b/plugins/fields/integer/integer.xml
@@ -21,17 +21,6 @@
 	<config>
 		<fields name="params">
 			<fieldset name="basic">
-				<field
-					name="multiple"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
-					description="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_DESC"
-				>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 	
 				<field
 					name="first"
@@ -62,6 +51,18 @@
 					size="5"
 					required="true"
 				/>
+
+				<field
+					name="multiple"
+					type="radio"
+					class="btn-group btn-group-yesno"
+					default="0"
+					label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
+					description="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_DESC"
+				>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
+				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/plugins/fields/integer/params/integer.xml
+++ b/plugins/fields/integer/params/integer.xml
@@ -32,7 +32,7 @@
 				label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
 				description="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_DESC"
 			>
-				<option value="">PLG_FIELDS_INTEGER_PARAMS_USE_GLOBAL</option>
+				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>

--- a/plugins/fields/integer/params/integer.xml
+++ b/plugins/fields/integer/params/integer.xml
@@ -3,17 +3,6 @@
 	<fields name="fieldparams">
 		<fieldset name="fieldparams">
 			<field
-				name="multiple"
-				type="list"
-				label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
-				description="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_DESC"
-			>
-				<option value="">PLG_FIELDS_INTEGER_PARAMS_USE_GLOBAL</option>
-				<option value="1">JYES</option>
-				<option value="0">JNO</option>
-			</field>
-
-			<field
 				name="first"
 				type="number"
 				label="PLG_FIELDS_INTEGER_PARAMS_FIRST_LABEL"
@@ -36,6 +25,17 @@
 				description="PLG_FIELDS_INTEGER_PARAMS_STEP_DESC"
 				size="5"
 			/>
+
+			<field
+				name="multiple"
+				type="list"
+				label="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_LABEL"
+				description="PLG_FIELDS_INTEGER_PARAMS_MULTIPLE_DESC"
+			>
+				<option value="">PLG_FIELDS_INTEGER_PARAMS_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
+			</field>
 		</fieldset>
 	</fields>
 </form>

--- a/plugins/fields/list/list.xml
+++ b/plugins/fields/list/list.xml
@@ -20,17 +20,6 @@
 		<fields name="params">
 			<fieldset name="basic">
 				<field
-					name="multiple"
-					type="radio"
-					class="btn-group btn-group-yesno"
-					default="0"
-					label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
-					description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
-				>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-				<field
 					name="options"
 					type="subform" layout="joomla.form.field.subform.repeatable-table"
 					icon="list" multiple="true"
@@ -52,6 +41,17 @@
 							type="text"
 						/>
 					</form>
+				</field>				
+				<field
+					name="multiple"
+					type="radio"
+					class="btn-group btn-group-yesno"
+					default="0"
+					label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
+					description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
+				>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
 				</field>
 			</fieldset>
 		</fields>

--- a/plugins/fields/list/params/list.xml
+++ b/plugins/fields/list/params/list.xml
@@ -3,16 +3,6 @@
 	<fields name="fieldparams">
 		<fieldset name="fieldparams">
 			<field
-				name="multiple"
-				type="list"
-				label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
-				description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
-			>
-				<option value="">PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL</option>
-				<option value="1">JYES</option>
-				<option value="0">JNO</option>
-			</field>
-			<field
 				name="options"
 				type="subform" layout="joomla.form.field.subform.repeatable-table"
 				icon="list" multiple="true"
@@ -34,6 +24,16 @@
 						type="text"
 					/>
 				</form>
+			</field>
+			<field
+				name="multiple"
+				type="list"
+				label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
+				description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
+			>
+				<option value="">PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL</option>
+				<option value="1">JYES</option>
+				<option value="0">JNO</option>
 			</field>
 		</fieldset>
 	</fields>

--- a/plugins/fields/list/params/list.xml
+++ b/plugins/fields/list/params/list.xml
@@ -31,7 +31,7 @@
 				label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
 				description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
 			>
-				<option value="">PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL</option>
+				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>


### PR DESCRIPTION
This PR is a cosmetic change for consistency that ensures the param for multiple is towards the end of the options and not the first. It was already thiis way in some plugins but not all