### PR TITLE
Correcting contact's articles order

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -294,7 +294,8 @@ class ContactModelContact extends JModelForm
 				->select('a.access')
 				->select('a.catid')
 				->select('a.created')
-				->select('a.language');
+				->select('a.language')
+				->select('a.publish_up');
 
 			// SQL Server changes
 			$case_when = ' CASE WHEN ';
@@ -316,7 +317,7 @@ class ContactModelContact extends JModelForm
 				->join('LEFT', '#__categories as c on a.catid=c.id')
 				->where('a.created_by = ' . (int) $contact->user_id)
 				->where('a.access IN (' . $groups . ')')
-				->order('a.state DESC, a.created DESC');
+				->order('a.publish_up DESC');
 
 			// Filter per language if plugin published
 			if (JLanguageMultilang::isEnabled())
@@ -476,7 +477,8 @@ class ContactModelContact extends JModelForm
 						->select('a.access')
 						->select('a.catid')
 						->select('a.created')
-						->select('a.language');
+						->select('a.language')
+						->select('a.publish_up');
 
 					// SQL Server changes
 					$case_when = ' CASE WHEN ';
@@ -498,7 +500,7 @@ class ContactModelContact extends JModelForm
 						->join('LEFT', '#__categories as c on a.catid=c.id')
 						->where('a.created_by = ' . (int) $result->user_id)
 						->where('a.access IN (' . $groups . ')')
-						->order('a.state DESC, a.created DESC');
+						->order('a.publish_up DESC');
 
 					// Filter per language if plugin published
 					if (JLanguageMultilang::isEnabled())


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15856

### Testing Instructions
Create a contact for a user who is the author of some articles, make sure to set different Publishing dates for these articles and archive one of them.
Display the contact for that user in frontend. Make sure Articles are set to display.

### Actual result

When displaying a contact's articles, they are displayed by Archived descendant first and then by Created date descendant.

We have 
`->order('a.state DESC, a.created DESC');`
and
`$query->where('a.state IN (1,2)')` (2 is for the Archived)

This makes no sense (or should be the choice of the user, see further)

### Expected result
After patching, they will be displayed by publishing date descendant.
Archives are also displayed in that order, therefore would be mixed among other articles.
This solves https://github.com/joomla/joomla-cms/issues/15856

@AlexRed 

### Note: this patch could be largely improved
We may create new params to choose the way these articles are displayed: 
Recently Created, Recently Published, Recently Modified (as in mod_articles_latest), and include or not Archives and Archives first/last.

I can modify this PR to include these new params. If we do, as langs are frozen for 3.7.1, it would be for a future version.

Please test patch and feedback wanted! 😄 




