### PR TITLE
Allow "alternate layouts" for the content - field plugin

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_content_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to display a custom field which has been inserted with the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area."
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to display a custom field which has been inserted with the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area.<br><b>Possible Syntax:</b><br/><ul><li><code>{field 1}</code> will display the field with the ID 1</li><li><code>{field 1,foo}</code> will display the selected field using the alternative layout 'foo'.</li><li><code>{fieldgroup 2}</code> will display all fields within the fieldgroup with the ID 2.</li></ul>"

--- a/administrator/language/en-GB/en-GB.plg_content_fields.ini
+++ b/administrator/language/en-GB/en-GB.plg_content_fields.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CONTENT_FIELDS="Content - Fields"
-PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to display a custom field which has been inserted with the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area.<br><b>Possible Syntax:</b><br/><ul><li><code>{field 1}</code> will display the field with the ID 1</li><li><code>{field 1,foo}</code> will display the selected field using the alternative layout 'foo'.</li><li><code>{fieldgroup 2}</code> will display all fields within the fieldgroup with the ID 2.</li></ul>"
+PLG_CONTENT_FIELDS_XML_DESCRIPTION="This plugin allows you to display a custom field which has been inserted with the 'Button - Fields' plugin or using Syntax: {field #} directly into the editor area.<br><strong>Possible Syntax:</strong><br><ul><li><code>{field 1}</code> will display the field with the ID 1</li><li><code>{field 1,foo}</code> will display the selected field using the alternative layout 'foo'.</li><li><code>{fieldgroup 2}</code> will display all fields within the fieldgroup with the ID 2.</li></ul>"

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -79,9 +79,12 @@ class PlgContentFields extends JPlugin
 
 			foreach ($matches as $i => $match)
 			{
-				// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID
-				$id     = (int) $match[2];
-				$output = '';
+				// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID and optional the layout
+				$explode = explode(',', $match[2]);
+				$id      = (int) $explode[0];
+				$layout  = !empty($explode[1]) ? trim($explode[1]) : 'render';
+				$output  = '';
+
 
 				if ($match[1] == 'field' && $id)
 				{
@@ -89,7 +92,7 @@ class PlgContentFields extends JPlugin
 					{
 						$output = FieldsHelper::render(
 							$context,
-							'field.render',
+							'field.' . $layout,
 							array(
 								'item'    => $item,
 								'context' => $context,
@@ -114,7 +117,7 @@ class PlgContentFields extends JPlugin
 					{
 						$output = FieldsHelper::render(
 							$context,
-							'fields.render',
+							'fields.' . $layout,
 							array(
 								'item'    => $item,
 								'context' => $context,


### PR DESCRIPTION
Pull Request for Issue #14753 .

### Summary of Changes
This PR adds an additional, optional parameter to the field plugin tag: `{field ID, LAYOUT}`.
This allows to customize how a field gets rendered when included in the item body.

### Testing Instructions
* Copy and rename the file /components/com_field/layouts/field/render.php to /templates/protostar/html/layouts/com_fields/field/foo.php.
* Adjust the layout so you can distinguish it from the original (eg remove the label or add some text to it)
* Create a field and add some value to it.
* Insert that field into the article body using the field button (or writing the plugin tag manually) and then add a comma after the ID and add the name of your custom layout (eg "foo"). Tag should look like `{field 1, foo}`
* Check the article in frontend

### Expected result
The field should be shown with your adjusted layout

### Actual result
The standard layout is used always

### Documentation Changes Required
Don't think there is one.
I've adjusted the plugin description text to include the possible syntaxes.