### PR TITLE
[4.0] Simplify for loop in articles model

### DIFF
--- a/administrator/components/com_content/Model/Articles.php
+++ b/administrator/components/com_content/Model/Articles.php
@@ -407,10 +407,10 @@ class Articles extends ListModel
 		{
 			$groups = \JFactory::getUser()->getAuthorisedViewLevels();
 
-			for ($x = 0, $count = count($items); $x < $count; $x++)
+			foreach ($items as $x => $item)
 			{
 				// Check the access level. Remove articles the user shouldn't see
-				if (!in_array($items[$x]->access, $groups))
+				if (!in_array($item->access, $groups))
 				{
 					unset($items[$x]);
 				}

--- a/administrator/components/com_content/Model/Articles.php
+++ b/administrator/components/com_content/Model/Articles.php
@@ -407,10 +407,10 @@ class Articles extends ListModel
 		{
 			$groups = \JFactory::getUser()->getAuthorisedViewLevels();
 
-			foreach ($items as $x => $item)
+			foreach (array_keys($items) as $x)
 			{
 				// Check the access level. Remove articles the user shouldn't see
-				if (!in_array($item->access, $groups))
+				if (!in_array($items[$x]->access, $groups))
 				{
 					unset($items[$x]);
 				}


### PR DESCRIPTION
### Summary of Changes
Just a small code improvement: Use foreach instead of a complex for loop (so we always use the correct key)

### Testing Instructions
The backend articles view should work exactly the same before and after the patch