### PR TITLE
Allow backend menu module to still work without client_id column

### DIFF
--- a/administrator/modules/mod_menu/preset/enabled.php
+++ b/administrator/modules/mod_menu/preset/enabled.php
@@ -162,7 +162,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
-	$menuTypes = ArrayHelper::sortObjects($menuTypes, array('client_id', 'title'), 1, false);
+	$menuTypes = ArrayHelper::sortObjects($menuTypes, isset($menuTypes[0]->client_id) ? array('client_id', 'title') : 'title', 1, false);
 
 	foreach ($menuTypes as $mti => $menuType)
 	{
@@ -197,7 +197,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 			$titleicon = ' <span class="label" title="' . $menuType->title_native . '">' . $menuType->sef . '</span>';
 		}
 
-		if (isset($menuTypes[$mti - 1]) && $menuTypes[$mti - 1]->client_id != $menuType->client_id)
+		if (isset($menuTypes[$mti - 1], $menuType->client_id) && $menuTypes[$mti - 1]->client_id != $menuType->client_id)
 		{
 			$this->addSeparator(JText::_('JADMINISTRATOR'));
 		}


### PR DESCRIPTION
Pull Request for Issue #15145

### Summary of Changes
Allow backend menu module to still work with old (pre j37) database structure, i.e. without client_id column.

### Testing Instructions
Install J3.5.1
Enable error reporting
Update it to 3.7 rc*
When update scripts asks for confirmation for update, there are notices at the top of page. 
After this patch to the update package, there should be no notices.

### Documentation Changes Required
None
