### PR TITLE
Fixed calendar field hint

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -110,7 +110,7 @@ JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
 		<input type="text" id="<?php echo $id; ?>" name="<?php
 		echo $name; ?>" value="<?php
 		echo htmlspecialchars(($value != "0000-00-00 00:00:00") ? $value : '', ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attributes; ?>
-		<?php !empty($hint) ? 'placeholder="' . $hint . '"' : ''; ?> data-alt-value="<?php
+		<?php echo !empty($hint) ? 'placeholder="' . $hint . '"' : ''; ?> data-alt-value="<?php
 		echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" autocomplete="off"/>
 		<button type="button" class="<?php echo ($readonly || $disabled) ? "hidden " : ''; ?>btn btn-secondary"
 			id="<?php echo  $id; ?>_btn"


### PR DESCRIPTION
The code to display hint property in calendar fields is there, but it doesn't work.

### Testing Instructions
Create a new (or modify an existing) calendar field, in the front-end or backend, and ensure to assign it a "hint" property, as shown in the picture:
I have temporary modified the calendar fields already present in Article Manager, to save me a lot of time.
![xml](https://cloud.githubusercontent.com/assets/1609992/25232658/0e48f1ca-25d4-11e7-89cd-0e7471d6e95d.png)


Before the patch, the hint does not show.
![no-hint](https://cloud.githubusercontent.com/assets/1609992/25232650/089c70e4-25d4-11e7-9b0f-bb9015b6f58e.png)


After the patch, the hint is there.
![hint](https://cloud.githubusercontent.com/assets/1609992/25232642/03c13636-25d4-11e7-90a8-f922c6c95b8b.png)
