### PR TITLE
Smart Search Options

### DIFF
--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -113,8 +113,8 @@
 			description="COM_FINDER_CONFIG_EXPAND_ADVANCED_DESCRIPTION"
 			showon="show_advanced:1"
 		>
-			<option value="1">JYES</option>
-			<option value="0">JNO</option>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
 		<field
 			name="show_date_filters"


### PR DESCRIPTION
All the other similar options are Show/Hide but this one was Yes/No
The same option in regular search was also Show/Hide

This PR resolves that

### before
<img width="345" alt="screenshotr19-06-22" src="https://cloud.githubusercontent.com/assets/1296369/23918137/a587dd60-08e9-11e7-96a6-ff836ceb002e.png">
