### PR TITLE
[com_associations] Creating missing filters

### DIFF
--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -369,7 +369,7 @@ class AssociationsModelAssociations extends JModelList
 		// Filter on the level.
 		if ($level = $this->getState('filter.level'))
 		{
-			$query->where($db->qn( 'a.level') . ' <= ' . ((int) $level + (int) $baselevel - 1));
+			$query->where($db->qn('a.level') . ' <= ' . ((int) $level + (int) $baselevel - 1));
 		}
 
 		// Filter by menu type.

--- a/administrator/components/com_associations/models/associations.php
+++ b/administrator/components/com_associations/models/associations.php
@@ -369,8 +369,7 @@ class AssociationsModelAssociations extends JModelList
 		// Filter on the level.
 		if ($level = $this->getState('filter.level'))
 		{
-			$tableAlias = in_array($extensionName, array('com_menus', 'com_categories')) ? 'a' : 'c';
-			$query->where($db->qn($tableAlias . '.level') . ' <= ' . ((int) $level + (int) $baselevel - 1));
+			$query->where($db->qn( 'a.level') . ' <= ' . ((int) $level + (int) $baselevel - 1));
 		}
 
 		// Filter by menu type.

--- a/administrator/components/com_associations/views/associations/view.html.php
+++ b/administrator/components/com_associations/views/associations/view.html.php
@@ -128,7 +128,7 @@ class AssociationsViewAssociations extends JViewLegacy
 					unset($this->activeFilters['state']);
 					$this->filterForm->removeField('state', 'filter');
 				}
-				if ($type !== 'category')
+				if (empty($support['category']))
 				{
 					unset($this->activeFilters['category_id']);
 					$this->filterForm->removeField('category_id', 'filter');
@@ -138,7 +138,7 @@ class AssociationsViewAssociations extends JViewLegacy
 					unset($this->activeFilters['menutype']);
 					$this->filterForm->removeField('menutype', 'filter');
 				}
-				if (!in_array($extensionName, array('com_categories', 'com_menus')))
+				if (empty($support['level']))
 				{
 					unset($this->activeFilters['level']);
 					$this->filterForm->removeField('level', 'filter');
@@ -213,7 +213,7 @@ class AssociationsViewAssociations extends JViewLegacy
 		{
 			JToolbarHelper::title(JText::_('COM_ASSOCIATIONS_TITLE_LIST_SELECT'), 'contract');
 		}
-	
+
 		if ($user->authorise('core.admin', 'com_associations') || $user->authorise('core.options', 'com_associations'))
 		{
 			if (!isset($this->typeName))

--- a/administrator/components/com_contact/helpers/associations.php
+++ b/administrator/components/com_contact/helpers/associations.php
@@ -152,6 +152,7 @@ class ContactAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['category'] = true;
 
 					$tables = array(
 						'a' => '#__contact_details'
@@ -170,6 +171,7 @@ class ContactAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['level'] = true;
 
 					$tables = array(
 						'a' => '#__categories'

--- a/administrator/components/com_content/helpers/associations.php
+++ b/administrator/components/com_content/helpers/associations.php
@@ -150,6 +150,7 @@ class ContentAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['category'] = true;
 
 					$tables = array(
 						'a' => '#__content'
@@ -168,6 +169,7 @@ class ContentAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['level'] = true;
 
 					$tables = array(
 						'a' => '#__categories'

--- a/administrator/components/com_menus/helpers/associations.php
+++ b/administrator/components/com_menus/helpers/associations.php
@@ -145,6 +145,7 @@ class MenusAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['level'] = true;
 
 					$tables = array(
 						'a' => '#__menu'

--- a/administrator/components/com_newsfeeds/helpers/associations.php
+++ b/administrator/components/com_newsfeeds/helpers/associations.php
@@ -154,6 +154,7 @@ class NewsfeedsAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['category'] = true;
 
 					$tables = array(
 						'a' => '#__newsfeeds'
@@ -171,6 +172,7 @@ class NewsfeedsAssociationsHelper extends JAssociationExtensionHelper
 					$support['state'] = true;
 					$support['acl'] = true;
 					$support['checkout'] = true;
+					$support['level'] = true;
 
 					$tables = array(
 						'a' => '#__categories'


### PR DESCRIPTION
This PR allows filtering items (articles, contacts, newsfeeds) per category.
It also allows to filter categories (for articles, contacts, newsfeeds) per level.
It also allows filtering menu items per level

Testing instructions

Create a multingual site with associations. 2 languages are enough.

Create articles, contacts, newsfeeds tagged to one language (it's enough for the test but one can test with both languages.)
Create categories and sub-categories for each component above tagged to one language (it's enough for the test but one can test with both languages.)
Create menu items and sub-menu items tagged to one language (it's enough for the test but one can test with both languages.)

Display Associations list: 
/administrator/index.php?option=com_associations&view=associations

Before patch, there is no filtering of the items above by category.
Before patch there is no filtering by level for categories or menu items.

After patch these are now available.
Test everything is fine.

For categories

![screen shot 2017-03-15 at 18 51 57](https://cloud.githubusercontent.com/assets/869724/23963101/8c463c08-09b0-11e7-8cd5-a61f4defbd53.png)

For Menu items

![screen shot 2017-03-15 at 18 53 21](https://cloud.githubusercontent.com/assets/869724/23963141/b2cc5970-09b0-11e7-944f-0209f48a1d61.png)

For items

![screen shot 2017-03-15 at 18 54 20](https://cloud.githubusercontent.com/assets/869724/23963204/d5967d8c-09b0-11e7-8d10-ad96279322e1.png)

Note: this PR does not solve yet the sorting by category.


@rdeutz 

