### PR TITLE
[com_fields] Consider the show label option in the contact field override

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -13,10 +13,11 @@ if (!key_exists('field', $displayData))
 	return;
 }
 
-$field = $displayData['field'];
-$label = $field->label;
-$value = $field->value;
-$class = $field->params->get('render_class');
+$field     = $displayData['field'];
+$label     = $field->label;
+$value     = $field->value;
+$class     = $field->params->get('render_class');
+$showLabel = $field->params->get('showlabel');
 
 if (!$value)
 {
@@ -26,14 +27,15 @@ if (!$value)
 if ($field->context == 'com_contact.mail')
 {
 	// Prepare the value for the contact form mail
-	echo $label . ': ' . $value . "\r\n";
+	echo ($showLabel ? $label . ': ' : '') . $value . "\r\n";
 	return;
 }
 
 ?>
-
 <dt class="contact-field-entry <?php echo $class; ?>">
-	<span class="field-label"><?php echo htmlentities($label); ?>: </span>
+	<?php if ($showLabel == 1) : ?>
+        <span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
+	<?php endif; ?>
 </dt>
 <dd class="contact-field-entry <?php echo $class; ?>">
 	<span class="field-value"><?php echo $value; ?></span>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -16,14 +16,14 @@ if (!key_exists('field', $displayData))
 $field = $displayData['field'];
 $label = JText::_($field->label);
 $value = $field->value;
-$showlabel = $field->params->get('showlabel');
+$showLabel = $field->params->get('showlabel');
 
 if ($value == '')
 {
 	return;
 }
 ?>
-<?php if ($showlabel == 1) : ?>
+<?php if ($showLabel == 1) : ?>
 	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 <?php endif; ?>
 <span class="field-value"><?php echo $value; ?></span>


### PR DESCRIPTION
Pull Request for Issue #15304.

### Summary of Changes
Consider the show label setting in the contact field override.

A question remains. Should the whole `<dt></dt>` being hidden or just the span which shows the label?

### Testing Instructions
- Create a contact custom field.
- Set the show label option to false.
- Edit a contact and fill in a value for the new field.
- Save the contact.
- Create a contact menu item.
- Open the contact on the front.

### Expected result
The label is not shown for the custom field.

### Actual result
The label is shown for the custom field.