### PR TITLE
Fix form-horizontal for non-latin or long language strings

### DIFF
--- a/administrator/components/com_config/view/component/tmpl/default.php
+++ b/administrator/components/com_config/view/component/tmpl/default.php
@@ -78,7 +78,10 @@ JFactory::getDocument()->addScriptDeclaration(
 							</div>
 						<?php endif; ?>
 						<?php foreach ($this->form->getFieldset($name) as $field) : ?>
-							<?php $dataShowOn = ''; ?>
+							<?php
+								$dataShowOn = '';
+								$groupClass = $field->type === 'Spacer' ? ' field-spacer' : '';
+							?>
 							<?php if ($field->showon) : ?>
 								<?php JHtml::_('jquery.framework'); ?>
 								<?php JHtml::_('script', 'jui/cms.js', array('version' => 'auto', 'relative' => true)); ?>
@@ -87,7 +90,7 @@ JFactory::getDocument()->addScriptDeclaration(
 							<?php if ($field->hidden) : ?>
 								<?php echo $field->input; ?>
 							<?php else : ?>
-								<div class="control-group"<?php echo $dataShowOn; ?>>
+								<div class="control-group<?php echo $groupClass; ?>"<?php echo $dataShowOn; ?>>
 									<?php if ($name != 'permissions') : ?>
 										<div class="control-label">
 											<?php echo $field->label; ?>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7289,7 +7289,6 @@ h6 {
 	max-height: 800px;
 }
 .form-horizontal .control-label {
-	width: auto;
 	padding-right: 5px;
 	text-align: left;
 }

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7300,6 +7300,9 @@ h6 {
 		width: 220px;
 	}
 }
+.form-horizontal .field-spacer>.control-label {
+	width: auto;
+}
 .form-horizontal #jform_catid_chzn {
 	vertical-align: middle;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1620,6 +1620,8 @@ legend + .control-group {
 }
 .form-horizontal .control-label {
 	float: left;
+	max-width: 160px;
+	min-width: 160px;
 	width: 160px;
 	padding-top: 5px;
 	text-align: right;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1620,8 +1620,6 @@ legend + .control-group {
 }
 .form-horizontal .control-label {
 	float: left;
-	max-width: 160px;
-	min-width: 160px;
 	width: 160px;
 	padding-top: 5px;
 	text-align: right;
@@ -7291,7 +7289,6 @@ h6 {
 	max-height: 800px;
 }
 .form-horizontal .control-label {
-	width: auto;
 	padding-right: 5px;
 	text-align: left;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7300,6 +7300,9 @@ h6 {
 		width: 220px;
 	}
 }
+.form-horizontal .field-spacer>.control-label {
+	width: auto;
+}
 .form-horizontal #jform_catid_chzn {
 	vertical-align: middle;
 }

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -17,6 +17,9 @@
 			}
 		}
 	}
+	.field-spacer>.control-label{
+		width: auto;
+	}
 	#jform_catid_chzn {
 		vertical-align: middle;
 	}

--- a/administrator/templates/isis/less/blocks/_forms.less
+++ b/administrator/templates/isis/less/blocks/_forms.less
@@ -7,7 +7,6 @@
 .form-horizontal {
 	// Float the labels left
 	.control-label {
-		width: auto;
 		padding-right: 5px;
 		text-align: left;
 		// Set a width for the spacer hr so it shows
@@ -209,7 +208,7 @@ textarea.noResize {
 				border-width: 0 0 1px 1px;
 				.icon-minus:before {
 					content: "I";
-					
+
 				}
 			}
 			&.btn-primary {
@@ -277,15 +276,15 @@ textarea.noResize {
 				padding-bottom: 15px;
 			}
 		}
-		table, thead, tbody, th, td, tr { 
-			display: block; 
+		table, thead, tbody, th, td, tr {
+			display: block;
 		}
 		table {
 			border: 1px solid #ddd;
 		}
 		thead {
-			
-			th { 
+
+			th {
 				position: absolute;
 				top: -9999px;
 				left: -9999px;
@@ -298,15 +297,15 @@ textarea.noResize {
 				}
 			}
 		}
-		tr { 
+		tr {
 			margin: 0;
     		padding: 0;
 			border: 0;
 		}
-		td { 
+		td {
 			border: none;
 			position: relative;
-			padding-left: 50%; 
+			padding-left: 50%;
 		}
 		tbody {
 			td:first-of-type {
@@ -315,13 +314,13 @@ textarea.noResize {
 				&:before {top:18px;}
 			}
 		}
-		
-		td:before { 
+
+		td:before {
 			content: attr(data-column);
 			position: absolute;
 			top: 13px;
 			left: 10px;
-			padding-right: 10px; 
+			padding-right: 10px;
 		}
 	}
 }

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -25,6 +25,7 @@ defined('JPATH_BASE') or die;
 		foreach ($displayData->form->getFieldset($fieldname) as $field)
 		{
 			$datashowon = '';
+			$groupClass = $field->type === 'Spacer' ? ' field-spacer' : '';
 
 			if ($field->showon)
 			{
@@ -33,7 +34,7 @@ defined('JPATH_BASE') or die;
 				$datashowon = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\'';
 			}
 			?>
-			<div class="control-group"<?php echo $datashowon; ?>>
+			<div class="control-group<?php echo $groupClass; ?>"<?php echo $datashowon; ?>>
 				<?php if (!isset($displayData->showlabel) || $displayData->showlabel) : ?>
 					<div class="control-label"><?php echo $field->label; ?></div>
 				<?php endif; ?>

--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -116,7 +116,7 @@ class JFormFieldSpacer extends JFormField
 	 */
 	public function renderField($options = array())
 	{
-		$options['class'] = empty($options['class']) ? 'field-spacer' : $options['class'] .  ' field-spacer';
+		$options['class'] = empty($options['class']) ? 'field-spacer' : $options['class'] . ' field-spacer';
 
 		return parent::renderField($options);
 	}

--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -104,4 +104,20 @@ class JFormFieldSpacer extends JFormField
 	{
 		return $this->getLabel();
 	}
+
+	/**
+	 * Method to get a control group with label and input.
+	 *
+	 * @param   array  $options  Options to be passed into the rendering of the field
+	 *
+	 * @return  string  A string containing the html for the control group
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function renderField($options = array())
+	{
+		$options['class'] = empty($options['class']) ? 'field-spacer' : $options['class'] .  ' field-spacer';
+
+		return parent::renderField($options);
+	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix form-horizontal for non-latin or long language strings.

Please look for this languages specifies fix: @infograf768 

Before fix:
![before](https://cloud.githubusercontent.com/assets/1041797/25560417/a3ffbd54-2d5c-11e7-939d-c9f08532b23b.png)

After fix:
![screenshot-lang j-2017-04-30-04-20-12](https://cloud.githubusercontent.com/assets/1041797/25560421/ad7d319a-2d5c-11e7-8aab-2dc1d72cc9e9.png)

Optional width 200px:

```
max-width: 200px;
min-width: 200px;
width: 200px;
```

Testing latest version Firefox, Chrome and etc Chromius based brawsers.



