### PR TITLE
Fixing wrong default value for calendar showtime attribute

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -1020,7 +1020,7 @@ abstract class JHtml
 		$filter       = isset($attribs['filter']) && $attribs['filter'] == '';
 		$todayBtn     = isset($attribs['todayBtn']) ? $attribs['todayBtn'] : true;
 		$weekNumbers  = isset($attribs['weekNumbers']) ? $attribs['weekNumbers'] : false;
-		$showTime     = isset($attribs['showTime']) ? $attribs['showTime'] : true;
+		$showTime     = isset($attribs['showTime']) ? $attribs['showTime'] : false;
 		$fillTable    = isset($attribs['fillTable']) ? $attribs['fillTable'] : true;
 		$timeFormat   = isset($attribs['timeFormat']) ? $attribs['timeFormat'] : 24;
 		$singleHeader = isset($attribs['singleHeader']) ? $attribs['singleHeader'] : false;

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -165,7 +165,7 @@ class JFormFieldCalendar extends JFormField
 			$this->filter       = (string) $this->element['filter'] ? (string) $this->element['filter'] : 'USER_UTC';
 			$this->todaybutton  = (string) $this->element['todaybutton'] ? (string) $this->element['todaybutton'] : 'true';
 			$this->weeknumbers  = (string) $this->element['weeknumbers'] ? (string) $this->element['weeknumbers'] : 'false';
-			$this->showtime     = (string) $this->element['showtime'] ? (string) $this->element['showtime'] : 'true';
+			$this->showtime     = (string) $this->element['showtime'] ? (string) $this->element['showtime'] : 'false';
 			$this->filltable    = (string) $this->element['filltable'] ? (string) $this->element['filltable'] : 'true';
 			$this->timeformat   = (int) $this->element['timeformat'] ? (int) $this->element['timeformat'] : 24;
 			$this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';


### PR DESCRIPTION
The new calendar can now show a time field which the old calendar couldn't. Unfortunately this new feature is enabled by default which means the calendar now shows a time field for all extensions using it regardless if the field expects a time part or not. This is a wrong behavior due to (at least) two points:
* The attribute is named `showtime` which implies that if not present it would not show a time. But actually to show the time you can omit it completely and to hide it you need to add `showtime="false"`
* The default format attribute for the calendar field is `%Y-%m-%d`, which means it expects only the date.

### Summary of Changes
This PR changes the default value for that attribute to `false` instead of `true`.


### Testing Instructions
* Change for example the article.xml file and adjust the `publish_up` field (https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/forms/article.xml#L102-L109). Remove the `showtime` attribute.


### Expected result
The calendar shows no time field


### Actual result
The calendar shows a time field

#### Further Testing
* Make sure saving works and doesn't give you a warning, especially when testing with another language where the date format is different to english (eg german).
* Test with various combinations of the `translateformat`, `showtime` and `format` attributes. For example removing them all should result in the date only.

### Documentation Changes Required
None
Obviously, this is not fully backward compatible with 3.7.0 as it changes the default behavior. Imho it isn't a big deal as it only affects the display of the calendar popup.