### PR TITLE
[4.0] [com_associations] Normalising list display

### DIFF
--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -14,7 +14,6 @@ JLoader::register('AssociationsHelper', JPATH_ADMINISTRATOR . '/components/com_a
 JHtml::_('jquery.framework');
 JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-JHtml::_('formbehavior.chosen', 'select');
 
 $listOrder        = $this->escape($this->state->get('list.fullordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -32,127 +32,124 @@ JText::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 JHtml::_('script', 'com_associations/admin-associations-default.min.js', false, true);
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_associations&view=associations'); ?>" method="post" name="adminForm" id="adminForm">
-<?php if (!empty( $this->sidebar)) : ?>
-	<div id="j-sidebar-container" class="span2">
-		<?php echo $this->sidebar; ?>
-	</div>
-	<div id="j-main-container" class="span10">
-<?php else : ?>
-	<div id="j-main-container">
-<?php endif;?>
-<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-no-items">
-			<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+	<div class="row">
+		<div class="col-md-12">
+			<div id="j-main-container" class="j-main-container">
+				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<?php if (empty($this->items)) : ?>
+					<div class="alert alert-warning alert-no-items">
+						<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+					</div>
+				<?php else : ?>
+					<table class="table table-striped" id="associationsList">
+					<thead>
+						<tr>
+							<?php if (!empty($this->typeSupports['state'])) : ?>
+								<th style="width:1%" class="center nowrap">
+									<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
+								</th>
+							<?php endif; ?>
+							<th class="nowrap">
+								<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'title', $listDirn, $listOrder); ?>
+							</th>
+							<th style="width:15%" class="nowrap">
+								<?php echo JText::_('JGRID_HEADING_LANGUAGE'); ?>
+							</th>
+							<th style="width:5%" class="nowrap">
+								<?php echo JText::_('COM_ASSOCIATIONS_HEADING_ASSOCIATION'); ?>
+							</th>
+							<th style="width:15%" class="nowrap">
+								<?php echo JText::_('COM_ASSOCIATIONS_HEADING_NO_ASSOCIATION'); ?>
+							</th>
+							<?php if (!empty($this->typeFields['menutype'])) : ?>
+								<th style="width:10%" class="nowrap">
+									<?php echo JHtml::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); $colSpan++; ?>
+								</th>
+							<?php endif; ?>
+							<?php if (!empty($this->typeFields['access'])) : ?>
+								<th style="width:5%" class="nowrap hidden-sm-down">
+									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); $colSpan++; ?>
+								</th>
+							<?php endif; ?>
+							<th style="width:1%" class="nowrap hidden-sm-down text-center">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'id', $listDirn, $listOrder); ?>
+							</th>
+						</tr>
+					</thead>
+					<tfoot>
+						<tr>
+							<td colspan="<?php echo $colSpan; ?>">
+								<?php echo $this->pagination->getListFooter(); ?>
+							</td>
+						</tr>
+					</tfoot>
+					<tbody>
+					<?php foreach ($this->items as $i => $item) :
+						$canCheckin = true;
+						$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
+						$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
+						$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
+					?>
+						<tr class="row<?php echo $i % 2; ?>">
+							<?php if (!empty($this->typeSupports['state'])) : ?>
+								<td class="center">
+									<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
+								</td>
+							<?php endif; ?>
+							<td class="nowrap has-context">
+								<?php if (isset($item->level)) : ?>
+									<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
+								<?php endif; ?>
+								<?php if ($canCheckin && $isCheckout) : ?>
+									<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.', $canCheckin); ?>
+								<?php endif; ?>
+								<?php if ($canEdit && !$isCheckout) : ?>
+									<a href="<?php echo JRoute::_($this->editUri . '&id=' . (int) $item->id); ?>">
+									<?php echo $this->escape($item->title); ?></a>
+								<?php else : ?>
+									<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
+								<?php endif; ?>
+								<?php if (!empty($this->typeFields['alias'])) : ?>
+									<span class="small">
+										<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+									</span>
+								<?php endif; ?>
+								<?php if (!empty($this->typeFields['catid'])) : ?>
+									<div class="small">
+										<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
+									</div>
+								<?php endif; ?>
+							</td>
+							<td class="small">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+							<td>
+								<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, !$isCheckout, false); ?>
+							</td>
+							<td>
+								<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, !$isCheckout, true); ?>
+							</td>
+							<?php if (!empty($this->typeFields['menutype'])) : ?>
+								<td class="small">
+									<?php echo $this->escape($item->menutype_title); ?>
+								</td>
+							<?php endif; ?>
+							<?php if (!empty($this->typeFields['access'])) : ?>
+								<td class="small hidden-sm-down">
+									<?php echo $this->escape($item->access_level); ?>
+								</td>
+							<?php endif; ?>
+							<td class="hidden-sm-down text-center">
+								<?php echo $item->id; ?>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+					</tbody>
+					</table>
+				<?php endif; ?>
+				<input type="hidden" name="task" value="">
+				<?php echo JHtml::_('form.token'); ?>
+			</div>
 		</div>
