### PR TITLE
Make sure we're being called from the command line, not a web interface

### DIFF
--- a/cli/deletefiles.php
+++ b/cli/deletefiles.php
@@ -6,6 +6,12 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+// Make sure we're being called from the command line, not a web interface
+if (PHP_SAPI !== 'cli')
+{
+	die('This is a command line only application.');
+}
+
 // We are a valid entry point.
 const _JEXEC = 1;
 

--- a/cli/garbagecron.php
+++ b/cli/garbagecron.php
@@ -6,6 +6,12 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+// Make sure we're being called from the command line, not a web interface
+if (PHP_SAPI !== 'cli')
+{
+	die('This is a command line only application.');
+}
+
 // Initialize Joomla framework
 const _JEXEC = 1;
 

--- a/cli/update_cron.php
+++ b/cli/update_cron.php
@@ -10,7 +10,14 @@
  * This is a CRON script which should be called from the command-line, not the
  * web. For example something like:
  * /usr/bin/php /path/to/site/cli/update_cron.php
+ * so we make sure we're being called from the command line, not a web interface
  */
+if (PHP_SAPI !== 'cli')
+{
+	die('This is a command line only application.');
+}
+
+
 
 // Set flag that this is a parent file.
 const _JEXEC = 1;


### PR DESCRIPTION
Pull Request for Issue Make sure CLI files are only called from the command line, not a web interface

### Summary of Changes

Adds the following check to the CLI files

```php
// Make sure we're being called from the command line, not a web interface
if (PHP_SAPI !== 'cli')
{
	die('This is a command line only application.');
}
```

### Testing Instructions
check that the CLI files still work and cannot be called from a web interface


### Expected result
CLI file should still work
CLI files cannot be called from a web interface


### Actual result
CLI file should still work
CLI files cannot be called from a web interface


### Documentation Changes Required
none
