### PR TITLE
Create Article menu [regression]

### DIFF
--- a/components/com_content/views/form/tmpl/edit.xml
+++ b/components/com_content/views/form/tmpl/edit.xml
@@ -28,7 +28,6 @@
 				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
 				description="JGLOBAL_CHOOSE_CATEGORY_DESC"
 				extension="com_content"
-				required="true"
 				select="true"
 				new="true"
 				edit="true"


### PR DESCRIPTION
Pull Request for Issue #15083 .


This PR fixes a mistake I made in #14639 when I added the ability to create a category on the fly and mistakenly also made the category a required field. 

This PR removes that requirement. If a category is not selected then the user can save the article in any category
If a category is selected then the user can only save the article in the selected category
