### PR TITLE
[com_fields] Define the batch commands

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -43,6 +43,16 @@ class FieldsModelField extends JModelAdmin
 	protected $batch_copymove = 'group_id';
 
 	/**
+	 * Allowed batch commands
+	 *
+	 * @var array
+	 */
+	protected $batch_commands = array(
+		'assetgroup_id' => 'batchAccess',
+		'language_id'   => 'batchLanguage'
+	);
+
+	/**
 	 * @var array
 	 *
 	 * @since   3.7.0

--- a/administrator/components/com_fields/models/group.php
+++ b/administrator/components/com_fields/models/group.php
@@ -16,6 +16,23 @@ defined('_JEXEC') or die;
 class FieldsModelGroup extends JModelAdmin
 {
 	/**
+	 * @var null|string
+	 *
+	 * @since   3.7.0
+	 */
+	public $typeAlias = null;
+
+	/**
+	 * Allowed batch commands
+	 *
+	 * @var array
+	 */
+	protected $batch_commands = array(
+		'assetgroup_id' => 'batchAccess',
+		'language_id'   => 'batchLanguage'
+	);
+
+	/**
 	 * Method to save the form data.
 	 *
 	 * @param   array  $data  The form data.

--- a/administrator/components/com_fields/views/groups/tmpl/default_batch_body.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default_batch_body.php
@@ -2,7 +2,7 @@
 /**
  * @package     Joomla.Administrator
  * @subpackage  com_fields
- * 
+ *
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
@@ -15,12 +15,12 @@ JHtml::_('formbehavior.chosen', 'select');
 	<div class="row-fluid">
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.language'); ?>
+				<?php echo JLayoutHelper::render('joomla.html.batch.language', array()); ?>
 			</div>
 		</div>
 		<div class="control-group span6">
 			<div class="controls">
-				<?php echo JHtml::_('batch.access'); ?>
+				<?php echo JLayoutHelper::render('joomla.html.batch.access', array()); ?>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Pull Request for Issue #14991.

### Summary of Changes
The set of available batch commands is not defined for a custom field.

### Testing Instructions
- Go to Contents > Fields.
- Create a text field.
- In the Fields list, click Check All checkbox.
- Click Batch button.
- Select the en-GB language
- Click Process button.

### Expected result
No entry in the error log.

### Actual result
Error log contains an entry:
`PHP Notice: Undefined index: tag in \joomla-cms-staging\libraries\legacy\model\admin.php on line 258`