### PR TITLE
a11y template preview missing alt

### DIFF
--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -88,7 +88,7 @@ class JHtmlTemplates
 						'width' => '800px',
 						'footer' => $footer
 					),
-					$body = '<div><img src="' . $preview . '" style="max-width:100%"></div>'
+					$body = '<div><img src="' . $preview . '" style="max-width:100%" alt="' . $template . '"></div>'
 				);
 			}
 		}


### PR DESCRIPTION
When you click on the thumbnail (shown in screenshot below) it opens a modal with the preview image of the template. There was no alt tag for this image. This PR adds one

<img width="427" alt="screenshotr19-41-00" src="https://cloud.githubusercontent.com/assets/1296369/24060212/19b59968-0b4a-11e7-95ec-71280b1c8ae1.png">
