### PR TITLE
[4.0] Replaced remaining js alerts for joomla alerts for the toolbar buttons

### DIFF
--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -13,9 +13,11 @@ JHtml::_('behavior.core');
 
 $title = $displayData['title'];
 JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-$message = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
+JText::script('WARNING');
+$warning = "{'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+$alert = "Joomla.renderMessages(" . $warning . ")";
 ?>
-<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $message; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
+<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
 	<span class="icon-checkbox-partial" title="<?php echo $title; ?>"></span>
 	<?php echo $title; ?>
 </button>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -13,9 +13,9 @@ JHtml::_('behavior.core');
 
 $title = $displayData['title'];
 JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-JText::script('WARNING');
-$warning = "{'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
-$alert = "Joomla.renderMessages(" . $warning . ")";
+JText::script('ERROR');
+$message = "{'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+$alert = "Joomla.renderMessages(" . $message . ")";
 ?>
 <button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
 	<span class="icon-checkbox-partial" title="<?php echo $title; ?>"></span>

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -88,15 +88,15 @@ class JToolbarButtonConfirm extends JToolbarButton
 	protected function _getCommand($msg, $name, $task, $list)
 	{
 		JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
-		JText::script('WARNING');
+		JText::script('ERROR');
 
 		$cmd = "if (confirm('" . $msg . "')) { Joomla.submitbutton('" . $task . "'); }";
 
 		if ($list)
 		{
 
-			$warning = "{'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
-			$alert = "Joomla.renderMessages(" . $warning . ")";
+			$message = "{'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+			$alert = "Joomla.renderMessages(" . $message . ")";
 			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
 			
 		}

--- a/libraries/cms/toolbar/button/confirm.php
+++ b/libraries/cms/toolbar/button/confirm.php
@@ -88,12 +88,15 @@ class JToolbarButtonConfirm extends JToolbarButton
 	protected function _getCommand($msg, $name, $task, $list)
 	{
 		JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
+		JText::script('WARNING');
 
 		$cmd = "if (confirm('" . $msg . "')) { Joomla.submitbutton('" . $task . "'); }";
 
 		if ($list)
 		{
-			$alert = "alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
+
+			$warning = "{'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+			$alert = "Joomla.renderMessages(" . $warning . ")";
 			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
 			
 		}

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -122,7 +122,7 @@ class JToolbarButtonStandard extends JToolbarButton
 
 		if ($list)
 		{
-			$messages = "{'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+			$messages = "{'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
 			$alert = "Joomla.renderMessages(" . $messages . ")";
 			$cmd   = "if (document.adminForm.boxchecked.value == 0) { " . $alert . " } else { " . $cmd . " }";
 		}

--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -123,7 +123,7 @@ class JToolbarButtonTest extends TestCaseDatabase
 	{
 		$type = array('Standard', 'test');
 
-		$expected = "\n<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { Joomla.submitbutton(''); }\" class=\"btn btn-sm btn-outline-primary\">\n\t<span class=\"icon-test\"></span>\n\t</button>\n";
+		$expected = "\n<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { Joomla.submitbutton(''); }\" class=\"btn btn-sm btn-outline-primary\">\n\t<span class=\"icon-test\"></span>\n\t</button>\n";
 
 		$this->assertEquals(
 			$expected,

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -92,7 +92,7 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
+		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
 			. "\t<span class=\"icon-confirm-test\"></span>\n"
 			. "\tConfirm?</button>\n";
 

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -92,9 +92,10 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
+		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'warning': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
 			. "\t<span class=\"icon-confirm-test\"></span>\n"
 			. "\tConfirm?</button>\n";
+
 
 		$this->assertEquals(
 			$this->object->fetchButton('Confirm', 'Confirm action?', 'confirm-test', 'Confirm?', 'article.save'),


### PR DESCRIPTION
### Summary of Changes

As a followup to the Pull Request #15315 , besides the standard buttons I've noticed there were still buttons in the toolbar with the standard JS alert() on click when no item is selected, the batch button and the delete button, for instance, in Users. I've replaced the JS alert with the Joomla alert for those remaining buttons, I believe all buttons in the toolbar now have the Joomla alert on click when no item is selected.  

### Testing Instructions

Go to Banners and press Batch with no items selected and go to Users and press Delete with no items selected. In both cases you should see the Joomla alert instead of the JS alert().

### Expected result

Toolbar buttons batch and toolbar standard buttons with a confirm dialog and Joomla alert on click.

![deepinscreenshot20170416134643](https://cloud.githubusercontent.com/assets/6710380/25071361/a780e3fa-22ac-11e7-966c-427485eb5442.png)

![deepinscreenshot20170416134712](https://cloud.githubusercontent.com/assets/6710380/25071362/a790d65c-22ac-11e7-807d-87729d54072e.png)


### Actual result

Toolbar buttons batch and toolbar standard buttons with a confirm dialog and standard JS alert() on click.

![deepinscreenshot20170416132255](https://cloud.githubusercontent.com/assets/6710380/25071355/7c8e1596-22ac-11e7-97bb-6c264aa6fde5.png)

![deepinscreenshot20170416132354](https://cloud.githubusercontent.com/assets/6710380/25071356/7c9e07ee-22ac-11e7-8588-e2dfae690219.png)

### Documentation Changes Required

None
