### PR TITLE
[Multilanguage] Normalising Hathor Associations fielset label

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -438,7 +438,6 @@ class CategoriesModelCategory extends JModelAdmin
 				$fields->addAttribute('name', 'associations');
 				$fieldset = $fields->addChild('fieldset');
 				$fieldset->addAttribute('name', 'item_associations');
-				$fieldset->addAttribute('description', 'COM_CATEGORIES_ITEM_ASSOCIATIONS_FIELDSET_DESC');
 
 				foreach ($languages as $language)
 				{

--- a/administrator/components/com_contact/models/contact.php
+++ b/administrator/components/com_contact/models/contact.php
@@ -547,7 +547,6 @@ class ContactModelContact extends JModelAdmin
 				$fields->addAttribute('name', 'associations');
 				$fieldset = $fields->addChild('fieldset');
 				$fieldset->addAttribute('name', 'item_associations');
-				$fieldset->addAttribute('description', 'COM_CONTACT_ITEM_ASSOCIATIONS_FIELDSET_DESC');
 
 				foreach ($languages as $language)
 				{

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -735,7 +735,6 @@ class ContentModelArticle extends JModelAdmin
 				$fields->addAttribute('name', 'associations');
 				$fieldset = $fields->addChild('fieldset');
 				$fieldset->addAttribute('name', 'item_associations');
-				$fieldset->addAttribute('description', 'COM_CONTENT_ITEM_ASSOCIATIONS_FIELDSET_DESC');
 
 				foreach ($languages as $language)
 				{

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1212,7 +1212,6 @@ class MenusModelItem extends JModelAdmin
 				$fields->addAttribute('name', 'associations');
 				$fieldset = $fields->addChild('fieldset');
 				$fieldset->addAttribute('name', 'item_associations');
-				$fieldset->addAttribute('description', 'COM_MENUS_ITEM_ASSOCIATIONS_FIELDSET_DESC');
 
 				foreach ($languages as $language)
 				{

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -519,7 +519,6 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 				$fields->addAttribute('name', 'associations');
 				$fieldset = $fields->addChild('fieldset');
 				$fieldset->addAttribute('name', 'item_associations');
-				$fieldset->addAttribute('description', 'COM_NEWSFEEDS_ITEM_ASSOCIATIONS_FIELDSET_DESC');
 
 				foreach ($languages as $language)
 				{

--- a/administrator/language/en-GB/en-GB.com_categories.ini
+++ b/administrator/language/en-GB/en-GB.com_categories.ini
@@ -47,6 +47,7 @@ COM_CATEGORIES_FILTER_SEARCH_DESC="Search in title, alias and note. Prefix with 
 COM_CATEGORIES_FILTER_SEARCH_LABEL="Search Categories"
 COM_CATEGORIES_HAS_SUBCATEGORY_ITEMS="%d items are assigned to this category's subcategories."
 COM_CATEGORIES_HAS_SUBCATEGORY_ITEMS_1="%d item is assigned to one of this category's subcategories."
+; The following 2 strings are deprecated and will be removed with 4.0.
 COM_CATEGORIES_ITEM_ASSOCIATIONS_FIELDSET_LABEL="Category Item Associations"
 COM_CATEGORIES_ITEM_ASSOCIATIONS_FIELDSET_DESC="Multilingual only! This choice will only display if the Language Filter parameter 'Item Associations' is set to 'Yes'. Choose a category item for the target language. This association will let the Language Switcher module redirect to the associated category item in another language. If used, make sure to display the Language switcher module on the concerned pages. A category item set to language 'All' can't be associated."
 COM_CATEGORIES_ITEMS_SEARCH_FILTER="Search"

--- a/administrator/language/en-GB/en-GB.com_contact.ini
+++ b/administrator/language/en-GB/en-GB.com_contact.ini
@@ -258,6 +258,7 @@ COM_CONTACT_ICONS_SETTINGS="Icons"
 COM_CONTACT_HEADING_ASSOCIATION="Association"
 COM_CONTACT_HITS_DESC="Number of hits for this contact."
 COM_CONTACT_ID_LABEL="ID"
+; The following 2 strings are deprecated and will be removed with 4.0.
 COM_CONTACT_ITEM_ASSOCIATIONS_FIELDSET_LABEL="Contact Item Associations"
 COM_CONTACT_ITEM_ASSOCIATIONS_FIELDSET_DESC="Multilingual only! This choice will only display if the Language Filter parameter 'Item Associations' is set to 'Yes'. Choose a contact item for the target language. This association will let the Language Switcher module redirect to the associated contact item in another language. If used, make sure to display the Language switcher module on the concerned pages. A contact item set to language 'All' can't be associated."
 COM_CONTACT_MAIL_FIELDSET_LABEL="Mail Options"

--- a/administrator/language/en-GB/en-GB.com_content.ini
+++ b/administrator/language/en-GB/en-GB.com_content.ini
@@ -125,6 +125,7 @@ COM_CONTENT_HEADING_DATE_CREATED="Date Created"
 COM_CONTENT_HEADING_DATE_PUBLISH_UP="Start Publishing"
 COM_CONTENT_HEADING_DATE_PUBLISH_DOWN="Finish Publishing"
 COM_CONTENT_ID_LABEL="ID"
+; The following 2 strings are deprecated and will be removed with 4.0.
 COM_CONTENT_ITEM_ASSOCIATIONS_FIELDSET_LABEL="Content Item Associations"
 COM_CONTENT_ITEM_ASSOCIATIONS_FIELDSET_DESC="Multilingual only! This choice will only display if the Language Filter parameter 'Item Associations' is set to 'Yes'. Choose a content item for the target language. This association will let the Language Switcher module redirect to the associated content item in another language. If used, make sure to display the Language switcher module on the concerned pages. A content item set to language 'All' can't be associated."
 COM_CONTENT_LEFT="Left"

--- a/administrator/language/en-GB/en-GB.com_menus.ini
+++ b/administrator/language/en-GB/en-GB.com_menus.ini
@@ -68,6 +68,7 @@ COM_MENUS_HTML_UNPUBLISH_HEADING="Unpublish the heading menu item"
 COM_MENUS_HTML_UNPUBLISH_SEPARATOR="Unpublish the separator menu item"
 COM_MENUS_HTML_UNPUBLISH_URL="Unpublish the external URL menu item"
 COM_MENUS_INTEGRATION_FIELDSET_LABEL="Integration"
+; The following 2 strings are deprecated and will be removed with 4.0.
 COM_MENUS_ITEM_ASSOCIATIONS_FIELDSET_LABEL="Menu Item Associations"
 COM_MENUS_ITEM_ASSOCIATIONS_FIELDSET_DESC="Multilingual only! This choice will only display if the Language Filter parameter 'Item Associations' is set to 'Yes'. Choose a menu item for the target language. This association will let the Language Switcher module redirect to the associated menu item in another language. If used, make sure to display the Language switcher module on the concerned pages. A menu item set to language 'All' can't be associated."
 COM_MENUS_ITEM_DETAILS="Details"

--- a/administrator/language/en-GB/en-GB.com_newsfeeds.ini
+++ b/administrator/language/en-GB/en-GB.com_newsfeeds.ini
@@ -94,6 +94,7 @@ COM_NEWSFEEDS_FLOAT_FIRST_LABEL="First Image Float"
 COM_NEWSFEEDS_FLOAT_LABEL="Image Float"
 COM_NEWSFEEDS_FLOAT_SECOND_LABEL="Second Image Float"
 COM_NEWSFEEDS_HEADING_ASSOCIATION="Association"
+; The following 2 strings are deprecated and will be removed with 4.0.
 COM_NEWSFEEDS_ITEM_ASSOCIATIONS_FIELDSET_LABEL="News Feed Item Association"
 COM_NEWSFEEDS_ITEM_ASSOCIATIONS_FIELDSET_DESC="Multilingual only! This choice will only display if the Language Filter parameter 'Item Associations' is set to 'Yes'. Choose a news feed item for the target language. This association will let the Language Switcher module redirect to the associated news feed item in another language. If used, make sure to display the Language switcher module on the concerned pages. A news feed item set to language 'All' can't be associated."
 COM_NEWSFEEDS_LEFT="Left"

--- a/administrator/templates/hathor/html/com_categories/category/edit.php
+++ b/administrator/templates/hathor/html/com_categories/category/edit.php
@@ -143,7 +143,7 @@ $assoc = JLanguageAssociations::isEnabled();
 			<?php endforeach; ?>
 
 			<?php if ($assoc) : ?>
-				<?php echo JHtml::_('sliders.panel', JText::_('COM_CATEGORIES_ITEM_ASSOCIATIONS_FIELDSET_LABEL'), '-options');?>
+				<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php endif; ?>
 

--- a/administrator/templates/hathor/html/com_contact/contact/edit.php
+++ b/administrator/templates/hathor/html/com_contact/contact/edit.php
@@ -181,7 +181,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</fieldset>
 
 			<?php if ($assoc) : ?>
-				<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_ITEM_ASSOCIATIONS_FIELDSET_LABEL'), '-options');?>
+				<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php endif; ?>
 

--- a/administrator/templates/hathor/html/com_content/article/edit.php
+++ b/administrator/templates/hathor/html/com_content/article/edit.php
@@ -245,7 +245,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</fieldset>
 
 		<?php if ($assoc) : ?>
-			<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTENT_ITEM_ASSOCIATIONS_FIELDSET_LABEL'), '-options');?>
+			<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 			<?php echo $this->loadTemplate('associations'); ?>
 		<?php endif; ?>
 

--- a/administrator/templates/hathor/html/com_menus/item/edit_options.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit_options.php
@@ -65,6 +65,6 @@ $assoc = JLanguageAssociations::isEnabled();
 	<?php endforeach;?>
 
 	<?php if ($assoc) : ?>
-		<?php echo JHtml::_('sliders.panel', JText::_('COM_MENUS_ITEM_ASSOCIATIONS_FIELDSET_LABEL'), '-options');?>
+		<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 		<?php echo $this->loadTemplate('associations'); ?>
 	<?php endif; ?>

--- a/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
+++ b/administrator/templates/hathor/html/com_newsfeeds/newsfeed/edit.php
@@ -131,7 +131,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			</fieldset>
 
 			<?php if ($assoc) : ?>
-				<?php echo JHtml::_('sliders.panel', JText::_('COM_NEWSFEEDS_ITEM_ASSOCIATIONS_FIELDSET_LABEL'), '-options');?>
+				<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 				<?php echo $this->loadTemplate('associations'); ?>
 			<?php endif; ?>
 


### PR DESCRIPTION
Pull Request for discussion in https://github.com/joomla/joomla-cms/pull/14623

### Summary of Changes
Hathor will now use the Global language string already used in Isis for its Associations slider

Descriptions for these fieldsets were no more used for a while. Modified code.

Related language strings are marked as deprecated


### Testing Instructions
Set a multilingual site with associations.
Set Hathor as your default template.

Edit or create an article
Edit or create a category
Edit or create a contact
Edit or create a Newsfeed
Edit or create a menu item


### Expected result

before patch one will get

![hathor_before](https://cloud.githubusercontent.com/assets/869724/23942837/d48e03b2-096d-11e7-8a23-e15a24edd9d5.png)

After patch

![hathor after](https://cloud.githubusercontent.com/assets/869724/23942862/e664da3e-096d-11e7-8012-6ced34104b67.png)

The other changes in code just have to be reviewed.