### PR TITLE
[a11y] finder - smart search

### DIFF
--- a/administrator/components/com_finder/views/filter/tmpl/edit.php
+++ b/administrator/components/com_finder/views/filter/tmpl/edit.php
@@ -71,7 +71,7 @@ JFactory::getDocument()->addStyleDeclaration('
 						<?php echo $this->form->renderField('map_count'); ?>
 					</div>
 					<button class="btn btn-default" type="button" class="jform-rightbtn" onclick="jQuery('.filter-node').each(function () { this.click(); });">
-						<span class="icon-checkbox-partial"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?></button>
+						<span class="icon-checkbox-partial" aria-hidden="true"></span> <?php echo JText::_('JGLOBAL_SELECTION_INVERT'); ?></button>
 
 					<button class="btn btn-default pull-right" type="button" id="rightbtn" ><?php echo JText::_('COM_FINDER_FILTER_SHOW_ALL'); ?></button>
 					<hr>

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -119,7 +119,8 @@ JFactory::getDocument()->addScriptDeclaration('
 					</td>
 					<td class="center hidden-phone hidden-tablet">
 						<?php if (intval($item->publish_start_date) or intval($item->publish_end_date) or intval($item->start_date) or intval($item->end_date)) : ?>
-							<span class="icon-calendar pop hasPopover" data-placement="left" title="<?php echo JText::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?>" data-content="<?php echo JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>"></span>
+							<span class="icon-calendar pop hasPopover" aria-hidden="true" data-placement="left" title="<?php echo JText::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?>" data-content="<?php echo JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>"></span>
+							<span class="element-invisible"><?php echo JText::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?></span>
 						<?php endif; ?>
 					</td>
 					<td class="small break-word hidden-phone hidden-tablet">

--- a/administrator/components/com_finder/views/index/tmpl/default.php
+++ b/administrator/components/com_finder/views/index/tmpl/default.php
@@ -120,7 +120,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<td class="center hidden-phone hidden-tablet">
 						<?php if (intval($item->publish_start_date) or intval($item->publish_end_date) or intval($item->start_date) or intval($item->end_date)) : ?>
 							<span class="icon-calendar pop hasPopover" aria-hidden="true" data-placement="left" title="<?php echo JText::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?>" data-content="<?php echo JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>"></span>
-							<span class="element-invisible"><?php echo JText::_('COM_FINDER_INDEX_DATE_INFO_TITLE'); ?></span>
+							<span class="element-invisible"><?php echo JText::sprintf('COM_FINDER_INDEX_DATE_INFO', $item->publish_start_date, $item->publish_end_date, $item->start_date, $item->end_date); ?>"></span>
 						<?php endif; ?>
 					</td>
 					<td class="small break-word hidden-phone hidden-tablet">


### PR DESCRIPTION
Continuing the work to prevent assistive technology reading out the value of an icon. This PR addresses the icons in com_finder as show in the screenshots below.

<img width="916" alt="screenshotr11-35-09" src="https://cloud.githubusercontent.com/assets/1296369/24586457/42f3a634-1799-11e7-9b5a-927b046fb67c.png">
<img width="508" alt="screenshotr11-37-59" src="https://cloud.githubusercontent.com/assets/1296369/24586458/42fbf2bc-1799-11e7-83f2-3e590ab64c42.png">
