### PR TITLE
Make SQL Server driver's connection error messages infinitely more useful

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -134,7 +134,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// Attempt to connect to the server.
 		if (!($this->connection = @ sqlsrv_connect($this->options['host'], $config)))
 		{
-			throw new JDatabaseExceptionConnecting('Database sqlsrv_connect failed');
+			throw new JDatabaseExceptionConnecting('Database sqlsrv_connect failed, ' . print_r( sqlsrv_errors(), true));
 		}
 
 		// Make sure that DB warnings are not returned as errors.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -134,7 +134,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// Attempt to connect to the server.
 		if (!($this->connection = @ sqlsrv_connect($this->options['host'], $config)))
 		{
-			throw new JDatabaseExceptionConnecting('Database sqlsrv_connect failed, ' . print_r( sqlsrv_errors(), true));
+			throw new JDatabaseExceptionConnecting('Database sqlsrv_connect failed, ' . print_r(sqlsrv_errors(), true));
 		}
 
 		// Make sure that DB warnings are not returned as errors.


### PR DESCRIPTION
### Summary of Changes

The Microsoft SQL Server driver's (hereon: sqlsrv) error messages are useless. This PR returns the full error message stack which gives INFINITELY MORE USEFUL error messages.

### Testing Instructions

Screw up your MS SQL Server installation and try to install a new Joomla! site.

### Expected result

An error message with some clue about what is going on.

### Actual result

A uselesserror message `Could not connect to the database. Connector returned number: Database sqlsrv_connect failed`. No crap, Sherlock, something's wrong? Gee, I'd have never guessed... Don't tell me why it failed, I like guessing :@

### After applying the PR

sqlsrv's ridiculous error message changes to something more informative. In my case:

> Could not connect to the database. Connector returned number: Database sqlsrv_connect failed, Array ( [0] => Array ( [0] => 08001 [SQLSTATE] => 08001 [1] => 53 [code] => 53 [2] => [Microsoft][ODBC Driver 11 for SQL Server]Named Pipes Provider: Could not open a connection to SQL Server [53]. [message] => [Microsoft][ODBC Driver 11 for SQL Server]Named Pipes Provider: Could not open a connection to SQL Server [53]. ) [1] => Array ( [0] => HYT00 [SQLSTATE] => HYT00 [1] => 0 [code] => 0 [2] => [Microsoft][ODBC Driver 11 for SQL Server]Login timeout expired [message] => [Microsoft][ODBC Driver 11 for SQL Server]Login timeout expired ) [2] => Array ( [0] => 08001 [SQLSTATE] => 08001 [1] => 53 [code] => 53 [2] => [Microsoft][ODBC Driver 11 for SQL Server]A network-related or instance-specific error has occurred while establishing a connection to SQL Server. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online. [message] => [Microsoft][ODBC Driver 11 for SQL Server]A network-related or instance-specific error has occurred while establishing a connection to SQL Server. Server is not found or not accessible. Check if instance name is correct and if SQL Server is configured to allow remote connections. For more information see SQL Server Books Online. ) )

A-ha! The instance name had a typo. I only lost half a day to that @#$%^&*()!!!

### Documentation Changes Required

None

### Backwards compatibility breaks

None