### PR TITLE
[4.0] Check for existence of parse_ini_file at installation time

### DIFF
--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -199,12 +199,12 @@ class InstallationModelSetup extends JModelBase
 				$disabled_functions[$i] = trim($disabled_functions[$i]);
 			}
 
-			$result = !in_array('parse_ini_string', $disabled_functions);
+			$result = !in_array('parse_ini_string', $disabled_functions) && !in_array('parse_ini_file', $disabled_functions);
 		}
 		else
 		{
 			// Attempt to detect their existence; even pure PHP implementation of them will trigger a positive response, though.
-			$result = function_exists('parse_ini_string');
+			$result = function_exists('parse_ini_string') && function_exists('parse_ini_file');
 		}
 
 		return $result;


### PR DESCRIPTION
first part of fixing #15587 is to not allow new installations of Joomla that dont meet the minimum requirements (E.g. parse_ini_file is required for Joomla, therefore cannot be disabled

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

