### PR TITLE
\JHelperTags::getTagItemsQuery(); does not respond to $anyOrAll when passing in an array of tags

### DIFF
--- a/libraries/cms/helper/tags.php
+++ b/libraries/cms/helper/tags.php
@@ -532,13 +532,13 @@ class JHelperTags extends JHelper
 		$nullDate = $db->quote($db->getNullDate());
 		$nowDate = $db->quote(JFactory::getDate()->toSql());
 
-		$ntagsr = substr_count($tagId, ',') + 1;
-
 		// Force ids to array and sanitize
 		$tagIds = (array) $tagId;
 		$tagIds = implode(',', $tagIds);
 		$tagIds = explode(',', $tagIds);
 		$tagIds = ArrayHelper::toInteger($tagIds);
+
+		$ntagsr = count($tagIds);
 
 		// If we want to include children we have to adjust the list of tags.
 		// We do not search child tags when the match all option is selected.


### PR DESCRIPTION
### Summary of Changes
Counting of the number of tags did not accommodate for arrays that are passed in as parameter to `\JHelperTags::getTagItemsQuery(); `

When passed in an array of tags the $ntagsr variable is always 1, causing the $anyOrAll boolean to have no effect on the created query.

Counting of the input tags is now done after converting the parameter to array and sanitizing it.

`$ntagsr = count($tagIds);`

### Testing Instructions
```
$tagsHelper = new \JHelperTags;

$anyOrAll = true;
$query1 = $tagsHelper->getTagItemsQuery(
[ 1, 2, 3 ],
[1],
false,
"c.core_created_time",
"DESC",
$anyOrAll,
"all",
"1"
);

$anyOrAll = false;
$query2 = $tagsHelper->getTagItemsQuery(
[ 1, 2, 3 ],
[1],
false,
"c.core_created_time",
"DESC",
$anyOrAll,
"all",
"1"
);

```
### Expected result
$query2 should have a HAVING statement to only select results that have ALL the tags.


### Actual result
$query1 and $query2 both return the same query. Counting the amount of tags passed to the method is returning 1, causing the HAVING statement to never get added:


```
// Counting the tags
$ntagsr = substr_count($tagId, ',') + 1;

//Returns 1 when $tagId is an array

// Use HAVING if matching all tags and we are matching more than one tag.
if ($ntagsr > 1 && $anyOrAll != 1 && $includeChildren != 1)
{
	// The number of results should equal the number of tags requested.
	$query->having("match_count = " . (int) $ntagsr);
}
// This never gets executed when passing in an array

```

### Documentation Changes Required
None