### PR TITLE
[4.0] Aurora name case

### DIFF
--- a/templates/aurora/error.php
+++ b/templates/aurora/error.php
@@ -41,9 +41,9 @@ if ($params->get('logoFile'))
 {
 	$logo = '<img src="' . JUri::root() . $params->get('logoFile') . '" alt="' . $sitename . '" />';
 }
-elseif ($params->get('sitetitle'))
+elseif ($params->get('siteTitle'))
 {
-	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($params->get('sitetitle')) . '</span>';
+	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($params->get('siteTitle')) . '</span>';
 }
 else
 {

--- a/templates/aurora/index.php
+++ b/templates/aurora/index.php
@@ -69,9 +69,9 @@ if ($this->params->get('logoFile'))
 {
 	$logo = '<img src="' . JUri::root() . $this->params->get('logoFile') . '" alt="' . $sitename . '">';
 }
-elseif ($this->params->get('sitetitle'))
+elseif ($this->params->get('siteTitle'))
 {
-	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($this->params->get('sitetitle'), ENT_COMPAT, 'UTF-8') . '</span>';
+	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($this->params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
 }
 else
 {
@@ -106,8 +106,8 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 				<a href="<?php echo $this->baseurl; ?>/">
 					<?php echo $logo; ?>
 				</a>
-				<?php if ($this->params->get('sitedescription')) : ?>
-					<div class="site-description"><?php echo htmlspecialchars($this->params->get('sitedescription')); ?></div>
+				<?php if ($this->params->get('siteDescription')) : ?>
+					<div class="site-description"><?php echo htmlspecialchars($this->params->get('siteDescription')); ?></div>
 				<?php endif; ?>
 			</div>
 

--- a/templates/aurora/offline.php
+++ b/templates/aurora/offline.php
@@ -68,9 +68,9 @@ if ($this->params->get('logoFile'))
 {
 	$logo = '<img src="' . JUri::root() . $this->params->get('logoFile') . '" alt="' . $sitename . '" />';
 }
-elseif ($this->params->get('sitetitle'))
+elseif ($this->params->get('siteTitle'))
 {
-	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($this->params->get('sitetitle')) . '</span>';
+	$logo = '<span class="site-title" title="' . $sitename . '">' . htmlspecialchars($this->params->get('siteTitle')) . '</span>';
 }
 else
 {

--- a/templates/aurora/templateDetails.xml
+++ b/templates/aurora/templateDetails.xml
@@ -54,7 +54,7 @@
 				/>
 
 				<field
-					name="sitetitle" 
+					name="siteTitle" 
 					type="text" 
 					default=""
 					label="JGLOBAL_TITLE"
@@ -63,7 +63,7 @@
 				/>
 
 				<field
-					name="sitedescription" 
+					name="siteDescription" 
 					type="text" 
 					default=""
 					label="JGLOBAL_DESCRIPTION"


### PR DESCRIPTION
For consistency this PR makes sure that all field names are in the format wordWord - before this PR some were and some weren't

To test make sure the sitename and site description fields in the aurora template options still work
