### PR TITLE
[4.0] CMS not Cms in comments

### DIFF
--- a/administrator/components/com_categories/Controller/Categories.php
+++ b/administrator/components/com_categories/Controller/Categories.php
@@ -27,7 +27,7 @@ class Categories extends Admin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  The array of possible config values. Optional.
 	 *
-	 * @return  \Joomla\Cms\Model\Model  The model.
+	 * @return  \Joomla\CMS\Model\Model  The model.
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_categories/Controller/Category.php
+++ b/administrator/components/com_categories/Controller/Category.php
@@ -170,7 +170,7 @@ class Category extends Form
 	/**
 	 * Function that allows child controller access to model data after the data has been saved.
 	 *
-	 * @param   \Joomla\Cms\Model\Model  $model      The data model object.
+	 * @param   \Joomla\CMS\Model\Model  $model      The data model object.
 	 * @param   array                    $validData  The validated data.
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/Model/Category.php
+++ b/administrator/components/com_categories/Model/Category.php
@@ -59,7 +59,7 @@ class Category extends Admin
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MvcFactoryInterface  $factory  The factory.
 	 *
-	 * @see     \Joomla\Cms\Model\Model
+	 * @see     \Joomla\CMS\Model\Model
 	 * @since   3.2
 	 */
 	public function __construct($config = array(), MvcFactoryInterface $factory = null)
@@ -125,7 +125,7 @@ class Category extends Admin
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\Cms\Table\Table  A JTable object
+	 * @return  \Joomla\CMS\Table\Table  A JTable object
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_contact/Controller/Contacts.php
+++ b/administrator/components/com_contact/Controller/Contacts.php
@@ -97,7 +97,7 @@ class Contacts extends Admin
 	 * @param   string  $prefix  The prefix for the PHP class name.
 	 * @param   array   $config  Array of configuration parameters.
 	 *
-	 * @return  \Joomla\Cms\Model\Model
+	 * @return  \Joomla\CMS\Model\Model
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_contact/Model/Contact.php
+++ b/administrator/components/com_contact/Model/Contact.php
@@ -431,7 +431,7 @@ class Contact extends Admin
 	/**
 	 * Prepare and sanitise the table prior to saving.
 	 *
-	 * @param   \Joomla\Cms\Table\Table  $table  The Table object
+	 * @param   \Joomla\CMS\Table\Table  $table  The Table object
 	 *
 	 * @return  void
 	 *
@@ -477,7 +477,7 @@ class Contact extends Admin
 	/**
 	 * A protected method to get a set of ordering conditions.
 	 *
-	 * @param   \Joomla\Cms\Table\Table  $table  A record object.
+	 * @param   \Joomla\CMS\Table\Table  $table  A record object.
 	 *
 	 * @return  array  An array of conditions to add to add to ordering queries.
 	 *

--- a/components/com_contact/Controller/Contact.php
+++ b/components/com_contact/Controller/Contact.php
@@ -28,7 +28,7 @@ class Contact extends Form
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\Cms\Model\Model  The model.
+	 * @return  \Joomla\CMS\Model\Model  The model.
 	 *
 	 * @since   1.6.4
 	 */


### PR DESCRIPTION
Fix error in the comments

Note I also found multiple instances in the code as well but I left them out of this PR as I wasn't sure if they were waiting conversion

eg
`use Joomla\Cms\Component\ComponentHelper;
`
in libraries\src\CMS\View\FormView.php
