### PR TITLE
define $options as an array if its not already an array - the code is expecting an array.

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -617,6 +617,10 @@ abstract class JHtml
 		}
 		else
 		{
+			if (!is_array($options))
+			{
+				$options = array();
+			}
 			$options['relative']      = isset($options['relative']) ? $options['relative'] : false;
 			$options['pathOnly']      = isset($options['pathOnly']) ? $options['pathOnly'] : false;
 			$options['detectBrowser'] = isset($options['detectBrowser']) ? $options['detectBrowser'] : true;


### PR DESCRIPTION
Pull Request relating to Issue #15548 and #15600.

'stylesheet' function in /libraries/cms/html/html.php takes an $options which may or may not be an array. After upgrading to Joomla 3.7 I was seeing 'Cannot use a scalar value warning' warnings displayed in the frontend website relating to lines 620, 621, 622 and 623. There have been some changes to this function in the last couple of days - I don't know whether there has been an unintended consequence as a result. 

### Summary of Changes

In the section that produced warnings, the $options variable is expected to be an array. I've added a check to say that if it's not an array then define it as an empty array. If it is already an array then there is no impact. The code is expecting it to be an array. 

### Testing Instructions 

Just tested in the browser. No automated tests added. 

### Expected result

No 'Cannot use a scalar value warning' warnings 

### Actual result



### Documentation Changes Required

None. 
