### PR TITLE
[4.0] [com_fields] Articles filterform misalignment fixed

### DIFF
--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -41,11 +41,15 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-				<div id="filter-bar" class="js-stools-container-bar float-left">
-					<div class="btn-group float-left">
-						<?php echo $this->filterForm->getField('context')->input; ?>
-					</div>&nbsp;
-				</div>
+                <div id="filter-bar" class="js-stools clearfix">
+                    <div class="js-stools-container-list hidden-md-down">
+                        <div class="ordering-select hidden-sm-down">
+                            <div class="js-stools-field-list">
+								<?php echo $this->filterForm->getField('context')->input; ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -45,7 +45,7 @@ if ($saveOrder)
                     <div class="js-stools-container-list hidden-md-down">
                         <div class="ordering-select hidden-sm-down">
                             <div class="js-stools-field-list">
-								<?php echo $this->filterForm->getField('context')->input; ?>
+                                <?php echo $this->filterForm->getField('context')->input; ?>
                             </div>
                         </div>
                     </div>

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -41,15 +41,15 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-                <div id="filter-bar" class="js-stools clearfix">
-                    <div class="js-stools-container-list hidden-md-down">
-                        <div class="ordering-select hidden-sm-down">
-                            <div class="js-stools-field-list">
-                                <?php echo $this->filterForm->getField('context')->input; ?>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+				<div id="filter-bar" class="js-stools clearfix">
+					<div class="js-stools-container-list hidden-md-down">
+						<div class="ordering-select hidden-sm-down">
+							<div class="js-stools-field-list">
+								<?php echo $this->filterForm->getField('context')->input; ?>
+							</div>
+						</div>
+					</div>
+				</div>
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -43,7 +43,7 @@ if ($saveOrder)
 			<div id="j-main-container" class="j-main-container">
 				<div id="filter-bar" class="js-stools clearfix">
 					<div class="js-stools-container-list hidden-md-down">
-						<div class="ordering-select hidden-sm-down">
+						<div class="hidden-sm-down">
 							<div class="js-stools-field-list">
 								<?php echo $this->filterForm->getField('context')->input; ?>
 							</div>

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -46,11 +46,15 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-				<div id="filter-bar" class="js-stools-container-bar float-left">
-					<div class="btn-group float-left">
-						<?php echo $this->filterForm->getField('context')->input; ?>
-					</div>&nbsp;
-				</div>
+                <div id="filter-bar" class="js-stools clearfix">
+                    <div class="js-stools-container-list hidden-md-down">
+                        <div class="ordering-select hidden-sm-down">
+                            <div class="js-stools-field-list">
+								<?php echo $this->filterForm->getField('context')->input; ?>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -46,15 +46,15 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-                <div id="filter-bar" class="js-stools clearfix">
-                    <div class="js-stools-container-list hidden-md-down">
-                        <div class="ordering-select hidden-sm-down">
-                            <div class="js-stools-field-list">
-                                <?php echo $this->filterForm->getField('context')->input; ?>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+				<div id="filter-bar" class="js-stools clearfix">
+					<div class="js-stools-container-list hidden-md-down">
+						<div class="ordering-select hidden-sm-down">
+							<div class="js-stools-field-list">
+								<?php echo $this->filterForm->getField('context')->input; ?>
+							</div>
+						</div>
+					</div>
+				</div>
 				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -50,7 +50,7 @@ if ($saveOrder)
                     <div class="js-stools-container-list hidden-md-down">
                         <div class="ordering-select hidden-sm-down">
                             <div class="js-stools-field-list">
-								<?php echo $this->filterForm->getField('context')->input; ?>
+                                <?php echo $this->filterForm->getField('context')->input; ?>
                             </div>
                         </div>
                     </div>

--- a/administrator/components/com_fields/views/groups/tmpl/default.php
+++ b/administrator/components/com_fields/views/groups/tmpl/default.php
@@ -48,7 +48,7 @@ if ($saveOrder)
 			<div id="j-main-container" class="j-main-container">
 				<div id="filter-bar" class="js-stools clearfix">
 					<div class="js-stools-container-list hidden-md-down">
-						<div class="ordering-select hidden-sm-down">
+						<div class="hidden-sm-down">
 							<div class="js-stools-field-list">
 								<?php echo $this->filterForm->getField('context')->input; ?>
 							</div>


### PR DESCRIPTION
Pull Request for Issue #14742 .

### Summary of Changes

Fixed the misalignment both in the Fields view and Field Groups view, shifted the filterform to the right alongside the other filterforms from the search tools bar in order to be more organized and fix the misalignment. Not sure if this is the right solution that was expected but solves the problem and organizes the filterforms in the same place. 

### Testing Instructions

Go to Content -> Fields  or Content -> Field Groups and check if the articles filterform is in the far right next to the other filterforms from the search tools bar.

### Expected result

Articles filterform on the far right next to other filterforms from the search tools bar:

Fields view:
![deepinscreenshot20170416212455](https://cloud.githubusercontent.com/assets/6710380/25074044/47b42ae2-22eb-11e7-87a6-ea273bc42549.png)

Field groups view:
![deepinscreenshot20170416212523](https://cloud.githubusercontent.com/assets/6710380/25074045/47cb102c-22eb-11e7-98a4-6d46ca0d272c.png)

### Actual result

Articles filterform on the left misaligned from the search tools bar.

Fields view:
![deepinscreenshot20170416212811](https://cloud.githubusercontent.com/assets/6710380/25074068/bbcc6e4e-22eb-11e7-8f73-403aaebc1ab5.png)

Field groups:
![deepinscreenshot20170416212828](https://cloud.githubusercontent.com/assets/6710380/25074069/bbe3466e-22eb-11e7-8157-81be4f0731a5.png)

### Documentation Changes Required
None.
