### PR TITLE
Correcting Notices when saving article in frontend

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -467,7 +467,7 @@ class ContentModelArticle extends JModelAdmin
 	public function validate($form, $data, $group = null)
 	{
 		// Don't allow to change the users if not allowed to access com_users.
-		if (($data['created_by'] || $data['modified_by']) && !JFactory::getUser()->authorise('core.manage', 'com_users'))
+		if (JFactory::getApplication()->isClient('administrator') && !JFactory::getUser()->authorise('core.manage', 'com_users'))
 		{
 			if (isset($data['created_by']))
 			{


### PR DESCRIPTION
When saving an article in frontend one gets 2 notices:

`PHP Notice:  Undefined index: created_by in /administrator/components/com_content/models/article.php on line 470`
`PHP Notice:  Undefined index: modified_by in /administrator/components/com_content/models/article.php on line 470`

### Summary of Changes
The validate method is OK in backend as it prevents users without users manager permissions to modify these fields input, but it is unnecessary in frontend as these fields are already Unset in the xml.

Therefore this PR checks for client instead.


### Testing Instructions
Before patch, save an article in frontend. The Notices will display in the PHP logs.
After patch no more Notices.

