### PR TITLE
[Associations] Prevent choosing a checked out item when changing Target

### DIFF
--- a/administrator/components/com_associations/views/associations/tmpl/modal.php
+++ b/administrator/components/com_associations/views/associations/tmpl/modal.php
@@ -21,10 +21,12 @@ JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 
-$function   = $app->input->getCmd('function', 'jSelectAssociation');
-$listOrder  = $this->escape($this->state->get('list.ordering'));
-$listDirn   = $this->escape($this->state->get('list.direction'));
-$colSpan    = 4;
+$function         = $app->input->getCmd('function', 'jSelectAssociation');
+$listOrder        = $this->escape($this->state->get('list.ordering'));
+$listDirn         = $this->escape($this->state->get('list.direction'));
+$canManageCheckin = JFactory::getUser()->authorise('core.manage', 'com_checkin');
+$colSpan          = 4;
+
 $iconStates = array(
 	-2 => 'icon-trash',
 	0  => 'icon-unpublish',
@@ -102,6 +104,10 @@ $app->getDocument()->addScriptDeclaration(
 			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
+				$canCheckin = true;
+				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
+				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
+				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);
 				?>
 				<tr class="row<?php echo $i % 2; ?>">
 					<?php if (!empty($this->typeSupports['state'])) : ?>
@@ -113,7 +119,17 @@ $app->getDocument()->addScriptDeclaration(
 						<?php if (isset($item->level)) : ?>
 							<?php echo JLayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level)); ?>
 						<?php endif; ?>
-						<a class="select-link" href="javascript:void(0);" data-id="<?php echo $item->id; ?>"><?php echo $this->escape($item->title); ?></a>
+						<?php if (($canEdit && !$isCheckout) || ($canEdit && $canCheckin && $isCheckout)) : ?>
+							<a class="select-link" href="javascript:void(0);" data-id="<?php echo $item->id; ?>">
+							<?php echo $this->escape($item->title); ?></a>
+						<?php elseif ($canEdit && $isCheckout) : ?>
+							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'associations.'); ?>
+							<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
+							<?php echo $this->escape($item->title); ?></span>
+						<?php else : ?>
+							<span title="<?php echo JText::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>">
+							<?php echo $this->escape($item->title); ?></span>
+						<?php endif; ?>
 						<?php if (!empty($this->typeFields['alias'])) : ?>
 							<span class="small">
 								<?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>

--- a/administrator/components/com_associations/views/associations/tmpl/modal.php
+++ b/administrator/components/com_associations/views/associations/tmpl/modal.php
@@ -104,7 +104,6 @@ $app->getDocument()->addScriptDeclaration(
 			</tfoot>
 			<tbody>
 			<?php foreach ($this->items as $i => $item) :
-				$canCheckin = true;
 				$canEdit    = AssociationsHelper::allowEdit($this->extensionName, $this->typeName, $item->id);
 				$canCheckin = $canManageCheckin || AssociationsHelper::canCheckinItem($this->extensionName, $this->typeName, $item->id);
 				$isCheckout = AssociationsHelper::isCheckoutItem($this->extensionName, $this->typeName, $item->id);


### PR DESCRIPTION
### General Testing Instructions
Create a multilanguage site, associate some articles (here in French/English), leave some articles non associated.

### Test
Log with a Super User, edit an article for example in fr-FR and leave it in edit state (Here : "Newarticlefrench"). The article is now checked out.

Create a Manager with access to Multilingual associations and log with another browser.

Choose in the Multilingual associations list an Article tagged to English.
It is already associated here to "Article (fr-fr)"

![screen shot 2017-05-08 at 13 19 59](https://cloud.githubusercontent.com/assets/869724/25802131/3ecfcb2c-33f1-11e7-98d3-63cafae645c9.png)

Then click to open the side by side. Choose French as Target language. Then use the "Change Target" button.
The modal displays with all articles: 
Note that "Newarticlefrench" is NOT marked as checked-out and can be chosen by the Manager.

![screen shot 2017-05-08 at 08 34 30](https://cloud.githubusercontent.com/assets/869724/25793196/6d014000-33cb-11e7-9979-45b16252b0e8.png)

If selected, we get:
![screen shot 2017-05-08 at 08 51 22](https://cloud.githubusercontent.com/assets/869724/25793227/90127c1c-33cb-11e7-9fe4-07d420454a36.png)

### What this patch does
It lets choose in the modal the already associated article OR another one which is not checked out.

Patch, create another article and save it. Here "another article french", then do as above.
You will now get 

![screen shot 2017-05-08 at 12 37 45](https://cloud.githubusercontent.com/assets/869724/25802026/d2a228e6-33f0-11e7-8345-22601dc660ab.png)

"Article (fr-fr)" (the original associated article) can still be chosen, as well as the new article "another article french", but not anymore "Newarticlefrench".

@rdeutz  and all.

