### PR TITLE
Fix php 5.6 sqlsrv dll downloads on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,8 +24,6 @@ install:
     - IF EXIST C:\tools\php (SET PHP=0)
     - ps: >-
           appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-          $VC = "vc14"
-          $PHPBuild = "x64"
     - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLL's
@@ -62,8 +60,8 @@ install:
         If ($env:PHP -eq "1") {
           $wincache = "2.0.0.8"
           cd c:\tools\php\ext
-          appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip
-          7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip > $null
+          appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-vc14-x64.zip
+          7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
           Remove-Item C:\tools\php\ext* -include .zip
           cd c:\tools\php}
     - IF %PHP%==1 echo extension=php_wincache.dll >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,12 +23,27 @@ services:
 install:
     - IF EXIST C:\tools\php (SET PHP=0)
     - ps: >-
+        If ($env:php_ver_target -eq "5.6") {
+          appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y --forcex86 php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+          $VC = "vc11"
+          $PHPBuild = "x86"
+        } Else {
           appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-    - appveyor-retry cinst -y sqlite
+          $VC = "vc14"
+          $PHPBuild = "x64"
+        }
+    - cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLL's
     - ps: >-
         If ($env:PHP -eq "1") {
+          If ($env:php_ver_target -eq "5.6") {
+            appveyor-retry appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
+            7z x -y php-sqlsrv.zip > $null
+            copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
+            copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll
+            Remove-Item C:\tools\php\* -include .zip
+          } Else {
             $DLLVersion = "4.1.6.1"
             cd c:\tools\php\ext
             appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
@@ -36,7 +51,7 @@ install:
             appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
             7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
             Remove-Item c:\tools\php\ext* -include .zip
-            cd c:\tools\php}
+            cd c:\tools\php}}
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
@@ -45,23 +60,30 @@ install:
     - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
     - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
     - ps: >-
+        If ($env:php_ver_target -eq "5.6") {
+          Add-Content php.ini "`nextension=php_sqlsrv_nts.dll"
+          Add-Content php.ini "`nextension=php_pdo_sqlsrv_nts.dll"
+          Add-Content php.ini "`n"
+        } Else {
           Add-Content php.ini "`nextension=php_sqlsrv.dll"
           Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
           Add-Content php.ini "`n"
+        }
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
     - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
+    - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
     # Get the Wincache DLLs
     - ps: >-
         If ($env:PHP -eq "1") {
-          $wincache = "2.0.0.8"
+          If ($env:php_ver_target -eq "5.6") {$wincache = "1.3.7.12"} Else {$wincache = "2.0.0.8"}
           cd c:\tools\php\ext
-          appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-vc14-x64.zip
-          7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
+          appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip
+          7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip > $null
           Remove-Item C:\tools\php\ext* -include .zip
           cd c:\tools\php}
     - IF %PHP%==1 echo extension=php_wincache.dll >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,6 +5,7 @@ clone_folder: C:\projects\joomla-cms
 ## Build matrix for lowest and highest possible targets
 environment:
   matrix:
+  - php_ver_target: 5.6
   - php_ver_target: 7.0
   - php_ver_target: 7.1
 
