### PR TITLE
[4.0] Add a preload manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,10 @@ Desktop.ini
 # Extra files installed by Composer not needed in the CMS environment
 # This should only ignore files like unit testing or READMEs, production
 # code must remain to ensure all libraries properly function
+/libraries/vendor/fig/link-util/test
+/libraries/vendor/fig/link-util/composer.json
+/libraries/vendor/fig/link-util/phpcs.xml
+/libraries/vendor/fig/link-util/README.md
 /libraries/vendor/ircmaxell/password-compat/test
 /libraries/vendor/ircmaxell/password-compat/.travis.yml
 /libraries/vendor/ircmaxell/password-compat/composer.json
@@ -159,6 +163,8 @@ Desktop.ini
 /libraries/vendor/psr/http-message/CHANGELOG.md
 /libraries/vendor/psr/http-message/composer.json
 /libraries/vendor/psr/http-message/README.md
+/libraries/vendor/psr/link/composer.json
+/libraries/vendor/psr/link/README.md
 /libraries/vendor/psr/log/Psr/Log/Test
 /libraries/vendor/psr/log/.gitignore
 /libraries/vendor/psr/log/composer.json
@@ -170,6 +176,12 @@ Desktop.ini
 /libraries/vendor/symfony/polyfill-util/composer.json
 /libraries/vendor/symfony/polyfill-util/README.md
 /libraries/vendor/symfony/polyfill-util/TestListener.php
+/libraries/vendor/symfony/web-link/Tests
+/libraries/vendor/symfony/web-link/.gitignore
+/libraries/vendor/symfony/web-link/CHANGELOG.md
+/libraries/vendor/symfony/web-link/composer.json
+/libraries/vendor/symfony/web-link/phpunit.xml.dist
+/libraries/vendor/symfony/web-link/README.md
 /libraries/vendor/symfony/yaml/Tests
 /libraries/vendor/symfony/yaml/.gitignore
 /libraries/vendor/symfony/yaml/CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -59,10 +59,13 @@
         "joomla/string": "~2.0@dev",
         "joomla/uri": "~2.0@dev",
         "joomla/utilities": "~2.0@dev",
+        "fig/link-util": "~1.0",
         "ircmaxell/password-compat": "1.*",
         "paragonie/random_compat": "~2.0",
         "phpmailer/phpmailer": "~6.0@rc",
+        "psr/link": "~1.0",
         "symfony/polyfill-php56": "~1.0",
+        "symfony/web-link": "3.3.*",
         "symfony/yaml": "2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "48bfaafe8baa33842e617863b280b2cf",
+    "content-hash": "b613ddcdbbd75d0a8efe5d925be06ddf",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -122,6 +122,60 @@
                 "symmetric key cryptography"
             ],
             "time": "2016-10-10T15:20:26+00:00"
+        },
+        {
+            "name": "fig/link-util",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link-util.git",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link-util/zipball/1a07821801a148be4add11ab0603e4af55a72fac",
+                "reference": "1a07821801a148be4add11ab0603e4af55a72fac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0",
+                "psr/link": "~1.0@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.1",
+                "squizlabs/php_codesniffer": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common utility implementations for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-17T18:31:11+00:00"
         },
         {
             "name": "ircmaxell/password-compat",
@@ -1339,6 +1393,55 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
+            "name": "psr/link",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/link.git",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Link\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for HTTP links",
+            "keywords": [
+                "http",
+                "http-link",
+                "link",
+                "psr",
+                "psr-13",
+                "rest"
+            ],
+            "time": "2016-10-28T16:06:13+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.2",
             "source": {
@@ -1492,6 +1595,77 @@
                 "shim"
             ],
             "time": "2016-11-14T01:06:16+00:00"
+        },
+        {
+            "name": "symfony/web-link",
+            "version": "v3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-link.git",
+                "reference": "9c1c9d4b34daa843b340ea305a639affc9b46a61"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-link/zipball/9c1c9d4b34daa843b340ea305a639affc9b46a61",
+                "reference": "9c1c9d4b34daa843b340ea305a639affc9b46a61",
+                "shasum": ""
+            },
+            "require": {
+                "fig/link-util": "^1.0",
+                "php": ">=5.5.9",
+                "psr/link": "^1.0"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^2.8|^3.0",
+                "symfony/http-foundation": "^2.8|^3.0",
+                "symfony/http-kernel": "^2.8|^3.0"
+            },
+            "suggest": {
+                "symfony/http-kernel": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\WebLink\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony WebLink Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dns-prefetch",
+                "http",
+                "http2",
+                "link",
+                "performance",
+                "prefetch",
+                "preload",
+                "prerender",
+                "psr13",
+                "push"
+            ],
+            "time": "2017-04-12T14:15:58+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -9,11 +9,13 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\AbstractWebApplication;
 use Joomla\CMS\Document\Factory;
 use Joomla\CMS\Document\FactoryInterface;
 use Joomla\CMS\Document\PreloadManager;
 use Joomla\CMS\Document\PreloadManagerInterface;
 use Joomla\CMS\Document\RendererInterface;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * Document class, provides an easy interface to parse and display a document
