### PR TITLE
[a11y] icons for Multilingual status module

### DIFF
--- a/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
@@ -26,7 +26,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($this->defaultHome == true) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+					<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_DEFAULT_HOME_MODULE_PUBLISHED'); ?>
@@ -36,7 +36,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_homes) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+					<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_HOMES_MISSING'); ?>
@@ -46,7 +46,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_disabled) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+					<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_LANGUAGEFILTER_DISABLED'); ?>
@@ -56,7 +56,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_switchers) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+					<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_LANGSWITCHER_UNPUBLISHED'); ?>
@@ -67,7 +67,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 			<?php if (array_key_exists($contentlang->lang_code, $this->homepages) && (!array_key_exists($contentlang->lang_code, $this->site_langs) || !$contentlang->published)) : ?>
 				<tr class="warning">
 					<td>
-						<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+						<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 					</td>
 					<td>
 						<?php echo JText::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_CONTENT_LANGUAGE', $contentlang->lang_code); ?>
@@ -77,7 +77,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 			<?php if (!array_key_exists($contentlang->lang_code, $this->site_langs)) : ?>
 				<tr class="warning">
 					<td>
-						<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+						<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 					</td>
 					<td>
 						<?php echo JText::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_LANGUAGE_TAG', $contentlang->lang_code); ?>
@@ -88,7 +88,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($this->listUsersError) : ?>
 			<tr class="info">
 				<td>
-					<span class="icon-help" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JHELP'); ?></span></span>
+					<span class="icon-help" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JHELP'); ?></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_CONTACTS_ERROR_TIP'); ?>
@@ -187,7 +187,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 				<?php // Published Site languages ?>
 				<?php if ($status->element) : ?>
 						<td class="center">
-							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
+							<span class="icon-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JYES'); ?></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
@@ -197,21 +197,21 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 				<?php // Published Content languages ?>
 				<?php if ($status->lang_code && $status->published) : ?>
 						<td class="center">
-							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
+							<span class="icon-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JYES'); ?></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
-							<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+							<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 						</td>
 				<?php endif; ?>
 				<?php // Published Home pages ?>
 				<?php if ($status->home_language) : ?>
 						<td class="center">
-							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
+							<span class="icon-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JYES'); ?></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
-							<span class="icon-not-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JNO'); ?></span></span>
+							<span class="icon-not-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JNO'); ?></span>
 						</td>
 						</td>
 				<?php endif; ?>
@@ -224,22 +224,22 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 							<?php echo $contentlang->lang_code; ?>
 						</td>
 						<td class="center">
-							<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+							<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 						</td>
 						<td class="center">
 							<?php if ($contentlang->published) : ?>
-								<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
+								<span class="icon-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JYES'); ?></span>
 							<?php elseif (!$contentlang->published && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-								<span class="icon-not-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JNO'); ?></span></span>
+								<span class="icon-not-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JNO'); ?></span>
 							<?php elseif (!$contentlang->published) : ?>
-								<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+								<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 							<?php endif; ?>
 						</td>
 						<td class="center">
 							<?php if (!array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-								<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
+								<span class="icon-pending" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span>
 							<?php else : ?>
-								<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
+								<span class="icon-ok" aria-hidden="true"></span><span class="element-invisible"><?php echo JText::_('JYES'); ?></span>
 							<?php endif; ?>
 						</td>
 				<?php endif; ?>

--- a/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
+++ b/administrator/components/com_languages/views/multilangstatus/tmpl/default.php
@@ -26,7 +26,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($this->defaultHome == true) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending"></span>
+					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_DEFAULT_HOME_MODULE_PUBLISHED'); ?>
@@ -36,7 +36,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_homes) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending"></span>
+					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_HOMES_MISSING'); ?>
@@ -46,7 +46,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_disabled) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending"></span>
+					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_LANGUAGEFILTER_DISABLED'); ?>
@@ -56,7 +56,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($notice_switchers) : ?>
 			<tr class="warning">
 				<td>
