### PR TITLE
Calendar placeholder doesn't work

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -110,7 +110,7 @@ JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
 		<input type="text" id="<?php echo $id; ?>" name="<?php
 		echo $name; ?>" value="<?php
 		echo htmlspecialchars(($value != "0000-00-00 00:00:00") ? $value : '', ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attributes; ?>
-		<?php !empty($hint) ? 'placeholder="' . $hint . '"' : ''; ?> data-alt-value="<?php
+		<?php echo !empty($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : ''; ?> data-alt-value="<?php
 		echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" autocomplete="off"/>
 		<button type="button" class="<?php echo ($readonly || $disabled) ? "hidden " : ''; ?>btn btn-secondary"
 			id="<?php echo  $id; ?>_btn"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
`placeholder=""` attribute doesn't work on new calendar field due to missing echo.


### Testing Instructions
Call `JHtml::_('calendar')` with a `'placeholder' => 'test'` in the `$attribs` array, eg:

```php
JHtml::_('calendar', $value, $name, $id, $format = '%Y-%m-%d', $attribs = array('placeholder' => 'test'));
```
### Expected result
placeholder="test" in the HTML output.


### Actual result
No placeholder attribute shown in HTML.


### Documentation Changes Required
None
