### PR TITLE
Remove empty class attribute in label tag

### DIFF
--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -55,6 +55,6 @@ if ($required)
 }
 
 ?>
-<label id="<?php echo $id; ?>" for="<?php echo $for; ?>" class="<?php echo implode(' ', $classes); ?>"<?php echo $title; ?><?php echo $position; ?>>
+<label id="<?php echo $id; ?>" for="<?php echo $for; ?>"<?php if (!empty($classes)) echo ' class="' . implode(' ', $classes) . '"'; ?><?php echo $title; ?><?php echo $position; ?>>
 	<?php echo $text; ?><?php if ($required) : ?><span class="star">&#160;*</span><?php endif; ?>
 </label>


### PR DESCRIPTION
Pull Request for Issue #15415.

### Summary of Changes
Do not output `class` attribute if it is empty.
 
### Testing Instructions
Edit an article.
View page source.
Search for `class=""`.
None should be found in `<label>` tag.

