### PR TITLE
Clear cache with more operations

### DIFF
--- a/administrator/components/com_installer/controllers/install.php
+++ b/administrator/components/com_installer/controllers/install.php
@@ -28,15 +28,11 @@ class InstallerControllerInstall extends JControllerLegacy
 		// Check for request forgeries.
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
+		/** @var InstallerModelInstall $model */
 		$model = $this->getModel('install');
 
-		if ($result = $model->install())
-		{
-			$cache = JFactory::getCache('mod_menu');
-			$cache->clean();
-
-			// TODO: Reset the users acl here as well to kill off any missing bits.
-		}
+		// TODO: Reset the users acl here as well to kill off any missing bits.
+		$result = $model->install();
 
 		$app = JFactory::getApplication();
 		$redirect_url = $app->getUserState('com_installer.redirect_url');

--- a/administrator/components/com_installer/controllers/manage.php
+++ b/administrator/components/com_installer/controllers/manage.php
@@ -58,6 +58,7 @@ class InstallerControllerManage extends JControllerLegacy
 		else
 		{
 			// Get the model.
+			/** @var InstallerModelManage $model */
 			$model = $this->getModel('manage');
 
 			// Change the state of the records.
@@ -95,7 +96,9 @@ class InstallerControllerManage extends JControllerLegacy
 		// Check for request forgeries.
 		JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
-		$eid   = $this->input->get('cid', array(), 'array');
+		$eid = $this->input->get('cid', array(), 'array');
+
+		/** @var InstallerModelManage $model */
 		$model = $this->getModel('manage');
 
 		$eid = ArrayHelper::toInteger($eid, array());

--- a/administrator/components/com_installer/controllers/update.php
+++ b/administrator/components/com_installer/controllers/update.php
@@ -43,11 +43,6 @@ class InstallerControllerUpdate extends JControllerLegacy
 
 		$model->update($uid, $minimum_stability);
 
-		if ($model->getState('result', false))
-		{
-			JFactory::getCache('mod_menu')->clean();
-		}
-
 		$app          = JFactory::getApplication();
 		$redirect_url = $app->getUserState('com_installer.redirect_url');
 

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -225,6 +225,8 @@ class InstallerModelInstall extends JModelLegacy
 		$this->cleanCache('_system', 1);
 		$this->cleanCache('com_modules', 0);
 		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('com_plugins', 0);
+		$this->cleanCache('com_plugins', 1);
 		$this->cleanCache('mod_menu', 0);
 		$this->cleanCache('mod_menu', 1);
 

--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -220,6 +220,14 @@ class InstallerModelInstall extends JModelLegacy
 
 		JInstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);
 
+		// Clear the cached extension data and menu cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+		$this->cleanCache('com_modules', 0);
+		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('mod_menu', 0);
+		$this->cleanCache('mod_menu', 1);
+
 		return $result;
 	}
 

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -146,6 +146,14 @@ class InstallerModelManage extends InstallerModel
 			}
 		}
 
+		// Clear the cached extension data and menu cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+		$this->cleanCache('com_modules', 0);
+		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('mod_menu', 0);
+		$this->cleanCache('mod_menu', 1);
+
 		return $result;
 	}
 
@@ -260,6 +268,14 @@ class InstallerModelManage extends InstallerModel
 		$this->setState('name', $installer->get('name'));
 		$app->setUserState('com_installer.message', $installer->message);
 		$app->setUserState('com_installer.extension_message', $installer->get('extension_message'));
+
+		// Clear the cached extension data and menu cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+		$this->cleanCache('com_modules', 0);
+		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('mod_menu', 0);
+		$this->cleanCache('mod_menu', 1);
 
 		return $result;
 	}

--- a/administrator/components/com_installer/models/manage.php
+++ b/administrator/components/com_installer/models/manage.php
@@ -274,6 +274,8 @@ class InstallerModelManage extends InstallerModel
 		$this->cleanCache('_system', 1);
 		$this->cleanCache('com_modules', 0);
 		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('com_plugins', 0);
