### PR TITLE
New Isis tempalte prevents chosen dropdown from working properly

### DIFF
--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7024,10 +7024,6 @@ h6 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
-.control-group .chzn-container {
-	width: 100% !important;
-	max-width: 220px;
-}
 .chzn-container-single .chzn-single {
 	background-color: #fff;
 	background-clip: inherit;


### PR DESCRIPTION
Chosen dropdown provides 2 ways to set the width of the dropdown element:
1. Specify it as inline style in the select element (`<select style="width: 500px;" ...`) or
2. Specify it as an option for the chosen() function (`width: '600px'`)
See [related documentation](https://harvesthq.github.io/chosen/).

The new style introduced in the Isis template forces the width to a different value (which also causes a horizontal collapse in case of blank items).

There is no reasonable way for third party extensions developers to specify a custom with for their own dropdown elements.

To fix this problem, I've removed two css lines that in principle, we should not use anyway, since the chosen dropdown control offers other ways to set its width.

However it's possible that @ciar4n remembers the reason for these lines and can help us by providing further details.

### Testing Instructions
Create a select anywhere in the back-end
```
<?php
JFactory::getDocument()->addStyleSheet(JUri::root(true) . "/media/jui/css/chosen.css");
JFactory::getDocument()->addScript(JUri::root(true) . "/media/jui/js/chosen.jquery.js");

<div class="control-group">
	<select style="width: 500px;" class="chosenize">
		<option>Option</option>
	</select>
</div>
```
Pay attention to encase it in a "control-group" wrapper as shown, since the issue only affects dropdown elements within a "control-group" wrapper.
Also pay attention to the class assigned (in this case "chosenize"), which must correspond to that used in the following JavaScript.

Run the following JavaScript to transform the select into a chosen dropdown:
```
jQuery(document).ready(function ($)
{
	// 600px overrides the value of 500px specified in the PHP code
	$('.chosenize').chosen({ width: '600px' });
});

```

### Expected result
I expect the dropdown was 500 or 600 px wide, with the precedence to the value specified in the JavaScript.

### Actual result
The dropdown is 220 px wide.

