### PR TITLE
[4.0] Allow the info URL to be empty

### DIFF
--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -48,6 +48,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				$this->currentUpdate->detailsurl = $this->_url;
 				$this->currentUpdate->folder = '';
 				$this->currentUpdate->client_id = 1;
+				$this->currentUpdate->infourl = '';
 				break;
 
 			// Don't do anything


### PR DESCRIPTION
### Summary of Changes

This change allows the info URL to be optional in 4.0 as it is declared as not NULL and 4.0 now uses the strict mode.

### Testing Instructions

- install 4.0
- install a the following component (developed by @NunoLopes96)
[component_joomla-master.zip](https://github.com/joomla/joomla-cms/files/990808/component_joomla-master.zip)
- it is pointing as update server to `https://www.jah-tz.de/downloads/core/lists.xml`
- as you can see you installed version 0.0.1 and my update server have 4.0.0
- currently you don't get a update
- apply this patch
- the update is shown

### Expected result

Even without infourl parameter the update should work (as it is a optional one)

### Actual result

The update is not showen without the infourl in the update XML this fixes it.

### Documentation Changes Required

None.