### PR TITLE
Porting PasswordHash from PHP4 to PHP 5-7 syntax

### DIFF
--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -24,13 +24,17 @@
 # Obviously, since this code is in the public domain, the above are not
 # requirements (there can be none), but merely suggestions.
 #
+/*
+ * Modified for Joomla!
+ * - Porting from PHP4 to PHP 5-7 syntax
+ */
 class PasswordHash {
-	var $itoa64;
-	var $iteration_count_log2;
-	var $portable_hashes;
-	var $random_state;
+	private $itoa64;
+	private $iteration_count_log2;
+	private $portable_hashes;
+	private $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 


### PR DESCRIPTION
It seems that the original library is no longer maintained.

PHP 4 style constructors are deprecated, and will be removed in future.
### Summary of Changes
Porting PasswordHash from PHP4 to PHP 5-7 syntax.
Run JUserHelperTest.php successfully.
