### PR TITLE
Warning while saving Global configuration

### DIFF
--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -283,7 +283,7 @@ class ConfigModelApplication extends ConfigModelForm
 		 * Look for a custom cache_path
 		 * First check if a path is given in the submitted data, then check if a path exists in the previous data, otherwise use the default
 		 */
-		if (isset($data['cache_path']))
+		if (!empty($data['cache_path']))
 		{
 			$path = $data['cache_path'];
 		}


### PR DESCRIPTION
Go to Global configuration, "System" tab, and ensure to enable System cache, but leave blank the field 'Path to Cache Folder'.
The Save button produces the following warning:

> The folder at is not writable and cannot be used for the cache, using the default [...]/cache instead.

This bug has been introduced yesterday https://github.com/joomla/joomla-cms/pull/15757

### Summary of Changes
An empty string passes the isset() check, but it's not a valid folder.
Fixed the check for 'cache_path' variabile.
