### PR TITLE
[hathor] com_banners missing options slider

### DIFF
--- a/administrator/templates/hathor/html/com_banners/banner/edit.php
+++ b/administrator/templates/hathor/html/com_banners/banner/edit.php
@@ -94,6 +94,22 @@ JFactory::getDocument()->addScriptDeclaration("
 			</ul>
 		</fieldset>
 
+	<?php echo JHtml::_('sliders.panel', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS'), 'otherparams'); ?>
+		<fieldset class="panelform">
+		<legend class="element-invisible"><?php echo JText::_('JGLOBAL_FIELDSET_PUBLISHING'); ?></legend>
+
+		<ul class="adminformlist">
+			<?php foreach ($this->form->getFieldset('otherparams') as $field) : ?>
+				<li><?php echo $field->label; ?>
+					<?php echo $field->input; ?></li>
+			<?php endforeach; ?>
+			<?php foreach ($this->form->getFieldset('bannerdetails') as $field) : ?>
+				<li><?php echo $field->label; ?>
+					<?php echo $field->input; ?></li>
+			<?php endforeach; ?>
+		</ul>	
+		</fieldset>
+
 	<?php echo JHtml::_('sliders.panel', JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS'), 'metadata'); ?>
 		<fieldset class="panelform">
 		<legend class="element-invisible"><?php echo JText::_('JGLOBAL_FIELDSET_METADATA_OPTIONS'); ?></legend>

--- a/administrator/templates/hathor/html/com_banners/banner/edit.php
+++ b/administrator/templates/hathor/html/com_banners/banner/edit.php
@@ -96,7 +96,7 @@ JFactory::getDocument()->addScriptDeclaration("
 
 	<?php echo JHtml::_('sliders.panel', JText::_('COM_BANNERS_GROUP_LABEL_BANNER_DETAILS'), 'otherparams'); ?>
 		<fieldset class="panelform">
-		<legend class="element-invisible"><?php echo JText::_('JGLOBAL_FIELDSET_PUBLISHING'); ?></legend>
+		<legend class="element-invisible"><?php echo JText::_('COM_BANNERS_BANNER_DETAILS'); ?></legend>
 
 		<ul class="adminformlist">
 			<?php foreach ($this->form->getFieldset('otherparams') as $field) : ?>


### PR DESCRIPTION
When creating a banner using the hathor template the slider for the banner options was missing

### before
<img width="516" alt="screenshotr09-59-29" src="https://cloud.githubusercontent.com/assets/1296369/24853890/6a466fbe-1dd4-11e7-92fc-924b92c9bf55.png">

### after
<img width="522" alt="screenshotr09-59-10" src="https://cloud.githubusercontent.com/assets/1296369/24853900/7176f79a-1dd4-11e7-8654-2004c0a73a8c.png">

