### PR TITLE
[4.0] Install test data

### DIFF
--- a/installation/model/forms/summary.xml
+++ b/installation/model/forms/summary.xml
@@ -30,7 +30,7 @@
 			name="sample_file"
 			type="installation.sample"
 			class="radio btn-group btn-group-reverse"
-			label="INSTL_SITE_INSTALL_SAMPLE_LABEL"
+			label="INSTL_SAMPLE_TESTING_SET"
 		/>
 	</fieldset>
 </form>


### PR DESCRIPTION
This is a TEMPORARY pr while we are in early development stage and only have one sample data set available for testing.

It changes the text on the screen from
#### Install Sample Data

to
#### Test English (GB) Sample Data

This is to avoid the situation where we have had bug reports about the "default install" when there is not default sample data to be installed prepared yet. Remember the testng sample data is never shipped wwith Joomla

(Yes i am aware that the testing data needs updating but thats another issue)

