### PR TITLE
[4.0] Fix installation app

### DIFF
--- a/installation/controller/default.php
+++ b/installation/controller/default.php
@@ -38,13 +38,13 @@ class InstallationControllerDefault extends JControllerBase
 			$defaultView = 'remove';
 		}
 
-		$vName   = $this->input->getWord('view', $defaultView);
+		$vName   = $this->getInput()->getWord('view', $defaultView);
 		$vFormat = $app->getDocument()->getType();
-		$lName   = $this->input->getWord('layout', 'default');
+		$lName   = $this->getInput()->getWord('layout', 'default');
 
 		if (strcmp($vName, $defaultView) == 0)
 		{
-			$this->input->set('view', $defaultView);
+			$this->getInput()->set('view', $defaultView);
 		}
 
 		switch ($vName)

--- a/installation/controller/install/languages.php
+++ b/installation/controller/install/languages.php
@@ -51,7 +51,7 @@ class InstallationControllerInstallLanguages extends JControllerBase
 		JSession::checkToken() or $app->sendJsonResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
 
 		// Get array of selected languages
-		$lids = $this->input->get('cid', [], 'array');
+		$lids = $this->getInput()->get('cid', [], 'array');
 		$lids = ArrayHelper::toInteger($lids, []);
 
 		if (!$lids)

--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -50,7 +50,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		$model = new InstallationModelLanguages;
 
 		// Check for request forgeries in the administrator language
-		$admin_lang = $this->input->getString('administratorlang', false);
+		$admin_lang = $this->getInput()->getString('administratorlang', false);
 
 		// Check that the string is an ISO Language Code avoiding any injection.
 		if (!preg_match('/^[a-z]{2}(\-[A-Z]{2})?$/', $admin_lang))
@@ -71,7 +71,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		}
 
 		// Check for request forgeries in the site language
-		$frontend_lang = $this->input->getString('frontendlang', false);
+		$frontend_lang = $this->getInput()->getString('frontendlang', false);
 
 		// Check that the string is an ISO Language Code avoiding any injection.
 		if (!preg_match('/^[a-z]{2}(\-[A-Z]{2})?$/', $frontend_lang))
@@ -92,7 +92,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		}
 
 		// Check if user has activated the multilingual site
-		$data = $this->input->post->get('jform', array(), 'array');
+		$data = $this->getInput()->post->get('jform', array(), 'array');
 
 		if ((int) $data['activateMultilanguage'])
 		{

--- a/installation/controller/setlanguage.php
+++ b/installation/controller/setlanguage.php
@@ -55,7 +55,7 @@ class InstallationControllerSetlanguage extends JControllerBase
 		$model = new InstallationModelSetup;
 
 		// Get the posted values from the request and validate them.
-		$data   = $this->input->post->get('jform', [], 'array');
+		$data   = $this->getInput()->post->get('jform', [], 'array');
 		$return = $model->validate($data, 'preinstall');
 
 		$r = new stdClass;
@@ -67,7 +67,7 @@ class InstallationControllerSetlanguage extends JControllerBase
 			 * The validate method enqueued all messages for us, so we just need to
 			 * redirect back to the site setup screen.
 			 */
-			$r->view = $this->input->getWord('view', 'site');
+			$r->view = $this->getInput()->getWord('view', 'site');
 			$app->sendJsonResponse($r);
 		}
 
@@ -78,7 +78,7 @@ class InstallationControllerSetlanguage extends JControllerBase
 		JFactory::$language = JLanguage::getInstance($return['language']);
 
 		// Redirect to the page.
-		$r->view = $this->input->getWord('view', 'site');
+		$r->view = $this->getInput()->getWord('view', 'site');
 		$app->sendJsonResponse($r);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
After https://github.com/joomla/joomla-cms/pull/14041 merged, installation app is broken. The reason is because $input and $app become private properties, so we need to use $this->getInput() instead of $this->input in controller classes.

### Testing Instructions
I tested the change myself. So @wilsonge can review and merge it to get installation works again.