### PR TITLE
[TinyMCE] Improving legacy warning

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -139,7 +139,7 @@ PLG_TINY_FIELD_VISUALCHARS_DESC="See invisible characters, specifically non-brea
 PLG_TINY_FIELD_VISUALCHARS_LABEL="Visualchars"
 PLG_TINY_FIELD_WORDCOUNT_DESC="Turn on/off word count."
 PLG_TINY_FIELD_WORDCOUNT_LABEL="Word Count"
-PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> has been updated. Currently it uses your existing configuration. By editing the plugin, you can now assign and customise various layouts to specific user groups."
+PLG_TINY_LEGACY_WARNING="The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> has been updated. Currently it uses your existing configuration. By editing the plugin, you can now assign and customise various layouts to specific user groups. <br />Warning: when editing the plugin, you will lose all your previous settings!"
 PLG_TINY_SET_TARGET_PANEL_DESCRIPTION="<strong>Existing sets of the TinyMCE panel, and options for each set.</strong><br />In each set you can add or remove from <strong>the available menus and buttons</strong>."
 PLG_TINY_SET_TITLE="Set %s"
 PLG_TINY_SET_PRESET_BUTTON_ADVANCED="Use advanced preset"


### PR DESCRIPTION
### Summary of Changes
Improving TinyMCE warning when updating to 3.7.0

### Testing Instructions
Update a 3.6.5 to staging.

Modifying from
`The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> has been updated. Currently it uses your existing configuration. By editing the plugin, you can now assign and customise various layouts to specific user groups.`
to
`The <a href="_QQ_"%s"_QQ_">TinyMCE Editor Plugin</a> has been updated. Currently it uses your existing configuration. By editing the plugin, you can now assign and customise various layouts to specific user groups. <br />Warning: when editing the plugin, you will lose all your previous settings!`