@@ -38,7 +39,7 @@ install:
     - ps: >-
         If ($env:PHP -eq "1") {
           If ($env:php_ver_target -eq "5.6") {
-            appveyor-retry appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
+            appveyor-retry appveyor DownloadFile https://cdn.joomla.org/ci/php-sqlsrv.zip
             7z x -y php-sqlsrv.zip > $null
             copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
             copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,6 @@ clone_folder: C:\projects\joomla-cms
 ## Build matrix for lowest and highest possible targets
 environment:
   matrix:
-  - php_ver_target: 5.6
   - php_ver_target: 7.0
   - php_ver_target: 7.1
 
@@ -24,27 +23,14 @@ services:
 install:
     - IF EXIST C:\tools\php (SET PHP=0)
     - ps: >-
-        If ($env:php_ver_target -eq "5.6") {
-          appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y --forcex86 php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-          $VC = "vc11"
-          $PHPBuild = "x86"
-        } Else {
           appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
           $VC = "vc14"
           $PHPBuild = "x64"
-        }
-    - cinst -y sqlite
+    - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLL's
     - ps: >-
         If ($env:PHP -eq "1") {
-          If ($env:php_ver_target -eq "5.6") {
-            appveyor-retry appveyor DownloadFile https://files.nette.org/misc/php-sqlsrv.zip
-            7z x -y php-sqlsrv.zip > $null
-            copy SQLSRV\php_sqlsrv_56_nts.dll ext\php_sqlsrv_nts.dll
-            copy SQLSRV\php_pdo_sqlsrv_56_nts.dll ext\php_pdo_sqlsrv_nts.dll
-            Remove-Item C:\tools\php\* -include .zip
-          } Else {
             $DLLVersion = "4.1.6.1"
             cd c:\tools\php\ext
             appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/sqlsrv/$($DLLVersion)/php_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
@@ -52,7 +38,7 @@ install:
             appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/pdo_sqlsrv/$($DLLVersion)/php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip
             7z x -y php_pdo_sqlsrv-$($DLLVersion)-$($env:php_ver_target)-nts-vc14-x64.zip > $null
             Remove-Item c:\tools\php\ext* -include .zip
-            cd c:\tools\php}}
+            cd c:\tools\php}
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
@@ -61,27 +47,20 @@ install:
     - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
     - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
     - ps: >-
-        If ($env:php_ver_target -eq "5.6") {
-          Add-Content php.ini "`nextension=php_sqlsrv_nts.dll"
-          Add-Content php.ini "`nextension=php_pdo_sqlsrv_nts.dll"
-          Add-Content php.ini "`n"
-        } Else {
           Add-Content php.ini "`nextension=php_sqlsrv.dll"
           Add-Content php.ini "`nextension=php_pdo_sqlsrv.dll"
           Add-Content php.ini "`n"
-        }
     - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
     - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
     - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
-    - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini
     - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
     # Get the Wincache DLLs
     - ps: >-
         If ($env:PHP -eq "1") {
-          If ($env:php_ver_target -eq "5.6") {$wincache = "1.3.7.12"} Else {$wincache = "2.0.0.8"}
+          $wincache = "2.0.0.8"
           cd c:\tools\php\ext
           appveyor-retry appveyor DownloadFile http://windows.php.net/downloads/pecl/releases/wincache/$($wincache)/php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip
           7z x -y php_wincache-$($wincache)-$($env:php_ver_target)-nts-$($VC)-$($PHPBuild).zip > $null

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ install:
           $VC = "vc14"
           $PHPBuild = "x64"
         }
-    - cinst -y sqlite
+    - appveyor-retry cinst -y sqlite
     - cd C:\tools\php
     # Get the MSSQL DLL's
     - ps: >-


### PR DESCRIPTION
Pull Request for Issue the sqlsrv files we were using are no longer available and/or plagued by DNS issues.

### Summary of Changes
Fix php 5.6 sqlsrv dll downloads on appveyor as the sqlsrv files we were using are no longer available and/or plagued by DNS issues.
includes the changes from #15705 

There are no other known source of compiled DLLs for SQLSRV for php 5.6.  The official source for sqlsrv php 5.6 via PECL requires compiling the c files to create a DLL.  I was able to get the source files during a moment when they were not down due to DNS issues, the files are attached.
[php-sqlsrv.zip](https://github.com/joomla/joomla-cms/files/967150/php-sqlsrv.zip)

these precompiled files were added to a Joomla URL for downloads

official releases
- https://pecl.php.net/package/sqlsrv
- https://pecl.php.net/package/pdo_sqlsrv

### Testing Instructions
tests pass / code review

supersedes PR #15705 