### PR TITLE
[Fix]Component dropdown does not get the ??MISSING_LANGUAGESTRING??

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -148,14 +148,14 @@ abstract class ModMenuHelper
 						|| $lang->load($component->element . '.sys', JPATH_ADMINISTRATOR . '/components/' . $component->element, null, false, true);
 					}
 
-					$component->text = $lang->hasKey($component->title) ? JText::_($component->title) : $component->alias;
+					$component->text = JText::_(strtoupper($component->title));
 				}
 			}
 			// Sub-menu level.
 			// Add the submenu link if it is defined.
 			elseif (isset($result[$component->parent_id]) && isset($result[$component->parent_id]->submenu) && !empty($component->link))
 			{
-				$component->text = $lang->hasKey($component->title) ? JText::_($component->title) : $component->alias;
+				$component->text = JText::_(strtoupper($component->title));
 
 				$result[$component->parent_id]->submenu[] = &$component;
 			}


### PR DESCRIPTION
Pull Request for Issue #15211

### Summary of Changes

Lets use the magic language system there is no fallback needed

### Testing Instructions

- install staging
- enable debug language
- install e.g german (or any other 3.6.5 language pack)
- switch to that language in the backend

### Expected result

??COM_ASSOCIATIONS?? in the components dropdown

### Actual result

"Multilingual Associations" (even without the ** arround it)
![image](https://cloud.githubusercontent.com/assets/2596554/24877080/4abb570e-1e2e-11e7-9e01-2e0d26953b46.png)


### Documentation Changes Required

None