### PR TITLE
Path disclosure: PHP Notice on Sysinfo

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -482,18 +482,13 @@ class AdminModelSysInfo extends JModelLegacy
 				'authorUrl'    => 'unknown',
 			);
 
-			$manifest = json_decode($extension->manifest_cache);
-
-			if (!$manifest instanceof stdClass)
-			{
-				continue;
-			}
+			$manifest = new Registry($extension->manifest_cache);
 
 			$extraData = array(
-				'author'       => $manifest->author,
-				'version'      => $manifest->version,
-				'creationDate' => $manifest->creationDate,
-				'authorUrl'    => $manifest->authorUrl,
+				'author'       => $manifest->get('author', ''),
+				'version'      => $manifest->get('version', ''),
+				'creationDate' => $manifest->get('creationDate', ''),
+				'authorUrl'    => $manifest->get('authorUrl', '')
 			);
 
 			$installed[$extension->name] = array_merge($installed[$extension->name], $extraData);


### PR DESCRIPTION
While creating a list of the installed extensions, AdminModelSysInfo::getExtensions() accesses properties whose existence is not guaranteed, and depends on third party extensions xml manifests files.

PHP Notice:  Undefined property: stdClass::$authorUrl in [...]/administrator/components/com_admin/models/sysinfo.php on line 496

### Summary of Changes
Replaced
"array based access" + "validation of data parsed"
with
"usage of JRegistry".

### Testing Instructions
1. Enable error reporting.
2. Install an extension whose manifest xml file lacks one of the following fields: author, version, creationDate or authorUrl.
3. Alternatively, remove one of the fields listed above by editing the column manifest_cache field in #__extensions table. Ensure to respect the json syntax in this case.
4. Once in "System Information" menu, press "Download as text" or "Download as json" button.

### Actual result
The PHP warning appears at the beginning of the export plain text file, and in the error log of the web server.
