### PR TITLE
[com_fields] Restored PHP 5.3 backward compatibility

### DIFF
--- a/administrator/components/com_fields/tables/group.php
+++ b/administrator/components/com_fields/tables/group.php
@@ -119,9 +119,9 @@ class FieldsTableGroup extends JTable
 	 */
 	protected function _getAssetName()
 	{
-		$component = explode('.', $this->context)[0];
+		$component = explode('.', $this->context);
 
-		return $component . '.fieldgroup.' . (int) $this->id;
+		return $component[0] . '.fieldgroup.' . (int) $this->id;
 	}
 
 	/**
@@ -157,12 +157,12 @@ class FieldsTableGroup extends JTable
 	 */
 	protected function _getAssetParentId(JTable $table = null, $id = null)
 	{
-		$component = explode('.', $this->context)[0];
+		$component = explode('.', $this->context);
 		$db = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
 			->from($db->quoteName('#__assets'))
-			->where($db->quoteName('name') . ' = ' . $db->quote($component));
+			->where($db->quoteName('name') . ' = ' . $db->quote($component[0]));
 		$db->setQuery($query);
 
 		if ($assetId = (int) $db->loadResult())


### PR DESCRIPTION
"Function array dereferencing" would break PHP 5.3 backward compatibility.

To be merged on code review.