### PR TITLE
Make the JMenu class abstract

### DIFF
--- a/libraries/src/CMS/Menu/AbstractMenu.php
+++ b/libraries/src/CMS/Menu/AbstractMenu.php
@@ -16,9 +16,8 @@ use Joomla\Registry\Registry;
  * Menu class
  *
  * @since  1.5
- * @note   Will become abstract in Joomla 4
  */
-class AbstractMenu
+abstract class AbstractMenu
 {
 	/**
 	 * Array to hold the menu items
@@ -349,8 +348,5 @@ class AbstractMenu
 	 *
 	 * @since   1.5
 	 */
-	public function load()
-	{
-		return array();
-	}
+	abstract public function load();
 }

--- a/libraries/src/CMS/Menu/AbstractMenu.php
+++ b/libraries/src/CMS/Menu/AbstractMenu.php
@@ -98,6 +98,11 @@ abstract class AbstractMenu
 	 */
 	public static function getInstance($client, $options = array())
 	{
+		if (!$client)
+		{
+			throw new \Exception(\JText::sprintf('JLIB_APPLICATION_ERROR_MENU_LOAD', $client), 500);
+		}
+
 		if (empty(self::$instances[$client]))
 		{
 			// Create a Menu object

--- a/libraries/src/CMS/Menu/AdministratorMenu.php
+++ b/libraries/src/CMS/Menu/AdministratorMenu.php
@@ -17,4 +17,15 @@ defined('JPATH_PLATFORM') or die;
  */
 class AdministratorMenu extends AbstractMenu
 {
+	/**
+	 * Loads the menu items
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function load()
+	{
+		return array();
+	}
 }

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -289,7 +289,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 */
 	public function testGetMenu()
 	{
-		$this->assertInstanceOf('JMenu', $this->class->getMenu(''));
+		$this->assertInstanceOf('JMenu', $this->class->getMenu('Administrator'));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Makes the `JMenu` class abstract in the J4 branch

### Testing Instructions
Check menus in frontend and backend continue to work

### Documentation Changes Required
Document change that you can't create a JMenu class directly and people must implement the load method in their subclasses

