### PR TITLE
Performance improvement for category form field

### DIFF
--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -124,7 +124,7 @@ abstract class JHtmlCategory
 
 				if ($item->language !== '*')
 				{
-					$item->title .= ' (' . $language . ')';
+					$item->title .= ' (' . $item->language . ')';
 				}
 
 				static::$items[$hash][] = JHtml::_('select.option', $item->id, $item->title);

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -49,7 +49,7 @@ abstract class JHtmlCategory
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 
 			$query = $db->getQuery(true)
-				->select('a.id, a.title, a.level')
+				->select('a.id, a.title, a.level, a.language')
 				->from('#__categories AS a')
 				->where('a.parent_id > 0');
 
@@ -121,6 +121,12 @@ abstract class JHtmlCategory
 			{
 				$repeat = ($item->level - 1 >= 0) ? $item->level - 1 : 0;
 				$item->title = str_repeat('- ', $repeat) . $item->title;
+
+				if ($item->language !== '*')
+				{
+					$item->title .= ' (' . $language . ')';
+				}
+
 				static::$items[$hash][] = JHtml::_('select.option', $item->id, $item->title);
 			}
 		}

--- a/libraries/legacy/form/field/category.php
+++ b/libraries/legacy/form/field/category.php
@@ -69,25 +69,6 @@ class JFormFieldCategory extends JFormFieldList
 				$options = JHtml::_('category.options', $extension, $filters);
 			}
 
-			// Displays language code if not set to All
-			foreach ($options as $option)
-			{
-				// Create a new query object.
-				$db = JFactory::getDbo();
-				$query = $db->getQuery(true)
-					->select($db->quoteName('language'))
-					->where($db->quoteName('id') . '=' . (int) $option->value)
-					->from($db->quoteName('#__categories'));
-
-				$db->setQuery($query);
-				$language = $db->loadResult();
-
-				if ($language !== '*')
-				{
-					$option->text = $option->text . ' (' . $language . ')';
-				}
-			}
-
 			// Verify permissions.  If the action attribute is set, then we scan the options.
 			if ((string) $this->element['action'])
 			{


### PR DESCRIPTION
### Improvement for PR #9739

### Summary of Changes
Do not load `language` column separately for each `<option> in <select>` field - `JFormFieldCategory`.
Instead do this once in `JHtmlCategory`.


### Testing Instructions
Joomla should works as before.
Before test you have to have a few categories (at least a few multi languages) for articles.
Enable debug mode.

Go to edit some menu item (or articles view) in backend.
Check what categories you have in search field Category - some of them should have suffix like " (en-GB)".
Check number of queries in debug position at the bottom of page.
Find queries which look like `"SELECT language FROM #__categories WHERE ..."`.
If you have 50 categories for articles then you will see 50 queries like above.

Apply patch.
The above queries disappear.
Joomla will still (as before) show category title with language code in brackets if language is not set as `All`.


### Expected result
Not too many queries related to category field.

### Actual result
If you have 100 categories for articles then joomla adds 100 additional simple queries for each category item (`<option>`) in form field.

### Documentation Changes Required
None.