### PR TITLE
Namespace MVC for Joomla 4.0

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -19,18 +19,18 @@ JLoader::registerAlias('JData',                        '\\Joomla\\Data\\DataObje
 JLoader::registerAlias('JDataSet',                     '\\Joomla\\Data\\DataSet', '4.0');
 JLoader::registerAlias('JDataDumpable',                '\\Joomla\\Data\\DumpableInterface', '4.0');
 
-JLoader::registerAlias('JModelAdmin',                  '\\Joomla\\Cms\\Model\\Admin', '4.0');
-JLoader::registerAlias('JModelForm',                   '\\Joomla\\Cms\\Model\\Form', '4.0');
-JLoader::registerAlias('JModelItem',                   '\\Joomla\\Cms\\Model\\Item', '4.0');
+JLoader::registerAlias('JModelAdmin',                  '\\Joomla\\Cms\\Model\\AdminModel', '4.0');
+JLoader::registerAlias('JModelForm',                   '\\Joomla\\Cms\\Model\\FormModel', '4.0');
+JLoader::registerAlias('JModelItem',                   '\\Joomla\\Cms\\Model\\ItemModel', '4.0');
 JLoader::registerAlias('JModelList',                   '\\Joomla\\Cms\\Model\\ListModel', '4.0');
-JLoader::registerAlias('JModelLegacy',                 '\\Joomla\\Cms\\Model\\Model', '4.0');
+JLoader::registerAlias('JModelLegacy',                 '\\Joomla\\Cms\\Model\\BaseModel', '4.0');
 JLoader::registerAlias('JViewCategories',              '\\Joomla\\Cms\\View\\Categories', '4.0');
 JLoader::registerAlias('JViewCategory',                '\\Joomla\\Cms\\View\\Category', '4.0');
 JLoader::registerAlias('JViewCategoryfeed',            '\\Joomla\\Cms\\View\\CategoryFeed', '4.0');
-JLoader::registerAlias('JViewLegacy',                  '\\Joomla\\Cms\\View\\View', '4.0');
-JLoader::registerAlias('JControllerAdmin',             '\\Joomla\\Cms\\Controller\\Admin', '4.0');
-JLoader::registerAlias('JControllerLegacy',            '\\Joomla\\Cms\\Controller\\Controller', '4.0');
-JLoader::registerAlias('JControllerForm',              '\\Joomla\\Cms\\Controller\\Form', '4.0');
+JLoader::registerAlias('JViewLegacy',                  '\\Joomla\\Cms\\View\\HtmlView', '4.0');
+JLoader::registerAlias('JControllerAdmin',             '\\Joomla\\Cms\\Controller\\AdminController', '4.0');
+JLoader::registerAlias('JControllerLegacy',            '\\Joomla\\Cms\\Controller\\BaseController', '4.0');
+JLoader::registerAlias('JControllerForm',              '\\Joomla\\Cms\\Controller\\FormController', '4.0');
 JLoader::registerAlias('JTableInterface',              '\\Joomla\\Cms\\Table\\TableInterface', '4.0');
 JLoader::registerAlias('JTable',                       '\\Joomla\\Cms\\Table\\Table', '4.0');
 JLoader::registerAlias('JTableNested',                 '\\Joomla\\Cms\\Table\\Nested', '4.0');

--- a/libraries/cms/component/record.php
+++ b/libraries/cms/component/record.php
@@ -45,6 +45,15 @@ class JComponentRecord extends JObject
 	protected $params;
 
 	/**
+	 * The component manifest
+	 *
+	 * @var    string|Registry
+	 * @since  __DEPLOY_VERSION__
+	 * @note   This field is protected to require reading this field to proxy through the getter to convert the params to a Registry instance
+	 */
+	protected $manifest;
+
+	/**
 	 * Indicates if this component is enabled
 	 *
 	 * @var    integer
@@ -139,5 +148,36 @@ class JComponentRecord extends JObject
 	public function setParams($params)
 	{
 		$this->params = $params;
+	}
+
+	/**
+	 * Returns the component manifest cache
+	 *
+	 * @return  Registry
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getManifest()
+	{
+		if (!($this->manifest instanceof Registry))
+		{
+			$this->manifest = new Registry($this->manifest);
+		}
+
+		return $this->manifest;
+	}
+
+	/**
+	 * Sets the menu item parameters
+	 *
+	 * @param   Registry|string  $manifest  The data to be stored as the parameters
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setManifest($manifest)
+	{
+		$this->manifest = $manifest;
 	}
 }

--- a/libraries/src/Cms/Controller/AdminController.php
+++ b/libraries/src/Cms/Controller/AdminController.php
@@ -21,16 +21,8 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class Admin extends Controller
+class AdminController extends BaseController
 {
-	/**
-	 * The URL option for the component.
-	 *
-	 * @var    string
-	 * @since  1.6
-	 */
-	protected $option;
-
 	/**
 	 * The prefix to use with controller messages.
 	 *
@@ -76,29 +68,23 @@ class Admin extends Controller
 		$this->registerTask('orderup', 'reorder');
 		$this->registerTask('orderdown', 'reorder');
 
-		// Guess the option as com_NameOfController.
-		if (empty($this->option))
-		{
-			$this->option = 'com_' . strtolower($this->getName());
-		}
-
 		// Guess the \JText message prefix. Defaults to the option.
 		if (empty($this->text_prefix))
 		{
-			$this->text_prefix = strtoupper($this->option);
+			if (isset($config['text_prefix']))
+			{
+				$this->text_prefix = strtoupper($config['text_prefix']);
+			}
+			else
+			{
+				$this->text_prefix = strtoupper($this->option);
+			}
 		}
 
 		// Guess the list view as the suffix, eg: OptionControllerSuffix.
 		if (empty($this->view_list))
 		{
-			$r = null;
-
-			if (!preg_match('/(.*)Controller(.*)/i', get_class($this), $r))
-			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_CONTROLLER_GET_NAME'), 500);
-			}
-
-			$this->view_list = strtolower($r[2]);
+			$this->view_list = strtolower($this->getControllerName());
 		}
 	}
 
@@ -114,14 +100,12 @@ class Admin extends Controller
 		// Check for request forgeries
 		\JSession::checkToken() or die(\JText::_('JINVALID_TOKEN'));
 
-		$app = \JFactory::getApplication();
-
 		// Get items to remove from the request.
-		$cid = $app->input->get('cid', array(), 'array');
+		$cid = $this->input->get('cid', array(), 'array');
 
 		if (!is_array($cid) || count($cid) < 1)
 		{
-			$app->getLogger()->warning(\JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), array('category' => 'jerror'));
+			\JFactory::getApplication()->getLogger()->warning(\JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), array('category' => 'jerror'));
 		}
 		else
 		{
@@ -190,17 +174,15 @@ class Admin extends Controller
 		// Check for request forgeries
 		\JSession::checkToken() or die(\JText::_('JINVALID_TOKEN'));
 
-		$app = \JFactory::getApplication();
-
 		// Get items to publish from the request.
-		$cid = $app->input->get('cid', array(), 'array');
+		$cid = $this->input->get('cid', array(), 'array');
 		$data = array('publish' => 1, 'unpublish' => 0, 'archive' => 2, 'trash' => -2, 'report' => -3);
 		$task = $this->getTask();
 		$value = ArrayHelper::getValue($data, $task, 0, 'int');
 
 		if (empty($cid))
 		{
-			$app->getLogger()->warning(\JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), array('category' => 'jerror'));
+			\JFactory::getApplication()->getLogger()->warning(\JText::_($this->text_prefix . '_NO_ITEM_SELECTED'), array('category' => 'jerror'));
 		}
 		else
 		{
@@ -269,7 +251,7 @@ class Admin extends Controller
 		// Check for request forgeries.
 		\JSession::checkToken() or jexit(\JText::_('JINVALID_TOKEN'));
 
-		$ids = \JFactory::getApplication()->input->post->get('cid', array(), 'array');
+		$ids = $this->input->post->get('cid', array(), 'array');
 		$inc = ($this->getTask() == 'orderup') ? -1 : 1;
 
 		$model = $this->getModel();
@@ -283,14 +265,12 @@ class Admin extends Controller
 
 			return false;
 		}
-		else
-		{
-			// Reorder succeeded.
-			$message = \JText::_('JLIB_APPLICATION_SUCCESS_ITEM_REORDERED');
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
 
-			return true;
-		}
+		// Reorder succeeded.
+		$message = \JText::_('JLIB_APPLICATION_SUCCESS_ITEM_REORDERED');
+		$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
+
+		return true;
 	}
 
 	/**
@@ -327,14 +307,12 @@ class Admin extends Controller
 
 			return false;
 		}
-		else
-		{
-			// Reorder succeeded.
-			$this->setMessage(\JText::_('JLIB_APPLICATION_SUCCESS_ORDERING_SAVED'));
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 
-			return true;
-		}
+		// Reorder succeeded.
+		$this->setMessage(\JText::_('JLIB_APPLICATION_SUCCESS_ORDERING_SAVED'));
+		$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+
+		return true;
 	}
 
 	/**
@@ -349,7 +327,7 @@ class Admin extends Controller
 		// Check for request forgeries.
 		\JSession::checkToken() or jexit(\JText::_('JINVALID_TOKEN'));
 
-		$ids = \JFactory::getApplication()->input->post->get('cid', array(), 'array');
+		$ids = $this->input->post->get('cid', array(), 'array');
 
 		$model = $this->getModel();
 		$return = $model->checkin($ids);
@@ -362,14 +340,12 @@ class Admin extends Controller
 
 			return false;
 		}
-		else
-		{
-			// Checkin succeeded.
-			$message = \JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($ids));
-			$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
 
-			return true;
-		}
+		// Checkin succeeded.
+		$message = \JText::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', count($ids));
+		$this->setRedirect(\JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false), $message);
+
+		return true;
 	}
 
 	/**
@@ -402,5 +378,28 @@ class Admin extends Controller
 
 		// Close the application
 		\JFactory::getApplication()->close();
+	}
+
+	/**
+	 * Method to get an admin model object, loading it if required.
+	 *
+	 * @param   string  $name    The model name. Optional.
+	 * @param   string  $prefix  The class prefix. Optional.
+	 * @param   array   $config  Configuration array for model. Optional.
+	 *
+	 * @return  \Joomla\Cms\Model\AdminModel |boolean  Model object on success; otherwise false on failure.
+	 *
+	 * @since   3.0
+	 */
+	public function getModel($name = '', $prefix = '', $config = array('ignore_request' => true))
+	{
+		if (empty($name))
+		{
+			$name = $this->getControllerName();
+
+			$name = \Joomla\String\Inflector::getInstance()->toSingular($name);
+		}
+
+		return parent::getModel($name, $prefix, $config);
 	}
 }

