### PR TITLE
Escape the field placeholder

### DIFF
--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -110,7 +110,7 @@ JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
 		<input type="text" id="<?php echo $id; ?>" name="<?php
 		echo $name; ?>" value="<?php
 		echo htmlspecialchars(($value != "0000-00-00 00:00:00") ? $value : '', ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attributes; ?>
-		<?php echo !empty($hint) ? 'placeholder="' . $hint . '"' : ''; ?> data-alt-value="<?php
+		<?php echo !empty($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : ''; ?> data-alt-value="<?php
 		echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" autocomplete="off"/>
 		<button type="button" class="<?php echo ($readonly || $disabled) ? "hidden " : ''; ?>btn btn-secondary"
 			id="<?php echo  $id; ?>_btn"


### PR DESCRIPTION
Pull Request for Issue #15427 

### Summary of Changes

Escape placeholder text provided by admin so that it can contain `"` and other chars

After applying PR you can have a placeholder of:

`enter a "birth date" here`

<img width="457" alt="screen shot 2017-04-27 at 17 30 21" src="https://cloud.githubusercontent.com/assets/400092/25493788/406c4cce-2b6f-11e7-9a4f-14b4214e75d0.png">
