### PR TITLE
Test suite `@covers` annotations

### DIFF
--- a/tests/unit/suites/administrator/includes/JAdministratorHelperTest.php
+++ b/tests/unit/suites/administrator/includes/JAdministratorHelperTest.php
@@ -53,6 +53,8 @@ class JAdministratorHelperTest extends TestCase
 
 	/**
 	 * Tests the findOption() method simulating a guest.
+	 *
+	 * @covers  JAdministratorHelper::findOption
 	 */
 	public function testFindOptionGuest()
 	{
@@ -77,6 +79,8 @@ class JAdministratorHelperTest extends TestCase
 
 	/**
 	 * Tests the findOption() method simulating a user without login admin permissions.
+	 *
+	 * @covers  JAdministratorHelper::findOption
 	 */
 	public function testFindOptionCanNotLoginAdmin()
 	{
@@ -103,6 +107,8 @@ class JAdministratorHelperTest extends TestCase
 
 	/**
 	 * Tests the findOption() method simulating a user who is able to log in to admin.
+	 *
+	 * @covers  JAdministratorHelper::findOption
 	 */
 	public function testFindOptionCanLoginAdmin()
 	{
@@ -129,6 +135,8 @@ class JAdministratorHelperTest extends TestCase
 
 	/**
 	 * Tests the findOption() method simulating the option at a special value.
+	 *
+	 * @covers  JAdministratorHelper::findOption
 	 */
 	public function testFindOptionCanLoginAdminOptionSet()
 	{

--- a/tests/unit/suites/finderIndexer/FinderIndexerHelperTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerHelperTest.php
@@ -39,6 +39,7 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexerHelper::parse
 	 */
 	public function testParse()
 	{
@@ -49,6 +50,14 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 		);
 	}
 
+	/**
+	 * Tests the stem method
+	 *
+	 * @return  void
+	 *
+	 * @since   3.0
+	 * @covers  FinderIndexerHelper::stem
+	 */
 	public function testStem()
 	{
 		$this->assertEquals(
@@ -63,6 +72,7 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerHelper::addContentType
 	 */
 	public function testAddContentType()
 	{
@@ -87,6 +97,7 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerHelper::isCommon
 	 */
 	public function testIsCommon()
 	{
@@ -107,6 +118,7 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexerHelper::getDefaultLanguage
 	 */
 	public function testGetDefaultLanguage()
 	{
@@ -123,6 +135,7 @@ class FinderIndexerHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexerHelper::getPrimaryLanguage
 	 */
 	public function testGetPrimaryLanguage()
 	{

--- a/tests/unit/suites/finderIndexer/FinderIndexerParserTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerParserTest.php
@@ -21,6 +21,7 @@ class FinderIndexerParserTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexerParser::getInstance
 	 */
 	public function testGetInstance()
 	{
@@ -38,6 +39,7 @@ class FinderIndexerParserTest extends \PHPUnit\Framework\TestCase
 	 *
 	 * @since   3.0
 	 *
+	 * @covers  FinderIndexerParser::getInstance
 	 * @expectedException  Exception
 	 */
 	public function testGetInstance_noParser()

--- a/tests/unit/suites/finderIndexer/FinderIndexerResultTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerResultTest.php
@@ -69,6 +69,8 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::__get
+	 * @covers  FinderIndexerResult::__set
 	 */
 	public function test__getAndSet()
 	{
@@ -86,6 +88,7 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::__get
 	 */
 	public function test__getNull()
 	{
@@ -101,6 +104,8 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::__isset
+	 * @covers  FinderIndexerResult::__unset
 	 */
 	public function testMagicSetters()
 	{
@@ -126,6 +131,7 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::getElement
 	 */
 	public function testGetElementNull()
 	{
@@ -141,6 +147,8 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::getElement
+	 * @covers  FinderIndexerResult::setElement
 	 */
 	public function testGetAndSetElement()
 	{
@@ -158,6 +166,9 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::addInstruction
+	 * @covers  FinderIndexerResult::getInstructions
+	 * @covers  FinderIndexerResult::removeInstruction
 	 */
 	public function testManipulateInstructions()
 	{
@@ -192,6 +203,7 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::getTaxonomy
 	 */
 	public function testGetTaxonomy()
 	{
@@ -207,6 +219,7 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::addTaxonomy
 	 */
 	public function testTaxonomy()
 	{
@@ -229,6 +242,7 @@ class FinderIndexerResultTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerResult::setLanguage
 	 */
 	public function testSetLanguage()
 	{

--- a/tests/unit/suites/finderIndexer/FinderIndexerStemmerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerStemmerTest.php
@@ -21,6 +21,7 @@ class FinderIndexerStemmerTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexerStemmer::getInstance
 	 */
 	public function testGetInstance()
 	{
@@ -38,6 +39,7 @@ class FinderIndexerStemmerTest extends \PHPUnit\Framework\TestCase
 	 *
 	 * @since   3.0
 	 *
+	 * @covers  FinderIndexerStemmer::getInstance
 	 * @expectedException  Exception
 	 */
 	public function testGetInstance_noParser()

--- a/tests/unit/suites/finderIndexer/FinderIndexerTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTest.php
@@ -76,6 +76,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::getInstance
 	 */
 	public function testGetInstance()
 	{
@@ -91,6 +92,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::getInstance
 	 */
 	public function testGetInstanceSqlazure()
 	{
@@ -108,6 +110,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::getInstance
 	 * @expectedException  RuntimeException
 	 */
 	public function testGetInstanceException()
@@ -123,6 +126,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::getState
 	 */
 	public function testGetState()
 	{
@@ -138,6 +142,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::setState
 	 */
 	public function testSetState()
 	{
@@ -166,6 +171,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::setState
 	 */
 	public function testSetStateBadData()
 	{
@@ -186,6 +192,7 @@ class FinderIndexerTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.0
+	 * @covers  FinderIndexer::resetState
 	 */
 	public function testResetState()
 	{

--- a/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
+++ b/tests/unit/suites/finderIndexer/FinderIndexerTokenTest.php
@@ -60,6 +60,7 @@ class FinderIndexerTokenTest extends TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerToken::__construct
 	 */
 	public function test__construct()
 	{

--- a/tests/unit/suites/finderIndexer/parser/FinderIndexerParserHtmlTest.php
+++ b/tests/unit/suites/finderIndexer/parser/FinderIndexerParserHtmlTest.php
@@ -45,6 +45,8 @@ class FinderIndexerParserHtmlTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Method to test the parse and process methods.
+	 *
+	 * @covers  FinderIndexerParserHtml::parse
 	 */
 	public function testParse()
 	{
@@ -60,6 +62,8 @@ class FinderIndexerParserHtmlTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Test with parsing more complex HTML.
+	 *
+	 * @covers  FinderIndexerParserHtml::parse
 	 */
 	public function testParseComplex()
 	{
@@ -100,6 +104,8 @@ class FinderIndexerParserHtmlTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Tests the removal of unwanted HTML blocks.
+	 *
+	 * @covers  FinderIndexerParserHtml::parse
 	 */
 	public function testRemoveBlocks()
 	{
@@ -146,6 +152,8 @@ class FinderIndexerParserHtmlTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Tests the parsing of HTML tags spanning the 2Kbyte boundary.
+	 *
+	 * @covers  FinderIndexerParserHtml::parse
 	 */
 	public function testBlockBoundary()
 	{

--- a/tests/unit/suites/finderIndexer/parser/FinderIndexerParserRtfTest.php
+++ b/tests/unit/suites/finderIndexer/parser/FinderIndexerParserRtfTest.php
@@ -45,6 +45,8 @@ class FinderIndexerParserRtfTest extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * Method to test the parse and process methods.
+	 *
+	 * @covers  FinderIndexerParserRtf::parse
 	 */
 	public function testParse()
 	{

--- a/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerFrTest.php
+++ b/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerFrTest.php
@@ -48,6 +48,7 @@ class FinderIndexerStemmerFrTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerFr::stem
 	 */
 	public function testStem()
 	{
@@ -63,6 +64,7 @@ class FinderIndexerStemmerFrTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerFr::stem
 	 */
 	public function testStemShort()
 	{
@@ -78,6 +80,7 @@ class FinderIndexerStemmerFrTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerFr::stem
 	 */
 	public function testStemWrongLanguage()
 	{

--- a/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerPorter_EnTest.php
+++ b/tests/unit/suites/finderIndexer/stemmer/FinderIndexerStemmerPorter_EnTest.php
@@ -49,6 +49,7 @@ class FinderIndexerStemmerPorter_EnTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerPorter_En::stem
 	 */
 	public function testStem()
 	{
@@ -107,6 +108,7 @@ class FinderIndexerStemmerPorter_EnTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerPorter_En::stem
 	 */
 	public function testStemShort()
 	{
@@ -122,6 +124,7 @@ class FinderIndexerStemmerPorter_EnTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @since   3.1
+	 * @covers  FinderIndexerStemmerPorter_En::stem
 	 */
 	public function testStemWrongLanguage()
 	{

--- a/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationAdministratorTest.php
@@ -158,6 +158,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getClientId
 	 */
 	public function testGetClientId()
 	{
@@ -170,6 +171,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getName
 	 */
 	public function testGetName()
 	{
@@ -182,6 +184,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getMenu
 	 */
 	public function testGetMenu()
 	{
@@ -194,6 +197,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getPathway
 	 */
 	public function testGetPathway()
 	{
@@ -206,6 +210,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getRouter
 	 */
 	public function testGetRouter()
 	{
@@ -218,6 +223,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::getTemplate
 	 */
 	public function testGetTemplate()
 	{
@@ -236,6 +242,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::isAdmin
 	 */
 	public function testIsAdmin()
 	{
@@ -248,6 +255,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::isSite
 	 */
 	public function testIsSite()
 	{
@@ -259,7 +267,8 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since  3.7.0
+	 * @since   3.7.0
+	 * @covers  JApplicationAdministrator::isClient
 	 */
 	public function testIsClient()
 	{
@@ -273,6 +282,7 @@ class JApplicationAdministratorTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationAdministrator::render
 	 */
 	public function testRender()
 	{

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -159,6 +159,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::__construct
 	 */
 	public function test__construct()
 	{
@@ -175,6 +176,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::__construct
 	 */
 	public function test__constructDependancyInjection()
 	{
@@ -209,6 +211,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::execute
 	 */
 	public function testExecuteWithoutDocument()
 	{
@@ -230,6 +233,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::execute
 	 */
 	public function testExecuteWithDocument()
 	{
@@ -267,6 +271,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.7.0
+	 * @covers  JApplicationCms::get
 	 */
 	public function testGet()
 	{
@@ -284,6 +289,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getCfg
 	 */
 	public function testGetCfg()
 	{
@@ -301,6 +307,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getInstance
 	 */
 	public function testGetInstance()
 	{
@@ -319,6 +326,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getMenu
 	 */
 	public function testGetMenu()
 	{
@@ -331,6 +339,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getPathway
 	 */
 	public function testGetPathway()
 	{
@@ -343,6 +352,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getRouter
 	 */
 	public function testGetRouter()
 	{
@@ -355,6 +365,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::getTemplate
 	 */
 	public function testGetTemplate()
 	{
@@ -371,6 +382,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::isAdmin
 	 */
 	public function testIsAdmin()
 	{
@@ -383,6 +395,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::isSite
 	 */
 	public function testIsSite()
 	{
@@ -394,7 +407,8 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since  3.7.0
+	 * @since   3.7.0
+	 * @covers  JApplicationCms::isClient
 	 */
 	public function testIsClient()
 	{
@@ -408,6 +422,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirect()
 	{
@@ -467,6 +482,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectLegacy()
 	{
@@ -536,6 +552,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectLegacyWithEmptyMessageAndEmptyStatus()
 	{
@@ -601,6 +618,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectWithHeadersSent()
 	{
@@ -631,6 +649,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectWithJavascriptRedirect()
 	{
@@ -664,6 +683,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectWithMoved()
 	{
@@ -722,6 +742,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 *
 	 * @dataProvider  getRedirectData
 	 * @since   3.2
+	 * @covers  JApplicationCms::redirect
 	 */
 	public function testRedirectWithUrl($url, $base, $request, $expected)
 	{
@@ -752,6 +773,7 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationCms::render
 	 */
 	public function testRender()
 	{

--- a/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationSiteTest.php
@@ -158,6 +158,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getClientId
 	 */
 	public function testGetClientId()
 	{
@@ -170,6 +171,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getName
 	 */
 	public function testGetName()
 	{
@@ -182,6 +184,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getMenu
 	 */
 	public function testGetMenu()
 	{
@@ -194,6 +197,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getParams
 	 */
 	public function testGetParams()
 	{
@@ -214,6 +218,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getPathway
 	 */
 	public function testGetPathway()
 	{
@@ -226,6 +231,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getRouter
 	 */
 	public function testGetRouter()
 	{
@@ -238,6 +244,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getTemplate
 	 */
 	public function testGetTemplate()
 	{
@@ -254,6 +261,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::isAdmin
 	 */
 	public function testIsAdmin()
 	{
@@ -266,6 +274,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::isSite
 	 */
 	public function testIsSite()
 	{
@@ -277,7 +286,8 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 *
 	 * @return  void
 	 *
-	 * @since  3.7.0
+	 * @since   3.7.0
+	 * @covers  JApplicationSite::isClient
 	 */
 	public function testIsClient()
 	{
@@ -291,6 +301,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::render
 	 */
 	public function testRender()
 	{
@@ -314,6 +325,8 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getDetectBrowser
+	 * @covers  JApplicationSite::setDetectBrowser
 	 */
 	public function testSetGetDetectBrowser()
 	{
@@ -328,6 +341,8 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::getLanguageFilter
+	 * @covers  JApplicationSite::setLanguageFilter
 	 */
 	public function testSetGetLanguageFilter()
 	{
@@ -342,6 +357,7 @@ class JApplicationSiteTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JApplicationSite::setTemplate
 	 */
 	public function testSetTemplate()
 	{

--- a/tests/unit/suites/libraries/cms/helper/JHelperContentTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperContentTest.php
@@ -90,6 +90,7 @@ class JHelperContentTest extends TestCaseDatabase
 	 *
 	 * @since   3.2
 	 * @dataProvider  languageIdProvider
+	 * @covers  JHelperContent::getLanguageId
 	 */
 	public function testGetLanguageId($languageName, $expected)
 	{
@@ -97,12 +98,13 @@ class JHelperContentTest extends TestCaseDatabase
 		$this->assertEquals($languageId, $expected);
 	}
 
-	/*
-	 *  Tests the getRowData() method
+	/**
+	 * Tests the getRowData() method
 	 *
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JHelperContent::getRowData
 	 */
 	public function testGetRowData()
 	{

--- a/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperMediaTest.php
@@ -102,6 +102,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 *
 	 * @dataProvider  isImageProvider
 	 * @since         3.2
+	 * @covers        JHelperMedia::isImage
 	 */
 	public function testIsImage($fileName, $expected)
 	{
@@ -115,6 +116,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JHelperMedia::getTypeIcon
 	 */
 	public function testGetTypeIcon()
 	{
@@ -128,6 +130,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JHelperMedia::countFiles
 	 */
 	public function testCountFiles()
 	{
@@ -169,6 +172,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 *
 	 * @dataProvider  canUploadProvider
 	 * @since         3.2
+	 * @covers        JHelperMedia::canUpload
 	 */
 	public function testCanUpload($file, $expected)
 	{
@@ -205,6 +209,7 @@ class JHelperMediaTest extends TestCaseDatabase
 	 *
 	 * @dataProvider  imageResizeProvider
 	 * @since         3.2
+	 * @covers        JHelperMedia::imageResize
 	 */
 	public function testImageResize($width, $height, $target, $expected)
 	{

--- a/tests/unit/suites/libraries/cms/helper/JHelperTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperTest.php
@@ -90,6 +90,7 @@ class JHelperTest extends TestCaseDatabase
 	 *
 	 * @since   3.2
 	 * @dataProvider  languageIdProvider
+	 * @covers  JHelper::getLanguageId
 	 */
 	public function testGetLanguageId($languageName, $expected)
 	{
@@ -103,6 +104,7 @@ class JHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JHelper::getRowData
 	 */
 	public function testGetRowData()
 	{
@@ -123,6 +125,7 @@ class JHelperTest extends TestCaseDatabase
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @covers  JHelper::getDataObject
 	 */
 	public function testDataObject()
 	{


### PR DESCRIPTION
Partial Pull Request for Issue #15741

### Summary of Changes

Starts adding `@covers` annotations to the test suite

### Testing Instructions

Review and ensure annotations accurately reflect the main method(s) the test is supposed to cover.