### PR TITLE
[com_fields] mysql for fields_categories missing IF NOT EXISTS

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2016-08-29.sql
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   KEY `idx_language` (`language`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE `#__fields_categories` (
+CREATE TABLE IF NOT EXISTS `#__fields_categories` (
   `field_id` int(11) NOT NULL DEFAULT 0,
   `category_id` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`field_id`,`category_id`)

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -693,7 +693,7 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
 -- Table structure for table `#__fields_categories`
 --
 
-CREATE TABLE `#__fields_categories` (
+CREATE TABLE IF NOT EXISTS `#__fields_categories` (
   `field_id` int(11) NOT NULL DEFAULT 0,
   `category_id` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`field_id`,`category_id`)


### PR DESCRIPTION
As title says: when creating the new fields_categories table, the query does not contain `IF NOT EXISTS`

### Summary of Changes
Can be merged on review

Note: I did not change anyhting for postgres or azure as I have no idea about the equivalent, if there is one.

@rdeutz @wilsonge @alikon 