### PR TITLE
[com_fields] Set the language on the contact form data

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -116,7 +116,7 @@ class ContactModelContact extends JModelForm
 	{
 		$data = (array) JFactory::getApplication()->getUserState('com_contact.contact.data', array());
 
-		if (empty($data['language'])&& JLanguageMultilang::isEnabled())
+		if (empty($data['language']) && JLanguageMultilang::isEnabled())
 		{
 			$data['language'] = JFactory::getLanguage()->getTag();
 		}

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -116,7 +116,7 @@ class ContactModelContact extends JModelForm
 	{
 		$data = (array) JFactory::getApplication()->getUserState('com_contact.contact.data', array());
 
-		if (empty($data['language']))
+		if (empty($data['language'])&& JLanguageMultilang::isEnabled())
 		{
 			$data['language'] = JFactory::getLanguage()->getTag();
 		}

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -116,6 +116,11 @@ class ContactModelContact extends JModelForm
 	{
 		$data = (array) JFactory::getApplication()->getUserState('com_contact.contact.data', array());
 
+		if (empty($data['language']))
+		{
+			$data['language'] = JFactory::getLanguage()->getTag();
+		}
+
 		$this->preprocessData('com_contact.contact', $data);
 
 		return $data;


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/15223#issuecomment-293275646 .

### Summary of Changes
On multilanguage sites when a user open the contact form page, only fields should be displayed which do belong to the actual language.

### Testing Instructions
- Install a fresh joomla without sample data but with **multilanguage**. Select some additional languages to install.
- Create a Contact -> Mail field and assign it to a language which is not en-GB.
- Create a contact.
- Create a "Single Contact" menu item.
- On the front make sure you open the page with the English language.
- Click in the contact menu link.

### Expected result
No field is shown.

### Actual result
The field is shown which does not belong to the English language.