### PR TITLE
add appveyor-retry to downloads

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - ps: >-
         If ($env:PHP -eq "1") {
           If ($env:php_ver_target -eq "5.6") {
-            appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
+            appveyor-retry appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
             7z x -y php-sqlsrv.zip > $null
             copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
             copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll
@@ -83,7 +83,7 @@ install:
         If ($env:PHP -eq "1") {
           If ($env:php_ver_target -eq "5.6") {$wincache = "1.3.7.12"} Else {$wincache = "2.0.0.8"}
           cd c:\tools\php\ext
-          appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip
+          appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip
           7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip > $null
           Remove-Item C:\tools\php\ext* -include .zip
           cd c:\tools\php}


### PR DESCRIPTION
Pull Request for Issue solution to resolve intermittent module dll download failure on php 5.6

### Summary of Changes
add `appveyor-retry` to download lines to help ensure stability if a download connection failure happens


### Testing Instructions
code review / test passes
