### PR TITLE
#15420 fixed new/edit field cancel button issue, having error page on click of cancel button

### DIFF
--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -118,7 +118,7 @@ class FieldsViewField extends JViewLegacy
 				'btn-success'
 			);
 
-			JToolbarHelper::cancel('contact.cancel');
+			JToolbarHelper::cancel('field.cancel');
 		}
 		else
 		{
@@ -151,7 +151,7 @@ class FieldsViewField extends JViewLegacy
 				'btn-success'
 			);
 
-			JToolbarHelper::cancel('contact.cancel', 'JTOOLBAR_CLOSE');
+			JToolbarHelper::cancel('field.cancel', 'JTOOLBAR_CLOSE');
 		}
 
 		JToolbarHelper::help('JHELP_COMPONENTS_FIELDS_FIELDS_EDIT');


### PR DESCRIPTION
fixed new/edit field cancel button issue, having error page on click of cancel button

Pull Request for Issue #15420 .

### Summary of Changes


### Testing Instructions
Goto Administrator->content->fields->new and click on cancel button.

### Expected result
Redirected to fields listing page.


### Actual result
Having error page.



### Documentation Changes Required

