### PR TITLE
[com_content] - add random order to featured view

### DIFF
--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -99,7 +99,7 @@
 				<option value="vote" requires="vote">JGLOBAL_VOTES_DESC</option>
 				<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
 				<option value="rank" requires="vote">JGLOBAL_RATINGS_DESC</option>
-				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>				
+				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>		
 			</field>
 
 			<field name="order_date" type="list"

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -94,12 +94,12 @@
 				<option value="rauthor">JGLOBAL_AUTHOR_REVERSE_ALPHABETICAL</option>
 				<option value="hits">JGLOBAL_MOST_HITS</option>
 				<option value="rhits">JGLOBAL_LEAST_HITS</option>
+				<option value="random">JGLOBAL_RANDOM_ORDER</option>
 				<option value="order">JGLOBAL_ORDERING</option>
 				<option value="vote" requires="vote">JGLOBAL_VOTES_DESC</option>
 				<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
 				<option value="rank" requires="vote">JGLOBAL_RATINGS_DESC</option>
-				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
-				<option value="random">JGLOBAL_RANDOM_ORDER</option>
+				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>				
 			</field>
 
 			<field name="order_date" type="list"

--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -99,6 +99,7 @@
 				<option value="rvote" requires="vote">JGLOBAL_VOTES_ASC</option>
 				<option value="rank" requires="vote">JGLOBAL_RATINGS_DESC</option>
 				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
+				<option value="random">JGLOBAL_RANDOM_ORDER</option>
 			</field>
 
 			<field name="order_date" type="list"


### PR DESCRIPTION
Pull Request for Issue #15220 .

### Summary of Changes
add random order option to featured view


### Testing Instructions
![featuredrandorder](https://cloud.githubusercontent.com/assets/181681/24924371/d4082e76-1ef4-11e7-863e-76ecac28038e.PNG)


### Expected result
you can select random order for featured articles




### Actual result
no random option

