### PR TITLE
[Tags] Respect the current user access levels

### DIFF
--- a/libraries/cms/form/field/tag.php
+++ b/libraries/cms/form/field/tag.php
@@ -158,6 +158,10 @@ class JFormFieldTag extends JFormFieldList
 			$query->where('a.published IN (' . implode(',', $published) . ')');
 		}
 
+		// Respect the current user Access levels
+		$viewlevels = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
+		$query->where('a.access IN (' . $viewlevels . ')');
+
 		$query->order('a.lft ASC');
 
 		// Get the options.


### PR DESCRIPTION
Pull Request for Issue #8569

### Summary of Changes

Respect the access levels 

### Testing Instructions

Create a TAG in the Tags component, set the access to Super Users
Login in as a manager or another user not in Super User group
Create new article and select Tags

### Expected result

The tag with view access Super Users is not visible (for non superusers)

### Actual result

All tags visible, regardless of access set in Tag component (for non superusers)

### Documentation Changes Required

None