### PR TITLE
Remove profile form if no profile fields to display. Resolves issue #14420 (re-submission of PR #14885)

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -334,7 +334,7 @@ class PlgUserProfile extends JPlugin
 			}
 		}
 
-		//drop the profile form entirely if there aren't any fields to display.
+		// Drop the profile form entirely if there aren't any fields to display.
 		$remainingfields = $form->getGroup('profile');
 		if (!count($remainingfields))
 		{

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -334,6 +334,13 @@ class PlgUserProfile extends JPlugin
 			}
 		}
 
+		//drop the profile form entirely if there aren't any fields to display.
+		$remainingfields = $form->getGroup('profile');
+		if (!count($remainingfields))
+		{
+			$form->removeGroup('profile');
+		}
+
 		return true;
 	}
 

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -336,6 +336,7 @@ class PlgUserProfile extends JPlugin
 
 		// Drop the profile form entirely if there aren't any fields to display.
 		$remainingfields = $form->getGroup('profile');
+
 		if (!count($remainingfields))
 		{
 			$form->removeGroup('profile');


### PR DESCRIPTION
Pull Request for Issue #14420.

(re-submission of previous PR #14885)

### Summary of Changes

In the user profile plugin, if there are no user profile fields to display, then do not show the user profile tab.

### Testing Instructions

* Start with a standard Joomla installation.
* Activate the User Profile plugin, and set all fields to disabled except for the Terms Of Service field.
* Create a new user via normal front-end registration form. ToS field should appear on the registration form, but no other profile fields.
* Now switch to the admin panel, and bring up the new user's details in the user management.
* Note that the user profile tab should not appear.

### Expected result

* After this change, the profile tab should not be shown in this case, as there would be no fields on it to display.

### Actual result

* In current Joomla (3.6.5) and earlier, given the above scenario, the profile tab would appear in the management tab, but clicking on the tab would just give you a blank form.

### Documentation Changes Required

None.
