### PR TITLE
Deprecate some useless events

### DIFF
--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -261,6 +261,9 @@ class JEditor extends JObject
 
 		$document = JFactory::getDocument();
 
+		/**
+		 * @deprecated 4.0 Use JHtml::_('script', ...) instead
+		 */
 		if (method_exists($document, 'addCustomTag') && !empty($return))
 		{
 			$document->addCustomTag($return);
@@ -338,6 +341,8 @@ class JEditor extends JObject
 	 * @return  string
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated 4.0 Bind any particular functionality to form submit 
 	 */
 	public function save($editor)
 	{
@@ -374,6 +379,8 @@ class JEditor extends JObject
 	 * @return  string
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated 4.0 Use the API: Joomla.editors.instances['jform_articletext'].getValue();
 	 */
 	public function getContent($editor)
 	{
@@ -405,6 +412,8 @@ class JEditor extends JObject
 	 * @return  string
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated 4.0 Use the API: Joomla.editors.instances['jform_articletext'].setValue('Joomla! rocks');
 	 */
 	public function setContent($editor, $html)
 	{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Since #12561 Joomla has a set of (client side) methods to deal with the editors contents therefore creating javascript code for that is useless!

#### Always use the API
as explained in full in `media/system/core.js`: 
```js
// Only define the Joomla namespace if not defined.
Joomla = window.Joomla || {};

// Only define editors if not defined
Joomla.editors = Joomla.editors || {};

// An object to hold each editor instance on page, only define if not defined.
Joomla.editors.instances = Joomla.editors.instances || {
	/**
	 * *****************************************************************
	 * All Editors MUST register, per instance, the following callbacks:
	 * *****************************************************************
	 *
	 * getValue         Type  Function  Should return the complete data from the editor
	 *                                  Example: function () { return this.element.value; }
	 * setValue         Type  Function  Should replace the complete data of the editor
	 *                                  Example: function (text) { return this.element.value = text; }
	 * replaceSelection Type  Function  Should replace the selected text of the editor
	 *                                  If nothing selected, will insert the data at the cursor
	 *                                  Example: function (text) { return insertAtCursor(this.element, text); }
	 *
	 * USAGE (assuming that jform_articletext is the textarea id)
	 * {
	 *   To get the current editor value:
	 *      Joomla.editors.instances['jform_articletext'].getValue();
	 *   To set the current editor value:
	 *      Joomla.editors.instances['jform_articletext'].setValue('Joomla! rocks');
	 *   To replace(selection) or insert a value at  the current editor cursor:
	 *      replaceSelection: Joomla.editors.instances['jform_articletext'].replaceSelection('Joomla! rocks')
	 * }
	 *
	 * *********************************************************
	 * ANY INTERACTION WITH THE EDITORS SHOULD USE THE ABOVE API
	 * *********************************************************
	 *
	 * jInsertEditorText() @deprecated 4.0
	 */
	};
```
For further examples please check the XTD-buttons!

### Testing Instructions
Code review

### Documentation Changes Required
