### PR TITLE
Implement stats debug modus using contstants

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_stats.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_stats.ini
@@ -7,6 +7,7 @@ PLG_SYSTEM_STATS="System - Joomla! Statistics"
 PLG_SYSTEM_STATS_BTN_NEVER_SEND="Never"
 PLG_SYSTEM_STATS_BTN_SEND_ALWAYS="Always"
 PLG_SYSTEM_STATS_BTN_SEND_NOW="Once"
+; The following two strings are deprecated for 4.0
 PLG_SYSTEM_STATS_DEBUG_DESC="Enable debug for testing purposes. Statistics will be sent on every page load."
 PLG_SYSTEM_STATS_DEBUG_LABEL="Debug"
 PLG_SYSTEM_STATS_INTERVAL_DESC="Statistics will be sent every X hours. The default is 12."

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-// Uncomment the following line to enable debug mode (update notification email sent every single time)
+// Uncomment the following line to enable debug mode for testing purposes. Note statistics will be sent on every page load.
 // define('PLG_SYSTEM_STATS_DEBUG', 1);
 
 /**

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+// Uncomment the following line to enable debug mode (update notification email sent every single time)
+// define('PLG_SYSTEM_STATS_DEBUG', 1);
+
 /**
  * Statistics system plugin. This sends anonymous data back to the Joomla! Project about the
  * PHP, SQL, Joomla and OS versions
@@ -363,7 +366,7 @@ class PlgSystemStats extends JPlugin
 	 */
 	private function isDebugEnabled()
 	{
-		return ((int) $this->params->get('debug', 0) === 1);
+		return defined('PLG_SYSTEM_STATS_DEBUG');
 	}
 
 	/**

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-// Uncomment the following line to enable debug mode for testing purposes. Note: statistics will be sent on every page load.
+// Uncomment the following line to enable debug mode for testing purposes. Note: statistics will be sent on every page load
 // define('PLG_SYSTEM_STATS_DEBUG', 1);
 
 /**

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-// Uncomment the following line to enable debug mode for testing purposes. Note statistics will be sent on every page load.
+// Uncomment the following line to enable debug mode for testing purposes. Note: statistics will be sent on every page load.
 // define('PLG_SYSTEM_STATS_DEBUG', 1);
 
 /**

--- a/plugins/system/stats/stats.xml
+++ b/plugins/system/stats/stats.xml
@@ -50,7 +50,7 @@
 					description="PLG_SYSTEM_STATS_MODE_DESC"
 					label="PLG_SYSTEM_STATS_MODE_LABEL"
 					default="1"
-					>
+				>
 					<option value="1">PLG_SYSTEM_STATS_MODE_OPTION_ALWAYS_SEND</option>
 					<option value="2">PLG_SYSTEM_STATS_MODE_OPTION_ON_DEMAND</option>
 					<option value="3">PLG_SYSTEM_STATS_MODE_OPTION_NEVER_SEND</option>
@@ -62,19 +62,6 @@
 					default="0"
 					size="15"
 				/>
-			</fieldset>
-			<fieldset name="advanced">
-				<field
-					name="debug"
-					type="radio"
-					label="PLG_SYSTEM_STATS_DEBUG_LABEL"
-					description="PLG_SYSTEM_STATS_DEBUG_DESC"
-					class="btn-group btn-group-yesno"
-					default="0"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
 			</fieldset>
 		</fields>
 	</config>


### PR DESCRIPTION
Pull Request for Issue #14634

### Summary of Changes

implement debug modus using contstants cc @brianteeman It took longer that expected sorry for that :( see: https://github.com/joomla/joomla-cms/pull/14634
### Testing Instructions

- apply this patch
- confirm the GUI debug option is gone (Plugin settings advanced tab is gone)
- go to the stats file
- uncomment the line
- confirm the method `isDebugEnabled()` return true.

### Expected result

Works, without GUI option

### Actual result

Works, just with the GUI option

### Documentation Changes Required

None.