### PR TITLE
[4.0] Update scss_lint gem to v0.52.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'http://rubygems.org'
 
-gem 'scss_lint', '~> 0.50.3'
+gem 'scss_lint', '~> 0.52.0'

--- a/scss-lint-report.xml
+++ b/scss-lint-report.xml
@@ -1,1 +1,1 @@
-<?xml version="1.0"?><testsuites errors="0"><testsuite name="scss-lint" timestamp="2017-03-10T14:52:15"/></testsuites>
+<?xml version="1.0"?><testsuites errors="0"><testsuite name="scss-lint" timestamp="2017-03-27T16:00:12"/></testsuites>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the ruby gem `scss_lint` to v0.52.0 and recompile

---------------

Note to @Ciaran and @dgt41, you'll both need to run `gem install scss_lint` once this is merged.

