### PR TITLE
[4.0]Fix typo in Joomla\Cms\Editor\Editor class

### DIFF
--- a/libraries/src/Cms/Component/ComponentHelper.php
+++ b/libraries/src/Cms/Component/ComponentHelper.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Libraries
  * @subpackage  Component
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component;

--- a/libraries/src/Cms/Component/Router/RouterInterface.php
+++ b/libraries/src/Cms/Component/Router/RouterInterface.php
@@ -2,8 +2,8 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router;

--- a/libraries/src/Cms/Component/Router/RouterInterface.php
+++ b/libraries/src/Cms/Component/Router/RouterInterface.php
@@ -2,8 +2,8 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router;

--- a/libraries/src/Cms/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Cms/Component/Router/Rules/MenuRules.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Libraries
  * @subpackage  Component
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router\Rules;

--- a/libraries/src/Cms/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Cms/Component/Router/Rules/NomenuRules.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Libraries
  * @subpackage  Component
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router\Rules;

--- a/libraries/src/Cms/Component/Router/Rules/RulesInterface.php
+++ b/libraries/src/Cms/Component/Router/Rules/RulesInterface.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Libraries
  * @subpackage  Component
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router\Rules;

--- a/libraries/src/Cms/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Cms/Component/Router/Rules/StandardRules.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Libraries
  * @subpackage  Component
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
 namespace Joomla\Cms\Component\Router\Rules;

--- a/libraries/src/Cms/Editor/Editor.php
+++ b/libraries/src/Cms/Editor/Editor.php
@@ -79,7 +79,7 @@ class Editor implements DispatcherAwareInterface
 		// Set the dispatcher
 		if (!is_object($dispatcher))
 		{
-			$dispatcher = JFactory::getContainer()->get('dispatcher');
+			$dispatcher = \JFactory::getContainer()->get('dispatcher');
 		}
 
 		$this->setDispatcher($dispatcher);

--- a/libraries/src/Cms/View/Category.php
+++ b/libraries/src/Cms/View/Category.php
@@ -3,8 +3,8 @@
  * @package     Joomla.Cms
  * @subpackage  View
  *
- * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\Cms\View;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is a typo in Joomla\Cms\Editor\Editor class causes unittest fails on 4.0-dev branch (maybe a merge conflict). This PR fixes it


### Testing Instructions
Code review. @wilsonge Please review and merge it.

