### PR TITLE
Intro image was calling fulltext alt attibute.

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -105,7 +105,7 @@ JFactory::getDocument()->addScriptDeclaration("
 						<?php if ($images->image_intro_caption) : ?>
 							<?php echo 'class="caption"' . ' title="' . htmlspecialchars($images->image_intro_caption) . '"'; ?>
 						<?php endif; ?>
-						src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_fulltext_alt); ?>"/>
+						src="<?php echo $images->image_intro; ?>" alt="<?php echo htmlspecialchars($images->image_intro_alt); ?>"/>
 				</div>
 			<?php endif; ?>
 			</span>


### PR DESCRIPTION
When listing tags, with show images enabled the alt was calling the full text image alt, but calling the intro image for display. 

Fixes the alt text to use intro, inline with the image.

Noticed when inspecting #14636 