### PR TITLE
Pass Attachment Disposition to PHPMailer Parent

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -464,17 +464,17 @@ class JMail extends PHPMailer
 					{
 						if (!empty($name))
 						{
-							$result = parent::addAttachment($file, $name[$key], $encoding, $type);
+							$result = parent::addAttachment($file, $name[$key], $encoding, $type, $disposition);
 						}
 						else
 						{
-							$result = parent::addAttachment($file, $name, $encoding, $type);
+							$result = parent::addAttachment($file, $name, $encoding, $type, $disposition);
 						}
 					}
 				}
 				else
 				{
-					$result = parent::addAttachment($path, $name, $encoding, $type);
+					$result = parent::addAttachment($path, $name, $encoding, $type, $disposition);
 				}
 
 				// Check for boolean false return if exception handling is disabled


### PR DESCRIPTION
### Summary of Changes
The JMail method `addAttachment` accepts the parameter `$disposition` however does not pass it to the parent class PHPMailer's method of the same name.
Thus the change is to pass the paremeter `$disposition` to the parent class.

### Testing Instructions
None, does not change existing behaviour (ony adds functionality that got lost).

### Documentation Changes Required
None

Pull Request for Issue #14818 .


