### PR TITLE
Hide display parameter for mail context

### DIFF
--- a/administrator/components/com_contact/models/forms/fields/mail.xml
+++ b/administrator/components/com_contact/models/forms/fields/mail.xml
@@ -5,7 +5,7 @@
 			<field
 				name="display"
 				type="hidden"
-			    default="2"
+				default="2"
 			/>
 		</fieldset>
 	</fields>

--- a/administrator/components/com_contact/models/forms/fields/mail.xml
+++ b/administrator/components/com_contact/models/forms/fields/mail.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
+		<fieldset name="basic">
+			<field
+				name="display"
+				type="hidden"
+			    default="2"
+			/>
+		</fieldset>
+	</fields>
+</form>


### PR DESCRIPTION
### Summary of Changes
Hides the display parameter for Contact -> Mail custom fields.

See more details in #15915.

### Testing Instructions
Create a new Contact -> Mail custom field.

### Expected result
The "Automatic Display" field in options is not displayed.

### Actual result
The "Automatic Display" field in options is displayed.