### PR TITLE
[4.0] Add support for input addon

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -74,8 +74,8 @@ $attributes = array(
 	!empty($validationtext) ? 'data-validation-text="' . $validationtext . '"' : '',
 );
 
-$addonBeforeHtml = '<span class="input-group-addon">' .$addonBefore . '</span>';
-$addonAfterHtml  = '<span class="input-group-addon">' .$addonAfter . '</span>';
+$addonBeforeHtml = '<span class="input-group-addon">' . $addonBefore . '</span>';
+$addonAfterHtml  = '<span class="input-group-addon">' . $addonAfter . '</span>';
 ?>
 
 <?php if (!empty($addonBefore) || !empty($addonAfter)) : ?>

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -74,11 +74,26 @@ $attributes = array(
 	!empty($validationtext) ? 'data-validation-text="' . $validationtext . '"' : '',
 );
 ?>
-<input type="text" name="<?php
-echo $name; ?>" id="<?php
-echo $id; ?>" <?php
-echo $dirname; ?> value="<?php
-echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo implode(' ', $attributes); ?>>
+
+
+
+<?php if (!empty($addon)) : ?>
+	<div class="input-group">
+<?php endif; ?>
+
+<input
+	type="text"
+	name="<?php echo $name; ?>"
+	id="<?php echo $id; ?>"
+	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+	<?php echo $dirname; ?>
+	<?php echo implode(' ', $attributes); ?>>
+
+<?php if (!empty($addon)) : ?>
+	<span class="input-group-addon"><?php echo $addon; ?></span>
+	</div>
+<?php endif; ?>
+
 <?php if ($options) : ?>
 	<datalist id="<?php echo $id; ?>_datalist">
 		<?php foreach ($options as $option) : ?>

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -75,23 +75,19 @@ $attributes = array(
 );
 ?>
 
-
-
 <?php if (!empty($addon)) : ?>
-	<div class="input-group">
+<div class="input-group">
 <?php endif; ?>
-
-<input
-	type="text"
-	name="<?php echo $name; ?>"
-	id="<?php echo $id; ?>"
-	value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
-	<?php echo $dirname; ?>
-	<?php echo implode(' ', $attributes); ?>>
-
+	<input
+		type="text"
+		name="<?php echo $name; ?>"
+		id="<?php echo $id; ?>"
+		value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+		<?php echo $dirname; ?>
+		<?php echo implode(' ', $attributes); ?>>
 <?php if (!empty($addon)) : ?>
 	<span class="input-group-addon"><?php echo $addon; ?></span>
-	</div>
+</div>
 <?php endif; ?>
 
 <?php if ($options) : ?>

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -73,11 +73,19 @@ $attributes = array(
 	// @TODO add a proper string here!!!
 	!empty($validationtext) ? 'data-validation-text="' . $validationtext . '"' : '',
 );
+
+$addonBeforeHtml = '<span class="input-group-addon">' .$addonBefore . '</span>';
+$addonAfterHtml  = '<span class="input-group-addon">' .$addonAfter . '</span>';
 ?>
 
-<?php if (!empty($addon)) : ?>
+<?php if (!empty($addonBefore) || !empty($addonAfter)) : ?>
 <div class="input-group">
 <?php endif; ?>
+
+	<?php if (!empty($addonBefore)) : ?>
+		<?php echo $addonBeforeHtml; ?>
+	<?php endif; ?>
+
 	<input
 		type="text"
 		name="<?php echo $name; ?>"
