### PR TITLE
[com_postinstall] - hathor message postgres sql error

### DIFF
--- a/administrator/templates/hathor/postinstall/hathormessage.php
+++ b/administrator/templates/hathor/postinstall/hathormessage.php
@@ -29,7 +29,7 @@ function hathormessage_postinstall_condition()
 		$query = $db->getQuery(true)
 			->select('template')
 			->from($db->quoteName('#__template_styles'))
-			->where($db->quoteName('home') . ' = 1')
+			->where($db->quoteName('home') . ' = ' . $db->quote('1'))
 			->where($db->quoteName('client_id') . ' = 1');
 
 		// Get the global setting about the default template
@@ -108,7 +108,7 @@ function hathormessage_postinstall_action()
 	{
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__template_styles'))
-			->set($db->quoteName('home') . ' = 0')
+			->set($db->quoteName('home') . ' = ' . $db->quote('0'))
 			->where($db->quoteName('template') . ' = "hathor"')
 			->where($db->quoteName('client_id') . ' = 1');
 
@@ -117,7 +117,7 @@ function hathormessage_postinstall_action()
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__template_styles'))
-			->set($db->quoteName('home') . ' = 1')
+			->set($db->quoteName('home') . ' = ' . $db->quote('1'))
 			->where($db->quoteName('template') . ' = "isis"')
 			->where($db->quoteName('client_id') . ' = 1')
 			->where($db->quoteName('id') . ' = ' . $isisStyleId[0]);


### PR DESCRIPTION
fix #__template_styles sql  cast error


### Summary of Changes
the field home of #__template_styles is declared as varchar 
db's other than mysql doesn't like different type



### Testing Instructions
with postgresql go to
Control panel 
and 
Components->Post-installation messages

gives error



### Expected result
no error


### Actual result
sql error
![er1](https://cloud.githubusercontent.com/assets/181681/25061150/4f9e019c-21b0-11e7-8f8f-09a3522d1ccd.PNG)

![er2](https://cloud.githubusercontent.com/assets/181681/25061154/613fbb20-21b0-11e7-8bdf-744ae3e0c6aa.PNG)