--- a/libraries/src/Cms/Controller/BaseController.php
+++ b/libraries/src/Cms/Controller/BaseController.php
@@ -11,8 +11,8 @@ namespace Joomla\Cms\Controller;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Cms\Model\Model;
-use Joomla\Cms\View\View;
+use Joomla\Input\Input;
+use Joomla\Cms\Model\BaseModel;
 
 /**
  * Base class for a Joomla Controller
@@ -22,7 +22,7 @@ use Joomla\Cms\View\View;
  *
  * @since  2.5.5
  */
-class Controller  implements ControllerInterface
+class BaseController  implements ControllerInterface
 {
 	/**
 	 * The base path of the controller
@@ -89,6 +89,14 @@ class Controller  implements ControllerInterface
 	protected $model_prefix;
 
 	/**
+	 * The prefix of the views
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $viewPrefix;
+
+	/**
 	 * The set of search directories for resources (views).
 	 *
 	 * @var    array
@@ -139,10 +147,25 @@ class Controller  implements ControllerInterface
 	/**
 	 * Instance container containing the views.
 	 *
-	 * @var    \Joomla\Cms\View\View[]
+	 * @var    \Joomla\Cms\View\AbstractView[]
 	 * @since  3.4
 	 */
 	protected static $views;
+
+	/**
+	 * The URL option for the component.
+	 *
+	 * @var    string
+	 * @since  1.6
+	 */
+	protected $option;
+
+	/**
+	 * The base namespace of the component
+	 *
+	 * @var string
+	 */
+	protected $namespace = null;
 
 	/**
 	 * Adds to the stack of model paths in LIFO order.
@@ -156,7 +179,7 @@ class Controller  implements ControllerInterface
 	 */
 	public static function addModelPath($path, $prefix = '')
 	{
-		Model::addIncludePath($path, $prefix);
+		BaseModel::addIncludePath($path, $prefix);
 	}
 
 	/**
@@ -323,30 +346,39 @@ class Controller  implements ControllerInterface
 	 * @param   array  $config  An optional associative array of configuration settings.
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
+	 * @param   Input  $input   The controller input
 	 *
 	 * @since   3.0
 	 */
-	public function __construct($config = array())
+	public function __construct($config = array(), Input $input = null)
 	{
-		$this->methods = array();
-		$this->message = null;
+		$this->methods     = array();
+		$this->message     = null;
 		$this->messageType = 'message';
-		$this->paths = array();
-		$this->redirect = null;
-		$this->taskMap = array();
+		$this->paths       = array();
+		$this->redirect    = null;
+		$this->taskMap     = array();
 
 		if (defined('JDEBUG') && JDEBUG)
 		{
 			\JLog::addLogger(array('text_file' => 'jcontroller.log.php'), \JLog::ALL, array('controller'));
 		}
 
-		$this->input = \JFactory::getApplication()->input;
+		$app = \JFactory::getApplication();
+		$this->input  = $input ? $input : $app->input;
+		$this->option = $this->input->getCmd('option');
 
+		// Detect component from controller class name if not provided in input
+		if (empty($this->option))
+		{
+			$this->option = \JComponentHelper::getComponentName(get_class($this));
+		}
+		
 		// Determine the methods to exclude from the base class.
-		$xMethods = get_class_methods('\JControllerLegacy');
+		$xMethods = get_class_methods('\\Joomla\\Cms\\Controller\\BaseController');
 
 		// Get the public methods in this class using reflection.
-		$r = new \ReflectionClass($this);
+		$r        = new \ReflectionClass($this);
 		$rMethods = $r->getMethods(\ReflectionMethod::IS_PUBLIC);
 
 		foreach ($rMethods as $rMethod)
@@ -396,6 +428,9 @@ class Controller  implements ControllerInterface
 			$this->registerDefaultTask('display');
 		}
 
+		// Get component namespace from manifest cache
+		$this->namespace = \JComponentHelper::getNamespace($this->option);
+
 		// Set the models prefix
 		if (empty($this->model_prefix))
 		{
@@ -404,9 +439,45 @@ class Controller  implements ControllerInterface
 				// User-defined prefix
 				$this->model_prefix = $config['model_prefix'];
 			}
+			elseif ($this->namespace)
+			{
+				if ($app->isClient('site'))
+				{
+					$this->model_prefix = $this->namespace . '\\Site\\Model\\';
+				}
+				else
+				{
+					$this->model_prefix = $this->namespace . '\\Admin\\Model\\';
+				}
+			}
 			else
 			{
 				$this->model_prefix = ucfirst($this->name) . 'Model';
+			}
+		}
+
+		// Set the views prefix
+		if (empty($this->viewPrefix))
+		{
+			if (array_key_exists('view_prefix', $config))
+			{
+				// User-defined prefix
+				$this->viewPrefix = $config['view_prefix'];
+			}
+			elseif ($this->namespace)
+			{
+				if ($app->isClient('site'))
+				{
+					$this->viewPrefix = $this->namespace . '\\Site\\View\\';
+				}
+				else
+				{
+					$this->viewPrefix = $this->namespace . '\\Admin\\View\\';
+				}
+			}
+			else
+			{
+				$this->viewPrefix = ucfirst($this->name) . 'View';
 			}
 		}
 
@@ -534,17 +605,27 @@ class Controller  implements ControllerInterface
 	 * @param   string  $prefix  Optional model prefix.
 	 * @param   array   $config  Configuration array for the model. Optional.
 	 *
