### PR TITLE
Fix styling of contact links

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_links.php
+++ b/components/com_contact/views/contact/tmpl/default_links.php
@@ -21,7 +21,7 @@ defined('_JEXEC') or die;
 <?php endif; ?>
 
 <div class="contact-links">
-	<ul class="nav nav-tabs nav-stacked">
+	<ul class="nav nav-pills flex-column">
 		<?php
 		// Letters 'a' to 'e'
 		foreach (range('a', 'e') as $char) :
@@ -38,8 +38,8 @@ defined('_JEXEC') or die;
 			// If no label is present, take the link
 			$label = $label ?: $link;
 			?>
-			<li>
-				<a href="<?php echo $link; ?>" itemprop="url">
+			<li class="nav-item">
+				<a class="nav-link" href="<?php echo $link; ?>" itemprop="url">
 					<?php echo $label; ?>
 				</a>
 			</li>


### PR DESCRIPTION
### Summary of Changes
Fixes the styling of links in the contact view

### Testing Instructions
Install J4 with sample data and check the single contact view menu item links tab

### Expected result
<img width="568" alt="screen shot 2017-04-20 at 14 35 43" src="https://cloud.githubusercontent.com/assets/1986000/25233618/54fa2852-25d7-11e7-9297-f2baf8577c46.png">

### Actual result
<img width="566" alt="screen shot 2017-04-20 at 14 39 04" src="https://cloud.githubusercontent.com/assets/1986000/25233621/5b89565c-25d7-11e7-9ac8-112d2bf289f3.png">

### Documentation Changes Required
None
