### PR TITLE
Additional sorting fixes

### DIFF
--- a/administrator/modules/mod_latest/helper.php
+++ b/administrator/modules/mod_latest/helper.php
@@ -40,13 +40,13 @@ abstract class ModLatestHelper
 		switch ($params->get('ordering'))
 		{
 			case 'm_dsc':
-				$model->setState('list.fullordering', 'modified DESC, created');
+				$model->setState('list.ordering', 'modified DESC, created');
 				$model->setState('list.direction', 'DESC');
 				break;
 
 			case 'c_dsc':
 			default:
-				$model->setState('list.fullordering', 'created DESC');
+				$model->setState('list.ordering', 'created');
 				$model->setState('list.direction', 'DESC');
 				break;
 		}

--- a/administrator/modules/mod_popular/helper.php
+++ b/administrator/modules/mod_popular/helper.php
@@ -37,7 +37,7 @@ abstract class ModPopularHelper
 				' a.created, a.hits');
 
 		// Set Ordering filter
-		$model->setState('list.fullordering', 'a.hits DESC');
+		$model->setState('list.ordering', 'a.hits');
 		$model->setState('list.direction', 'DESC');
 
 		// Set Category Filter


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
After merging of #15655 the popular article module in cpanel is broken.
I assume that both mod_latest and mod_popular needs to be reverted back from list.fullordering.


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

