### PR TITLE
Set default for "captcha" param to empty

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -350,7 +350,7 @@
 			type="plugins"
 			label="COM_CONTENT_FIELD_CAPTCHA_LABEL"
 			description="COM_CONTENT_FIELD_CAPTCHA_DESC"
-			default="0"
+			default=""
 			folder="captcha"
 			filter="cmd"
 		>


### PR DESCRIPTION
Pull Request for Issue #15666.

### Summary of Changes
Changing the default value for the new "Allow Captcha on submit" param in com_content options -> "Editing Layout" to "" (empty) so the "- Use Default -" Option actually can be selected.

### Testing Instructions
* Try changing the parameter to "-Use Default -" and save the options


### Expected result
Selected "-Use Default -" value stays


### Actual result
After saving the value goes back to "- None Selected -".


### Documentation Changes Required

