### PR TITLE
Implement helper hooks for the updater

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -524,7 +524,7 @@ class InstallerModelUpdate extends JModelList
 		
 		switch ($table->type)
 		{
-			// Components could have a helper with the credentials
+			// Components could have a helper which adds additional datas
 			case 'component':
 				$ename = str_replace('com_', '', $table->element);
 				$fname = $ename . '.php';
@@ -543,7 +543,8 @@ class InstallerModelUpdate extends JModelList
 				}
 
 				break;
-				
+
+			// Modules could have a helper which adds additional datas
 			case 'module':
 				$cname = str_replace('_', '', $table->element) . 'Helper';
 				$path = ($table->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $table->element . '/helper.php';
@@ -560,9 +561,9 @@ class InstallerModelUpdate extends JModelList
 			
 				break;
 				
+			// If we have a plugin, we can use the plugin trigger "onInstallerBeforePackageDownload"
+			// But we should make sure, that our plugin is loaded, so we don't need a second "installer" plugin
 			case 'plugin':
-				// If we have a plugin, we can use the plugin trigger "onInstallerBeforePackageDownload"
-				// But we should make sure, that our plugin is loaded, so we don't need two plugins
 				$cname = str_replace('plg_', '', $table->element);
 				JPluginHelper::importPlugin($table->folder, $cname);
 				break;

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -528,7 +528,7 @@ class InstallerModelUpdate extends JModelList
 		
 		switch ($table->type)
 		{
-			// Components could have a helper which adds additional datas
+			// Components could have a helper which adds additional data
 			case 'component':
 				$ename = str_replace('com_', '', $table->element);
 				$fname = $ename . '.php';
@@ -548,7 +548,7 @@ class InstallerModelUpdate extends JModelList
 
 				break;
 
-			// Modules could have a helper which adds additional datas
+			// Modules could have a helper which adds additional data
 			case 'module':
 				$cname = str_replace('_', '', $table->element) . 'Helper';
 				$path = ($table->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $table->element . '/helper.php';

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -520,7 +520,7 @@ class InstallerModelUpdate extends JModelList
 	 *
 	 * @return  void
 	 *
-	 * @since	__DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function preparePreUpdate($update, $table)
 	{

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -517,6 +517,10 @@ class InstallerModelUpdate extends JModelList
 	 *
 	 * @param   JUpdate       $update  An update definition
 	 * @param   JTableUpdate  $table   The update instance from the database
+	 *
+	 * @return  void
+	 *
+	 * @since	__DEPLOY_VERSION__
 	 */
 	protected function preparePreUpdate($update, $table)
 	{
@@ -530,7 +534,7 @@ class InstallerModelUpdate extends JModelList
 				$fname = $ename . '.php';
 				$cname = ucfirst($ename) . 'Helper';
 
-				$path = JPATH_ADMINISTRATOR . '/components/' . $table->element . '/helpers/' .  $fname;
+				$path = JPATH_ADMINISTRATOR . '/components/' . $table->element . '/helpers/' . $fname;
 				
 				if (JFile::exists($path))
 				{

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -358,6 +358,8 @@ class InstallerModelUpdate extends JModelList
 			$update->loadFromXml($instance->detailsurl, $minimum_stability);
 			$update->set('extra_query', $instance->extra_query);
 
+			$this->preparePreUpdate($update, $instance);
+
 			// Install sets state and enqueues messages
 			$res = $this->install($update);
 
@@ -508,5 +510,62 @@ class InstallerModelUpdate extends JModelList
 		$data = JFactory::getApplication()->getUserState($this->context, array());
 
 		return $data;
+	}
+
+	/**
+	 * Method to add parameters to the update
+	 *
+	 * @param   JUpdate       $update  An update definition
+	 * @param   JTableUpdate  $table   The update instance from the database
+	 */
+	protected function preparePreUpdate($update, $table)
+	{
+		jimport('joomla.filesystem.file');
+		
+		switch ($table->type)
+		{
+			// Components could have a helper with the credentials
+			case 'component':
+				$ename = str_replace('com_', '', $table->element);
+				$fname = $ename . '.php';
+				$cname = ucfirst($ename) . 'Helper';
+
+				$path = JPATH_ADMINISTRATOR . '/components/' . $table->element . '/helpers/' .  $fname;
+				
+				if (JFile::exists($path))
+				{
+					require_once $path;
+					
+					if (class_exists($cname) && is_callable(array($cname, 'prepareUpdate')))
+					{
+						call_user_func_array(array($cname, 'prepareUpdate'), array(&$update, &$table));
+					}
+				}
+
+				break;
+				
+			case 'module':
+				$cname = str_replace('_', '', $table->element) . 'Helper';
+				$path = ($table->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $table->element . '/helper.php';
+				
+				if (JFile::exists($path))
+				{
+					require_once $path;
+					
+					if (class_exists($cname) && is_callable(array($cname, 'prepareUpdate')))
+					{
+						call_user_func_array(array($cname, 'prepareUpdate'), array(&$update, &$table));
+					}
+				}
+			
+				break;
+				
+			case 'plugin':
+				// If we have a plugin, we can use the plugin trigger "onInstallerBeforePackageDownload"
+				// But we should make sure, that our plugin is loaded, so we don't need two plugins
+				$cname = str_replace('plg_', '', $table->element);
+				JPluginHelper::importPlugin($table->folder, $cname);
+				break;
+		}
 	}
 }


### PR DESCRIPTION
### Summary of Changes
#### Background
If you have a commercial extension (or want to add dynamic parameters to your update call) you can relay on the "extra_query" field from [this patch](https://github.com/joomla/joomla-cms/pull/2508/files) or use a "installer" plugin which was implemented in [this patch](https://github.com/joomla/joomla-cms/pull/2769/files). But that means, if you have an plugin/module/extension you'll have to ship an extra update plugin or adjust the database row with (e.g.) credentials.

#### The Idea
A lot of components/Modules shiping a helper file which can be used for a lot of additional tasks (like language associaction in components or Ajax calls in Modules). With this patch a developer cann add a "prepareUpdate" method to his/her helper file which will be called before the download of the update will be started. That means, the method could augment the download url with own parameters on the fly (e.g. append a key) without shipping an update plugin.
Also for plugins itself it looked strange for me to ship an plugin for updating a plugin. So this patch just make sure, that the plugin itself is loaded, so the update call can be implemented in the plugin itself.

### Testing Instructions
That's the hard part:
First you need a component/module/plugin which supports the update functionallity from Joomla!.
Second you need an older version of this extension, so the update process can be triggert.
Last but not least you have to adjust the helper file or (if you test a plugin) the plugin itself:

#### Component ```com_example```:
Go to administrator/components/com_example/helpers/example.php, make sure you have a class ```ExampleHelper``` and add the following method:

```
/**
 * Method to add parameters to the update
 *
 * @param   JUpdate       $update  An update definition
 * @param   JTableUpdate  $table   The update instance from the database
 */
public static function prepareUpdate($update, $table)
{
    exit('works');
}
```

#### Module ```mod_example```:
Go to (administrator)/modules/mod_example/helper.php, make sure you have a class ```modExampleHelper``` and add the following method:

```
/**
 * Method to add parameters to the update
 *
 * @param   JUpdate       $update  An update definition
 * @param   JTableUpdate  $table   The update instance from the database
 */
public static function prepareUpdate($update, $table)
{
    exit('works');
}
```

#### Plugin```plg_example```:
Just add the following trigger to your plugin

```
public function onInstallerBeforePackageDownload($url, $headers)
{
    exit('works');
}
```
Now if you execute the update, the different methods should be triggered (depending on the type of your extension)

