### PR TITLE
DEBUG LANGUAGE: Allow debug when ini file missing

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -742,14 +742,18 @@ class JLanguage
 				$oldFilename = $filename;
 
 				// Check the standard file name
-				$path = JLanguageHelper::getLanguagePath($basePath, $this->default);
-				$filename = $internal ? $this->default : $this->default . '.' . $extension;
-				$filename = "$path/$filename.ini";
-
-				// If the one we tried is different than the new name, try again
-				if ($oldFilename != $filename)
+				if (!$this->debug)
 				{
-					$result = $this->loadLanguage($filename, $extension, false);
+					$path = JLanguageHelper::getLanguagePath($basePath, $this->default);
+
+					$filename = $internal ? $this->default : $this->default . '.' . $extension;
+					$filename = "$path/$filename.ini";
+
+					// If the one we tried is different than the new name, try again
+					if ($oldFilename != $filename)
+					{
+						$result = $this->loadLanguage($filename, $extension, false);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/14796

### Summary of Changes
Prevent loading default language en-GB when debug language is ON


### Testing Instructions
Install a site with 2 languages. Set the administrator language to else than en-GB.
Delete some ini files from the other language.
(In https://github.com/joomla/joomla-cms/issues/14796 com_associations.ini did not exist for the 3.6.5 language packs.)

Set Debug Language ON in Global configuration.

### Expected result
As the ini file is missing, constants should be displayed as ??CONSTANT??


### Actual result
en-GB replaces the missing values because the language does not contain the ini file

![screen shot 2017-03-20 at 11 34 54](https://cloud.githubusercontent.com/assets/869724/24096269/4936685c-0d61-11e7-834a-d16acc7e6412.png)


PATCH and retest

You should now get this (example with com_associations. Admin lang is Italian in this case.

![screen shot 2017-03-20 at 11 24 11](https://cloud.githubusercontent.com/assets/869724/24096229/08990a70-0d61-11e7-9acd-369ec2208a23.png)

@Bakual @mbabker @zero-24 
