### PR TITLE
Fails saving Native Name for Content Languages when installation folder is deleted

### DIFF
--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -313,9 +313,9 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			$contentLanguageNativeTitle = $contentLanguageTitle;
 
 			// If exist, load the native title from the language xml metadata.
-			if (isset($siteLanguageMetadata['nativeName']) && $siteLanguageMetadata['nativeName'])
+			if (isset($siteLanguageManifest['nativeName']) && $siteLanguageManifest['nativeName'])
 			{
-				$contentLanguageNativeTitle = $siteLanguageMetadata['nativeName'];
+				$contentLanguageNativeTitle = $siteLanguageManifest['nativeName'];
 			}
 
 			// Try to load a language string from the installation language var. Will be removed in 4.0.


### PR DESCRIPTION
Install RC3 or staging.
DELETE the installation folder.

Install this pack (or your own lang pack containing the <nativeName> metadata in the site xx-XX.xml) https://github.com/infograf768/fr-FR-3.x/releases/download/v3.7.0.1.RC3/fr-FR_joomla_lang_full_3.7.0v1.zip

Before patch: the nativeName is picked from the name.
After patch it is correctly set.

