### PR TITLE
a11y icon - select

### DIFF
--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -95,7 +95,7 @@ class JFormFieldMenutype extends JFormFieldList
 		$html[] = '<span class="input-append"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '" ' . $size . $class . ' />';
 		$html[] = '<a href="#menuTypeModal" role="button" class="btn btn-primary" data-toggle="modal" title="' . JText::_('JSELECT') . '">'
-			. '<span class="icon-list icon-white"></span> '
+			. '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. JText::_('JSELECT') . '</a></span>';
 		$html[] = JHtml::_(
 			'bootstrap.renderModal',

--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -83,7 +83,7 @@ jQuery(function() {";
 			<button name="Search" type="submit" class="btn btn-primary disabled"><span class="icon-search icon-white"></span> <?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?></button>
 		<?php endif; ?>
 		<?php if ($this->params->get('show_advanced', 1)) : ?>
-			<a href="#advancedSearch" data-toggle="collapse" class="btn"><span class="icon-list"></span> <?php echo JText::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
+			<a href="#advancedSearch" data-toggle="collapse" class="btn"><span class="icon-list" aria-hidden="true"></span> <?php echo JText::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
 		<?php endif; ?>
 	</fieldset>
 


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use cases shown in the image below

<img width="501" alt="screenshotr15-18-22" src="https://cloud.githubusercontent.com/assets/1296369/24050110/c7b398b4-0b25-11e7-8a1b-142093bd8a5b.png">
<img width="303" alt="screenshotr15-21-21" src="https://cloud.githubusercontent.com/assets/1296369/24050111/c7b85afc-0b25-11e7-96e7-29568f8b190d.png">
