### PR TITLE
Fix #__menu root published state on update from 3.6.5 (and older) to 3.7.x

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-03-09.sql
@@ -1,3 +1,4 @@
+UPDATE `#__categories` SET `published` = 1 WHERE `alias` = 'root';
 UPDATE `#__categories` AS `c` INNER JOIN (
 	SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
 	FROM `#__categories` AS `c2`
@@ -6,6 +7,7 @@ UPDATE `#__categories` AS `c` INNER JOIN (
 ON c.id = c2.id
 SET published = c2.newPublished;
 
+UPDATE `#__menu` SET `published` = 1 WHERE `alias` = 'root';
 UPDATE `#__menu` AS `c` INNER JOIN (
 	SELECT c2.id, CASE WHEN MIN(p.published) > 0 THEN MAX(p.published) ELSE MIN(p.published) END AS newPublished
 	FROM `#__menu` AS `c2`

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-03-09.sql
@@ -1,3 +1,4 @@
+UPDATE "#__categories" SET published = 1 WHERE alias = 'root';
 UPDATE "#__categories" AS "c"
 SET published = c2.newPublished
 FROM (
@@ -7,6 +8,7 @@ INNER JOIN "#__categories" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
 GROUP BY c2.id) AS c2
 WHERE c2.id = c.id;
 
+UPDATE "#__menu" SET published = 1 WHERE alias = 'root';
 UPDATE "#__menu" AS "c"
 SET published = c2.newPublished
 FROM (

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-03-09.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-03-09.sql
@@ -1,3 +1,4 @@
+UPDATE "#__categories" SET published = 1 WHERE alias = 'root';
 UPDATE "c"
 SET published = c2.newPublished
 FROM "#__categories" AS "c"
@@ -7,6 +8,7 @@ FROM "#__categories" AS "c2"
 INNER JOIN "#__categories" AS "p" ON p.lft <= c2.lft AND c2.rgt <= p.rgt
 GROUP BY c2.id) AS c2 ON c2.id = c.id;
 
+UPDATE "#__menu" SET published = 1 WHERE alias = 'root';
 UPDATE "c"
 SET published = c2.newPublished
 FROM "#__menu" AS "c"


### PR DESCRIPTION
Pull Request for Issue #15749

### Summary of Changes
To prevent similar issues I have added additional `UPDATE` query to repair published state for root row in `#__menu` and `#__categories`.

### Testing Instructions
Update Joomla 3.6.5 to Joomla 3.7.0 with this patch.

### Expected result
Even you have unpublished root, all menu items and categories should be OK after upgrade to 3.7 with current patch.

### Actual result
If you have `#__menu` table row with alias='root' trashed or not published then all its children will be not published.

### Documentation Changes Required
No
