### PR TITLE
Fix RGBA value for JFormFieldColor

### DIFF
--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -208,7 +208,7 @@ class JFormFieldColor extends JFormField
 		{
 			$color = 'none';
 		}
-		elseif ($color['0'] != '#')
+		elseif ($color['0'] != '#' && $this->format == 'hex')
 		{
 			$color = '#' . $color;
 		}


### PR DESCRIPTION
### Testing Instructions
Create a new JFormFieldColor:
`<field
                type="color"
                label="Border color"
                name="borderColor"
                format="rgba"
                default="rgba(255, 99, 132, 1)"/>`
Before change: color value = #rgba(255, 99, 132, 1)
After change:color value = rgba(255, 99, 132, 1)
P/s: This just apply with rgba format
