### PR TITLE
[com_fields] Encode the path properly

### DIFF
--- a/plugins/fields/imagelist/tmpl/imagelist.php
+++ b/plugins/fields/imagelist/tmpl/imagelist.php
@@ -32,7 +32,7 @@ foreach ($value as $path)
 	}
 
 	$buffer .= '<img src="images/' . $fieldParams->get('directory', '/')
-				. '/' . $path . '"' . $class . '/>';
+				. '/' . htmlentities($path) . '"' . $class . '/>';
 }
 
 echo $buffer;

--- a/plugins/fields/integer/tmpl/integer.php
+++ b/plugins/fields/integer/tmpl/integer.php
@@ -21,4 +21,4 @@ if (is_array($value))
 	$value = implode(', ', $value);
 }
 
-echo htmlentities($value);
+echo (int)$value;

--- a/plugins/fields/integer/tmpl/integer.php
+++ b/plugins/fields/integer/tmpl/integer.php
@@ -21,4 +21,4 @@ if (is_array($value))
 	$value = implode(', ', $value);
 }
 
-echo (int)$value;
+echo (int) $value;

--- a/plugins/fields/media/tmpl/media.php
+++ b/plugins/fields/media/tmpl/media.php
@@ -31,7 +31,7 @@ foreach ($value as $path)
 		continue;
 	}
 
-	$buffer .= '<img src="' . $path . '"' . $class . '/>';
+	$buffer .= '<img src="' . htmlentities($path) . '"' . $class . '/>';
 }
 
 echo $buffer;

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -22,4 +22,4 @@ if (!JUri::isInternal($value))
 	$attributes = 'rel="nofollow noopener noreferrer" target="_blank"';
 }
 
-echo '<a href="' . $value . '" ' . $attributes . '>' . $value . '</a>';
+echo '<a href="' . htmlspecialchars($value) . '" ' . $attributes . '>' . htmlspecialchars($value) . '</a>';


### PR DESCRIPTION
When rendering the media field, then the path must be encoded.

Confirmed with JSST ( @SniperSister ) .

Merge by review @rdeutz.