### PR TITLE
a11y icons in layouts

### DIFF
--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -19,7 +19,7 @@ $legacy = $displayData['legacy'];
 	<?php if ($legacy) : ?>
 		<?php echo JHtml::_('image', 'system/new.png', JText::_('JNEW'), null, true); ?>
 	<?php else : ?>
-		<span class="icon-plus"></span>
+		<span class="icon-plus" aria-hidden="true"></span>
 		<?php echo JText::_('JNEW'); ?>
 	<?php endif; ?>
 <?php else : ?>

--- a/layouts/joomla/content/icons/email.php
+++ b/layouts/joomla/content/icons/email.php
@@ -17,7 +17,7 @@ $legacy = $displayData['legacy'];
 	<?php if ($legacy) : ?>
 		<?php echo JHtml::_('image', 'system/emailButton.png', JText::_('JGLOBAL_EMAIL'), null, true); ?>
 	<?php else : ?>
-		<span class="icon-envelope"></span>
+		<span class="icon-envelope" aria-hidden="true"></span>
 		<?php echo JText::_('JGLOBAL_EMAIL'); ?>
 	<?php endif; ?>
 <?php else : ?>

--- a/layouts/joomla/content/icons/print_popup.php
+++ b/layouts/joomla/content/icons/print_popup.php
@@ -18,7 +18,7 @@ $legacy = $displayData['legacy'];
 		<?php // Checks template image directory for image, if none found default are loaded ?>
 		<?php echo JHtml::_('image', 'system/printButton.png', JText::_('JGLOBAL_PRINT'), null, true); ?>
 	<?php else : ?>
-		<span class="icon-print"></span>
+		<span class="icon-print" aria-hidden="true"></span>
 		<?php echo JText::_('JGLOBAL_PRINT'); ?>
 	<?php endif; ?>
 <?php else : ?>

--- a/layouts/joomla/content/icons/print_screen.php
+++ b/layouts/joomla/content/icons/print_screen.php
@@ -18,7 +18,7 @@ $legacy = $displayData['legacy'];
 		<?php // Checks template image directory for image, if none found default are loaded ?>
 		<?php echo JHtml::_('image', 'system/printButton.png', JText::_('JGLOBAL_PRINT'), null, true); ?>
 	<?php else : ?>
-		<span class="icon-print"></span>
+		<span class="icon-print" aria-hidden="true"></span>
 		<?php echo JText::_('JGLOBAL_PRINT'); ?>
 	<?php endif; ?>
 <?php else : ?>

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 ?>
 			<dd class="hits">
-					<span class="icon-eye-open"></span>
+					<span class="icon-eye-open" aria-hidden="true"></span>
 					<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>" />
 					<?php echo JText::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
 			</dd>

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -15,7 +15,7 @@ $item = $displayData['item'];
 
 <p class="readmore">
 	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url">
-		<span class="icon-chevron-right"></span>
+		<span class="icon-chevron-right" aria-hidden="true"></span>
 		<?php if (!$params->get('access-view')) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
 		elseif ($readmore = $item->alternative_readmore) :

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -27,6 +27,6 @@ $button = $displayData;
 	}
 	?>
 	<a class="<?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $href, $onclick; ?> rel="<?php echo $button->get('options'); ?>">
-		<span class="icon-<?php echo $button->get('name'); ?>"></span> <?php echo $button->get('text'); ?>
+		<span class="icon-<?php echo $button->get('name'); ?>" aria-hidden="true"></span> <?php echo $button->get('text'); ?>
 	</a>
 <?php endif;

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -22,5 +22,5 @@ extract($displayData);
 JHtml::_('behavior.modal', 'button.modal_' . $item);
 ?>
 <button class="btn modal_<?php echo $item; ?>" title="<?php echo $label; ?>" href="<?php echo $link; ?>" rel="{handler: 'iframe', size: {x: 800, y: 500}}">
-	<span class="icon-archive"></span><?php echo $label; ?>
+	<span class="icon-archive" aria-hidden="true"></span><?php echo $label; ?>
 </button>

