### PR TITLE
Magic quotes removal since PHP 5.4 Deprecated it..

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -8,9 +8,6 @@
 
 defined('_JEXEC') or die;
 
-// Joomla system checks.
-@ini_set('magic_quotes_runtime', 0);
-
 // System includes
 require_once JPATH_LIBRARIES . '/bootstrap.php';
 

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -8,9 +8,6 @@
 
 defined('_JEXEC') or die;
 
-// Joomla system checks.
-@ini_set('magic_quotes_runtime', 0);
-
 // System includes
 require_once JPATH_LIBRARIES . '/bootstrap.php';
 

--- a/installation/application/framework.php
+++ b/installation/application/framework.php
@@ -14,7 +14,6 @@ defined('_JEXEC') or die;
  */
 
 const JDEBUG = false;
-@ini_set('magic_quotes_runtime', 0);
 
 /*
  * Check if a configuration file already exists.

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -368,13 +368,6 @@ class InstallationModelSetup extends JModelBase
 		$setting->recommended = true;
 		$settings[] = $setting;
 
-		// Check for magic quotes runtimes.
-		$setting = new stdClass;
-		$setting->label = JText::_('INSTL_MAGIC_QUOTES_RUNTIME');
-		$setting->state = (bool) ini_get('magic_quotes_runtime');
-		$setting->recommended = false;
-		$settings[] = $setting;
-
 		// Check for output buffering.
 		$setting = new stdClass;
 		$setting->label = JText::_('INSTL_OUTPUT_BUFFERING');

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -25,9 +25,6 @@ function jexit($message = 0)
 
 define('_JEXEC', 1);
 
-// Fix magic quotes.
-ini_set('magic_quotes_runtime', 0);
-
 // Maximise error reporting.
 ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL);


### PR DESCRIPTION
PHP5.4 deprecated MAGIC_QUOTES_RUNTIME, since J4 is PHP5.5 there's no need for it. 