### PR TITLE
Implementation of the new Exception-Handling

### DIFF
--- a/administrator/components/com_admin/views/profile/view.html.php
+++ b/administrator/components/com_admin/views/profile/view.html.php
@@ -58,9 +58,7 @@ class AdminViewProfile extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->form->setValue('password',	null);

--- a/administrator/components/com_admin/views/sysinfo/view.html.php
+++ b/administrator/components/com_admin/views/sysinfo/view.html.php
@@ -70,7 +70,7 @@ class AdminViewSysinfo extends JViewLegacy
 		// Access check.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		$this->php_settings = $this->get('PhpSettings');

--- a/administrator/components/com_admin/views/sysinfo/view.json.php
+++ b/administrator/components/com_admin/views/sysinfo/view.json.php
@@ -30,7 +30,7 @@ class AdminViewSysinfo extends JViewLegacy
 		// Access check.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		header('MIME-Version: 1.0');

--- a/administrator/components/com_admin/views/sysinfo/view.text.php
+++ b/administrator/components/com_admin/views/sysinfo/view.text.php
@@ -30,7 +30,7 @@ class AdminViewSysinfo extends JViewLegacy
 		// Access check.
 		if (!JFactory::getUser()->authorise('core.admin'))
 		{
-			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		header('Content-Type: text/plain; charset=utf-8');

--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -69,8 +69,6 @@ class AssociationsViewAssociation extends JViewLegacy
 		if (count($errors = $this->get('Errors')))
 		{
 			throw new Exception(implode("\n", $errors), 500);
-
-			return false;
 		}
 
 		$this->app  = JFactory::getApplication();

--- a/administrator/components/com_banners/views/banner/view.html.php
+++ b/administrator/components/com_banners/views/banner/view.html.php
@@ -56,9 +56,7 @@ class BannersViewBanner extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_banners/views/banners/view.html.php
+++ b/administrator/components/com_banners/views/banners/view.html.php
@@ -65,9 +65,7 @@ class BannersViewBanners extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		BannersHelper::addSubmenu('banners');

--- a/administrator/components/com_banners/views/client/view.html.php
+++ b/administrator/components/com_banners/views/client/view.html.php
@@ -63,9 +63,7 @@ class BannersViewClient extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_banners/views/clients/view.html.php
+++ b/administrator/components/com_banners/views/clients/view.html.php
@@ -57,9 +57,7 @@ class BannersViewClients extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		BannersHelper::addSubmenu('clients');

--- a/administrator/components/com_banners/views/download/view.html.php
+++ b/administrator/components/com_banners/views/download/view.html.php
@@ -37,9 +37,7 @@ class BannersViewDownload extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		return parent::display($tpl);

--- a/administrator/components/com_banners/views/tracks/view.html.php
+++ b/administrator/components/com_banners/views/tracks/view.html.php
@@ -57,9 +57,7 @@ class BannersViewTracks extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		BannersHelper::addSubmenu('tracks');

--- a/administrator/components/com_banners/views/tracks/view.raw.php
+++ b/administrator/components/com_banners/views/tracks/view.raw.php
@@ -33,9 +33,7 @@ class BannersViewTracks extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$document = JFactory::getDocument();

--- a/administrator/components/com_cache/views/cache/view.html.php
+++ b/administrator/components/com_cache/views/cache/view.html.php
@@ -47,9 +47,7 @@ class CacheViewCache extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_categories/views/categories/view.html.php
+++ b/administrator/components/com_categories/views/categories/view.html.php
@@ -84,9 +84,7 @@ class CategoriesViewCategories extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Preprocess the list of items to find ordering divisions.

--- a/administrator/components/com_categories/views/category/view.html.php
+++ b/administrator/components/com_categories/views/category/view.html.php
@@ -70,9 +70,7 @@ class CategoriesViewCategory extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Check for tag type

--- a/administrator/components/com_checkin/views/checkin/view.html.php
+++ b/administrator/components/com_checkin/views/checkin/view.html.php
@@ -71,9 +71,7 @@ class CheckinViewCheckin extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_contact/views/contact/view.html.php
+++ b/administrator/components/com_contact/views/contact/view.html.php
@@ -54,9 +54,7 @@ class ContactViewContact extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// If we are forcing a language in modal (used for associations).

--- a/administrator/components/com_contact/views/contacts/view.html.php
+++ b/administrator/components/com_contact/views/contacts/view.html.php
@@ -81,9 +81,7 @@ class ContactViewContacts extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Preprocess the list of items to find ordering divisions.

--- a/administrator/components/com_content/views/article/view.html.php
+++ b/administrator/components/com_content/views/article/view.html.php
@@ -69,9 +69,7 @@ class ContentViewArticle extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// If we are forcing a language in modal (used for associations).

--- a/administrator/components/com_content/views/articles/view.html.php
+++ b/administrator/components/com_content/views/articles/view.html.php
@@ -90,9 +90,7 @@ class ContentViewArticles extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Levels filter - Used in Hathor.

--- a/administrator/components/com_content/views/featured/view.html.php
+++ b/administrator/components/com_content/views/featured/view.html.php
@@ -87,9 +87,7 @@ class ContentViewFeatured extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Levels filter - Used in Hathor.

--- a/administrator/components/com_contenthistory/views/compare/view.html.php
+++ b/administrator/components/com_contenthistory/views/compare/view.html.php
@@ -37,9 +37,7 @@ class ContenthistoryViewCompare extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		return parent::display($tpl);

--- a/administrator/components/com_contenthistory/views/history/view.html.php
+++ b/administrator/components/com_contenthistory/views/history/view.html.php
@@ -40,9 +40,7 @@ class ContenthistoryViewHistory extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		return parent::display($tpl);

--- a/administrator/components/com_contenthistory/views/preview/view.html.php
+++ b/administrator/components/com_contenthistory/views/preview/view.html.php
@@ -46,9 +46,7 @@ class ContenthistoryViewPreview extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		return parent::display($tpl);

--- a/administrator/components/com_fields/fields.php
+++ b/administrator/components/com_fields/fields.php
@@ -22,7 +22,7 @@ $parts = FieldsHelper::extract($context);
 
 if (!$parts || !JFactory::getUser()->authorise('core.manage', $parts[0]))
 {
-	return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+	throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 }
 
 $controller = JControllerLegacy::getInstance('Fields');

--- a/administrator/components/com_fields/views/field/view.html.php
+++ b/administrator/components/com_fields/views/field/view.html.php
@@ -57,9 +57,7 @@ class FieldsViewField extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		JFactory::getApplication()->input->set('hidemainmenu', true);

--- a/administrator/components/com_fields/views/fields/view.html.php
+++ b/administrator/components/com_fields/views/fields/view.html.php
@@ -78,9 +78,7 @@ class FieldsViewFields extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Display a warning if the fields system plugin is disabled

--- a/administrator/components/com_fields/views/group/view.html.php
+++ b/administrator/components/com_fields/views/group/view.html.php
@@ -75,9 +75,7 @@ class FieldsViewGroup extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		JFactory::getApplication()->input->set('hidemainmenu', true);

--- a/administrator/components/com_fields/views/groups/view.html.php
+++ b/administrator/components/com_fields/views/groups/view.html.php
@@ -78,9 +78,7 @@ class FieldsViewGroups extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Display a warning if the fields system plugin is disabled

--- a/administrator/components/com_finder/views/filter/view.html.php
+++ b/administrator/components/com_finder/views/filter/view.html.php
@@ -65,9 +65,7 @@ class FinderViewFilter extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/administrator/components/com_finder/views/filters/view.html.php
+++ b/administrator/components/com_finder/views/filters/view.html.php
@@ -75,9 +75,7 @@ class FinderViewFilters extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/administrator/components/com_finder/views/maps/view.html.php
+++ b/administrator/components/com_finder/views/maps/view.html.php
@@ -80,9 +80,7 @@ class FinderViewMaps extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');

--- a/administrator/components/com_finder/views/statistics/view.html.php
+++ b/administrator/components/com_finder/views/statistics/view.html.php
@@ -40,9 +40,7 @@ class FinderViewStatistics extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		return parent::display($tpl);

--- a/administrator/components/com_installer/views/languages/view.html.php
+++ b/administrator/components/com_installer/views/languages/view.html.php
@@ -53,9 +53,7 @@ class InstallerViewLanguages extends InstallerViewDefault
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -47,9 +47,7 @@ class InstallerViewManage extends InstallerViewDefault
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Include the component HTML helpers.

--- a/administrator/components/com_languages/views/installed/view.html.php
+++ b/administrator/components/com_languages/views/installed/view.html.php
@@ -70,9 +70,7 @@ class LanguagesViewInstalled extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_languages/views/language/view.html.php
+++ b/administrator/components/com_languages/views/language/view.html.php
@@ -39,9 +39,7 @@ class LanguagesViewLanguage extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_languages/views/languages/view.html.php
+++ b/administrator/components/com_languages/views/languages/view.html.php
@@ -42,9 +42,7 @@ class LanguagesViewLanguages extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -64,9 +64,7 @@ class MenusViewItems extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->ordering = array();

--- a/administrator/components/com_menus/views/menu/view.html.php
+++ b/administrator/components/com_menus/views/menu/view.html.php
@@ -57,9 +57,7 @@ class MenusViewMenu extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_menus/views/menus/view.html.php
+++ b/administrator/components/com_menus/views/menus/view.html.php
@@ -63,9 +63,7 @@ class MenusViewMenus extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_messages/views/config/view.html.php
+++ b/administrator/components/com_messages/views/config/view.html.php
@@ -40,9 +40,7 @@ class MessagesViewConfig extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Bind the record to the form.

--- a/administrator/components/com_messages/views/message/view.html.php
+++ b/administrator/components/com_messages/views/message/view.html.php
@@ -40,9 +40,7 @@ class MessagesViewMessage extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_modules/views/module/view.html.php
+++ b/administrator/components/com_modules/views/module/view.html.php
@@ -39,9 +39,7 @@ class ModulesViewModule extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -43,9 +43,7 @@ class ModulesViewModules extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// We don't need the toolbar in the modal window.

--- a/administrator/components/com_modules/views/positions/view.html.php
+++ b/administrator/components/com_modules/views/positions/view.html.php
@@ -38,9 +38,7 @@ class ModulesViewPositions extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		parent::display($tpl);

--- a/administrator/components/com_modules/views/select/view.html.php
+++ b/administrator/components/com_modules/views/select/view.html.php
@@ -35,9 +35,7 @@ class ModulesViewSelect extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->state = &$state;

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -58,9 +58,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// If we are forcing a language in modal (used for associations).

--- a/administrator/components/com_plugins/views/plugin/view.html.php
+++ b/administrator/components/com_plugins/views/plugin/view.html.php
@@ -38,9 +38,7 @@ class PluginsViewPlugin extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_plugins/views/plugins/view.html.php
+++ b/administrator/components/com_plugins/views/plugins/view.html.php
@@ -40,9 +40,7 @@ class PluginsViewPlugins extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_redirect/views/link/view.html.php
+++ b/administrator/components/com_redirect/views/link/view.html.php
@@ -40,9 +40,7 @@ class RedirectViewLink extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -50,9 +50,7 @@ class RedirectViewLinks extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Show messages about the enabled plugin and if the plugin should collect URLs

--- a/administrator/components/com_search/views/searches/view.html.php
+++ b/administrator/components/com_search/views/searches/view.html.php
@@ -45,9 +45,7 @@ class SearchViewSearches extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Check if plugin is enabled

--- a/administrator/components/com_tags/views/tag/view.html.php
+++ b/administrator/components/com_tags/views/tag/view.html.php
@@ -44,9 +44,7 @@ class TagsViewTag extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$input->set('hidemainmenu', true);

--- a/administrator/components/com_tags/views/tags/view.html.php
+++ b/administrator/components/com_tags/views/tags/view.html.php
@@ -40,9 +40,7 @@ class TagsViewTags extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Preprocess the list of items to find ordering divisions.

--- a/administrator/components/com_templates/views/style/view.html.php
+++ b/administrator/components/com_templates/views/style/view.html.php
@@ -56,9 +56,7 @@ class TemplatesViewStyle extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_templates/views/styles/view.html.php
+++ b/administrator/components/com_templates/views/styles/view.html.php
@@ -44,9 +44,7 @@ class TemplatesViewStyles extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_templates/views/templates/view.html.php
+++ b/administrator/components/com_templates/views/templates/view.html.php
@@ -65,9 +65,7 @@ class TemplatesViewTemplates extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/controller.php
+++ b/administrator/components/com_users/controller.php
@@ -63,9 +63,7 @@ class UsersController extends JControllerLegacy
 
 		if (!$this->canView($view))
 		{
-			JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
-
-			return;
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		// Check for edit form.

--- a/administrator/components/com_users/views/debuggroup/view.html.php
+++ b/administrator/components/com_users/views/debuggroup/view.html.php
@@ -54,7 +54,7 @@ class UsersViewDebuggroup extends JViewLegacy
 		// Access check.
 		if (!JFactory::getUser()->authorise('core.manage', 'com_users'))
 		{
-			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		$this->actions       = $this->get('DebugActions');

--- a/administrator/components/com_users/views/debuggroup/view.html.php
+++ b/administrator/components/com_users/views/debuggroup/view.html.php
@@ -72,9 +72,7 @@ class UsersViewDebuggroup extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/debuguser/view.html.php
+++ b/administrator/components/com_users/views/debuguser/view.html.php
@@ -72,9 +72,7 @@ class UsersViewDebuguser extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/debuguser/view.html.php
+++ b/administrator/components/com_users/views/debuguser/view.html.php
@@ -54,7 +54,7 @@ class UsersViewDebuguser extends JViewLegacy
 		// Access check.
 		if (!JFactory::getUser()->authorise('core.manage', 'com_users'))
 		{
-			return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+			throw new JAccessExceptionNotallowed(JText::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
 		$this->actions       = $this->get('DebugActions');

--- a/administrator/components/com_users/views/group/view.html.php
+++ b/administrator/components/com_users/views/group/view.html.php
@@ -50,9 +50,7 @@ class UsersViewGroup extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/groups/view.html.php
+++ b/administrator/components/com_users/views/groups/view.html.php
@@ -60,9 +60,7 @@ class UsersViewGroups extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/level/view.html.php
+++ b/administrator/components/com_users/views/level/view.html.php
@@ -50,9 +50,7 @@ class UsersViewLevel extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/levels/view.html.php
+++ b/administrator/components/com_users/views/levels/view.html.php
@@ -60,9 +60,7 @@ class UsersViewLevels extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_users/views/user/view.html.php
+++ b/administrator/components/com_users/views/user/view.html.php
@@ -46,9 +46,7 @@ class UsersViewUser extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Prevent user from modifying own group(s)

--- a/administrator/components/com_users/views/users/view.html.php
+++ b/administrator/components/com_users/views/users/view.html.php
@@ -94,9 +94,7 @@ class UsersViewUsers extends JViewLegacy
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{
-			JError::raiseError(500, implode("\n", $errors));
-
-			return false;
+			throw new Exception(implode("\n", $errors), 500);
 		}
 
 		// Include the component HTML helpers.


### PR DESCRIPTION
Implementation of the new Exception-Handling

### Summary of Changes
Removed unneeded unreachable statement 8b46567
Exception code must be second paramter ea18fe7
Implemented new exception handling (JError is deprecated) 523eab6
Implemented new exception handling (JError is deprecated). e66b103
Status Code for "not authorized" should be 403 Forbidden. e66b103

### Testing Instructions
Tested should be all backend components

A: Check for access
Change access level and try to access componentes.
Try to runn an error.

B: Check for errors 
Tested should be check for errors in view.html.php files of all backend components. 
Try to runn an error.

### Expected result
A: Error message should be thrown 
Exception Error 403 JERROR_ALERTNOAUTHOR

B: Error message should be thrown 
Exception Error 'Status Code' $error 

### Actual result
Implementation of the error handling still panding in some components, Exception-Handling works already fine in some components. Actual result is the same, but improved with Exception-Handling,
and not with Joomla Framework outdated deprecated JError.

Implementation of the new Exception-Handling
