### PR TITLE
Fix wrong parameter ordering in controller contructor

### DIFF
--- a/libraries/src/CMS/Controller/Controller.php
+++ b/libraries/src/CMS/Controller/Controller.php
@@ -330,11 +330,10 @@ class Controller implements ControllerInterface
 		}
 		else
 		{
-			self::$instance = new $class($config, $app, $input);
+			self::$instance = new $class($config, null, $app, $input);
 		}
 
-		// Instantiate the class, store it to the static container, and return it
-		return self::$instance = new $class($config, $app, $input);
+		return self::$instance;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Joomla 4 is now broken because wrong parameter ordering in constructor

### Testing Instructions
Code review. Ping @wilsonge 