### PR TITLE
added the space between text and table border

### DIFF
--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -115,7 +115,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				</tbody>
 			</table>
 			<?php endif; ?>
-			<div><?php echo JText::_('COM_INSTALLER_MSG_DISCOVER_DESCRIPTION'); ?></div>
+			<div style="padding-left: 10px"><?php echo JText::_('COM_INSTALLER_MSG_DISCOVER_DESCRIPTION'); ?></div>
 			<input type="hidden" name="task" value="" />
 			<input type="hidden" name="boxchecked" value="0" />
 			<?php echo JHtml::_('form.token'); ?>


### PR DESCRIPTION
Pull Request for Issue #14839 .

### Summary of Changes
Added the space between table border and text displayed.Added padding


### Testing Instructions
Go to Menu, Extensions -> Manage -> Discover.


### Expected result
![101](https://cloud.githubusercontent.com/assets/9814784/24167913/8e5c5782-0e9e-11e7-826a-d1ff4d90b7bf.PNG)




### Actual result
![102](https://cloud.githubusercontent.com/assets/9814784/24167922/930e7328-0e9e-11e7-8113-f475fc1ac130.PNG)



### Documentation Changes Required
None
