### PR TITLE
Add test and fix for date_constructor for PHP Versions lower 7.1.0

### DIFF
--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -107,13 +107,6 @@ class JDate extends DateTime
 		date_default_timezone_set('UTC');
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
-		// From php version 7.1 use an integer to initialise the datatime object.
-		// See http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
-		if ($date === 'now' && version_compare(PHP_VERSION, '7.1.0', '>='))
-		{
-			$data = time();
-		}
-
 		// Call the DateTime constructor.
 		parent::__construct($date, $tz);
 

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -107,11 +107,11 @@ class JDate extends DateTime
 		date_default_timezone_set('UTC');
 		$date = is_numeric($date) ? date('c', $date) : $date;
 
-		// If php version below 7.1 and current time, add the microseconds to date.
+		// From php version 7.1 use an integer to initialise the datatime object.
 		// See http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds
-		if ($date === 'now' && version_compare(PHP_VERSION, '7.1.0', '<'))
+		if ($date === 'now' && version_compare(PHP_VERSION, '7.1.0', '>='))
 		{
-			$date = parent::createFromFormat('U.u', number_format(microtime(true), 6, '.', ''), $tz)->format('Y-m-d H:i:s.u');
+			$data = time();
 		}
 
 		// Call the DateTime constructor.

--- a/tests/unit/suites/libraries/joomla/date/JDateTest.php
+++ b/tests/unit/suites/libraries/joomla/date/JDateTest.php
@@ -542,6 +542,44 @@ class JDateTest extends TestCase
 	}
 
 	/**
+	 * Testing the Constructor for now when not using UTC
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  JDate::__construct
+	 */
+	public function test__constructForNowWhenNotUsingUTC()
+	{
+		$jdate   = new JDate('now', new DateTimeZone('US/Central'));
+		$phpdate = new DateTime('now', new DateTimeZone('US/Central'));
+
+		$this->assertSame(
+			$jdate->format('D m/d/Y H:i', true),
+			$phpdate->format('D m/d/Y H:i')
+		);
+	}
+
+	/**
+	 * Testing the Constructor for now when using UTC
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @covers  JDate::__construct
+	 */
+	public function test__constructForNowWhenUsingUTC()
+	{
+		$jdate   = new JDate('now', new DateTimeZone('UTC'));
+		$phpdate = new DateTime('now', new DateTimeZone('UTC'));
+
+		$this->assertSame(
+			$jdate->format('D m/d/Y H:i'),
+			$phpdate->format('D m/d/Y H:i')
+		);
+	}
+
+	/**
 	 * Testing the Constructor
 	 *
 	 * @param   string  $date      The date.


### PR DESCRIPTION
### Summary of Changes
Fix for JDate Constructor, integrates the test case from #15642 but with true as 2nd parameter for the format method (default is false and means that we get the time in GMT)

### Testing Instructions
Test should be processed with two different PHP Versions one lower 7.1.0 and one 7.1.0 or greater. The results should be the "same" for all versions after the patch is applied.

* Add the follwing PHP code to your template:
``` php
echo 'Timezone US/Central: ';
$jdateUS   = new JDate('now', new DateTimeZone('US/Central'));
$phpdateUS = new DateTime('now', new DateTimeZone('US/Central'));
echo $jdateUS->format('D m/d/Y H:i', true) . ' | ' . $phpdateUS->format('D m/d/Y H:i');
echo '<br>';
echo 'Timezone UTC: ';
$jdateUTC   = new JDate('now', new DateTimeZone('UTC'));
$phpdateUTC = new DateTime('now', new DateTimeZone('UTC'));
echo $jdateUTC->format('D m/d/Y H:i', true) . ' | ' . $phpdateUTC->format('D m/d/Y H:i');
echo '<br>';
echo 'Timezone not set: ';
$jdateNoTZ   = new JDate('now');
$phpdateNoTZ = new DateTime('now');
echo $jdateNoTZ->format('D m/d/Y H:i', true) . ' | ' . $phpdateNoTZ->format('D m/d/Y H:i');
```

* Access your site
* Change the PHP version
* Access your site again

* Apply patch

* Access your site
* Change the PHP version
* Access your site again

Test is successful when after appling the patch you get correct results, time in a row must be the same expect the last line. 

### Results
Keep in mind your results are depending on your timezone and the time you are running the test. For me the 2 hour difference in the "Timezone not set" row is ok because I am on CEST what is GMT+2.

The Error is in the "Timezone US/Central" row for PHP Version lower 7.1.0, in my case 5.6.30.

**Before Patch:**

7.1.1 (local time 14:29)
Timezone US/Central: Sat 05/06/2017 07:29 | Sat 05/06/2017 07:29
Timezone UTC: Sat 05/06/2017 12:29 | Sat 05/06/2017 12:29
Timezone not set: Sat 05/06/2017 12:29 | Sat 05/06/2017 14:29

5.6.30 (local time 14:31)
Timezone US/Central: Sat 05/06/2017 12:31 | Sat 05/06/2017 07:31
Timezone UTC: Sat 05/06/2017 12:31 | Sat 05/06/2017 12:31
Timezone not set: Sat 05/06/2017 12:31 | Sat 05/06/2017 14:31

**After Patch**

7.1.1 (local time 14:35)
Timezone US/Central: Sat 05/06/2017 07:35 | Sat 05/06/2017 07:35
Timezone UTC: Sat 05/06/2017 12:35 | Sat 05/06/2017 12:35
Timezone not set: Sat 05/06/2017 12:35 | Sat 05/06/2017 14:35

5.6.30  (local time 14:34)
Timezone US/Central: Sat 05/06/2017 07:34 | Sat 05/06/2017 07:34
Timezone UTC: Sat 05/06/2017 12:34 | Sat 05/06/2017 12:34
Timezone not set: Sat 05/06/2017 12:34 | Sat 05/06/2017 14:34

### Documentation Changes Required
None
