### PR TITLE
Offline page not working in the Beez3 template

### DIFF
--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -20,14 +20,14 @@ $this->setHtml5(true);
 JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
 
 // Styles
-JHtml::_('stylesheet', 'templates/system/css/offline.css', array('version' => 'auto', 'relative' => false));
+JHtml::_('stylesheet', 'templates/system/css/offline.css', array('version' => 'auto'));
 
 if ($this->direction == 'rtl')
 {
-	JHtml::_('stylesheet', 'templates/system/css/offline_rtl.css', array('version' => 'auto', 'relative' => false));
+	JHtml::_('stylesheet', 'templates/system/css/offline_rtl.css', array('version' => 'auto'));
 }
 
-JHtml::_('stylesheet', 'templates/system/css/general.css', array('version' => 'auto', 'relative' => false));
+JHtml::_('stylesheet', 'templates/system/css/general.css', array('version' => 'auto'));
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -20,14 +20,14 @@ $this->setHtml5(true);
 JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
 
 // Styles
-JHtml::_('stylesheet', 'offline.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'templates/system/css/offline.css', array('version' => 'auto', 'relative' => false));
 
 if ($this->direction == 'rtl')
 {
-	JHtml::_('stylesheet', 'offline_rtl.css', array('version' => 'auto', 'relative' => true));
+	JHtml::_('stylesheet', 'templates/system/css/offline_rtl.css', array('version' => 'auto', 'relative' => false));
 }
 
-JHtml::_('stylesheet', 'general.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'templates/system/css/general.css', array('version' => 'auto', 'relative' => false));
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');


### PR DESCRIPTION
Pull Request for Issue #15614 .

### Summary of Changes
The Beez3 template doesn't have an error.php so the default system template error.php is loaded. In that case the paths to the CSS files are incorrect as they are looking for the CSS files in the Beez3 template CSS folder and not in the system CSS folder.

### Testing Instructions

- Login in the Administrator
- Go to the templates and set the Beez3 template as default
- Go to Global Configuration and set the site offline
- Visit the website
- Now the login box has no styling because the stylesheets are missing
- Apply the patch
- The stylesheets for the login box is now loaded and the styling should be normal.

![beez3-offline-page-patch](https://cloud.githubusercontent.com/assets/5610413/25567998/9244092e-2df9-11e7-93cf-4bb731404ca9.jpg)


### Expected result
The login box should be centered and have styling

### Actual result
The login box has no styling because the stylesheets are not loaded