### PR TITLE
rel=Noopener

### DIFF
--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -121,7 +121,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo $item->detailsurl; ?>
 								<?php if (isset($item->infourl)) : ?>
 									<br />
-									<a href="<?php echo $item->infourl; ?>" target="_blank" rel="noopener"><?php echo $this->escape($item->infourl); ?></a>
+									<a href="<?php echo $item->infourl; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->infourl); ?></a>
 								<?php endif; ?>
 							</span>
 								</td>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -121,7 +121,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo $item->detailsurl; ?>
 								<?php if (isset($item->infourl)) : ?>
 									<br />
-									<a href="<?php echo $item->infourl; ?>" target="_blank"><?php echo $this->escape($item->infourl); ?></a>
+									<a href="<?php echo $item->infourl; ?>" target="_blank" rel="noopener"><?php echo $this->escape($item->infourl); ?></a>
 								<?php endif; ?>
 							</span>
 								</td>

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -87,7 +87,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<?php echo JText::_($item->update_site_name); ?>
 								<br />
 								<span class="small break-word">
-									<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener"><?php echo $this->escape($item->location); ?></a>
+									<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->location); ?></a>
 								</span>
 							</label>
 						</td>

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -87,7 +87,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<?php echo JText::_($item->update_site_name); ?>
 								<br />
 								<span class="small break-word">
-									<a href="<?php echo $item->location; ?>" target="_blank"><?php echo $this->escape($item->location); ?></a>
+									<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener"><?php echo $this->escape($item->location); ?></a>
 								</span>
 							</label>
 						</td>

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -126,11 +126,11 @@ else
 			// Fix wrong display of Joomla!® in RTL language
 			if ($lang->isRtl())
 			{
-				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener">Joomla!</a><sup>&#174;&#x200E;</sup>';
+				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener noreferrer">Joomla!</a><sup>&#174;&#x200E;</sup>';
 			}
 			else
 			{
-				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener">Joomla!</a><sup>&#174;</sup>';
+				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener noreferrer">Joomla!</a><sup>&#174;</sup>';
 			}
 			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla);
 			?>

--- a/administrator/templates/hathor/login.php
+++ b/administrator/templates/hathor/login.php
@@ -126,11 +126,11 @@ else
 			// Fix wrong display of Joomla!® in RTL language
 			if ($lang->isRtl())
 			{
-				$joomla = '<a href="https://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;&#x200E;</sup>';
+				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener">Joomla!</a><sup>&#174;&#x200E;</sup>';
 			}
 			else
 			{
-				$joomla = '<a href="https://www.joomla.org" target="_blank">Joomla!</a><sup>&#174;</sup>';
+				$joomla = '<a href="https://www.joomla.org" target="_blank" rel="noopener">Joomla!</a><sup>&#174;</sup>';
 			}
 			echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla);
 			?>

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -130,7 +130,7 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		<p class="pull-right">
 			&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?>
 		</p>
-		<a class="login-joomla hasTooltip" href="https://www.joomla.org" target="_blank" title="<?php echo JHtml::_('tooltipText', 'TPL_ISIS_ISFREESOFTWARE'); ?>"><span class="icon-joomla"></span></a>
+		<a class="login-joomla hasTooltip" href="https://www.joomla.org" target="_blank"  rel="noopener" title="<?php echo JHtml::_('tooltipText', 'TPL_ISIS_ISFREESOFTWARE'); ?>"><span class="icon-joomla"></span></a>
 		<a href="<?php echo $frontEndUri->toString(); ?>" target="_blank" class="pull-left"><span class="icon-out-2"></span><?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?></a>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -130,7 +130,7 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		<p class="pull-right">
 			&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?>
 		</p>
-		<a class="login-joomla hasTooltip" href="https://www.joomla.org" target="_blank"  rel="noopener" title="<?php echo JHtml::_('tooltipText', 'TPL_ISIS_ISFREESOFTWARE'); ?>"><span class="icon-joomla"></span></a>
+		<a class="login-joomla hasTooltip" href="https://www.joomla.org" target="_blank"  rel="noopener noreferrer" title="<?php echo JHtml::_('tooltipText', 'TPL_ISIS_ISFREESOFTWARE'); ?>"><span class="icon-joomla"></span></a>
 		<a href="<?php echo $frontEndUri->toString(); ?>" target="_blank" class="pull-left"><span class="icon-out-2"></span><?php echo JText::_('COM_LOGIN_RETURN_TO_SITE_HOME_PAGE'); ?></a>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />

--- a/components/com_contact/views/contact/tmpl/default_address.php
+++ b/components/com_contact/views/contact/tmpl/default_address.php
@@ -122,7 +122,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" itemprop="url">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener" itemprop="url">
 			<?php echo JStringPunycode::urlToUTF8($this->contact->webpage); ?></a>
 		</span>
 	</dd>

