### PR TITLE
Remove check as JApplicationCli constructor has a check for this

### DIFF
--- a/bin/keychain.php
+++ b/bin/keychain.php
@@ -10,12 +10,6 @@
 
 // @deprecated  4.0  Deprecated without replacement
 
-// Make sure we're being called from the command line, not a web interface
-if (PHP_SAPI !== 'cli')
-{
-	die('This is a command line only application.');
-}
-
 // We are a valid entry point.
 define('_JEXEC', 1);
 

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -18,12 +18,6 @@
  *                           Purges and rebuilds the index (search filters are preserved).
  */
 
-// Make sure we're being called from the command line, not a web interface
-if (PHP_SAPI !== 'cli')
-{
-	die('This is a command line only application.');
-}
-
 // We are a valid entry point.
 const _JEXEC = 1;
 


### PR DESCRIPTION
Pull Request for Issue # Check is unnecessary as JApplicationCli constructor has a check for this.

### Summary of Changes
Removes duplicated code


### Testing Instructions
CLI scripts are still work in CLI and not accessible via things like web interface. 

**(code review might be sufficent)**

### Expected result
CLI scripts are still work in CLI and not accessible via things like web interface. 


### Actual result
CLI scripts are still work in CLI and not accessible via things like web interface. 


### Documentation Changes Required
none
