### PR TITLE
[com_associations] Improving associated tip

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -223,7 +223,7 @@ class AssociationsHelper extends JHelperContent
 					$db->setQuery($query);
 					$category_title = $db->loadResult();
 
-					$additional = '<strong>' . JText::_('JCATEGORY') . '</strong> : ' . $category_title . '<br />';
+					$additional = '<strong>' . JText::sprintf('JCATEGORY_SPRINTF', $category_title) . '</strong> <br />';
 				}
 				elseif (isset($items[$langCode]['menutype']))
 				{
@@ -238,7 +238,7 @@ class AssociationsHelper extends JHelperContent
 					$db->setQuery($query);
 					$menutype_title = $db->loadResult();
 
-					$additional = '<strong>' . JText::_('COM_ASSOCIATIONS_HEADING_MENUTYPE') . '</strong> : ' . $menutype_title . '<br />';
+					$additional = '<strong>' . JText::sprintf('COM_MENUS_MENU_SPRINTF', $menutype_title) . '</strong><br />';
 				}
 
 				$labelClass  = '';

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -210,13 +210,35 @@ class AssociationsHelper extends JHelperContent
 				$title       = $items[$langCode][$titleFieldName];
 				$additional  = '';
 
-				if (isset($items[$langCode]['category_title']))
+				if (isset($items[$langCode]['catid']))
 				{
-					$additional = '<br/>' . JText::_('JCATEGORY') . ': ' . $items[$langCode]['category_title'];
+					$db = JFactory::getDbo();
+
+					// Get the category name
+					$query = $db->getQuery(true)
+						->select($db->quoteName('title'))
+						->from($db->quoteName('#__categories'))
+						->where($db->quoteName('id') . ' = ' . $db->quote($items[$langCode]['catid']));
+
+					$db->setQuery($query);
+					$category_title = $db->loadResult();
+
+					$additional = '<strong>' . JText::_('JCATEGORY') . '</strong> : ' . $category_title . '<br />';
 				}
-				elseif (isset($items[$langCode]['menu_title']))
+				elseif (isset($items[$langCode]['menutype']))
 				{
-					$additional = '<br/>' . JText::_('COM_ASSOCIATIONS_HEADING_MENUTYPE') . ': ' . $items[$langCode]['menu_title'];
+					$db = JFactory::getDbo();
+
+					// Get the menutype name
+					$query = $db->getQuery(true)
+						->select($db->quoteName('title'))
+						->from($db->quoteName('#__menu_types'))
+						->where($db->quoteName('menutype') . ' = ' . $db->quote($items[$langCode]['menutype']));
+
+					$db->setQuery($query);
+					$menutype_title = $db->loadResult();
+
+					$additional = '<strong>' . JText::_('COM_ASSOCIATIONS_HEADING_MENUTYPE') . '</strong> : ' . $menutype_title . '<br />';
 				}
 
 				$labelClass  = '';


### PR DESCRIPTION
In the Gsoc project the tip for associated items included more infos.
1. For items, it was also showing the category it belongs to
2. For menu items, it was also showing in which Menu Type it is

This PR reinstates this functionnality:

Before patch for articles (would be the same for contacts and newsfeeds)
![screen shot 2017-03-16 at 10 20 18](https://cloud.githubusercontent.com/assets/869724/23989278/35011efe-0a32-11e7-9e31-e9cd2411f390.png)

After patch
![screen shot 2017-03-16 at 10 13 36](https://cloud.githubusercontent.com/assets/869724/23989201/e90525b8-0a31-11e7-9f2a-f4e976636e4e.png)

before patch for Menu items
![screen shot 2017-03-16 at 10 21 37](https://cloud.githubusercontent.com/assets/869724/23989332/62b0997e-0a32-11e7-81a3-dd9b396ce8eb.png)

After patch
![screen shot 2017-03-16 at 10 22 47](https://cloud.githubusercontent.com/assets/869724/23989376/8b4cfbca-0a32-11e7-896f-fc9ffda189f4.png)

Testing instructions:
Create a multilingual site (from staging)
Associate some menu items and some articles/contacts/newsfeeds
Display com_associations list and choose the type and language you want to display.


@brianteeman @alikon @rdeutz 

