### PR TITLE
content.language layout: changing 'default' to 'undefined'

### DIFF
--- a/layouts/joomla/content/language.php
+++ b/layouts/joomla/content/language.php
@@ -11,11 +11,7 @@ defined('JPATH_BASE') or die;
 
 $item = $displayData;
 
-if ($item->language == '')
-{
-	echo JText::_('JDEFAULT');
-}
-elseif ($item->language == '*')
+if ($item->language == '*')
 {
 	echo JText::alt('JALL', 'language');
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/14816

### Summary of Changes
Changing language display to undefined instead of default when the item language is not set (usually by accident (See https://github.com/joomla/joomla-cms/issues/14562) or when a language has been set to some items on a multilang site and the content language is deleted.

### Testing Instructions
One can test using same conditions as https://github.com/joomla/joomla-cms/issues/14562 or by deleting a content language and looking at the items managers

Can be merged on Review.

@Bakual 