### PR TITLE
[beez] Can't save content when captcha is enabled

### DIFF
--- a/templates/beez3/html/com_content/form/edit.php
+++ b/templates/beez3/html/com_content/form/edit.php
@@ -75,7 +75,7 @@ endif;
 				</button>
 			</div>
 			<?php if ($this->captchaEnabled) : ?>
-					<?php echo $this->form->renderField('captcha'); ?>
+				<?php echo $this->form->renderField('captcha'); ?>
 			<?php endif; ?>
 			<?php echo $this->form->getInput('articletext'); ?>
 

--- a/templates/beez3/html/com_content/form/edit.php
+++ b/templates/beez3/html/com_content/form/edit.php
@@ -74,7 +74,9 @@ endif;
 					<?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
-
+			<?php if ($this->captchaEnabled) : ?>
+					<?php echo $this->form->renderField('captcha'); ?>
+			<?php endif; ?>
 			<?php echo $this->form->getInput('articletext'); ?>
 
 	</fieldset>


### PR DESCRIPTION
### Summary of Changes
Add the missing code to display captcha when creating content with the Beez template

### Testing Instructions
Configure and enable the recaptcha plugin
In article options enable captcha on submit
<img width="350" alt="screenshotr14-05-25" src="https://cloud.githubusercontent.com/assets/1296369/24151025/7e2b5f20-0e3f-11e7-835b-cb23b441fb26.png">
Create a menu item type to create an article

### Expected result
Captcha displayed on the front end when creating an article


### Actual result
Test with protostar - captcha displayed
Test with beez - captcha NOT displayed and article cannot be saved



