### PR TITLE
[4.0] Namespace CMS

### DIFF
--- a/administrator/components/com_content/Controller/Article.php
+++ b/administrator/components/com_content/Controller/Article.php
@@ -29,7 +29,7 @@ class Article extends Form
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MvcFactoryInterface  $factory  The factory.
-	 * @param   CmsApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The JApplication for the dispatcher
 	 * @param   \JInput              $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_content/Controller/Articles.php
+++ b/administrator/components/com_content/Controller/Articles.php
@@ -29,7 +29,7 @@ class Articles extends Admin
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MvcFactoryInterface  $factory  The factory.
-	 * @param   CmsApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The JApplication for the dispatcher
 	 * @param   \JInput              $input    Input
 	 *
 	 * @since   3.0

--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -23,7 +23,7 @@ JLoader::registerAlias('JApplicationAdministrator',         '\\Joomla\\CMS\\Appl
 JLoader::registerAlias('JApplicationHelper',                '\\Joomla\\CMS\\Application\\ApplicationHelper', '4.0');
 JLoader::registerAlias('JApplicationBase',                  '\\Joomla\\CMS\\Application\\BaseApplication', '4.0');
 JLoader::registerAlias('JApplicationCli',                   '\\Joomla\\CMS\\Application\\CliApplication', '4.0');
-JLoader::registerAlias('JApplicationCms',                   '\\Joomla\\CMS\\Application\\CmsApplication', '4.0');
+JLoader::registerAlias('JApplicationCms',                   '\\Joomla\\CMS\\Application\\CMSApplication', '4.0');
 JLoader::registerAlias('JApplicationDaemon',                '\\Joomla\\CMS\\Application\\DaemonApplication', '4.0');
 JLoader::registerAlias('JApplicationSite',                  '\\Joomla\\CMS\\Application\\SiteApplication', '4.0');
 JLoader::registerAlias('JApplicationWeb',                   '\\Joomla\\CMS\\Application\\WebApplication', '4.0');

--- a/libraries/src/CMS/Application/AdministratorApplication.php
+++ b/libraries/src/CMS/Application/AdministratorApplication.php
@@ -20,7 +20,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.2
  */
-class AdministratorApplication extends CmsApplication
+class AdministratorApplication extends CMSApplication
 {
 	/**
 	 * Class constructor.

--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -24,7 +24,7 @@ use Joomla\Session\SessionEvent;
  *
  * @since  3.2
  */
-abstract class CmsApplication extends WebApplication implements ContainerAwareInterface
+abstract class CMSApplication extends WebApplication implements ContainerAwareInterface
 {
 	use ContainerAwareTrait;
 
@@ -103,7 +103,7 @@ abstract class CmsApplication extends WebApplication implements ContainerAwareIn
 	/**
 	 * Application instances container.
 	 *
-	 * @var    CmsApplication[]
+	 * @var    CMSApplication[]
 	 * @since  3.2
 	 */
 	protected static $instances = array();
@@ -514,15 +514,15 @@ abstract class CmsApplication extends WebApplication implements ContainerAwareIn
 	}
 
 	/**
-	 * Returns a reference to the global CmsApplication object, only creating it if it doesn't already exist.
+	 * Returns a reference to the global CMSApplication object, only creating it if it doesn't already exist.
 	 *
-	 * This method must be invoked as: $web = CmsApplication::getInstance();
+	 * This method must be invoked as: $web = CMSApplication::getInstance();
 	 *
-	 * @param   string     $name       The name (optional) of the CmsApplication class to instantiate.
+	 * @param   string     $name       The name (optional) of the CMSApplication class to instantiate.
 	 * @param   string     $prefix     The class name prefix of the object.
 	 * @param   Container  $container  An optional dependency injection container to inject into the application.
 	 *
-	 * @return  CmsApplication
+	 * @return  CMSApplication
 	 *
 	 * @since   3.2
 	 * @throws  \RuntimeException
@@ -531,7 +531,7 @@ abstract class CmsApplication extends WebApplication implements ContainerAwareIn
 	{
 		if (empty(static::$instances[$name]))
 		{
-			// Create a CmsApplication object.
+			// Create a CMSApplication object.
 			$classname = $prefix . ucfirst($name);
 
 			if (!class_exists($classname))

--- a/libraries/src/CMS/Application/SiteApplication.php
+++ b/libraries/src/CMS/Application/SiteApplication.php
@@ -20,7 +20,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.2
  */
-final class SiteApplication extends CmsApplication
+final class SiteApplication extends CMSApplication
 {
 	/**
 	 * Option to filter by language

--- a/libraries/src/CMS/Controller/Admin.php
+++ b/libraries/src/CMS/Controller/Admin.php
@@ -54,7 +54,7 @@ class Admin extends Controller
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MvcFactoryInterface  $factory  The factory.
-	 * @param   CmsApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The JApplication for the dispatcher
 	 * @param   \JInput              $input    Input
 	 *
 	 * @since   3.0

--- a/libraries/src/CMS/Controller/Controller.php
+++ b/libraries/src/CMS/Controller/Controller.php
@@ -10,7 +10,7 @@ namespace Joomla\CMS\Controller;
 
 defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Application\CmsApplication;
+use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Model\Model;
 use Joomla\CMS\Mvc\Factory\LegacyFactory;
 use Joomla\CMS\Mvc\Factory\MvcFactoryInterface;
@@ -343,7 +343,7 @@ class Controller implements ControllerInterface
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MvcFactoryInterface  $factory  The factory.
-	 * @param   CmsApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The JApplication for the dispatcher
 	 * @param   \JInput              $input    Input
 	 *
 	 * @since   3.0

--- a/libraries/src/CMS/Controller/Form.php
+++ b/libraries/src/CMS/Controller/Form.php
@@ -67,7 +67,7 @@ class Form extends Controller
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MvcFactoryInterface  $factory  The factory.
-	 * @param   CmsApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The JApplication for the dispatcher
 	 * @param   \JInput              $input    Input
 	 *
 	 * @since   3.0

--- a/libraries/src/CMS/Dispatcher/Dispatcher.php
+++ b/libraries/src/CMS/Dispatcher/Dispatcher.php
@@ -9,7 +9,7 @@
 namespace Joomla\CMS\Dispatcher;
 
 use Joomla\CMS\Access\Exception\Notallowed;
-use Joomla\CMS\Application\CmsApplication;
+use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Controller\Controller;
 use Joomla\CMS\Mvc\Factory\MvcFactoryInterface;
 use Joomla\CMS\Mvc\Factory\MvcFactory;
@@ -29,7 +29,7 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * The JApplication instance
 	 *
-	 * @var    CmsApplication
+	 * @var    CMSApplication
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
@@ -66,13 +66,13 @@ abstract class Dispatcher implements DispatcherInterface
 	 * Constructor for Dispatcher
 	 *
 	 * @param   string               $namespace  Namespace of the Extension
-	 * @param   CmsApplication       $app        The JApplication for the dispatcher
+	 * @param   CMSApplication       $app        The JApplication for the dispatcher
 	 * @param   \JInput              $input      JInput
 	 * @param   MvcFactoryInterface  $factory    The factory object for the component
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct($namespace, CmsApplication $app, \JInput $input = null, MvcFactoryInterface $factory = null)
+	public function __construct($namespace, CMSApplication $app, \JInput $input = null, MvcFactoryInterface $factory = null)
 	{
 		$this->namespace = rtrim($namespace, '\\') . '\\';
 		$this->app       = $app;
@@ -156,7 +156,7 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * The application the dispatcher is working with.
 	 *
-	 * @return  CmsApplication
+	 * @return  CMSApplication
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */


### PR DESCRIPTION
We changed to use CMS and not Cms for the folder as it follows are stylgeuide to use all uppercase where it in an acronym that is read aloud letter by letter and not as a word.

This PR changes CmsApplication to be CMSApplication following the same rule