### PR TITLE
Remove typo spaces in a generated url in com_associations

### DIFF
--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -134,7 +134,7 @@ class AssociationsViewAssociation extends JViewLegacy
 			$this->targetId         = $matches[1];
 			$this->targetLanguage   = $matches[0];
 			$task                   = $typeName . '.' . $this->targetAction;
-			$this->defaultTargetSrc = JRoute::_($this->editUri . '&task= ' . $task . ' &id=' . (int) $this->targetId);
+			$this->defaultTargetSrc = JRoute::_($this->editUri . '&task=' . $task . '&id=' . (int) $this->targetId);
 			$this->form->setValue('itemlanguage', '', $this->targetLanguage . ':' . $this->targetId . ':' . $this->targetAction);
 		}
 


### PR DESCRIPTION
@infograf768 

### Summary of Changes

before path there were spaces in the url - encoded to %20 - Joomla discards those, but still untidy
`
string(142) "/administrator/index.php?option=com_content&view=article&extension=com_content&tmpl=component&task=%20article.edit%20&id=2"`

After PR the url is 

`"/administrator/index.php?option=com_content&view=article&extension=com_content&tmpl=component&task=article.edit&id=2"`

Found while debugging #15945
