### PR TITLE
Allow loading of preset more than once.

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -343,7 +343,7 @@ class JAdminCssMenu
 
 		if ($menutype == '*')
 		{
-			require_once __DIR__ . '/preset/' . ($enabled ? 'enabled.php' : 'disabled.php');
+			require __DIR__ . '/preset/' . ($enabled ? 'enabled.php' : 'disabled.php');
 		}
 		else
 		{
@@ -374,7 +374,7 @@ class JAdminCssMenu
 						// In recovery mode, load the preset inside a special root node.
 						$this->addChild(new JMenuNode(JText::_('MOD_MENU_RECOVERY_MENU_ROOT'), '#'), true);
 
-						require_once __DIR__ . '/preset/enabled.php';
+						require __DIR__ . '/preset/enabled.php';
 
 						$this->addSeparator();
 


### PR DESCRIPTION
Fixes #14532

### Summary of Changes
Remove `require_once` and use `require` to load preset menu.

Please see the issue #14532 by @brianteeman

