### PR TITLE
Fix b/c break in JMenuItem

### DIFF
--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -249,7 +249,7 @@ class JMenuItem extends stdClass
 	/**
 	 * Method check if a certain otherwise inaccessible properties of the form field object is set.
 	 *
-	 * @param   string  $name   The property name to check.
+	 * @param   string  $name  The property name to check.
 	 *
 	 * @return  boolean
 	 *

--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -253,7 +253,7 @@ class JMenuItem extends stdClass
 	 *
 	 * @return  boolean
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 * @deprecated  4.0 Deprecated without replacement
 	 */
 	public function __isset($name)

--- a/libraries/cms/menu/item.php
+++ b/libraries/cms/menu/item.php
@@ -247,6 +247,26 @@ class JMenuItem extends stdClass
 	}
 
 	/**
+	 * Method check if a certain otherwise inaccessible properties of the form field object is set.
+	 *
+	 * @param   string  $name   The property name to check.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   3.7.0
+	 * @deprecated  4.0 Deprecated without replacement
+	 */
+	public function __isset($name)
+	{
+		if ($name === 'params')
+		{
+			return !($this->params instanceof Registry);
+		}
+
+		return $this->get($name) !== null;
+	}
+
+	/**
 	 * Returns the menu item parameters
 	 *
 	 * @return  Registry


### PR DESCRIPTION
Pull Request for Issue https://twitter.com/joovlaki/status/856913614367752196 (because apparently we can only take issues submitted over twitter now).

### Summary of Changes
Fixes a b/c break in JMenuItem when checking if params is set

### Testing Instructions
Run `isset(\JFactory::getApplication()->getMenu()->getActive()->params)` on pages with and without a active menu item

### Expected result
Code gives the correct result

### Actual result
It doesn't

### Documentation Changes Required
None
