### PR TITLE
[com_fields] Set the language on the registration form data

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -326,6 +326,11 @@ class UsersModelRegistration extends JModelForm
 	{
 		$data = $this->getData();
 
+		if (empty($data->language))
+		{
+			$data->language = JFactory::getLanguage()->getTag();
+		}
+
 		$this->preprocessData('com_users.registration', $data);
 
 		return $data;


### PR DESCRIPTION
Pull Request for Issue #14865.

### Summary of Changes
On multilanguage sites when a user open the registration page, only fields should be displayed which do belong to the actual language.

### Testing Instructions
- Install a fresh joomla without sample data but with **multilanguage**. Select some additional languages to install.
- Create a user field and assign it to a language which is not en-GB.
- Enable user registration in the user options.
- On the front make sure you open the page with the English language.
- Click in the log in module on register.

### Expected result
No field is shown.

### Actual result
The field is shown which does not belong to the English language.