### PR TITLE
Set default value for data attribute in updater

### DIFF
--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -263,7 +263,7 @@ class JUpdater extends JAdapter
 
 		// Get the update information from the remote update XML document
 		/** @var JUpdateAdapter $adapter */
-		$adapter       = $this->_adapters[ $updateSite['type']];
+		$adapter       = $this->_adapters[$updateSite['type']];
 		$update_result = $adapter->findUpdate($updateSite);
 
 		// Version comparison operator.
@@ -303,6 +303,11 @@ class JUpdater extends JAdapter
 				foreach ($update_result['updates'] as $current_update)
 				{
 					$current_update->extra_query = $updateSite['extra_query'];
+
+					if (!isset($current_update->data)
+					{
+						$current_update->data = '';
+					}
 
 					/** @var JTableUpdate $update */
 					$update = JTable::getInstance('update');

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -304,7 +304,7 @@ class JUpdater extends JAdapter
 				{
 					$current_update->extra_query = $updateSite['extra_query'];
 
-					if (!isset($current_update->data)
+					if (!isset($current_update->data))
 					{
 						$current_update->data = '';
 					}


### PR DESCRIPTION
Pull Request for Issue #14471

### Summary of Changes

If not set we set the data attribute to '' vs NULL.

### Testing Instructions

- Install 4.0
- go to the options and set this: https://update.joomla.org/core/nightlies/next_major_list.xml as your custom update URL
- apply this patch
- We got the `Expected result`

### Expected result

Joomla find the update to 4.0.0-dev2 and allow a update to the last nightly version

### Actual result

Joomla don't find any update.

### Documentation Changes Required

None

### Additional Information

This PR is vs staging as the code should also be there as it fixes a issue also present in staging. And staging is goint to be synced to 4.0-dev.