### PR TITLE
Admin menu - Site configuration link

### DIFF
--- a/administrator/language/en-GB/en-GB.com_config.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_config.sys.ini
@@ -8,7 +8,7 @@ COM_CONFIG_XML_DESCRIPTION="Configuration Manager"
 
 COM_CONFIG_COMPONENT_VIEW_DEFAULT_DESC="Display the configuration options for the selected component."
 COM_CONFIG_COMPONENT_VIEW_DEFAULT_TITLE="Component Configuration Options"
-COM_CONFIG_CONFIG_VIEW_DEFAULT_DESC="Displays basic site configuration options."
+COM_CONFIG_CONFIG_VIEW_DEFAULT_DESC="Displays global site configuration options."
 COM_CONFIG_CONFIG_VIEW_DEFAULT_TITLE="Site Configuration Options"
 COM_CONFIG_TEMPLATES_VIEW_DEFAULT_DESC="Displays template parameter options if the template allows this."
 COM_CONFIG_TEMPLATES_VIEW_DEFAULT_TITLE="Display Template Options"


### PR DESCRIPTION
When creating a new menu item type in the admin to link to the Global Configuration the description displayed uses the word "basic". They are anything but basic ;) This corrects the string to use the word global