### PR TITLE
[com_menus] - remove notice

### DIFF
--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -228,8 +228,9 @@ class MenusControllerItems extends JControllerAdmin
 				{
 					if ($errors)
 					{
-						$app = JFactory::getApplication();
-						$app->enqueueMessage(JText::plural($this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING', count($cid)), 'error');
+						$ntext = $this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING';
+						$app   = JFactory::getApplication();
+						$app->enqueueMessage(JText::plural($ntext, count($cid)), 'error');
 					}
 					else
 					{

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -228,25 +228,23 @@ class MenusControllerItems extends JControllerAdmin
 				{
 					if ($errors)
 					{
-						$ntext = $this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING';
 						$app   = JFactory::getApplication();
-						$app->enqueueMessage(JText::plural($ntext, count($cid)), 'error');
+						$app->enqueueMessage(JText::plural($this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING', count($cid)), 'error');
 					}
 					else
 					{
-						$ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
+						$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_PUBLISHED', count($cid)));
 					}
 				}
 				elseif ($value == 0)
 				{
-					$ntext = $this->text_prefix . '_N_ITEMS_UNPUBLISHED';
+					$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_UNPUBLISHED', count($cid)));
 				}
 				else
 				{
-					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
+					$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_TRASHED', count($cid)));
+					
 				}
-
-				$this->setMessage(JText::plural($ntext, count($cid)));
 			}
 			catch (Exception $e)
 			{

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -222,29 +222,32 @@ class MenusControllerItems extends JControllerAdmin
 			try
 			{
 				$model->publish($cid, $value);
-				$errors = $model->getErrors();
+				$errors      = $model->getErrors();
+				$messageType = 'message';
 
 				if ($value == 1)
 				{
 					if ($errors)
 					{
-						$app   = JFactory::getApplication();
-						$app->enqueueMessage(JText::plural($this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING', count($cid)), 'error');
+						$messageType = 'error';
+						$ntext       = $this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING';
 					}
 					else
 					{
-						$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_PUBLISHED', count($cid)));
+						$ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
 					}
 				}
 				elseif ($value == 0)
 				{
-					$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_UNPUBLISHED', count($cid)));
+					$ntext = $this->text_prefix . '_N_ITEMS_UNPUBLISHED';
 				}
 				else
 				{
-					$this->setMessage(JText::plural($this->text_prefix . '_N_ITEMS_TRASHED', count($cid)));
-					
+					$ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
 				}
+
+				$this->setMessage(JText::plural($ntext, count($cid)), $messageType);
+
 			}
 			catch (Exception $e)
 			{


### PR DESCRIPTION
Pull Request for Issue #14951 .

### Summary of Changes
remove notice `Undefined variable: ntext `


### Testing Instructions
Create a menu with a menu item.
Disable this menu.
Try to enable the menu item under this menu.



### Expected result
no notice


### Actual result
PHP Notice: Undefined variable: ntext in \administrator\components\com_menus\controllers\items.php on line 248


