### PR TITLE
[hathor] com_banners editor

### DIFF
--- a/administrator/templates/hathor/html/com_banners/banner/edit.php
+++ b/administrator/templates/hathor/html/com_banners/banner/edit.php
@@ -66,8 +66,12 @@ JFactory::getDocument()->addScriptDeclaration("
 				</div>
 				</li>
 
-				<li><?php echo $this->form->getLabel('description'); ?>
-				<?php echo $this->form->getInput('description'); ?></li>
+				<li>
+				<?php echo $this->form->getLabel('description'); ?>
+				<div class="clr"></div>
+				<?php echo $this->form->getInput('description'); ?>
+				<div class="clr"></div>
+				</li>
 
 				<li><?php echo $this->form->getLabel('language'); ?>
 				<?php echo $this->form->getInput('language'); ?></li>


### PR DESCRIPTION
Fix the display of the editor in com_banners

### before
<img width="855" alt="screenshotr09-40-34" src="https://cloud.githubusercontent.com/assets/1296369/24853267/67628366-1dd2-11e7-8b66-cf6e5d377cca.png">


###after
<img width="785" alt="screenshotr09-43-18" src="https://cloud.githubusercontent.com/assets/1296369/24853276/6c9ece84-1dd2-11e7-92bf-14f75e55fb1e.png">
