### PR TITLE
Fix readonly state for legacy TinyMCE mode

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -151,7 +151,7 @@ class PlgEditorTinymce extends JPlugin
 				$app->setUserState('plg_editors_tinymce.config_legacy_warn_count', ++$config_warn_count);
 			}
 
-			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author);
+			return $this->onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons, $id, $asset, $author, $params);
 		}
 
 		if (empty($id))
@@ -1213,6 +1213,7 @@ class PlgEditorTinymce extends JPlugin
 	 * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
 	 * @param   string   $asset    The object asset
 	 * @param   object   $author   The author.
+	 * @param   array    $params   Associative array of editor parameters.
 	 *
 	 * @return  string
 	 *
@@ -1220,7 +1221,7 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @deprecated 4.0
 	 */
-	private function onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null)
+	private function onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
 	{
 		if (empty($id))
 		{
@@ -1258,6 +1259,9 @@ class PlgEditorTinymce extends JPlugin
 		$textarea->height  = $height;
 		$textarea->content = $content;
 
+		// Set editor to readonly mode
+		$textarea->readonly = !empty($params['readonly']);
+
 		// Render Editor markup
 		$editor = '<div class="editor js-editor-tinymce">';
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
@@ -1272,6 +1276,12 @@ class PlgEditorTinymce extends JPlugin
 			if (!empty($btns['names']))
 			{
 				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', array('version' => 'auto', 'relative' => true), array('defer' => 'defer'));
+			}
+
+			// Set editor to readonly mode
+			if (!empty($params['readonly']))
+			{
+				$options['tinyMCE'][$fieldName]['readonly'] = 1;
 			}
 
 			$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1221,7 +1221,8 @@ class PlgEditorTinymce extends JPlugin
 	 *
 	 * @deprecated 4.0
 	 */
-	private function onDisplayLegacy($name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
+	private function onDisplayLegacy(
+		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
 	{
 		if (empty($id))
 		{


### PR DESCRIPTION
Pull Request for Issue #15243.

### Summary of Changes
Adds the readonly code also to the "legacy" mode in TinyMCE


### Testing Instructions
* I'm not exactly sure how to get into that legacy mode. I guess it's after an update from 3.6.5 as long as you didn't save the tinymce editor plugin options.
* Create an article or category (or any other place that has an editor)

### Expected result
Empty editor field


### Actual result
The editor field contains a notice about an undefined property "$readonly".


### Documentation Changes Required
None
