### PR TITLE
Suppress empty class attribute in permissions

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -252,10 +252,10 @@ class JFormFieldRules extends JFormField
 
 			if ((int) $group->value === 1)
 			{
-				$active = 'active';
+				$active = ' class="active"';
 			}
 
-			$html[] = '<li class="' . $active . '">';
+			$html[] = '<li' . $active . '>';
 			$html[] = '<a href="#permission-' . $group->value . '" data-toggle="tab">';
 			$html[] = JLayoutHelper::render('joomla.html.treeprefix', array('level' => $group->level + 1)) . $group->text;
 			$html[] = '</a>';

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -248,12 +248,7 @@ class JFormFieldRules extends JFormField
 		foreach ($groups as $group)
 		{
 			// Initial Active Tab
-			$active = '';
-
-			if ((int) $group->value === 1)
-			{
-				$active = ' class="active"';
-			}
+			$active = (int) $group->value === 1 ? ' class="active"' : '';
 
 			$html[] = '<li' . $active . '>';
 			$html[] = '<a href="#permission-' . $group->value . '" data-toggle="tab">';
@@ -270,12 +265,7 @@ class JFormFieldRules extends JFormField
 		foreach ($groups as $group)
 		{
 			// Initial Active Pane
-			$active = '';
-
-			if ((int) $group->value === 1)
-			{
-				$active = ' active';
-			}
+			$active = (int) $group->value === 1 ? ' active' : '';
 
 			$html[] = '<div class="tab-pane' . $active . '" id="permission-' . $group->value . '">';
 			$html[] = '<table class="table table-striped">';


### PR DESCRIPTION
### Summary of Changes
Don't output empty class attribute.

### Testing Instructions
Edit an article.
Click on Permissions tab.
View page source.

**Before:**

![emptyclass](https://cloud.githubusercontent.com/assets/368084/24731916/2fc2b718-1a22-11e7-80b1-81646b794856.jpg)

**After:**

![fixedclass](https://cloud.githubusercontent.com/assets/368084/24731919/347e1522-1a22-11e7-9d61-e4894a829d5a.jpg)