### PR TITLE
[com_fields] Support to include component specific form files

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -920,6 +920,7 @@ class FieldsModelField extends JModelAdmin
 	protected function preprocessForm(JForm $form, $data, $group = 'content')
 	{
 		$component  = $this->state->get('field.component');
+		$section    = $this->state->get('field.section');
 		$dataObject = $data;
 
 		if (is_array($dataObject))
@@ -966,6 +967,21 @@ class FieldsModelField extends JModelAdmin
 		$form->setFieldAttribute('type', 'component', $component);
 		$form->setFieldAttribute('group_id', 'context', $this->state->get('field.context'));
 		$form->setFieldAttribute('rules', 'component', $component);
+
+		// Looking first in the component models/forms folder
+		$path = JPath::clean(JPATH_ADMINISTRATOR . '/components/' . $component . '/models/forms/fields/' . $section . '.xml');
+
+		if (file_exists($path))
+		{
+			$lang = JFactory::getLanguage();
+			$lang->load($component, JPATH_BASE, null, false, true);
+			$lang->load($component, JPATH_BASE . '/components/' . $component, null, false, true);
+
+			if (!$form->loadFile($path, false))
+			{
+				throw new Exception(JText::_('JERROR_LOADFILE_FAILED'));
+			}
+		}
 
 		// Trigger the default form events.
 		parent::preprocessForm($form, $data, $group);

--- a/administrator/components/com_users/models/forms/fields/user.xml
+++ b/administrator/components/com_users/models/forms/fields/user.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
+		<fieldset name="basic">
+			<field
+				name="display"
+				type="hidden"
+			    default="2"
+			/>
+		</fieldset>
+	</fields>
+</form>


### PR DESCRIPTION
### Summary of Changes
Com_categories has a nice little feature which allows the component developer to place a form file on `/administrator/components/com_foo/models/forms/category.xml` which get loaded when editing a category.
This pr introduces the same functionality for com_fields. If a file is found on the location `/administrator/components/com_foo/models/forms/fields/bar.xml` then this file get loaded when the entity com_foo.bar is edited.

Additionally an overwrite is added which hides the "Automatic Display" field for com_users as it is not relevant for that component.

It should fix #14377 and #15244.

### Testing Instructions
Create a new User custom field.

### Expected result
The "Automatic Display" field in options is not displayed.

### Actual result
The "Automatic Display" field in options is displayed.

### Documentation Changes Required
Would be nice to have that feature documented.