--- a/layouts/joomla/links/link.php
+++ b/layouts/joomla/links/link.php
@@ -18,6 +18,6 @@ $text    = empty($displayData['text']) ? '' : ('<span class="j-links-link">' . $
 ?>
 <li<?php echo $id; ?>>
 	<a href="<?php echo JFilterOutput::ampReplace($displayData['link']); ?>"<?php echo $target . $onclick . $title; ?>>
-		<span class="icon-<?php echo $displayData['image']; ?>"></span> <?php echo $text; ?>
+		<span class="icon-<?php echo $displayData['image']; ?>" aria-hidden="true"></span> <?php echo $text; ?>
 	</a>
 </li>

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -19,7 +19,7 @@ $text    = empty($displayData['text']) ? '' : ('<span>' . $displayData['text'] .
 <div class="row-fluid"<?php echo $id; ?>>
 	<div class="span12">
 		<a href="<?php echo $displayData['link']; ?>"<?php echo $target . $onclick . $title; ?>>
-			<span class="icon-<?php echo $displayData['image']; ?>"></span> <?php echo $text; ?>
+			<span class="icon-<?php echo $displayData['image']; ?>" aria-hidden="true"></span> <?php echo $text; ?>
 		</a>
 	</div>
 </div>

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -18,7 +18,7 @@ $name = $displayData;
 			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"
 			title="<?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>"
 		>
-			<span class="icon-eye"></span> <?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
+			<span class="icon-eye" aria-hidden="true"></span> <?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
 		</a>
 	</div>
 </div>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -16,6 +16,6 @@ JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 $message = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
 ?>
 <button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $message; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-small">
-	<span class="icon-checkbox-partial" title="<?php echo $title; ?>"></span>
+	<span class="icon-checkbox-partial" aria-hidden="true" title="<?php echo $title; ?>"></span>
 	<?php echo $title; ?>
 </button>

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -16,6 +16,6 @@ $text   = $displayData['text'];
 
 ?>
 <button onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-small">
-	<span class="icon-question-sign"></span>
+	<span class="icon-question-sign" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -27,6 +27,6 @@ $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'out-3';
 $text     = isset($displayData['text']) ? $displayData['text'] : '';
 ?>
 <button class="<?php echo $class; ?>" data-toggle="modal" data-target="#<?php echo $selector; ?>">
-	<span class="icon-<?php echo $icon; ?>"></span>
+	<span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -18,6 +18,6 @@ $name    = $displayData['name'];
 $onClose = $displayData['onClose'];
 ?>
 <button onclick="<?php echo $doTask; ?>" class="btn btn-small" data-toggle="collapse" data-target="#collapse-<?php echo $name; ?>"<?php echo $onClose; ?>>
-	<span class="icon-cog"></span>
+	<span class="icon-cog" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -12,6 +12,6 @@ defined('JPATH_BASE') or die;
 $icon = empty($displayData['icon']) ? 'generic' : preg_replace('#\.[^ .]*$#', '', $displayData['icon']);
 ?>
 <h1 class="page-title">
-	<span class="icon-<?php echo $icon; ?>"></span>
+	<span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
 	<?php echo $displayData['title']; ?>
 </h1>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -15,5 +15,5 @@ JHtml::_('behavior.framework');
 <a rel="{handler: 'iframe', size: {x: <?php echo $displayData['height']; ?>, y: <?php echo $displayData['width']; ?>}}"
 	href="index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id=<?php echo (int) $displayData['itemId']; ?>&amp;type_id=<?php echo $displayData['typeId']; ?>&amp;type_alias=<?php echo $displayData['typeAlias']; ?>&amp;<?php echo JSession::getFormToken(); ?>=1"
 	title="<?php echo $displayData['title']; ?>" class="btn btn-small modal_jform_contenthistory">
-	<span class="icon-archive"></span> <?php echo $displayData['title']; ?>
+	<span class="icon-archive" aria-hidden="true"></span> <?php echo $displayData['title']; ?>
 </a>

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
@@ -95,7 +95,7 @@ class JToolbarButtonHelpTest extends TestCaseDatabase
 	public function testFetchButton()
 	{
 		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-small\">\n"
-			. "\t<span class=\"icon-question-sign\"></span>\n"
+			. "\t<span class=\"icon-question-sign\" aria-hidden=\"true\"></span>\n"
 			. "\tJTOOLBAR_HELP</button>\n";
 
 		$this->assertEquals(


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR should address all the remaining icons in the layouts folder where we do have text