### PR TITLE
Fix PHP notices in hathor with new menu items

### DIFF
--- a/administrator/templates/hathor/html/com_menus/item/edit.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit.php
@@ -72,11 +72,17 @@ Joomla.submitbutton = function(task, type){
 // Add the script to the document head.
 JFactory::getDocument()->addScriptDeclaration($script);
 
+// In case of modal
+$input = JFactory::getApplication()->input;
+$isModal  = $input->get('layout') == 'modal' ? true : false;
+$layout   = $isModal ? 'modal' : 'edit';
+$tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+$clientId = $this->state->get('item.client_id', 0);
 ?>
 
 <div class="menuitem-edit">
 
-<form action="<?php echo JRoute::_('index.php?option=com_menus&layout=edit&id='.(int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
+<form action="<?php echo JRoute::_('index.php?option=com_menus&view=item&client_id=' . $clientId . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="item-form" class="form-validate">
 
 <div class="col main-section">
 	<fieldset class="adminform">
@@ -143,7 +149,10 @@ JFactory::getDocument()->addScriptDeclaration($script);
 
 				<li><?php echo $this->form->getLabel('id'); ?>
 				<?php echo $this->form->getInput('id'); ?></li>
-		</ul>
+
+                <li><?php echo $this->form->getLabel('client_id'); ?>
+					<?php echo $this->form->getInput('client_id'); ?></li>
+            </ul>
 
 	</fieldset>
 </div>

--- a/administrator/templates/hathor/html/com_menus/item/edit_options.php
+++ b/administrator/templates/hathor/html/com_menus/item/edit_options.php
@@ -64,7 +64,7 @@ $assoc = JLanguageAssociations::isEnabled();
 		</fieldset>
 	<?php endforeach;?>
 
-	<?php if ($assoc) : ?>
+	<?php if ($assoc && $this->state->get('item.client_id') != 1) : ?>
 		<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_ASSOCIATIONS'), '-options');?>
 		<?php echo $this->loadTemplate('associations'); ?>
 	<?php endif; ?>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -63,7 +63,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
             		<label class="selectlabel" for="filter_published">
 				<?php echo JText::_('JOPTION_SELECT_PUBLISHED'); ?>
 			</label>
-			<select name="filter_published" id="filter_published">
+			<select name="filter[published]" id="filter_published">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_PUBLISHED');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('jgrid.publishedOptions', array('archived' => false)), 'value', 'text', $this->state->get('filter.published'), true);?>
 			</select>
@@ -71,7 +71,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
             		<label class="selectlabel" for="filter_access">
 				<?php echo JText::_('JOPTION_SELECT_ACCESS'); ?>
 			</label>
-			<select name="filter_access" id="filter_access">
+			<select name="filter[access]" id="filter_access">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_ACCESS');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('access.assetgroups'), 'value', 'text', $this->state->get('filter.access'));?>
 			</select>
@@ -79,7 +79,7 @@ $assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.cli
 			<label class="selectlabel" for="filter_language">
 				<?php echo JText::_('JOPTION_SELECT_LANGUAGE'); ?>
 			</label>
-			<select name="filter_language" id="filter_language">
+			<select name="filter[language]" id="filter_language">
 				<option value=""><?php echo JText::_('JOPTION_SELECT_LANGUAGE');?></option>
 				<?php echo JHtml::_('select.options', JHtml::_('contentlanguage.existing', true, true), 'value', 'text', $this->state->get('filter.language'));?>
 			</select>

--- a/administrator/templates/hathor/html/com_menus/items/default.php
+++ b/administrator/templates/hathor/html/com_menus/items/default.php
@@ -23,7 +23,7 @@ $ordering  = ($listOrder == 'a.lft');
 $canOrder  = $user->authorise('core.edit.state', 'com_menus');
 $saveOrder = ($listOrder == 'a.lft' && $listDirn == 'asc');
 $menutypeid	= (int) $this->state->get('menutypeid');
-$assoc     = JLanguageAssociations::isEnabled();
+$assoc     = JLanguageAssociations::isEnabled() && $this->state->get('filter.client_id') == 0;;
 ?>
 
 <?php // Set up the filter bar. ?>
@@ -151,7 +151,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 					<?php if ($item->checked_out) : ?>
 						<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'items.', $canCheckin); ?>
 					<?php endif; ?>
-					<?php if ($canEdit) : ?>
+					<?php if ($canEdit && !$item->protected) : ?>
 						<a href="<?php echo JRoute::_('index.php?option=com_menus&task=item.edit&id='.(int) $item->id);?>">
 							<?php echo $this->escape($item->title); ?></a>
 					<?php else : ?>
@@ -195,7 +195,7 @@ $assoc     = JLanguageAssociations::isEnabled();
 				<td class="center">
 					<?php if ($item->type == 'component') : ?>
 						<?php if ($item->language == '*' || $item->home == '0'):?>
-							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange);?>
+							<?php echo JHtml::_('jgrid.isdefault', $item->home, $i, 'items.', ($item->language != '*' || !$item->home) && $canChange  && !$item->protected);?>
 						<?php elseif ($canChange):?>
 							<a href="<?php echo JRoute::_('index.php?option=com_menus&task=items.unsetDefault&cid[]='.$item->id.'&'.JSession::getFormToken().'=1'); ?>">
 								<?php if ($item->language_image) : ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/15079#issuecomment-291426073 .

### Summary of Changes
JM mentioned creating a menu item in hathor and then switching back to ISIS gave a PHP Notice. This should patch that case (note I couldn't reproduce so I'm not 100%)

Note this does not 'fix' adding admin menu items to hathor. it just fixes the bug about creating the site ones

### Testing Instructions
Check menu is created in hathor without warnings. Swap to isis and see no warnings

### Expected result
It all works

### Actual result
`Fatal error: Cannot use object of type stdClass as array in /administrator/components/com_menus/models/item.php on line 603`

### Documentation Changes Required
None