### PR TITLE
Fix Cannot use a scalar value warning

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -673,7 +673,7 @@ abstract class JHtml
 	public static function script($file, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($options) && !is_array($attribs))
+		if (!is_array($options))
 		{
 			JLog::add('The script method signature used has changed, use (file, options, attributes) instead.', JLog::WARNING, 'deprecated');
 


### PR DESCRIPTION
Per #15548, multiple Cannot use a scalar value as an array warning are showing on many sites after update to Joomla 3.7

Pull Request for Issue # 15448.

### Summary of Changes

Removed test on $attribs being an array. Issue analysis by George Wilson is here: https://github.com/joomla/joomla-cms/issues/15548#issuecomment-297187686

### Testing Instructions

On site showing those warnings, applying the patch should stop them, and restored functionalities that may be broken (Some Payplans features stop working) because the corresponding javascript file is actually not inserted in the page.

### Expected result



### Actual result



### Documentation Changes Required

