### PR TITLE
[com_fields] Update the values correctly on save field

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -156,20 +156,48 @@ class FieldsModelField extends JModelAdmin
 		// If the options have changed delete the values
 		if ($field && isset($data['fieldparams']['options']) && isset($field->fieldparams['options']))
 		{
-			$oldParams = json_decode($field->fieldparams['options']);
-			$newParams = json_decode($data['fieldparams']['options']);
+			$oldParams = $this->getParams($field->fieldparams['options']);
+			$newParams = $this->getParams($data['fieldparams']['options']);
 
-			if (is_object($oldParams) && is_object($newParams) && $oldParams->name != $newParams->name)
+			if (true || is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
+				$names = array();
+				foreach ($newParams as $param) {
+					$names[] = $param['value'];
+				}
 				$query = $db->getQuery(true);
 				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id)
-					->where("value not in ('" . implode("','", $newParams->name) . "')");
+					->where("value NOT IN ('" . implode("','", $names) . "')");
 				$db->setQuery($query);
 				$db->execute();
 			}
 		}
 
 		return true;
+	}
+
+	/**
+	 * Convertes the unknown params into an object.
+	 *
+	 * @param   mixed     $params  The params.
+	 *
+	 * @return  stdClass  Object on success, false on failure.
+	 *
+	 * @since   3.7.0
+	 */
+	private function getParams($params)
+	{
+		if (is_string($params))
+		{
+			$params = json_decode($params);
+		}
+
+		if (is_array($params))
+		{
+			$params = (object)$params;
+		}
+
+		return $params;
 	}
 
 	/**

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -162,7 +162,8 @@ class FieldsModelField extends JModelAdmin
 			if (is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
 				$names = array();
-				foreach ($newParams as $param) {
+				foreach ($newParams as $param)
+				{
 					$names[] = $param['value'];
 				}
 				$query = $db->getQuery(true);
@@ -179,7 +180,7 @@ class FieldsModelField extends JModelAdmin
 	/**
 	 * Convertes the unknown params into an object.
 	 *
-	 * @param   mixed     $params  The params.
+	 * @param   mixed  $params  The params.
 	 *
 	 * @return  stdClass  Object on success, false on failure.
 	 *
@@ -194,7 +195,7 @@ class FieldsModelField extends JModelAdmin
 
 		if (is_array($params))
 		{
-			$params = (object)$params;
+			$params = (object) $params;
 		}
 
 		return $params;

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -164,11 +164,11 @@ class FieldsModelField extends JModelAdmin
 				$names = array();
 				foreach ($newParams as $param)
 				{
-					$names[] = $param['value'];
+					$names[] = $db->q($param['value']);
 				}
 				$query = $db->getQuery(true);
 				$query->delete('#__fields_values')->where('field_id = ' . (int) $field->id)
-					->where("value NOT IN ('" . implode("','", $names) . "')");
+					->where('value NOT IN (' . implode(',', $names) . ')');
 				$db->setQuery($query);
 				$db->execute();
 			}

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -178,7 +178,7 @@ class FieldsModelField extends JModelAdmin
 	}
 
 	/**
-	 * Convertes the unknown params into an object.
+	 * Converts the unknown params into an object.
 	 *
 	 * @param   mixed  $params  The params.
 	 *

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -159,7 +159,7 @@ class FieldsModelField extends JModelAdmin
 			$oldParams = $this->getParams($field->fieldparams['options']);
 			$newParams = $this->getParams($data['fieldparams']['options']);
 
-			if (true || is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
+			if (is_object($oldParams) && is_object($newParams) && $oldParams != $newParams)
 			{
 				$names = array();
 				foreach ($newParams as $param) {


### PR DESCRIPTION
Pull Request for Issue #14589.

### Summary of Changes
When the options did change of a list, radio or checkbox field then it didn't work correctly since the move to subformfields in #13069.


### Testing Instructions
- Create a checkbox field with multiple options.
- Edit an article and select some of the options.
- Go back to the field and delete an option you have selected in the article.
- Create a new option.
- Save the field.


### Expected result
The article has still the options selected which are not touched and the option is unselected.


### Actual result
An error is thrown as in #14589.

