### PR TITLE
Refill fields when there is an error in the registration

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -243,7 +243,8 @@ class UsersModelRegistration extends JModelForm
 			// Override the base user data with any data in the session.
 			$temp = (array) $app->getUserState('com_users.registration.data', array());
 
-			$form = $this->getForm(array());
+			// Don't load the data in this getForm call, or we'll call ourself
+			$form = $this->getForm(array(), false);
 
 			foreach ($temp as $k => $v)
 			{

--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -247,8 +247,21 @@ class UsersModelRegistration extends JModelForm
 
 			foreach ($temp as $k => $v)
 			{
+				// Here we could have a grouped field, let's check it
+				if (is_array($v))
+				{
+					$this->data->$k = new stdClass;
+
+					foreach ($v as $key => $val)
+					{
+						if ($form->getField($key, $k) !== false)
+						{
+							$this->data->$k->$key = $val;
+						}
+					}
+				}
 				// Only merge the field if it exists in the form.
-				if ($form->getField($k) !== false)
+				elseif ($form->getField($k) !== false)
 				{
 					$this->data->$k = $v;
 				}


### PR DESCRIPTION
### Summary of Changes
If the registration has an error, the form is after reload empty, also grouped fields (like the profile plugin) have no values after an error. This patch fixes both


### Testing Instructions
Case 1:
1. Activate the registration
2. Fill out all fields with some values, use for the email an already used email
3. submit the form

Case 2:
1. Activate the registration
2. Activate the profile plugin
3. Fill out all fields with some values, use for the email an already used email
4. submit the form

### Expected result
Case 1+2: An error appears + all fields (beside the PW) has the submitted values


### Actual result
The form is empty