-	<?php else : ?>
-		<table class="table table-striped" id="associationsList">
-			<thead>
-				<tr>
-					<?php if (!empty($this->typeSupports['state'])) : ?>
-						<th style="width:1%" class="center nowrap">
-							<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
-						</th>
-					<?php endif; ?>
-					<th class="nowrap">
-						<?php echo JHtml::_('searchtools.sort', 'JGLOBAL_TITLE', 'title', $listDirn, $listOrder); ?>
-					</th>
-					<th style="width:15%" class="nowrap">
-						<?php echo JText::_('JGRID_HEADING_LANGUAGE'); ?>
-					</th>
-					<th style="width:5%" class="nowrap">
-						<?php echo JText::_('COM_ASSOCIATIONS_HEADING_ASSOCIATION'); ?>
-					</th>
-					<th style="width:15%" class="nowrap">
-						<?php echo JText::_('COM_ASSOCIATIONS_HEADING_NO_ASSOCIATION'); ?>
-					</th>
-					<?php if (!empty($this->typeFields['menutype'])) : ?>
-						<th style="width:10%" class="nowrap">
-							<?php echo JHtml::_('searchtools.sort', 'COM_ASSOCIATIONS_HEADING_MENUTYPE', 'menutype_title', $listDirn, $listOrder); $colSpan++; ?>
-						</th>
-					<?php endif; ?>
-					<?php if (!empty($this->typeFields['access'])) : ?>
-						<th style="width:5%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); $colSpan++; ?>
-						</th>
-					<?php endif; ?>
-					<th style="width:1%" class="nowrap hidden-phone">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'id', $listDirn, $listOrder); ?>
-					</th>
-				</tr>
-			</thead>
-			<tfoot>
-				<tr>
-					<td colspan="<?php echo $colSpan; ?>">
-						<?php echo $this->pagination->getListFooter(); ?>
-					</td>
-				</tr>
-			</tfoot>
-			<tbody>
-			<?php foreach ($this->items as $i => $item) :
-				$canCheckin = true;
-				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
-				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
-				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
-				?>
-				<tr class="row<?php echo $i % 2; ?>">
-					<?php if (!empty($this->typeSupports['state'])) : ?>
-						<td class="center">
-							<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
-						</td>
-					<?php endif; ?>
-					<td class="nowrap has-context">
-						<?php if (isset($item->level)) : ?>
-							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
-						<?php endif; ?>
-						<?php if ($canCheckin && $isCheckout) : ?>
-							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.', $canCheckin); ?>
-						<?php endif; ?>
-						<?php if ($canEdit && !$isCheckout) : ?>
-							<a href="<?php echo JRoute::_($this->editUri . '&id=' . (int) $item->id); ?>">
-							<?php echo $this->escape($item->title); ?></a>
-						<?php else : ?>
-							<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
-						<?php endif; ?>
-						<?php if (!empty($this->typeFields['alias'])) : ?>
-							<span class="small">
-								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-							</span>
-						<?php endif; ?>
-						<?php if (!empty($this->typeFields['catid'])) : ?>
-							<div class="small">
-								<?php echo JText::_('JCATEGORY') . ": " . $this->escape($item->category_title); ?>
-							</div>
-						<?php endif; ?>
-					</td>
-					<td class="small">
-						<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-					</td>
-					<td>
-						<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, !$isCheckout, false); ?>
-					</td>
-					<td>
-						<?php echo AssociationsHelper::getAssociationHtmlList($this->extensionName, $this->typeName, (int) $item->id, $item->language, !$isCheckout, true); ?>
-					</td>
-					<?php if (!empty($this->typeFields['menutype'])) : ?>
-						<td class="small">
-							<?php echo $this->escape($item->menutype_title); ?>
-						</td>
-					<?php endif; ?>
-					<?php if (!empty($this->typeFields['access'])) : ?>
-						<td class="small hidden-phone">
-							<?php echo $this->escape($item->access_level); ?>
-						</td>
-					<?php endif; ?>
-					<td class="hidden-phone">
-						<?php echo $item->id; ?>
-					</td>
-				</tr>
-				<?php endforeach; ?>
-			</tbody>
-		</table>
-	<?php endif; ?>
-	<input type="hidden" name="task" value="">
-	<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -44,7 +44,7 @@ JHtml::_('script', 'com_associations/admin-associations-default.min.js', false, 
 					<thead>
 						<tr>
 							<?php if (!empty($this->typeSupports['state'])) : ?>
-								<th style="width:1%" class="center nowrap">
+								<th style="width:1%" class="text-center nowrap">
 									<?php echo JHtml::_('searchtools.sort', 'JSTATUS', 'state', $listDirn, $listOrder); $colSpan++; ?>
 								</th>
 							<?php endif; ?>
@@ -91,7 +91,7 @@ JHtml::_('script', 'com_associations/admin-associations-default.min.js', false, 
 					?>
 						<tr class="row<?php echo $i % 2; ?>">
 							<?php if (!empty($this->typeSupports['state'])) : ?>
-								<td class="center">
+								<td class="text-center">
 									<span class="<?php echo $iconStates[$this->escape($item->state)]; ?>"></span>
 								</td>
 							<?php endif; ?>


### PR DESCRIPTION
This normalises the list display markup.
After PR one should get:
![screen shot 2017-04-22 at 11 05 57](https://cloud.githubusercontent.com/assets/869724/25303068/f49469f2-274b-11e7-9839-e67d98857696.png)
![screen shot 2017-04-22 at 11 08 33](https://cloud.githubusercontent.com/assets/869724/25303082/0fe4d26e-274c-11e7-82a1-5d9ae9613901.png)

Note: remains to solve the Select Language and Select Item Type filters dropdown who do not have a min-width.
