### PR TITLE
[4.0 ]Installation password bug

### DIFF
--- a/installation/model/forms/site.xml
+++ b/installation/model/forms/site.xml
@@ -42,7 +42,7 @@
 			name="admin_password"
 			type="password"
 			id="admin_password"
-			class="form-control validate-password-strength"
+			class="form-control"
 			label="INSTL_ADMIN_PASSWORD_LABEL"
 			required="true"
 			strengthmeter="true"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Remove an attribute that was causing a bug when typing password on installation

### Testing Instructions

Write till 3 characters on the password filed

### Expected result

No "empty" message

### Actual result

Actually this is showing that the field is empty when its not

