### PR TITLE
[Isis] btn-group btn + btn margin fix

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -2440,6 +2440,9 @@ input[type="submit"].btn.btn-mini {
 .btn-group:first-child {
 	*margin-left: 0;
 }
+.btn-group .btn + .btn {
+	margin-left: -1px;
+}
 .btn-group + .btn-group {
 	margin-left: 5px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -2440,6 +2440,9 @@ input[type="submit"].btn.btn-mini {
 .btn-group:first-child {
 	*margin-left: 0;
 }
+.btn-group .btn + .btn {
+	margin-left: -1px;
+}
 .btn-group + .btn-group {
 	margin-left: 5px;
 }

--- a/administrator/templates/isis/less/bootstrap/button-groups.less
+++ b/administrator/templates/isis/less/bootstrap/button-groups.less
@@ -12,6 +12,9 @@
   vertical-align: middle; // match .btn alignment given font-size hack above
   white-space: nowrap; // prevent buttons from wrapping when in tight spaces (e.g., the table on the tests page)
   .ie7-restore-left-whitespace();
+  .btn + .btn {
+    margin-left: -1px;
+  }
 }
 
 // Space out series of button groups


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is a couple of instances where multiple .btn within a .btn-group shows double borders between each button. This PR fixes that.

### Testing Instructions
Instances which I found (possibly more).

Apply patch and navigate to...

- Article edit -> Versions
- Content -> Media

### Before Patch
![btn-group1b](https://cloud.githubusercontent.com/assets/2803503/24320717/9aa55e30-1132-11e7-8d01-82e872334b38.png)

![btn-group1a](https://cloud.githubusercontent.com/assets/2803503/24320716/9639aad6-1132-11e7-92d8-6f0590d05b00.png)

### After Patch
![btn-group2b](https://cloud.githubusercontent.com/assets/2803503/24320726/bb299afe-1132-11e7-9e03-a3bb38159660.png)

![btn-group2a](https://cloud.githubusercontent.com/assets/2803503/24320732/d9e5f26c-1132-11e7-9993-769efa0cd2fb.png)



### Documentation Changes Required
None