### PR TITLE
[4.0] Fix admin login link URL's

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -90,8 +90,8 @@ if ($spacing > 0)
 		</div>
 
 		<div class="forgot">
-			<div><a target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind"><?php echo JText::_('MOD_LOGIN_REMIND'); ?></a></div>
-			<div><a target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset"><?php echo JText::_('MOD_LOGIN_RESET'); ?></a></div>
+			<div><a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind"><?php echo JText::_('MOD_LOGIN_REMIND'); ?></a></div>
+			<div><a href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset"><?php echo JText::_('MOD_LOGIN_RESET'); ?></a></div>
 		</div>
 
 		<input type="hidden" name="option" value="com_login">

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -90,8 +90,8 @@ if ($spacing > 0)
 		</div>
 
 		<div class="forgot">
-			<div><a href="<?php echo JRoute::_('index.php?option=com_users&view=remind'); ?>"><?php echo JText::_('MOD_LOGIN_REMIND'); ?></a></div>
-			<div><a href="<?php echo JRoute::_('index.php?option=com_users&view=reset'); ?>"><?php echo JText::_('MOD_LOGIN_RESET'); ?></a></div>
+			<div><a target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_users&view=remind"><?php echo JText::_('MOD_LOGIN_REMIND'); ?></a></div>
+			<div><a target="_blank" href="<?php echo JUri::root(); ?>index.php?option=com_users&view=reset"><?php echo JText::_('MOD_LOGIN_RESET'); ?></a></div>
 		</div>
 
 		<input type="hidden" name="option" value="com_login">


### PR DESCRIPTION
Pull Request for Issue #15786 

### Summary of Changes

Fixes the URL's for "Forgot your username" and "Forgot your password".

Also added `target="_blank"` so the user doesn't have to manually navigate back to the admin page after.