@@ -235,6 +237,14 @@ class JDocument
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $preloadManager = null;
+
+	/**
+	 * The supported preload types
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $preloadTypes = ['preload', 'dns-prefetch', 'preconnect', 'prefetch', 'prerender'];
 
 	/**
 	 * Class constructor.
@@ -473,7 +483,7 @@ class JDocument
 	 * Adds a linked script to the page
 	 *
 	 * @param   string  $url      URL to the linked script.
-	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9')
+	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'))
 	 * @param   array   $attribs  Array of attributes. Example: array('id' => 'scriptid', 'async' => 'async', 'data-test' => 1)
 	 *
 	 * @return  JDocument instance of $this to allow chaining
@@ -656,7 +666,7 @@ class JDocument
 	 * Adds a linked stylesheet to the page
 	 *
 	 * @param   string  $url      URL to the linked style sheet
-	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9')
+	 * @param   array   $options  Array of options. Example: array('version' => 'auto', 'conditional' => 'lt IE 9', 'preload' => array('preload'))
 	 * @param   array   $attribs  Array of attributes. Example: array('id' => 'stylesheet', 'data-test' => 1)
 	 *
 	 * @return  JDocument instance of $this to allow chaining
@@ -1262,5 +1272,79 @@ class JDocument
 
 		$app->mimeType = $this->_mime;
 		$app->charSet  = $this->_charset;
+
+		// Handle preloading for configured assets in web applications
+		if ($app instanceof AbstractWebApplication)
+		{
+			$this->preloadAssets();
+		}
+	}
+
+	/**
+	 * Generate the Link header for assets configured for preloading
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function preloadAssets()
+	{
+		// Process stylesheets first
+		foreach ($this->_styleSheets as $link => $properties)
+		{
+			if (empty($properties['options']['preload']))
+			{
+				continue;
+			}
+
+			foreach ($properties['options']['preload'] as $preloadMethod)
+			{
+				// Make sure the preload method is supported, special case for `dns-prefetch` to convert it to the right method name
+				if ($preloadMethod === 'dns-prefetch')
+				{
+					$this->getPreloadManager()->dnsPrefetch($link);
+				}
+				elseif (in_array($preloadMethod, $this->preloadTypes))
+				{
+					$this->getPreloadManager()->$preloadMethod($link);
+				}
+				else
+				{
+					throw new InvalidArgumentException(sprintf('The "%s" method is not supported for preloading.', $preloadMethod), 500);
+				}
+			}
+		}
+
+		// Now process scripts
+		foreach ($this->_scripts as $link => $properties)
+		{
+			if (empty($properties['options']['preload']))
+			{
+				continue;
+			}
+
+			foreach ($properties['options']['preload'] as $preloadMethod)
+			{
+				// Make sure the preload method is supported, special case for `dns-prefetch` to convert it to the right method name
+				if ($preloadMethod === 'dns-prefetch')
+				{
+					$this->getPreloadManager()->dnsPrefetch($link);
+				}
+				elseif (in_array($preloadMethod, $this->preloadTypes))
+				{
+					$this->getPreloadManager()->$preloadMethod($link);
+				}
+				else
+				{
+					throw new InvalidArgumentException(sprintf('The "%s" method is not supported for preloading.', $preloadMethod), 500);
+				}
+			}
+		}
+
+		// Check if the manager's provider has links, if so add the Link header
+		if ($links = $this->getPreloadManager()->getLinkProvider()->getLinks())
+		{
+			JFactory::getApplication()->setHeader('Link', (new HttpHeaderSerializer)->serialize($links));
+		}
 	}
 }

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -11,6 +11,8 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Document\Factory;
 use Joomla\CMS\Document\FactoryInterface;
+use Joomla\CMS\Document\PreloadManager;
+use Joomla\CMS\Document\PreloadManagerInterface;
 use Joomla\CMS\Document\RendererInterface;
 
 /**
@@ -227,6 +229,14 @@ class JDocument
 	protected $factory;
 
 	/**
+	 * Preload manager
+	 *
+	 * @var    PreloadManagerInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $preloadManager = null;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   array  $options  Associative array of options
@@ -282,6 +292,15 @@ class JDocument
 		else
 		{
 			$this->setFactory(new Factory);
+		}
+
+		if (array_key_exists('preloadManager', $options))
+		{
+			$this->setPreloadManager($options['preloadManager']);
+		}
+		else
+		{
+			$this->setPreloadManager(new PreloadManager);
 		}
 	}
 
@@ -911,6 +930,34 @@ class JDocument
 	public function getMediaVersion()
 	{
 		return $this->mediaVersion;
+	}
+
+	/**
+	 * Set the preload manager
+	 *
+	 * @param   PreloadManagerInterface  $preloadManager  The preload manager service
+	 *
+	 * @return  JDocument instance of $this to allow chaining
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setPreloadManager(PreloadManagerInterface $preloadManager)
+	{
+		$this->preloadManager = $preloadManager;
+
+		return $this;
+	}
+
+	/**
+	 * Return the preload manager
+	 *
+	 * @return  PreloadManagerInterface
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPreloadManager()
+	{
+		return $this->preloadManager;
 	}
 
 	/**

--- a/libraries/src/CMS/Document/PreloadManager.php
+++ b/libraries/src/CMS/Document/PreloadManager.php
@@ -10,15 +10,37 @@ namespace Joomla\CMS\Document;
 
 defined('_JEXEC') or die;
 
+use Fig\Link\GenericLinkProvider;
+use Fig\Link\Link;
 use Psr\Link\EvolvableLinkProviderInterface;
 
 /**
- * Joomla! Preload Manager Interface
+ * Joomla! Preload Manager
  *
  * @since  __DEPLOY_VERSION__
  */
