### PR TITLE
Publishing article options frontend

### DIFF
--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -108,18 +108,16 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php if ($params->get('save_history', 0)) : ?>
 					<?php echo $this->form->renderField('version_note'); ?>
 				<?php endif; ?>
-				<?php // Do not show these publishing options if the edit form is configured not to. ?>
 				<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
 					<?php echo $this->form->renderField('created_by_alias'); ?>
 				<?php endif; ?>
 				<?php if ($this->item->params->get('access-change')) : ?>
 					<?php echo $this->form->renderField('state'); ?>
 					<?php echo $this->form->renderField('featured'); ?>
-					<?php // Do not show these publishing options if the edit form is configured not to. ?>
-						<?php if ($params->get('show_publishing_options', 1) == 1) : ?>					
-							<?php echo $this->form->renderField('publish_up'); ?>
-							<?php echo $this->form->renderField('publish_down'); ?>
-						<?php endif; ?>
+					<?php if ($params->get('show_publishing_options', 1) == 1) : ?>					
+						<?php echo $this->form->renderField('publish_up'); ?>
+						<?php echo $this->form->renderField('publish_down'); ?>
+					<?php endif; ?>
 				<?php endif; ?>
 				<?php echo $this->form->renderField('access'); ?>
 				<?php if (is_null($this->item->id)) : ?>
