### PR TITLE
Add actual position where the error happens in the trace

### DIFF
--- a/libraries/joomla/document/error.php
+++ b/libraries/joomla/document/error.php
@@ -220,6 +220,12 @@ class JDocumentError extends JDocument
 			return;
 		}
 
-		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $this->_error->getTrace()));
+		// The back trace
+		$backtrace = $this->_error->getTrace();
+
+		// Add the position of the actual file
+		array_unshift($backtrace, array('file' => $this->_error->getFile(), 'line' => $this->_error->getLine(), 'function' => ''));
+
+		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $backtrace));
 	}
 }


### PR DESCRIPTION
### Summary of Changes
When debug mode is activated and an exception is thrown, then the stack trace is shown. This trace includes the call stack except the information where the actual error happened. This PR includes that information.

This is a similar pr #14169. Looks like that during the 3.7 lifecycle something has changed as it works now with a JLayout.

### Testing Instructions
- Set debugging to yes in the global configuration 
![image](https://cloud.githubusercontent.com/assets/251072/23172860/8b69eb46-f857-11e6-853a-87ebd7971408.png)
- In the file /administrator/components/com_content/content.php after line 8 add the code `throw new Exception();`
- In the back end open Content -> Articles

### Expected result
A stack trace is shown where the last line is
> /administrator/components/com_content/content.php:9

### Actual result
A stack trace is shown where the last line is
> /libraries/cms/component/helper.php:394
