### PR TITLE
[com_fields] Fields do not delete from the database when deleted from the back end

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -447,21 +447,31 @@ class FieldsModelField extends JModelAdmin
 
 			if (!empty($pks))
 			{
-				// Delete Values
-				$query = $this->getDbo()->getQuery(true);
+				$db = $this->getDbo();
 
-				$query->delete($query->qn('#__fields_values'))
-					->where($query->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
+				// Delete the values
+				$query = $db->getQuery(true);
 
-				$this->getDbo()->setQuery($query)->execute();
+				$query->delete($db->qn('#__fields_values'))
+					->where($db->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
 
-				// Delete Assigned Categories
-				$query = $this->getDbo()->getQuery(true);
+				$db->setQuery($query)->execute();
 
-				$query->delete($query->qn('#__fields_categories'))
-					->where($query->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
+				// Delete the assigned Categories
+				$query = $db->getQuery(true);
 
-				$this->getDbo()->setQuery($query)->execute();
+				$query->delete($db->qn('#__fields_categories'))
+					->where($db->qn('field_id') . ' IN(' . implode(',', $pks) . ')');
+
+				$db->setQuery($query)->execute();
+
+				// Delete the fields
+				$query = $db->getQuery(true);
+
+				$query->delete($db->qn('#__fields'))
+					->where($db->qn('id') . ' IN(' . implode(',', $pks) . ')');
+
+				$db->setQuery($query)->execute();
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #15230 

### Summary of Changes

delete the field if the uses which this.

### Testing Instructions

Create a new field
Delete the field

### Expected result

Cannot see the field in the database

### Actual result

The field remains in the database

### Documentation Changes Required

none