### PR TITLE
Set minimum width of td fields for calendar field

### DIFF
--- a/media/system/css/fields/calendar.css
+++ b/media/system/css/fields/calendar.css
@@ -75,6 +75,7 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 	border: 0;
 	cursor : pointer;
 	font-size: 12px;
+	min-width: 38px;
 }
 
 .calendar-container table tbody td.day.wn {
@@ -91,7 +92,6 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 .calendar-container table tbody td.today {
 	position: relative;
 	height: 100%;
-	width: 100%;
 	font-weight: bold;
 }
 .calendar-container table tbody td.today:after {


### PR DESCRIPTION
### Summary of Changes

In some cases lack of set width for td element and 100% width for td with 'today' class breaks the table.

Set minimum width of td fields to 38px and removed 100% from td with 'today' class.

### Testing Instructions

You can see the problem for example on Aura template from Themeforest (https://themeforest.net/item/aura-responsive-multipurpose-joomla-template/11509513), here is a screenshot from that: http://imgur.com/WOSz6FP

### Expected result

All td elements in table should have the same width.

### Actual result

Before the fix the td element with 'today' class tried to take as much space as possible, see here: http://imgur.com/a/T6Jgf

