### PR TITLE
copy code form JObject and extend stdClass

### DIFF
--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -297,6 +297,7 @@ class JMenuItem extends stdClass
 	 * @return  mixed    The value of the property.
 	 *
 	 * @since   3.7.0
+	 * @deprecated  4.0
 	 */
 	public function get($property, $default = null)
 	{
@@ -317,6 +318,7 @@ class JMenuItem extends stdClass
 	 * @return  mixed  Previous value of the property.
 	 *
 	 * @since   3.7.0
+	 * @deprecated  4.0
 	 */
 	public function set($property, $value = null)
 	{

--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -16,7 +16,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.7.0
  */
-class JMenuItem extends JObject
+class JMenuItem extends stdClass
 {
 	/**
 	 * Primary key
@@ -286,5 +286,43 @@ class JMenuItem extends JObject
 	public function setParams($params)
 	{
 		$this->params = $params;
+	}
+
+	/**
+	 * Returns a property of the object or the default value if the property is not set.
+	 *
+	 * @param   string  $property  The name of the property.
+	 * @param   mixed   $default   The default value.
+	 *
+	 * @return  mixed    The value of the property.
+	 *
+	 * @since   3.7.0
+	 */
+	public function get($property, $default = null)
+	{
+		if (isset($this->$property))
+		{
+			return $this->$property;
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Modifies a property of the object, creating it if it does not already exist.
+	 *
+	 * @param   string  $property  The name of the property.
+	 * @param   mixed   $value     The value of the property to set.
+	 *
+	 * @return  mixed  Previous value of the property.
+	 *
+	 * @since   3.7.0
+	 */
+	public function set($property, $value = null)
+	{
+		$previous = isset($this->$property) ? $this->$property : null;
+		$this->$property = $value;
+
+		return $previous;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #15498

### Summary of Changes
This let JMenuItem extend stdClass to make the check in the legacyrouter valid. It also copies needed functions from JObject
