### PR TITLE
Remove width on toolbar btn-success

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8561,6 +8561,9 @@ td.nowrap.has-context {
 	margin-right: 4px;
 	padding: 0 10px;
 }
+#toolbar .btn-success {
+	min-width: 148px;
+}
 #toolbar .btn-primary [class^="icon-"],
 #toolbar .btn-primary [class*=" icon-"],
 #toolbar .btn-warning [class^="icon-"],
@@ -8599,9 +8602,6 @@ td.nowrap.has-context {
 }
 #toolbar iframe .btn-group .btn {
 	margin-left: -1px !important;
-}
-#toolbar-new .btn-success {
-	width: 148px;
 }
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8561,9 +8561,6 @@ td.nowrap.has-context {
 	margin-right: 4px;
 	padding: 0 10px;
 }
-#toolbar .btn-success {
-	width: 148px;
-}
 #toolbar .btn-primary [class^="icon-"],
 #toolbar .btn-primary [class*=" icon-"],
 #toolbar .btn-warning [class^="icon-"],
@@ -8602,6 +8599,9 @@ td.nowrap.has-context {
 }
 #toolbar iframe .btn-group .btn {
 	margin-left: -1px !important;
+}
+#toolbar-new .btn-success {
+	width: 148px;
 }
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8561,6 +8561,9 @@ td.nowrap.has-context {
 	margin-right: 4px;
 	padding: 0 10px;
 }
+#toolbar .btn-success {
+	min-width: 148px;
+}
 #toolbar .btn-primary [class^="icon-"],
 #toolbar .btn-primary [class*=" icon-"],
 #toolbar .btn-warning [class^="icon-"],
@@ -8599,9 +8602,6 @@ td.nowrap.has-context {
 }
 #toolbar iframe .btn-group .btn {
 	margin-left: -1px !important;
-}
-#toolbar-new .btn-success {
-	width: 148px;
 }
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8561,9 +8561,6 @@ td.nowrap.has-context {
 	margin-right: 4px;
 	padding: 0 10px;
 }
-#toolbar .btn-success {
-	width: 148px;
-}
 #toolbar .btn-primary [class^="icon-"],
 #toolbar .btn-primary [class*=" icon-"],
 #toolbar .btn-warning [class^="icon-"],
@@ -8602,6 +8599,9 @@ td.nowrap.has-context {
 }
 #toolbar iframe .btn-group .btn {
 	margin-left: -1px !important;
+}
+#toolbar-new .btn-success {
+	width: 148px;
 }
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -62,9 +62,6 @@
 	    margin-right: 4px;
 	    padding: 0 10px;
 	}
-	.btn-success {
-		width: 148px;
-	}
 	.btn-primary,
 	.btn-warning,
 	.btn-danger,
@@ -99,6 +96,11 @@
 		margin-left: -1px !important;
 	}
 } 
+
+#toolbar-new .btn-success {
+	width: 148px;
+}
+
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {
 	float: left;

--- a/administrator/templates/isis/less/blocks/_toolbar.less
+++ b/administrator/templates/isis/less/blocks/_toolbar.less
@@ -62,6 +62,9 @@
 	    margin-right: 4px;
 	    padding: 0 10px;
 	}
+	.btn-success {
+		min-width: 148px;
+	}
 	.btn-primary,
 	.btn-warning,
 	.btn-danger,
@@ -96,11 +99,6 @@
 		margin-left: -1px !important;
 	}
 } 
-
-#toolbar-new .btn-success {
-	width: 148px;
-}
-
 html[dir=rtl] #toolbar #toolbar-options,
 html[dir=rtl] #toolbar #toolbar-help {
 	float: left;


### PR DESCRIPTION
Pull Request for Issue #15578 .

### Summary of Changes
`#toolbar .btn-success` has a set width. This PR removes this and applies it to just the 'New' button.

### Testing Instructions
See #15578. Easiest way to test is to use your browser inspector. Add `btn-success` to any button within the toolbar (eg. `btn btn-small btn-success`), then change the button text and ensure the text does not wrap.

### Documentation Changes Required
None
