### PR TITLE
Only delete properties set in data and keep ordering intact

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -446,7 +446,7 @@ class PlgUserProfile extends JPlugin
 
 				foreach ($data['profile'] as $k => $v)
 				{
-					while(in_array($order, $usedOrdering))
+					while (in_array($order, $usedOrdering))
 					{
 						$order++;
 					}

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -414,22 +414,43 @@ class PlgUserProfile extends JPlugin
 		{
 			try
 			{
+				$db = JFactory::getDbo();
+
 				// Sanitize the date
 				$data['profile']['dob'] = $this->date;
 
-				$db = JFactory::getDbo();
+				$keys = array_keys($data['profile']);
+
+				foreach ($keys as &$key)
+				{
+					$key = 'profile.' . $key;
+					$key = $db->quote($key);
+				}
+
 				$query = $db->getQuery(true)
 					->delete($db->quoteName('#__user_profiles'))
 					->where($db->quoteName('user_id') . ' = ' . (int) $userId)
-					->where($db->quoteName('profile_key') . ' LIKE ' . $db->quote('profile.%'));
+					->where($db->quoteName('profile_key') . ' IN (' . implode(',', $keys) . ')');
 				$db->setQuery($query);
 				$db->execute();
+
+				$query = $db->getQuery(true)
+					->select($db->quoteName('ordering'))
+					->from($db->quoteName('#__user_profiles'))
+					->where($db->quoteName('user_id') . ' = ' . (int) $userId);
+				$db->setQuery($query);
+				$usedOrdering = $db->loadColumn();
 
 				$tuples = array();
 				$order = 1;
 
 				foreach ($data['profile'] as $k => $v)
 				{
+					while(in_array($order, $usedOrdering))
+					{
+						$order++;
+					}
+
 					$tuples[] = '(' . $userId . ', ' . $db->quote('profile.' . $k) . ', ' . $db->quote(json_encode($v)) . ', ' . ($order++) . ')';
 				}
 


### PR DESCRIPTION
Pull Request for Issue #9129

### Summary of Changes



### Testing Instructions
* Enable the user - profile plugin.
* Within the plugin, under "User profile fields for registration and administrator user forms" select optional for the "Favorite Book" field.
* under "User profile fields for profile edit form", select "disable" for the "Favorite Book" field.
* Create a user in the administrator panel and fill in the "Favorite Book" field.
* Go to the front-end, select "edit your profile" and hit submit.

Expected result

The "Favorite Book" field should stay the same.

Actual result

Before Patch: If you go to the administrator panel the "Favorite Book" field will be empty.
After Patch: If you go to the administrator panel the "Favorite Book" field will as before.