### PR TITLE
Apache 2.4+ compatibility without mod_access_compat for #15457

### DIFF
--- a/libraries/vendor/.htaccess
+++ b/libraries/vendor/.htaccess
@@ -1,1 +1,9 @@
-Deny from all
+# Apache 2.4+
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Apache 2.0-2.2
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>


### PR DESCRIPTION
Pull Request for Issue # .
### Summary of Changes
.htaccess added in PR #15457 will not work on Apache 2.4+ servers without [mod_access_compat](http://httpd.apache.org/docs/2.4/mod/mod_access_compat.html) loaded
### Testing Instructions
- apply this patch
- try to direct access the files in the libraries/vendor/ folder (testing on apache 2.2 and Apache 2.4+ without loaded mod_access_compat is required)
### Expected result
No access to libraries/vendor/ on Apache 2.4+ without loaded mod_access_compat
### Actual result
Access to libraries/vendor/ on Apache 2.4+ without loaded mod_access_compat
### Documentation Changes Required
N/A