### PR TITLE
Support the form name in the grid sort JHTML function

### DIFF
--- a/components/com_content/views/category/tmpl/default_articles.php
+++ b/components/com_content/views/category/tmpl/default_articles.php
@@ -93,7 +93,7 @@ $tableClass = $this->params->get('show_headings') != 1 ? ' table-noheader' : '';
 		<thead>
 			<tr>
 				<th scope="col" id="categorylist_header_title">
-					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder); ?>
+					<?php echo JHtml::_('grid.sort', 'JGLOBAL_TITLE', 'a.title', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
 				</th>
 				<?php if ($date = $this->params->get('list_show_date')) : ?>
 					<th scope="col" id="categorylist_header_date">

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -64,12 +64,13 @@ abstract class JHtmlGrid
 	 * @param   string  $task           An optional task override
 	 * @param   string  $new_direction  An optional direction for the new column
 	 * @param   string  $tip            An optional text shown as tooltip title instead of $title
+	 * @param   string  $form           An optional form selector
 	 *
 	 * @return  string
 	 *
 	 * @since   1.5
 	 */
-	public static function sort($title, $order, $direction = 'asc', $selected = '', $task = null, $new_direction = 'asc', $tip = '')
+	public static function sort($title, $order, $direction = 'asc', $selected = '', $task = null, $new_direction = 'asc', $tip = '', $form = null)
 	{
 		JHtml::_('behavior.core');
 		JHtml::_('bootstrap.popover');
@@ -87,7 +88,12 @@ abstract class JHtmlGrid
 			$direction = ($direction == 'desc') ? 'asc' : 'desc';
 		}
 
-		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\');return false;"'
+		if ($form)
+		{
+			$form = ', document.getElementById(\'' . $form . '\')';
+		}
+
+		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'' . $form . ');return false;"'
 			. ' class="hasPopover" title="' . htmlspecialchars(JText::_($tip ?: $title)) . '"'
 			. ' data-content="' . htmlspecialchars(JText::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '" data-placement="top">';
 


### PR DESCRIPTION
### Summary of Changes
The grid sort JS function supports to pass a form attribute. The JHTML wrapper `JHtml::_('grid.sort');` should support that functionality.

This pr doesn't change an existing behavior, it just adds a new option, so the results of the test should be the same.


### Testing Instructions
- Create some articles.
- Create an "Articles -> Category List" menu item
- On the front open the menu item
- Sort by the title column

### Expected result
The list is sorted by the title.

### Actual result
The list is sorted by the title.