### PR TITLE
Support readonly editors

### DIFF
--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -19,6 +19,7 @@ $data = $displayData;
 	rows="<?php echo $data->rows; ?>"
 	style="width: <?php echo $data->width; ?>; height: <?php echo $data->height; ?>;"
 	class="<?php echo empty($data->class) ? 'mce_editable' : $data->class; ?>"
+	<?php echo $data->readonly ? ' readonly disabled' : ''; ?>
 >
 	<?php echo $data->content; ?>
 </textarea>

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -315,6 +315,9 @@ class JEditor extends JObject
 		$args['row'] = $row;
 		$args['buttons'] = $buttons;
 		$args['id'] = $id ?: $name;
+		$args['asset'] = $asset;
+		$args['author'] = $author;
+		$args['params'] = $params;
 		$args['event'] = 'onDisplay';
 
 		$results[] = $this->_editor->update($args);

--- a/libraries/cms/form/field/editor.php
+++ b/libraries/cms/form/field/editor.php
@@ -241,11 +241,12 @@ class JFormFieldEditor extends JFormFieldTextarea
 	{
 		// Get an editor object.
 		$editor = $this->getEditor();
+		$readonly = $this->readonly || $this->disabled;
 
 		return $editor->display(
 			$this->name, htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8'), $this->width, $this->height, $this->columns, $this->rows,
 			$this->buttons ? (is_array($this->buttons) ? array_merge($this->buttons, $this->hide) : $this->hide) : false, $this->id, $this->asset,
-			$this->form->getValue($this->authorField), array('syntax' => (string) $this->element['syntax'])
+			$this->form->getValue($this->authorField), array('syntax' => (string) $this->element['syntax'], 'readonly' => $readonly)
 		);
 	}
 

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -196,6 +196,12 @@ class PlgEditorCodemirror extends JPlugin
 		// Options for the CodeMirror constructor.
 		$options = new stdClass;
 
+		// Is field readonly?
+		if (!empty($params['readonly']))
+		{
+			$options->readOnly = 'nocursor';
+		}
+
 		// Should we focus on the editor on load?
 		$options->autofocus = (boolean) $this->params->get('autoFocus', true);
 

--- a/plugins/editors/none/none.php
+++ b/plugins/editors/none/none.php
@@ -122,9 +122,11 @@ class PlgEditorNone extends JPlugin
 			$height .= 'px';
 		}
 
+		$readonly = !empty($params['readonly']) ? ' readonly disabled' : '';
+
 		$editor = '<div class="js-editor-none">'
 			. '<textarea name="' . $name . '" id="' . $id . '" cols="' . $col . '" rows="' . $row
-			. '" style="width: ' . $width . '; height: ' . $height . ';">' . $content . '</textarea>'
+			. '" style="width: ' . $width . '; height: ' . $height . ';"' . $readonly . '>' . $content . '</textarea>'
 			. $this->_displayButtons($id, $buttons, $asset, $author)
 			. '</div>';
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -204,6 +204,12 @@ class PlgEditorTinymce extends JPlugin
 				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', array('version' => 'auto', 'relative' => true), array('defer' => 'defer'));
 			}
 
+			// Set editor to readonly mode
+			if (!empty($params['readonly']))
+			{
+				$options['tinyMCE'][$fieldName]['readonly'] = 1;
+			}
+
 			$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
 			$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
 
@@ -672,12 +678,6 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['force_br_newlines'] = false;
 			$scriptOptions['force_p_newlines']  = true;
 			$scriptOptions['forced_root_block'] = 'p';
-		}
-
-		// Set editor to readonly mode
-		if (!empty($params['readonly']))
-		{
-			$scriptOptions['readonly'] = 1;
 		}
 
 		$scriptOptions['rel_list'] = array(

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -133,7 +133,7 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @return  string
 	 */
-	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
+	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
 	{
 		$app = JFactory::getApplication();
 
@@ -161,6 +161,13 @@ class PlgEditorTinymce extends JPlugin
 		$nameGroup     = explode('[', preg_replace('/\[\]|\]/', '', $name));
 		$fieldName     = end($nameGroup);
 		$scriptOptions = array();
+
+		// Set editor to readonly mode
+		if (!empty($params['readonly']))
+		{
+			// Do something funny here to put TinyMCE into readonly mode.
+			// Joomla.editors.instances['article_text'].instance.setMode('readonly');
+		}
 
 		// Check for existing options
 		$doc     = JFactory::getDocument();

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -188,6 +188,9 @@ class PlgEditorTinymce extends JPlugin
 		$textarea->height  = $height;
 		$textarea->content = $content;
 
+		// Set editor to readonly mode
+		$textarea->readonly = !empty($params['readonly']);
+
 		// Render Editor markup
 		$editor = '<div class="js-editor-tinymce">';
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -130,10 +130,12 @@ class PlgEditorTinymce extends JPlugin
 	 * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
 	 * @param   string   $asset    The object asset
 	 * @param   object   $author   The author.
+	 * @param   array    $params   Associative array of editor parameters.
 	 *
 	 * @return  string
 	 */
-	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
+	public function onDisplay(
+		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
 	{
 		$app = JFactory::getApplication();
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -162,13 +162,6 @@ class PlgEditorTinymce extends JPlugin
 		$fieldName     = end($nameGroup);
 		$scriptOptions = array();
 
-		// Set editor to readonly mode
-		if (!empty($params['readonly']))
-		{
-			// Do something funny here to put TinyMCE into readonly mode.
-			// Joomla.editors.instances['article_text'].instance.setMode('readonly');
-		}
-
 		// Check for existing options
 		$doc     = JFactory::getDocument();
 		$options = $doc->getScriptOptions('plg_editor_tinymce');
@@ -679,6 +672,12 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['force_br_newlines'] = false;
 			$scriptOptions['force_p_newlines']  = true;
 			$scriptOptions['forced_root_block'] = 'p';
+		}
+
+		// Set editor to readonly mode
+		if (!empty($params['readonly']))
+		{
+			$scriptOptions['readonly'] = 1;
 		}
 
 		$scriptOptions['rel_list'] = array(


### PR DESCRIPTION
Pull Request for Issue #13665 .

### Summary of Changes
This PR adds support for readonly/disabled editors


### Testing Instructions
* Create a new custom field of the type "editor" and either set the permission so it is not editable (that's the case by default in the contact form) or enabled readonly or disabled in the field options
* Check the item where the field appears
* Test with all three core editors (TinyMCE, Codemirror, None)

Another test:
* Edit the editor formfield spec in a form XML and add a `readonly="true"` attribute to it. Eg edit /administrator/models/forms/article.xml and change
````
<field 
	name="articletext"
	type="editor"
	label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
	description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
	filter="JComponentHelper::filterText"
	buttons="true"
/>
````
to
````
<field
	name="articletext"
	type="editor"
	label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
	description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
	filter="JComponentHelper::filterText"
	buttons="true"
	readonly="true"
/>
````
* Check the item

### Expected result
Editor should be readonly/disabled.


### Actual result
You can edit the content fine.


### Documentation Changes Required
https://docs.joomla.org/Editor_form_field_type can now have added attributes "readonly" and "disabled" (they both do the same thing here).