### PR TITLE
[4.0] Ignore languages apart from en-GB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,14 @@ media/jui/less
 # CSS map files #
 .map
 
+# Languages #
+administrator/language/*
+!administrator/language/en-GB
+administrator/manifests/packages/*
+!administrator/manifests/packages/pkg_en-GB.xml
+language/*
+!language/en-GB
+
 # phpDocumentor Logs #
 phpdoc-*
 

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,10 @@ administrator/language/*
 !administrator/language/en-GB
 administrator/manifests/packages/*
 !administrator/manifests/packages/pkg_en-GB.xml
+!administrator/language/overrides/index.html
 language/*
 !language/en-GB
+!language/overrides/index.html
 
 # phpDocumentor Logs #
 phpdoc-*


### PR DESCRIPTION
### Summary of Changes

Those submitting PR's may have additional languages installed, so this PR will ignore all languages apart from en-GB.

Just makes life a little easier by being able to do `git add .` rather than having to manually add individual folders.

@mbabker this seem ok?
