### PR TITLE
Fix smart search indexer for mysql - part only for J4

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -307,7 +307,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 				' JOIN ' . $db->quoteName('#__finder_tokens') . ' AS t2 ON t2.term = t1.term' .
 				' LEFT JOIN ' . $db->quoteName('#__finder_terms') . ' AS t ON t.term = t1.term' .
 				' WHERE t2.context = %d AND t.term_id IS NOT NULL' .
-				' GROUP BY t1.term' .
+				' GROUP BY t1.term, t.term_id, t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context, t1.language' .
 				' ORDER BY t1.term DESC';
 
 		// Iterate through the contexts and aggregate the tokens per context.
@@ -340,7 +340,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 			' SELECT ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language' .
 			' FROM ' . $db->quoteName('#__finder_tokens_aggregate') . ' AS ta' .
 			' WHERE ta.term_id = 0' .
-			' GROUP BY ta.term'
+			' GROUP BY ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language'
 		);
 		$db->execute();
 
@@ -414,7 +414,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 				' ROUND(SUM(' . $db->quoteName('context_weight') . '), 8)' .
 				' FROM ' . $db->quoteName('#__finder_tokens_aggregate') .
 				' WHERE ' . $db->quoteName('map_suffix') . ' = ' . $db->quote($suffix) .
-				' GROUP BY ' . $db->quoteName('term') .
+				' GROUP BY ' . $db->quoteName('term') . ', ' . $db->quoteName('term_id') .
 				' ORDER BY ' . $db->quoteName('term') . ' DESC'
 			);
 			$db->execute();

--- a/administrator/components/com_finder/helpers/indexer/driver/mysql.php
+++ b/administrator/components/com_finder/helpers/indexer/driver/mysql.php
@@ -288,6 +288,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 		 */
 		$query = 'INSERT INTO ' . $db->quoteName('#__finder_tokens_aggregate') .
 				' (' . $db->quoteName('term_id') .
+				', ' . $db->quoteName('map_suffix') .
 				', ' . $db->quoteName('term') .
 				', ' . $db->quoteName('stem') .
 				', ' . $db->quoteName('common') .
@@ -295,10 +296,11 @@ class FinderIndexerDriverMysql extends FinderIndexer
 				', ' . $db->quoteName('term_weight') .
 				', ' . $db->quoteName('context') .
 				', ' . $db->quoteName('context_weight') .
+				', ' . $db->quoteName('total_weight') .
 				', ' . $db->quoteName('language') . ')' .
 				' SELECT' .
-				' t.term_id, t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context,' .
-				' ROUND( t1.weight * COUNT( t2.term ) * %F, 8 ) AS context_weight, t1.language' .
+				' COALESCE(t.term_id, 0), \'\', t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context,' .
+				' ROUND( t1.weight * COUNT( t2.term ) * %F, 8 ) AS context_weight, 0, t1.language' .
 				' FROM (' .
 				'   SELECT DISTINCT t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context, t1.language' .
 				'   FROM ' . $db->quoteName('#__finder_tokens') . ' AS t1' .
@@ -306,7 +308,7 @@ class FinderIndexerDriverMysql extends FinderIndexer
 				' ) AS t1' .
 				' JOIN ' . $db->quoteName('#__finder_tokens') . ' AS t2 ON t2.term = t1.term' .
 				' LEFT JOIN ' . $db->quoteName('#__finder_terms') . ' AS t ON t.term = t1.term' .
-				' WHERE t2.context = %d AND t.term_id IS NOT NULL' .
+				' WHERE t2.context = %d' .
 				' GROUP BY t1.term, t.term_id, t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context, t1.language' .
 				' ORDER BY t1.term DESC';
 

--- a/components/com_finder/views/search/tmpl/default_results.php
+++ b/components/com_finder/views/search/tmpl/default_results.php
@@ -70,9 +70,9 @@ defined('_JEXEC') or die;
 	<div class="search-pages-counter">
 		<?php
 			// Prepare the pagination string.  Results X - Y of Z
-			$start = (int) $this->pagination->get('limitstart') + 1;
-			$total = (int) $this->pagination->get('total');
-			$limit = (int) $this->pagination->get('limit') * $this->pagination->get('pages.current');
+			$start = (int) $this->pagination->limitstart + 1;
+			$total = (int) $this->pagination->total;
+			$limit = (int) $this->pagination->limit * $this->pagination->pagesCurrent;
 			$limit = (int) ($limit > $total ? $total : $limit);
 
 			echo JText::sprintf('COM_FINDER_SEARCH_RESULTS_OF', $start, $limit, $total);


### PR DESCRIPTION
### Summary of Changes
* Fix smart search indexer for mysql, related to #14811 for J3
* Fix a few lines in front end template for smart search, take a look at code.


### Testing Instructions
Go to backend - Smart Search extension.
Click on button "Index" 
Test front end search form at `index.php?option=com_finder&view=search`
(type 'red' or 'green') - before patch there is `error page`, after patch joomla finds an item.

### Expected result
All works, front end search form too.


### Actual result
`Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 't1.stem' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by`


### Documentation Changes Required
No
