### PR TITLE
[a11y] Span not i and icons

### DIFF
--- a/administrator/components/com_finder/views/maps/tmpl/default.php
+++ b/administrator/components/com_finder/views/maps/tmpl/default.php
@@ -71,11 +71,11 @@ JFactory::getDocument()->addScriptDeclaration('
 					</th>
 					<?php endif; ?>
 					<th width="1%" class="nowrap center">
-						<i class="icon-publish"></i>
+						<span class="icon-publish" aria-hidden="true"></span>
 						<span class="hidden-phone"><?php echo JText::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?></span>
 					</th>
 					<th width="1%" class="nowrap center">
-						<i class="icon-unpublish"></i>
+						<span class="icon-unpublish" aria-hidden="true"></span>
 						<span class="hidden-phone"><?php echo JText::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?></span>
 					</th>
 				</tr>

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -135,7 +135,7 @@ $colSpan = $clientId === 1 ? 9 : 10;
 							<?php else : ?>
 								<?php // Extension is not enabled, show a message that indicates this. ?>
 								<button class="btn btn-micro hasTooltip" title="<?php echo JText::_('COM_MODULES_MSG_MANAGE_EXTENSION_DISABLED'); ?>">
-									<i class="icon-ban-circle"></i>
+									<span class="icon-ban-circle" aria-hidden="true"></span>
 								</button>
 							<?php endif; ?>
 							</div>

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -68,11 +68,11 @@ JFactory::getDocument()->addScriptDeclaration('
 							<?php echo JHtml::_('searchtools.sort', 'COM_USERS_HEADING_GROUP_TITLE', 'a.title', $listDirn, $listOrder); ?>
 						</th>
 						<th width="1%" class="nowrap center">
-							<i class="icon-publish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></i>
+							<span class="icon-publish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
 						</th>
 						<th width="1%" class="nowrap center">
-							<i class="icon-unpublish hasTooltip" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></i>
+							<span class="icon-unpublish hasTooltip" aria-hidden="true" title="<?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></span>
 							<span class="hidden-phone"><?php echo JText::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
 						</th>
 						<th width="1%" class="nowrap hidden-phone">

--- a/administrator/templates/hathor/html/com_modules/modules/default.php
+++ b/administrator/templates/hathor/html/com_modules/modules/default.php
@@ -169,7 +169,7 @@ $saveOrder = $listOrder == 'ordering';
 					<?php else : ?>
 						<?php // Extension is not enabled, show a message that indicates this. ?>
 							<button class="btn btn-micro hasTooltip" title="<?php echo JText::_('COM_MODULES_MSG_MANAGE_EXTENSION_DISABLED'); ?>">
-								<i class="icon-ban-circle"></i>
+								<span class="icon-ban-circle" aria-hidden="true"></span>
 							</button>
 					<?php endif; ?>					
 				</td>

--- a/administrator/templates/isis/html/layouts/joomla/form/field/media.php
+++ b/administrator/templates/isis/html/layouts/joomla/form/field/media.php
@@ -124,7 +124,7 @@ $url    = ($readonly ? ''
 		<span rel="popover" class="add-on pop-helper field-media-preview"
 			title="<?php echo	JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'); ?>" data-content="<?php echo JText::_('JLIB_FORM_MEDIA_PREVIEW_EMPTY'); ?>"
 			data-original-title="<?php echo JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'); ?>" data-trigger="hover">
-			<i class="icon-eye"></i>
+			<span class="icon-eye" aria-hidden="true"></span>
 		</span>
 	<?php else: ?>
 	<div class="input-append">

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -147,7 +147,7 @@ if ($showPreview)
 		$tooltip = $previewImgEmpty . $previewImg;
 		$options = array(
 			'title' => JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'),
-					'text' => '<i class="icon-eye"></i>',
+					'text' => '<span class="icon-eye" aria-hidden="true"></span>',
 					'class' => 'hasTipPreview'
 					);
 
@@ -174,7 +174,7 @@ echo '	<input type="text" name="' . $name . '" id="' . $id . '" value="'
 	. $authorField) . '&amp;fieldid=' . $id . '&amp;folder=' . $folder) . '"'
 	. ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}"'; ?>>
  <?php echo JText::_('JLIB_FORM_BUTTON_SELECT'); ?></a><a class="btn hasTooltip" title="<?php echo JText::_('JLIB_FORM_BUTTON_CLEAR'); ?>" href="#" onclick="jInsertFieldValue('', '<?php echo $id; ?>'); return false;">
-	<i class="icon-remove"></i></a>
+	<span class="icon-remove" aria-hidden="true"></span></a>
 
 
 </div>

--- a/libraries/joomla/form/fields/repeatable.php
+++ b/libraries/joomla/form/fields/repeatable.php
@@ -57,7 +57,7 @@ class JFormFieldRepeatable extends JFormField
 		$head_row_str = array();
 		$body_row_str = array();
 		$head_row_str[] = '<th></th>';
-		$body_row_str[] = '<td><span class="sortable-handler " style="cursor: move;"><i class="icon-menu"></i></span></td>';
+		$body_row_str[] = '<td><span class="sortable-handler " style="cursor: move;"><span class="icon-menu" aria-hidden="true"></span></span></td>';
 		foreach ($subForm->getFieldset() as $field)
 		{
 			// Reset name to simple

--- a/templates/protostar/html/layouts/joomla/form/field/media.php
+++ b/templates/protostar/html/layouts/joomla/form/field/media.php
@@ -122,7 +122,7 @@ $url    = ($readonly ? ''
 		<span rel="popover" class="add-on pop-helper field-media-preview"
 			title="<?php echo	JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'); ?>" data-content="<?php echo JText::_('JLIB_FORM_MEDIA_PREVIEW_EMPTY'); ?>"
 			data-original-title="<?php echo JText::_('JLIB_FORM_MEDIA_PREVIEW_SELECTED_IMAGE'); ?>" data-trigger="hover">
-			<i class="icon-eye"></i>
+			<span class="icon-eye" aria-hidden="true"></span>
 		</span>
 	<?php else: ?>
 	<div class="input-append">


### PR DESCRIPTION
Convert the last batch of icons that had an i tag instead of a span and continue the work to make sure they have aria-hidden=true so that a screenreader wont try to read the font character

Please note that after applying this PR there may still be instances of an i tag - that is because there are other similar PRs awaiting testing/merge