### PR TITLE
Grunt2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 node_modules/
 /build/assets_tmp
 scss-lint-report.xml
+/dev/assets/packages.json
 
 # Removed in Joomla 4 #
 administrator/templates/isis

--- a/dev/assets/index.html
+++ b/dev/assets/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><title></title>

--- a/dev/assets/package.json
+++ b/dev/assets/package.json
@@ -1,8 +1,0 @@
-{
- "name": "joomla-assets",
- "version": "4.0.0",
- "description": "External assets that Joomla is using",
- "dependencies": {
-  "jquery": "2.2.4","jquery-migrate": "1.4.1","bootstrap": "~4.0.0-alpha.5","tether": "1.3.7","font-awesome": "4.6.3","jquery-minicolors": "2.1.10","jquery-sortable": "0.9.13","jquery-ui": "1.12.1","mediaelement": "2.22.0","punycode": "1.4.1","tinymce": "4.4.3","awesomplete": "1.1.1","dragula": "3.7.2","codemirror": "5.19.0"  },
-  "license": "GPL-2.0+"
-}

--- a/grunt-readme.md
+++ b/grunt-readme.md
@@ -47,7 +47,7 @@ For running sass linting we require that ruby is installed on the system.
 - Install Ruby:  https://rubyinstaller.org
 - Run: `gem install scss_lint` to install the linter
 
-Will update the following external sourced static assets that Joomla is using and is defined in /grunt-settings.yaml
+Will update the following external sourced static assets that Joomla is using and is defined in /grunt_settings.yaml
 
 
 The following are always fetched with curl (no module available)

--- a/grunt-readme.md
+++ b/grunt-readme.md
@@ -47,22 +47,8 @@ For running sass linting we require that ruby is installed on the system.
 - Install Ruby:  https://rubyinstaller.org
 - Run: `gem install scss_lint` to install the linter
 
-Will update the following external sourced static assets that Joomla is using.
+Will update the following external sourced static assets that Joomla is using and is defined in /grunt-settings.yaml
 
-- Jquery
-- Jquery-migrate
-- Bootstrap
-- Tether
-- Font awesome
-- Jquery-minicolors
-- Jquery-sortable
-- Jquery-ui
-- MediaElement
-- Punycode
-- TinyMCE
-- Awesomplete
-- Dragula
-- Codemirror
 
 The following are always fetched with curl (no module available)
 


### PR DESCRIPTION
As discusses in #15502 

Remove /dev/assets/packages.json from repo
Add /dev/assets/index.html to the repo so that the folder is created
updated readme to refer to the grunt_settings.yaml file instead of listing the extensions as this is easier to keep up to date

add /dev/assets/packages.json to gitignore to stop it getting merged again