### PR TITLE
Pivate Messages Disable all editor-xtd plugins

### DIFF
--- a/administrator/components/com_messages/models/forms/message.xml
+++ b/administrator/components/com_messages/models/forms/message.xml
@@ -24,6 +24,6 @@
 			required="true"
 			filter="JComponentHelper::filterText"
 			buttons="true"
-			hide="readmore,pagebreak,image,article,module" />
+			hide="readmore,pagebreak,image,article,module,contact,menu" />
 	</fieldset>
 </form>

--- a/administrator/components/com_messages/models/forms/message.xml
+++ b/administrator/components/com_messages/models/forms/message.xml
@@ -23,7 +23,6 @@
 			description="COM_MESSAGES_FIELD_MESSAGE_DESC"
 			required="true"
 			filter="JComponentHelper::filterText"
-			buttons="true"
-			hide="readmore,pagebreak,image,article,module,contact,menu" />
+			buttons="false" />
 	</fieldset>
 </form>


### PR DESCRIPTION
The editor-xrd plugins are useless when creating private messages

Before this PR all but two (contact and menu) were disabled
After this PR all cored editor-xtd plugins are hidden