### PR TITLE
[com_languages] - Installed Languages Filter

### DIFF
--- a/administrator/components/com_languages/models/forms/filter_installed.xml
+++ b/administrator/components/com_languages/models/forms/filter_installed.xml
@@ -31,6 +31,8 @@
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="name ASC">COM_LANGUAGES_HEADING_LANGUAGE_ASC</option>
 			<option value="name DESC">COM_LANGUAGES_HEADING_LANGUAGE_DESC</option>
+			<option value="nativeName ASC">COM_LANGUAGES_HEADING_TITLE_NATIVE_ASC</option>
+			<option value="nativeName DESC">COM_LANGUAGES_HEADING_TITLE_NATIVE_DESC</option>
 			<option value="language ASC">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
 			<option value="language DESC">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
 			<option value="published ASC">COM_LANGUAGES_HEADING_DEFAULT_ASC</option>

--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -74,6 +74,7 @@ class LanguagesModelInstalled extends JModelList
 		{
 			$config['filter_fields'] = array(
 				'name',
+				'nativeName',
 				'language',
 				'author',
 				'published',


### PR DESCRIPTION
Pull Request for Issue #15298 .

### Summary of Changes

added missed filter field "nativeName" 

### Testing Instructions
Steps to reproduce the issue

Install multiple languages and go to Languages->Installed

### Expected result

All columns are clickable as sort and display the direction icon
Filters in the dropdown match the column order and all have ascending and descending options

### Actual result
Native Title column does not have direction arrows
Native Title is at the end of the filters dropdown list and doesnt have ascending or descending options


