### PR TITLE
Strict standards violation

### DIFF
--- a/libraries/joomla/github/package/repositories/statistics.php
+++ b/libraries/joomla/github/package/repositories/statistics.php
@@ -153,13 +153,14 @@ class JGithubPackageRepositoriesStatistics  extends JGithubPackage
 	 *
 	 * @param   JHttpResponse  $response      The response.
 	 * @param   integer        $expectedCode  The expected "good" code.
+	 * @param   boolean        $decode        If the should be response be JSON decoded.
 	 *
 	 * @return  mixed
 	 *
 	 * @since   1.0
 	 * @throws  \DomainException
 	 */
-	protected function processResponse(JHttpResponse $response, $expectedCode = 200)
+	protected function processResponse(JHttpResponse $response, $expectedCode = 200, $decode = true)
 	{
 		if (202 == $response->code)
 		{
@@ -169,6 +170,6 @@ class JGithubPackageRepositoriesStatistics  extends JGithubPackage
 			);
 		}
 
-		return parent::processResponse($response, $expectedCode);
+		return parent::processResponse($response, $expectedCode, $decode);
 	}
 }


### PR DESCRIPTION
Declaration of method JGithubPackageRepositoriesStatistics::processResponse() was not compatible with JGithubObject::processResponse()

To be merged on review.