### PR TITLE
Prevent html markup from being rendered to the email

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -19,15 +19,15 @@ $value     = $field->value;
 $class     = $field->params->get('render_class');
 $showLabel = $field->params->get('showlabel');
 
-if (!$value)
-{
-	return;
-}
-
 if ($field->context == 'com_contact.mail')
 {
 	// Prepare the value for the contact form mail
 	echo ($showLabel ? $label . ': ' : '') . $value . "\r\n";
+	return;
+}
+
+if (!$value)
+{
 	return;
 }
 

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -61,8 +61,8 @@ if (!$isMail)
 // Loop through the fields and print them
 foreach ($fields as $field)
 {
-	// If the value is empty dp nothing
-	if (!isset($field->value) || !$field->value)
+	// If the value is empty do nothing
+	if (empty($field->value) && !$isMail)
 	{
 		continue;
 	}
@@ -75,3 +75,4 @@ if (!$isMail)
 	// Close the container
 	echo '</dl>';
 }
+


### PR DESCRIPTION
### Summary of Changes
Prevent html markup from being rendered to the email when an empty (optional) field value has been submitted.

### Testing Instructions
#### Prerequisites
The installation you test this in should be able to send an actual email.
- Create a contact item (link to a user or fill in a valid email address)
- Create a menu item linking to that contact
- Create a custom text field in the mail context (filter). Just give it a name e.g. foobar or test
- Save the field (it doesn't have to be in a group)
- In the permissions tab of that very field, change "Edit Custom Field Value" from Inherited to Allowed

If everything worked fine, visiting that previously created contact in the frontend should show you the default contact form + the test field.
- Fill in every field but the test field (should be marked "optional") and submit the form.

### Expected result
The expected result would be an email including the fields submitted by the form, including the label followed by a colon (e.g. Test:)

### Actual result
The mail send includes the following HTML markup instead of the label of our custom field.
```
<dl class="fields-container">
	</dl>
```

Apply the patch and test again. The markup should be replaced by the label and / or the value, depending on the fields settings.