### PR TITLE
Normalize extension parameter of JCategories::getInstance()

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -125,7 +125,7 @@ class JCategories
 	 */
 	public static function getInstance($extension, $options = array())
 	{
-		$hash = md5($extension . serialize($options));
+		$hash = md5(strtolower($extension) . serialize($options));
 
 		if (isset(self::$instances[$hash]))
 		{

--- a/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
+++ b/tests/unit/suites/libraries/legacy/categories/JCategoriesTest.php
@@ -89,6 +89,24 @@ class JCategoriesTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Tests JCategories::getInstance() returns the same instance regardless of the case of the extension parameter
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testGetInstanceWithDifferentCasing()
+	{
+		$instance = JCategories::getInstance('Content');
+
+		$this->assertSame(
+			$instance,
+			JCategories::getInstance('content'),
+			'JCategories::getInstance() should return the same instance regardless of the case of the extension parameter.'
+		);
+	}
+
+	/**
 	 * Tests JCategories::get()
 	 *
 	 * @return  void


### PR DESCRIPTION
### Summary of Changes

It is possible to get separate `JCategories` objects based on the casing of the `$extension` parameter you pass to `JCategories::getInstance()`.  This will result in running extra database queries because the internal cache doesn't persist across instances.  The side effect of this is most notable in an internationalized website when the language module generates routes for the different languages, with the 3.7 code you will get duplicate database queries at least with com_content because one part of the router passes `$extension = 'Content'` and another part passes `$extension = 'content'`.

### Testing Instructions

Prior to the patch being applied, enable debug mode and add this code snippet to your template:

```php
// Replace ID 2 with a valid category ID on your site if necessary
JCategories::getInstance('Content')->get(2);
JCategories::getInstance('content')->get(2);
```

Without the patch, in your database queries section of the debug output, you should have duplicate queries coming from the `JCategories::_load()` method.  After applying the patch, the duplicate query should go away.

### Expected result

A single singleton instance of a `JCategories` object after normalizing the parameters

### Actual result

A separate `JCategories` instance for an extension based on the casing of the extension name provided to the `getInstance()` method.

### Documentation Changes Required

If someone is really relying on the casing to get "fresh" instances, this won't work anymore.  But this is really such an edge case and unexpected behavior that if you're relying on this broken logic, you've got other issues to address in your code.