### PR TITLE
[4.0]Fix component dispatcher loadLanguage() method

### DIFF
--- a/libraries/src/CMS/Dispatcher/Dispatcher.php
+++ b/libraries/src/CMS/Dispatcher/Dispatcher.php
@@ -80,6 +80,7 @@ abstract class Dispatcher implements DispatcherInterface
 		$this->factory   = $factory ? $factory : new MvcFactory($namespace, $this->app);
 
 		$this->loadLanguage();
+
 		$this->autoLoad();
 	}
 
@@ -93,8 +94,10 @@ abstract class Dispatcher implements DispatcherInterface
 	protected function loadLanguage()
 	{
 		// Load common and local language files.
-		$this->app->getLanguage()->load($this->app->scope, JPATH_BASE, null, false, true) ||
-		$this->app->getLanguage()->load($this->app->scope, JPATH_COMPONENT, null, false, true);
+		$language = $this->app->getLanguage() ?: \JFactory::getLanguage();
+
+		$language->load($this->app->scope, JPATH_BASE, null, false, true) ||
+		$language->load($this->app->scope, JPATH_COMPONENT, null, false, true);
 	}
 
 

--- a/libraries/src/CMS/Dispatcher/Dispatcher.php
+++ b/libraries/src/CMS/Dispatcher/Dispatcher.php
@@ -80,7 +80,6 @@ abstract class Dispatcher implements DispatcherInterface
 		$this->factory   = $factory ? $factory : new MvcFactory($namespace, $this->app);
 
 		$this->loadLanguage();
-
 		$this->autoLoad();
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In case frontend code need to call a backend controller code (For example, com_config frontend call backend module controller save method to save module parameters), we will need some code like this (assume com_modules is already namespaced)

```php
JLoader::register('ModulesDispatcher', JPATH_ADMINISTRATOR . '/components/com_modules/dispatcher.php');

$app             = \Joomla\CMS\Application\CmsApplication::getInstance('administrator');
$dispatcher      = new ModulesDispatcher('Joomla\\Component\\Modules', $app, $input);
$controllerClass = $dispatcher->getController('Module');

// Execute backend controller
$return = $controllerClass->save();
```
When the dispatcher object is created, it call loadLanguage() https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/CMS/Dispatcher/Dispatcher.php#L93 method. The problem is that **$this->app->getLanguage()** return null and it causes fatal error ($language is only available in application object after calling **doExecute()** method). This PR proposes a fix for that issue


### Testing Instructions
This is code review only for Joomla 4 team