### PR TITLE
[com_associations] Display Copy Reference to Target only for extensions using the save2copy task

### DIFF
--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -76,10 +76,25 @@ class AssociationsViewAssociation extends JViewLegacy
 		$this->app  = JFactory::getApplication();
 		$this->form = $this->get('Form');
 		$input      = $this->app->input;
-
 		$this->referenceId = $input->get('id', 0, 'int');
 
 		list($extensionName, $typeName) = explode('.', $input->get('itemtype'));
+
+		$extension = AssociationsHelper::getSupportedExtension($extensionName);
+		$types     = $extension->get('types');
+
+		if (array_key_exists($typeName, $types))
+		{
+			$this->type          = $types[$typeName];
+			$this->typeSupports  = array();
+			$details             = $this->type->get('details');
+
+			if (array_key_exists('support', $details))
+			{
+				$support = $details['support'];
+				$this->typeSupports = $support;
+			}
+		}
 
 		$this->extensionName = $extensionName;
 		$this->typeName      = $typeName;
@@ -187,7 +202,10 @@ class AssociationsViewAssociation extends JViewLegacy
 			. JText::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
 		);
 
-		JToolBarHelper::custom('copy', 'copy.png', '', 'COM_ASSOCIATIONS_COPY_REFERENCE', false);
+		if ($this->typeName === 'category' || $this->extensionName === 'com_menus' || $this->typeSupports['save2copy'])
+		{
+			JToolBarHelper::custom('copy', 'copy.png', '', 'COM_ASSOCIATIONS_COPY_REFERENCE', false);
+		}
 
 		JToolbarHelper::cancel('association.cancel', 'JTOOLBAR_CLOSE');
 		JToolbarHelper::help('JHELP_COMPONENTS_ASSOCIATIONS_EDIT');

--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -88,11 +88,17 @@ class AssociationsViewAssociation extends JViewLegacy
 			$this->type          = $types[$typeName];
 			$this->typeSupports  = array();
 			$details             = $this->type->get('details');
+			$this->save2copy     = false;
 
 			if (array_key_exists('support', $details))
 			{
 				$support = $details['support'];
 				$this->typeSupports = $support;
+			}
+
+			if (!empty($this->typeSupports['save2copy']))
+			{
+				$this->save2copy = true;
 			}
 		}
 
@@ -202,7 +208,7 @@ class AssociationsViewAssociation extends JViewLegacy
 			. JText::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
 		);
 
-		if ($this->typeName === 'category' || $this->extensionName === 'com_menus' || $this->typeSupports['save2copy'])
+		if ($this->typeName === 'category' || $this->extensionName === 'com_menus' || $this->save2copy === true)
 		{
 			JToolBarHelper::custom('copy', 'copy.png', '', 'COM_ASSOCIATIONS_COPY_REFERENCE', false);
 		}

--- a/administrator/components/com_contact/helpers/associations.php
+++ b/administrator/components/com_contact/helpers/associations.php
@@ -153,6 +153,7 @@ class ContactAssociationsHelper extends JAssociationExtensionHelper
 					$support['acl'] = true;
 					$support['checkout'] = true;
 					$support['category'] = true;
+					$support['save2copy'] = true;
 
 					$tables = array(
 						'a' => '#__contact_details'

--- a/administrator/components/com_content/helpers/associations.php
+++ b/administrator/components/com_content/helpers/associations.php
@@ -150,6 +150,7 @@ class ContentAssociationsHelper extends JAssociationExtensionHelper
 					$support['acl'] = true;
 					$support['checkout'] = true;
 					$support['category'] = true;
+					$support['save2copy'] = true;
 
 					$tables = array(
 						'a' => '#__content'

--- a/administrator/components/com_newsfeeds/helpers/associations.php
+++ b/administrator/components/com_newsfeeds/helpers/associations.php
@@ -154,6 +154,7 @@ class NewsfeedsAssociationsHelper extends JAssociationExtensionHelper
 					$support['acl'] = true;
 					$support['checkout'] = true;
 					$support['category'] = true;
+					$support['save2copy'] = true;
 
 					$tables = array(
 						'a' => '#__newsfeeds'


### PR DESCRIPTION
Some 3rd party extensions may not support `save2copy`.

### Summary of Changes
This patch adds in the associations helper a new `$support` variable.
`$support['save2copy'] = true;`


### Testing Instructions
On a multingual site, using core extensions, make sure `Copy Reference to Target` works and is always displayed as usual.

Test that the button is not displayed when it is set to false or absent from the associations helper, in com_content for example.
administrator/components/com_content/helpers/associations.php 

@rdeutz  Can be merged on review.
@alikon 