### PR TITLE
a11y icons for associations

### DIFF
--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -69,7 +69,7 @@ class JFormFieldModalAssociation extends JFormField
 			. ' data-change="' . JText::_('COM_ASSOCIATIONS_CHANGE_TARGET') . '"'
 			. ' role="button"'
 			. ' href="#associationSelect' . $this->id . 'Modal">'
-			. '<span class="icon-file"></span>'
+			. '<span class="icon-file" aria-hdden="true"></span>'
 			. '<span id="select-change-text"></span>'
 			. '</a>';
 

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -69,7 +69,7 @@ class JFormFieldModalAssociation extends JFormField
 			. ' data-change="' . JText::_('COM_ASSOCIATIONS_CHANGE_TARGET') . '"'
 			. ' role="button"'
 			. ' href="#associationSelect' . $this->id . 'Modal">'
-			. '<span class="icon-file" aria-hdden="true"></span>'
+			. '<span class="icon-file" aria-hidden="true"></span>'
 			. '<span id="select-change-text"></span>'
 			. '</a>';
 

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -78,7 +78,7 @@ class JFormFieldModalAssociation extends JFormField
  				. ' class="btn' . ($value ? '' : ' hidden') . '"'
  				. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
  				. ' id="remove-assoc">'
- 				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+ 				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
  				. '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '" />';

--- a/administrator/components/com_categories/models/fields/modal/category.php
+++ b/administrator/components/com_categories/models/fields/modal/category.php
@@ -135,7 +135,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' role="button"'
 				. ' href="#ModalSelect' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_CHANGE_CATEGORY') . '">'
-				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '<span class="icon-file" aria-hidden="true"></span> ' . JText::_('JSELECT')
 				. '</a>';
 		}
 
@@ -149,7 +149,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' role="button"'
 				. ' href="#ModalNew' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_NEW_CATEGORY') . '">'
-				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '<span class="icon-new" aria-hidden="true"></span> ' . JText::_('JACTION_CREATE')
 				. '</a>';
 		}
 
@@ -163,7 +163,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' role="button"'
 				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CATEGORIES_EDIT_CATEGORY') . '">'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit" aria-hidden="true"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -175,7 +175,7 @@ class JFormFieldModal_Category extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' href="#"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
 				. '</a>';
 		}
 

--- a/administrator/components/com_contact/models/fields/modal/contact.php
+++ b/administrator/components/com_contact/models/fields/modal/contact.php
@@ -124,7 +124,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' role="button"'
 				. ' href="#ModalSelect' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_CHANGE_CONTACT') . '">'
-				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '<span class="icon-file" aria-hidden="true"></span> ' . JText::_('JSELECT')
 				. '</a>';
 		}
 
@@ -138,7 +138,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' role="button"'
 				. ' href="#ModalNew' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_NEW_CONTACT') . '">'
-				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '<span class="icon-new" aria-hidden="true"></span> ' . JText::_('JACTION_CREATE')
 				. '</a>';
 		}
 
@@ -152,7 +152,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' role="button"'
 				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTACT_EDIT_CONTACT') . '">'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit" aria-hidden="true"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -164,7 +164,7 @@ class JFormFieldModal_Contact extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' href="#"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
 				. '</a>';
 		}
 

--- a/administrator/components/com_content/models/fields/modal/article.php
+++ b/administrator/components/com_content/models/fields/modal/article.php
@@ -127,7 +127,7 @@ class JFormFieldModal_Article extends JFormField
 				. ' role="button"'
 				. ' href="#ModalSelect' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTENT_CHANGE_ARTICLE') . '">'
-				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '<span class="icon-file" aria-hidden="true"></span> ' . JText::_('JSELECT')
 				. '</a>';
 		}
 
@@ -141,7 +141,7 @@ class JFormFieldModal_Article extends JFormField
 				. ' role="button"'
 				. ' href="#ModalNew' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTENT_NEW_ARTICLE') . '">'
