### PR TITLE
Hide full path disclosure warnings on faked url

### DIFF
--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -29,6 +29,11 @@ class ContenthistoryHelper
 	{
 		$result = array();
 
+		if ($object === null)
+		{
+			return $result;
+		}
+
 		foreach ($object as $name => $value)
 		{
 			$result[$name] = $value;
@@ -288,6 +293,11 @@ class ContenthistoryHelper
 	public static function mergeLabels($object, $formValues)
 	{
 		$result = new stdClass;
+
+		if ($object === null)
+		{
+			return $result;
+		}
 
 		$labelsArray = $formValues->labels;
 		$valuesArray = $formValues->values;


### PR DESCRIPTION
### Summary of Changes

Don't generate warnings, with full path disclosure 
Need to be logged in as admin so not a `security` issue really. 

### Testing Instructions

Go to http://127.0.0.1:8000/administrator/index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component
or 
http://127.0.0.1:8000/administrator/index.php?option=com_contenthistory&view=compare&layout=compare

See warnings

### Expected result

No warnings

### Actual result

```
 Warning: Invalid argument supplied for foreach() in /Users/phil/Sites/joomla-cms/administrator/components/com_contenthistory/helpers/contenthistory.php on line 32
 
 Warning: Invalid argument supplied for foreach() in /Users/phil/Sites/joomla-cms/administrator/components/com_contenthistory/helpers/contenthistory.php on line 295
 **The most recent request was denied because it contained an invalid security token. Please refresh the page and try again.**
```

### Documentation Changes Required

None