### PR TITLE
[mod_languages] Remove empty class attributes

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -46,7 +46,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 		<ul class="<?php echo $params->get('lineheight', 1) ? 'lang-block' : 'lang-inline'; ?> dropdown-menu" dir="<?php echo JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active || $params->get('show_active', 0)) : ?>
-				<li class="<?php echo $language->active ? 'lang-active' : ''; ?>" >
+				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo $language->link; ?>">
 					<?php if ($language->image) : ?>
 						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -62,7 +62,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 	<ul class="<?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active || $params->get('show_active', 0)) : ?>
-			<li class="<?php echo $language->active ? 'lang-active' : ''; ?>" dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
+			<li<?php echo $language->active ? ' class="lang-active"' : ''; ?> dir="<?php echo $language->rtl ? 'rtl' : 'ltr'; ?>">
 			<a href="<?php echo $language->link; ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>


### PR DESCRIPTION
### Summary of Changes
Remove empty class attributes.

### Testing Instructions
Install languages.
Publish `Language Switcher` plugin.
Go to the frontend.
View page source.

### Expected result
![class-after](https://cloud.githubusercontent.com/assets/368084/25047281/abea43aa-20ea-11e7-88fc-bdc492cc0196.jpg)

### Actual result
![class-before](https://cloud.githubusercontent.com/assets/368084/25047280/a9628160-20ea-11e7-9d52-bac3af405323.jpg)