### PR TITLE
[com_fields] Clear the list values

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -42,7 +42,8 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
-		if (!is_array($data) || empty($data['com_fields']) || empty($item->id))
+		// Check if data is an array and the item has an id
+		if (!is_array($data) || empty($item->id))
 		{
 			return true;
 		}
@@ -53,29 +54,35 @@ class PlgSystemFields extends JPlugin
 			$context = $item->extension . '.categories';
 		}
 
-		$fieldsData = $data['com_fields'];
-		$parts      = FieldsHelper::extract($context, $item);
+		// Check the context
+		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
 		{
 			return true;
 		}
 
+		// Compile the right context for the fields
 		$context = $parts[0] . '.' . $parts[1];
 
 		// Loading the fields
-		$fieldsObjects = FieldsHelper::getFields($context, $item);
+		$fields = FieldsHelper::getFields($context, $item);
 
-		if (!$fieldsObjects)
+		if (!$fields)
 		{
 			return true;
 		}
 
+		// Get the fields data
+		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
+
 		// Loading the model
 		$model = JModelLegacy::getInstance('Field', 'FieldsModel', array('ignore_request' => true));
 
-		foreach ($fieldsObjects as $field)
+		// Loop over the fields
+		foreach ($fields as $field)
 		{
+			// Determine the value if it is available from the data
 			$value = key_exists($field->alias, $fieldsData) ? $fieldsData[$field->alias] : null;
 
 			// Setting the value for the field and the item

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -42,7 +42,7 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentAfterSave($context, $item, $isNew, $data = array())
 	{
-		if (!is_array($data) || empty($data['com_fields']))
+		if (!is_array($data) || empty($data['com_fields']) || empty($item->id))
 		{
 			return true;
 		}
@@ -76,26 +76,10 @@ class PlgSystemFields extends JPlugin
 
 		foreach ($fieldsObjects as $field)
 		{
-			// Only save the fields with the alias from the data
-			if (!key_exists($field->alias, $fieldsData))
-			{
-				continue;
-			}
-
-			$id = null;
-
-			if (isset($item->id))
-			{
-				$id = $item->id;
-			}
-
-			if (!$id)
-			{
-				continue;
-			}
+			$value = key_exists($field->alias, $fieldsData) ? $fieldsData[$field->alias] : null;
 
 			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $context, $id, $fieldsData[$field->alias]);
+			$model->setFieldValue($field->id, $context, $item->id, $value);
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issue #14357.

### Summary of Changes
It is not possible to clear all values in a list. This pr fixes it.

Additionally it clears up the `onContentAfterSave` function.

### Testing Instructions
- Create a list custom field with multiple options and set multiple to true.
- Adit an article.
- Select some options in the list field.
- Save the article.
- Edit the article.
- Deselect all options in the list field.
- Save the article.


### Expected result
The list field is empty.


### Actual result
The list field contains the values from the last save and is not empty.


### Documentation Changes Required

