### PR TITLE
Fix for issue #15498

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -91,7 +91,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		}
 
 		// Are we dealing with an article or category that is attached to a menu item?
-		if (($menuItem instanceof stdClass)
+		if ($menuItem !== null
 			&& $menuItem->query['view'] == $query['view']
 			&& isset($query['id'])
 			&& $menuItem->query['id'] == (int) $query['id'])


### PR DESCRIPTION
Pull Request for Issue #15498 .

### Summary of Changes
It's bad practice to typehint against a stdClass instance. Instead it's better to check we don't get `null` back from `JMenu::getActive` or `JMenu::getItem`

### Testing Instructions
Install staging with sample testing data. Go to the featured articles page. Before patch the home page has a url like `JROOT/index.php/19-sample-data-articles/joomla/24-joomla`. After the patch it should be JROOT/index.php

### Documentation Changes Required
None
