### PR TITLE
a11y icons in com_templates archive preview

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -258,10 +258,10 @@ if ($this->type == 'font')
 					<?php foreach ($this->archive as $file) : ?>
 						<li>
 							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR) : ?>
-								<span class="icon-folder"></span>&nbsp;<?php echo $file; ?>
+								<span class="icon-folder" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR) : ?>
-								<span class="icon-file"></span>&nbsp;<?php echo $file; ?>
+								<span class="icon-file" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 						</li>
 					<?php endforeach; ?>

--- a/administrator/templates/hathor/html/com_templates/template/default.php
+++ b/administrator/templates/hathor/html/com_templates/template/default.php
@@ -334,10 +334,10 @@ if ($this->type == 'font')
 					<?php foreach ($this->archive as $file): ?>
 						<li>
 							<?php if (substr($file, -1) === DIRECTORY_SEPARATOR): ?>
-								<span class="icon-folder"></span>&nbsp;<?php echo $file; ?>
+								<span class="icon-folder" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 							<?php if (substr($file, -1) != DIRECTORY_SEPARATOR): ?>
-								<span class="icon-file"></span>&nbsp;<?php echo $file; ?>
+								<span class="icon-file" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
 							<?php endif; ?>
 						</li>
 					<?php endforeach; ?>


### PR DESCRIPTION
In com_templates if you select a zip file you will see a preview as shown in the screenshot below

For accessibility we need to add the aria-hidden tag to the icon

<img width="667" alt="screenshotr19-54-30" src="https://cloud.githubusercontent.com/assets/1296369/24060562/b5c0ff22-0b4b-11e7-9178-6bd1583f39ed.png">
