### PR TITLE
Fix vote ordering

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -762,6 +762,7 @@
 	<fieldset name="list_default_parameters"
 		label="JGLOBAL_LIST_LAYOUT_OPTIONS"
 		description="COM_CONTENT_CONFIG_LIST_SETTINGS_DESC"
+		addfieldpath="/administrator/components/com_content/models/fields"
 	>
 
 		<field name="show_pagination_limit"
@@ -836,21 +837,21 @@
 		</field>
 
 		<field name="list_show_votes"
-			type="list"
+			type="votelist"
 			default="0"
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC">
-			<option value="1" requires="vote">JSHOW</option>
-			<option value="0" requires="vote">JHIDE</option>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
 
 		<field name="list_show_ratings"
-			type="list"
+			type="votelist"
 			default="0"
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC">
-			<option value="1" requires="vote">JSHOW</option>
-			<option value="0" requires="vote">JHIDE</option>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
 		</field>
 
 	</fieldset>

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -52,7 +52,8 @@ class ContentModelArticles extends JModelList
 				'author_id',
 				'category_id',
 				'level',
-				'tag'
+				'tag',
+				'rating_count', 'rating',
 			);
 
 			if (JLanguageAssociations::isEnabled())
@@ -322,14 +323,8 @@ class ContentModelArticles extends JModelList
 		}
 
 		// Add the list ordering clause.
-		$orderCol  = $this->state->get('list.fullordering', 'a.id');
-		$orderDirn = '';
-
-		if (empty($orderCol))
-		{
-			$orderCol  = $this->state->get('list.ordering', 'a.id');
-			$orderDirn = $this->state->get('list.direction', 'DESC');
-		}
+		$orderCol  = $this->state->get('list.ordering', 'a.id');
+		$orderDirn = $this->state->get('list.direction', 'DESC');
 
 		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 

--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -55,7 +55,8 @@ class ContentModelFeatured extends ContentModelArticles
 				'author_id',
 				'category_id',
 				'level',
-				'tag'
+				'tag',
+				'rating_count', 'rating',
 			);
 		}
 
@@ -220,14 +221,8 @@ class ContentModelFeatured extends ContentModelArticles
 		}
 
 		// Add the list ordering clause.
-		$orderCol  = $this->state->get('list.fullordering', 'a.title');
-		$orderDirn = '';
-
-		if (empty($orderCol))
-		{
-			$orderCol  = $this->state->get('list.ordering', 'a.title');
-			$orderDirn = $this->state->get('list.direction', 'ASC');
-		}
+		$orderCol  = $this->state->get('list.ordering', 'a.title');
+		$orderDirn = $this->state->get('list.direction', 'ASC');
 
 		$query->order($db->escape($orderCol) . ' ' . $db->escape($orderDirn));
 

--- a/administrator/components/com_content/models/fields/votelist.php
+++ b/administrator/components/com_content/models/fields/votelist.php
@@ -30,6 +30,7 @@ class JFormFieldVotelist extends JFormFieldList
 	 * Method to get the field options.
 	 *
 	 * @return array The field option objects.
+	 *
 	 * @throws \Exception
 	 *
 	 * @since  __DEPLOY_VERSION__

--- a/administrator/components/com_content/models/fields/votelist.php
+++ b/administrator/components/com_content/models/fields/votelist.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+JFormHelper::loadFieldClass('list');
+
+/**
+ * Votelist Field class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JFormFieldVotelist extends JFormFieldList
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'Votelist';
+
+	/**
+	 * Method to get the field options.
+	 *
+	 * @return array The field option objects.
+	 * @throws \Exception
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function getOptions()
+	{
+		// Requires vote plugin enabled
+		return JPluginHelper::isEnabled('content', 'vote') ? parent::getOptions() : array();
+	}
+}

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -18,7 +18,7 @@ JHtml::_('formbehavior.chosen', 'select');
 $app       = JFactory::getApplication();
 $user      = JFactory::getUser();
 $userId    = $user->get('id');
-$listOrder = str_replace(' ' . $this->state->get('list.direction'), '', $this->state->get('list.fullordering'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'a.ordering';
 $columns   = 10;

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -17,7 +17,7 @@ JHtml::_('formbehavior.chosen', 'select');
 
 $user      = JFactory::getUser();
 $userId    = $user->get('id');
-$listOrder = str_replace(' ' . $this->state->get('list.direction'), '', $this->state->get('list.fullordering'));
+$listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'fp.ordering';
 $columns   = 10;

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -117,12 +117,6 @@ class JFormFieldList extends JFormField
 				{
 					continue;
 				}
-
-				// Requires vote plugin enabled
-				if (in_array('vote', $requires) && !JPluginHelper::isEnabled('content', 'vote'))
-				{
-					continue;
-				}
 			}
 
 			$value = (string) $option['value'];


### PR DESCRIPTION
Pull Request for Issue #15549.

### Summary of Changes
Changes the articles and featured models back to using the list.ordering state instead of the list.fullordering one. Added the new ordring options to the whitelist.

This also removes the check for the vote plugin from JFormFieldList because that class certainly shouldn't he to deal with that. Instead I created a new custom formfield class for com_content. The behavior of the respective parameters is exactly the same as before.


### Testing Instructions
* Test that ordering in the article and featured article manager works. Article manager by default should be ID Descending, featured one title ascending.
* Test that sorting by votes and ratings works.

### Expected result
Works


### Actual result
Default is ID ascending for the article manager.


### Documentation Changes Required
None. This restores previous behavior.