### PR TITLE
Redirection fails on multiple status values #15737

### DIFF
--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -719,7 +719,7 @@ class JApplicationWeb extends JApplicationBase
 				if ('status' == strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header('HTTP/1.1 ' . $header['value'], null, (int) $header['value']);
+					$this->header('HTTP/1.1 ' . $header['value'], true);
 				}
 				else
 				{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -565,8 +565,8 @@ class JApplicationWeb extends JApplicationBase
 				}
 
 				// All other cases use the more efficient HTTP header for redirection.
-				$this->header($this->responseMap[$status]);
-				$this->header('Location: ' . $url);
+				$this->setHeader('Status', $this->responseMap[$status], true);
+				$this->setHeader('Location', $url, true);
 			}
 		}
 

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -719,7 +719,7 @@ class JApplicationWeb extends JApplicationBase
 				if ('status' == strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
-					$this->header('HTTP/1.1 ' . $header['value'], true);
+					$this->header('HTTP/1.1 ' . (int) $header['value'], true);
 				}
 				else
 				{

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -565,7 +565,7 @@ class JApplicationWeb extends JApplicationBase
 				}
 
 				// All other cases use the more efficient HTTP header for redirection.
-				$this->setHeader('Status', $this->responseMap[$status], true);
+				$this->setHeader('Status', $status, true);
 				$this->setHeader('Location', $url, true);
 			}
 		}

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -432,7 +432,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
-			array('HTTP/1.1 303 See other', true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[0]
 		);
 
