### PR TITLE
Adding core.options to Global Configuration Permissions

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -1190,6 +1190,11 @@
 				title="JACTION_ADMIN_GLOBAL"
 				description="COM_CONFIG_ACTION_ADMIN_DESC"
 			/>
+            <action
+				name="core.options"
+				title="JACTION_OPTIONS"
+				description="COM_CONFIG_ACTION_OPTIONS_DESC"
+            />
 			<action
 				name="core.manage"
 				title="JACTION_MANAGE"

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -1190,11 +1190,11 @@
 				title="JACTION_ADMIN_GLOBAL"
 				description="COM_CONFIG_ACTION_ADMIN_DESC"
 			/>
-            <action
+			<action
 				name="core.options"
 				title="JACTION_OPTIONS"
 				description="COM_CONFIG_ACTION_OPTIONS_DESC"
-            />
+			/>
 			<action
 				name="core.manage"
 				title="JACTION_MANAGE"

--- a/administrator/language/en-GB/en-GB.com_config.ini
+++ b/administrator/language/en-GB/en-GB.com_config.ini
@@ -15,6 +15,7 @@ COM_CONFIG_ACTION_LOGIN_ADMIN_DESC="Allows users in the group to login to the Ba
 COM_CONFIG_ACTION_LOGIN_OFFLINE_DESC="Allows users in the group to access the Frontend site when site is offline."
 COM_CONFIG_ACTION_LOGIN_SITE_DESC="Allows users in the group to login to the Frontend site."
 COM_CONFIG_ACTION_MANAGE_DESC="Allows users in the group to access all of the administration interface except Global Configuration."
+COM_CONFIG_ACTION_OPTIONS_DESC="Allows users in the group to edit the options except the permissions of any extension."
 COM_CONFIG_CACHE_SETTINGS="Cache Settings"
 COM_CONFIG_CACHE_WARNING="Failed to clear cache automatically, you may need to do so manually."
 COM_CONFIG_COMPONENT_FIELDSET_LABEL="Component"


### PR DESCRIPTION
### Summary of Changes
With #4975 and #6978 the action `core.options` is added to components, but not to the Permissions settings in the Global Configuration. This Pull Request is adding this action to the Global Configuration Permissions so users can set the permission for this actions on the global level, rather then having to set the permission for each component individually. 

### Testing Instructions
1) Confirm the "Configure Options Only" is not available in the Permission tab of the Global Configuration, but available for components like com_content and com_contact.
2) Apply patch
3) Go to the Article Manager and confirm the "Configure Options Only" is not set for the Manager group (default installation). 
<img width="1361" alt="screen_shot_2017-04-30_at_21_15_52" src="https://cloud.githubusercontent.com/assets/522834/25567354/e98dcc00-2deb-11e7-9c8e-59b3547b7cf3.png">
4) Check if the "Configure Options Only" is now available in the Permission tab of the Global Configuration and set it to allowed:
<img width="1359" alt="screen_shot_2017-04-30_at_21_16_28" src="https://cloud.githubusercontent.com/assets/522834/25567360/17b13f72-2dec-11e7-9955-72eb729f4922.png">
5) Go back to the Article Manager Permissions and confirm the action is now allowed, by inheriting the Global Configuration setting
<img width="1361" alt="screen_shot_2017-04-30_at_21_16_41" src="https://cloud.githubusercontent.com/assets/522834/25567367/30539782-2dec-11e7-82d2-73b9121838fc.png">

The "Configure Options Only" should also be visible in the Group and User "Advanced Permissions Report"