### PR TITLE
[com_fields] Pass the default catid correctly to the form

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -278,20 +278,22 @@ class FieldsHelper
 		$component = $parts[0];
 		$section   = $parts[1];
 
-		$assignedCatids = isset($data->catid) ? $data->catid : (isset($data->fieldscatid) ? $data->fieldscatid : null);
+		$assignedCatids = isset($data->catid) ? $data->catid : (isset($data->fieldscatid) ? $data->fieldscatid : $form->getValue('catid'));
 
-		if (!$assignedCatids && $form->getField('catid'))
+		if (!$assignedCatids && $formField = $form->getField('catid'))
 		{
+			$assignedCatids = $formField->getAttribute('default', null);
+
 			// Choose the first category available
 			$xml = new DOMDocument;
-			$xml->loadHTML($form->getField('catid')->__get('input'));
+			$xml->loadHTML($formField->__get('input'));
 			$options = $xml->getElementsByTagName('option');
 
-			if ($firstChoice = $options->item(0))
+			if (!$assignedCatids && $firstChoice = $options->item(0))
 			{
 				$assignedCatids = $firstChoice->getAttribute('value');
-				$data->fieldscatid = $assignedCatids;
 			}
+			$data->fieldscatid = $assignedCatids;
 		}
 
 		/*

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -205,6 +205,7 @@ class ContentModelForm extends ContentModelArticle
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
 		$params = $this->getState()->get('params');
+
 		if ($params && $params->get('enable_category') == 1)
 		{
 			$form->setFieldAttribute('catid', 'default', $params->get('catid', 1));

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -200,7 +200,7 @@ class ContentModelForm extends ContentModelArticle
 	 *
 	 * @return  void
 	 *
-	 * @since   3.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -205,7 +205,7 @@ class ContentModelForm extends ContentModelArticle
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
 		$params = $this->getState()->get('params');
-		if ($params->get('enable_category') == 1)
+		if ($params && $params->get('enable_category') == 1)
 		{
 			$form->setFieldAttribute('catid', 'default', $params->get('catid', 1));
 			$form->setFieldAttribute('catid', 'readonly', 'true');

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -190,4 +190,27 @@ class ContentModelForm extends ContentModelArticle
 
 		return parent::save($data);
 	}
+
+	/**
+	 * Allows preprocessing of the JForm object.
+	 *
+	 * @param   JForm   $form   The form object
+	 * @param   array   $data   The data to be merged into the form object
+	 * @param   string  $group  The plugin group to be executed
+	 *
+	 * @return  void
+	 *
+	 * @since   3.0
+	 */
+	protected function preprocessForm(JForm $form, $data, $group = 'content')
+	{
+		$params = $this->getState()->get('params');
+		if ($params->get('enable_category') == 1)
+		{
+			$form->setFieldAttribute('catid', 'default', $params->get('catid', 1));
+			$form->setFieldAttribute('catid', 'readonly', 'true');
+		}
+
+		return parent::preprocessForm($form, $data, $group);
+	}
 }

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -105,12 +105,6 @@ class ContentViewForm extends JViewLegacy
 		$this->params->merge($this->item->params);
 		$this->user   = $user;
 
-		if ($params->get('enable_category') == 1)
-		{
-			$this->form->setFieldAttribute('catid', 'default', $params->get('catid', 1));
-			$this->form->setFieldAttribute('catid', 'readonly', 'true');
-		}
-
 		// Propose current language as default when creating new article
 		if (empty($this->item->id) && JLanguageMultilang::isEnabled())
 		{


### PR DESCRIPTION
Pull Request for Issue #14697.

### Summary of Changes
This pr reads the default category from the form or form field when explicitly set and loads the right fields.


### Testing Instructions
- Create category "Test".
- Create a field group "Example" for articles.
- Create field "Testfield1" assigned to group "Example" and to category "Test".
- Create field "Testfield2" assigned to group "Example" and to category "Uncategorized".
- Create a menu item "Create Article" and set the default category to "Test".
- On the front, open that menu link.


### Expected result
The default category is "Test" and only the "Testfield1" is visible.


### Actual result
The default category is "Uncategorized" and only the "Testfield2" is visible.

