### PR TITLE
Languages: Changing error order when reinstalling a language

### DIFF
--- a/libraries/joomla/table/language.php
+++ b/libraries/joomla/table/language.php
@@ -58,9 +58,17 @@ class JTableLanguage extends JTable
 	 */
 	public function store($updateNulls = false)
 	{
-		// Verify that the sef field is unique
 		$table = JTable::getInstance('Language', 'JTable', array('dbo' => $this->getDbo()));
 
+		// Verify that the language code is unique
+		if ($table->load(array('lang_code' => $this->lang_code)) && ($table->lang_id != $this->lang_id || $this->lang_id == 0))
+		{
+			$this->setError(JText::_('JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_LANG_CODE'));
+
+			return false;
+		}
+
+		// Verify that the sef field is unique
 		if ($table->load(array('sef' => $this->sef)) && ($table->lang_id != $this->lang_id || $this->lang_id == 0))
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_SEF'));
@@ -72,14 +80,6 @@ class JTableLanguage extends JTable
 		if ($this->image && $table->load(array('image' => $this->image)) && ($table->lang_id != $this->lang_id || $this->lang_id == 0))
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_IMAGE'));
-
-			return false;
-		}
-
-		// Verify that the language code is unique
-		if ($table->load(array('lang_code' => $this->lang_code)) && ($table->lang_id != $this->lang_id || $this->lang_id == 0))
-		{
-			$this->setError(JText::_('JLIB_DATABASE_ERROR_LANGUAGE_UNIQUE_LANG_CODE'));
 
 			return false;
 		}


### PR DESCRIPTION
### Summary of Changes
This changes the order of the errors when installing a language and creating a Content Language.

In 3.7.0/staging, a Content Language is automatically created (unpublished) when installing a language.
When uninstalling this language, the Content Language remains (which is correct behavior).
When the same language is installed again, the code checks for uniqueness of
sef
image (flag) used
Language Tag

The order is not important when editing Content Languages, but it is when reinstalling a language.

This PR reorders the errors
1. Language Tag
2. sef
3. Image


After patch when reinstalling a language for which the Content Language already exists, one will get:

![screen shot 2017-03-31 at 10 54 43](https://cloud.githubusercontent.com/assets/869724/24544067/2dbade60-1602-11e7-8c74-28ea05ee1e00.png)

Instead of:
`Unable to create a content language for Persian language: A content language already exists with this Image.`

Thanks @imanickam  for finding this issue.
Testers welcome.