+		$this->cleanCache('com_plugins', 1);
 		$this->cleanCache('mod_menu', 0);
 		$this->cleanCache('mod_menu', 1);
 

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -371,6 +371,14 @@ class InstallerModelUpdate extends JModelList
 			$result = $res & $result;
 		}
 
+		// Clear the cached extension data and menu cache
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
+		$this->cleanCache('com_modules', 0);
+		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('mod_menu', 0);
+		$this->cleanCache('mod_menu', 1);
+
 		// Set the final state
 		$this->setState('result', $result);
 	}
@@ -525,7 +533,7 @@ class InstallerModelUpdate extends JModelList
 	protected function preparePreUpdate($update, $table)
 	{
 		jimport('joomla.filesystem.file');
-		
+
 		switch ($table->type)
 		{
 			// Components could have a helper which adds additional data
@@ -535,11 +543,11 @@ class InstallerModelUpdate extends JModelList
 				$cname = ucfirst($ename) . 'Helper';
 
 				$path = JPATH_ADMINISTRATOR . '/components/' . $table->element . '/helpers/' . $fname;
-				
+
 				if (JFile::exists($path))
 				{
 					require_once $path;
-					
+
 					if (class_exists($cname) && is_callable(array($cname, 'prepareUpdate')))
 					{
 						call_user_func_array(array($cname, 'prepareUpdate'), array(&$update, &$table));
@@ -552,19 +560,19 @@ class InstallerModelUpdate extends JModelList
 			case 'module':
 				$cname = str_replace('_', '', $table->element) . 'Helper';
 				$path = ($table->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $table->element . '/helper.php';
-				
+
 				if (JFile::exists($path))
 				{
 					require_once $path;
-					
+
 					if (class_exists($cname) && is_callable(array($cname, 'prepareUpdate')))
 					{
 						call_user_func_array(array($cname, 'prepareUpdate'), array(&$update, &$table));
 					}
 				}
-			
+
 				break;
-				
+
 			// If we have a plugin, we can use the plugin trigger "onInstallerBeforePackageDownload"
 			// But we should make sure, that our plugin is loaded, so we don't need a second "installer" plugin
 			case 'plugin':

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -376,6 +376,8 @@ class InstallerModelUpdate extends JModelList
 		$this->cleanCache('_system', 1);
 		$this->cleanCache('com_modules', 0);
 		$this->cleanCache('com_modules', 1);
+		$this->cleanCache('com_plugins', 0);
+		$this->cleanCache('com_plugins', 1);
 		$this->cleanCache('mod_menu', 0);
 		$this->cleanCache('mod_menu', 1);
 

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1747,6 +1747,7 @@ class MenusModelItem extends JModelAdmin
 	{
 		parent::cleanCache('com_menus', 0);
 		parent::cleanCache('com_modules');
-		parent::cleanCache('mod_menu');
+		parent::cleanCache('mod_menu', 0);
+		parent::cleanCache('mod_menu', 1);
 	}
 }

--- a/administrator/components/com_menus/models/menu.php
+++ b/administrator/components/com_menus/models/menu.php
@@ -352,6 +352,7 @@ class MenusModelMenu extends JModelForm
 	{
 		parent::cleanCache('com_menus', 0);
 		parent::cleanCache('com_modules');
-		parent::cleanCache('mod_menu');
+		parent::cleanCache('mod_menu', 0);
+		parent::cleanCache('mod_menu', 1);
 	}
 }


### PR DESCRIPTION
### Summary of Changes

Adds some additional cache clear calls with more operations, including:

- com_installer:
    - Install, uninstall, publish, unpublish tasks will clear the `_system`, `mod_menu`, `com_modules`, and `com_plugins` groups
- com_menus:
    - Add the `mod_menu` group for the admin side when updating menus and menu items

### Testing Instructions

With caching enabled, perform any of the above listed operations and ensure the respective cache data is cleared