### PR TITLE
[com_fields] Add a check if the default value is correct based on JFormRules

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -737,10 +737,12 @@ class FieldsHelper
 				{
 					$fieldDescription['path'] = null;
 				}
+
 				if (!array_key_exists('rules', $fieldDescription))
 				{
 					$fieldDescription['rules'] = null;
 				}
+
 				$data[$fieldDescription['type']] = $fieldDescription;
 			}
 		}

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -391,6 +391,12 @@ class FieldsHelper
 				JFormHelper::addFieldPath($path);
 			}
 
+			if ($path = $fieldTypes[$field->type]['rules'])
+			{
+				// Add the lookup path for the rule
+				JFormHelper::addRulePath($path);
+			}
+
 			$fieldsPerGroup[$field->group_id][] = $field;
 		}
 
@@ -730,6 +736,10 @@ class FieldsHelper
 				if (!array_key_exists('path', $fieldDescription))
 				{
 					$fieldDescription['path'] = null;
+				}
+				if (!array_key_exists('rules', $fieldDescription))
+				{
+					$fieldDescription['rules'] = null;
 				}
 				$data[$fieldDescription['type']] = $fieldDescription;
 			}

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -73,6 +73,14 @@ abstract class FieldsPlugin extends JPlugin
 				$data['path'] = $path;
 			}
 
+			$path = $root . '/rules';
+
+			// Add the path when it exists
+			if (file_exists($path))
+			{
+				$data['rules'] = $path;
+			}
+
 			$types[] = $data;
 		}
 

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -123,6 +123,7 @@ class FieldsModelField extends JModelAdmin
 		if ($message !== true)
 		{
 			$this->setError($message);
+
 			return false;
 		}
 
@@ -195,7 +196,7 @@ class FieldsModelField extends JModelAdmin
 	 *
 	 * @param   array  $data  The data.
 	 *
-	 * @return  true|string  true if valid, a string when not.
+	 * @return  true|string  true if valid, a string containing the expection message when not.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -215,8 +216,10 @@ class FieldsModelField extends JModelAdmin
 			return true;
 		}
 
+		$path = $types[$data['type']]['rules'];
+
 		// Add the path for the rules of the plugin when available
-		if ($path = $types[$data['type']]['rules'])
+		if ($path)
 		{
 			// Add the lookup path for the rule
 			JFormHelper::addRulePath($path);
@@ -228,7 +231,7 @@ class FieldsModelField extends JModelAdmin
 		$obj->fieldparams = new Registry(!empty($obj->fieldparams) ? $obj->fieldparams : array());
 
 		// Prepare the dom
-		$dom  = new DOMDocument();
+		$dom  = new DOMDocument;
 		$node = $dom->appendChild(new DOMElement('form'));
 
 		// Trigger the event to create the field dom node
@@ -260,7 +263,7 @@ class FieldsModelField extends JModelAdmin
 			// Check if the test succeeded
 			return $result === true ? : JText::_('COM_FIELDS_FIELD_INVALID_DEFAULT_VALUE');
 		}
-		catch(UnexpectedValueException $e)
+		catch (UnexpectedValueException $e)
 		{
 			return $e->getMessage();
 		}

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -119,6 +119,7 @@ class FieldsModelField extends JModelAdmin
 		JPluginHelper::importPlugin('fields');
 
 		$message = $this->checkDefaultValue($data);
+
 		if ($message !== true)
 		{
 			$this->setError($message);

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -241,7 +241,7 @@ class FieldsModelField extends JModelAdmin
 		try
 		{
 			$result = $rule->test(simplexml_import_dom($node->firstChild), $data['default_value']);
-			return $result ? : 'Invalid default value';
+			return $result ? : JText::_('COM_FIELDS_FIELD_INVALID_DEFAULT_VALUE');
 		}
 		catch(UnexpectedValueException $e)
 		{

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -191,7 +191,7 @@ class FieldsModelField extends JModelAdmin
 
 
 	/**
-	 * Checks if the default value is valid of the given data. If a string is returned then
+	 * Checks if the default value is valid for the given data. If a string is returned then
 	 * it can be assumed that the default value is invalid.
 	 *
 	 * @param   array  $data  The data.

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -196,7 +196,7 @@ class FieldsModelField extends JModelAdmin
 	 *
 	 * @param   array  $data  The data.
 	 *
-	 * @return  true|string  true if valid, a string containing the expection message when not.
+	 * @return  true|string  true if valid, a string containing the exception message when not.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */

--- a/administrator/language/en-GB/en-GB.com_fields.ini
+++ b/administrator/language/en-GB/en-GB.com_fields.ini
@@ -28,6 +28,7 @@ COM_FIELDS_FIELD_IMAGE_ALT_DESC="Alternative text used for visitors without acce
 COM_FIELDS_FIELD_IMAGE_ALT_LABEL="Alt Text"
 COM_FIELDS_FIELD_IMAGE_DESC="Image label."
 COM_FIELDS_FIELD_IMAGE_LABEL="Image"
+COM_FIELDS_FIELD_INVALID_DEFAULT_VALUE="The default value is invalid."
 COM_FIELDS_FIELD_LABEL_DESC="The label of the field to display."
 COM_FIELDS_FIELD_LABEL_LABEL="Label"
 COM_FIELDS_FIELD_LANGUAGE_DESC="Assign a language to this field."

--- a/libraries/joomla/form/rule/calendar.php
+++ b/libraries/joomla/form/rule/calendar.php
@@ -31,7 +31,7 @@ class JFormRuleCalendar extends JFormRule
 	 *
 	 * @return  boolean  True if the value is valid, false otherwise.
 	 *
-	 * @since   11.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{

--- a/libraries/joomla/form/rule/calendar.php
+++ b/libraries/joomla/form/rule/calendar.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Form
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JFormRuleCalendar extends JFormRule
+{
+	/**
+	 * Method to test the calendar value for a valid parts.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 * @param   Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   JForm             $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   11.1
+	 */
+	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
+	{
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+
+		if (!$required && empty($value))
+		{
+			return true;
+		}
+
+		if (strtolower($value) == 'now')
+		{
+			return true;
+		}
+
+		try
+		{
+			return JFactory::getDate($value) instanceof JDate;
+		}
+		catch (Exception $e)
+		{
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #15005.

### Summary of Changes
This pr adds support to check the default value of a custom field when a JFormRule exists. Additionally it adds support of rules for field plugins to a be found by JForm.


### Testing Instructions
- Create a calendar custom field
- Set as default value `test`
- Save the field

Please also save the field with the following default values which should be correct:
- now
- NOW
- 2017-02-09

The same can also be tested with any other field which has a rule.


### Expected result
The field is not saved and an error message is shown.


### Actual result
The field saves normally.


### Documentation Changes Required

