### PR TITLE
a11y icons for banners

### DIFF
--- a/administrator/components/com_banners/models/fields/clicks.php
+++ b/administrator/components/com_banners/models/fields/clicks.php
@@ -37,6 +37,6 @@ class JFormFieldClicks extends JFormField
 
 		return '<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '>'
-			. '<span class="icon-refresh"></span> ' . JText::_('COM_BANNERS_RESET_CLICKS') . '</a>';
+			. '<span class="icon-refresh" aria-hidden="true"></span> ' . JText::_('COM_BANNERS_RESET_CLICKS') . '</a>';
 	}
 }

--- a/administrator/components/com_banners/models/fields/impmade.php
+++ b/administrator/components/com_banners/models/fields/impmade.php
@@ -37,6 +37,6 @@ class JFormFieldImpMade extends JFormField
 
 		return '<input class="input-small" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
 			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly" /> <a class="btn" ' . $onclick . '>'
-			. '<span class="icon-refresh"></span> ' . JText::_('COM_BANNERS_RESET_IMPMADE') . '</a>';
+			. '<span class="icon-refresh" aria-hidden="true"></span> ' . JText::_('COM_BANNERS_RESET_IMPMADE') . '</a>';
 	}
 }


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use case shown in the image below
<img width="394" alt="screenshotr15-33-12" src="https://cloud.githubusercontent.com/assets/1296369/24050700/9af2cba4-0b27-11e7-86a4-b6c48aeee13f.png">
