### PR TITLE
[4.0] Fix PHPUnit tests in JModelList

### DIFF
--- a/tests/unit/suites/libraries/cms/model/JModelListTest.php
+++ b/tests/unit/suites/libraries/cms/model/JModelListTest.php
@@ -42,7 +42,7 @@ class JModelListTest extends TestCaseDatabase
 		JFactory::$application = $this->getMockCmsApp();
 		JFactory::$session = $this->getMockSession();
 
-		$this->object = new JModelList(array("filter_fields" => array("field1", "field2")));
+		$this->object = new \Joomla\CMS\Model\ListModel(array("filter_fields" => array("field1", "field2")));
 	}
 
 	/**
@@ -81,7 +81,7 @@ class JModelListTest extends TestCaseDatabase
 	 */
 	public function testContextIsSetInConstructor()
 	{
-		$this->assertSame("com_joomla\cms\model\list.\listmodel", TestReflection::getValue($this->object, 'context'));
+		$this->assertSame("com_.listmodel", TestReflection::getValue($this->object, 'context'));
 	}
 
 	/**
@@ -134,7 +134,7 @@ class JModelListTest extends TestCaseDatabase
 		$this->object->setState('list.ordering', 'enabled');
 		$this->object->setState('list.direction', 'ASC');
 
-		$expectedString = "com_joomla\cms\model\list.\listmodel:1:0:100:enabled:ASC";
+		$expectedString = "com_.listmodel:1:0:100:enabled:ASC";
 
 		$this->assertSame(md5($expectedString), $method->invokeArgs($this->object, array('1')));
 	}
@@ -401,7 +401,7 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock->expects($this->once())
 			->method('getUserState')
 			->with(
-				$this->equalTo('com_joomla\cms\model\list.\listmodel'),
+				$this->equalTo('com_.listmodel'),
 				$this->equalTo(new stdClass)
 			)
 			->will(
@@ -451,7 +451,7 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock->expects($this->once())
 			->method('getUserState')
 			->with(
-				$this->equalTo('com_joomla\cms\model\list.\listmodel'),
+				$this->equalTo('com_.listmodel'),
 				$this->equalTo(new stdClass)
 			)
 			->will($this->returnValue($data));
@@ -485,12 +485,12 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
 				array($this->equalTo('global.list.limit'), $this->equalTo('limit'), $this->equalTo(null), $this->equalTo('uint')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -539,12 +539,12 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
 				array($this->equalTo('global.list.limit'), $this->equalTo('limit'), $this->equalTo(null), $this->equalTo('uint')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('inwhitelist'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('inwhitelist'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -591,12 +591,12 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
 				array($this->equalTo('global.list.limit'), $this->equalTo('limit'), $this->equalTo(null), $this->equalTo('uint')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -639,12 +639,12 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
 				array($this->equalTo('global.list.limit'), $this->equalTo('limit'), $this->equalTo(null), $this->equalTo('uint')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.ordercol'), $this->equalTo('filter_order'), $this->equalTo('col'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.orderdirn'), $this->equalTo('filter_order_Dir'), $this->equalTo('ASC'), $this->equalTo('none')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -703,9 +703,9 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -756,9 +756,9 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -806,9 +806,9 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -854,9 +854,9 @@ class JModelListTest extends TestCaseDatabase
 		$applicationMock = $this->getMockCmsApp();
 		$applicationMock->method('getUserStateFromRequest')
 			->withConsecutive(
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
-				array($this->equalTo('com_joomla\cms\model\list.\listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
+				array($this->equalTo('com_.listmodel.filter'), $this->equalTo('filter'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.list'), $this->equalTo('list'), $this->equalTo(array()), $this->equalTo('array')),
+				array($this->equalTo('com_.listmodel.limitstart'), $this->equalTo('limitstart'), $this->equalTo(0))
 			)
 			->will(
 				$this->onConsecutiveCalls(


### PR DESCRIPTION
### Summary of Changes

Fixed the failing JModelList tests in 4.x branch.. Because we changed the class name from JModelList to ModelList the extension is now empty (instead of com_j before, now we have com_), this detection needs fixing in the Model itself.

### Testing Instructions

Review travis is green, don't look at the code or you will cry (i just made it work again)

How you can test 15 times that the context is (magically) com_.listmodel is.. just don't look at the code please.

Going to rewrite the tests once we are nearer to an stable namespaced MVC layer..

### Expected result

Travis passes

### Actual result

Travis fails

### Documentation Changes Required

none