@@ -501,7 +501,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		);
 
 		$this->assertEquals(
-			array('HTTP/1.1 303 See other', true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[0]
 		);
 
@@ -566,7 +566,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 
 		// The redirect gives a 303 error code
 		$this->assertEquals(
-			array('HTTP/1.1 303 See other', true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[0]
 		);
 
@@ -681,7 +681,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
-			array('HTTP/1.1 301 Moved Permanently', true, null),
+			array('HTTP/1.1 301', true, null),
 			$this->class->headers[0]
 		);
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1122,8 +1122,9 @@ class JApplicationWebTest extends TestCase
 	 *
 	 * @since   11.3
 	 */
-	public function testRedirectWithExistingStatusCode()
+	public function testRedirectWithExistingStatusCode1()
 	{
+		// Case Sensitive: status
 		$this->class->setHeader('status', 201);
 
 		$base = 'http://mydomain.com/';
@@ -1179,6 +1180,68 @@ class JApplicationWebTest extends TestCase
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
 			$this->class->headers[7]
+		);
+	}
+
+	/**
+	 * Tests the JApplicationWeb::redirect method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testRedirectWithExistingStatusCode2()
+	{	
+		// Case Sensitive: Status
+		$this->class->setHeader('Status', 201);
+
+		$base = 'http://mydomain.com/';
+		$url = 'index.php';
+
+		// Inject the client information.
+		TestReflection::setValue(
+			$this->class,
+			'client',
+			(object) array(
+				'engine' => JApplicationWebClient::GECKO,
+			)
+		);
+
+		// Inject the internal configuration.
+		$config = new Registry;
+		$config->set('uri.base.full', $base);
+
+		TestReflection::setValue($this->class, 'config', $config);
+
+		$this->class->redirect($url, false);
+
+		$this->assertEquals(
+			array('HTTP/1.1 303', true, null),
+			$this->class->headers[0]
+		);
+
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[5]
+		);
+
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[6]
 		);
 	}
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1146,33 +1146,39 @@ class JApplicationWebTest extends TestCase
 
 		$this->class->redirect($url, false);
 
+		// It has two statuses, but the second status will be the final status
 		$this->assertEquals(
-			array('HTTP/1.1 303', true, null),
+			array('HTTP/1.1 201', true, null),
 			$this->class->headers[0]
 		);
 
 		$this->assertEquals(
-			array('Location: ' . $base . $url, true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[1]
 		);
 
 		$this->assertEquals(
-			array('Content-Type: text/html; charset=utf-8', true, null),
+			array('Location: ' . $base . $url, true, null),
 			$this->class->headers[2]
 		);
 
-		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[3]
+		);
 
-		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+		$this->assertRegexp('/Expires/',$this->class->headers[4][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[5][0]);
 
 		$this->assertEquals(
 			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
-			$this->class->headers[5]
+			$this->class->headers[6]
 		);
 
 		$this->assertEquals(
 			array('Pragma: no-cache', true, null),
-			$this->class->headers[6]
+			$this->class->headers[7]
 		);
 	}
 
@@ -1384,7 +1390,7 @@ class JApplicationWebTest extends TestCase
 
 		$this->assertEquals(
 			array(
-				array('HTTP/1.1 200', null, 200),
+				array('HTTP/1.1 200', true, null),
 				array('X-JWeb-SendHeaders: foo', true, null),
 			),
 			$this->class->headers

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1086,7 +1086,7 @@ class JApplicationWebTest extends TestCase
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
-			array('HTTP/1.1 303 See other', true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[0]
 		);
 
@@ -1147,7 +1147,7 @@ class JApplicationWebTest extends TestCase
 		$this->class->redirect($url, false);
 
 		$this->assertEquals(
-			array('HTTP/1.1 303 See other', true, null),
+			array('HTTP/1.1 303', true, null),
 			$this->class->headers[0]
 		);
 
@@ -1259,7 +1259,7 @@ class JApplicationWebTest extends TestCase
 		$this->class->redirect($url, true);
 
 		$this->assertEquals(
-			array('HTTP/1.1 301 Moved Permanently', true, null),
+			array('HTTP/1.1 301', true, null),
 			$this->class->headers[0]
 		);
 

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -1116,6 +1116,67 @@ class JApplicationWebTest extends TestCase
 	}
 
 	/**
+	 * Tests the JApplicationWeb::redirect method.
+	 *
+	 * @return  void
+	 *
+	 * @since   11.3
+	 */
+	public function testRedirectWithExistingStatusCode()
+	{
+		$this->class->setHeader('status', 201);
+
+		$base = 'http://mydomain.com/';
+		$url = 'index.php';
+
+		// Inject the client information.
+		TestReflection::setValue(
+			$this->class,
+			'client',
+			(object) array(
+				'engine' => JApplicationWebClient::GECKO,
+			)
+		);
+
+		// Inject the internal configuration.
+		$config = new Registry;
+		$config->set('uri.base.full', $base);
+
+		TestReflection::setValue($this->class, 'config', $config);
+
+		$this->class->redirect($url, false);
+
+		$this->assertEquals(
+			array('HTTP/1.1 303 See other', true, null),
+			$this->class->headers[0]
+		);
+
+		$this->assertEquals(
+			array('Location: ' . $base . $url, true, null),
+			$this->class->headers[1]
+		);
+
+		$this->assertEquals(
+			array('Content-Type: text/html; charset=utf-8', true, null),
+			$this->class->headers[2]
+		);
+
+		$this->assertRegexp('/Expires/',$this->class->headers[3][0]);
+
+		$this->assertRegexp('/Last-Modified/',$this->class->headers[4][0]);
+
+		$this->assertEquals(
+			array('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0', true, null),
+			$this->class->headers[5]
+		);
+
+		$this->assertEquals(
+			array('Pragma: no-cache', true, null),
+			$this->class->headers[6]
+		);
+	}
+
+	/**
 	 * Tests the JApplicationWeb::redirect method with headers already sent.
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for Issue #15737 .

### Summary of Changes

Fixed JApplicationWeb to generate the redirection headers with the same headers API that it is called on respond(). 

Now, it is generating the headers adding them as a raw header. If the there's an extra Status (e.g. a 201 defined with setHeader), it replaces the 303.

### Testing Instructions

Test that all redirections work Ok. For example, when items are saved.

This issue was discovered with an extension running on FOF2 (the controller defined a Status 201 and, in a second step, calls a redirection). So, any extension running FOF2 is also a good test (save items).

### Expected result

All redirections work OK.

### Actual result

When multiple statuses are defined, the 303 redirection is lost and the status defined with setHeader('Status'... overrides any previous header('HTTP 1.1 303 See other');

### Documentation Changes Required

