### PR TITLE
Added a method to get user timezone as DateTimezone instance

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -717,7 +717,7 @@ abstract class JHtml
 			{
 				return $includes[0];
 			}
-			
+
 			return $includes;
 		}
 
@@ -786,7 +786,7 @@ abstract class JHtml
 			$date = JFactory::getDate($input, 'UTC');
 
 			// Set the correct time zone based on the user configuration.
-			$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+			$date->setTimezone($user->getTimezone());
 		}
 		// UTC date converted to server time zone.
 		elseif ($tz === false)

--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -178,7 +178,7 @@ abstract class JHtmlJGrid
 			$nullDate = JFactory::getDbo()->getNullDate();
 			$nowDate = JFactory::getDate()->toUnix();
 
-			$tz = new DateTimeZone(JFactory::getUser()->getParam('timezone', JFactory::getConfig()->get('offset')));
+			$tz = JFactory::getUser()->getTimezone();
 
 			$publish_up = ($publish_up != $nullDate) ? JFactory::getDate($publish_up, 'UTC')->setTimeZone($tz) : false;
 			$publish_down = ($publish_down != $nullDate) ? JFactory::getDate($publish_down, 'UTC')->setTimeZone($tz) : false;

--- a/libraries/fof/form/field/calendar.php
+++ b/libraries/fof/form/field/calendar.php
@@ -146,7 +146,7 @@ class FOFFormFieldCalendar extends JFormFieldCalendar implements FOFFormField
 					if ((int) $this->value)
 					{
 						// Get a date object based on the correct timezone.
-						$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+						$date->setTimezone($user->getTimezone());
 					}
 					break;
 

--- a/libraries/fof/form/header/fielddate.php
+++ b/libraries/fof/form/header/fielddate.php
@@ -104,7 +104,7 @@ class FOFFormHeaderFielddate extends FOFFormHeaderField
 				{
 					// Get a date object based on the correct timezone.
 					$date = FOFPlatform::getInstance()->getDate($this->value, 'UTC');
-					$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+					$date->setTimezone($user->getTimezone());
 
 					// Transform the date string.
 					$searchvalue = $date->format('Y-m-d H:i:s', true, false);

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -226,7 +226,7 @@ class JFormFieldCalendar extends JFormField
 				{
 					// Get a date object based on the correct timezone.
 					$date = JFactory::getDate($this->value, 'UTC');
-					$date->setTimezone(new DateTimeZone($user->getParam('timezone', $config->get('offset'))));
+					$date->setTimezone($user->getTimezone());
 
 					// Transform the date string.
 					$this->value = $date->format('Y-m-d H:i:s', true, false);

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1337,7 +1337,7 @@ class JForm
 					}
 
 					// Get the user timezone setting defaulting to the server timezone setting.
-					$offset = JFactory::getUser()->getParam('timezone', JFactory::getConfig()->get('offset'));
+					$offset = JFactory::getUser()->getTimezone();
 
 					// Return a MySQL formatted datetime string in UTC.
 					try

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -532,6 +532,20 @@ class JUser extends JObject
 	}
 
 	/**
+	 * Method to get the user timezone.
+	 *
+	 * If the user didn't set a timezone, it will return the server timezone
+	 *
+	 * @return DateTimeZone
+	 */
+	public function getTimezone()
+	{
+		$timezone = $this->getParam('timezone', JFactory::getApplication()->get('offset', 'GMT'));
+
+		return new DateTimeZone($timezone);
+	}
+
+	/**
 	 * Method to get the user parameters
 	 *
 	 * @param   object  $params  The user parameters object

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -537,6 +537,8 @@ class JUser extends JObject
 	 * If the user didn't set a timezone, it will return the server timezone
 	 *
 	 * @return DateTimeZone
+	 *
+	 * @since __DEPLOY_VERSION__
 	 */
 	public function getTimezone()
 	{


### PR DESCRIPTION
### Summary of Changes
I added function to the JUser to get the user timezone, which is very useful for any developer working with date and time in Joomla.
It's a simple function, but it already simplifies some cumbersome library calls.

### Testing Instructions
Fill and save any form field using calendar field with 'user_utc', like article publish date for example

### Expected result
The date and time saved should be the set date and time...