### PR TITLE
[Hathor] Displaying custom fields in category edit

### DIFF
--- a/administrator/templates/hathor/html/com_categories/category/edit.php
+++ b/administrator/templates/hathor/html/com_categories/category/edit.php
@@ -117,9 +117,9 @@ $assoc = JLanguageAssociations::isEnabled();
 				<?php echo $this->loadTemplate('metadata'); ?>
 			</fieldset>
 
-			<?php $fieldSets = $this->form->getFieldsets('attribs'); ?>
+			<?php $fieldSets = $this->form->getFieldsets(); ?>
 			<?php foreach ($fieldSets as $name => $fieldSet) : ?>
-				<?php if ($name != 'editorConfig' && $name != 'basic-limited') : ?>
+				<?php if ($name !== 'basic' && $name !== 'item_associations' && $name !== 'jmetadata') : ?>
 					<?php
 					$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CATEGORIES_' . $name . '_FIELDSET_LABEL';
 					echo JHtml::_('sliders.panel', JText::_($label), $name . '-options');


### PR DESCRIPTION
The custom fields do not display in Hathor when they are set for an Article or a Contact category.

After patch, they will. 
To test, create and publish a fieldgroup after choosing Category in the dropdown.
Create a field after choosing Category in the dropdown.

![screen shot 2017-04-12 at 08 41 42](https://cloud.githubusercontent.com/assets/869724/24944522/eb597eb0-1f5b-11e7-9b9c-c6fae1fcc40e.png)
![screen shot 2017-04-12 at 08 41 17](https://cloud.githubusercontent.com/assets/869724/24944523/eb5ad382-1f5b-11e7-9b8e-1f7b8f923c1a.png)

You should get this

![screen shot 2017-04-12 at 08 38 11](https://cloud.githubusercontent.com/assets/869724/24944418/6b7dcd36-1f5b-11e7-8ac3-0b767a8a37d8.png)
