### PR TITLE
[com_fields] Use plugin specific language strings for the default value

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -3,10 +3,8 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-
-COM_FIELDS_FIELD_DEFAULT_VALUE_LABEL="Default Users"
-COM_FIELDS_FIELD_DEFAULT_VALUE_DESC="A comma separated list of user ids."
-
 PLG_FIELDS_USER="Fields - User"
+PLG_FIELDS_USER_DEFAULT_VALUE_LABEL="Default Users"
+PLG_FIELDS_USER_DEFAULT_VALUE_DESC="A comma separated list of user ids."
 PLG_FIELDS_USER_LABEL="User (%s)"
 PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets you create new fields of type 'user' in any extensions where custom fields are supported."

--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USER="Fields - User"
-PLG_FIELDS_USER_DEFAULT_VALUE_LABEL="Default Users"
 PLG_FIELDS_USER_DEFAULT_VALUE_DESC="A comma separated list of user ids."
+PLG_FIELDS_USER_DEFAULT_VALUE_LABEL="Default Users"
 PLG_FIELDS_USER_LABEL="User (%s)"
 PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets you create new fields of type 'user' in any extensions where custom fields are supported."

--- a/plugins/fields/user/params/user.xml
+++ b/plugins/fields/user/params/user.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<field
+		name="default_value"
+		type="textarea"
+		filter="raw"
+		label="PLG_FIELDS_USER_DEFAULT_VALUE_LABEL"
+		description="PLG_FIELDS_USER_DEFAULT_VALUE_DESC"
+	/>
+</form>


### PR DESCRIPTION
Pull Request for Issue #14674.

### Summary of Changes
Sets different language strings fro the user default field. Fixes the all problem introduced in #14404.


### Testing Instructions
- Create a text field.
- Create a user field.


### Expected result
- On the text field the standard default text is shown.
- On the user field a different, user specific text is shown for the default field.


### Actual result
- On the text field the user specific text is shown for the default field.
- On the user field the user specific text is shown for the default field.
