### PR TITLE
[a11y] com_users add a note

### DIFF
--- a/administrator/components/com_users/helpers/html/users.php
+++ b/administrator/components/com_users/helpers/html/users.php
@@ -55,7 +55,7 @@ class JHtmlUsers
 		$title = JText::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . JRoute::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId) . '" class="hasTooltip btn btn-mini" title="'
-			. $title . '"><span class="icon-vcard"></span><span class="hidden-phone">' . $title . '</span></a>';
+			. $title . '"><span class="icon-vcard" aria-hidden="true"></span><span class="hidden-phone">' . $title . '</span></a>';
 	}
 
 	/**


### PR DESCRIPTION
Continuing the work to ensure  have an aria-hidden value to prevent the value of the font being read by assistive technology

This PR is for the "add a note" button seen in com_users as below

<img width="475" alt="screenshotr11-12-47" src="https://cloud.githubusercontent.com/assets/1296369/24586329/aa65dda4-1795-11e7-9d5c-41855c7c0c2f.png">
