### PR TITLE
Remove useless @todo

### DIFF
--- a/administrator/components/com_languages/views/overrides/view.html.php
+++ b/administrator/components/com_languages/views/overrides/view.html.php
@@ -113,7 +113,6 @@ class LanguagesViewOverrides extends JViewLegacy
 		JHtmlSidebar::setAction('index.php?option=com_languages&view=overrides');
 
 		JHtmlSidebar::addFilter(
-			// @todo need a label here
 			'',
 			'filter_language_client',
 			JHtml::_('select.options', $this->languages, null, 'text', $this->state->get('filter.language_client')),


### PR DESCRIPTION
As far as I can tell this TODO is either outdated or wrong - looking at the code I can see
`
<label for="filter_language_client" class="element-invisible"></label>
`
So there is a label and there is nothing TODO
