### PR TITLE
[a11y] com_modules

### DIFF
--- a/administrator/components/com_modules/layouts/toolbar/newmodule.php
+++ b/administrator/components/com_modules/layouts/toolbar/newmodule.php
@@ -12,6 +12,6 @@ defined('_JEXEC') or die;
 $text = JText::_('JTOOLBAR_NEW');
 ?>
 <button onclick="location.href='index.php?option=com_modules&amp;view=select'" class="btn btn-small btn-success" title="<?php echo $text; ?>">
-	<span class="icon-plus icon-white"></span>
+	<span class="icon-plus icon-white" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
+++ b/administrator/components/com_modules/views/module/tmpl/edit_assignment.php
@@ -153,14 +153,14 @@ JFactory::getDocument()->addScriptDeclaration($script);
 						<ul class="dropdown-menu">
 							<li class="nav-header"><?php echo JText::_('COM_MODULES_SUBITEMS'); ?></li>
 							<li class="divider"></li>
-							<li class=""><a class="checkall" href="javascript://"><span class="icon-checkbox"></span> <?php echo JText::_('JSELECT'); ?></a>
+							<li class=""><a class="checkall" href="javascript://"><span class="icon-checkbox" aria-hidden="true"></span> <?php echo JText::_('JSELECT'); ?></a>
 							</li>
-							<li><a class="uncheckall" href="javascript://"><span class="icon-checkbox-unchecked"></span> <?php echo JText::_('COM_MODULES_DESELECT'); ?></a>
+							<li><a class="uncheckall" href="javascript://"><span class="icon-checkbox-unchecked" aria-hidden="true"></span> <?php echo JText::_('COM_MODULES_DESELECT'); ?></a>
 							</li>
 							<div class="treeselect-menu-expand">
 							<li class="divider"></li>
-							<li><a class="expandall" href="javascript://"><span class="icon-plus"></span> <?php echo JText::_('COM_MODULES_EXPAND'); ?></a></li>
-							<li><a class="collapseall" href="javascript://"><span class="icon-minus"></span> <?php echo JText::_('COM_MODULES_COLLAPSE'); ?></a></li>
+							<li><a class="expandall" href="javascript://"><span class="icon-plus" aria-hidden="true"></span> <?php echo JText::_('COM_MODULES_EXPAND'); ?></a></li>
+							<li><a class="collapseall" href="javascript://"><span class="icon-minus" aria-hidden="true"></span> <?php echo JText::_('COM_MODULES_COLLAPSE'); ?></a></li>
 							</div>
 						</ul>
 					</div>


### PR DESCRIPTION
Continuing the work to prevent assistive technology reading out the value of an icon. This PR addresses the icons in com_modules as show in the screenshots below.

<img width="449" alt="screenshotr20-52-44" src="https://cloud.githubusercontent.com/assets/1296369/24590560/f3527e4a-17e6-11e7-92c9-aba491c80a46.png">
<img width="514" alt="screenshotr20-55-03" src="https://cloud.githubusercontent.com/assets/1296369/24590561/f357742c-17e6-11e7-97ee-849331400bf2.png">

