### PR TITLE
Beez Template style options - showon

### DIFF
--- a/templates/beez3/templateDetails.xml
+++ b/templates/beez3/templateDetails.xml
@@ -107,11 +107,14 @@
 				</field>
 
 				<field name="headerImage" type="media"
-					label="TPL_BEEZ3_FIELD_HEADER_IMAGE_LABEL" description="TPL_BEEZ3_FIELD_HEADER_IMAGE_DESC" />
+					label="TPL_BEEZ3_FIELD_HEADER_IMAGE_LABEL" 
+					description="TPL_BEEZ3_FIELD_HEADER_IMAGE_DESC" 
+					showon="templatecolor:image" />
 
 				<field name="backgroundcolor" type="color" default="#eee"
 					label="TPL_BEEZ3_FIELD_HEADER_BACKGROUND_COLOR_LABEL"
-					description="TPL_BEEZ3_FIELD_HEADER_BACKGROUND_COLOR_DESC" />
+					description="TPL_BEEZ3_FIELD_HEADER_BACKGROUND_COLOR_DESC"
+					showon="templatecolor:image" />
 
 			</fieldset>
 		</fields>


### PR DESCRIPTION
The final two options are only available if the previous one was set to Custom

This PR hides the fields using showon unless the Template Colour option is set to Custom

