### PR TITLE
add appveyor-retry to SQLite download

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ install:
           $VC = "vc14"
           $PHPBuild = "x64"
         }
-    - cinst -y sqlite
+    - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLL's
     - ps: >-


### PR DESCRIPTION
Pull Request for Issue SQLite on php7 appveyor test sometimes doesn't install .

### Summary of Changes

add appveyor-retry to SQLite download

### Testing Instructions

code review

### Documentation Changes Required
none
