### PR TITLE
Fix Language parsing when parse_ini_file disabled

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -830,9 +830,16 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-		$contents = file_get_contents($filename);
-		$contents = str_replace('_QQ_', '"\""', $contents);
-		$strings = @parse_ini_string($contents);
+		if (!function_exists('parse_ini_file'))
+		{
+			$contents = file_get_contents($filename);
+			$contents = str_replace('_QQ_', '"\""', $contents);
+			$strings = @parse_ini_string($contents);
+		}
+		else
+		{
+			$strings = @parse_ini_file($filename);
+		}
 
 		if (!is_array($strings))
 		{

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -830,7 +830,14 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-		$strings = FOFUtilsIniParser::parse_ini_file($filename, true);
+        if (!function_exists('parse_ini_file'))
+        {
+            return FOFUtilsIniParser::parse_ini_file_php($filename, true);
+        }
+        else
+        {
+            return parse_ini_file($filename);
+        }
 
 		// Restore error tracking to what it was before.
 		if ($this->debug)

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -831,13 +831,13 @@ class JLanguage
 		}
 
 		if (!function_exists('parse_ini_file'))
-        {
+        	{
 			return FOFUtilsIniParser::parse_ini_file_php($filename, true);
 		}
 		else
 		{
 			return parse_ini_file($filename);
-        }
+        	}
 
 		// Restore error tracking to what it was before.
 		if ($this->debug)

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -833,6 +833,7 @@ class JLanguage
 		if (!function_exists('parse_ini_file'))
 		{
 			$contents = file_get_contents($filename);
+			$contents = str_replace('_QQ_', '"\""', $contents);
 			$strings = @parse_ini_string($contents);
 		}
 		else

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -833,7 +833,6 @@ class JLanguage
 		if (!function_exists('parse_ini_file'))
 		{
 			$contents = file_get_contents($filename);
-			$contents = str_replace('_QQ_', '"\""', $contents);
 			$strings = @parse_ini_string($contents);
 		}
 		else

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -830,7 +830,7 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-		$strings = @parse_ini_file($filename);
+		$strings = FOFUtilsIniParser::parse_ini_file($filename, true);
 
 		// Restore error tracking to what it was before.
 		if ($this->debug)

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -831,13 +831,13 @@ class JLanguage
 		}
 
 		if (!function_exists('parse_ini_file'))
-        	{
+		{
 			return FOFUtilsIniParser::parse_ini_file_php($filename, true);
 		}
 		else
 		{
 			return parse_ini_file($filename);
-        	}
+		}
 
 		// Restore error tracking to what it was before.
 		if ($this->debug)

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -832,11 +832,18 @@ class JLanguage
 
 		if (!function_exists('parse_ini_file'))
 		{
-			return FOFUtilsIniParser::parse_ini_file_php($filename, true);
+			$contents = file_get_contents($filename);
+			$contents = str_replace('_QQ_', '"\""', $contents);
+			$strings = @parse_ini_string($contents);
 		}
 		else
 		{
-			return parse_ini_file($filename);
+			$strings = @parse_ini_file($filename);
+		}
+
+		if (!is_array($strings))
+		{
+			$strings = array();
 		}
 
 		// Restore error tracking to what it was before.

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -830,13 +830,13 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-        if (!function_exists('parse_ini_file'))
+		if (!function_exists('parse_ini_file'))
         {
-            return FOFUtilsIniParser::parse_ini_file_php($filename, true);
-        }
-        else
-        {
-            return parse_ini_file($filename);
+			return FOFUtilsIniParser::parse_ini_file_php($filename, true);
+		}
+		else
+		{
+			return parse_ini_file($filename);
         }
 
 		// Restore error tracking to what it was before.

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -830,16 +830,9 @@ class JLanguage
 			ini_set('track_errors', true);
 		}
 
-		if (!function_exists('parse_ini_file'))
-		{
-			$contents = file_get_contents($filename);
-			$contents = str_replace('_QQ_', '"\""', $contents);
-			$strings = @parse_ini_string($contents);
-		}
-		else
-		{
-			$strings = @parse_ini_file($filename);
-		}
+		$contents = file_get_contents($filename);
+		$contents = str_replace('_QQ_', '"\""', $contents);
+		$strings = @parse_ini_string($contents);
 
 		if (!is_array($strings))
 		{

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -854,7 +854,7 @@ class JLanguage
 			$this->debugFile($filename);
 		}
 
-		return is_array($strings) ? $strings : array();
+		return $strings;
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -739,22 +739,24 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 	public function testExists()
 	{
 		$this->assertFalse(
-			JLanguage::exists(null)
+			JLanguageHelper::exists(null)
 		);
 
 		$basePath = __DIR__ . '/data';
 
 		$this->assertTrue(
-			JLanguage::exists('en-GB', $basePath)
+			JLanguageHelper::exists('en-GB', $basePath)
 		);
 
 		$this->assertFalse(
-			JLanguage::exists('es-ES', $basePath)
+			JLanguageHelper::exists('es-ES', $basePath)
 		);
 	}
 
 	/**
-	 * Test...
+	 * Test parsing of language ini files
+	 * Note that if parse_ini_file is disabled on the webhost then FOF parser is used which actually repairs bad
+	 * ini syntax slightly so the bad.ini test will fail, because bad.ini will be cleaned and loaded correctly by FOF
 	 *
 	 * @return void
 	 */
@@ -774,11 +776,15 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 			'Line: ' . __LINE__ . ' test that the strings were parsed correctly.'
 		);
 
-		$strings = $this->inspector->parse(__DIR__ . '/data/bad.ini');
+		/**
+		 * suppressor used as we know this will generate a warning message
+		 * syntax error, unexpected BOOL_TRUE in
+		 */
+		$strings = @$this->inspector->parse(__DIR__ . '/data/bad.ini');
 
 		$this->assertEquals(
 			$strings,
-			array(),
+			false, // False because it did not load correctly, which is good, thats what we are testing
 			'Line: ' . __LINE__ . ' bad ini file should not load properly.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -784,7 +784,7 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertEquals(
 			$strings,
-			false, // False because it did not load correctly, which is good, thats what we are testing
+			array(),
 			'Line: ' . __LINE__ . ' bad ini file should not load properly.'
 		);
 	}

--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -755,8 +755,6 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test parsing of language ini files
-	 * Note that if parse_ini_file is disabled on the webhost then FOF parser is used which actually repairs bad
-	 * ini syntax slightly so the bad.ini test will fail, because bad.ini will be cleaned and loaded correctly by FOF
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
closes #15587

Use sensible code to process ini files when moronic web hosts disable parse_ini_file in php.ini

Please test
