### PR TITLE
Fixed wrong data type declaration

### DIFF
--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -300,7 +300,7 @@ class JUpdater extends JAdapter
 
 			if (array_key_exists('updates', $update_result) && count($update_result['updates']))
 			{
-				/** @var JUpdate $current_update */
+				/** @var JTableUpdate $current_update */
 				foreach ($update_result['updates'] as $current_update)
 				{
 					$current_update->extra_query = $updateSite['extra_query'];


### PR DESCRIPTION
$current_update is declared as JUpdate, but actually it's a JTableUpdate instead.
If it was a JUpdate, the subsequent calls to properties `$current_update->extra_query` and `$current_update->version` would cause a fatal error, since they are protected properties.

It can be verified with the help of a the debugger.
