### PR TITLE
Register JToolBar correctly

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -147,6 +147,7 @@ JLoader::registerAlias('JUcmContent',                       '\\Joomla\\CMS\\Ucm\
 JLoader::registerAlias('JUcmType',                          '\\Joomla\\CMS\\Ucm\\UcmType', '4.0');
 
 JLoader::registerAlias('JToolbar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
+JLoader::registerAlias('JToolBar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
 JLoader::registerAlias('JToolbarButton',                    '\\Joomla\\CMS\\Toolbar\\ToolbarButton', '4.0');
 JLoader::registerAlias('JToolbarButtonConfirm',             '\\Joomla\\CMS\\Toolbar\\Button\\ConfirmButton', '4.0');
 JLoader::registerAlias('JToolbarButtonCustom',              '\\Joomla\\CMS\\Toolbar\\Button\\CustomButton', '4.0');

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -72,8 +72,6 @@ JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');
 
 // Register classes where the names have been changed to fit the autoloader rules
 // @deprecated  4.0
-JLoader::register('JToolBar', JPATH_PLATFORM . '/cms/toolbar/toolbar.php');
-JLoader::register('JButton',  JPATH_PLATFORM . '/cms/toolbar/button.php');
 JLoader::register('JInstallerComponent',  JPATH_PLATFORM . '/cms/installer/adapter/component.php');
 JLoader::register('JInstallerFile',  JPATH_PLATFORM . '/cms/installer/adapter/file.php');
 JLoader::register('JInstallerLanguage',  JPATH_PLATFORM . '/cms/installer/adapter/language.php');


### PR DESCRIPTION
`JToolbar` is also available as `JToolBar`. This pr creates the alias correctly.

Actually the back end of 3.8 throws a class _JToolBar not found error_.

Can be merged on review @wilsonge.