### PR TITLE
Missing translation for the new 'Components menu container' menu item type

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -181,7 +181,7 @@ class MenusHelper
 					  a.lft')
 			->from('#__menu AS a');
 
-		$query->select('e.name as componentname')
+		$query->select('e.name as componentname, e.element')
 			->join('left', '#__extensions e ON e.extension_id = a.component_id');
 
 		if (JLanguageMultilang::isEnabled())

--- a/administrator/components/com_menus/views/item/tmpl/edit_container.php
+++ b/administrator/components/com_menus/views/item/tmpl/edit_container.php
@@ -92,7 +92,7 @@ JFactory::getDocument()->addStyleDeclaration($style);
 
 					foreach ($menuLinks as $i => $link) : ?>
 						<?php
-						if ($extension = $link->componentname):
+						if ($extension = $link->element):
 							$lang->load("$extension.sys", JPATH_ADMINISTRATOR, null, false, true)
 							|| $lang->load("$extension.sys", JPATH_ADMINISTRATOR . '/components/' . $extension, null, false, true);
 						endif;


### PR DESCRIPTION
Steps to reproduce the issue

Install an extension such as Virtuemart

Expected result

All values in 'Show or Hide Menu Items' are translated as the standard
Joomla admin menu

Actual result

Only item marked as COM_XXX in the XML manifest file are translated,
none of the XXX are translated
![menu_container_translation](https://cloud.githubusercontent.com/assets/17835460/23865676/b64a5e30-0816-11e7-9bd2-469a42aa3d8f.PNG)
