### PR TITLE
Subpackage names

### DIFF
--- a/administrator/components/com_contact/helpers/associations.php
+++ b/administrator/components/com_contact/helpers/associations.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_contact
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_menus/helpers/associations.php
+++ b/administrator/components/com_menus/helpers/associations.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_menus
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_newsfeeds/helpers/associations.php
+++ b/administrator/components/com_newsfeeds/helpers/associations.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_newsfeeds
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/templates/hathor/html/layouts/joomla/toolbar/modal.php
+++ b/administrator/templates/hathor/html/layouts/joomla/toolbar/modal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_messages
+ * @subpackage  Layout
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Fields.Url
+ * @subpackage  Fields.URL
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Installer.FolderInstaller
+ * @subpackage  Installer.folderInstaller
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Installer.Urlinstaller
+ * @subpackage  Installer.urlinstaller
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  System.Stats
+ * @subpackage  System.stats
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/system/stats/layouts/field/uniqueid.php
+++ b/plugins/system/stats/layouts/field/uniqueid.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  System.Stats
+ * @subpackage  System.stats
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  System.Stats
+ * @subpackage  System.stats
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/system/stats/layouts/stats.php
+++ b/plugins/system/stats/layouts/stats.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  System.Stats
+ * @subpackage  System.stats
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/twofactorauth/yubikey/tmpl/form.php
+++ b/plugins/twofactorauth/yubikey/tmpl/form.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Twofactorauth.totp.tmpl
+ * @subpackage  Twofactorauth.yubikey.tmpl
  *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
Fix copy paste errors where the wrong subpackage is used
Consistency check so that the case is consistent across the subpackage


(bored at a usergroup)