### PR TITLE
Allow Reverse Proxies to do the SSL for Joomla

### DIFF
--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -63,7 +63,19 @@ class JUri extends Uri
 			if ($uri == 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if 
+				(
+					(
+						isset($_SERVER['HTTPS']) && 
+						!empty($_SERVER['HTTPS']) && 
+						(strtolower($_SERVER['HTTPS']) != 'off')
+					) 
+					||
+				    (
+						isset($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+						$_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'  
+					)
+				)
 				{
 					$https = 's://';
 				}

--- a/libraries/vendor/joomla/application/src/AbstractWebApplication.php
+++ b/libraries/vendor/joomla/application/src/AbstractWebApplication.php
@@ -636,7 +636,8 @@ abstract class AbstractWebApplication extends AbstractApplication
 	 */
 	public function isSSLConnection()
 	{
-		return (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off');
+		return (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) != 'off') ||
+		       (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Changed tests wether to create HTTPS links to also include a check for the header HTTP_X_FORWARDED_PROTO.


### Testing Instructions

Configure your server to add a header HTTP_X_FORWARDED_PROTO "https"
With nginx:
proxy_set_header X-Forwarded-Proto $thescheme;

### Expected result

Links created by joomla should use the HTTPS protocol

### Actual result

They are created using HTTP protocol, because that is the protocol used by the Reverse Proxy to access the Joomla machine.

### Documentation Changes Required

