### PR TITLE
Inject the JInput dependency into the session handler

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -594,8 +594,13 @@ abstract class JFactory
 		// Config time is in minutes
 		$options['expire'] = ($conf->get('lifetime')) ? $conf->get('lifetime') * 60 : 900;
 
+		// The session handler needs a JInput object, we can inject it without having a hard dependency to an application instance
+		$input = self::$application ? self::getApplication()->input : new JInput;
+
 		$sessionHandler = new JSessionHandlerJoomla($options);
-		$session        = JSession::getInstance($handler, $options, $sessionHandler);
+		$sessionHandler->input = $input;
+
+		$session = JSession::getInstance($handler, $options, $sessionHandler);
 
 		if ($session->getState() == 'expired')
 		{


### PR DESCRIPTION
### Summary of Changes

Calling `JFactory::getSession()` without a properly configured session already injected into `JFactory::$session` results in an invalid `JSession` object being created in that the internal dependencies are not fully initialized.  Namely, the `JSessionHandlerJoomla` class needs a `JInput` instance which is not injected at all.  The web applications build the `JSession` object on their own and correctly call `JSession::initialise()` with the needed dependencies, hence the reason this bug has not been previously reported; it takes running a custom web application not extending `JApplicationCms` or a CLI application to reproduce the issue.

### Testing Instructions

Place the following script in your site's `cli` directory:

```php
<?php
// We are a valid entry point.
const _JEXEC = 1;

// Load system defines
if (file_exists(dirname(__DIR__) . '/defines.php'))
{
	require_once dirname(__DIR__) . '/defines.php';
}

if (!defined('_JDEFINES'))
{
	define('JPATH_BASE', dirname(__DIR__));
	require_once JPATH_BASE . '/includes/defines.php';
}

// Get the framework.
require_once JPATH_LIBRARIES . '/import.legacy.php';

// Bootstrap the CMS libraries.
require_once JPATH_LIBRARIES . '/cms.php';

// Configure error reporting to maximum for CLI output.
error_reporting(E_ALL);
ini_set('display_errors', 1);

class SessionTestCli extends JApplicationCli
{
	public function doExecute()
	{
		JFactory::getUser();
		$this->out('User retrieved');
	}
}

// Instantiate the application object, passing the class name to JCli::getInstance
// and use chaining to execute the application.
JApplicationCli::getInstance('SessionTestCli')->execute();
```

### Expected result

```sh
Michaels-MacBook-Pro:joomla-cms mbabker$ php cli/session_test.php 
User retrieved
```

### Actual result

```sh
Michaels-MacBook-Pro:joomla-cms mbabker$ php cli/session_test.php 

Notice: Trying to get property of non-object in /libraries/joomla/session/handler/joomla.php on line 69

Call Stack:
    0.0003     361576   1. {main}() /cli/session_test.php:0
    0.0333    1729656   2. JApplicationCli->execute() /cli/session_test.php:38
    0.0333    1729656   3. SessionTestCli->doExecute() /libraries/joomla/application/cli.php:142
    0.0333    1729656   4. JFactory::getUser() /cli/session_test.php:31
    0.0352    1884160   5. JSession->get() /libraries/joomla/factory.php:236
    0.0352    1884160   6. JSession->start() /libraries/joomla/session/session.php:486
    0.0352    1884160   7. JSession->_start() /libraries/joomla/session/session.php:608
    0.0352    1884160   8. JSessionHandlerJoomla->start() /libraries/joomla/session/session.php:648

Error displaying the error page: Application Instantiation Error: Call to a member function get() on null
```
