### PR TITLE
New Isis template prevents chosen dropdown from working properly

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7027,6 +7027,9 @@ h6 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
+.control-group .chzn-container {
+	max-width: 100%;
+}
 .control-group .chzn-container .chzn-choices li.search-field,
 .control-group .chzn-container .chzn-choices li.search-field input {
 	width: 100% !important;
@@ -7351,19 +7354,31 @@ h6 {
 .form-inline-header .controls {
 	padding-right: 20px;
 }
+fieldset[class^="form-"] {
+	min-width: 100%;
+}
 fieldset.checkboxes input {
 	float: left;
 }
 fieldset.checkboxes li {
 	list-style: none;
 }
+.control-group,
+.controls,
+.controls input[type="text"],
+.controls input[type="number"],
+.controls input[type="email"],
+.controls select,
+.controls textarea {
+	max-width: 100%;
+}
 .controls .btn-group > .btn {
 	min-width: 50px;
 	margin-left: -1px;
 }
 .controls .btn-group.btn-group-yesno {
-	width: 100%;
-	max-width: 220px;
+	width: 220px;
+	max-width: 100%;
 }
 .controls .btn-group.btn-group-yesno > .btn {
 	width: 50%;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7027,10 +7027,6 @@ h6 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
-.control-group .chzn-container {
-	width: 100% !important;
-	max-width: 220px;
-}
 .control-group .chzn-container .chzn-choices li.search-field,
 .control-group .chzn-container .chzn-choices li.search-field input {
 	width: 100% !important;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7186,9 +7186,6 @@ h6 {
 	margin: 1px 0;
 	padding: 0 !important;
 }
-#jform_tags_chzn.chzn-container {
-	max-width: 440px;
-}
 .chzn-color.chzn-single[rel="value_1"],
 .chzn-color-reverse.chzn-single[rel="value_0"],
 .chzn-color-state.chzn-single[rel="value_1"],

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7354,6 +7354,11 @@ h6 {
 fieldset[class^="form-"] {
 	min-width: 100%;
 }
+@-moz-document url-prefix() {
+	fieldset[class^="form-"] {
+		display: table-cell;
+	}
+}
 fieldset.checkboxes input {
 	float: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7027,6 +7027,9 @@ h6 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
+.control-group .chzn-container {
+	max-width: 100%;
+}
 .control-group .chzn-container .chzn-choices li.search-field,
 .control-group .chzn-container .chzn-choices li.search-field input {
 	width: 100% !important;
@@ -7351,19 +7354,31 @@ h6 {
 .form-inline-header .controls {
 	padding-right: 20px;
 }
+fieldset[class^="form-"] {
+	min-width: 100%;
+}
 fieldset.checkboxes input {
 	float: left;
 }
 fieldset.checkboxes li {
 	list-style: none;
 }
+.control-group,
+.controls,
+.controls input[type="text"],
+.controls input[type="number"],
+.controls input[type="email"],
+.controls select,
+.controls textarea {
+	max-width: 100%;
+}
 .controls .btn-group > .btn {
 	min-width: 50px;
 	margin-left: -1px;
 }
 .controls .btn-group.btn-group-yesno {
-	width: 100%;
-	max-width: 220px;
+	width: 220px;
+	max-width: 100%;
 }
 .controls .btn-group.btn-group-yesno > .btn {
 	width: 50%;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7027,10 +7027,6 @@ h6 {
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }
-.control-group .chzn-container {
-	width: 100% !important;
-	max-width: 220px;
-}
 .control-group .chzn-container .chzn-choices li.search-field,
 .control-group .chzn-container .chzn-choices li.search-field input {
 	width: 100% !important;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7186,9 +7186,6 @@ h6 {
 	margin: 1px 0;
 	padding: 0 !important;
 }
-#jform_tags_chzn.chzn-container {
-	max-width: 440px;
-}
 .chzn-color.chzn-single[rel="value_1"],
 .chzn-color-reverse.chzn-single[rel="value_0"],
 .chzn-color-state.chzn-single[rel="value_1"],

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7354,6 +7354,11 @@ h6 {
 fieldset[class^="form-"] {
 	min-width: 100%;
 }
+@-moz-document url-prefix() {
+	fieldset[class^="form-"] {
+		display: table-cell;
+	}
+}
 fieldset.checkboxes input {
 	float: left;
 }

--- a/administrator/templates/isis/less/blocks/_chzn-override.less
+++ b/administrator/templates/isis/less/blocks/_chzn-override.less
@@ -6,6 +6,7 @@
 
 // Fluid width
 .control-group .chzn-container {
+    max-width: 100%;
     .chzn-choices li.search-field,
     .chzn-choices li.search-field input { // Fix for #13594
         width: 100% !important; 

--- a/administrator/templates/isis/less/blocks/_chzn-override.less
+++ b/administrator/templates/isis/less/blocks/_chzn-override.less
@@ -6,8 +6,6 @@
 
 // Fluid width
 .control-group .chzn-container {
-    width: 100% !important;
-    max-width: 220px; 
     .chzn-choices li.search-field,
     .chzn-choices li.search-field input { // Fix for #13594
         width: 100% !important; 

--- a/administrator/templates/isis/less/blocks/_chzn-override.less
+++ b/administrator/templates/isis/less/blocks/_chzn-override.less
@@ -181,9 +181,6 @@
     margin: 1px 0;
     padding: 0 !important;
 }
-#jform_tags_chzn.chzn-container {
-    max-width: 440px;
-}
 
 /* Chosen color styles */
 .chzn-color.chzn-single[rel="value_1"],

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -88,6 +88,11 @@
 		padding-right: 20px;
 	}
 }
+/* Make fieldsets responsive */
+fieldset[class^="form-"] {
+	min-width: 100%;
+}
+
 /* Display checkboxes without bullets in list */
 fieldset.checkboxes input {
 	float: left;
@@ -97,6 +102,18 @@ fieldset.checkboxes li {
 	list-style: none;
 }
 
+/* Make form elements responsive */
+.control-group,
+.controls,
+.controls input[type="text"],
+.controls input[type="number"],
+.controls input[type="email"],
+.controls select,
+.controls textarea
+{
+	max-width: 100%;
+}
+
 /* Min-width on buttons */
 .controls .btn-group > .btn {
 	min-width: 50px;
@@ -104,8 +121,8 @@ fieldset.checkboxes li {
 }
 
 .controls .btn-group.btn-group-yesno {
-	width: 100%;
-	max-width: 220px;
+	width: 220px;
+	max-width: 100%;
 	> .btn {
 		width: 50%;
 		min-width: 40px;

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -92,6 +92,10 @@
 fieldset[class^="form-"] {
 	min-width: 100%;
 }
+/* Make fieldsets responsive in Firefox. See http://getbootstrap.com/css/#tables-responsive */
+@-moz-document url-prefix() {
+  fieldset[class^="form-"] { display: table-cell; }
+}
 
 /* Display checkboxes without bullets in list */
 fieldset.checkboxes input {


### PR DESCRIPTION
Chosen dropdown provides 2 ways to set the width of the dropdown element:
1. Specify it as inline style in the select element (`<select style="width: 500px;" ...`) or
2. Specify it as an option for the chosen() function (`width: '600px'`)
See [related documentation](https://harvesthq.github.io/chosen/).

The new style introduced in the Isis template forces the width to a different value (which also causes a horizontal collapse in case of blank items).

There is no reasonable way for third party extensions developers to specify a custom with for their own dropdown elements.

To fix this problem, I've removed two css lines that in principle, we should not use anyway, since the chosen dropdown control offers other ways to set its width.

However it's possible that @ciar4n remembers the reason for these lines and can help us by providing further details.

### Testing Instructions
Create a select anywhere in the back-end
```
<?php
JFactory::getDocument()->addStyleSheet(JUri::root(true) . "/media/jui/css/chosen.css");
JFactory::getDocument()->addScript(JUri::root(true) . "/media/jui/js/chosen.jquery.js");

<div class="control-group">
	<select style="width: 500px;" class="chosenize">
		<option>Option</option>
	</select>
</div>
```
Pay attention to encase it in a "control-group" wrapper as shown, since the issue only affects dropdown elements within a "control-group" wrapper.
Also pay attention to the class assigned (in this case "chosenize"), which must correspond to that used in the following JavaScript.

Run the following JavaScript to transform the select into a chosen dropdown:
```
jQuery(document).ready(function ($)
{
	// 600px overrides the value of 500px specified in the PHP code
	$('.chosenize').chosen({ width: '600px' });
});

```

### Expected result
I expect the dropdown was 500 or 600 px wide, with the precedence to the value specified in the JavaScript.

### Actual result
The dropdown is 220 px wide.

