### PR TITLE
Add test cases for JDate constructor demonstrating broken timezone handling

### DIFF
--- a/tests/unit/suites/libraries/joomla/date/JDateTest.php
+++ b/tests/unit/suites/libraries/joomla/date/JDateTest.php
@@ -542,6 +542,44 @@ class JDateTest extends TestCase
 	}
 
 	/**
+	 * Testing the Constructor for now when not using UTC
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  JDate::__construct
+	 */
+	public function test__constructForNowWhenNotUsingUTC()
+	{
+		$jdate   = new JDate('now', new DateTimeZone('US/Central'));
+		$phpdate = new DateTime('now', new DateTimeZone('US/Central'));
+
+		$this->assertSame(
+			$jdate->format('D m/d/Y H:i'),
+			$phpdate->format('D m/d/Y H:i')
+		);
+	}
+
+	/**
+	 * Testing the Constructor for now when using UTC
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  JDate::__construct
+	 */
+	public function test__constructForNowWhenUsingUTC()
+	{
+		$jdate   = new JDate('now', new DateTimeZone('UTC'));
+		$phpdate = new DateTime('now', new DateTimeZone('UTC'));
+
+		$this->assertSame(
+			$jdate->format('D m/d/Y H:i'),
+			$phpdate->format('D m/d/Y H:i')
+		);
+	}
+
+	/**
 	 * Testing the Constructor
 	 *
 	 * @param   string  $date      The date.


### PR DESCRIPTION
### Summary of Changes

With 3.7, the internals of `JDate` are now terribly broken.  The attempt to handle the PHP 7.1 B/C break of supporting microseconds has also caused internal damage to the timezone handling of the system.  This PR demonstrates the broken timezone handling.

This is obviously not a complete PR to address the bug, simply one that should be used to ensure our issue is fixed.  Whether this commit is combined into a final PR or merged separately is up to whomever acts on this.

### Expected result

Tests pass

### Actual result

Tests fail

### Additional Resources

https://twitter.com/mbabker/status/857568147771187201