### PR TITLE
[4.0] Fix unit tests and runtime exception issue

### DIFF
--- a/libraries/src/CMS/Application/WebApplication.php
+++ b/libraries/src/CMS/Application/WebApplication.php
@@ -152,7 +152,7 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		// Only create the object if it doesn't exist.
 		if (empty(static::$instance))
 		{
-			if (!class_exists($name) && (is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication')))
+			if (!class_exists($name) || is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
 			{
 				throw new \RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}

--- a/libraries/src/CMS/Application/WebApplication.php
+++ b/libraries/src/CMS/Application/WebApplication.php
@@ -152,7 +152,7 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		// Only create the object if it doesn't exist.
 		if (empty(static::$instance))
 		{
-			if (!class_exists($name) || is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
+			if (!class_exists($name) || !is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
 			{
 				throw new \RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}

--- a/libraries/src/CMS/Application/WebApplication.php
+++ b/libraries/src/CMS/Application/WebApplication.php
@@ -152,7 +152,7 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		// Only create the object if it doesn't exist.
 		if (empty(static::$instance))
 		{
-			if (!class_exists($name) || !is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
+			if (!class_exists($name) && (is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication')))
 			{
 				throw new \RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}

--- a/libraries/src/CMS/Application/WebApplication.php
+++ b/libraries/src/CMS/Application/WebApplication.php
@@ -152,7 +152,7 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		// Only create the object if it doesn't exist.
 		if (empty(static::$instance))
 		{
-			if (!class_exists($name) || !is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
+			if (!is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
 			{
 				throw new \RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}

--- a/libraries/src/CMS/Application/WebApplication.php
+++ b/libraries/src/CMS/Application/WebApplication.php
@@ -152,7 +152,7 @@ abstract class WebApplication extends AbstractWebApplication implements Dispatch
 		// Only create the object if it doesn't exist.
 		if (empty(static::$instance))
 		{
-			if (!class_exists($name) && (is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication')))
+			if (!class_exists($name) || !is_subclass_of($name, '\\Joomla\\CMS\\Application\\WebApplication'))
 			{
 				throw new \RuntimeException(sprintf('Unable to load application: %s', $name), 500);
 			}

--- a/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
@@ -82,6 +82,7 @@ class JControllerFormTest extends TestCase
 				// Neutralise a JPATH_COMPONENT not defined error.
 				'base_path' => JPATH_BASE . '/component/com_foobar'
 			),
+			null,
 			JFactory::getApplication(),
 			null
 		);
@@ -93,6 +94,7 @@ class JControllerFormTest extends TestCase
 				// Neutralise a JPATH_COMPONENT not defined error.
 				'base_path' => JPATH_BASE . '/component/com_foobar'
 			),
+			null,
 			JFactory::getApplication(),
 			null
 		);

--- a/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
+++ b/tests/unit/suites/libraries/cms/controller/JControllerFormTest.php
@@ -63,6 +63,7 @@ class JControllerFormTest extends TestCase
 				// Neutralise a JPATH_COMPONENT not defined error.
 				'base_path' => JPATH_BASE . '/component/com_foobar'
 			),
+			null,
 			JFactory::getApplication(),
 			null
 		);

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -327,7 +327,7 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testGetInstance()
 	{
-		$app = JApplicationWeb::getInstance('\\JApplicationWebInspector');
+		$app = JApplicationWeb::getInstance('JApplicationWebInspector');
 
 		$this->assertInstanceOf('JApplicationWebInspector', $app);
 		$this->assertSame($app, JApplicationWeb::getInstance('JApplicationWebInspector'), 'The same application object was not returned.');

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -327,7 +327,7 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function testGetInstance()
 	{
-		$app = JApplicationWeb::getInstance('JApplicationWebInspector');
+		$app = JApplicationWeb::getInstance('\\JApplicationWebInspector');
 
 		$this->assertInstanceOf('JApplicationWebInspector', $app);
 		$this->assertSame($app, JApplicationWeb::getInstance('JApplicationWebInspector'), 'The same application object was not returned.');


### PR DESCRIPTION
### Summary of Changes

Fixes the unit tests in the 4.0-dev branch and an issue in the WebApplication class

### Testing Instructions

Check if travis is green, test that everything is still working and do a code review

### Expected result

RuntimeException is thrown

### Actual result

Fatal error because runtime exception is not thrown

### Documentation Changes Required

None