### PR TITLE
[com_templates] Fix invalid markup

### DIFF
--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -77,7 +77,7 @@ class JHtmlTemplates
 			{
 				$preview = $baseUrl . '/templates/' . $template . '/template_preview.png';
 				$footer = '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-					. JText::_('JTOOLBAR_CLOSE') . '</a>';
+					. JText::_('JTOOLBAR_CLOSE') . '</button>';
 
 				$html .= JHtml::_(
 					'bootstrap.renderModal',

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -64,6 +64,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<tr class="row<?php echo $i % 2; ?>">
 					<td class="center hidden-phone">
 						<?php echo JHtml::_('templates.thumb', $item->element, $item->client_id); ?>
+						<?php echo JHtml::_('templates.thumbModal', $item->element, $item->client_id); ?>
 					</td>
 					<td class="template-name">
 						<a href="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . (int) $item->extension_id . '&file=' . $this->file); ?>">
@@ -99,7 +100,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<div><a href="<?php echo $this->escape($url); ?>"><?php echo $this->escape($url); ?></a></div>
 						<?php endif; ?>
 					</td>
-					<?php echo JHtml::_('templates.thumbModal', $item->element, $item->client_id); ?>
 				</tr>
 				<?php endforeach; ?>
 			</tbody>

--- a/administrator/components/com_templates/views/templates/tmpl/default.php
+++ b/administrator/components/com_templates/views/templates/tmpl/default.php
@@ -47,7 +47,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<th width="15%" class="hidden-phone">
 						<?php echo JText::_('JDATE'); ?>
 					</th>
-					<th width="25%" class="hidden-phone" >
+					<th width="25%" class="hidden-phone">
 						<?php echo JText::_('JAUTHOR'); ?>
 					</th>
 				</tr>


### PR DESCRIPTION
### Summary of Changes
Fix closing tag to match opening tag.
Remove space.
Move modal code into table cell.

### Testing Instructions
Go to Extensions > Templates > Templates
View source page.
Scroll to the bottom to see the following:
![templates](https://cloud.githubusercontent.com/assets/368084/24642242/c7bfa530-18ba-11e7-8d03-b655d8581721.jpg)