@@ -85,8 +93,12 @@ $attributes = array(
 		value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
 		<?php echo $dirname; ?>
 		<?php echo implode(' ', $attributes); ?>>
-<?php if (!empty($addon)) : ?>
-	<span class="input-group-addon"><?php echo $addon; ?></span>
+
+	<?php if (!empty($addonAfter)) : ?>
+		<?php echo $addonAfterHtml; ?>
+	<?php endif; ?>
+
+<?php if (!empty($addonBefore) || !empty($addonAfter)) : ?>
 </div>
 <?php endif; ?>
 

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -51,12 +51,20 @@ class JFormFieldText extends JFormField
 	protected $dirname;
 
 	/**
-	 * Input addon
+	 * Input addon before
 	 *
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $addon;
+	protected $addonBefore;
+
+	/**
+	 * Input addon after
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $addonAfter;
 
 	/**
 	 * Name of the layout being used to render the field
@@ -81,7 +89,8 @@ class JFormFieldText extends JFormField
 		{
 			case 'maxLength':
 			case 'dirname':
-			case 'addon':
+			case 'addonBefore':
+			case 'addonAfter':
 			case 'inputmode':
 				return $this->$name;
 		}
@@ -116,8 +125,12 @@ class JFormFieldText extends JFormField
 				$this->inputmode = (string) $value;
 				break;
 
-			case 'addon':
-				$this->addon = (string) $value;
+			case 'addonBefore':
+				$this->addonBefore = (string) $value;
+				break;
+
+			case 'addonAfter':
+				$this->addonAfter = (string) $value;
 				break;
 
 			default:
@@ -170,7 +183,8 @@ class JFormFieldText extends JFormField
 
 			$this->maxLength = (int) $this->element['maxlength'];
 
-			$this->addon = (string) $this->element['addon'];
+			$this->addonBefore = (string) $this->element['addonBefore'];
+			$this->addonAfter  = (string) $this->element['addonAfter'];
 		}
 
 		return $result;
@@ -286,12 +300,13 @@ class JFormFieldText extends JFormField
 		$options  = (array) $this->getSuggestions();
 
 		$extraData = array(
-			'maxLength' => $maxLength,
-			'pattern'   => $this->pattern,
-			'inputmode' => $inputmode,
-			'dirname'   => $dirname,
-			'addon'     => $this->addon,
-			'options'   => $options,
+			'maxLength'   => $maxLength,
+			'pattern'     => $this->pattern,
+			'inputmode'   => $inputmode,
+			'dirname'     => $dirname,
+			'addonBefore' => $this->addonBefore,
+			'addonAfter'  => $this->addonAfter,
+			'options'     => $options,
 		);
 
 		return array_merge($data, $extraData);

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -51,6 +51,14 @@ class JFormFieldText extends JFormField
 	protected $dirname;
 
 	/**
+	 * Input addon
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $addon;
+
+	/**
 	 * Name of the layout being used to render the field
 	 *
 	 * @var    string
@@ -73,6 +81,7 @@ class JFormFieldText extends JFormField
 		{
 			case 'maxLength':
 			case 'dirname':
+			case 'addon':
 			case 'inputmode':
 				return $this->$name;
 		}
@@ -105,6 +114,10 @@ class JFormFieldText extends JFormField
 
 			case 'inputmode':
 				$this->inputmode = (string) $value;
+				break;
+
+			case 'addon':
+				$this->addon = (string) $value;
 				break;
 
 			default:
@@ -156,6 +169,8 @@ class JFormFieldText extends JFormField
 			$this->dirname = $dirname ? $this->getName($this->fieldname . '_dir') : false;
 
 			$this->maxLength = (int) $this->element['maxlength'];
+
+			$this->addon = (string) $this->element['addon'];
 		}
 
 		return $result;
@@ -275,6 +290,7 @@ class JFormFieldText extends JFormField
 			'pattern'   => $this->pattern,
 			'inputmode' => $inputmode,
 			'dirname'   => $dirname,
+			'addon'     => $this->addon,
 			'options'   => $options,
 		);
 

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -283,12 +283,14 @@
 
 				<field
 					name="fontSize"
-					type="text"
+					type="integer"
 					label="PLG_CODEMIRROR_FIELD_FONT_SIZE_LABEL"
 					description="PLG_CODEMIRROR_FIELD_FONT_SIZE_DESC"
+					first="6"
+					last="16"
+					step="1"
 					default="13"
 					filter="intval"
-					addon="px"
 				/>
 
 				<field

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -283,14 +283,12 @@
 
 				<field
 					name="fontSize"
-					type="integer"
+					type="text"
 					label="PLG_CODEMIRROR_FIELD_FONT_SIZE_LABEL"
 					description="PLG_CODEMIRROR_FIELD_FONT_SIZE_DESC"
-					first="6"
-					last="16"
-					step="1"
 					default="13"
 					filter="intval"
+					addon="px"
 				/>
 
 				<field


### PR DESCRIPTION
### Summary of Changes

In Bootstrap, you have [input addons](http://v4-alpha.getbootstrap.com/components/input-group) and currently in Joomla, if you want to achieve this, you need to create an custom form field.

Other than that, I see a low of extension devs definiing these sort of things in the language string.

### Testing Instructions

Add the following code to an XML file for an extension:

You can use `addonBefore` or `addonAfter` or both. Take your pick.

```
<field
	name="foo"
	type="text"
	label="Font Size"
	default="13"
        addonBefore="foo"
	addonAfter="px"
/>
```

### Expected result

![screeny](https://cloud.githubusercontent.com/assets/2019801/25900134/4bd479cc-358a-11e7-9763-926175f1257a.png)


### Documentation Changes Required

`addonBefore` and `addonAfter` attributes will need adding to: https://docs.joomla.org/Text_form_field_type


