### PR TITLE
Invalid markup with color field

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -60,6 +60,7 @@ $class        = ' class="' . trim('minicolors ' . $class) . ($validate == 'color
 $control      = $control ? ' data-control="' . $control . '"' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
 $keywords     = $keywords ? ' data-keywords="' . $keywords . '"' : '';
+$validate     = $validate ? ' data-validate="' . $validate . '"' : '';
 $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $hint . '"' : ' placeholder="' . $placeholder . '"';


### PR DESCRIPTION
### Summary of Changes
Fix invalid markup with color field.

### Testing Instructions
Go to Content > Fields.
Click `New` button.
Enter title and select `Colour` type. 
Click `Save & Close` button.
Go to Content > Articles.
Edit an article.
View page source.
Find `data-format="hex"color`.

### Expected result
![custom-valid-color](https://cloud.githubusercontent.com/assets/368084/25013284/e1fab3ee-2027-11e7-8c6a-d34c5c4f7fa3.jpg)

### Actual result
![custom-invalid-color](https://cloud.githubusercontent.com/assets/368084/25013211/9f7881d6-2027-11e7-804f-2e478ff0f564.jpg)