### PR TITLE
[com_content] - add categories filter to archived view

### DIFF
--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -127,7 +127,7 @@ class ContentModelArchive extends ContentModelArticles
 
 		if (count($catids)>0)
 		{
-			$query->where('c.id IN (' .  implode($catids, ', ') . ')');
+			$query->where('c.id IN (' . implode($catids, ', ') . ')');
 		}
 
 		return $query;

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -81,8 +81,10 @@ class ContentModelArchive extends ContentModelArticles
 	 */
 	protected function getListQuery()
 	{
-		$params = $this->state->params;
-		$catids = $params->get('catid', array());
+		$params           = $this->state->params;
+		$app              = JFactory::getApplication('site');
+		$catids           = $app->input->getVar('catid', array());
+		$catids           = array_values(array_diff($catids, array('')));
 		$articleOrderDate = $params->get('order_date');
 
 		// Create a new query object.
@@ -123,9 +125,9 @@ class ContentModelArchive extends ContentModelArticles
 			$query->where($query->year($queryDate) . ' = ' . $year);
 		}
 
-		if (count($catids))
+		if (count($catids)>0)
 		{
-			$query->where('c.id IN (' .  implode($catids, ', ') .')');
+			$query->where('c.id IN (' .  implode($catids, ', ') . ')');
 		}
 
 		return $query;

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -82,6 +82,7 @@ class ContentModelArchive extends ContentModelArticles
 	protected function getListQuery()
 	{
 		$params = $this->state->params;
+		$catids = $params->get('catid', array());
 		$articleOrderDate = $params->get('order_date');
 
 		// Create a new query object.
@@ -120,6 +121,11 @@ class ContentModelArchive extends ContentModelArticles
 		if ($year = $this->getState('filter.year'))
 		{
 			$query->where($query->year($queryDate) . ' = ' . $year);
+		}
+
+		if (count($catids))
+		{
+			$query->where('c.id IN (' .  implode($catids, ', ') .')');
 		}
 
 		return $query;

--- a/components/com_content/models/archive.php
+++ b/components/com_content/models/archive.php
@@ -127,7 +127,7 @@ class ContentModelArchive extends ContentModelArticles
 
 		if (count($catids)>0)
 		{
-			$query->where('c.id IN (' . implode($catids, ', ') . ')');
+			$query->where('c.id IN (' . implode(', ', $catids) . ')');
 		}
 
 		return $query;

--- a/components/com_content/views/archive/tmpl/default.xml
+++ b/components/com_content/views/archive/tmpl/default.xml
@@ -9,14 +9,13 @@
 		</message>
 	</layout>
 
-	<!-- Add fields to the parameters object for the layout. -->
-	<fields name="params">
-
-		<!-- Basic options. -->
-		<fieldset name="basic" label="JGLOBAL_ARCHIVE_OPTIONS"
+	<!-- Add fields to the request variables for the layout. -->
+	<fields name="request">
+		<fieldset name="request"
+			addfieldpath="/administrator/components/com_categories/models/fields"
 		>
-
-			<field	name="catid"
+			<field
+				name="catid"
 				type="category"
 				extension="com_content"
 				multiple="true"
@@ -26,6 +25,15 @@
 			>
 				<option value="">JOPTION_ALL_CATEGORIES</option>
 			</field>
+		</fieldset>
+	</fields>
+
+	<!-- Add fields to the parameters object for the layout. -->
+	<fields name="params">
+
+		<!-- Basic options. -->
+		<fieldset name="basic" label="JGLOBAL_ARCHIVE_OPTIONS"
+		>
 
 			<field name="orderby_sec" type="list"
 				default="alpha"

--- a/components/com_content/views/archive/tmpl/default.xml
+++ b/components/com_content/views/archive/tmpl/default.xml
@@ -16,6 +16,17 @@
 		<fieldset name="basic" label="JGLOBAL_ARCHIVE_OPTIONS"
 		>
 
+			<field	name="catid"
+				type="category"
+				extension="com_content"
+				multiple="true"
+				size="5"
+				label="JCATEGORY"
+				description="JFIELD_CATEGORY_DESC"
+			>
+				<option value="">JOPTION_ALL_CATEGORIES</option>
+			</field>
+
 			<field name="orderby_sec" type="list"
 				default="alpha"
 				description="JGLOBAL_ARTICLE_ORDER_DESC"


### PR DESCRIPTION
Pull Request for Issue #14923 .

### Summary of Changes
try to adress 

> 2) In the existing archived view being able to filter to a given category.


### Testing Instructions

![archivedcat](https://cloud.githubusercontent.com/assets/181681/24876055/80522612-1e2a-11e7-8891-99a8a76d2896.png)


### Expected result

able to filter archived article on categories too

### Actual result
no option to filter on categories

