### PR TITLE
[4.0] Fix frontend editing styling

### DIFF
--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -64,10 +64,10 @@ JFactory::getDocument()->addScriptDeclaration("
 
 			<div>
 				<?php echo JText::_('COM_CONFIG_MODULES_MODULE_NAME') ?>
-				<span class="label label-default"><?php echo $this->item['title'] ?></span>
+				<span class="badge badge-default"><?php echo $this->item['title'] ?></span>
 				&nbsp;&nbsp;
 				<?php echo JText::_('COM_CONFIG_MODULES_MODULE_TYPE') ?>
-				<span class="label label-default"><?php echo $this->item['module'] ?></span>
+				<span class="badge badge-default"><?php echo $this->item['module'] ?></span>
 			</div>
 			<hr>
 

--- a/components/com_config/view/modules/tmpl/default.php
+++ b/components/com_config/view/modules/tmpl/default.php
@@ -33,34 +33,25 @@ JFactory::getDocument()->addScriptDeclaration("
 ");
 ?>
 
-<form
-	action="<?php echo JRoute::_('index.php?option=com_config'); ?>"
-	method="post" name="adminForm" id="modules-form"
-	class="form-validate">
-
+<form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="modules-form" class="form-validate">
 	<div class="row">
-
-		<!-- Begin Content -->
 		<div class="col-md-12">
 
-			<div class="btn-toolbar">
+			<div>
 				<div class="btn-group">
-					<button type="button" class="btn btn-primary"
-						onclick="Joomla.submitbutton('config.save.modules.apply')">
+					<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.modules.apply')">
 						<span class="icon-apply"></span>
 						<?php echo JText::_('JAPPLY') ?>
 					</button>
 				</div>
 				<div class="btn-group">
-					<button type="button" class="btn"
-						onclick="Joomla.submitbutton('config.save.modules.save')">
+					<button type="button" class="btn btn-secondary" onclick="Joomla.submitbutton('config.save.modules.save')">
 						<span class="icon-save"></span>
 						<?php echo JText::_('JSAVE') ?>
 					</button>
 				</div>
 				<div class="btn-group">
-					<button type="button" class="btn"
-						onclick="Joomla.submitbutton('config.cancel.modules')">
+					<button type="button" class="btn btn-danger" onclick="Joomla.submitbutton('config.cancel.modules')">
 						<span class="icon-cancel"></span>
 						<?php echo JText::_('JCANCEL') ?>
 					</button>
@@ -82,109 +73,108 @@ JFactory::getDocument()->addScriptDeclaration("
 
 			<div class="row">
 				<div class="col-md-12">
-					<fieldset class="form-horizontal">
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('title'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('title'); ?>
-							</div>
-						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('showtitle'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('showtitle'); ?>
-							</div>
-						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('position'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->loadTemplate('positions'); ?>
-							</div>
-						</div>
 
-						<hr>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('title'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('title'); ?>
+						</div>
+					</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('showtitle'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('showtitle'); ?>
+						</div>
+					</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('position'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->loadTemplate('positions'); ?>
+						</div>
+					</div>
 
-						<?php
-						if (JFactory::getUser()->authorise('core.edit.state', 'com_modules.module.' . $this->item['id'])) : ?>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('published'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('published'); ?>
-							</div>
-						</div>
-						<?php endif ?>
+					<hr>
 
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('publish_up'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('publish_up'); ?>
-							</div>
+					<?php
+					if (JFactory::getUser()->authorise('core.edit.state', 'com_modules.module.' . $this->item['id'])) : ?>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('published'); ?>
 						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('publish_down'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('publish_down'); ?>
-							</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('published'); ?>
 						</div>
+					</div>
+					<?php endif ?>
 
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('access'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('access'); ?>
-							</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('publish_up'); ?>
 						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('ordering'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('ordering'); ?>
-							</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('publish_up'); ?>
 						</div>
+					</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('publish_down'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('publish_down'); ?>
+						</div>
+					</div>
 
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('language'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('language'); ?>
-							</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('access'); ?>
 						</div>
-						<div class="control-group">
-							<div class="control-label">
-								<?php echo $this->form->getLabel('note'); ?>
-							</div>
-							<div class="controls">
-								<?php echo $this->form->getInput('note'); ?>
-							</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('access'); ?>
 						</div>
-
-						<hr>
-
-						<div id="options">
-							<?php echo $this->loadTemplate('options'); ?>
+					</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('ordering'); ?>
 						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('ordering'); ?>
+						</div>
+					</div>
 
-						<?php if ($hasContent) : ?>
-							<div class="tab-pane" id="custom">
-								<?php echo $this->form->getInput('content'); ?>
-							</div>
-						<?php endif; ?>
-					</fieldset>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('language'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('language'); ?>
+						</div>
+					</div>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $this->form->getLabel('note'); ?>
+						</div>
+						<div class="controls">
+							<?php echo $this->form->getInput('note'); ?>
+						</div>
+					</div>
+
+					<hr>
+
+					<div id="options">
+						<?php echo $this->loadTemplate('options'); ?>
+					</div>
+
+					<?php if ($hasContent) : ?>
+						<div class="tab-pane" id="custom">
+							<?php echo $this->form->getInput('content'); ?>
+						</div>
+					<?php endif; ?>
 				</div>
 
 				<input type="hidden" name="id" value="<?php echo $this->item['id']; ?>">
@@ -195,7 +185,5 @@ JFactory::getDocument()->addScriptDeclaration("
 			</div>
 
 		</div>
-		<!-- End Content -->
 	</div>
-
 </form>

--- a/components/com_config/view/modules/tmpl/default_options.php
+++ b/components/com_config/view/modules/tmpl/default_options.php
@@ -26,7 +26,7 @@ endif;
 ?>
 <?php echo JHtml::_('bootstrap.addSlide', 'collapseTypes', JText::_($label), 'collapse' . ($i++)); ?>
 
-<ul class="nav nav-tabs nav-stacked">
+<ul class="nav flex-column">
 <?php foreach ($this->form->getFieldset($name) as $field) : ?>
 
 	<li>

--- a/components/com_config/view/modules/tmpl/default_positions.php
+++ b/components/com_config/view/modules/tmpl/default_positions.php
@@ -10,6 +10,8 @@
 defined('_JEXEC') or die;
 $positions = $this->model->getPositions();
 
+JHtml::_('formbehavior.chosen', '#jform_position', null, array('disable_search_threshold' => 0 ));
+
 // Add custom position to options
 $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 
@@ -17,7 +19,7 @@ $customGroupText = JText::_('COM_MODULES_CUSTOM_POSITION');
 $attr = array(
 	'id'          => 'jform_position',
 	'list.select' => $this->item['position'],
-	'list.attr'   => 'class="chzn-custom-value" '
+	'list.attr'   => 'class="chzn-custom-value custom-select" '
 		. 'data-custom_group_text="' . $customGroupText . '" '
 		. 'data-no_results_text="' . JText::_('COM_MODULES_ADD_CUSTOM_POSITION') . '" '
 		. 'data-placeholder="' . JText::_('COM_MODULES_TYPE_OR_SELECT_POSITION') . '" '

--- a/components/com_config/view/templates/tmpl/default.php
+++ b/components/com_config/view/templates/tmpl/default.php
@@ -25,19 +25,19 @@ JFactory::getDocument()->addScriptDeclaration("
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
-
 	<div class="row">
-		<!-- Begin Content -->
 
-		<div class="btn-toolbar">
+		<div>
 			<div class="btn-group">
 				<button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('config.save.templates.apply')">
-					<span class="icon-ok"></span> <?php echo JText::_('JSAVE') ?>
+					<span class="icon-ok"></span>
+					<?php echo JText::_('JSAVE') ?>
 				</button>
 			</div>
 			<div class="btn-group">
-				<button type="button" class="btn" onclick="Joomla.submitbutton('config.cancel')">
-					<span class="icon-cancel"></span> <?php echo JText::_('JCANCEL') ?>
+				<button type="button" class="btn btn-danger" onclick="Joomla.submitbutton('config.cancel')">
+					<span class="icon-cancel"></span>
+					<?php echo JText::_('JCANCEL') ?>
 				</button>
 			</div>
 		</div>
@@ -54,7 +54,5 @@ JFactory::getDocument()->addScriptDeclaration("
 		<input type="hidden" name="task" value="">
 		<?php echo JHtml::_('form.token'); ?>
 
-		<!-- End Content -->
 	</div>
-
 </form>

--- a/components/com_config/view/templates/tmpl/default_options.php
+++ b/components/com_config/view/templates/tmpl/default_options.php
@@ -9,39 +9,31 @@
 
 defined('_JEXEC') or die;
 
-// Load chosen.css
-
-
-?>
-<?php
-
-	$fieldSets = $this->form->getFieldsets('params');
+$fieldSets = $this->form->getFieldsets('params');
 ?>
 
 <legend><?php echo JText::_('COM_CONFIG_TEMPLATE_SETTINGS'); ?></legend>
 
 <?php
 
-	// Search for com_config field set
-	if (!empty($fieldSets['com_config'])) : ?>
-
-	<fieldset class="form-horizontal">
-		<?php echo $this->form->renderFieldset('com_config'); ?>
-	</fieldset>
-
-<?php else :
-
+// Search for com_config field set
+if (!empty($fieldSets['com_config']))
+{
+	echo $this->form->renderFieldset('com_config');
+}
+else
+{
 	// Fall-back to display all in params
-	foreach ($fieldSets as $name => $fieldSet) :
-	$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CONFIG_' . $name . '_FIELDSET_LABEL';
+	foreach ($fieldSets as $name => $fieldSet)
+	{
+		$label = !empty($fieldSet->label) ? $fieldSet->label : 'COM_CONFIG_' . $name . '_FIELDSET_LABEL';
 
-	if (isset($fieldSet->description) && trim($fieldSet->description)) :
-		echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
-	endif;
-	?>
+		if (isset($fieldSet->description) && trim($fieldSet->description))
+		{
+			echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
+		}
 
-<fieldset class="form-horizontal">
-	<?php echo $this->form->renderFieldset($name); ?>
-</fieldset>
-	<?php endforeach;
-	endif;
+		echo $this->form->renderFieldset($name);
+
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #15764

Note that this PR doesn't remove any modules in the edit view. It simply fixes the styling.

### Before:
<img width="1047" alt="fb8771e2-3000-11e7-8b7c-82c7525d8ce3" src="https://cloud.githubusercontent.com/assets/2019801/25668952/17c0aa3a-3020-11e7-8460-d177df90ddb6.png">

### After:

![screeny](https://cloud.githubusercontent.com/assets/2019801/25668956/1b801854-3020-11e7-8ca3-1abf7de1b1b9.png)