-				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '<span class="icon-new" aria-hidden="true"></span> ' . JText::_('JACTION_CREATE')
 				. '</a>';
 		}
 
@@ -155,7 +155,7 @@ class JFormFieldModal_Article extends JFormField
 				. ' role="button"'
 				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_CONTENT_EDIT_ARTICLE') . '">'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit" aria-hidden="true"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -167,7 +167,7 @@ class JFormFieldModal_Article extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' href="#"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
 				. '</a>';
 		}
 

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -234,7 +234,7 @@ class JFormFieldModal_Menu extends JFormField
 				. ' role="button"'
 				. ' href="#ModalSelect' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_MENUS_CHANGE_MENUITEM') . '">'
-				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '<span class="icon-file" aria-hidden="true"></span> ' . JText::_('JSELECT')
 				. '</a>';
 		}
 
@@ -248,7 +248,7 @@ class JFormFieldModal_Menu extends JFormField
 				. ' role="button"'
 				. ' href="#ModalNew' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_MENUS_NEW_MENUITEM') . '">'
-				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '<span class="icon-new" aria-hidden="true"></span> ' . JText::_('JACTION_CREATE')
 				. '</a>';
 		}
 
@@ -262,7 +262,7 @@ class JFormFieldModal_Menu extends JFormField
 				. ' role="button"'
 				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_MENUS_EDIT_MENUITEM') . '">'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit" aria-hidden="true"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -274,7 +274,7 @@ class JFormFieldModal_Menu extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' href="#"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
 				. '</a>';
 		}
 

--- a/administrator/components/com_modules/layouts/toolbar/cancelselect.php
+++ b/administrator/components/com_modules/layouts/toolbar/cancelselect.php
@@ -12,5 +12,5 @@ defined('_JEXEC') or die;
 $text = JText::_('JTOOLBAR_CANCEL');
 ?>
 <button onclick="location.href='index.php?option=com_modules'" class="btn" title="<?php echo $text; ?>">
-	<span class="icon-remove"></span> <?php echo $text; ?>
+	<span class="icon-remove" aria-hidden="true"></span> <?php echo $text; ?>
 </button>

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -124,7 +124,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' role="button"'
 				. ' href="#ModalSelect' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_CHANGE_FEED') . '">'
-				. '<span class="icon-file"></span> ' . JText::_('JSELECT')
+				. '<span class="icon-file" aria-hidden="true"></span> ' . JText::_('JSELECT')
 				. '</a>';
 		}
 
@@ -138,7 +138,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' role="button"'
 				. ' href="#ModalNew' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_NEW_NEWSFEED') . '">'
-				. '<span class="icon-new"></span> ' . JText::_('JACTION_CREATE')
+				. '<span class="icon-new" aria-hidden="true"></span> ' . JText::_('JACTION_CREATE')
 				. '</a>';
 		}
 
@@ -152,7 +152,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' role="button"'
 				. ' href="#ModalEdit' . $modalId . '"'
 				. ' title="' . JHtml::tooltipText('COM_NEWSFEEDS_EDIT_NEWSFEED') . '">'
-				. '<span class="icon-edit"></span> ' . JText::_('JACTION_EDIT')
+				. '<span class="icon-edit" aria-hidden="true"></span> ' . JText::_('JACTION_EDIT')
 				. '</a>';
 		}
 
@@ -164,7 +164,7 @@ class JFormFieldModal_Newsfeed extends JFormField
 				. ' id="' . $this->id . '_clear"'
 				. ' href="#"'
 				. ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-				. '<span class="icon-remove"></span>' . JText::_('JCLEAR')
+				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
 				. '</a>';
 		}
 


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use case shown in the image below

<img width="282" alt="screenshotr14-48-15" src="https://cloud.githubusercontent.com/assets/1296369/24048824/f5fc7c30-0b21-11e7-87f6-210eb23af098.png">

Thanks to @fuzzbomb for his guidance on this - there is more to come