### PR TITLE
[com_install] - fix for all languages filter

### DIFF
--- a/administrator/components/com_installer/models/languages.php
+++ b/administrator/components/com_installer/models/languages.php
@@ -179,8 +179,9 @@ class InstallerModelLanguages extends JModelList
 
 		// Count the non-paginated list
 		$this->languageCount = count($languages);
+		$limit               = ($this->getState('list.limit') > 0) ? $this->getState('list.limit') : $this->languageCount;
 
-		return array_slice($languages, $this->getStart(), $this->getState('list.limit'));
+		return array_slice($languages, $this->getStart(), $limit);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #15290 .

### Summary of Changes
set a default when "all languages" is selected


### Testing Instructions
Extensions: Install Languages and set the filter to display ALL


### Expected result
all langauges


### Actual result
no result


