### PR TITLE
[fields] imagepath tooltip

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_imagelist.ini
@@ -5,7 +5,7 @@
 
 PLG_FIELDS_IMAGELIST="Fields - Imagelist"
 PLG_FIELDS_IMAGELIST_LABEL="List of Images (%s)"
-PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed."
+PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed relative to the default image folder."
 PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_DESC="The class which is added to the image (src tag)."
 PLG_FIELDS_IMAGELIST_PARAMS_IMAGE_CLASS_LABEL="Image Class"

--- a/administrator/language/en-GB/en-GB.plg_fields_media.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_media.ini
@@ -5,7 +5,7 @@
 
 PLG_FIELDS_MEDIA="Fields - Media"
 PLG_FIELDS_MEDIA_LABEL="Media (%s)"
-PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed."
+PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_DESC="The filesystem path to the directory containing the image files to be listed relative to the default image folder."
 PLG_FIELDS_MEDIA_PARAMS_DIRECTORY_LABEL="Directory"
 PLG_FIELDS_MEDIA_PARAMS_IMAGE_CLASS_DESC="The class which is added to the image (src tag)."
 PLG_FIELDS_MEDIA_PARAMS_IMAGE_CLASS_LABEL="Image Class"


### PR DESCRIPTION
PR for #14519

The current tooltip says "The filesystem path to the directory containing the image files to be listed."
but it starts the display at /
Which implies to the user that it is pointing to the root folder
It is actually displaying the filesystem path AFTER the "Path to Images Folder" as defined in the Media component options

This PR updates the string used to say
"The filesystem path to the directory containing the image files to be listed relative to the default image folder.""

Which more accurately reflects the path
