### PR TITLE
Change minutes to seconds

### DIFF
--- a/libraries/vendor/joomla/session/src/SessionInterface.php
+++ b/libraries/vendor/joomla/session/src/SessionInterface.php
@@ -16,9 +16,9 @@ namespace Joomla\Session;
 interface SessionInterface extends \IteratorAggregate
 {
 	/**
-	 * Get expiration time in minutes
+	 * Get expiration time in seconds
 	 *
-	 * @return  integer  The session expiration time in minutes
+	 * @return  integer  The session expiration time in seconds
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */


### PR DESCRIPTION
### Summary of Changes

The Session Interface has a wrong session expiration unit. Expiration/life time should be in seconds instead of minutes.

see https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/joomla/factory.php#L621
and https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/vendor/joomla/session/src/Session.php#L43

