### PR TITLE
[4.0] added space between menu item and description

### DIFF
--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -41,7 +41,9 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php $menutype = base64_encode(json_encode($menutype)); ?>
 					<a class="choose_type list-group-item list-group-item-action" href="#" title="<?php echo JText::_($item->description); ?>"
 						onclick="setmenutype('<?php echo $menutype; ?>')">
-						<?php echo $title; ?>
+						<div class="p-2">
+							<?php echo $title; ?>
+						</div>
 						<small class="text-muted">
 							<?php echo JText::_($item->description); ?>
 						</small>

--- a/administrator/components/com_menus/views/menutypes/tmpl/default.php
+++ b/administrator/components/com_menus/views/menutypes/tmpl/default.php
@@ -41,7 +41,7 @@ JFactory::getDocument()->addScriptDeclaration('
 					<?php $menutype = base64_encode(json_encode($menutype)); ?>
 					<a class="choose_type list-group-item list-group-item-action" href="#" title="<?php echo JText::_($item->description); ?>"
 						onclick="setmenutype('<?php echo $menutype; ?>')">
-						<div class="p-2">
+						<div class="pr-2">
 							<?php echo $title; ?>
 						</div>
 						<small class="text-muted">


### PR DESCRIPTION
Pull Request for Issue #15340 .

### Summary of Changes
Added the space between Menu item name and description


### Testing Instructions
Apply the patch and test


### Expected result
![menu item space new](https://cloud.githubusercontent.com/assets/9814784/25079325/058f191a-2359-11e7-8f67-ecc114eb122c.PNG)



### Actual result
![menu item space old](https://cloud.githubusercontent.com/assets/9814784/25079329/0ae490d4-2359-11e7-8244-b63528772693.PNG)



### Documentation Changes Required
None