-interface PreloadManagerInterface
+class PreloadManager implements PreloadManagerInterface
 {
+	/**
+	 * The link provider
+	 *
+	 * @var    EvolvableLinkProviderInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $linkProvider;
+
+	/**
+	 * PreloadManager constructor
+	 *
+	 * @param   EvolvableLinkProviderInterface  $linkProvider  The link provider
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(EvolvableLinkProviderInterface $linkProvider = null)
+	{
+		$this->linkProvider = $linkProvider ?: new GenericLinkProvider;
+	}
+
 	/**
 	 * Get the link provider
 	 *
@@ -26,7 +48,10 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getLinkProvider();
+	public function getLinkProvider()
+	{
+		return $this->linkProvider;
+	}
 
 	/**
 	 * Set the link provider
@@ -37,7 +62,12 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setLinkProvider(EvolvableLinkProviderInterface $linkProvider);
+	public function setLinkProvider(EvolvableLinkProviderInterface $linkProvider)
+	{
+		$this->linkProvider = $linkProvider;
+
+		return $this;
+	}
 
 	/**
 	 * Preloads a resource.
@@ -49,7 +79,10 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preload($uri, array $attributes = []);
+	public function preload($uri, array $attributes = [])
+	{
+		$this->link($uri, 'preload', $attributes);
+	}
 
 	/**
 	 * Resolves a resource origin as early as possible.
@@ -61,7 +94,10 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dnsPrefetch($uri, array $attributes = []);
+	public function dnsPrefetch($uri, array $attributes = [])
+	{
+		$this->link($uri, 'dns-prefetch', $attributes);
+	}
 
 	/**
 	 * Initiates a early connection to a resource (DNS resolution, TCP handshake, TLS negotiation).
@@ -73,7 +109,10 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preconnect($uri, array $attributes = []);
+	public function preconnect($uri, array $attributes = [])
+	{
+		$this->link($uri, 'preconnect', $attributes);
+	}
 
 	/**
 	 * Indicates to the client that it should prefetch this resource.
@@ -85,7 +124,10 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prefetch($uri, array $attributes = []);
+	public function prefetch($uri, array $attributes = [])
+	{
+		$this->link($uri, 'prefetch', $attributes);
+	}
 
 	/**
 	 * Indicates to the client that it should prerender this resource.
@@ -97,5 +139,31 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prerender($uri, array $attributes = []);
+	public function prerender($uri, array $attributes = [])
+	{
+		$this->link($uri, 'prerender', $attributes);
+	}
+
+	/**
+	 * Adds a "Link" HTTP header.
+	 *
+	 * @param   string  $uri         The relation URI
+	 * @param   string  $rel         The relation type (e.g. "preload", "prefetch", "prerender" or "dns-prefetch")
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function link($uri, $rel, array $attributes = [])
+	{
+		$link = new Link($rel, $uri);
+
+		foreach ($attributes as $key => $value)
+		{
+			$link = $link->withAttribute($key, $value);
+		}
+
+		$this->setLinkProvider($this->getLinkProvider()->withLink($link));
+	}
 }

--- a/libraries/src/CMS/Document/PreloadManager.php
+++ b/libraries/src/CMS/Document/PreloadManager.php
@@ -2,8 +2,8 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\CMS\Document;

--- a/libraries/src/CMS/Document/PreloadManagerInterface.php
+++ b/libraries/src/CMS/Document/PreloadManagerInterface.php
@@ -2,8 +2,8 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
- * @license    GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
 namespace Joomla\CMS\Document;

--- a/libraries/src/CMS/Document/PreloadManagerInterface.php
+++ b/libraries/src/CMS/Document/PreloadManagerInterface.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Document;
+
+defined('_JEXEC') or die;
+
+/**
+ * Joomla! Preload Manager Interface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface PreloadManagerInterface
+{
+	/**
+	 * Preloads a resource.
+	 *
+	 * @param   string  $uri         A public path
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('crossorigin' => 'use-credentials')")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function preload($uri, array $attributes = []);
+
+	/**
+	 * Resolves a resource origin as early as possible.
+	 *
+	 * @param   string  $uri         A public path
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dnsPrefetch($uri, array $attributes = []);
+
+	/**
+	 * Initiates a early connection to a resource (DNS resolution, TCP handshake, TLS negotiation).
+	 *
+	 * @param   string  $uri         A public path
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function preconnect($uri, array $attributes = []);
+
+	/**
+	 * Indicates to the client that it should prefetch this resource.
+	 *
+	 * @param   string  $uri         A public path
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function prefetch($uri, array $attributes = []);
+
+	/**
+	 * Indicates to the client that it should prerender this resource .
+	 *
+	 * @param   string  $uri         A public path
+	 * @param   array   $attributes  The attributes of this link (e.g. "array('as' => true)", "array('pr' => 0.5)")
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function prerender($uri, array $attributes = []);
+}

--- a/libraries/vendor/composer/autoload_psr4.php
+++ b/libraries/vendor/composer/autoload_psr4.php
@@ -10,7 +10,9 @@ return array(
     'Symfony\\Polyfill\\Util\\' => array($vendorDir . '/symfony/polyfill-util'),
     'Symfony\\Polyfill\\Php56\\' => array($vendorDir . '/symfony/polyfill-php56'),
     'Symfony\\Component\\Yaml\\' => array($vendorDir . '/symfony/yaml'),
+    'Symfony\\Component\\WebLink\\' => array($vendorDir . '/symfony/web-link'),
     'Psr\\Log\\' => array($vendorDir . '/psr/log/Psr/Log'),
+    'Psr\\Link\\' => array($vendorDir . '/psr/link/src'),
     'Psr\\Http\\Message\\' => array($vendorDir . '/psr/http-message/src'),
     'Psr\\Container\\' => array($vendorDir . '/psr/container/src'),
     'PHPMailer\\PHPMailer\\' => array($vendorDir . '/phpmailer/phpmailer/src'),
@@ -35,5 +37,6 @@ return array(
     'Joomla\\Controller\\' => array($vendorDir . '/joomla/controller/src'),
     'Joomla\\Application\\' => array($vendorDir . '/joomla/application/src'),
     'Joomla\\' => array($baseDir . '/libraries/src'),
+    'Fig\\Link\\' => array($vendorDir . '/fig/link-util/src'),
     'Composer\\CaBundle\\' => array($vendorDir . '/composer/ca-bundle/src'),
 );

--- a/libraries/vendor/composer/autoload_static.php
+++ b/libraries/vendor/composer/autoload_static.php
@@ -37,10 +37,12 @@ class ComposerStaticInit423c8facdf90155590c7b49e979f3a1e
             'Symfony\\Polyfill\\Util\\' => 22,
             'Symfony\\Polyfill\\Php56\\' => 23,
             'Symfony\\Component\\Yaml\\' => 23,
+            'Symfony\\Component\\WebLink\\' => 26,
         ),
         'P' => 
         array (
             'Psr\\Log\\' => 8,
+            'Psr\\Link\\' => 9,
             'Psr\\Http\\Message\\' => 17,
             'Psr\\Container\\' => 14,
             'PHPMailer\\PHPMailer\\' => 20,
@@ -69,6 +71,10 @@ class ComposerStaticInit423c8facdf90155590c7b49e979f3a1e
             'Joomla\\Application\\' => 19,
             'Joomla\\' => 7,
         ),
+        'F' => 
+        array (
+            'Fig\\Link\\' => 9,
+        ),
         'C' => 
         array (
             'Composer\\CaBundle\\' => 18,
@@ -92,9 +98,17 @@ class ComposerStaticInit423c8facdf90155590c7b49e979f3a1e
         array (
             0 => __DIR__ . '/..' . '/symfony/yaml',
         ),
+        'Symfony\\Component\\WebLink\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/symfony/web-link',
+        ),
         'Psr\\Log\\' => 
         array (
             0 => __DIR__ . '/..' . '/psr/log/Psr/Log',
+        ),
+        'Psr\\Link\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/psr/link/src',
         ),
         'Psr\\Http\\Message\\' => 
         array (
@@ -191,6 +205,10 @@ class ComposerStaticInit423c8facdf90155590c7b49e979f3a1e
         'Joomla\\' => 
         array (
             0 => __DIR__ . '/../../..' . '/libraries/src',
+        ),
+        'Fig\\Link\\' => 
+        array (
+            0 => __DIR__ . '/..' . '/fig/link-util/src',
         ),
         'Composer\\CaBundle\\' => 
         array (

--- a/libraries/vendor/composer/installed.json
+++ b/libraries/vendor/composer/installed.json
@@ -1646,5 +1646,185 @@
             "joomla",
             "oauth2"
         ]
+    },
+    {
+        "name": "psr/link",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/php-fig/link.git",
+            "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/php-fig/link/zipball/eea8e8662d5cd3ae4517c9b864493f59fca95562",
+            "reference": "eea8e8662d5cd3ae4517c9b864493f59fca95562",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.3.0"
+        },
+        "time": "2016-10-28T16:06:13+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Psr\\Link\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "PHP-FIG",
+                "homepage": "http://www.php-fig.org/"
+            }
+        ],
+        "description": "Common interfaces for HTTP links",
+        "keywords": [
+            "http",
+            "http-link",
+            "link",
+            "psr",
+            "psr-13",
+            "rest"
+        ]
+    },
+    {
+        "name": "fig/link-util",
+        "version": "1.0.0",
+        "version_normalized": "1.0.0.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/php-fig/link-util.git",
+            "reference": "1a07821801a148be4add11ab0603e4af55a72fac"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/php-fig/link-util/zipball/1a07821801a148be4add11ab0603e4af55a72fac",
+            "reference": "1a07821801a148be4add11ab0603e4af55a72fac",
+            "shasum": ""
+        },
+        "require": {
+            "php": ">=5.5.0",
+            "psr/link": "~1.0@dev"
+        },
+        "require-dev": {
+            "phpunit/phpunit": "^5.1",
+            "squizlabs/php_codesniffer": "^2.3.1"
+        },
+        "time": "2016-10-17T18:31:11+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "1.0.x-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Fig\\Link\\": "src/"
+            }
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "PHP-FIG",
+                "homepage": "http://www.php-fig.org/"
+            }
+        ],
+        "description": "Common utility implementations for HTTP links",
+        "keywords": [
+            "http",
+            "http-link",
+            "link",
+            "psr",
+            "psr-13",
+            "rest"
+        ]
+    },
+    {
+        "name": "symfony/web-link",
+        "version": "v3.3.2",
+        "version_normalized": "3.3.2.0",
+        "source": {
+            "type": "git",
+            "url": "https://github.com/symfony/web-link.git",
+            "reference": "9c1c9d4b34daa843b340ea305a639affc9b46a61"
+        },
+        "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/symfony/web-link/zipball/9c1c9d4b34daa843b340ea305a639affc9b46a61",
+            "reference": "9c1c9d4b34daa843b340ea305a639affc9b46a61",
+            "shasum": ""
+        },
+        "require": {
+            "fig/link-util": "^1.0",
+            "php": ">=5.5.9",
+            "psr/link": "^1.0"
+        },
+        "require-dev": {
+            "symfony/event-dispatcher": "^2.8|^3.0",
+            "symfony/http-foundation": "^2.8|^3.0",
+            "symfony/http-kernel": "^2.8|^3.0"
+        },
+        "suggest": {
+            "symfony/http-kernel": ""
+        },
+        "time": "2017-04-12T14:15:58+00:00",
+        "type": "library",
+        "extra": {
+            "branch-alias": {
+                "dev-master": "3.3-dev"
+            }
+        },
+        "installation-source": "dist",
+        "autoload": {
+            "psr-4": {
+                "Symfony\\Component\\WebLink\\": ""
+            },
+            "exclude-from-classmap": [
+                "/Tests/"
+            ]
+        },
+        "notification-url": "https://packagist.org/downloads/",
+        "license": [
+            "MIT"
+        ],
+        "authors": [
+            {
+                "name": "Kévin Dunglas",
+                "email": "dunglas@gmail.com"
+            },
+            {
+                "name": "Symfony Community",
+                "homepage": "https://symfony.com/contributors"
+            }
+        ],
+        "description": "Symfony WebLink Component",
+        "homepage": "https://symfony.com",
+        "keywords": [
+            "dns-prefetch",
+            "http",
+            "http2",
+            "link",
+            "performance",
+            "prefetch",
+            "preload",
+            "prerender",
+            "psr13",
+            "push"
+        ]
     }
 ]

--- a/libraries/vendor/fig/link-util/LICENSE.md
+++ b/libraries/vendor/fig/link-util/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2016 :author_name <:author_email>
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/libraries/vendor/fig/link-util/src/EvolvableLinkProviderTrait.php
+++ b/libraries/vendor/fig/link-util/src/EvolvableLinkProviderTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Fig\Link;
+
+use Psr\Link\LinkInterface;
+use Psr\Link\EvolvableLinkProviderInterface;
+
+/**
+ * Class EvolvableLinkProviderTrait
+ *
+ * @implements EvolvableLinkProviderInterface
+ */
+trait EvolvableLinkProviderTrait
+{
+    use LinkProviderTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withLink(LinkInterface $link)
+    {
+        $that = clone($this);
+        $splosh = spl_object_hash($link);
+        if (!array_key_exists($splosh, $that->links)) {
+            $that->links[$splosh] = $link;
+        }
+        return $that;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withoutLink(LinkInterface $link)
+    {
+        $that = clone($this);
+        $splosh = spl_object_hash($link);
+        unset($that->links[$splosh]);
+        return $that;
+    }
+}

--- a/libraries/vendor/fig/link-util/src/EvolvableLinkTrait.php
+++ b/libraries/vendor/fig/link-util/src/EvolvableLinkTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+
+namespace Fig\Link;
+
+use Psr\Link\EvolvableLinkInterface;
+
+/**
+ * Class EvolvableLinkTrait
+ *
+ * @implements EvolvableLinkInterface
+ */
+trait EvolvableLinkTrait
+{
+    use LinkTrait;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return EvolvableLinkInterface
+     */
+    public function withHref($href)
+    {
+        /** @var EvolvableLinkInterface $that */
+        $that = clone($this);
+        $that->href = $href;
+
+        $that->templated = ($this->hrefIsTemplated($href));
+
+        return $that;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return EvolvableLinkInterface
+     */
+    public function withRel($rel)
+    {
+        /** @var EvolvableLinkInterface $that */
+        $that = clone($this);
+        $that->rel[$rel] = true;
+        return $that;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return EvolvableLinkInterface
+     */
+    public function withoutRel($rel)
+    {
+        /** @var EvolvableLinkInterface $that */
+        $that = clone($this);
+        unset($that->rel[$rel]);
+        return $that;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return EvolvableLinkInterface
+     */
+    public function withAttribute($attribute, $value)
+    {
+        /** @var EvolvableLinkInterface $that */
+        $that = clone($this);
+        $that->attributes[$attribute] = $value;
+        return $that;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return EvolvableLinkInterface
+     */
+    public function withoutAttribute($attribute)
+    {
+        /** @var EvolvableLinkInterface $that */
+        $that = clone($this);
+        unset($that->attributes[$attribute]);
+        return $that;
+    }
+}

--- a/libraries/vendor/fig/link-util/src/GenericLinkProvider.php
+++ b/libraries/vendor/fig/link-util/src/GenericLinkProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Fig\Link;
+
+use Psr\Link\EvolvableLinkProviderInterface;
+use Psr\Link\LinkInterface;
+
+class GenericLinkProvider implements EvolvableLinkProviderInterface
+{
+    use EvolvableLinkProviderTrait;
+
+    /**
+     * Constructs a new link provider.
+     *
+     * @param LinkInterface[] $links
+     *   Optionally, specify an initial set of links for this provider.
+     *   Note that the keys of the array will be ignored.
+     */
+    public function __construct(array $links = [])
+    {
+        // This block will throw a type error if any item isn't a LinkInterface, by design.
+        array_filter($links, function (LinkInterface $item) {
+            return true;
+        });
+
+        $hashes = array_map('spl_object_hash', $links);
+        $this->links = array_combine($hashes, $links);
+    }
+}

--- a/libraries/vendor/fig/link-util/src/Link.php
+++ b/libraries/vendor/fig/link-util/src/Link.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace Fig\Link;
+
+use Psr\Link\EvolvableLinkInterface;
+
+class Link implements EvolvableLinkInterface
+{
+    use EvolvableLinkTrait;
+
+    /**
+     * Link constructor.
+     *
+     * @param string $rel
+     *   A single relationship to include on this link.
+     * @param string $href
+     *   An href for this link.
+     */
+    public function __construct($rel = '', $href = '')
+    {
+        if ($rel) {
+            $this->rel[$rel] = true;
+        }
+        $this->href = $href;
+    }
+}

--- a/libraries/vendor/fig/link-util/src/LinkProviderTrait.php
+++ b/libraries/vendor/fig/link-util/src/LinkProviderTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace Fig\Link;
+
+use Psr\Link\LinkProviderInterface;
+use Psr\Link\LinkInterface;
+
+/**
+ * Class LinkProviderTrait
+ *
+ * @implements LinkProviderInterface
+ */
+trait LinkProviderTrait
+{
+    /**
+     * An array of the links in this provider.
+     *
+     * The keys of the array MUST be the spl_object_hash() of the object being stored.
+     * That helps to ensure uniqueness.
+     *
+     * @var LinkInterface[]
+     */
+    private $links = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLinks()
+    {
+        return $this->links;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLinksByRel($rel)
+    {
+        $filter = function (LinkInterface $link) use ($rel) {
+            return in_array($rel, $link->getRels());
+        };
+        return array_filter($this->links, $filter);
+    }
+}

--- a/libraries/vendor/fig/link-util/src/LinkTrait.php
+++ b/libraries/vendor/fig/link-util/src/LinkTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Fig\Link;
+
+use Psr\Link\LinkInterface;
+
+/**
+ * Class LinkTrait
+ *
+ * @inherits LinkInterface
+ */
+trait LinkTrait
+{
+    use TemplatedHrefTrait;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    private $href = '';
+
+    /**
+     * The set of rels on this link.
+     *
+     * Note: Because rels are an exclusive set, we use the keys of the array
+     * to store the rels that have been added, not the values. The values
+     * are simply boolean true.  A rel is present if the key is set, false
+     * otherwise.
+     *
+     * @var string[]
+     */
+    private $rel = [];
+
+    /**
+     *
+     *
+     * @var string
+     */
+    private $attributes = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHref()
+    {
+        return $this->href;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTemplated()
+    {
+        return $this->hrefIsTemplated($this->href);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRels()
+    {
+        return array_keys($this->rel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+}

--- a/libraries/vendor/fig/link-util/src/TemplatedHrefTrait.php
+++ b/libraries/vendor/fig/link-util/src/TemplatedHrefTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Fig\Link;
+
+trait TemplatedHrefTrait
+{
+    /**
+     * Determines if an href is a templated link or not.
+     *
+     * @see https://tools.ietf.org/html/rfc6570
+     *
+     * @param string $href
+     *   The href value to check.
+     *
+     * @return bool
+     *   True if the specified href is a templated path, False otherwise.
+     */
+    private function hrefIsTemplated($href)
+    {
+        return strpos($href, '{') !== false ||strpos($href, '}') !== false;
+    }
+}

--- a/libraries/vendor/psr/link/LICENSE.md
+++ b/libraries/vendor/psr/link/LICENSE.md
@@ -1,0 +1,21 @@
+# The MIT License (MIT)
+
+Copyright (c) 2016 PHP Framework Interoperability Group
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.

--- a/libraries/vendor/psr/link/src/EvolvableLinkInterface.php
+++ b/libraries/vendor/psr/link/src/EvolvableLinkInterface.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Psr\Link;
+
+/**
+ * An evolvable link value object.
+ */
+interface EvolvableLinkInterface extends LinkInterface
+{
+    /**
+     * Returns an instance with the specified href.
+     *
+     * @param string $href
+     *   The href value to include.  It must be one of:
+     *     - An absolute URI, as defined by RFC 5988.
+     *     - A relative URI, as defined by RFC 5988. The base of the relative link
+     *       is assumed to be known based on context by the client.
+     *     - A URI template as defined by RFC 6570.
+     *     - An object implementing __toString() that produces one of the above
+     *       values.
+     *
+     * An implementing library SHOULD evaluate a passed object to a string
+     * immediately rather than waiting for it to be returned later.
+     *
+     * @return static
+     */
+    public function withHref($href);
+
+    /**
+     * Returns an instance with the specified relationship included.
+     *
+     * If the specified rel is already present, this method MUST return
+     * normally without errors, but without adding the rel a second time.
+     *
+     * @param string $rel
+     *   The relationship value to add.
+     * @return static
+     */
+    public function withRel($rel);
+
+    /**
+     * Returns an instance with the specified relationship excluded.
+     *
+     * If the specified rel is already not present, this method MUST return
+     * normally without errors.
+     *
+     * @param string $rel
+     *   The relationship value to exclude.
+     * @return static
+     */
+    public function withoutRel($rel);
+
+    /**
+     * Returns an instance with the specified attribute added.
+     *
+     * If the specified attribute is already present, it will be overwritten
+     * with the new value.
+     *
+     * @param string $attribute
+     *   The attribute to include.
+     * @param string $value
+     *   The value of the attribute to set.
+     * @return static
+     */
+    public function withAttribute($attribute, $value);
+
+
+    /**
+     * Returns an instance with the specified attribute excluded.
+     *
+     * If the specified attribute is not present, this method MUST return
+     * normally without errors.
+     *
+     * @param string $attribute
+     *   The attribute to remove.
+     * @return static
+     */
+    public function withoutAttribute($attribute);
+}

--- a/libraries/vendor/psr/link/src/EvolvableLinkProviderInterface.php
+++ b/libraries/vendor/psr/link/src/EvolvableLinkProviderInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Psr\Link;
+
+/**
+ * An evolvable link provider value object.
+ */
+interface EvolvableLinkProviderInterface extends LinkProviderInterface
+{
+    /**
+     * Returns an instance with the specified link included.
+     *
+     * If the specified link is already present, this method MUST return normally
+     * without errors. The link is present if $link is === identical to a link
+     * object already in the collection.
+     *
+     * @param LinkInterface $link
+     *   A link object that should be included in this collection.
+     * @return static
+     */
+    public function withLink(LinkInterface $link);
+
+    /**
+     * Returns an instance with the specifed link removed.
+     *
+     * If the specified link is not present, this method MUST return normally
+     * without errors. The link is present if $link is === identical to a link
+     * object already in the collection.
+     *
+     * @param LinkInterface $link
+     *   The link to remove.
+     * @return static
+     */
+    public function withoutLink(LinkInterface $link);
+}

--- a/libraries/vendor/psr/link/src/LinkInterface.php
+++ b/libraries/vendor/psr/link/src/LinkInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Psr\Link;
+
+/**
+ * A readable link object.
+ */
+interface LinkInterface
+{
+    /**
+     * Returns the target of the link.
+     *
+     * The target link must be one of:
+     * - An absolute URI, as defined by RFC 5988.
+     * - A relative URI, as defined by RFC 5988. The base of the relative link
+     *     is assumed to be known based on context by the client.
+     * - A URI template as defined by RFC 6570.
+     *
+     * If a URI template is returned, isTemplated() MUST return True.
+     *
+     * @return string
+     */
+    public function getHref();
+
+    /**
+     * Returns whether or not this is a templated link.
+     *
+     * @return bool
+     *   True if this link object is templated, False otherwise.
+     */
+    public function isTemplated();
+
+    /**
+     * Returns the relationship type(s) of the link.
+     *
+     * This method returns 0 or more relationship types for a link, expressed
+     * as an array of strings.
+     *
+     * @return string[]
+     */
+    public function getRels();
+
+    /**
+     * Returns a list of attributes that describe the target URI.
+     *
+     * @return array
+     *   A key-value list of attributes, where the key is a string and the value
+     *  is either a PHP primitive or an array of PHP strings. If no values are
+     *  found an empty array MUST be returned.
+     */
+    public function getAttributes();
+}

--- a/libraries/vendor/psr/link/src/LinkProviderInterface.php
+++ b/libraries/vendor/psr/link/src/LinkProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Psr\Link;
+
+/**
+ * A link provider object.
+ */
+interface LinkProviderInterface
+{
+    /**
+     * Returns an iterable of LinkInterface objects.
+     *
+     * The iterable may be an array or any PHP \Traversable object. If no links
+     * are available, an empty array or \Traversable MUST be returned.
+     *
+     * @return LinkInterface[]|\Traversable
+     */
+    public function getLinks();
+
+    /**
+     * Returns an iterable of LinkInterface objects that have a specific relationship.
+     *
+     * The iterable may be an array or any PHP \Traversable object. If no links
+     * with that relationship are available, an empty array or \Traversable MUST be returned.
+     *
+     * @return LinkInterface[]|\Traversable
+     */
+    public function getLinksByRel($rel);
+}

--- a/libraries/vendor/symfony/web-link/EventListener/AddLinkHeaderListener.php
+++ b/libraries/vendor/symfony/web-link/EventListener/AddLinkHeaderListener.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\EventListener;
+
+use Psr\Link\LinkProviderInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
+
+/**
+ * Adds the Link HTTP header to the response.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @final
+ */
+class AddLinkHeaderListener implements EventSubscriberInterface
+{
+    private $serializer;
+
+    public function __construct()
+    {
+        $this->serializer = new HttpHeaderSerializer();
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $linkProvider = $event->getRequest()->attributes->get('_links');
+        if (!$linkProvider instanceof LinkProviderInterface || !$links = $linkProvider->getLinks()) {
+            return;
+        }
+
+        $event->getResponse()->headers->set('Link', $this->serializer->serialize($links), false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(KernelEvents::RESPONSE => 'onKernelResponse');
+    }
+}

--- a/libraries/vendor/symfony/web-link/HttpHeaderSerializer.php
+++ b/libraries/vendor/symfony/web-link/HttpHeaderSerializer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink;
+
+use Psr\Link\LinkInterface;
+
+/**
+ * Serializes a list of Link instances to a HTTP Link header.
+ *
+ * @see https://tools.ietf.org/html/rfc5988
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+final class HttpHeaderSerializer
+{
+    /**
+     * Builds the value of the "Link" HTTP header.
+     *
+     * @param LinkInterface[]|\Traversable $links
+     *
+     * @return string|null
+     */
+    public function serialize($links)
+    {
+        $elements = array();
+        foreach ($links as $link) {
+            if ($link->isTemplated()) {
+                continue;
+            }
+
+            $attributesParts = array('', sprintf('rel="%s"', implode(' ', $link->getRels())));
+            foreach ($link->getAttributes() as $key => $value) {
+                if (is_array($value)) {
+                    foreach ($value as $v) {
+                        $attributesParts[] = sprintf('%s="%s"', $key, $v);
+                    }
+
+                    continue;
+                }
+
+                if (!is_bool($value)) {
+                    $attributesParts[] = sprintf('%s="%s"', $key, $value);
+
+                    continue;
+                }
+
+                if (true === $value) {
+                    $attributesParts[] = $key;
+                }
+            }
+
+            $elements[] = sprintf('<%s>%s', $link->getHref(), implode('; ', $attributesParts));
+        }
+
+        return $elements ? implode(',', $elements) : null;
+    }
+}

--- a/libraries/vendor/symfony/web-link/LICENSE
+++ b/libraries/vendor/symfony/web-link/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2017 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
### Summary of Changes

To support HTTP preloading, a new `PreloadManager` service is introduced and hooked into `JDocument` to allow developers to register preload links.

### Testing Instructions

In `JHtmlJquery`, change the line actually loading the jQuery file to read this:

```php
JHtml::_('script', 'vendor/jquery/jquery.min.js', array('version' => 'auto', 'relative' => true, 'detectDebug' => $debug, 'preload' => array('preload')));
```

With this patch applied, the base response should have a `Link:</media/vendor/jquery/js/jquery.min.js>; rel="preload"` header.

### Documentation Changes Required

To use this API to preload stylesheet and JavaScript assets through either `JHtml` or `JDocument` directly, a new `preload` key is added to the `$options` array.  This is an array of the preload types that should be used for an item.  So `'preload' => array('preload')` would only add the resource with `rel="preload"` and `'preload' => array('preload', 'prefetch')` would add a value for both `rel="preload"` and `rel="prefetch"`.

The `Link` header is computed as the last step of `JDocument::render()`, meaning this happens after the `onBeforeCompileHead` event has been run and the `<head>` element generated, but will be before the `onAfterRender` event.  So this is hookable until pretty late in the request, but afterwards you would need to get the header and manually edit that.

The preload support is not limited to stylesheets and JavaScripts loaded through `JDocument` or `JHtml`.  In fact, there is a new `JDocument::getPreloadManager()` method which will fetch the new `PreloadManager` service and through this you can add preloading requests for any supported reference type.

`JDocument` will support any `Joomla\CMS\Document\PreloadManagerInterface` implementation, allowing developers to create their own objects if desired.  This can be injected through the options array or through the public set method.

Internally, the default `Joomla\CMS\Document\PreloadManager` implementation uses `Fig\Link\GenericLinkProvider` as the internal link provider but any provider implementing PSR-13's `Psr\Link\EvolvableLinkProviderInterface` can be set using the preload manager's  `setLinkProvider` method.

Lastly, I am only doing this for 4.0 because all of the code required to make an API supporting this is already written elsewhere (Symfony's new WebLink component and the PHP-FIG's Link utilities package) and the dependencies aren't PHP 5.3 compatible.  Sure, we can write all of the logic ourselves and get it into 3.x, but frankly I'd rather not do the work to sort out how to internally track these resources or build the `Link` header with the correct structure.

### TODO

- [ ] Sort out passing optional attributes into the preload manager service from `JDocument`
- [ ] Automated testing