--- a/components/com_contact/views/contact/tmpl/default_address.php
+++ b/components/com_contact/views/contact/tmpl/default_address.php
@@ -122,7 +122,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener" itemprop="url">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener noreferrer" itemprop="url">
 			<?php echo JStringPunycode::urlToUTF8($this->contact->webpage); ?></a>
 		</span>
 	</dd>

--- a/components/com_content/views/article/tmpl/default_links.php
+++ b/components/com_content/views/article/tmpl/default_links.php
@@ -48,7 +48,7 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// Open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer">' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank" rel="nofollow noopener noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 

--- a/components/com_content/views/article/tmpl/default_links.php
+++ b/components/com_content/views/article/tmpl/default_links.php
@@ -48,20 +48,20 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// Open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener">' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 
 						case 2:
 							// Open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\" rel=\"noopener\">" .
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\" rel=\"noopener noreferrer\">" .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 						case 3:
 							// Open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} nopener">' .
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} noopener noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 

--- a/components/com_content/views/article/tmpl/default_links.php
+++ b/components/com_content/views/article/tmpl/default_links.php
@@ -48,20 +48,20 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// Open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow">' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 
 						case 2:
 							// Open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\">" .
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\" rel=\"noopener\">" .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 						case 3:
 							// Open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}}">' .
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} nopener">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -65,7 +65,7 @@ $this->addScriptOptions('system.installation', array('url' => JRoute::_('index.p
 			<h5>
 				<?php // Fix wrong display of Joomla!® in RTL language ?>
 				<?php $joomla  = '<a href="https://www.joomla.org" target="_blank">Joomla!</a><sup>' . (JFactory::getLanguage()->isRtl() ? '&#x200E;' : '') . '</sup>'; ?>
-				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank" rel="noopener">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
+				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank" rel="noopener noreferrer">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
 				<?php echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla, $license); ?>
 			</h5>
 		</div>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -65,7 +65,7 @@ $this->addScriptOptions('system.installation', array('url' => JRoute::_('index.p
 			<h5>
 				<?php // Fix wrong display of Joomla!® in RTL language ?>
 				<?php $joomla  = '<a href="https://www.joomla.org" target="_blank">Joomla!</a><sup>' . (JFactory::getLanguage()->isRtl() ? '&#x200E;' : '') . '</sup>'; ?>
-				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
+				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank" rel="noopener">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
 				<?php echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla, $license); ?>
 			</h5>
 		</div>

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -38,7 +38,7 @@ $baseurl = JUri::base();
 					<?php if ($target == 1) : ?>
 						<?php // Open in a new window ?>
 						<a
-							href="<?php echo $link; ?>" target="_blank"
+							href="<?php echo $link; ?>" target="_blank" rel="noopener"
 							title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
 							<img
 								src="<?php echo $baseurl . $imageurl; ?>"

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -38,7 +38,7 @@ $baseurl = JUri::base();
 					<?php if ($target == 1) : ?>
 						<?php // Open in a new window ?>
 						<a
-							href="<?php echo $link; ?>" target="_blank" rel="noopener"
+							href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
 							title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
 							<img
 								src="<?php echo $baseurl . $imageurl; ?>"

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -41,6 +41,7 @@ if ($item->menu_image)
 if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
+	$attributes['rel'] = 'noopener';
 }
 elseif ($item->browserNav == 2)
 {

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -41,7 +41,7 @@ if ($item->menu_image)
 if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
-	$attributes['rel'] = 'noopener';
+	$attributes['rel'] = 'noopener noreferrer';
 }
 elseif ($item->browserNav == 2)
 {

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -19,7 +19,7 @@ $attributes = '';
 
 if (!JUri::isInternal($value))
 {
-	$attributes = 'rel="nofollow" target="_blank"';
+	$attributes = 'rel="nofollow nopener" target="_blank"';
 }
 
 echo '<a href="' . $value . '" ' . $attributes . '>' . $value . '</a>';

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -19,7 +19,7 @@ $attributes = '';
 
 if (!JUri::isInternal($value))
 {
-	$attributes = 'rel="nofollow nopener" target="_blank"';
+	$attributes = 'rel="nofollow noopener noreferrer" target="_blank"';
 }
 
 echo '<a href="' . $value . '" ' . $attributes . '>' . $value . '</a>';

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2037,7 +2037,7 @@ class PlgSystemDebug extends JPlugin
 
 			if (!$this->linkFormat)
 			{
-				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank" rel="noopener">';
+				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank" rel="noopener noreferrer">';
 				$htmlCallStack .= JText::_('PLG_DEBUG_LINK_FORMAT') . '</a>]</div>';
 			}
 		}

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -2037,7 +2037,7 @@ class PlgSystemDebug extends JPlugin
 
 			if (!$this->linkFormat)
 			{
-				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank">';
+				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank" rel="noopener">';
 				$htmlCallStack .= JText::_('PLG_DEBUG_LINK_FORMAT') . '</a>]</div>';
 			}
 		}

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -24,12 +24,12 @@ defined('_JEXEC') or die;
 	</p>
 	<ul>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1') ?>
 			</a>
 		</li>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2') ?>
 			</a>
 		</li>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -24,12 +24,12 @@ defined('_JEXEC') or die;
 	</p>
 	<ul>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener noreferrer">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1') ?>
 			</a>
 		</li>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener noreferrer">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2') ?>
 			</a>
 		</li>

