### PR TITLE
Double Quotes Not Escaped Properly

### DIFF
--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -190,7 +190,7 @@ COM_INSTALLER_N_UPDATESITES_UNPUBLISHED_1="%d update site successfully disabled.
 COM_INSTALLER_NEW_INSTALL="New Install"
 COM_INSTALLER_NEW_VERSION="Available"
 COM_INSTALLER_NO_INSTALL_TYPE_FOUND="No Install Type Found"
-COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title="Plugin Manager">Plugin Manager</a> to enable the plugins."
+COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title=\"Plugin Manager\">Plugin Manager</a> to enable the plugins."
 COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED="Failed to download package. Download it and install manually from <a href='%1$s'>%1$s</a>."
 COM_INSTALLER_PACKAGE_FILE="Package File"
 COM_INSTALLER_PREFERENCES_DESCRIPTION="Fine tune how extensions installation and updates work."

--- a/administrator/language/en-GB/en-GB.com_installer.ini
+++ b/administrator/language/en-GB/en-GB.com_installer.ini
@@ -190,7 +190,7 @@ COM_INSTALLER_N_UPDATESITES_UNPUBLISHED_1="%d update site successfully disabled.
 COM_INSTALLER_NEW_INSTALL="New Install"
 COM_INSTALLER_NEW_VERSION="Available"
 COM_INSTALLER_NO_INSTALL_TYPE_FOUND="No Install Type Found"
-COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title=\"Plugin Manager\">Plugin Manager</a> to enable the plugins."
+COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title='Plugin Manager'>Plugin Manager</a> to enable the plugins."
 COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED="Failed to download package. Download it and install manually from <a href='%1$s'>%1$s</a>."
 COM_INSTALLER_PACKAGE_FILE="Package File"
 COM_INSTALLER_PREFERENCES_DESCRIPTION="Fine tune how extensions installation and updates work."


### PR DESCRIPTION
Pull Request for Issue # .
No issue tracker for this.

### Summary of Changes

Double Quotes Not Escaped Properly in the Language String COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND

Original Language String:
COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title="Plugin Manager">Plugin Manager</a> to enable the plugins."


Proposed Language String:
COM_INSTALLER_NO_INSTALLATION_PLUGINS_FOUND="No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href='index.php?option=com_plugins&view=plugins&filter[folder]=installer' title=\"Plugin Manager\">Plugin Manager</a> to enable the plugins."


Reason:
The double quotes enclosing the text string "Plugin Manager" is not escaped properly wither with "_QQ_" (current usage) or \" (future usage).  Because of this, the HTML generated where this language string is used is shown as below:

<div class="alert-message">No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href="index.php?option=com_plugins&amp;view=plugins&amp;filter[folder]=installer" title="Plugin" manager="">Plugin Manager</a> to enable the plugins.</div>

Notice the new attribute master next to the title attribute.

With the fully escaped double quotes, the HTML would like the following:

<div class="alert-message">No installation plugin has been enabled. At least one must be enabled to be able to use the installer. Go to the <a href="index.php?option=com_plugins&amp;view=plugins&amp;filter[folder]=installer" title="Plugin Manager">Plugin Manager</a> to enable the plugins.</div>


### Testing Instructions

- Login to the site's back-end
- Go to the screen "Plugins" (Extensions => Plugins)
- Disable all the plugins of the type "Installer"
- Go to the screen "Extensions: Install" (Extensions => Manage -> Install"
- You will see a warning notice about no installation plugins are enabled
- Inspect the HTML created for the Warning message


### Expected result

Review the summary of changes


### Actual result

Review the summary of changes


### Documentation Changes Required

None
