### PR TITLE
[j4] Default custom_data and system_data to an empty string

### DIFF
--- a/libraries/src/Cms/Table/Extension.php
+++ b/libraries/src/Cms/Table/Extension.php
@@ -20,6 +20,17 @@ use Joomla\Utilities\ArrayHelper;
  */
 class Extension extends Table
 {
+
+	/**
+	 * @var string
+	 */
+	public $custom_data = '';
+
+	/**
+	 * @var string
+	 */
+	public $system_data = '';
+
 	/**
 	 * Constructor
 	 *


### PR DESCRIPTION
### Summary of Changes
Discovery is broken on Joomla 4 becaus of an SQl error that custom_data and system_data don't have to be null.

Honestly I don't know what are this columns for, but they must be initialized with some data as the installer defines them as not nullable. Either way we always write some data into the coumns for an extension or we allow null values. Somebody a clue what these columns are for?

### Testing Instructions
- Install Joomla with the 4.0-dev branch.
- Download the override plugin from https://github.com/Digital-Peak-Incubator/plg_system_override/archive/master.zip
- Extract it to plugins/system
- In the back end got to _Extensions -> Manage -> Discover_
- Click on the Discover button on the top


### Expected result
The override plugin should appear in the list.


### Actual result
The list is empty.


### Documentation Changes Required
None as it is a bug.
