### PR TITLE
[com_fields] Changing text type to number type

### DIFF
--- a/plugins/fields/text/params/text.xml
+++ b/plugins/fields/text/params/text.xml
@@ -22,10 +22,12 @@
 
 			<field
 				name="maxlength"
-				type="text"
-				filter="integer"
+				type="number"
 				label="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_LABEL"
 				description="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_DESC"
+				min="0"
+				filter="integer"
+				validate="number"
 			/>
 		</fieldset>
 	</fields>

--- a/plugins/fields/text/text.xml
+++ b/plugins/fields/text/text.xml
@@ -41,10 +41,12 @@
 
 				<field
 					name="maxlength"
-					type="text"
-					filter="integer"
+					type="number"
 					label="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_LABEL"
 					description="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_DESC"
+					min="0"
+					filter="integer"
+					validate="number"
 				/>
 			</fieldset>
 		</fields>

--- a/plugins/fields/textarea/params/textarea.xml
+++ b/plugins/fields/textarea/params/textarea.xml
@@ -20,10 +20,12 @@
 
 			<field
 				name="maxlength"
-				type="text"
-				filter="integer"
+				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_LABEL"
 				description="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_DESC"
+				min="0"
+				filter="integer"
+				validate="number"
 			/>
 
 			<field

--- a/plugins/fields/textarea/textarea.xml
+++ b/plugins/fields/textarea/textarea.xml
@@ -41,10 +41,12 @@
 
 				<field
 					name="maxlength"
-					type="text"
-					filter="integer"
+					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_LABEL"
 					description="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_DESC"
+					min="0"
+					filter="integer"
+					validate="number"
 				/>
 
 				<field


### PR DESCRIPTION
The new `maxlength` field parameter introduced in https://github.com/joomla/joomla-cms/pull/14458 is using a text type, therefore it does not validate when saving.
It concerns text and textarea custom fields plugins

If someone enters some text i.e. "something" it is changed to `0` on save.

### Summary of Changes
Changed to `type="number"`


### Testing Instructions
Use staging. Patch.
After patch one will get:

![screen shot 2017-03-31 at 09 24 43](https://cloud.githubusercontent.com/assets/869724/24540620/489991b2-15f4-11e7-95c1-bbc7b9f9e427.png)

![screen shot 2017-03-31 at 09 25 08](https://cloud.githubusercontent.com/assets/869724/24540591/2dd37352-15f4-11e7-902a-de660aaef9e6.png)

If someone saves with some alpha string ("something", the field will be saved empty in the database instead of `0`

In any case the Tip is really incomplete (not changed in this PR yet).
We have multiple cases:
1. 
No value is set in the plugin params
No value is set for the field.
Result => No limit

2. 
0 is chosen in the plugin params
No value is set for the field.
Result => No limit

3. 
A value is set in the plugin params
No value is set for the field.
Result => The limit is the one set in the plugin params

4. 
Any value is set in the field.
Result => The limit is the one set in the field
If value is 0 => No limit.

Therefore we may need a specific tip for the plugin and another one for the field where some of this is explained as what we have now is only:
`"The maximum number of characters that can be entered."`

We could use for the plugin the existing constant `PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_DESC`
and for the field
`PLG_FIELDS_TEXT_FIELD_PARAMS_MAXLENGTH_DESC`

@brianteeman
Any idea to make these tips informative enough?

@laoneo @Bakual 