### PR TITLE
Partially revert autoloader changes

### DIFF
--- a/libraries/cms/router/site.php
+++ b/libraries/cms/router/site.php
@@ -752,8 +752,14 @@ class JRouterSite extends JRouter
 
 			if (!class_exists($class))
 			{
-				// Add the custom routing handler to the autoloader if it exists
-				JLoader::register($class, JPATH_SITE . '/components/' . $component . '/router.php');
+				// Use the component routing handler if it exists
+				$path = JPATH_SITE . '/components/' . $component . '/router.php';
+
+				// Use the custom routing handler if it exists
+				if (file_exists($path))
+				{
+					require_once $path;
+				}
 			}
 
 			if (class_exists($class))

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -233,7 +233,10 @@ class JLanguage
 
 		while (!class_exists($class) && $path)
 		{
-			JLoader::register($class, $path);
+			if (file_exists($path))
+			{
+				require_once $path;
+			}
 
 			$path = next($paths);
 		}

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -287,7 +287,7 @@ abstract class JTable extends JObject implements JObservableInterface, JTableInt
 				if ($tryThis = JPath::find($paths[$pathIndex++], strtolower($type) . '.php'))
 				{
 					// Import the class file.
-					JLoader::register($tableClass, $tryThis);
+					include_once $tryThis;
 				}
 			}
 

--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -276,19 +276,18 @@ class JControllerLegacy extends JObject
 		// Include the class if not present.
 		if (!class_exists($class))
 		{
-			JLoader::register($class, $path);
-
-			if (!class_exists($class))
+			// If the controller file path exists, include it.
+			if (file_exists($path))
 			{
-				if (isset($backuppath) && file_exists($backuppath))
-				{
-					JLoader::register($class, $backuppath);
-				}
-
-				if (!class_exists($class))
-				{
-					throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
-				}
+				require_once $path;
+			}
+			elseif (isset($backuppath) && file_exists($backuppath))
+			{
+				require_once $backuppath;
+			}
+			else
+			{
+				throw new InvalidArgumentException(JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER', $type, $format));
 			}
 		}
 
@@ -587,7 +586,7 @@ class JControllerLegacy extends JObject
 				return null;
 			}
 
-			JLoader::register($viewClass, $path);
+			require_once $path;
 
 			if (!class_exists($viewClass))
 			{

--- a/libraries/legacy/model/legacy.php
+++ b/libraries/legacy/model/legacy.php
@@ -188,7 +188,7 @@ abstract class JModelLegacy extends JObject
 				return false;
 			}
 
-			JLoader::register($modelClass, $path);
+			require_once $path;
 
 			if (!class_exists($modelClass))
 			{


### PR DESCRIPTION
### Summary of Changes

Some of the autoloader changes break things.  Revert.

### Testing Instructions

Install https://github.com/akeeba/loginguard/releases/tag/1.0.0 and see that `administrator/index.php?option=com_loginguard&task=methods.display&layout=firsttime` has a broken view.  Patch applied and it works

### Documentation Changes Required

DON'T CHANGE ANYMORE AUTOLOADER THINGS EVER AGAIN UNTIL NAMESPACES ARE SUPPORTED.  IF EVER.