### PR TITLE
Fixing JFilterInput adding byte offsets to character offset

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -1097,10 +1097,11 @@ class JFilterInput extends InputFilter
 			$pregMatch = ($quote == '"') ? '#(\"\s*/\s*>|\"\s*>|\"\s+|\"$)#' : "#(\'\s*/\s*>|\'\s*>|\'\s+|\'$)#";
 
 			// Get the portion after attribute value
-			if (preg_match($pregMatch, StringHelper::substr($remainder, $nextBefore), $matches, PREG_OFFSET_CAPTURE))
+			$attributeValueRemainder = StringHelper::substr($remainder, $nextBefore);
+			if (preg_match($pregMatch, $attributeValueRemainder, $matches, PREG_OFFSET_CAPTURE))
 			{
 				// We have a closing quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
-				$stringBeforeQuote = substr($remainder, 0, $matches[0][1]);
+				$stringBeforeQuote = substr($attributeValueToEnd, 0, $matches[0][1]);
 				$closeQuoteChars = StringHelper::strlen($stringBeforeQuote);
 				$nextAfter = $nextBefore + $matches[0][1];
 			}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -1082,12 +1082,12 @@ class JFilterInput extends InputFilter
 		 */
 		while (preg_match('#<[^>]*?=\s*?(\"|\')#s', $remainder, $matches, PREG_OFFSET_CAPTURE))
 		{
-			// We have found an opening quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
-			$stringBeforeQuote = substr($remainder, 0, $matches[1][1]);
-			$quotePosition = StringHelper::strlen($stringBeforeQuote);
+			// We have found a tag with an attribute, convert its byte position to a UTF-8 string length, using non-multibyte substr()
+			$stringBeforeTag = substr($remainder, 0, $matches[0][1]);
+			$tagPosition = StringHelper::strlen($stringBeforeTag);
 
-			// Get the portion before the attribute value
-			$nextBefore = $quotePosition + StringHelper::strlen($matches[0][0]);
+			// Get the character length before the attribute value
+			$nextBefore = $tagPosition + StringHelper::strlen($matches[0][0]);
 
 			/*
 			 * Figure out if we have a single or double quote and look for the matching closing quote

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -926,8 +926,10 @@ class JFilterInput extends InputFilter
 				// Find position of equal and open quotes ignoring
 				if (preg_match('#\s*=\s*\"#', $fromSpace, $matches, PREG_OFFSET_CAPTURE))
 				{
+					// We have found an attribute, convert its byte position to a UTF-8 string length, using non-multibyte substr()
+					$stringBeforeAttr = substr($fromSpace, 0, $matches[0][1]);
+					$startAttPosition = StringHelper::strlen($stringBeforeAttr);
 					$startAtt = $matches[0][0];
-					$startAttPosition = $matches[0][1];
 					$closeQuotes = StringHelper::strpos(
 						StringHelper::substr($fromSpace, ($startAttPosition + StringHelper::strlen($startAtt))), '"'
 						) + $startAttPosition + StringHelper::strlen($startAtt);
@@ -1080,8 +1082,11 @@ class JFilterInput extends InputFilter
 		 */
 		while (preg_match('#<[^>]*?=\s*?(\"|\')#s', $remainder, $matches, PREG_OFFSET_CAPTURE))
 		{
+			// We have found an opening quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
+			$stringBeforeQuote = substr($remainder, 0, $matches[1][1]);
+			$quotePosition = StringHelper::strlen($stringBeforeQuote);
+
 			// Get the portion before the attribute value
-			$quotePosition = $matches[0][1];
 			$nextBefore = $quotePosition + StringHelper::strlen($matches[0][0]);
 
 			/*
@@ -1094,7 +1099,9 @@ class JFilterInput extends InputFilter
 			// Get the portion after attribute value
 			if (preg_match($pregMatch, StringHelper::substr($remainder, $nextBefore), $matches, PREG_OFFSET_CAPTURE))
 			{
-				// We have a closing quote
+				// We have a closing quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
+				$stringBeforeQuote = substr($remainder, 0, $matches[0][1]);
+				$closeQuoteChars = StringHelper::strlen($stringBeforeQuote);
 				$nextAfter = $nextBefore + $matches[0][1];
 			}
 			else

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -1101,7 +1101,7 @@ class JFilterInput extends InputFilter
 			if (preg_match($pregMatch, $attributeValueRemainder, $matches, PREG_OFFSET_CAPTURE))
 			{
 				// We have a closing quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
-				$stringBeforeQuote = substr($attributeValueToEnd, 0, $matches[0][1]);
+				$stringBeforeQuote = substr($attributeValueRemainder, 0, $matches[0][1]);
 				$closeQuoteChars = StringHelper::strlen($stringBeforeQuote);
 				$nextAfter = $nextBefore + $matches[0][1];
 			}


### PR DESCRIPTION
Pull Request for Issue #15673 , thanks to @csthomas for describing the issue

### Summary of Changes
When preg_match() is used with flag: **PREG_OFFSET_CAPTURE**, the return **offsets are in bytes**

J3.7.0 made changes to use mult-byte strlen inside **Class JFilterInput**
-- thus the old code is now broken **because it adds character lengths to byte lengths**

Solution is to get the substring according to its byte length as provided by preg_match()
and then call multi-byte strlen to get its real character length

### Testing Instructions
I can not write now, but someone can contribute, and you can also see the test strings given in the issue (e.g. this one by @tonypartridge  
https://github.com/joomla/joomla-cms/issues/15673#issuecomment-300625229
https://github.com/joomla/joomla-cms/files/991337/JFilterInputerCleanMaxExeciutionErrorText.txt


### Expected result
With patch form saving (e.g. article edit form) without timeouts (and also unit tests pass ...)

### Actual result
Use test strings / examples given above to see the timeout because of inifinite loop in JFilterInput

### Documentation Changes Required
None
