### PR TITLE
Providing link for author only when a contact exists

### DIFF
--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -60,7 +60,7 @@ class PlgContentContact extends JPlugin
 		$contact = $this->getContactId($row->created_by);
 		$row->contactid = $contact->contactid;
 
-		if ($contact)
+		if ($row->contactid)
 		{
 			JLoader::register('ContactHelperRoute', JPATH_SITE . '/components/com_contact/helpers/route.php');
 			$row->contact_link = JRoute::_(ContactHelperRoute::getContactRoute($contact->contactid . ':' . $contact->alias, $contact->catid));


### PR DESCRIPTION
Pull Request for Issue #15852

See https://github.com/joomla/joomla-cms/issues/15852

### Testing Instructions
Create 2 articles, one with an author which has a contact, the other with an author for which no contact exists.
Make sure to enable Show Author and Link Author are set to Yes.
Display in frontend.

### Expected result
The article for which the author has no contact should not provide a link.


### Actual result
It does and the link is incorrect.

@AlexRed 