### PR TITLE
Add the field `name` to the table` #__ fields_groups`

### DIFF
--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -710,6 +710,7 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
   `asset_id` int(10) unsigned NOT NULL DEFAULT 0,
   `context` varchar(255) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
+  `name` varchar(255) NOT NULL DEFAULT '',
   `note` varchar(255) NOT NULL DEFAULT '',
   `description` text NOT NULL,
   `state` tinyint(1) NOT NULL DEFAULT '0',


### PR DESCRIPTION
…h the table `#__ fields`

This is necessary for convenient access to groups of fields in extensions, especially this will be useful in multilingual sites.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

