### PR TITLE
Menu items - empty list

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default.php
+++ b/administrator/components/com_menus/views/items/tmpl/default.php
@@ -50,7 +50,11 @@ if ($menuType == '')
 	<div id="j-main-container">
 <?php endif;?>
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'menutype'))); ?>
-		<?php if ($this->total > 0) : ?>
+		<?php if (empty($this->items)) : ?>
+			<div class="alert alert-no-items">
+				<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+			</div>
+		<?php else : ?>
 			<table class="table table-striped" id="itemList">
 				<thead>
 					<tr>


### PR DESCRIPTION
Some time ago we updated most list views so that there is a message if there is a message didsplayed if the list is empty

This wasnt done for com_menus and this PR fixes that

To test create a new menu with no menu items
Display the menu
Before the PR the view will be empty
After the Pr you will see a message

### Before
<img width="1122" alt="screenshotr13-43-39" src="https://cloud.githubusercontent.com/assets/1296369/23856899/16643062-07f3-11e7-81d0-1e5524c440aa.png">


### After

<img width="1072" alt="screenshotr13-39-15" src="https://cloud.githubusercontent.com/assets/1296369/23856847/ef75b0a2-07f2-11e7-95bd-e58ee91653b8.png">
