### PR TITLE
Change "Unable to create content language ..." to a notice

### DIFF
--- a/libraries/cms/installer/adapter/language.php
+++ b/libraries/cms/installer/adapter/language.php
@@ -366,7 +366,7 @@ class JInstallerAdapterLanguage extends JInstallerAdapter
 			{
 				JLog::add(
 					JText::sprintf('JLIB_INSTALLER_WARNING_UNABLE_TO_INSTALL_CONTENT_LANGUAGE', $siteLanguageManifest['name'], $tableLanguage->getError()),
-					JLog::WARNING,
+					JLog::NOTICE,
 					'jerror'
 				);
 			}


### PR DESCRIPTION
When installing a language where the respective content language already exists (eg due to uninstalling the language previously), you will currently get a warning that the content language couldn't be created automatically because there is already one with that tag.
A warning seems to be a bit harsh for something that is actually working just fine. A notice is more than enough.

### Summary of Changes
Changing the type of the message to a notice.

### Testing Instructions
* Install a language, uninstall it and install it again


### Expected result
Get a **notice** that the content language already exists.


### Actual result
Get a **warning** that the content language already exists.



### Documentation Changes Required
None
