### PR TITLE
recaptcha updates

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
+++ b/administrator/language/en-GB/en-GB.plg_captcha_recaptcha.ini
@@ -7,9 +7,9 @@ PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION="This CAPTCHA plugin uses the reCAPTCHA se
 PLG_CAPTCHA_RECAPTCHA="CAPTCHA - reCAPTCHA"
 
 ; Params
-PLG_RECAPTCHA_VERSION_1_WARNING_LABEL="You have selected Version 1.0. All new sites should be using Version 2.0. Version 1.0 is only maintained to provide support for Global Site keys which are no longer available from Google."
+PLG_RECAPTCHA_VERSION_1_WARNING_LABEL="You have selected Version 1.0. All new sites should be using Version 2.0. Since May 2016 version 1.0 has been deprecated and is only maintained to provide support for Global Site keys which are no longer available from Google. Version 1.0 will not work for new sites and continued functionality can not be guaranteed."
 PLG_RECAPTCHA_VERSION_LABEL="Version"
-PLG_RECAPTCHA_VERSION_DESC="Version 2.0 is the recommended version. Version 1.0 is required if using deprecated Global reCAPTCHA keys."
+PLG_RECAPTCHA_VERSION_DESC="Version 2.0 is the recommended version. Version 1.0 is required if using deprecated Global reCAPTCHA keys. It is no longer supported and will not work for new sites."
 ; The following two strings are deprecated and will be removed with 4.0. They generate wrong plural detection in Crowdin.
 PLG_RECAPTCHA_VERSION_1="1.0"
 PLG_RECAPTCHA_VERSION_2="2.0"

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -28,7 +28,7 @@
 					type="list"
 					label="PLG_RECAPTCHA_VERSION_LABEL"
 					description="PLG_RECAPTCHA_VERSION_DESC"
-					default="1.0"
+					default="2.0"
 					size="1"
 					>
 					<option value="1.0">PLG_RECAPTCHA_VERSION_V1</option>


### PR DESCRIPTION
As of May 2016 captcha version 1.0 is not avaailable for NEW sites. As a result this PR does two things

1. It changes the default to version2 from version 1
2. It updaates the desscription of the limits on version 1

https://developers.google.com/recaptcha/docs/versions#v1