### PR TITLE
[com_fields] Encode the list options

### DIFF
--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -42,7 +42,7 @@ class FieldsListPlugin extends FieldsPlugin
 		foreach ($this->getOptionsFromField($field) as $value => $name)
 		{
 			$option = new DOMElement('option', htmlentities($value));
-			$option->nodeValue = JText::_($name);
+			$option->nodeValue = htmlentities(JText::_($name));
 
 			$element = $fieldNode->appendChild($option);
 			$element->setAttribute('value', $value);

--- a/administrator/components/com_fields/libraries/fieldslistplugin.php
+++ b/administrator/components/com_fields/libraries/fieldslistplugin.php
@@ -41,7 +41,7 @@ class FieldsListPlugin extends FieldsPlugin
 
 		foreach ($this->getOptionsFromField($field) as $value => $name)
 		{
-			$option = new DOMElement('option', $value);
+			$option = new DOMElement('option', htmlentities($value));
 			$option->nodeValue = JText::_($name);
 
 			$element = $fieldNode->appendChild($option);


### PR DESCRIPTION
Pull Request for Issue #14609.

### Summary of Changes
Encodes the value for the list options.


### Testing Instructions
- Create a list custom field.
- Add an option with the text **Test** and the value **test&demo**.
- Add an option with the text **Test1** and the value **test**.
- Edit an article.


### Expected result
No error message is shown.

### Actual result
An error is shown:
`Warning: DOMElement::__construct(): unterminated entity reference b in //joomla-cms/administrator/components/com_fields/libraries/fieldslistplugin.php on line 44`


