### PR TITLE
Create Article Menu type - categories on the fly

### DIFF
--- a/components/com_content/views/form/tmpl/edit.xml
+++ b/components/com_content/views/form/tmpl/edit.xml
@@ -9,7 +9,9 @@
 		</message>
 	</layout>
 	<fields name="params">
-		<fieldset name="basic">
+		<fieldset name="basic"
+			addfieldpath="/administrator/components/com_categories/models/fields"
+		>
 			<field name="enable_category"
 				type="radio"
 				class="btn-group btn-group-yesno"
@@ -19,12 +21,21 @@
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>
 			</field>
-			<field name="catid"
-				type="category"
+
+			<field
+				name="catid"
+				type="modal_category"
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
-				description="JGLOBAL_CHOOSE_CATEGORY_DESC" 
-				showon="enable_category:1" />
+				required="true"
+				select="true"
+				new="true"
+				edit="true"
+				clear="true"
+				showon="enable_category:1"
+			/>
+
 
 			<field
 				name="redirect_menuitem"


### PR DESCRIPTION
We now have the ability to create categories on the fly as well as to select a category in menu items

This PR add the ability to do that when selecting a default category to use for the mennu item type Create Article

### Test instructions
Before PR you have a category list select after setting default category to yes in the options tab
After PR you have a modal select and a create

NOTE the tooltip needs to be updated as well but that has been done iin #14367
<img width="439" alt="screenshotr13-00-05" src="https://cloud.githubusercontent.com/assets/1296369/23949521/6d80be64-097f-11e7-9f0d-14d6bae8340c.png">

