### PR TITLE
Fix uninstalling an extension

### DIFF
--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -751,7 +751,7 @@ class JInstaller extends JAdapter
 		// Fire the onExtensionAfterInstall
 		JFactory::getApplication()->triggerEvent(
 			'onExtensionAfterUninstall',
-			array('installer' => clone $this, 'eid' => $identifier, 'result' => $result)
+			array('installer' => clone $this, 'eid' => $identifier, 'removed' => $result)
 		);
 
 		// Refresh versionable assets cache

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -128,17 +128,17 @@ class PlgExtensionJoomla extends JPlugin
 	 *
 	 * @param   JInstaller  $installer  Installer instance
 	 * @param   integer     $eid        Extension id
-	 * @param   boolean     $result     Installation result
+	 * @param   boolean     $removed    Installation result
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	public function onExtensionAfterUninstall($installer, $eid, $result)
+	public function onExtensionAfterUninstall($installer, $eid, $removed)
 	{
 		// If we have a valid extension ID and the extension was successfully uninstalled wipe out any
 		// update sites for it
-		if ($eid && $result)
+		if ($eid && $removed)
 		{
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)


### PR DESCRIPTION
Pull Request for part of Issue #14170 .

### Summary of Changes
Fixes uninstalling any extension in J4. This is because `result` is a protected property for the new plugin system meaning the plugin event is missing.

### Testing Instructions
Test uninstalling a language

### Expected result
It succeeds

### Actual result
`Too few arguments to function PlgExtensionJoomla::onExtensionAfterUninstall(), 2 passed in /Applications/MAMP/htdocs/joomla_400/libraries/cms/plugin/plugin.php on line 322 and exactly 3 expected`

### Documentation Changes Required
Document change in property of plugin event.
