### PR TITLE
[com_associations] - newsfeed  remove notice

### DIFF
--- a/administrator/components/com_newsfeeds/helpers/associations.php
+++ b/administrator/components/com_newsfeeds/helpers/associations.php
@@ -106,7 +106,7 @@ class NewsfeedsAssociationsHelper extends JAssociationExtensionHelper
 
 		switch ($typeName)
 		{
-			case 'contact':
+			case 'newsfeed':
 				$table = JTable::getInstance('Newsfeed', 'NewsfeedsTable');
 				break;
 


### PR DESCRIPTION
Pull Request for Issue #14647 .

### Summary of Changes
fixed the `$typeName`  case value


### Testing Instructions
In the multilingual associations component and select Newsfeeds as the Item type and any language (not all)


### Expected result
no notice


### Actual result
Notice: Trying to get property of non-object
