### PR TITLE
Remove empty locked cache file if callback function terminate process

### DIFF
--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -60,6 +60,7 @@ class JCacheStorageFile extends JCacheStorage
 					@fclose($handle);
 				}
 
+				// Delete only the existing file if it is empty.
 				if (@filesize($path) === 0)
 				{
 					@unlink($path);
@@ -445,7 +446,8 @@ class JCacheStorageFile extends JCacheStorage
 				return false;
 			}
 
-			if (filesize($path) == 0)
+			// If now the file does not exist then return false too.
+			if (@filesize($path) == 0)
 			{
 				return false;
 			}


### PR DESCRIPTION
Pull Request for Issue #15544

### Summary of Changes
Remove empty locked file at shutdown script if cache `callback` function terminate process on 404.

This is my second PR (previous #15558) 

### Reason
To save a cache file joomla requires lock method.
To create a lock for cache joomla has to create a file in the cache folder.
If a view method raise an error then cache process is hung up and the file can not be deleted.
The file is left empty.
Next request could find such file and display it as empty article.
 
### Testing Instructions
Take a look at the issue.

### Expected result
Error 404

### Actual result
Blank component.

### Documentation Changes Required
No