### PR TITLE
a11y icons menus

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -70,19 +70,19 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 							<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="10%" class="nowrap center">
-							<span class="icon-publish"></span>
+							<span class="icon-publish" aria-hidden="true"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_PUBLISHED_ITEMS'); ?></span>
 						</th>
 						<th width="10%" class="nowrap center">
-							<span class="icon-unpublish"></span>
+							<span class="icon-unpublish" aria-hidden="true"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_UNPUBLISHED_ITEMS'); ?></span>
 						</th>
 						<th width="10%" class="nowrap center">
-							<span class="icon-trash"></span>
+							<span class="icon-trash" aria-hidden="true"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_TRASHED_ITEMS'); ?></span>
 						</th>
 						<th width="20%" class="nowrap center">
-							<span class="icon-cube"></span>
+							<span class="icon-cube" aria-hidden="true"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_MENUS_HEADING_LINKED_MODULES'); ?></span>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use case shown in the image below
<img width="831" alt="screenshotr15-55-00" src="https://cloud.githubusercontent.com/assets/1296369/24051621/952df3bc-0b2a-11e7-827a-d95554ecc014.png">
