### PR TITLE
Skip activate task in fields system plugin

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -121,7 +121,7 @@ class PlgSystemFields extends JPlugin
 		$task = JFactory::getApplication()->input->getCmd('task');
 
 		// Skip fields save when we activate a user, because we will lose the saved data
-		if ($task === 'activate')
+		if (in_array($task, array('activate', 'block', 'unblock')))
 		{
 			return true;
 		}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -118,6 +118,14 @@ class PlgSystemFields extends JPlugin
 
 		$user = JFactory::getUser($userData['id']);
 
+		$task = JFactory::getApplication()->input->get('task');
+
+		// Skip fields save when we activate a user, because we will lose the saved data
+		if ($task === 'activate')
+		{
+			return true;
+		}
+
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -118,7 +118,7 @@ class PlgSystemFields extends JPlugin
 
 		$user = JFactory::getUser($userData['id']);
 
-		$task = JFactory::getApplication()->input->get('task');
+		$task = JFactory::getApplication()->input->getCmd('task');
 
 		// Skip fields save when we activate a user, because we will lose the saved data
 		if ($task === 'activate')


### PR DESCRIPTION
Pull Request for Issue #15194

### Summary of Changes
When activating a account we don't need to process the field check/save procedure 


### Testing Instructions
* Add a text field to a user e.g. Company
* Register a user (have set: New user account activation to administrator)
* process the activation

Data get's lost

Apply patch and do the same process

Data will not get lost

