### PR TITLE
[4.0] Archive filter - BS4 migration

### DIFF
--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -162,7 +162,7 @@ class ContentViewArchive extends JViewLegacy
 			$months,
 			'month',
 			array(
-				'list.attr' => 'size="1" class="inputbox"',
+				'list.attr' => 'size="1" class="custom-select"',
 				'list.select' => $state->get('filter.month'),
 				'option.key' => null
 			)
@@ -182,7 +182,7 @@ class ContentViewArchive extends JViewLegacy
 			'select.genericlist',
 			$years,
 			'year',
-			array('list.attr' => 'size="1" class="inputbox"', 'list.select' => $state->get('filter.year'))
+			array('list.attr' => 'size="1" class="custom-select"', 'list.select' => $state->get('filter.year'))
 		);
 		$form->limitField = $pagination->getLimitBox();
 

--- a/libraries/cms/pagination/pagination.php
+++ b/libraries/cms/pagination/pagination.php
@@ -593,7 +593,7 @@ class JPagination
 				'select.genericlist',
 				$limits,
 				$this->prefix . 'limit',
-				'class="inputbox input-mini" size="1" onchange="this.form.submit()"',
+				'class="custom-select" size="1" onchange="this.form.submit()"',
 				'value',
 				'text',
 				$selected

--- a/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
+++ b/tests/unit/suites/libraries/cms/pagination/JPaginationTest.php
@@ -463,7 +463,7 @@ class JPaginationTest extends TestCase
 	{
 		return array(
 			array(100, 0, 20, false,
-				"<select id=\"limit\" name=\"limit\" class=\"inputbox input-mini\" size=\"1\" onchange=\"this.form.submit()\">\n"
+				"<select id=\"limit\" name=\"limit\" class=\"custom-select\" size=\"1\" onchange=\"this.form.submit()\">\n"
 				. "\t<option value=\"5\">5</option>\n"
 				. "\t<option value=\"10\">10</option>\n"
 				. "\t<option value=\"15\">15</option>\n"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Migrates the archive filter (and limitField) to Bootstrap 4 

### Testing Instructions
Apply patch and navigate to com_content -> archive frontend view.

### Before
![archive-filter1](https://cloud.githubusercontent.com/assets/2803503/25081986/a4a79040-2345-11e7-83a4-12b241edfe6f.png)

### After
![archive-filter2](https://cloud.githubusercontent.com/assets/2803503/25081990/a7cd544e-2345-11e7-960b-0ee92434974c.png)

### Documentation Changes Required
None