-					<span class="icon-pending"></span>
+					<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_LANGSWITCHER_UNPUBLISHED'); ?>
@@ -67,7 +67,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 			<?php if (array_key_exists($contentlang->lang_code, $this->homepages) && (!array_key_exists($contentlang->lang_code, $this->site_langs) || !$contentlang->published)) : ?>
 				<tr class="warning">
 					<td>
-						<span class="icon-pending"></span>
+						<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 					</td>
 					<td>
 						<?php echo JText::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_CONTENT_LANGUAGE', $contentlang->lang_code); ?>
@@ -77,7 +77,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 			<?php if (!array_key_exists($contentlang->lang_code, $this->site_langs)) : ?>
 				<tr class="warning">
 					<td>
-						<span class="icon-pending"></span>
+						<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 					</td>
 					<td>
 						<?php echo JText::sprintf('COM_LANGUAGES_MULTILANGSTATUS_ERROR_LANGUAGE_TAG', $contentlang->lang_code); ?>
@@ -88,7 +88,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 		<?php if ($this->listUsersError) : ?>
 			<tr class="info">
 				<td>
-					<span class="icon-help"></span>
+					<span class="icon-help" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JHELP'); ?></span></span>
 				</td>
 				<td>
 					<?php echo JText::_('COM_LANGUAGES_MULTILANGSTATUS_CONTACTS_ERROR_TIP'); ?>
@@ -187,7 +187,7 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 				<?php // Published Site languages ?>
 				<?php if ($status->element) : ?>
 						<td class="center">
-							<span class="icon-ok"></span>
+							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
@@ -197,21 +197,22 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 				<?php // Published Content languages ?>
 				<?php if ($status->lang_code && $status->published) : ?>
 						<td class="center">
-							<span class="icon-ok"></span>
+							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
-							<span class="icon-pending"></span>
+							<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 						</td>
 				<?php endif; ?>
 				<?php // Published Home pages ?>
 				<?php if ($status->home_language) : ?>
 						<td class="center">
-							<span class="icon-ok"></span>
+							<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
 						</td>
 				<?php else : ?>
 						<td class="center">
-							<span class="icon-not-ok"></span>
+							<span class="icon-not-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JNO'); ?></span></span>
+						</td>
 						</td>
 				<?php endif; ?>
 				</tr>
@@ -223,22 +224,22 @@ $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_fi
 							<?php echo $contentlang->lang_code; ?>
 						</td>
 						<td class="center">
-							<span class="icon-pending"></span>
+							<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 						</td>
 						<td class="center">
 							<?php if ($contentlang->published) : ?>
-								<span class="icon-ok"></span>
+								<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
 							<?php elseif (!$contentlang->published && array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-								<span class="icon-not-ok"></span>
+								<span class="icon-not-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JNO'); ?></span></span>
 							<?php elseif (!$contentlang->published) : ?>
-								<span class="icon-pending"></span>
+								<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 							<?php endif; ?>
 						</td>
 						<td class="center">
 							<?php if (!array_key_exists($contentlang->lang_code, $this->homepages)) : ?>
-								<span class="icon-pending"></span>
+								<span class="icon-pending" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('WARNING'); ?></span></span>
 							<?php else : ?>
-								<span class="icon-ok"></span>
+								<span class="icon-ok" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JYES'); ?></span></span>
 							<?php endif; ?>
 						</td>
 				<?php endif; ?>


### PR DESCRIPTION
When reading our default markup for rendering icons, assisistive technology may have the following problems.

The assistive technology will not find any content to read out to a user
The assistive technology will read the unicode equivalent, which does not match up to what the icon means in context, or worse is just plain confusing. In our use case it is always plain wrong. For example the unicode character used to display the trashed icon is \4c which is equal to L

When an icon is not an interactive element the simplest way to provide a text alternative is to use the aria-hidden="true" attribute on the icon and to include the text with an additional element, such as a < span>, with appropriate CSS to visually hide the element while keeping it accessible to assistive technologies.

In this case we have the text and it is displayed so we just need to add the aria-hidden to prevent the icon being "read aloud"

This PR addresses the use case shown in the image below
<img width="1025" alt="screenshotr12-51-13" src="https://cloud.githubusercontent.com/assets/1296369/24453155/9d065c02-147e-11e7-9bff-7c7dcb3e7fc1.png">
