### PR TITLE
Notes - User tooltip

### DIFF
--- a/administrator/components/com_users/models/forms/note.xml
+++ b/administrator/components/com_users/models/forms/note.xml
@@ -20,6 +20,7 @@
 			class="input-medium"
 			required="true"
 			label="COM_USERS_FIELD_USER_ID_LABEL"
+			description="JLIB_FORM_SELECT_USER"
 			/>
 
 		<field


### PR DESCRIPTION
The user field label didn't have a tooltip. For consistency it really should.
This PR re-uses a generic string for the tooltip so there is no new language string

### Before
<img width="458" alt="screenshotr13-05-27" src="https://cloud.githubusercontent.com/assets/1296369/23997687/4ef685ca-0a4a-11e7-8ae3-7eb074672ecc.png">



### After

<img width="221" alt="screenshotr13-09-28" src="https://cloud.githubusercontent.com/assets/1296369/23997695/54bb9324-0a4a-11e7-934c-731525f4aadc.png">
