### PR TITLE
Stats-plugin debug mode

### DIFF
--- a/plugins/system/stats/stats.xml
+++ b/plugins/system/stats/stats.xml
@@ -63,6 +63,7 @@
 					size="15"
 				/>
 			</fieldset>
+			<!-- Uncomment the following fieldset to enable debug mode for testing purposes. Statistics will be sent on every page load
 			<fieldset name="advanced">
 				<field
 					name="debug"
@@ -76,6 +77,7 @@
 					<option value="0">JNO</option>
 				</field>
 			</fieldset>
+			-->	
 		</fields>
 	</config>
 </extension>


### PR DESCRIPTION
As discussed #14614 this PR comments out the debug mode

###Test Instructions
Before PR you have a tab called Advanced in the System-Joomla statistics plugin
After PR you dont have the tab
