### PR TITLE
[4.0] Editor 'toggle' spacing

### DIFF
--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $name = $displayData;
 
 ?>
-<div class="toggle-editor btn-toolbar float-right clearfix">
+<div class="toggle-editor btn-toolbar float-right clearfix mt-3">
 	<div class="btn-group">
 		<a class="btn btn-secondary" href="#"
 			onclick="tinyMCE.execCommand('mceToggleEditor', false, '<?php echo $name; ?>');return false;"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Adds spacing around editor toggle in com_content editor

### Testing Instructions
Apply patch and navigate to article-edit

### Before patch
![toggle1](https://cloud.githubusercontent.com/assets/2803503/24073696/71e9cace-0bf3-11e7-9fbe-e185a539cb0f.png)

### After patch
![toggle2](https://cloud.githubusercontent.com/assets/2803503/24073700/760f2c66-0bf3-11e7-8b80-42c139bda85d.png)

### Documentation Changes Required

