### PR TITLE
[com_fields] Use com_fields strings

### DIFF
--- a/plugins/fields/editor/params/editor.xml
+++ b/plugins/fields/editor/params/editor.xml
@@ -8,7 +8,7 @@
 				label="PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_LABEL"
 				description="PLG_FIELDS_EDITOR_PARAMS_SHOW_BUTTONS_DESC"
 			>
-				<option value="">PLG_FIELDS_EDITOR_PARAMS_USE_GLOBAL</option>
+				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>

--- a/plugins/fields/imagelist/params/imagelist.xml
+++ b/plugins/fields/imagelist/params/imagelist.xml
@@ -12,7 +12,7 @@
 				label="PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_LABEL"
 				description="PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC"
 			>
-				<option value="">PLG_FIELDS_IMAGELIST_PARAMS_USE_GLOBAL</option>
+				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="/">/</option>
 			</field>
 

--- a/plugins/fields/list/params/list.xml
+++ b/plugins/fields/list/params/list.xml
@@ -8,7 +8,7 @@
 				label="PLG_FIELDS_LIST_PARAMS_MULTIPLE_LABEL"
 				description="PLG_FIELDS_LIST_PARAMS_MULTIPLE_DESC"
 			>
-				<option value="">PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL</option>
+				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="1">JYES</option>
 				<option value="0">JNO</option>
 			</field>


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/14795#issuecomment-287701298.

### Summary of Changes
As with the pr #14683 some strings have been combined. This pr changes some missing ones.

![image](https://cloud.githubusercontent.com/assets/251072/24093565/cb0ac13c-0d54-11e7-897f-a23e5420a8d1.png)


### Testing Instructions
Create a list custom field.


### Expected result
The multiple attribute "Use from Plugin" should be visible.


### Actual result
The multiple attribute _PLG_FIELDS_TEXT_PARAMS_USE_GLOBAL_ is displayed.


### Documentation Changes Required

