### PR TITLE
Allow menu item separators to have labels in admin menu

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -97,11 +97,18 @@ class JAdminCssMenu
 	/**
 	 * Method to add a separator node
 	 *
+	 * @param   string  $title  The separator label text. A dash "-" can be used to use a horizontal bar instead of text label.
+	 *
 	 * @return  void
 	 */
-	public function addSeparator()
+	public function addSeparator($title = null)
 	{
-		$this->addChild(new JMenuNode(null, null, 'separator', false));
+		if ($title == '-' || $title == '')
+		{
+			$title = null;
+		}
+
+		$this->addChild(new JMenuNode($title, null, 'separator', false));
 	}
 
 	/**
@@ -168,7 +175,7 @@ class JAdminCssMenu
 
 		if ($this->_current->class == 'separator')
 		{
-			$class = ' class="divider"';
+			$class = $this->_current->title ? ' class="menuitem-group"' : ' class="divider"';
 		}
 
 		if ($this->_current->hasChildren() && $this->_current->class)
@@ -231,13 +238,13 @@ class JAdminCssMenu
 		{
 			echo '<a' . $linkClass . ' ' . $dataToggle . ' href="' . $this->_current->link . '">' . $this->_current->title . $dropdownCaret . '</a>';
 		}
-		elseif ($this->_current->title != null)
+		elseif ($this->_current->title != null && $this->_current->class != 'separator')
 		{
 			echo '<a' . $linkClass . ' ' . $dataToggle . '>' . $this->_current->title . $dropdownCaret . '</a>';
 		}
 		else
 		{
-			echo '<span></span>';
+			echo '<span>' . $this->_current->title . '</span>';
 		}
 
 		// Recurse through children if they exist
@@ -442,7 +449,7 @@ class JAdminCssMenu
 		{
 			if ($item->type == 'separator')
 			{
-				$this->addSeparator();
+				$this->addSeparator($item->text);
 			}
 			elseif ($item->type == 'heading' && !count($item->submenu))
 			{
@@ -466,7 +473,7 @@ class JAdminCssMenu
 						// Add a separator between dynamic menu items and components menu items
 						if (count($item->submenu) && count($components))
 						{
-							$this->addSeparator();
+							$this->addSeparator($item->text);
 						}
 
 						// Adding component submenu the old way, this assumes 2-level menu only

--- a/administrator/modules/mod_menu/preset/enabled.php
+++ b/administrator/modules/mod_menu/preset/enabled.php
@@ -158,7 +158,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 	$this->addSeparator();
 
 	$this->addChild(new JMenuNode(JText::_('MOD_MENU_MENUS_ALL_ITEMS'), 'index.php?option=com_menus&view=items&menutype=', 'class:allmenu'));
-	$this->addSeparator();
+	$this->addSeparator(JText::_('JSITE'));
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
@@ -199,7 +199,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 		if (isset($menuTypes[$mti - 1]) && $menuTypes[$mti - 1]->client_id != $menuType->client_id)
 		{
-			$this->addSeparator();
+			$this->addSeparator(JText::_('JADMINISTRATOR'));
 		}
 
 		$this->addChild(

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1967,10 +1967,8 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	*width: 100%;
 	height: 1px;
 	margin: 4px 1px;
-	*margin: -5px 0 5px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
 	border-bottom: 1px solid #eee;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1975,7 +1975,7 @@ table th[class*="span"],
 	border-top: 1px solid #eee;
 	border-bottom: 1px solid #eee;
 	background-color: #eee;
-	color: #666;
+	color: #555;
 	text-transform: capitalize;
 	font-size: 95%;
 	padding: 2px 0 24px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1966,6 +1966,20 @@ table th[class*="span"],
 	background-color: #F0F0F0;
 	border-bottom: 1px solid #fff;
 }
+.dropdown-menu .menuitem-group {
+	*width: 100%;
+	height: 1px;
+	margin: 4px 1px;
+	*margin: -5px 0 5px;
+	overflow: hidden;
+	border-top: 1px solid #eee;
+	border-bottom: 1px solid #eee;
+	background-color: #eee;
+	color: #666;
+	text-transform: capitalize;
+	font-size: 95%;
+	padding: 2px 0 24px;
+}
 .dropdown-menu > li > a {
 	display: block;
 	padding: 3px 20px;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1975,10 +1975,10 @@ table th[class*="span"],
 	border-top: 1px solid #eee;
 	border-bottom: 1px solid #eee;
 	background-color: #eee;
-	color: #666;
+	color: #555;
 	text-transform: capitalize;
 	font-size: 95%;
-    padding: 2px 0 24px;
+	padding: 2px 0 24px;
 }
 .dropdown-menu > li > a {
 	display: block;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1967,10 +1967,8 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	*width: 100%;
 	height: 1px;
 	margin: 4px 1px;
-	*margin: -5px 0 5px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
 	border-bottom: 1px solid #eee;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1966,6 +1966,20 @@ table th[class*="span"],
 	background-color: #F0F0F0;
 	border-bottom: 1px solid #fff;
 }
+.dropdown-menu .menuitem-group {
+	*width: 100%;
+	height: 1px;
+	margin: 4px 1px;
+	*margin: -5px 0 5px;
+	overflow: hidden;
+	border-top: 1px solid #eee;
+	border-bottom: 1px solid #eee;
+	background-color: #eee;
+	color: #666;
+	text-transform: capitalize;
+	font-size: 95%;
+    padding: 2px 0 24px;
+}
 .dropdown-menu > li > a {
 	display: block;
 	padding: 3px 20px;

--- a/media/jui/less/dropdowns.less
+++ b/media/jui/less/dropdowns.less
@@ -71,6 +71,22 @@
     .nav-divider(@dropdownDividerTop, @dropdownDividerBottom);
   }
 
+  // Labelled Separator (group label for menu items group) within the dropdown
+  .menuitem-group {
+    *width: 100%;
+    height: 1px;
+    margin: 4px 1px;
+    *margin: -5px 0 5px;
+    overflow: hidden;
+    border-top: 1px solid @grayLighter;
+    border-bottom: 1px solid @grayLighter;
+    background-color: @grayLighter;
+    color: @gray;
+    text-transform: capitalize;
+    font-size: 95%;
+    padding: 2px 0 24px;
+  }
+
   // Links within the dropdown menu
   > li > a {
     display: block;

--- a/media/jui/less/dropdowns.less
+++ b/media/jui/less/dropdowns.less
@@ -73,10 +73,8 @@
 
   // Labelled Separator (group label for menu items group) within the dropdown
   .menuitem-group {
-    *width: 100%;
     height: 1px;
     margin: 4px 1px;
-    *margin: -5px 0 5px;
     overflow: hidden;
     border-top: 1px solid @grayLighter;
     border-bottom: 1px solid @grayLighter;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2012,10 +2012,8 @@ table th[class*="span"],
 	border-bottom: 1px solid #fff;
 }
 .dropdown-menu .menuitem-group {
-	*width: 100%;
 	height: 1px;
 	margin: 4px 1px;
-	*margin: -5px 0 5px;
 	overflow: hidden;
 	border-top: 1px solid #eee;
 	border-bottom: 1px solid #eee;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -2011,6 +2011,20 @@ table th[class*="span"],
 	background-color: #e5e5e5;
 	border-bottom: 1px solid #fff;
 }
+.dropdown-menu .menuitem-group {
+	*width: 100%;
+	height: 1px;
+	margin: 4px 1px;
+	*margin: -5px 0 5px;
+	overflow: hidden;
+	border-top: 1px solid #eee;
+	border-bottom: 1px solid #eee;
+	background-color: #eee;
+	color: #555;
+	text-transform: capitalize;
+	font-size: 95%;
+	padding: 2px 0 24px;
+}
 .dropdown-menu > li > a {
 	display: block;
 	padding: 3px 20px;


### PR DESCRIPTION
### Summary of Changes
* Added an optional title parameter to `addSeparator()` method in backend menu class. Hence there are now two separator types:
    * Normal Separator (horizontal bar)
    * Labelled Separator

* In the preset menu, converted the separators between menus to labelled separators. This helps identify which menu are site menus and which are administrator menus.
* This labelled separators can also be used in the new custom backend menu by simply providing a label to the separator type menu item.

### Testing Instructions
* Install current staging and navigate to backend and see the drop down menu.which should look like

![menu](https://cloud.githubusercontent.com/assets/6706189/24503666/b34774ae-1570-11e7-9c73-ab546351cc0b.png)


* Add a custom administrator menu and set it as active backend menu.
* Add some items, separators with title and separators without title in custom backend menu
* Match your findings with expected results below.
* If there is no admin menu,the separator should also be hidden automatically.
* Test this on RTL layout also.

### Expected result
* The separators with title should appear as labelled separators whereas the separator without title should be displayed as normal separator.
* The separators should not be clickable

### Documentation Changes Required
Backend menu manager documentation should be updated.

@infograf768 @brianteeman 
