### PR TITLE
[4.0] Bugifx/fix keepalive

### DIFF
--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -416,23 +416,23 @@ JS
 		}
 
 		$app            = JFactory::getApplication();
-        $session        = $app->getSession();
-        $sessionHandler = $app->get('session_handler', 'database');
+		$session        = $app->getSession();
+		$sessionHandler = $app->get('session_handler', 'database');
 
-        // If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
-        $refreshTime = 300;
+		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
+		$refreshTime = 300;
 
-        if ($sessionHandler === 'database')
-        {
-            $lifeTime    = $session->getExpire();
-            $refreshTime = $lifeTime <= 60 ? 45 : $lifeTime - 60;
+		if ($sessionHandler === 'database')
+		{
+			$lifeTime    = $session->getExpire();
+			$refreshTime = $lifeTime <= 60 ? 45 : $lifeTime - 60;
 
-            // The longest refresh period is one hour to prevent integer overflow.
-            if ($refreshTime > 3600 || $refreshTime <= 0)
-            {
-                $refreshTime = 3600;
-            }
-        }
+			// The longest refresh period is one hour to prevent integer overflow.
+			if ($refreshTime > 3600 || $refreshTime <= 0)
+			{
+				$refreshTime = 3600;
+			}
+		}
 
 		// If we are in the frontend or logged in as a user, we can use the ajax component to reduce the load
 		$uri = 'index.php' . ($app->isClient('site') || !JFactory::getUser()->guest ? '?option=com_ajax&format=json' : '');
@@ -441,7 +441,8 @@ JS
 		static::core();
 
 		// Add keepalive script options.
-		JFactory::getDocument()->addScriptOptions('system.keepalive', array('interval' => $refreshTime * 1000, 'uri' => JRoute::_($uri)));
+		JFactory::getDocument()->addScriptOptions('system.keepalive',
+			array('interval' => $refreshTime * 1000, 'uri' => JRoute::_($uri)));
 
 		// Add script.
 		JHtml::_('script', 'system/keepalive.js', array('version' => 'auto', 'relative' => true));

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -440,8 +440,11 @@ JS
 		static::core();
 
 		// Add keepalive script options.
-		JFactory::getDocument()->addScriptOptions('system.keepalive',
-			array('interval' => $refreshTime * 1000, 'uri' => JRoute::_($uri)));
+		$options = array(
+			'interval' => $refreshTime * 1000,
+			'uri'      => JRoute::_($uri),
+		);
+		JFactory::getDocument()->addScriptOptions('system.keepalive', $options);
 
 		// Add script.
 		JHtml::_('script', 'system/keepalive.js', array('version' => 'auto', 'relative' => true));

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -415,29 +415,29 @@ JS
 			return;
 		}
 
-		$app = JFactory::getApplication();
+		$app            = JFactory::getApplication();
+        $session        = $app->getSession();
+        $sessionHandler = $app->get('session_handler', 'database');
 
-		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
-		if ($app->get('session_handler', 'filesystem') != 'database')
-		{
-			$refreshTime = 300000;
-		}
-		else
-		{
-			$life_time   = $app->getSession()->getExpire() * 1000;
-			$refreshTime = ($life_time <= 60000) ? 45000 : $life_time - 60000;
+        // If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
+        $refreshTime = 300;
 
-			// The longest refresh period is one hour to prevent integer overflow.
-			if ($refreshTime > 3600 || $refreshTime <= 0)
-			{
-				$refreshTime = 3600;
-			}
-		}
+        if ($sessionHandler === 'database')
+        {
+            $lifeTime    = $session->getExpire();
+            $refreshTime = $lifeTime <= 60 ? 45 : $lifeTime - 60;
+
+            // The longest refresh period is one hour to prevent integer overflow.
+            if ($refreshTime > 3600 || $refreshTime <= 0)
+            {
+                $refreshTime = 3600;
+            }
+        }
 
 		// If we are in the frontend or logged in as a user, we can use the ajax component to reduce the load
-		$uri = 'index.php' . (JFactory::getApplication()->isClient('site') || !JFactory::getUser()->guest ? '?option=com_ajax&format=json' : '');
+		$uri = 'index.php' . ($app->isClient('site') || !JFactory::getUser()->guest ? '?option=com_ajax&format=json' : '');
 
-		// Include core and polyfill for browsers lower than IE 9.
+		// Include core
 		static::core();
 
 		// Add keepalive script options.

--- a/libraries/cms/html/behavior.php
+++ b/libraries/cms/html/behavior.php
@@ -416,7 +416,6 @@ JS
 		}
 
 		$app            = JFactory::getApplication();
-		$session        = $app->getSession();
 		$sessionHandler = $app->get('session_handler', 'database');
 
 		// If the handler is not 'Database', we set a fixed, small refresh value (here: 5 min)
@@ -424,7 +423,7 @@ JS
 
 		if ($sessionHandler === 'database')
 		{
-			$lifeTime    = $session->getExpire();
+			$lifeTime    = $app->getSession()->getExpire();
 			$refreshTime = $lifeTime <= 60 ? 45 : $lifeTime - 60;
 
 			// The longest refresh period is one hour to prevent integer overflow.


### PR DESCRIPTION
### Summary of Changes

This PR fixes behaviour.keepalive.
behaviour.keepalive is not working (when using default db session handler) in current 4.0dev branch.
Users get logged out before keep alive request is fired.

### Testing Instructions

Go to global configuration => System tab
Make sure you use "database" as session handler
Set session lifetime to 1 (minute)
Reload page
Wait 45 seconds.

### Expected result

The keep alive ajax request should fire every 45 seconds to keep the user logged in.
(Please open dev tools network tab to (not) see the requests)

### Actual result

Keepalive request is not fired.
The refresh time of the interval  is wrong. The user gets logged out before the request is fired. 

fyi: currently the session cookie does not get updated at all. So you will get logged out after cookie expiration anyway, but that is out of the scope of this pr and needs to be fixed by another one.

