### PR TITLE
[finder] add missing id

### DIFF
--- a/components/com_finder/views/search/tmpl/default_form.php
+++ b/components/com_finder/views/search/tmpl/default_form.php
@@ -91,10 +91,12 @@ jQuery(function() {";
 		<div id="advancedSearch" class="collapse<?php if ($this->params->get('expand_advanced', 0)) echo ' in'; ?>">
 			<hr />
 			<?php if ($this->params->get('show_advanced_tips', 1)) : ?>
-				<div class="advanced-search-tip">
-					<?php echo JText::_('COM_FINDER_ADVANCED_TIPS'); ?>
+				<div id="search-query-explained">
+					<div class="advanced-search-tip">
+						<?php echo JText::_('COM_FINDER_ADVANCED_TIPS'); ?>
+					</div>
+					<hr />
 				</div>
-				<hr />
 			<?php endif; ?>
 			<div id="finder-filter-window">
 				<?php echo JHtml::_('filter.select', $this->query, $this->params); ?>


### PR DESCRIPTION
There is an ID of search-query-explained that is used to style the text block displayed on the search results view but it wasnt being used on the search form view

Pull Request for Issue #15519 .

### Before
<img width="558" alt="screenshotr11-37-50" src="https://cloud.githubusercontent.com/assets/1296369/25381452/bd691ae2-29ab-11e7-9d4b-0e25747a4350.png">


### After
<img width="546" alt="screenshotr11-37-39" src="https://cloud.githubusercontent.com/assets/1296369/25381456/c1dbaba8-29ab-11e7-9ae4-f945f74e516d.png">
