### PR TITLE
[4.0] Remove X-Content-Encoded-By header

### DIFF
--- a/libraries/vendor/joomla/application/src/AbstractWebApplication.php
+++ b/libraries/vendor/joomla/application/src/AbstractWebApplication.php
@@ -230,7 +230,6 @@ abstract class AbstractWebApplication extends AbstractApplication
 
 				// Set the encoding headers.
 				$this->setHeader('Content-Encoding', $encoding);
-				$this->setHeader('X-Content-Encoded-By', 'Joomla');
 
 				// Replace the output with the encoded data.
 				$this->setBody($gzdata);


### PR DESCRIPTION
removing header for 4.0 as commented here as unwanted Information Disclosure https://github.com/joomla/joomla-cms/blob/staging/libraries/legacy/response/response.php#L258
