### PR TITLE
[admin menus] Correcting filters and sorting

### DIFF
--- a/administrator/components/com_menus/models/forms/filter_itemsadmin.xml
+++ b/administrator/components/com_menus/models/forms/filter_itemsadmin.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<field
+		name="client_id"
+		type="list"
+		label=""
+		filtermode="selector"
+		onchange="this.form.submit();"
+	>
+		<option value="0">JSITE</option>
+		<option value="1">JADMINISTRATOR</option>
+	</field>
+	<field
+		name="menutype"
+		type="menu"
+		label="COM_MENUS_FILTER_CATEGORY"
+		description="JOPTION_FILTER_CATEGORY_DESC"
+		accesstype="manage"
+		clientid=""
+		showAll="false"
+		filtermode="selector"
+		onchange="this.form.submit();"
+		>
+		<option value="">COM_MENUS_SELECT_MENU</option>
+	</field>
+	<fields name="filter">
+		<field
+			name="search"
+			type="text"
+			label="COM_MENUS_ITEMS_SEARCH_FILTER_LABEL"
+			description="COM_MENUS_ITEMS_SEARCH_FILTER"
+			hint="JSEARCH_FILTER"
+			noresults="JGLOBAL_NO_MATCHING_RESULTS"
+		/>
+		<field
+			name="published"
+			type="status"
+			label="COM_MENUS_FILTER_PUBLISHED"
+			description="COM_MENUS_FILTER_PUBLISHED_DESC"
+			filter="*,0,1,-2"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_PUBLISHED</option>
+		</field>
+		<field
+			name="level"
+			type="integer"
+			label="JOPTION_FILTER_LEVEL"
+			description="JOPTION_FILTER_LEVEL_DESC"
+			first="1"
+			last="10"
+			step="1"
+			languages="*"
+			onchange="this.form.submit();"
+			>
+			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
+		</field>
+	</fields>
+	<fields name="list">
+		<field
+			name="fullordering"
+			type="list"
+			label="JGLOBAL_SORT_BY"
+			description="JGLOBAL_SORT_BY"
+			statuses="*,0,1,2,-2"
+			onchange="this.form.submit();"
+			default="a.lft ASC"
+			>
+			<option value="">JGLOBAL_SORT_BY</option>
+			<option value="a.lft ASC">JGRID_HEADING_ORDERING_ASC</option>
+			<option value="a.lft DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.published ASC">JSTATUS_ASC</option>
+			<option value="a.published DESC">JSTATUS_DESC</option>
+			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="menutype_title ASC">COM_MENUS_HEADING_MENU_ASC</option>
+			<option value="menutype_title DESC">COM_MENUS_HEADING_MENU_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
+		</field>
+		<field
+			name="limit"
+			type="limitbox"
+			label="COM_MENUS_LIST_LIMIT"
+			description="COM_MENUS_LIST_LIMIT_DESC"
+			class="input-mini"
+			default="25"
+			onchange="this.form.submit();"
+		/>
+	</fields>
+</form>

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -161,6 +161,12 @@ class MenusModelItems extends JModelList
 		$clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
 		$this->setState('filter.client_id', $clientId);
 
+		// Use a different filter file when client is administrator
+		if ($clientId == 1)
+		{
+			$this->filterFormName = 'filter_itemsadmin';
+		}
+
 		$this->setState('filter.menutype', $menuType);
 
 		$language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -357,15 +357,29 @@ class MenusViewItems extends JViewLegacy
 	 */
 	protected function getSortFields()
 	{
-		return array(
-			'a.lft'       => JText::_('JGRID_HEADING_ORDERING'),
-			'a.published' => JText::_('JSTATUS'),
-			'a.title'     => JText::_('JGLOBAL_TITLE'),
-			'a.home'      => JText::_('COM_MENUS_HEADING_HOME'),
-			'a.access'    => JText::_('JGRID_HEADING_ACCESS'),
-			'association' => JText::_('COM_MENUS_HEADING_ASSOCIATION'),
-			'language'    => JText::_('JGRID_HEADING_LANGUAGE'),
-			'a.id'        => JText::_('JGRID_HEADING_ID')
-		);
+		$this->state = $this->get('State');
+
+		if ($this->state->get('filter.client_id') == 0)
+		{
+			return array(
+				'a.lft'       => JText::_('JGRID_HEADING_ORDERING'),
+				'a.published' => JText::_('JSTATUS'),
+				'a.title'     => JText::_('JGLOBAL_TITLE'),
+				'a.home'      => JText::_('COM_MENUS_HEADING_HOME'),
+				'a.access'    => JText::_('JGRID_HEADING_ACCESS'),
+				'association' => JText::_('COM_MENUS_HEADING_ASSOCIATION'),
+				'language'    => JText::_('JGRID_HEADING_LANGUAGE'),
+				'a.id'        => JText::_('JGRID_HEADING_ID')
+			);
+		}
+		else
+		{
+			return array(
+				'a.lft'       => JText::_('JGRID_HEADING_ORDERING'),
+				'a.published' => JText::_('JSTATUS'),
+				'a.title'     => JText::_('JGLOBAL_TITLE'),
+				'a.id'        => JText::_('JGRID_HEADING_ID')
+			);
+		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/14655

### Summary of Changes
Adding a different filter file when client is administrator.
This file does not contain the Access and Language Filters.
The sorting does not contain: Home, Language, Access, Association


### Testing Instructions
Patch and display administrator menu items page.
### Expected result

![screen shot 2017-03-19 at 18 45 08](https://cloud.githubusercontent.com/assets/869724/24083308/cdfe9a24-0cd4-11e7-805e-3da63a7d9620.png)

@brianteeman @izharaazmi @yasirunilan