### PR TITLE
Allow check in from item in associations view

### DIFF
--- a/administrator/components/com_associations/controllers/associations.php
+++ b/administrator/components/com_associations/controllers/associations.php
@@ -68,4 +68,63 @@ class AssociationsControllerAssociations extends JControllerAdmin
 		$this->getModel('associations')->clean();
 		$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 	}
+
+	/**
+	 * Method to check in an item from the association item overview.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function checkin()
+	{
+		// Set the redirect so we can just stop processing when we find a  condition we can't process
+		$this->setRedirect(JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+
+		// Figure out if the item supports checking and check it in
+		$type = null;
+
+		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype'));
+
+		$extension = AssociationsHelper::getSupportedExtension($extensionName);
+		$types     = $extension->get('types');
+
+		if (!array_key_exists($typeName, $types))
+		{
+			return;
+		}
+
+		if (AssociationsHelper::typeSupportsCheckout($extensionName, $typeName) === false)
+		{
+			// How on earth we came to that point, eject internet
+			return;
+		}
+
+		$cid = $this->input->get('cid', array(), 'array');
+
+		if (empty($cid))
+		{
+			// Seems we don't have an id to work with.
+			return;
+		}
+
+		// We know the first element is the one we need because we don't allow multi selection of rows
+		$id = $cid[0];
+
+		if (AssociationsHelper::canCheckinItem($extensionName, $typeName, $id) === true)
+		{
+			$item = AssociationsHelper::getItem($extensionName, $typeName, $id);
+
+			$item->checkIn($id);
+
+			return;
+		}
+
+		$this->setRedirect(
+			JRoute::_('index.php?option=' . $this->option . '&view=' . $this->view_list),
+			JText::_('COM_ASSOCIATIONS_YOU_ARE_NOT_ALLOWED_TO_CHECKIN_THIS_ITEM')
+		);
+
+		return;
+	}
 }

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -22,10 +22,10 @@ $canManageCheckin = JFactory::getUser()->authorise('core.manage', 'com_checkin')
 $colSpan          = 5;
 
 $iconStates = array(
-		-2 => 'icon-trash',
-		0  => 'icon-unpublish',
-		1  => 'icon-publish',
-		2  => 'icon-archive',
+	-2 => 'icon-trash',
+	0  => 'icon-unpublish',
+	1  => 'icon-publish',
+	2  => 'icon-archive',
 );
 
 JText::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT');

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -122,6 +122,7 @@ JFactory::getDocument()->addScriptDeclaration('
 						</td>
 					<?php endif; ?>
 					<td class="nowrap has-context">
+						<span style="display: none"><?php echo JHtml::_('grid.id', $i, $item->id); ?></span>
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 						<?php endif; ?>
@@ -173,6 +174,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		</table>
 	<?php endif; ?>
 	<input type="hidden" name="task" value=""/>
-	<?php echo JHtml::_('form.token'); ?>
+    <input type="hidden" name="boxchecked" value="0" />
+    <?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/components/com_associations/views/associations/tmpl/default.php
+++ b/administrator/components/com_associations/views/associations/tmpl/default.php
@@ -22,10 +22,10 @@ $canManageCheckin = JFactory::getUser()->authorise('core.manage', 'com_checkin')
 $colSpan          = 5;
 
 $iconStates = array(
-	-2 => 'icon-trash',
-	0  => 'icon-unpublish',
-	1  => 'icon-publish',
-	2  => 'icon-archive',
+		-2 => 'icon-trash',
+		0  => 'icon-unpublish',
+		1  => 'icon-publish',
+		2  => 'icon-archive',
 );
 
 JText::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT');
@@ -110,7 +110,6 @@ JFactory::getDocument()->addScriptDeclaration('
 			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
-				$canCheckin = true;
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
 				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
 				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
@@ -125,6 +124,9 @@ JFactory::getDocument()->addScriptDeclaration('
 						<span style="display: none"><?php echo JHtml::_('grid.id', $i, $item->id); ?></span>
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
+						<?php endif; ?>
+						<?php if (!$canCheckin && $isCheckout) : ?>
+							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.'); ?>
 						<?php endif; ?>
 						<?php if ($canCheckin && $isCheckout) : ?>
 							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.', $canCheckin); ?>
@@ -174,7 +176,7 @@ JFactory::getDocument()->addScriptDeclaration('
 		</table>
 	<?php endif; ?>
 	<input type="hidden" name="task" value=""/>
-    <input type="hidden" name="boxchecked" value="0" />
-    <?php echo JHtml::_('form.token'); ?>
+	<input type="hidden" name="boxchecked" value="0" />
+	<?php echo JHtml::_('form.token'); ?>
 	</div>
 </form>

--- a/administrator/language/en-GB/en-GB.com_associations.ini
+++ b/administrator/language/en-GB/en-GB.com_associations.ini
@@ -49,3 +49,4 @@ COM_ASSOCIATIONS_TITLE_EDIT="Multilingual Associations: Edit Associations (%1s &
 COM_ASSOCIATIONS_TITLE_LIST="Multilingual Associations (%1s &gt; %2s)"
 COM_ASSOCIATIONS_TITLE_LIST_SELECT="Multilingual Associations: Select Item Type and Language"
 COM_ASSOCIATIONS_XML_DESCRIPTION="Improved multilingual content management component"
+COM_ASSOCIATIONS_YOU_ARE_NOT_ALLOWED_TO_CHECKIN_THIS_ITEM="You can't checkin this item"

--- a/administrator/language/en-GB/en-GB.com_associations.ini
+++ b/administrator/language/en-GB/en-GB.com_associations.ini
@@ -49,4 +49,4 @@ COM_ASSOCIATIONS_TITLE_EDIT="Multilingual Associations: Edit Associations (%1s &
 COM_ASSOCIATIONS_TITLE_LIST="Multilingual Associations (%1s &gt; %2s)"
 COM_ASSOCIATIONS_TITLE_LIST_SELECT="Multilingual Associations: Select Item Type and Language"
 COM_ASSOCIATIONS_XML_DESCRIPTION="Improved multilingual content management component"
-COM_ASSOCIATIONS_YOU_ARE_NOT_ALLOWED_TO_CHECKIN_THIS_ITEM="You can't checkin this item"
+COM_ASSOCIATIONS_YOU_ARE_NOT_ALLOWED_TO_CHECKIN_THIS_ITEM="You can't check in this item"


### PR DESCRIPTION
Pull Request for Issue #13999.

### Summary of Changes
Added a function to checkin item from the associations view.

### Testing Instructions
* Go to Components > Multilingual Association
* Filter by articles and english language (it can be another component and/or language)
* Open a Multilingual Association from the results
* Don't click close button, just open a new tab and go to Components > Multilingual Association, so the association will we locked and you will see the lock icon

**Before Patch**

If you click on check-in icon, nothing happens.

**After Patch**

The item is checked in.

**Please also test with other items as articles**
