### PR TITLE
Bug: Correcting category associations

### DIFF
--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -36,7 +36,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		$view   = $view === null ? $jinput->get('view') : $view;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
-		if ($view === 'article' || $view === 'featured')
+		if ($view === 'article')
 		{
 			if ($id)
 			{
@@ -74,7 +74,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 	{
 		$return = array();
 
-		if ($associations = self::getAssociations($id))
+		if ($associations = self::getAssociations($id, 'article'))
 		{
 			$levels    = JFactory::getUser()->getAuthorisedViewLevels();
 			$languages = JLanguageHelper::getLanguages();

--- a/components/com_content/helpers/association.php
+++ b/components/com_content/helpers/association.php
@@ -36,7 +36,7 @@ abstract class ContentHelperAssociation extends CategoryHelperAssociation
 		$view   = $view === null ? $jinput->get('view') : $view;
 		$id     = empty($id) ? $jinput->getInt('id') : $id;
 
-		if ($view === 'article' || $view === 'category' || $view === 'featured')
+		if ($view === 'article' || $view === 'featured')
 		{
 			if ($id)
 			{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15612

### Summary of Changes
Correcting faulty code in https://github.com/joomla/joomla-cms/pull/12042


### Testing Instructions
Create a multilingual site (2 languages is enough)

Create a new article category for each language. Associate these new categories.
Create an article in each of these new categories. Tagged to the same language.

In the mainmenu for one of the languages, create a new menu item of type category list displaying the new category tagged to the same language as the Home page of that menu.

In frontend, display this menu item. Using the language switcher, click on the flag of the other language

### Before patch
Clicking on that flag will display the home page of that language.

### After patch
The associated category will display correctly.


@oliver-74
Please confirm on issues.joomla.org

@Bakual 
This patch makes us lose the possible associated flag next to associated articles when displaying a blog or a category list. We do keep it OK when the view is `article` or `featured`.
Any way you see to not lose the feature for category views?