### PR TITLE
delete unused language string for custom field editor - option hide buttons

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_editor.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_editor.ini
@@ -5,7 +5,6 @@
 
 PLG_FIELDS_EDITOR="Fields - Editor"
 PLG_FIELDS_EDITOR_LABEL="Editor (%s)"
-PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_DESC="Comma separated list of editors-xtd plugin buttons to be hidden."
 PLG_FIELDS_EDITOR_PARAMS_BUTTONS_HIDE_LABEL="Hide Buttons"
 PLG_FIELDS_EDITOR_PARAMS_FILTER_DESC="Allow the system to save certain html tags or raw data."
 PLG_FIELDS_EDITOR_PARAMS_FILTER_LABEL="Filter"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15159

### Summary of Changes
I only deleted a language string. This language string is unused, if the pr https://github.com/joomla/joomla-cms/pull/15164 will bee merged.

