### PR TITLE
Deprecate the unused method sendAdminMail from JMail to be removed in 4.0

### DIFF
--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -757,6 +757,7 @@ class JMail extends PHPMailer
 	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
+	 * @deprecated  4.0  Without replacedment please implement it in your own code
 	 */
 	public function sendAdminMail($adminName, $adminEmail, $email, $type, $title, $author, $url = null)
 	{

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -757,7 +757,7 @@ class JMail extends PHPMailer
 	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
-	 * @deprecated  4.0  Without replacedment please implement it in your own code
+	 * @deprecated  4.0  Without replacement please implement it in your own code
 	 */
 	public function sendAdminMail($adminName, $adminEmail, $email, $type, $title, $author, $url = null)
 	{


### PR DESCRIPTION
Pull Request for Issue #10629

### Summary of Changes

Deprecates the unused method, without replacement to be implemented by the extension itself.

### Testing Instructions

Review as this is just a doc block change.

### Documentation Changes Required

None at this point.