### PR TITLE
Admin menu System information

### DIFF
--- a/administrator/language/en-GB/en-GB.com_admin.ini
+++ b/administrator/language/en-GB/en-GB.com_admin.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-COM_ADMIN="Administrator - System Information"
+COM_ADMIN="System Information"
 COM_ADMIN_ALPHABETICAL_INDEX="Alphabetical Index"
 COM_ADMIN_CACHE_DIRECTORY="(Cache Folder)"
 COM_ADMIN_CLEAR_RESULTS="Clear results"

--- a/administrator/language/en-GB/en-GB.com_admin.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_admin.sys.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-COM_ADMIN="Administrator - System Information"
+COM_ADMIN="System Information"
 COM_ADMIN_XML_DESCRIPTION="Administration system information component."
 
 COM_ADMIN_HELP_VIEW_DEFAULT_DESC="Get help regarding various pages in your Joomla administrator interface."


### PR DESCRIPTION
When creating a new Admin menu item the avaiable menu type are displayed in component alphabetical order.

Currently the System Information component will be displayed at the very top of the list as it is named Administrator-System Information. There is no need for this to prefixed with Administrator and by removing the prefix it is moved down the list into a more logical position
