### PR TITLE
[com_fields] Filtering by language should only be done when the site is multingual

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -326,7 +326,7 @@ class UsersModelRegistration extends JModelForm
 	{
 		$data = $this->getData();
 
-		if (empty($data->language))
+		if (JLanguageMultilang::isEnabled() && empty($data->language))
 		{
 			$data->language = JFactory::getLanguage()->getTag();
 		}


### PR DESCRIPTION
This corrects https://github.com/joomla/joomla-cms/pull/15223

See testing instructions there.

We should not filter by language on a monolanguage site.
Same issue here: https://github.com/joomla/joomla-cms/issues/15229
