### PR TITLE
ACL Debug missing String

### DIFF
--- a/administrator/language/en-GB/en-GB.com_modules.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_modules.sys.ini
@@ -5,6 +5,8 @@
 
 COM_MODULES="Modules"
 COM_MODULES_GENERAL="General"
+COM_MODULES_ACTION_EDITFRONTEND="Frontend Editing"
+COM_MODULES_ACTION_EDITFRONTEND_COMPONENT_DESC="Allows users in the group to edit in Frontend."
 COM_MODULES_MODULES_VIEW_DEFAULT_DESC="Shows a list of modules to manage"
 COM_MODULES_MODULES_VIEW_DEFAULT_TITLE="Module Manager"
 COM_MODULES_REDIRECT_EDIT_DESC="Select if module editing should be opened in the site or administration interface."

--- a/administrator/language/en-GB/en-GB.com_modules.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_modules.sys.ini
@@ -4,9 +4,9 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_MODULES="Modules"
-COM_MODULES_GENERAL="General"
 COM_MODULES_ACTION_EDITFRONTEND="Frontend Editing"
 COM_MODULES_ACTION_EDITFRONTEND_COMPONENT_DESC="Allows users in the group to edit in Frontend."
+COM_MODULES_GENERAL="General"
 COM_MODULES_MODULES_VIEW_DEFAULT_DESC="Shows a list of modules to manage"
 COM_MODULES_MODULES_VIEW_DEFAULT_TITLE="Module Manager"
 COM_MODULES_REDIRECT_EDIT_DESC="Select if module editing should be opened in the site or administration interface."


### PR DESCRIPTION
Go to Users->Groups and then select any of the Advanced Permission Report links
In search tools - select component - select modules

You will see that there are two missing strings for COM_MODULES_ACTION_EDITFRONTEND

Apply the patch and repeat and the strings are present
