### PR TITLE
Fix Undefined index: assetgroup_id & language_id and batch move to child of self error message

### DIFF
--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -160,7 +160,7 @@ class JObject
 		// Check if only the string is requested
 		if ($error instanceof Exception && $toString)
 		{
-			return (string) $error;
+			return $error->getMessage();
 		}
 
 		return $error;

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -344,7 +344,7 @@ class JTableNested extends JTable
 		{
 			$this->setError(
 				new UnexpectedValueException(
-					sprintf('%1%ss::moveByReference() is trying to make record ID %2$d a child of itself.', get_class($this), $pk)
+					sprintf('%1$s::moveByReference() is trying to make record ID %2$d a child of itself.', get_class($this), $pk)
 				)
 			);
 

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -255,7 +255,7 @@ abstract class JModelAdmin extends JModelForm
 
 		foreach ($this->batch_commands as $identifier => $command)
 		{
-			if (strlen($commands[$identifier]) > 0)
+			if (!empty($commands[$identifier]))
 			{
 				if (!$this->$command($commands[$identifier], $pks, $contexts))
 				{

--- a/tests/unit/suites/libraries/joomla/object/JObjectTest.php
+++ b/tests/unit/suites/libraries/joomla/object/JObjectTest.php
@@ -171,7 +171,7 @@ class JObjectTest extends \PHPUnit\Framework\TestCase
 		$this->o->setError($exception);
 		$this->assertThat(
 			$this->o->getError(3, true),
-			$this->equalTo((string) $exception)
+			$this->equalTo('error')
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #15132.

### Summary of Changes
Fix move to child error message. 
`JObject` was converting exception to string by casting instead of calling `getMessage` on `Exception` object. 
Fixed batch move error message when moving to child of self in menu manager, fields, categories.

### Testing Instructions
See #15132


### Documentation Changes Required
None