### PR TITLE
[4.0] Fix "grunt" not recognised

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "autoprefixer": "^6.7.7",
     "grunt": "latest",
+    "grunt-cli": "latest",
     "grunt-contrib-clean": "latest",
     "grunt-contrib-concat": "latest",
     "grunt-contrib-copy": "latest",


### PR DESCRIPTION
### Summary of Changes

After running `npm i` and trying to run a grunt task, the user sometimes gets an error saying grunt is not recognised as an internal or external command. This is because the `grunt-cli` package needs to be installed.

@dgt41 