-	 * @return  Model|boolean   Model object on success; otherwise false on failure.
+	 * @return  \Joomla\Cms\Model\BaseModel|boolean   Model object on success; otherwise false on failure.
 	 *
 	 * @since   3.0
 	 */
 	protected function createModel($name, $prefix = '', $config = array())
 	{
 		// Clean the model name
-		$modelName = preg_replace('/[^A-Z0-9_]/i', '', $name);
-		$classPrefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+		$modelName   = preg_replace('/[^A-Z0-9_]/i', '', $name);
+		$classPrefix = preg_replace('/[^A-Z0-9_\\\\]/i', '', $prefix);
 
-		return Model::getInstance($modelName, $classPrefix, $config);
+		// If this is a namespace controller, change model name to support auto-loader
+		if ($this->namespace)
+		{
+			$modelName = ucfirst($modelName);
+		}
+
+		// Basic model configuration data
+		$config['name']   = strtolower($modelName);
+		$config['option'] = $this->option;
+
+		return BaseModel::getInstance($modelName, $classPrefix, $config);
 	}
 
 	/**
@@ -560,7 +641,7 @@ class Controller  implements ControllerInterface
 	 * @param   string  $type    The type of view.
 	 * @param   array   $config  Configuration array for the view. Optional.
 	 *
-	 * @return  View|null  View object on success; null or error result on failure.
+	 * @return  \Joomla\Cms\View\AbstractView|null  View object on success; null or error result on failure.
 	 *
 	 * @since   3.0
 	 * @throws  \Exception
@@ -568,11 +649,27 @@ class Controller  implements ControllerInterface
 	protected function createView($name, $prefix = '', $type = '', $config = array())
 	{
 		// Clean the view name
-		$viewName = preg_replace('/[^A-Z0-9_]/i', '', $name);
-		$classPrefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
-		$viewType = preg_replace('/[^A-Z0-9_]/i', '', $type);
+		$viewName    = preg_replace('/[^A-Z0-9_]/i', '', $name);
+		$classPrefix = preg_replace('/[^A-Z0-9_\\\\]/i', '', $prefix);
+		$viewType    = preg_replace('/[^A-Z0-9_]/i', '', $type);
 
-		// Build the view class name
+		// Basic view configuration data
+		$config['name']   = strtolower($viewName);
+		$config['option'] = $this->option;
+
+		// If this is a namespace controller, create namespace view class
+		if ($this->namespace)
+		{
+			$viewClass = $classPrefix . ucfirst($viewName) . '\\' . ucfirst($viewType);
+
+			if (class_exists($viewClass))
+			{
+				return new $viewClass($config);
+			}
+
+			return null;
+		}
+
 		$viewClass = $classPrefix . $viewName;
 
 		if (!class_exists($viewClass))
@@ -653,7 +750,7 @@ class Controller  implements ControllerInterface
 
 				foreach ($urlparams as $key => $value)
 				{
-					// Add your safe URL parameters with variable type as value {@see JFilterInput::clean()}.
+					// Add your safe URL parameters with variable type as value {@see \JFilterInput::clean()}.
 					$registeredurlparams->$key = $value;
 				}
 
@@ -721,7 +818,7 @@ class Controller  implements ControllerInterface
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  Model|boolean  Model object on success; otherwise false on failure.
+	 * @return  \Joomla\Cms\Model\BaseModel|boolean  Model object on success; otherwise false on failure.
 	 *
 	 * @since   3.0
 	 */
@@ -736,6 +833,11 @@ class Controller  implements ControllerInterface
 		{
 			$prefix = $this->model_prefix;
 		}
+		elseif ($prefix == 'Site' || $prefix == 'Admin')
+		{
+			$prefix = $this->namespace . '\\' . $prefix . '\\Model\\';
+		}
+
 
 		if ($model = $this->createModel($name, $prefix, $config))
 		{
@@ -761,7 +863,7 @@ class Controller  implements ControllerInterface
 	}
 
 	/**
-	 * Method to get the controller name
+	 * Method to get the component name without com_ prefix, ie content, contact
 	 *
 	 * The dispatcher name is set by default parsed using the classname, or it can be set
 	 * by passing a $config['name'] in the class constructor
@@ -775,14 +877,7 @@ class Controller  implements ControllerInterface
 	{
 		if (empty($this->name))
 		{
-			$r = null;
-
-			if (!preg_match('/(.*)Controller/i', get_class($this), $r))
-			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_CONTROLLER_GET_NAME'), 500);
-			}
-
-			$this->name = strtolower($r[1]);
+			$this->name = strtolower(substr($this->option, 4));
 		}
 
 		return $this->name;
@@ -820,7 +915,7 @@ class Controller  implements ControllerInterface
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for view. Optional.
 	 *
-	 * @return  View  Reference to the view or an error.
+	 * @return  \Joomla\Cms\View\AbstractView  Reference to the view or an error.
 	 *
 	 * @since   3.0
 	 * @throws  \Exception
@@ -840,7 +935,11 @@ class Controller  implements ControllerInterface
 
 		if (empty($prefix))
 		{
-			$prefix = $this->getName() . 'View';
+			$prefix = $this->viewPrefix;
+		}
+		elseif ($prefix == 'Site' || $prefix == 'Admin')
+		{
+			$prefix = $this->namespace . '\\' . $prefix . '\\View\\';
 		}
 
 		if (empty(self::$views[$name][$type][$prefix]))
@@ -1128,5 +1227,28 @@ class Controller  implements ControllerInterface
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Method to get name of the controller, this should be the role of getName() method, but it was implemented wrong
+	 * and we still have to keep it to keep it backward compatible
+	 *
+	 * @return string
+	 */
+	protected function getControllerName()
+	{
+		if ($this->namespace)
+		{
+			return (new \ReflectionClass($this))->getShortName();
+		}
+
+		$r = null;
+
+		if (preg_match('/(.*)Controller(.*)/i', get_class($this), $r))
+		{
+			return strtolower($r[2]);
+		}
+
+		return 'Controller';
 	}
 }

--- a/libraries/src/Cms/Controller/FormController.php
+++ b/libraries/src/Cms/Controller/FormController.php
@@ -11,13 +11,15 @@ namespace Joomla\Cms\Controller;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\String\Inflector;
+
 /**
  * Controller tailored to suit most form-based admin operations.
  *
  * @since  1.6
  * @todo   Add ability to set redirect manually to better cope with frontend usage.
  */
