### PR TITLE
[4.0] Fixed missing form-validate classes in com_users

### DIFF
--- a/administrator/components/com_users/views/group/tmpl/edit.php
+++ b/administrator/components/com_users/views/group/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="group-form">
+<form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="group-form" class="form-validate">
 	<fieldset>
 		<legend><?php echo JText::_('COM_USERS_USERGROUP_DETAILS'); ?></legend>
 		<div class="control-group">

--- a/administrator/components/com_users/views/level/tmpl/edit.php
+++ b/administrator/components/com_users/views/level/tmpl/edit.php
@@ -15,7 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 JHtml::_('behavior.formvalidator');
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_users&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="level-form">
+<form action="<?php echo JRoute::_('index.php?option=com_users&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="level-form" class="form-validate">
 	<fieldset>
 		<legend><?php echo JText::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
 		<div class="control-group">

--- a/administrator/components/com_users/views/note/tmpl/edit.php
+++ b/administrator/components/com_users/views/note/tmpl/edit.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.formvalidator');
 ?>
-<form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form">
+<form action="<?php echo JRoute::_('index.php?option=com_users&view=note&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="note-form" class="form-validate">
 	<fieldset class="adminform">
 		<div class="control-group">
 			<div class="control-label">

--- a/administrator/components/com_users/views/user/tmpl/edit.php
+++ b/administrator/components/com_users/views/user/tmpl/edit.php
@@ -38,7 +38,7 @@ $fieldsets = $this->form->getFieldsets();
 $settings = array();
 ?>
 
-<form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" enctype="multipart/form-data">
+<form action="<?php echo JRoute::_('index.php?option=com_users&layout=edit&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="user-form" enctype="multipart/form-data" class="form-validate">
 
 	<?php echo JLayoutHelper::render('joomla.edit.item_title', $this); ?>
 


### PR DESCRIPTION
Pull Request for Issue #14914 .

### Summary of Changes

Placed the class "form-validate" in the edit views in com_users (group, level, note and user) in order to have the buttons in those views working.

### Testing Instructions

The problem was encountered in the com_users part in the following places: 

- When you click on Users -> Groups, select a user or create a new one and then try clicking Save or Cancel/Close.
- When you click on Users -> Access Levels, select a level or create a new one and then try clicking Save or Cancel/Close.
- When you click on Users -> User Notes, select a note or create a new one and then try clicking Save or Cancel/Close.
- When you click on Users -> Manage, select a user or create a new one and then try clicking Save or Cancel/Close.

Before the fix the Cancel/Close and Save buttons were not working as you can see in the figure:

![deepinscreenshot20170327031344](https://cloud.githubusercontent.com/assets/6710380/24363177/f287993a-1306-11e7-886e-b48b3157fdac.png)

After the fix when you click Save it should save normally without JS errors and when you click on Cancel/Close it should go back to the previous view.

### Expected result



### Actual result



### Documentation Changes Required

