### PR TITLE
[4.0] Fix com_menus JS error & styling tweak

### DIFF
--- a/administrator/components/com_menus/models/forms/menu.xml
+++ b/administrator/components/com_menus/models/forms/menu.xml
@@ -50,7 +50,7 @@
 			label="COM_MENUS_MENU_CLIENT_ID_LABEL"
 			description="COM_MENUS_MENU_CLIENT_ID_DESC"
 			default="0"
-			class="btn-group btn-group-yesno btn-group-reversed"
+			class="switcher switcher-primary"
 			required="true"
 		>
 			<option value="0">JSITE</option>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -16,18 +16,18 @@ $tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
 
 JHtml::_('behavior.core');
 JFactory::getDocument()->addScriptDeclaration('
-		setmenutype = function(type) {
-			var tmpl = ' . json_encode($tmpl) . ';
-			if (tmpl)
-			{
-				window.parent.Joomla.submitbutton("item.setType", type);
-				window.parent.jQuery("#menuTypeModal").modal("hide");
-			}
-			else
-			{
-				window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=" + type;
-			}
-		};
+	setmenutype = function(type) {
+		var tmpl = ' . json_encode($tmpl) . ';
+		if (tmpl)
+		{
+			window.parent.Joomla.submitbutton("item.setType", type);
+			window.parent.jQuery("#menuTypeModal").modal("hide");
+		}
+		else
+		{
+			window.location="index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=" + type;
+		}
+	};
 ');
 
 ?>

--- a/libraries/cms/html/bootstrap.php
+++ b/libraries/cms/html/bootstrap.php
@@ -551,7 +551,7 @@ abstract class JHtmlBootstrap
 			JHtml::_('bootstrap.framework');
 
 			// Setup options object
-			$opt['parent'] = isset($params['parent']) ? ($params['parent'] == true ? '#' . $selector : $params['parent']) : false;
+			$opt['parent'] = isset($params['parent']) ? ($params['parent'] == true ? '#' . $selector : $params['parent']) : '';
 			$opt['toggle'] = isset($params['toggle']) ? (boolean) $params['toggle'] : ($opt['parent'] === false || isset($params['active']) ? false : true);
 			$onShow        = isset($params['onShow']) ? (string) $params['onShow'] : null;
 			$onShown       = isset($params['onShown']) ? (string) $params['onShown'] : null;
@@ -631,7 +631,7 @@ abstract class JHtmlBootstrap
 			' data-parent="' . static::$loaded[__CLASS__ . '::startAccordion'][$selector]['parent'] . '"' : '';
 		$class     = (!empty($class)) ? ' ' . $class : '';
 
-		$html = '<div class="card' . $class . '">'
+		$html = '<div class="card mb-2' . $class . '">'
 			. '<a href="#' . $id . '" data-toggle="collapse"' . $parent . ' class="card-header' . $collapsed . '" role="tab">'
 			. $text
 			. '</a>'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

When creating a new menu item, opening the modal resulted in

> Error: COLLAPSE: Option "parent" provided type "boolean" but expected type "string".

This PR fixes that, along with some minor styling tweaks