-class Form extends Controller
+class FormController extends BaseController
 {
 	/**
 	 * The context for storing internal data, e.g. record.
@@ -26,14 +28,6 @@ class Form extends Controller
 	 * @since  1.6
 	 */
 	protected $context;
-
-	/**
-	 * The URL option for the component.
-	 *
-	 * @var    string
-	 * @since  1.6
-	 */
-	protected $option;
 
 	/**
 	 * The URL view item variable.
@@ -72,29 +66,23 @@ class Form extends Controller
 	{
 		parent::__construct($config);
 
-		// Guess the option as com_NameOfController
-		if (empty($this->option))
-		{
-			$this->option = 'com_' . strtolower($this->getName());
-		}
-
 		// Guess the \JText message prefix. Defaults to the option.
 		if (empty($this->text_prefix))
 		{
-			$this->text_prefix = strtoupper($this->option);
+			if (isset($config['text_prefix']))
+			{
+				$this->text_prefix = strtoupper($config['text_prefix']);
+			}
+			else
+			{
+				$this->text_prefix = strtoupper($this->option);
+			}
 		}
 
 		// Guess the context as the suffix, eg: OptionControllerContent.
 		if (empty($this->context))
 		{
-			$r = null;
-
-			if (!preg_match('/(.*)Controller(.*)/i', get_class($this), $r))
-			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_CONTROLLER_GET_NAME'), 500);
-			}
-
-			$this->context = strtolower($r[2]);
+			$this->context = strtolower($this->getControllerName());
 		}
 
 		// Guess the item view as the context.
@@ -106,29 +94,7 @@ class Form extends Controller
 		// Guess the list view as the plural of the item view.
 		if (empty($this->view_list))
 		{
-			// @TODO Probably worth moving to an inflector class based on
-			// http://kuwamoto.org/2007/12/17/improved-pluralizing-in-php-actionscript-and-ror/
-
-			// Simple pluralisation based on public domain snippet by Paul Osman
-			// For more complex types, just manually set the variable in your class.
-			$plural = array(
-				array('/(x|ch|ss|sh)$/i', "$1es"),
-				array('/([^aeiouy]|qu)y$/i', "$1ies"),
-				array('/([^aeiouy]|qu)ies$/i', "$1y"),
-				array('/(bu)s$/i', "$1ses"),
-				array('/s$/i', 's'),
-				array('/$/', 's'),
-			);
-
-			// Check for matches using regular expressions
-			foreach ($plural as $pattern)
-			{
-				if (preg_match($pattern[0], $this->view_item))
-				{
-					$this->view_list = preg_replace($pattern[0], $pattern[1], $this->view_item);
-					break;
-				}
-			}
+			$this->view_list = Inflector::getInstance()->toPlural($this->view_item);
 		}
 
 		// Apply, Save & New, and Save As copy should be standard on forms.
@@ -233,16 +199,14 @@ class Form extends Controller
 		{
 			return $this->allowEdit($data, $key);
 		}
-		else
-		{
-			return $this->allowAdd($data);
-		}
+
+		return $this->allowAdd($data);
 	}
 
 	/**
 	 * Method to run batch operations.
 	 *
-	 * @param   \JModelLegacy  $model  The model of the component being processed.
+	 * @param   \Joomla\Cms\Model\AdminModel $model The model of the component being processed.
 	 *
 	 * @return	boolean	 True if successful, false otherwise and internal error is set.
 	 *
@@ -278,12 +242,10 @@ class Form extends Controller
 
 			return true;
 		}
-		else
-		{
-			$this->setMessage(\JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_FAILED', $model->getError()), 'warning');
 
-			return false;
-		}
+		$this->setMessage(\JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_FAILED', $model->getError()), 'warning');
+
+		return false;
 	}
 
 	/**
@@ -437,7 +399,7 @@ class Form extends Controller
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \JModelLegacy  The model.
+	 * @return  \Joomla\Cms\Model\FormModel  The model.
 	 *
 	 * @since   1.6
 	 */

--- a/libraries/src/Cms/Controller/FormController.php
+++ b/libraries/src/Cms/Controller/FormController.php
@@ -206,7 +206,7 @@ class FormController extends BaseController
 	/**
 	 * Method to run batch operations.
 	 *
-	 * @param   \Joomla\Cms\Model\AdminModel $model The model of the component being processed.
+	 * @param   \Joomla\Cms\Model\AdminModel  $model  The model of the component being processed.
 	 *
 	 * @return	boolean	 True if successful, false otherwise and internal error is set.
 	 *

--- a/libraries/src/Cms/Dispatcher/Dispatcher.php
+++ b/libraries/src/Cms/Dispatcher/Dispatcher.php
@@ -8,39 +8,107 @@
 
 namespace Joomla\Cms\Dispatcher;
 
-use Joomla\Cms\Controller\Controller;
+use Joomla\Cms\Controller\BaseController;
+use Joomla\Input\Input;
 
 defined('_JEXEC') or die;
 
 /**
- * Base class for a Joomla Dispatcher
+ * Base class for a Joomla Component Dispatcher
  *
  * Dispatchers are responsible for checking ACL of a component if appropriate and
  * choosing an appropriate controller (and if necessary, a task) and executing it.
  *
  * @since  __DEPLOY_VERSION__
  */
-abstract class Dispatcher implements DispatcherInterface
+class Dispatcher implements DispatcherInterface
 {
 	/**
-	 * The JApplication instance
+	 * The namespace of the component which will be executed, ie Joomla\Component\Content
 	 *
-	 * @var     \JApplicationCms
+	 * @var string
+	 */
+	protected $cNamespace = null;
+
+	/**
+	 * The application object
+	 *
+	 * @var \JApplicationCms
+	 */
+	protected $app;
+
+	/**
+	 * The input object which will be passed to controller
+	 *
+	 * @var Input
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	private $app;
+	protected $input;
+
+	/**
+	 * The array store dispatcher/component config data
+	 *
+	 * @var array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $config;
 
 	/**
 	 * Constructor for Dispatcher
 	 *
-	 * @param   \JApplicationCms  $app  The JApplication for the dispatcher
+	 * @param   \JApplicationCms  $app     The JApplication for the dispatcher
+	 * @param   Input             $input   The controller input
+	 * @param   array             $config  An array of optional constructor options
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @throws \InvalidArgumentException
 	 */
-	public function __construct(\JApplicationCms $app)
+	public function __construct(\JApplicationCms $app = null, Input $input = null, array $config = array())
 	{
-		$this->app  = $app;
+		$this->app   = $app ? $app : \JFactory::getApplication();
+		$this->input = $input ? $input : $this->app->input;
+		$option      = $this->input->getCmd('option');
+
+		// Check to make sure the component is enabled
+		if (!\JComponentHelper::isEnabled($option))
+		{
+			throw new \InvalidArgumentException(\JText::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);
+		}
+
+		// Get component namespace from database if not set
+		if (empty($this->cNamespace))
+		{
+			$this->cNamespace = \JComponentHelper::getNamespace($option);
+		}
+
+		// Set default component config data
+		if (!isset($config['load_language']))
+		{
+			$config['load_language'] = false;
+		}
+
+		if (!isset($config['redirect']))
+		{
+			$config['redirect'] = true;
+		}
+
+		$this->config = $config;
+
+		// Register component auto-loader
+		$autoLoader = include JPATH_LIBRARIES . '/vendor/autoload.php';
+		$autoLoader->setPsr4($this->cNamespace . '\\Site\\', JPATH_ROOT . '/components/' . $option);
+		$autoLoader->setPsr4($this->cNamespace . '\\Admin\\', JPATH_ADMINISTRATOR . '/components/' . $option);
+
+		// Load common and local component language files.
+		if (!empty($this->config['load_language']))
+		{
+			$language = $this->app->getLanguage();
+			$language->load($option, JPATH_BASE, null, false, true) ||
+			$language->load($option, JPATH_BASE . '/components/' . $option, null, false, true);
+		}
 	}
 
 	/**
@@ -49,34 +117,113 @@ abstract class Dispatcher implements DispatcherInterface
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @throws \Exception
 	 */
 	public function dispatch()
 	{
+		$option = $this->input->getCmd('option');
+
 		// Check the user has permission to access this component if in the backend
-		if ($this->app->isClient('administrator') && !$this->app->getIdentity()->authorise('core.manage', $this->app->scope))
+		if ($this->app->isClient('administrator') && !$this->app->getIdentity()->authorise('core.manage', $option))
 		{
-			throw new \JAccessExceptionNotallowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			throw new \Exception(\JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-		// Load common and local language files.
-		$this->app->getLanguage()->load($this->app->scope, JPATH_BASE, null, false, true) ||
-			$this->app->getLanguage()->load($this->app->scope, JPATH_COMPONENT, null, false, true);
+		// Get the controller base on input data, execute the task for this component
+		$controller = $this->getController();
 
-		// Execute the task for this component
-		$controller = Controller::getInstance(ucwords(substr($this->app->scope, 4)));
-		$controller->execute($this->app->input->get('task'));
-		$controller->redirect();
+		// Execute controller and redirect if needed
+		$controller->execute($this->input->get('task', 'display'));
+
+		if ($this->config['redirect'])
+		{
+			$controller->redirect();
+		}
 	}
 
 	/**
 	 * The application the dispatcher is working with.
 	 *
-	 * @return \JApplicationCms
+	 * @return  BaseController
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function getApplication()
+	public function getController()
 	{
-		return $this->app;
+		$input   = $this->input;
+		$format  = $input->getWord('format');
+		$command = $input->getCmd('task', 'display');
+
+		if (strpos($command, '.') !== false)
+		{
+			// Explode the controller.task command.
+			list ($name, $task) = explode('.', $command);
+
+			$this->input->set('task', $task);
+		}
+		else
+		{
+			$name = 'controller';
+		}
+
+		if ($this->app->isClient('site'))
+		{
+			$controllerNamespace = $this->cNamespace . '\\Site\\Controller';
+		}
+		else
+		{
+			$controllerNamespace = $this->cNamespace . '\\Admin\\Controller';
+		}
+
+		// Build list of possible controller classes, should we support override, too?
+		$classes = array();
+
+		if ($format)
+		{
+			$classes[] = $controllerNamespace . '\\' . ucfirst($format) . '\\' . ucfirst($name);
+		}
+
+		$classes[] = $controllerNamespace . '\\' . ucfirst($name);
+
+		// Loop over possible create class and create the controller if class is found
+		foreach ($classes as $class)
+		{
+			if (class_exists($class))
+			{
+				return new $class($this->config, $this->input);
+			}
+		}
+
+		throw new \InvalidArgumentException(\JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER_CLASS', $class));
+	}
+
+	/**
+	 * Set controller input
+	 *
+	 * @param   mixed  $input  The input data for the request
+	 *
+	 * @return  Input The original input, might be used for backup purpose
+	 *
+	 * @throws  \InvalidArgumentException
+	 */
+	public function setInput($input)
+	{
+		$oldInput = $this->input;
+
+		if (is_array($input))
+		{
+			$this->input = new Input($input);
+		}
+		elseif ($input instanceof Input)
+		{
+			$this->input = $input;
+		}
+		else
+		{
+			throw new \InvalidArgumentException('Input needs to be an array or an object Input');
+		}
+
+		return $oldInput;
 	}
 }

--- a/libraries/src/Cms/Model/AdminModel.php
+++ b/libraries/src/Cms/Model/AdminModel.php
@@ -21,7 +21,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-abstract class Admin extends Form
+abstract class AdminModel extends FormModel
 {
 	/**
 	 * The prefix to use with controller messages.
@@ -976,6 +976,7 @@ abstract class Admin extends Form
 		$user = \JFactory::getUser();
 		$table = $this->getTable();
 		$pks = (array) $pks;
+		$checkedOutField = $table->getColumnAlias('checked_out');
 
 		// Include the plugins for the change of state event.
 		\JPluginHelper::importPlugin($this->events_map['change_state']);
@@ -998,7 +999,7 @@ abstract class Admin extends Form
 				}
 
 				// If the table is checked out by another user, drop it and report to the user trying to change its state.
-				if (property_exists($table, 'checked_out') && $table->checked_out && ($table->checked_out != $user->id))
+				if (property_exists($table, $checkedOutField) && $table->{$checkedOutField} && ($table->{$checkedOutField} != $user->id))
 				{
 					\JLog::add(\JText::_('JLIB_APPLICATION_ERROR_CHECKIN_USER_MISMATCH'), \JLog::WARNING, 'jerror');
 

--- a/libraries/src/Cms/Model/BaseModel.php
+++ b/libraries/src/Cms/Model/BaseModel.php
@@ -557,7 +557,8 @@ abstract class BaseModel extends \JObject
 
 	/**
 	 * Method to check if the given record is checked out by the current user
-	 * @param  $item
+	 *
+	 * @param   \stdClass  $item  The record to check
 	 *
 	 * @return  bool
 	 */

--- a/libraries/src/Cms/Model/BaseModel.php
+++ b/libraries/src/Cms/Model/BaseModel.php
@@ -11,8 +11,8 @@ namespace Joomla\Cms\Model;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\Cms\Table\Table;
 use Joomla\Utilities\ArrayHelper;
+use Joomla\Cms\Table\Table;
 
 /**
  * Base class for a Joomla Model
@@ -21,7 +21,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  2.5.5
  */
-abstract class Model extends \JObject
+abstract class BaseModel extends \JObject
 {
 	/**
 	 * Indicates if the internal state has been set
@@ -70,6 +70,13 @@ abstract class Model extends \JObject
 	 * @since  3.0
 	 */
 	protected $event_clean_cache = null;
+
+	/**
+	 * The base namespace of the component model belong to
+	 *
+	 * @var string
+	 */
+	protected $namespace = null;
 
 	/**
 	 * Add a directory where \JModelLegacy should search for models. You may
@@ -133,7 +140,7 @@ abstract class Model extends \JObject
 	 */
 	public static function addTablePath($path)
 	{
-		\JTable::addIncludePath($path);
+		Table::addIncludePath($path);
 	}
 
 	/**
@@ -167,7 +174,7 @@ abstract class Model extends \JObject
 	 * @param   string  $prefix  Prefix for the model class name. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  self|boolean   A \JModelLegacy instance or false on failure
+	 * @return  BaseModel|boolean   A \JModelLegacy instance or false on failure
 	 *
 	 * @since   3.0
 	 */
@@ -220,18 +227,20 @@ abstract class Model extends \JObject
 	 */
 	public function __construct($config = array())
 	{
-		// Guess the option from the class name (Option)Model(View).
 		if (empty($this->option))
 		{
-			$r = null;
-
-			if (!preg_match('/(.*)Model/i', get_class($this), $r))
+			if (isset($config['option']))
 			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
+				$this->option = $config['option'];
 			}
-
-			$this->option = 'com_' . strtolower($r[1]);
+			else
+			{
+				// Guess the option from the class name
+				$this->option = \JComponentHelper::getComponentName(get_class($this));
+			}
 		}
+
+		$this->namespace = \JComponentHelper::getNamespace($this->option);
 
 		// Set the view name
 		if (empty($this->name))
@@ -374,7 +383,7 @@ abstract class Model extends \JObject
 	{
 		// Clean the model name
 		$name = preg_replace('/[^A-Z0-9_]/i', '', $name);
-		$prefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+		$prefix = preg_replace('/[^A-Z0-9_\\\\]/i', '', $prefix);
 
 		// Make sure we are returning a DBO object
 		if (!array_key_exists('dbo', $config))
@@ -412,14 +421,21 @@ abstract class Model extends \JObject
 	{
 		if (empty($this->name))
 		{
-			$r = null;
-
-			if (!preg_match('/Model(.*)/i', get_class($this), $r))
+			if ($this->namespace)
 			{
-				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
+				$this->name = strtolower((new \ReflectionClass($this))->getShortName());
 			}
+			else
+			{
+				$r = null;
 
-			$this->name = strtolower($r[1]);
+				if (!preg_match('/Model(.*)/i', get_class($this), $r))
+				{
+					throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_MODEL_GET_NAME'), 500);
+				}
+
+				$this->name = strtolower($r[1]);
+			}
 		}
 
 		return $this->name;
@@ -461,11 +477,23 @@ abstract class Model extends \JObject
 	 * @since   3.0
 	 * @throws  \Exception
 	 */
-	public function getTable($name = '', $prefix = 'Table', $options = array())
+	public function getTable($name = '', $prefix = '', $options = array())
 	{
 		if (empty($name))
 		{
 			$name = $this->getName();
+		}
+
+		if (empty($prefix))
+		{
+			if ($this->namespace)
+			{
+				$prefix = $this->namespace . '\\Admin\\Table\\';
+			}
+			else
+			{
+				$prefix = 'Table';
+			}
 		}
 
 		if ($table = $this->_createTable($name, $prefix, $options))
@@ -528,6 +556,25 @@ abstract class Model extends \JObject
 	}
 
 	/**
+	 * Method to check if the given record is checked out by the current user
+	 * @param  $item
+	 *
+	 * @return  bool
+	 */
+	public function isCheckedOut($item)
+	{
+		$table = $this->getTable();
+		$checkedOutField = $table->getColumnAlias('checked_out');
+
+		if (property_exists($item, $checkedOutField) && $item->{$checkedOutField} != \JFactory::getUser()->id)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Method to auto-populate the model state.
 	 *
 	 * This method should only be called once per instantiation and is designed
@@ -587,7 +634,7 @@ abstract class Model extends \JObject
 		$conf = \JFactory::getConfig();
 
 		$options = array(
-			'defaultgroup' => ($group) ? $group : (isset($this->option) ? $this->option : \JFactory::getApplication()->input->get('option')),
+			'defaultgroup' => ($group) ? $group : $this->option,
 			'cachebase' => ($client_id) ? JPATH_ADMINISTRATOR . '/cache' : $conf->get('cache_path', JPATH_SITE . '/cache'),
 			'result' => true,
 		);

--- a/libraries/src/Cms/Model/FormModel.php
+++ b/libraries/src/Cms/Model/FormModel.php
@@ -21,7 +21,7 @@ use Joomla\Utilities\ArrayHelper;
  * @see    \JFormRule
  * @since  1.6
  */
-abstract class Form extends Model
+abstract class FormModel extends BaseModel
 {
 	/**
 	 * Array of form objects.
@@ -216,6 +216,10 @@ abstract class Form extends Model
 		\JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
 		\JForm::addFormPath(JPATH_COMPONENT . '/model/form');
 		\JForm::addFieldPath(JPATH_COMPONENT . '/model/field');
+
+		// Find XML Forms and Form Fields from resources folder for now. Will change it when there is final decision
+		\JForm::addFormPath(JPATH_COMPONENT . '/resources/forms');
+		\JForm::addFormPath(JPATH_COMPONENT . '/resources/fields');
 
 		try
 		{

--- a/libraries/src/Cms/Model/ItemModel.php
+++ b/libraries/src/Cms/Model/ItemModel.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  1.6
  */
-abstract class Item extends Model
+abstract class ItemModel extends BaseModel
 {
 	/**
 	 * An item.

--- a/libraries/src/Cms/Model/ListModel.php
+++ b/libraries/src/Cms/Model/ListModel.php
@@ -18,7 +18,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class ListModel extends Model
+class ListModel extends BaseModel
 {
 	/**
 	 * Internal memory based cache array of data.
@@ -340,26 +340,14 @@ class ListModel extends Model
 	 */
 	public function getFilterForm($data = array(), $loadData = true)
 	{
-		$form = null;
-
 		// Try to locate the filter form automatically. Example: ContentModelArticles => "filter_articles"
 		if (empty($this->filterFormName))
 		{
-			$classNameParts = explode('Model', get_called_class());
-
-			if (count($classNameParts) == 2)
-			{
-				$this->filterFormName = 'filter_' . strtolower($classNameParts[1]);
-			}
+			$this->filterFormName = 'filter_' . strtolower($this->getName());
 		}
 
-		if (!empty($this->filterFormName))
-		{
-			// Get the form.
-			$form = $this->loadForm($this->context . '.filter', $this->filterFormName, array('control' => '', 'load_data' => $loadData));
-		}
-
-		return $form;
+		// Return the form.
+		return $this->loadForm($this->context . '.filter', $this->filterFormName, array('control' => '', 'load_data' => $loadData));
 	}
 
 	/**
@@ -393,6 +381,10 @@ class ListModel extends Model
 		// Get the form.
 		\JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
 		\JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
+
+		// Find XML Forms and Form Fields from resources folder for now. Will change it when there is final decision
+		\JForm::addFormPath(JPATH_COMPONENT . '/resources/forms');
+		\JForm::addFormPath(JPATH_COMPONENT . '/resources/fields');
 
 		try
 		{

--- a/libraries/src/Cms/View/AbstractView.php
+++ b/libraries/src/Cms/View/AbstractView.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * @package     Joomla.Cms
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\View;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Cms\Model\BaseModel;
+
+/**
+ * Base class for a Joomla View
+ *
+ * Class holding methods for displaying presentation data.
+ *
+ * @since  2.5.5
+ */
+abstract class AbstractView extends \JObject
+{
+	/**
+	 * The active document object
+	 *
+	 * @var    \JDocument
+	 * @since  3.0
+	 */
+	public $document;
+
+	/**
+	 * The URL option for the component. It is usually passed by controller while it creates the view
+	 *
+	 * @var    string
+	 * @since  3.0
+	 */
+	protected $option = null;
+
+	/**
+	 * The name of the view
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	protected $_name = null;
+
+	/**
+	 * Registered models
+	 *
+	 * @var    array
+	 * @since  3.0
+	 */
+	protected $_models = array();
+
+	/**
+	 * The default model
+	 *
+	 * @var	   string
+	 * @since  3.0
+	 */
+	protected $_defaultModel = null;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   array  $config  A named configuration array for object construction.
+	 *                          name: the name (optional) of the view (defaults to the view class name suffix).
+	 *                          charset: the character set to use for display
+	 *                          escape: the name (optional) of the function to use for escaping strings
+	 *                          base_path: the parent path (optional) of the views directory (defaults to the component folder)
+	 *                          template_plath: the path (optional) of the layout directory (defaults to base_path + /views/ + view name
+	 *                          helper_path: the path (optional) of the helper files (defaults to base_path + /helpers/)
+	 *                          layout: the layout (optional) to use to display the view
+	 *
+	 * @since   3.0
+	 */
+	public function __construct($config = array())
+	{
+		// Set the view name
+		if (empty($this->_name))
+		{
+			if (array_key_exists('name', $config))
+			{
+				$this->_name = $config['name'];
+			}
+			else
+			{
+				$this->_name = $this->getName();
+			}
+		}
+
+		// Set the component name if passed
+		if (!empty($config['option']))
+		{
+			$this->option = $config['option'];
+		}
+	}
+
+	/**
+	 * Execute and display a template script.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
+	 *
+	 * @return  mixed  A string if successful, otherwise an Error object.
+	 *
+	 * @since   3.0
+	 */
+	abstract function display($tpl = null);
+
+	/**
+	 * Method to get data from a registered model or a property of the view
+	 *
+	 * @param   string  $property  The name of the method to call on the model or the property to get
+	 * @param   string  $default   The name of the model to reference or the default value [optional]
+	 *
+	 * @return  mixed  The return value of the method
+	 *
+	 * @since   3.0
+	 */
+	public function get($property, $default = null)
+	{
+		// If $model is null we use the default model
+		if (is_null($default))
+		{
+			$model = $this->_defaultModel;
+		}
+		else
+		{
+			$model = strtolower($default);
+		}
+
+		// First check to make sure the model requested exists
+		if (isset($this->_models[$model]))
+		{
+			// Model exists, let's build the method name
+			$method = 'get' . ucfirst($property);
+
+			// Does the method exist?
+			if (method_exists($this->_models[$model], $method))
+			{
+				// The method exists, let's call it and return what we get
+				return $this->_models[$model]->$method();
+			}
+		}
+
+		// Degrade to \JObject::get
+		return parent::get($property, $default);
+	}
+
+	/**
+	 * Method to get the model object
+	 *
+	 * @param   string  $name  The name of the model (optional)
+	 *
+	 * @return  BaseModel  The model object
+	 *
+	 * @since   3.0
+	 */
+	public function getModel($name = null)
+	{
+		if ($name === null)
+		{
+			$name = $this->_defaultModel;
+		}
+
+		return $this->_models[strtolower($name)];
+	}
+
+	/**
+	 * Method to add a model to the view.  We support a multiple model single
+	 * view system by which models are referenced by classname.  A caveat to the
+	 * classname referencing is that any classname prepended by \JModel will be
+	 * referenced by the name without \JModel, eg. \JModelCategory is just
+	 * Category.
+	 *
+	 * @param   BaseModel $model   The model to add to the view.
+	 * @param   boolean   $default Is this the default model?
+	 *
+	 * @return  BaseModel  The added model.
+	 *
+	 * @since   3.0
+	 */
+	public function setModel($model, $default = false)
+	{
+		$name = strtolower($model->getName());
+		$this->_models[$name] = $model;
+
+		if ($default)
+		{
+			$this->_defaultModel = $name;
+		}
+
+		return $model;
+	}
+
+	/**
+	 * Method to get the view name
+	 *
+	 * The model name by default parsed using the classname, or it can be set
+	 * by passing a $config['name'] in the class constructor
+	 *
+	 * @return  string  The name of the model
+	 *
+	 * @since   3.0
+	 * @throws  \Exception
+	 */
+	public function getName()
+	{
+		if (empty($this->_name))
+		{
+			$reflection = new \ReflectionClass($this);
+
+			if ($viewNamespace = $reflection->getNamespaceName())
+			{
+				$pos = strrpos($viewNamespace, '\\');
+
+				if ($pos !== false)
+				{
+					$this->_name = strtolower(substr($viewNamespace, $pos));
+				}
+			}
+			else
+			{
+				$className = get_class($this);
+				$viewPos   = strpos($className, 'View');
+
+				if ($viewPos != false)
+				{
+					$this->_name = strtolower(substr($className, $viewPos + 4));
+				}
+			}
+
+			if (empty($this->_name))
+			{
+				throw new \Exception(\JText::_('JLIB_APPLICATION_ERROR_VIEW_GET_NAME'), 500);
+			}
+		}
+
+		return $this->_name;
+	}
+}

--- a/libraries/src/Cms/View/AbstractView.php
+++ b/libraries/src/Cms/View/AbstractView.php
@@ -107,7 +107,7 @@ abstract class AbstractView extends \JObject
 	 *
 	 * @since   3.0
 	 */
-	abstract function display($tpl = null);
+	abstract public function display($tpl = null);
 
 	/**
 	 * Method to get data from a registered model or a property of the view
@@ -175,8 +175,8 @@ abstract class AbstractView extends \JObject
 	 * referenced by the name without \JModel, eg. \JModelCategory is just
 	 * Category.
 	 *
-	 * @param   BaseModel $model   The model to add to the view.
-	 * @param   boolean   $default Is this the default model?
+	 * @param   BaseModel  $model    The model to add to the view.
+	 * @param   boolean    $default  Is this the default model?
 	 *
 	 * @return  BaseModel  The added model.
 	 *
@@ -241,3 +241,4 @@ abstract class AbstractView extends \JObject
 		return $this->_name;
 	}
 }
+

--- a/libraries/src/Cms/View/Categories.php
+++ b/libraries/src/Cms/View/Categories.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.2
  */
-class Categories extends View
+class Categories extends HtmlView
 {
 	/**
 	 * State data

--- a/libraries/src/Cms/View/Category.php
+++ b/libraries/src/Cms/View/Category.php
@@ -16,7 +16,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.2
  */
-class Category extends View
+class Category extends HtmlView
 {
 	/**
 	 * State data
@@ -176,7 +176,7 @@ class Category extends View
 			foreach ($items as $itemElement)
 			{
 				$itemElement = (object) $itemElement;
-				$itemElement->event = new \stdClass;
+				$itemElement->event = new stdClass;
 
 				// For some plugins.
 				!empty($itemElement->description)? $itemElement->text = $itemElement->description : $itemElement->text = null;

--- a/libraries/src/Cms/View/CategoryFeed.php
+++ b/libraries/src/Cms/View/CategoryFeed.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  3.2
  */
-class CategoryFeed extends View
+class CategoryFeed extends HtmlView
 {
 	/**
 	 * Execute and display a template script.

--- a/libraries/src/Cms/View/FormView.php
+++ b/libraries/src/Cms/View/FormView.php
@@ -72,7 +72,7 @@ class FormView extends HtmlView
 	/**
 	 * Constructor
 	 *
-	 * @param   array   $config
+	 * @param   array   $config  An optional associative array of configuration settings.
 	 */
 	public function __construct(array $config)
 	{
@@ -91,6 +91,8 @@ class FormView extends HtmlView
 	}
 
 	/**
+	 * Execute and display a template script.
+	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
 	 * @return   mixed

--- a/libraries/src/Cms/View/FormView.php
+++ b/libraries/src/Cms/View/FormView.php
@@ -72,7 +72,7 @@ class FormView extends HtmlView
 	/**
 	 * Constructor
 	 *
-	 * @param array $config
+	 * @param   array   $config
 	 */
 	public function __construct(array $config)
 	{
@@ -91,9 +91,9 @@ class FormView extends HtmlView
 	}
 
 	/**
-	 * @param null $tpl
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return mixed
+	 * @return   mixed
 	 */
 	public function display($tpl = null)
 	{
@@ -115,6 +115,8 @@ class FormView extends HtmlView
 
 	/**
 	 * Prepare view data
+	 *
+	 * @return  void
 	 */
 	protected function initializeView()
 	{
@@ -122,10 +124,10 @@ class FormView extends HtmlView
 		$this->item  = $this->get('Item');
 		$this->state = $this->get('State');
 
-		// canDo property should be built by the child class before, if not, generate default value
+		// Property $canDo should be built by the child class before, if not, generate default value
 		if (!empty($this->canDo))
 		{
-			$this->canDo = new \JObject();
+			$this->canDo = new \JObject;
 		}
 	}
 
@@ -149,7 +151,7 @@ class FormView extends HtmlView
 
 		if (empty($this->toolbarTitle))
 		{
-			$langKey            = strtoupper($this->option . '_PAGE_' . ($checkedOut ? 'VIEW_' . $viewName : ($isNew ? 'ADD_' . $viewName : 'EDIT_' . $viewName)));
+			$langKey = strtoupper($this->option . '_PAGE_' . ($checkedOut ? 'VIEW_' . $viewName : ($isNew ? 'ADD_' . $viewName : 'EDIT_' . $viewName)));
 			$this->toolbarTitle = \JText::_($langKey);
 		}
 

--- a/libraries/src/Cms/View/FormView.php
+++ b/libraries/src/Cms/View/FormView.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * @package     Joomla.Cms
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\View;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Base class for a Joomla Form View
+ *
+ * Class holding methods for displaying presentation data.
+ *
+ * @since  2.5.5
+ */
+class FormView extends HtmlView
+{
+	/**
+	 * The \JForm object
+	 *
+	 * @var  \JForm
+	 */
+	protected $form;
+
+	/**
+	 * The active item
+	 *
+	 * @var  object
+	 */
+	protected $item;
+
+	/**
+	 * The model state
+	 *
+	 * @var  object
+	 */
+	protected $state;
+
+	/**
+	 * The actions the user is authorised to perform
+	 *
+	 * @var  \JObject
+	 */
+	protected $canDo;
+
+	/**
+	 * The toolbar title
+	 *
+	 * @var string
+	 */
+	protected $toolbarTitle;
+
+	/**
+	 * The preview link
+	 *
+	 * @var string
+	 */
+	protected $previewLink;
+
+	/**
+	 * The help link
+	 *
+	 * @var string
+	 */
+	protected $helpLink;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $config
+	 */
+	public function __construct(array $config)
+	{
+		parent::__construct($config);
+
+		// Set class properties from config data passed in constructor
+		if (isset($config['canDo']))
+		{
+			$this->canDo = $config['canDo'];
+		}
+
+		if (isset($config['help_link']))
+		{
+			$this->helpLink = $config['help_link'];
+		}
+	}
+
+	/**
+	 * @param null $tpl
+	 *
+	 * @return mixed
+	 */
+	public function display($tpl = null)
+	{
+		// Prepare view data
+		$this->initializeView();
+
+		// Check for errors.
+		if (count($errors = $this->get('Errors')))
+		{
+			throw new \JViewGenericdataexception(implode("\n", $errors), 500);
+		}
+
+		// Build toolbar
+		$this->addToolbar();
+
+		// Render the view
+		return parent::display($tpl);
+	}
+
+	/**
+	 * Prepare view data
+	 */
+	protected function initializeView()
+	{
+		$this->form  = $this->get('Form');
+		$this->item  = $this->get('Item');
+		$this->state = $this->get('State');
+
+		// canDo property should be built by the child class before, if not, generate default value
+		if (!empty($this->canDo))
+		{
+			$this->canDo = new \JObject();
+		}
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.6
+	 */
+	protected function addToolbar()
+	{
+		\JFactory::getApplication()->input->set('hidemainmenu', true);
+
+		$user       = \JFactory::getUser();
+		$userId     = $user->id;
+		$isNew      = ($this->item->id == 0);
+		$viewName   = $this->getName();
+		$checkedOut = $this->getModel()->isCheckedOut($this->item);
+		$canDo      = $this->canDo;
+
+		if (empty($this->toolbarTitle))
+		{
+			$langKey            = strtoupper($this->option . '_PAGE_' . ($checkedOut ? 'VIEW_' . $viewName : ($isNew ? 'ADD_' . $viewName : 'EDIT_' . $viewName)));
+			$this->toolbarTitle = \JText::_($langKey);
+		}
+
+		\JToolbarHelper::title(
+			$this->toolbarTitle,
+			'pencil-2 ' . $viewName . '-add'
+		);
+
+		// For new records, check the create permission.
+		if ($isNew && $canDo->get('core.create'))
+		{
+			\JToolbarHelper::saveGroup(
+				[
+					['apply', $viewName . '.apply'],
+					['save', $viewName . '.save'],
+					['save2new', $viewName . '.save2new']
+				],
+				'btn-success'
+			);
+
+			\JToolbarHelper::cancel($viewName . '.cancel');
+		}
+		else
+		{
+			// Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
+			if (property_exists($this->item, 'created_by'))
+			{
+				$itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
+			}
+			else
+			{
+				$itemEditable = $canDo->get('core.edit');
+			}
+
+			$toolbarButtons = [];
+
+			// Can't save the record if it's checked out and editable
+			if (!$checkedOut && $itemEditable)
+			{
+				$toolbarButtons[] = ['apply', $viewName . '.apply'];
+				$toolbarButtons[] = ['save', $viewName . '.save'];
+
+				// We can save this record, but check the create permission to see if we can return to make a new one.
+				if ($canDo->get('core.create'))
+				{
+					$toolbarButtons[] = ['save2new', $viewName . '.save2new'];
+				}
+			}
+
+			// If checked out, we can still save
+			if ($canDo->get('core.create'))
+			{
+				$toolbarButtons[] = ['save2copy', $viewName . '.save2copy'];
+			}
+
+			\JToolbarHelper::saveGroup(
+				$toolbarButtons,
+				'btn-success'
+			);
+
+			if (\JComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
+			{
+				\JToolbarHelper::versions($this->option . '.' . $viewName, $this->item->id);
+			}
+
+			if (!$isNew && $this->previewLink)
+			{
+				\JToolbarHelper::preview($this->previewLink, \JText::_('JGLOBAL_PREVIEW'), 'eye', 80, 90);
+			}
+
+			\JToolbarHelper::cancel($viewName . '.cancel', 'JTOOLBAR_CLOSE');
+		}
+
+		\JToolbarHelper::divider();
+
+		if ($this->helpLink)
+		{
+			\JToolbarHelper::help($this->helpLink);
+		}
+	}
+}

--- a/libraries/src/Cms/View/FormView.php
+++ b/libraries/src/Cms/View/FormView.php
@@ -72,7 +72,7 @@ class FormView extends HtmlView
 	/**
 	 * Constructor
 	 *
-	 * @param   array   $config  An optional associative array of configuration settings.
+	 * @param   array  $config  An optional associative array of configuration settings.
 	 */
 	public function __construct(array $config)
 	{

--- a/libraries/src/Cms/View/ListView.php
+++ b/libraries/src/Cms/View/ListView.php
@@ -124,6 +124,8 @@ class ListView extends HtmlView
 	}
 
 	/**
+	 * Execute and display a template script.
+	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
 	 * @return  mixed  A string if successful, otherwise an Error object.

--- a/libraries/src/Cms/View/ListView.php
+++ b/libraries/src/Cms/View/ListView.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * @package     Joomla.Cms
+ * @subpackage  View
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Cms\View;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Base class for a Joomla List View
+ *
+ * Class holding methods for displaying presentation data.
+ *
+ * @since  2.5.5
+ */
+class ListView extends HtmlView
+{
+	/**
+	 * An array of items
+	 *
+	 * @var  array
+	 */
+	protected $items;
+
+	/**
+	 * The pagination object
+	 *
+	 * @var  \JPagination
+	 */
+	protected $pagination;
+
+	/**
+	 * The model state
+	 *
+	 * @var  \JObject
+	 */
+	protected $state;
+
+	/**
+	 * The actions the user is authorised to perform
+	 *
+	 * @var  \JObject
+	 */
+	protected $canDo;
+
+	/**
+	 * Form object for search filters
+	 *
+	 * @var  \JForm
+	 */
+	public $filterForm;
+
+	/**
+	 * The active search filters
+	 *
+	 * @var  array
+	 */
+	public $activeFilters;
+
+	/**
+	 * The sidebar markup
+	 *
+	 * @var  string
+	 */
+	protected $sidebar;
+
+	/**
+	 * The flag which determine whether we want to show batch button
+	 *
+	 * @var bool
+	 */
+	protected $supportsBatch = true;
+
+	/**
+	 * The toolbar title
+	 *
+	 * @var string
+	 */
+	protected $toolbarTitle;
+
+	/**
+	 * The preview link
+	 *
+	 * @var string
+	 */
+	protected $previewLink;
+
+	/**
+	 * The help link for the view
+	 *
+	 * @var
+	 */
+	protected $helpLink;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $config
+	 */
+	public function __construct(array $config)
+	{
+		parent::__construct($config);
+
+		// Set class properties from config data passed in constructor
+		if (isset($config['canDo']))
+		{
+			$this->canDo = $config['canDo'];
+		}
+
+		if (isset($config['supports_batch']))
+		{
+			$this->supportsBatch = $config['supports_batch'];
+		}
+
+		if (isset($config['help_link']))
+		{
+			$this->helpLink = $config['help_link'];
+		}
+	}
+
+	/**
+	 * @param null $tpl
+	 *
+	 * @return mixed
+	 */
+	public function display($tpl = null)
+	{
+		// Prepare view data
+		$this->initializeView();
+
+		// Check for errors.
+		if (count($errors = $this->get('Errors')))
+		{
+			throw new \JViewGenericdataexception(implode("\n", $errors), 500);
+		}
+
+		// Build toolbar
+		$this->addToolbar();
+
+		// Render the view
+		return parent::display($tpl);
+	}
+
+	/**
+	 * Prepare view data
+	 */
+	protected function initializeView()
+	{
+		if ($this->getLayout() !== 'modal')
+		{
+			$helperClass = ucfirst(substr($this->option, 4));
+
+			if (is_callable($helperClass . '::addSubmenu'))
+			{
+				call_user_func(array($helperClass, 'getActions'), $this->getName());
+			}
+
+			$this->sidebar = \JHtmlSidebar::render();
+		}
+
+		$this->items         = $this->get('Items');
+		$this->pagination    = $this->get('Pagination');
+		$this->state         = $this->get('State');
+		$this->filterForm    = $this->get('FilterForm');
+		$this->activeFilters = $this->get('ActiveFilters');
+
+		// canDo property should be built by the child class before, if not, generate default value
+		if (!empty($this->canDo))
+		{
+			$this->canDo = new \JObject();
+		}
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.6
+	 */
+	protected function addToolbar()
+	{
+		$canDo = $this->canDo;
+		$user  = \JFactory::getUser();
+
+		// Get the toolbar object instance
+		$bar = \JToolbar::getInstance('toolbar');
+
+		$viewName = $this->getName();
+		$singularViewName = \Joomla\String\Inflector::getInstance()->toSingular($viewName);
+
+		if (empty($this->toolbarTitle))
+		{
+			$this->toolbarTitle = \JText::_(strtoupper($this->option . '_' . $viewName . '_TITLE'));
+		}
+
+		\JToolbarHelper::title($this->toolbarTitle, 'stack ' . $singularViewName);
+
+		if ($canDo->get('core.create'))
+		{
+			\JToolbarHelper::addNew($singularViewName . '.add');
+		}
+
+		if (($canDo->get('core.edit')) || ($canDo->get('core.edit.own')))
+		{
+			\JToolbarHelper::editList($singularViewName . '.edit');
+		}
+
+		if ($canDo->get('core.edit.state'))
+		{
+			\JToolbarHelper::publish($viewName . '.publish', 'JTOOLBAR_PUBLISH', true);
+			\JToolbarHelper::unpublish($viewName . '.unpublish', 'JTOOLBAR_UNPUBLISH', true);
+
+			if (isset($this->items[0]->featured))
+			{
+				\JToolbarHelper::custom($viewName . '.featured', 'featured.png', 'featured_f2.png', 'JFEATURE', true);
+				\JToolbarHelper::custom($viewName . '.unfeatured', 'unfeatured.png', 'featured_f2.png', 'JUNFEATURE', true);
+			}
+
+			\JToolbarHelper::archiveList('articles.archive');
+			\JToolbarHelper::checkin('articles.checkin');
+		}
+
+		// Add a batch button
+		if ($this->supportsBatch && $user->authorise('core.create', $this->option)
+			&& $user->authorise('core.edit', $this->option)
+			&& $user->authorise('core.edit.state', $this->option))
+		{
+			$title = \JText::_('JTOOLBAR_BATCH');
+
+			// Instantiate a new \JLayoutFile instance and render the batch button
+			$layout = new \JLayoutFile('joomla.toolbar.batch');
+
+			$dhtml = $layout->render(array('title' => $title));
+			$bar->appendButton('Custom', $dhtml, 'batch');
+		}
+
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		{
+			\JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', $viewName . '.delete', 'JTOOLBAR_EMPTY_TRASH');
+		}
+		elseif ($canDo->get('core.edit.state'))
+		{
+			\JToolbarHelper::trash($viewName . '.trash');
+		}
+
+		if ($user->authorise('core.admin', $this->option) || $user->authorise('core.options', $this->option))
+		{
+			\JToolbarHelper::preferences($this->option);
+		}
+
+		if ($this->helpLink)
+		{
+			\JToolbarHelper::help($this->helpLink);
+		}
+	}
+}

--- a/libraries/src/Cms/View/ListView.php
+++ b/libraries/src/Cms/View/ListView.php
@@ -93,14 +93,14 @@ class ListView extends HtmlView
 	/**
 	 * The help link for the view
 	 *
-	 * @var
+	 * @var string
 	 */
 	protected $helpLink;
 
 	/**
 	 * Constructor
 	 *
-	 * @param array $config
+	 * @param   array  $config  An optional associative array of configuration settings.
 	 */
 	public function __construct(array $config)
 	{
@@ -124,9 +124,9 @@ class ListView extends HtmlView
 	}
 
 	/**
-	 * @param null $tpl
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return mixed
+	 * @return  mixed  A string if successful, otherwise an Error object.
 	 */
 	public function display($tpl = null)
 	{
@@ -148,6 +148,8 @@ class ListView extends HtmlView
 
 	/**
 	 * Prepare view data
+	 *
+	 * @return  void
 	 */
 	protected function initializeView()
 	{
@@ -169,10 +171,10 @@ class ListView extends HtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 
-		// canDo property should be built by the child class before, if not, generate default value
+		// Property $canDo should be built by the child class before, if not, generate default value
 		if (!empty($this->canDo))
 		{
-			$this->canDo = new \JObject();
+			$this->canDo = new \JObject;
 		}
 	}
 

--- a/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
@@ -18,7 +18,7 @@ require_once __DIR__ . '/stubs/controllerform.php';
  *
  * @since       12.3
  */
-class JControllerFormTest extends TestCase
+class JControllerFormTest extends TestCaseDatabase
 {
 	/**
 	 * Sets up the fixture, for example, opens a network connection.

--- a/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
@@ -204,7 +204,7 @@ class JControllerLegacyTest extends TestCaseDatabase
 	 */
 	public function testGetName()
 	{
-		$this->assertEquals($this->class->getName(), 'joomla\\cms\\controller\\');
+		$this->assertEquals($this->class->getName(), 'joomla\cms\controller\base');
 
 		TestReflection::setValue($this->class, 'name', 'inspector');
 

--- a/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerLegacyTest.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/stubs/controller.php';
  *
  * @since       12.3
  */
-class JControllerLegacyTest extends TestCase
+class JControllerLegacyTest extends TestCaseDatabase
 {
 	/**
 	 * An instance of the test object.

--- a/tests/unit/suites/libraries/cms/model/JModelAdminTest.php
+++ b/tests/unit/suites/libraries/cms/model/JModelAdminTest.php
@@ -15,7 +15,7 @@
  *
  * @since       12.3
  */
-class JModelAdminTest extends TestCase
+class JModelAdminTest extends TestCaseDatabase
 {
 	/**
 	 * @var    JModelAdmin

--- a/tests/unit/suites/libraries/cms/model/JModelFormTest.php
+++ b/tests/unit/suites/libraries/cms/model/JModelFormTest.php
@@ -15,7 +15,7 @@
  *
  * @since       12.3
  */
-class JModelFormTest extends TestCase
+class JModelFormTest extends TestCaseDatabase
 {
 	/**
 	 * @var    JModelForm

--- a/tests/unit/suites/libraries/cms/model/JModelItemTest.php
+++ b/tests/unit/suites/libraries/cms/model/JModelItemTest.php
@@ -15,7 +15,7 @@
  *
  * @since       3.4
  */
-class JModelItemTest extends TestCase
+class JModelItemTest extends TestCaseDatabase
 {
 	/**
 	 * @var    JModelItem


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR is the combination of my 4 different PRs #14258, #14511, #14567, #14721. The main goal is support building namespace components in Joomla 4 while the current none namespace components will still work (backward compatible changes).

This PR also bring some new classes (FormView, ListView which help removing repeating code, making developing component faster). More improvements will continue being added in later phase

### Some new concepts

#### Component Dispatcher
See https://github.com/joomla/joomla-cms/pull/14258 for very long discussion. The role of component dispatcher is that it receives input, find the target controller, execute a task and perform redirection if needed. With the dispatcher, the component entry file will just become simple like this (we can remove the necessary if this file if agreed)

```php
(new Joomla\Cms\Dispatcher\Dispatcher())->dispatch();
```
Component dispatcher is also prepare for HMVC support in next phase.

#### Namespace component structure
The component needs to be restructured so that all (or at least Models, Views, Controllers classes) will be autoloaded with PSR-4 Autoloader:

- Controller classes will be located inside administrator/components/com_mycom/Controller, components/com_mycom/Controller folders.
- Model classes will be located inside administrator/components/com_mycom/Model, components/com_mycom/Model folders.
- View classes will be located inside administrator/components/com_mycom/View, components/com_mycom/View folders.

See https://github.com/joomdonation/joomla-cms/tree/namespace-com-content/administrator/components/com_content for sample namespace com_content in the backend. The component is namespaced by @laoneo, I just modified the code a bit to make it works with the structure I proposed. 

### Testing Instructions
Only developers review for now. If the concept is accepted, we can call for human testing later