### PR TITLE
[com_fields] Change default field in user custom field to user

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_fields_user.ini
+++ b/administrator/language/en-GB/en-GB.plg_fields_user.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_FIELDS_USER="Fields - User"
-PLG_FIELDS_USER_DEFAULT_VALUE_DESC="A comma separated list of user IDs."
-PLG_FIELDS_USER_DEFAULT_VALUE_LABEL="Default Users"
+PLG_FIELDS_USER_DEFAULT_VALUE_DESC="The default user."
+PLG_FIELDS_USER_DEFAULT_VALUE_LABEL="Default User"
 PLG_FIELDS_USER_LABEL="User (%s)"
 PLG_FIELDS_USER_XML_DESCRIPTION="This plugin lets you create new fields of type 'user' in any extensions where custom fields are supported."

--- a/plugins/fields/user/params/user.xml
+++ b/plugins/fields/user/params/user.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
+	<field
+		name="default_value"
+		type="user"
+		label="PLG_FIELDS_USER_DEFAULT_VALUE_LABEL"
+		description="PLG_FIELDS_USER_DEFAULT_VALUE_DESC"
+	/>
 	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
 		<fieldset name="basic">
 			<field


### PR DESCRIPTION
Pull Request for Issue #15453.

### Summary of Changes
Changes the default field for the user custom field from textarea to user.

### Testing Instructions
- Create a new user custom field.
- Select a user in the default value field.

### Expected result
When editing an article the user should be preselected in the user custom field.

### Actual result
The default field for the user custom field is a text area.