### PR TITLE
Code cleanup

### DIFF
--- a/administrator/components/com_content/views/article/tmpl/edit_metadata.php
+++ b/administrator/components/com_content/views/article/tmpl/edit_metadata.php
@@ -10,4 +10,3 @@
 defined('_JEXEC') or die;
 
 echo JLayoutHelper::render('joomla.edit.metadata', $this);
-?>

--- a/administrator/components/com_content/views/article/tmpl/modal_metadata.php
+++ b/administrator/components/com_content/views/article/tmpl/modal_metadata.php
@@ -10,4 +10,3 @@
 defined('_JEXEC') or die;
 
 echo JLayoutHelper::render('joomla.edit.metadata', $this);
-?>


### PR DESCRIPTION
Removed PHP closing tags.

PHP closing tags may indirectly generate (when they are followed by spaces or newline, and this is the case) the warning

> "Cannot modify header information - headers already sent"

I've modified two layout files accordingly, to reflect the project standards.
To be merged on review.