### PR TITLE
Add IE11+ and Edge browser matching

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -234,7 +234,7 @@ class JBrowser
 			{
 				$this->mobile = true;
 			}
-			// We have to check for Edge as the first browser, because Edge has somethink like:
+			// We have to check for Edge as the first browser, because Edge has something like:
 			// Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393
 			elseif (preg_match('|Edge/([0-9.]+)|', $this->agent, $version))
 			{

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -234,6 +234,31 @@ class JBrowser
 			{
 				$this->mobile = true;
 			}
+			// We have to check for Edge as the first browser, because Edge has somethink like:
+			// Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393
+			elseif (preg_match('|Edge/([0-9.]+)|', $this->agent, $version))
+			{
+				$this->setBrowser('edge');
+
+				if (strpos($version[1], '.') !== false)
+				{
+					list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+				}
+				else
+				{
+					$this->majorVersion = $version[1];
+					$this->minorVersion = 0;
+				}
+
+				/* Some Handhelds have their screen resolution in the
+				 * user agent string, which we can use to look for
+				 * mobile agents.
+				 */
+				if (preg_match('/; (120x160|240x280|240x320|320x320)\)/', $this->agent))
+				{
+					$this->mobile = true;
+				}
+			}
 			elseif (preg_match('|Opera[/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('opera');
@@ -276,9 +301,16 @@ class JBrowser
 				$this->setBrowser('palm');
 				$this->mobile = true;
 			}
-			elseif ((preg_match('|MSIE ([0-9.]+)|', $this->agent, $version)) || (preg_match('|Internet Explorer/([0-9.]+)|', $this->agent, $version)))
+			elseif ((preg_match('|MSIE ([0-9.]+)|', $this->agent, $version)) || (preg_match('|Internet Explorer/([0-9.]+)|', $this->agent, $version))
+					|| (preg_match('|Trident/([0-9.]+)|', $this->agent, $version)))
 			{
 				$this->setBrowser('msie');
+
+				// Special case for IE 11+
+				if (strpos($version[0], 'Trident') !== false && (preg_match('|rv:([0-9.]+)|', $this->agent, $version)))
+				{
+					list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+				}
 
 				if (strpos($version[1], '.') !== false)
 				{

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -307,9 +307,9 @@ class JBrowser
 				$this->setBrowser('msie');
 
 				// Special case for IE 11+
-				if (strpos($version[0], 'Trident') !== false && (preg_match('|rv:([0-9.]+)|', $this->agent, $version)))
+				if (strpos($version[0], 'Trident') !== false && strpos($version[0], 'rv:') !== false)
 				{
-					list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+					preg_match('|rv:([0-9.]+)|', $this->agent, $version);
 				}
 
 				if (strpos($version[1], '.') !== false)


### PR DESCRIPTION
### Summary of Changes
At the moment IE11+ and Edge will not recognized correctly, because Microsoft delivers "strange" user agents (see: https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx)

With this fix, Edge and IE11 will be regognized correctly


### Testing Instructions
The most common case, where a browser check will be used is while loading CSS/JS files.

So go to libraries/cms/html/html.php line 334 and add ```print_r($potential);```

```
else
{
	$potential = array($strip);
}
print_r($potential);
// If relative search in template directory or media directory
if ($relative)
{
```

If you go to your Joomla! page, you'll see that Joomla! tries to load different browser dependend CSS/JS files with the format ```filename_browsername_majorversion_minorversion``` (i.e. ```mozilla_5_0```).

### Expected result
If you browse with IE11 or Edge, Joomla! should recognize this browsers


### Actual result
IE11 will be recognized as Mozilla, Edge as Chrome.

Now apply patch and the correct versions should be displayed.
