### PR TITLE
[fields] Label

### DIFF
--- a/administrator/components/com_fields/models/forms/field.xml
+++ b/administrator/components/com_fields/models/forms/field.xml
@@ -182,7 +182,7 @@
 			label="COM_FIELDS_FIELD_LABEL_LABEL"
 			description="COM_FIELDS_FIELD_LABEL_DESC"
 			size="40"
-			required="true"
+			hint="JFIELD_ALIAS_PLACEHOLDER"
 		/>
 
 		<field


### PR DESCRIPTION
This field is marked as required which makes a user think they must complete it however it can never be blank as we have code that creates a label automatically from the title.

This PR removes the required value AND inserts the hint 'Auto-generate from title" just as we see in the alias field

### Before
<img width="422" alt="screenshotr17-01-13" src="https://cloud.githubusercontent.com/assets/1296369/24008832/c502cdc6-0a6a-11e7-95ed-836ca111d898.png">


### After

<img width="450" alt="screenshotr17-00-53" src="https://cloud.githubusercontent.com/assets/1296369/24008844/ceed586a-0a6a-11e7-90f3-49559b48a554.png">
