### PR TITLE
[4.0] Admin Help menu indents

### DIFF
--- a/administrator/modules/mod_menu/preset/enabled.php
+++ b/administrator/modules/mod_menu/preset/enabled.php
@@ -400,8 +400,8 @@ if ($showhelp == 1)
 	$this->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_TRANSLATIONS'), 'https://community.joomla.org/translations.html', '', false, '_blank')
 	);
-	$this->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_RESOURCES'), 'https://resources.joomla.org', 'class:help-jrd', false, '_blank'));
-	$this->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_COMMUNITY'), 'https://community.joomla.org', 'class:help-community', false, '_blank'));
+	$this->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_RESOURCES'), 'https://resources.joomla.org', '', false, '_blank'));
+	$this->addChild(new JMenuNode(JText::_('MOD_MENU_HELP_COMMUNITY'), 'https://community.joomla.org', '', false, '_blank'));
 	$this->addChild(
 		new JMenuNode(JText::_('MOD_MENU_HELP_SECURITY'), 'https://developer.joomla.org/security-centre.html', '', false, '_blank')
 	);


### PR DESCRIPTION
If you loook at the admin menu help section you will see that two menu items are indented. I cant see any logical reason for this.

The reason they are indented is that they have a class applied which again I can find no reference to or need for

### Before
<img width="185" alt="screenshotr15-03-37" src="https://cloud.githubusercontent.com/assets/1296369/24081997/3dad1b08-0cb6-11e7-866f-9fed3f8448a9.png">

### After

<img width="176" alt="screenshotr15-03-18" src="https://cloud.githubusercontent.com/assets/1296369/24082003/46da6082-0cb6-11e7-8475-4ecc339b806b.png">

