### PR TITLE
Media Manager remove Root text

### DIFF
--- a/administrator/components/com_media/views/medialist/tmpl/details.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details.php
@@ -86,8 +86,7 @@ $doc->addScriptDeclaration(
 		<p>
 			<span class="icon-folder"></span>
 			<?php
-				echo JText::_('JGLOBAL_ROOT'), ': ',
-					$params->get($path, 'images'),
+				echo $params->get($path, 'images'),
 					($this->state->folder != '') ? '/' . $this->state->folder : '';
 			?>
 		</p>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs.php
@@ -86,8 +86,7 @@ $doc->addScriptDeclaration(
 		<p>
 			<span class="icon-folder"></span>
 			<?php
-				echo JText::_('JGLOBAL_ROOT'), ': ',
-					$params->get($path, 'images'),
+				echo $params->get($path, 'images'),
 					($this->state->folder != '') ? '/' . $this->state->folder : '';
 			?>
 		</p>


### PR DESCRIPTION
In media manager the path is prefixed wth the word Root: Is that needed? It doesnt provide any information and is confusing.

This came up in a training session where the user was looking for a folder called root

This PR simply removes the word Root: as suggested by comments here #14597 in both the thumbnail and details view of the media component as linked to from the Content menu

### before
<img width="321" alt="screenshotr22-28-24" src="https://cloud.githubusercontent.com/assets/1296369/23973778/9ade5b50-09cf-11e7-9dd7-8754499b6dee.png">



### after
<img width="466" alt="screenshotr22-28-02" src="https://cloud.githubusercontent.com/assets/1296369/23973761/809a85fc-09cf-11e7-81fe-d27fbff5e287.png">