### PR TITLE
Fix cache file for issue #15544

### DIFF
--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -413,7 +413,7 @@ class JCacheStorageFile extends JCacheStorage
 		{
 			$time = @filemtime($path);
 
-			if (($time + $this->_lifetime) < $this->_now || empty($time))
+			if (($time + $this->_lifetime) < $this->_now || empty($time) || filesize($path) === 0)
 			{
 				@unlink($path);
 


### PR DESCRIPTION
Pull Request for Issue #15544

### Summary of Changes
Check cache file before use. 

### Reason
To save a cache file joomla requires lock method.
To create a lock for cache joomla has to create a file in the cache folder.
If a view method raise an error then cache process is hung up and the file can not be deleted.
The file is left empty.
Next request could find such file and display it as empty article.
 
### Simple solution
Check if the cache file is not empty.

I have added a more explanation at https://github.com/joomla/joomla-cms/pull/10767#issuecomment-297204766

### Testing Instructions
Take a look at the issue.

### Expected result
Error 404

### Actual result
Blank component.

### Documentation Changes Required
No