### PR TITLE
Using the supplied htaccess file will crash some servers

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -18,7 +18,7 @@
 
 ## No directory listings
 <IfModule autoindex>
-IndexIgnore *
+  IndexIgnore *
 </IfModule>
 
 ## Can be commented out if causes errors, see notes above.

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -17,7 +17,9 @@
 ##
 
 ## No directory listings
+<IfModule autoindex>
 IndexIgnore *
+</IfModule>
 
 ## Can be commented out if causes errors, see notes above.
 Options +FollowSymlinks


### PR DESCRIPTION
Wrap the IndexIgnore directive in an IfModule block to prevent it from being seen by system without auto index turned on.

Pull Request for Issue ##15031 .

### Summary of Changes

Wrapped it in an IfModule block

### Testing Instructions

disable mod_autoindex
see if site loads


### Expected result

Site should load

### Actual result



### Documentation Changes Required
