### PR TITLE
Set defined('_JEXEC') as first statement

### DIFF
--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -7,9 +7,9 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\Registry\Registry;
-
 defined('_JEXEC') or die;
+
+use Joomla\Registry\Registry;
 
 /**
  * GMail Authentication Plugin


### PR DESCRIPTION
### Summary of Changes

Set the "defined('_JEXEC') or die" as first statement in gmail authentication plugin.

### Testing Instructions

Code review.

### Documentation Changes Required

None.
