### PR TITLE
Changed ReGeX for float filter to accept .25 as float – fix #14156

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -192,7 +192,7 @@ class JFilterInput extends InputFilter
 				break;
 			case 'FLOAT':
 			case 'DOUBLE':
-				$pattern = '/[-+]?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?/';
+				$pattern = '/[-+]?[0-9]*(\.[0-9]+)?([eE][-+]?[0-9]+)?/';
 
 				if (is_array($source))
 				{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changed ReGeX for float filter to accept .25 as float


### Testing Instructions
$in = JApplicationCms::getInstance()->input;
die($in->getFloat('testFloat',0.0));

Navigate to the page and add the $_GET parameter testFloat=.25


### Expected result

Blank page except for the text ".25"

### Actual result



### Documentation Changes Required
NONE