@@ -137,7 +135,6 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo $this->form->renderField('language'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php // Do not show these publishing options if the edit form is configured not to. ?>
 			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 				<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
 					<?php echo $this->form->renderField('metadesc'); ?>

--- a/components/com_content/views/form/tmpl/edit.php
+++ b/components/com_content/views/form/tmpl/edit.php
@@ -108,12 +108,18 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php if ($params->get('save_history', 0)) : ?>
 					<?php echo $this->form->renderField('version_note'); ?>
 				<?php endif; ?>
-				<?php echo $this->form->renderField('created_by_alias'); ?>
+				<?php // Do not show these publishing options if the edit form is configured not to. ?>
+				<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
+					<?php echo $this->form->renderField('created_by_alias'); ?>
+				<?php endif; ?>
 				<?php if ($this->item->params->get('access-change')) : ?>
 					<?php echo $this->form->renderField('state'); ?>
 					<?php echo $this->form->renderField('featured'); ?>
-					<?php echo $this->form->renderField('publish_up'); ?>
-					<?php echo $this->form->renderField('publish_down'); ?>
+					<?php // Do not show these publishing options if the edit form is configured not to. ?>
+						<?php if ($params->get('show_publishing_options', 1) == 1) : ?>					
+							<?php echo $this->form->renderField('publish_up'); ?>
+							<?php echo $this->form->renderField('publish_down'); ?>
+						<?php endif; ?>
 				<?php endif; ?>
 				<?php echo $this->form->renderField('access'); ?>
 				<?php if (is_null($this->item->id)) : ?>
@@ -131,10 +137,13 @@ JFactory::getDocument()->addScriptDeclaration("
 				<?php echo $this->form->renderField('language'); ?>
 			<?php echo JHtml::_('bootstrap.endTab'); ?>
 
-			<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
-				<?php echo $this->form->renderField('metadesc'); ?>
-				<?php echo $this->form->renderField('metakey'); ?>
-			<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php // Do not show these publishing options if the edit form is configured not to. ?>
+			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
+				<?php echo JHtml::_('bootstrap.addTab', $this->tab_name, 'metadata', JText::_('COM_CONTENT_METADATA')); ?>
+					<?php echo $this->form->renderField('metadesc'); ?>
+					<?php echo $this->form->renderField('metakey'); ?>
+				<?php echo JHtml::_('bootstrap.endTab'); ?>
+			<?php endif; ?>
 
 			<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 

--- a/templates/beez3/html/com_content/form/edit.php
+++ b/templates/beez3/html/com_content/form/edit.php
@@ -227,6 +227,8 @@ endif;
 					<?php echo $this->form->getInput('tags'); ?>
 				</div>
 			</div>
+			<?php // Do not show these publishing options if the edit form is configured not to. ?>
+			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 			<div class="control-group">
 				<div class="control-label">
 					<?php echo $this->form->getLabel('created_by_alias'); ?>
@@ -235,7 +237,7 @@ endif;
 					<?php echo $this->form->getInput('created_by_alias'); ?>
 				</div>
 			</div>
-
+			<?php endif; ?>
 			<?php if ($this->item->params->get('access-change')) : ?>
 				<div class="control-group">
 					<div class="control-label">
@@ -253,6 +255,8 @@ endif;
 						<?php echo $this->form->getInput('featured'); ?>
 					</div>
 				</div>
+				<?php // Do not show these publishing options if the edit form is configured not to. ?>
+				<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('publish_up'); ?>
@@ -269,6 +273,7 @@ endif;
 						<?php echo $this->form->getInput('publish_down'); ?>
 					</div>
 				</div>
+				<?php endif; ?>
 			<?php endif; ?>
 			<div class="control-group">
 				<div class="control-label">
@@ -301,6 +306,8 @@ endif;
 			</div>
 	</fieldset>
 
+	<?php // Do not show these publishing options if the edit form is configured not to. ?>
+	<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 	<fieldset>
 		<legend><?php echo JText::_('COM_CONTENT_METADATA'); ?></legend>
 			<div class="control-group">
@@ -319,13 +326,14 @@ endif;
 					<?php echo $this->form->getInput('metakey'); ?>
 				</div>
 			</div>
-
+	</fieldset>
+	<?php endif; ?>
 		<input type="hidden" name="task" value="" />
 		<input type="hidden" name="return" value="<?php echo $this->return_page;?>" />
 		<?php if ($this->params->get('enable_category', 0) == 1) : ?>
 			<input type="hidden" name="jform[catid]" value="<?php echo $this->params->get('catid', 1);?>"/>
 		<?php endif;?>
 		<?php echo JHtml::_('form.token'); ?>
-	</fieldset>
+
 </form>
 </div>

--- a/templates/beez3/html/com_content/form/edit.php
+++ b/templates/beez3/html/com_content/form/edit.php
@@ -227,7 +227,6 @@ endif;
 					<?php echo $this->form->getInput('tags'); ?>
 				</div>
 			</div>
-			<?php // Do not show these publishing options if the edit form is configured not to. ?>
 			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 			<div class="control-group">
 				<div class="control-label">
@@ -255,7 +254,6 @@ endif;
 						<?php echo $this->form->getInput('featured'); ?>
 					</div>
 				</div>
-				<?php // Do not show these publishing options if the edit form is configured not to. ?>
 				<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 				<div class="control-group">
 					<div class="control-label">
@@ -306,7 +304,6 @@ endif;
 			</div>
 	</fieldset>
 
-	<?php // Do not show these publishing options if the edit form is configured not to. ?>
 	<?php if ($params->get('show_publishing_options', 1) == 1) : ?>	
 	<fieldset>
 		<legend><?php echo JText::_('COM_CONTENT_METADATA'); ?></legend>


### PR DESCRIPTION
### Summary of Changes
In the content component there is the option to disable Publishing options from the content creation form. However this only disables the fields when in the admin not when you are creating an article in the front end.

This came up during a site review where the client couldnt understand how the metadata and publishing dates were being changed when the option was disabled


### Testing Instructions
Set Show Publishing Options to hide
<img width="398" alt="screenshotr13-30-43" src="https://cloud.githubusercontent.com/assets/1296369/24149481/9bebda62-0e3a-11e7-82a1-be5987903018.png">



### Expected result
Publishing options hidden from the content form in the admin and front end


### Actual result
publishing options only hidden in the admin

After this PR the fields that are in the admin publishing tab will not be displayed on the front end content dorm if disabled. Note you need to check the fields that are disabled on the frontend as the fieldsets have different names and groups. Basically metadata, publish up and down and author alias will be hidden

An override for Beez has been included - you sihould check that as well.


### Documentation Changes Required

