### PR TITLE
Routing 404 fix

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -239,6 +239,14 @@ class JRouter
 		// Do the postprocess stage of the URL build process
 		$vars += $this->processParseRules($uri, self::PROCESS_AFTER);
 
+		// Check if all parts of the URL have been parsed.
+		// Otherwise we have an invalid URL
+		if (strlen($uri->getPath()) > 0 && array_key_exists('option', $vars)
+			&& JComponentHelper::getParams($vars['option'])->get('sef_advanced', 0))
+		{
+			throw new Exception('URL invalid', 404);
+		}
+
 		return array_merge($this->getVars(), $vars);
 	}
 

--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -433,6 +433,8 @@ class JRouterSite extends JRouter
 
 				$this->setVars($vars);
 			}
+
+			$route = implode('/', $segments);
 		}
 		else
 		{
@@ -442,6 +444,8 @@ class JRouterSite extends JRouter
 				$vars = $item->query;
 			}
 		}
+
+		$uri->setPath($route);
 
 		return $vars;
 	}

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -167,7 +167,7 @@ class JRouterSiteTest extends TestCaseDatabase
 				'map'     => array(array('sef_suffix', null, '1')),
 				'server'  => $server1,
 				'expVars' => array('option' => 'com_test3', 'Itemid' => '45'),
-				'expUrl'  => 'joomla/blog/tes'
+				'expUrl'  => 'joomla/blog/test'
 			),
 			array(
 				'url'     => '/joomla/blog/test%202',

--- a/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
+++ b/tests/unit/suites/libraries/cms/router/JRouterSiteTest.php
@@ -159,7 +159,7 @@ class JRouterSiteTest extends TestCaseDatabase
 				'map'     => array(array('sef_suffix', null, '1')),
 				'server'  => $server1,
 				'expVars' => array('format' => 'json', 'option' => 'com_test3', 'Itemid' => '45'),
-				'expUrl'  => 'joomla/blog/test.json'
+				'expUrl'  => 'joomla/blog/test'
 			),
 			array(
 				'url'     => '/joomla/blog/test.json/',
@@ -167,7 +167,7 @@ class JRouterSiteTest extends TestCaseDatabase
 				'map'     => array(array('sef_suffix', null, '1')),
 				'server'  => $server1,
 				'expVars' => array('option' => 'com_test3', 'Itemid' => '45'),
-				'expUrl'  => 'joomla/blog/test.json'
+				'expUrl'  => 'joomla/blog/tes'
 			),
 			array(
 				'url'     => '/joomla/blog/test%202',


### PR DESCRIPTION
This is an attempt to fix the 404 issue in the router. Note that I have done very very limited testing but this puts it out there for us to all work with. This pulls the fix from the Joomla 4 branch and implements it in the 3 branch.

Note for the 404 to be fixed any component must have a `sef_advanced` parameter. Note that if the router only uses the "new" router then this can be a hidden parameter. The parameter just needs to exist otherwise the component will have the current 404 bug (I believe that this isn't a b/c issue as no extensions currently use the new router and this parameter will be removed in Joomla 4)