### PR TITLE
Fix the loading of the table columns

### DIFF
--- a/libraries/joomla/database/importer/mysqli.php
+++ b/libraries/joomla/database/importer/mysqli.php
@@ -126,7 +126,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 	protected function getAlterTableSql(SimpleXMLElement $structure)
 	{
 		$table = $this->getRealTableName($structure['name']);
-		$oldFields = $this->db->getTableColumns($table);
+		$oldFields = $this->db->getTableColumns($table, false);
 		$oldKeys = $this->db->getTableKeys($table);
 		$alters = array();
 


### PR DESCRIPTION
### Summary of Changes
The second argument was missing so the fields were loaded as type only but the code is expecting the full information. Setting the second argument to false, loads all details and the test on line 132 will not throw notices because $column is now an object.

### Testing Instructions
Try to import the XML schema for a database table for an existing table. There will be several notices Notice: Trying to get property of non-object in D:\wamp64\www\joomla-cms\libraries\joomla\database\importer\mysqli.php on line 148

Apply the patch

The import now runs without any notices.

### Documentation Changes Required
None