### PR TITLE
Ignore languages apart from en-GB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,16 @@ phpdoc-*
 # Install from Web plugin #
 /plugins/installer/webinstaller
 
+# Languages #
+administrator/language/*
+!administrator/language/en-GB
+administrator/manifests/packages/*
+!administrator/manifests/packages/pkg_en-GB.xml
+!administrator/language/overrides/index.html
+language/*
+!language/en-GB
+!language/overrides/index.html
+
 # OSX #
 ._*
 .Spotlight-V100


### PR DESCRIPTION
### Summary of Changes

Those submitting PR's may have additional languages installed, so this PR will ignore all languages apart from en-GB.

Just makes life a little easier by being able to do `git add .` rather than having to manually add individual folders.

@zero-24 
