### PR TITLE
[com_fields] In frontend always implement view levels for fields

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -228,7 +228,7 @@ class FieldsModelFields extends JModelList
 		}
 
 		// Implement View Level Access
-		if (!$user->authorise('core.admin'))
+		if (!$app->isClient('administrator') || !$user->authorise('core.admin'))
 		{
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ') AND (a.group_id = 0 OR g.access IN (' . $groups . '))');


### PR DESCRIPTION
Pull Request for Issue #14380 .

### Summary of Changes
This adds a check to the fields model which only bypasses view level filtering in backend.

Currently, if you are logged in as SuperUser or with a user which has permissions to manage the fields the view level check is bypassed, but that only makes sense in backend, not in frontend.

### Testing Instructions
* Create a field in the context com_contact -> mail which is set to show only for "Guest" level.
* Create another field with the same context but set it to "Public".
* Login in with your SuperUser account and check the respective contact form.

### Expected result
Only see the fields which match the viewlevel (eg don't see the Guest one)

### Actual result
You see all fields

### Documentation Changes Required
None
