### PR TITLE
[com_associations] Add a space between attributes

### DIFF
--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -176,13 +176,13 @@ class AssociationsViewAssociation extends JViewLegacy
 		$bar = JToolbar::getInstance('toolbar');
 
 		$bar->appendButton(
-			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')"'
+			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')" '
 			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>'
 			. JText::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button>', 'reference'
 		);
 
 		$bar->appendButton(
-			'Custom', '<button onclick="Joomla.submitbutton(\'target\')"'
+			'Custom', '<button onclick="Joomla.submitbutton(\'target\')" '
 			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>'
 			. JText::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
 		);


### PR DESCRIPTION
Add a space after onclick attribute.

* Under Multilingual Associations, edit an item. (Edit Associations (Articles > Categories))
* Inspect HTML source code of page
* Search for `<button onclick="Joomla.submitbutton('reference')"`

```
<div class="btn-wrapper"  id="toolbar-reference">
	<button onclick="Joomla.submitbutton('reference')"class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>Save Reference</button></div>
<div class="btn-wrapper"  id="toolbar-target">
	<button onclick="Joomla.submitbutton('target')"class="btn btn-small btn-success"><span class="icon-apply icon-white"></span>Save Target</button></div>
```