### PR TITLE
We stopped using the word manager

### DIFF
--- a/administrator/language/en-GB/en-GB.com_cache.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_cache.sys.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
-COM_CACHE_CACHE_VIEW_DEFAULT_DESC="Clear Cache Manager"
+COM_CACHE_CACHE_VIEW_DEFAULT_DESC="Maintenance: Clear Cache"
 COM_CACHE_CACHE_VIEW_DEFAULT_TITLE="Clear Cache"
-COM_CACHE_PURGE_VIEW_DEFAULT_DESC="Clear Expired Cache Manager"
+COM_CACHE_PURGE_VIEW_DEFAULT_DESC="Maintenance: Clear Expired Cache"
 COM_CACHE_PURGE_VIEW_DEFAULT_TITLE="Clear Expired Cache"
 COM_CACHE_XML_DESCRIPTION="Component for cache management."


### PR DESCRIPTION
We stopped using the word manager some time ago

The new admin menu creator describes the cache as being manager pages

<img width="362" alt="screenshotr13-46-53" src="https://cloud.githubusercontent.com/assets/1296369/23832373/995e6c9a-072a-11e7-8f48-0d2d8bdef58a.png">

This PR changes the description to match the current sstyl eof using the word Maintenance
