### PR TITLE
[com_banners] Change class of the Unlimited checkbox

### DIFF
--- a/administrator/components/com_banners/models/fields/imptotal.php
+++ b/administrator/components/com_banners/models/fields/imptotal.php
@@ -43,7 +43,7 @@ class JFormFieldImpTotal extends JFormField
 
 		return '<input type="text" name="' . $this->name . '" id="' . $this->id . '" size="9" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8')
 			. '" ' . $class . $onchange . ' />'
-			. '<fieldset class="checkboxes impunlimited"><input id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . ' />'
+			. '<fieldset class="checkbox impunlimited"><input id="' . $this->id . '_unlimited" type="checkbox"' . $checked . $onclick . ' />'
 			. '<label for="' . $this->id . '_unlimited" id="jform-imp" type="text">' . JText::_('COM_BANNERS_UNLIMITED') . '</label></fieldset>';
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Change to `.checkbox` to add padding to the Unlimited checkbox.

This does not affect Hathor since the `Banner Details` tab which this checkbox resides is not available/accessible with this style.

### Testing Instructions
Edit a banner.
Click `Banner Details` tab.
View `Max. Impressions` field.

### Expected result
![unlimited-fixed](https://cloud.githubusercontent.com/assets/368084/24780449/499f5ba8-1aec-11e7-8127-e17a662b0f99.jpg)

### Actual result
![banner-unlimited](https://cloud.githubusercontent.com/assets/368084/24780468/7a6977fa-1aec-11e7-9b3c-ecbd58d0a0b3.jpg)
