### PR TITLE
Fixed wrong DocBlock summary for function canEditState

### DIFF
--- a/administrator/components/com_banners/models/client.php
+++ b/administrator/components/com_banners/models/client.php
@@ -54,7 +54,7 @@ class BannersModelClient extends JModelAdmin
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -617,7 +617,7 @@ class FieldsModelField extends JModelAdmin
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *

--- a/administrator/components/com_fields/models/group.php
+++ b/administrator/components/com_fields/models/group.php
@@ -130,7 +130,7 @@ class FieldsModelGroup extends JModelAdmin
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *

--- a/administrator/components/com_finder/models/index.php
+++ b/administrator/components/com_finder/models/index.php
@@ -73,7 +73,7 @@ class FinderModelIndex extends JModelList
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *

--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -55,7 +55,7 @@ class FinderModelMaps extends JModelList
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -669,7 +669,7 @@ abstract class JModelAdmin extends JModelForm
 	}
 
 	/**
-	 * Method to test whether a record can be deleted.
+	 * Method to test whether a record can have its state changed.
 	 *
 	 * @param   object  $record  A record object.
 	 *


### PR DESCRIPTION
### Summary of Changes

Fixed wrong DocBlock summary for function canEditState in some component models.

Original string:
Method to test whether a record can be deleted.

New string:
Method to test whether a record can have its state changed.

### Testing Instructions

Code review.

### Documentation Changes Required

None.
