### PR TITLE
a11y icons for calendar

### DIFF
--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -36,7 +36,7 @@ JHtml::_('bootstrap.tooltip');
 				</div>
 				<div class="span4">
 					<div class="small pull-right hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JGLOBAL_FIELD_CREATED_LABEL'); ?>">
-						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
+						<span class="icon-calendar" aria-hidden="true"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>
 			</div>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -42,7 +42,7 @@ JHtml::_('bootstrap.tooltip');
 			</div>
 			<div class="span4">
 				<div class="small pull-right hasTooltip" title="<?php echo JHtml::_('tooltipText', 'MOD_LOGGED_LAST_ACTIVITY'); ?>">
-					<span class="icon-calendar"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC5')); ?>
+					<span class="icon-calendar" aria-hidden="true"></span> <?php echo JHtml::_('date', $user->time, JText::_('DATE_FORMAT_LC5')); ?>
 				</div>
 			</div>
 		</div>

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -35,7 +35,7 @@ JHtml::_('bootstrap.tooltip');
 				</div>
 				<div class="span4">
 					<div class="small pull-right hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JGLOBAL_FIELD_CREATED_LABEL'); ?>">
-						<span class="icon-calendar"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
+						<span class="icon-calendar" aria-hidden="true"></span> <?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC5')); ?>
 					</div>
 				</div>
 			</div>

--- a/components/com_content/views/archive/tmpl/default_items.php
+++ b/components/com_content/views/archive/tmpl/default_items.php
@@ -78,7 +78,7 @@ $params = $this->params;
 				<?php if ($params->get('show_publish_date')) : ?>
 					<dd>
 						<div class="published">
-							<span class="icon-calendar"></span>
+							<span class="icon-calendar" aria-hidden="true"></span>
 							<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
 								<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
@@ -90,7 +90,7 @@ $params = $this->params;
 					<?php if ($params->get('show_modify_date')) : ?>
 						<dd>
 							<div class="modified">
-								<span class="icon-calendar"></span>
+								<span class="icon-calendar" aria-hidden="true"></span>
 								<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
 									<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
@@ -100,7 +100,7 @@ $params = $this->params;
 					<?php if ($params->get('show_create_date')) : ?>
 						<dd>
 							<div class="create">
-								<span class="icon-calendar"></span>
+								<span class="icon-calendar" aria-hidden="true"></span>
 								<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
 									<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
@@ -167,7 +167,7 @@ $params = $this->params;
 					<?php if ($params->get('show_publish_date')) : ?>
 						<dd>
 							<div class="published">
-								<span class="icon-calendar"></span>
+								<span class="icon-calendar" aria-hidden="true"></span>
 								<time datetime="<?php echo JHtml::_('date', $item->publish_up, 'c'); ?>" itemprop="datePublished">
 									<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $item->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 								</time>
@@ -179,7 +179,7 @@ $params = $this->params;
 				<?php if ($params->get('show_create_date')) : ?>
 					<dd>
 						<div class="create">
-							<span class="icon-calendar"></span>
+							<span class="icon-calendar" aria-hidden="true"></span>
 							<time datetime="<?php echo JHtml::_('date', $item->created, 'c'); ?>" itemprop="dateCreated">
 								<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>
@@ -189,7 +189,7 @@ $params = $this->params;
 				<?php if ($params->get('show_modify_date')) : ?>
 					<dd>
 						<div class="modified">
-							<span class="icon-calendar"></span>
+							<span class="icon-calendar" aria-hidden="true"></span>
 							<time datetime="<?php echo JHtml::_('date', $item->modified, 'c'); ?>" itemprop="dateModified">
 								<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $item->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 							</time>

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 ?>
 			<dd class="create">
-					<span class="icon-calendar"></span>
+					<span class="icon-calendar" aria-hidden="true"></span>
 					<time datetime="<?php echo JHtml::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
 						<?php echo JText::sprintf('COM_CONTENT_CREATED_DATE_ON', JHtml::_('date', $displayData['item']->created, JText::_('DATE_FORMAT_LC3'))); ?>
 					</time>

--- a/layouts/joomla/content/info_block/modify_date.php
+++ b/layouts/joomla/content/info_block/modify_date.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 ?>
 			<dd class="modified">
-				<span class="icon-calendar"></span>
+				<span class="icon-calendar" aria-hidden="true"></span>
 				<time datetime="<?php echo JHtml::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
 					<?php echo JText::sprintf('COM_CONTENT_LAST_UPDATED', JHtml::_('date', $displayData['item']->modified, JText::_('DATE_FORMAT_LC3'))); ?>
 				</time>

--- a/layouts/joomla/content/info_block/publish_date.php
+++ b/layouts/joomla/content/info_block/publish_date.php
@@ -10,7 +10,7 @@
 defined('JPATH_BASE') or die;
 ?>
 			<dd class="published">
-				<span class="icon-calendar"></span>
+				<span class="icon-calendar" aria-hidden="true"></span>
 				<time datetime="<?php echo JHtml::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
 					<?php echo JText::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', JHtml::_('date', $displayData['item']->publish_up, JText::_('DATE_FORMAT_LC3'))); ?>
 				</time>


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use case shown in the image below
<img width="152" alt="screenshotr15-09-11" src="https://cloud.githubusercontent.com/assets/1296369/24049661/9952699c-0b24-11e7-9bb4-ba7a40f78ede.png">
