### PR TITLE
Category Blog sort by unpublish date

### DIFF
--- a/components/com_content/helpers/query.php
+++ b/components/com_content/helpers/query.php
@@ -173,6 +173,9 @@ class ContentHelperQuery
 				$queryDate = ' CASE WHEN a.publish_up = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_up END ';
 				break;
 
+			case 'unpublished' :
+				$queryDate = ' CASE WHEN a.publish_down = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_down END ';
+				break;
 			case 'created' :
 			default :
 				$queryDate = ' a.created ';

--- a/components/com_content/views/category/tmpl/blog.xml
+++ b/components/com_content/views/category/tmpl/blog.xml
@@ -291,6 +291,7 @@
 					<option value="created">JGLOBAL_CREATED</option>
 					<option value="modified">JGLOBAL_MODIFIED</option>
 					<option value="published">JPUBLISHED</option>
+					<option value="unpublished">JUNPUBLISHED</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue #15886.

----
#### Original report

Hello since i posted this issue at a wrong place i am subitting it as new issue.
I'd love to order articles within a blog-view by unpublish date. Imagine a list of events or similar that should be displayed by their date: next event as first entry, second event as second entry and so on. But as you guys from event organisation know those events are not published in that way: maybe the third event is published as first because alle information is given early.
Here comes my idea: add th option to order by unpublish date: this allowes to create the articles in a chaotic order but show them by their unpubish date (the day after the event).

### Steps to reproduce the issue
- create category and a few articles within
- create menu item (category blog)
- order articles by date

### Expected result
- select option to order articles by unpublish date

### Actual result
- only options are publish_up, modified, created

### System information (as much as possible)
- Joomla 3.7.0 and before

### Additional comments
maybe it is possible to implement this to `root/components/com_content/category/blog.xml` around line 270

    <field
    	name="order_date"
    	type="list"
    	description="JGLOBAL_ORDERING_DATE_DESC"
    	label="JGLOBAL_ORDERING_DATE_LABEL"
    >
    	<option value="">JGLOBAL_USE_GLOBAL</option>
    	<option value="created">JGLOBAL_CREATED</option>
    	<option value="modified">JGLOBAL_MODIFIED</option>
    	<option value="published">JPUBLISHED</option>
    	<option value="unpublished">JUNPUBLISHED</option>
    </field>
and then add in `root/components/com_content/helpers/query.php` around line 170 this

    case 'unpublished' :
    	$queryDate = ' CASE WHEN a.publish_down = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_down END ';
    	break;
i think in J3.5 this used to work now it doesnt anymore

