### PR TITLE
Improve the override creator for JLayouts

### DIFF
--- a/administrator/components/com_templates/views/template/tmpl/default.php
+++ b/administrator/components/com_templates/views/template/tmpl/default.php
@@ -36,7 +36,7 @@ JFactory::getDocument()->addScriptDeclaration("
 jQuery(document).ready(function($){
 
 	// Hide all the folder when the page loads
-	$('.folder ul, .component-folder ul').hide();
+	$('.folder ul, .component-folder ul, .layout-folder ul').hide();
 
 	// Display the tree after loading
 	$('.directory-tree').removeClass('directory-tree');
@@ -45,7 +45,7 @@ jQuery(document).ready(function($){
 	$('.show > ul').show();
 
 	// Stop the default action of anchor tag on a click event
-	$('.folder-url, .component-folder-url').click(function(event){
+	$('.folder-url, .component-folder-url, .layout-folder-url').click(function(event){
 		event.preventDefault();
 	});
 
@@ -55,7 +55,7 @@ jQuery(document).ready(function($){
 	});
 
 	// Toggle the child indented list on a click event
-	$('.folder, .component-folder').bind('click',function(e){
+	$('.folder, .component-folder, .layout-folder').bind('click',function(e){
 		$(this).children('ul').toggle();
 		e.stopPropagation();
 	});
@@ -391,16 +391,25 @@ if ($this->type == 'font')
 		<legend><?php echo JText::_('COM_TEMPLATES_OVERRIDES_LAYOUTS'); ?></legend>
 		<ul class="nav nav-list">
 			<?php $token = JSession::getFormToken() . '=' . 1; ?>
-			<?php foreach ($this->overridesList['layouts'] as $layout) : ?>
-				<li>
-					<?php
-					$overrideLinkUrl = 'index.php?option=com_templates&view=template&task=template.overrides&folder=' . $layout->path
-							. '&id=' . $input->getInt('id') . '&file=' . $this->file . '&' . $token;
-					?>
-					<a href="<?php echo JRoute::_($overrideLinkUrl); ?>">
-						<span class="icon-copy"></span>&nbsp;<?php echo $layout->name; ?>
-					</a>
-				</li>
+			<?php foreach ($this->overridesList['layouts'] as $key => $value) : ?>
+			<li class="layout-folder">
+				<a href="#" class="layout-folder-url">
+					<span class="icon-folder"></span>&nbsp;<?php echo $key; ?>
+				</a>
+				<ul class="nav nav-list">
+					<?php foreach ($value as $layout) : ?>
+						<li>
+							<?php
+							$overrideLinkUrl = 'index.php?option=com_templates&view=template&task=template.overrides&folder=' . $layout->path
+									. '&id=' . $input->getInt('id') . '&file=' . $this->file . '&' . $token;
+							?>
+							<a href="<?php echo JRoute::_($overrideLinkUrl); ?>">
+								<span class="icon-copy"></span>&nbsp;<?php echo $layout->name; ?>
+							</a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</li>
 			<?php endforeach; ?>
 		</ul>
 	</div>


### PR DESCRIPTION
### Summary of Changes
Currently, the override creator only allows to create overrides for JLayouts located withing /layouts/joomla.
![current](https://cloud.githubusercontent.com/assets/1018684/24977414/4a592d36-1fcd-11e7-8827-2b2db59e232e.PNG)

This PR changes the code so it can also create overrides for the other global JLayouts plus for JLayouts located within a component folder (compontens/com_foo/layouts).
![new](https://cloud.githubusercontent.com/assets/1018684/24977507/9358122c-1fcd-11e7-94d4-73819983a6c4.PNG)

### Testing Instructions
* Create various overrides for JLayouts as well as view ones
* Adjust the created file a bit (you'll see the path to it in the success message) so you can see the override actually works

### Expected result
* You can create overrides for all global JLayouts as well as for component specific ones (eg com_fields)
* Your changes in the created override will have an effect

### Actual result
Only possible to create overrides for Jlayouts in /layouts/joomla

### Documentation Changes Required
Not that I'm aware

Pinging @angieradtke