### PR TITLE
CodeMirror Full Screen Modifiers

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_codemirror.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_codemirror.ini
@@ -57,6 +57,6 @@ PLG_CODEMIRROR_FIELD_VIM_KEYBINDING_DESC="Select this option to make CodeMirror 
 PLG_CODEMIRROR_FIELD_VIM_KEYBINDING_LABEL="Vim Keybinding"
 PLG_CODEMIRROR_FIELDSET_APPEARANCE_OPTIONS_LABEL="Appearance Options"
 PLG_CODEMIRROR_FIELDSET_TOOLBAR_OPTIONS_LABEL="Toolbar Options"
-PLG_CODEMIRROR_TOGGLE_FULL_SCREEN="Press %1$s to toggle Full Screen editing."
+PLG_CODEMIRROR_TOGGLE_FULL_SCREEN="Press %1$s %2$s to toggle Full Screen editing."
 PLG_CODEMIRROR_XML_DESCRIPTION="This plugin loads the CodeMirror editor."
 PLG_EDITORS_CODEMIRROR="Editor - CodeMirror"

--- a/plugins/editors/codemirror/layouts/editors/codemirror/element.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/element.php
@@ -18,6 +18,7 @@ $cols    = $displayData->cols;
 $rows    = $displayData->rows;
 $content = $displayData->content;
 $buttons = $displayData->buttons;
+$modifier = $params->get('fullScreenMod', '') !== '' ? implode($params->get('fullScreenMod', ''), ' + ') . ' + ' : '';
 
 JFactory::getDocument()->addScriptDeclaration('
 	jQuery(function () {
@@ -27,8 +28,9 @@ JFactory::getDocument()->addScriptDeclaration('
 	});
 ');
 ?>
-<p class="label"><?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $params->get('fullScreen', 'F10')); ?></p>
-
+<p class="label">
+    <?php echo JText::sprintf('PLG_CODEMIRROR_TOGGLE_FULL_SCREEN', $modifier, $params->get('fullScreen', 'F10')); ?>
+</p>
 <?php echo '<textarea name="', $name, '" id="', $id, '" cols="', $cols, '" rows="', $rows, '">', $content, '</textarea>'; ?>
 
 <?php echo $displayData->buttons; ?>


### PR DESCRIPTION
Pull Request for #14920

### Steps to reproduce the issue
CodeMirror editor (as used in the template editor) has a text string to indicate  the keystrokes required to put the editor in full screen mode
<img width="376" alt="screenshotr10-58-34" src="https://cloud.githubusercontent.com/assets/1296369/24351139/7fd36902-12dc-11e7-96a5-6177e4fc1021.png">

However there is also an option to add a key modifier eg Shift, Ctrl etc to the Key but there is no code to display the modifier in the string

<img width="341" alt="screenshotr10-58-43" src="https://cloud.githubusercontent.com/assets/1296369/24351183/a3b7a4b4-12dc-11e7-9398-2b6f31040c78.png">



### Actual result
Thanks to @C-Lodder 
