### PR TITLE
Deprecate less compiler

### DIFF
--- a/libraries/cms/less/formatter/joomla.php
+++ b/libraries/cms/less/formatter/joomla.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Libraries
  * @subpackage  Less
  * @since       3.4
+ * @deprecated  4.0  without replacement
  */
 class JLessFormatterJoomla extends lessc_formatter_classic
 {

--- a/libraries/cms/less/less.php
+++ b/libraries/cms/less/less.php
@@ -15,6 +15,7 @@ defined('JPATH_PLATFORM') or die;
  * @package     Joomla.Libraries
  * @subpackage  Less
  * @since       3.4
+ * @deprecated  4.0  without replacement
  */
 class JLess extends lessc
 {
@@ -42,7 +43,7 @@ class JLess extends lessc
 	 * Override compile to reset $this->allParsedFiles array to allow
 	 * parsing multiple files/strings using same imports.
 	 * PR: https://github.com/leafo/lessphp/pull/607
-	 * 
+	 *
 	 * For documentation on this please see /vendor/leafo/lessc.inc.php
 	 *
 	 * @param   string  $string  LESS string to parse.


### PR DESCRIPTION
The [less library](https://github.com/leafo/lessphp) we have in core is not maintained anymore. Additionally was scss overtaking less in recent months, so it is natural to retire that thing and remove it in Joomla 4.

Maintainer review.