### PR TITLE
[com_redirects] Fix text to not flushed left

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -12,8 +12,8 @@ $published = $this->state->get('filter.published');
 
 <div class="container-fluid">
 	<div class="row-fluid">
+		<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
 		<div class="control-group span12">
-			<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
 			<div class="controls">
 				<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -10,10 +10,10 @@ defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
 ?>
 
-<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
 <div class="container-fluid">
 	<div class="row-fluid">
 		<div class="control-group span12">
+			<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
 			<div class="controls">
 				<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>


### PR DESCRIPTION
### Summary of Changes
Fix padding

### Testing Instructions
Go to Components > Redirects
Click `Bulk Import` button.
Text is flushed left.
![bulk](https://cloud.githubusercontent.com/assets/368084/24580425/d8dfb9f4-16bc-11e7-9471-f5cf4cea8caf.jpg)