### PR TITLE
Fix typo in System - Fields plugin

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -86,7 +86,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->alias, $fieldsData) ? $fieldsData[$field->alias] : null;
 
 			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $id, $value);
+			$model->setFieldValue($field->id, $item->id, $value);
 		}
 
 		return true;


### PR DESCRIPTION
Pull Request for Issue #14932

### Summary of Changes
This PR fixes a typo in System - Fields plugin causes custom fields data not being saved


### Testing Instructions
1. Install staging

2. Create some custom fields for articles (can be Text custom fields)

3. Add/edit article. Before patch, the value entered for custom fields are not being saved. After patch, it is saved properly