### PR TITLE
Fix drag n drop install message issue for #15119

### DIFF
--- a/administrator/components/com_installer/controllers/install.php
+++ b/administrator/components/com_installer/controllers/install.php
@@ -19,7 +19,7 @@ class InstallerControllerInstall extends JControllerLegacy
 	/**
 	 * Install an extension.
 	 *
-	 * @return  void
+	 * @return  boolean
 	 *
 	 * @since   1.5
 	 */
@@ -30,7 +30,7 @@ class InstallerControllerInstall extends JControllerLegacy
 
 		$model = $this->getModel('install');
 
-		if ($model->install())
+		if ($result = $model->install())
 		{
 			$cache = JFactory::getCache('mod_menu');
 			$cache->clean();
@@ -65,6 +65,8 @@ class InstallerControllerInstall extends JControllerLegacy
 		}
 
 		$this->setRedirect($redirect_url);
+
+		return $result;
 	}
 
 	/**
@@ -76,14 +78,21 @@ class InstallerControllerInstall extends JControllerLegacy
 	 */
 	public function ajax_upload()
 	{
-		$this->install();
-
 		$app = JFactory::getApplication();
+		$message = $app->getUserState('com_installer.message');
+
+		// Do install
+		$result = $this->install();
+
+		// Get redirect URL
 		$redirect = $this->redirect;
+
+		// Push message queue to session because will will redirect page by JS, not $app->redirect().
+		$app->getSession()->set('application.queue', $app->getMessageQueue());
 
 		header('Content-Type: application/json');
 
-		echo new JResponseJson(array('redirect' => $redirect), $app->getUserState('com_installer.message'));
+		echo new JResponseJson(array('redirect' => $redirect), $message, !$result);
 
 		exit();
 	}

--- a/administrator/components/com_installer/controllers/install.php
+++ b/administrator/components/com_installer/controllers/install.php
@@ -87,7 +87,8 @@ class InstallerControllerInstall extends JControllerLegacy
 		// Get redirect URL
 		$redirect = $this->redirect;
 
-		// Push message queue to session because will will redirect page by JS, not $app->redirect().
+		// Push message queue to session because we will redirect page by Javascript, not $app->redirect().
+		// The "application.queue" is only set in redirect() method, so we must manually store it.
 		$app->getSession()->set('application.queue', $app->getMessageQueue());
 
 		header('Content-Type: application/json');

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -126,10 +126,10 @@ JFactory::getDocument()->addScriptDeclaration(
 
 				// Always redirect that can show message queue from session 
 				if (res.data.redirect) {
-                    location.href = res.data.redirect;
-                } else {
-                    location.href = 'index.php?option=com_installer&view=install';
-                }
+					location.href = res.data.redirect;
+				} else {
+					location.href = 'index.php?option=com_installer&view=install';
+				}
 			}).error (function (error) {
 				JoomlaInstaller.hideLoading();
 				alert(error.statusText);

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -120,16 +120,16 @@ JFactory::getDocument()->addScriptDeclaration(
 				cache: false,
 				contentType: false
 			}).done(function (res) {
-				if (res.success) {
-					if (res.data.redirect) {
-						location.href = res.data.redirect;
-					} else {
-						location.href = 'index.php?option=com_installer&view=install';
-					}
-				} else {
-					JoomlaInstaller.hideLoading();
-					alert(res.message);
+				if (!res.success) {
+					console.log(res.message, res.messages);
 				}
+
+				// Always redirect that can show message queue from session 
+				if (res.data.redirect) {
+                    location.href = res.data.redirect;
+                } else {
+                    location.href = 'index.php?option=com_installer&view=install';
+                }
 			}).error (function (error) {
 				JoomlaInstaller.hideLoading();
 				alert(error.statusText);


### PR DESCRIPTION
Pull Request for Issue #15119 .

### Summary of Changes

Fix no message issue after drag and drop extension installation.

### Testing Instructions

Go to extension installer, drag and drop an extension to install.

### Before PR

No flash message, only extension message.

### After PR

A green alert message will appear.

![p-2017-04-06-001](https://cloud.githubusercontent.com/assets/1639206/24763103/f72844b6-1b22-11e7-9ed8-7ed4d165b12f.jpg)