--- a/templates/beez3/html/com_contact/contact/default_address.php
+++ b/templates/beez3/html/com_contact/contact/default_address.php
@@ -111,7 +111,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener noreferrer">
 			<?php echo $this->contact->webpage; ?></a>
 		</span>
 	</dd>

--- a/templates/beez3/html/com_contact/contact/default_address.php
+++ b/templates/beez3/html/com_contact/contact/default_address.php
@@ -111,7 +111,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener">
 			<?php echo $this->contact->webpage; ?></a>
 		</span>
 	</dd>

--- a/templates/beez3/html/com_content/article/default_links.php
+++ b/templates/beez3/html/com_content/article/default_links.php
@@ -48,20 +48,20 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow">' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener>' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') .'</a>';
 							break;
 
 						case 2:
 							// open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '".$attribs."'); return false;\">".
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '".$attribs."'); return false;\" rel=\"noopener\">".
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8').'</a>';
 							break;
 						case 3:
 							// open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}}">'.
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} nopener">'.
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 

--- a/templates/beez3/html/com_content/article/default_links.php
+++ b/templates/beez3/html/com_content/article/default_links.php
@@ -48,20 +48,20 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener>' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer>' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') .'</a>';
 							break;
 
 						case 2:
 							// open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '".$attribs."'); return false;\" rel=\"noopener\">".
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '".$attribs."'); return false;\" rel=\"noopener noreferrer\">".
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8').'</a>';
 							break;
 						case 3:
 							// open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} nopener">'.
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} noopener noreferrer">'.
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 


### PR DESCRIPTION
I raised this issue last year with the JSST but it was rejected as a non-issue and more of a browser bug than something Joomla should be doing anything about. 

However as now the Google site auditing tool "lighthouse" (lighthouse report https://developers.google.com/web/tools/lighthouse/audits/noopener) will report this as both a performance and a security issue I believe there is no longer an excuse for not taking action in joomla. 

It is a really simple change that will not have any visible effect on a website that uses target="_blank" for any of its menu links and **_the links generated by tinyMCE already do this even if you were not aware of it._** This change will act to harden a Joomla website from malicious sites that trick you into creating links to their sites and has a claimed (by google) performance benefit.

### Frontend Menus
Menu items that are links to External Urls with the target set to New Window aka target="_blank". There is no need to apply this to other menu links with the target set to New Window as they are to our own web site and presumably you are not going to attack your own web site.

To test this create two menu items. One an article set to open in a new window and the other an external link set to open in a new window. Only the external link menu will have a rel="noopener" attribute

### Fields
We can also create links to external web site using the URL field type and this is hard coded to open in a new window with target="_blank" (_that's probably wrong to hard code but it is beyond the scope of this PR_)

To test this create a field of type URL for an article and then create an article that uses the field and check to see that the link is rendered with the rel="noopener" attribute

### Article Links
With articles we have the option to create up to three links - Link A, Link B, Link C. This PR adds the rel="noopener" attribute to the three options  new window, popup window, modal window

To test this enter a link for all three fields in an article using each of the changed options the three options  new window, popup window, modal window and check to see that the link is rendered with the rel="noopener" attribute

### Contact links
With contacts we have the option to complete a field called Website. This is hard coded to open in a new window with target="_blank" (_that's probably wrong to hard code but it is beyond the scope of this PR_)

To test this create a contact and complete the website field and check to see that the link is rendered with the rel="noopener" attribute

### Com_installer
Every update site has a target="_blank" link  to the external extension update site. This adds the rel="noopener" attribute to the link - note this is added to joomla.org links as well as its not possible to differentiate.
Every available update has an infourl that has a target="_blank" link  to the external extension site. This adds the rel="noopener" attribute to the link.
 
### External links to non Joomla properties
The rel="noopener" attribute has also been added to several hardcoded links within Joomla to non joomla owned properties.
1. Two Factor Auth Plugin
2. Debug Plugin
3. Installation GPL link

### External links to Joomla properties
 I assumed we are not going to attack our own users sites but to prevent tools like limelight from reporting security errors I have also added the rel=noopener to the links to the joomla.org homepage that are publically visible on the admin login page
