### PR TITLE
Allow to set a field within fields without fieldset

### DIFF
--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1014,7 +1014,6 @@ class JForm
 		// We couldn't find a fieldset to add the field. Now we are checking, if we have set only a group
 		if (!empty($group))
 		{
-			// Roberto condition
 			$fields = &$this->findGroup($group);
 
 			// If an appropriate fields element was found for the group, add the element.

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1011,7 +1011,25 @@ class JForm
 			return true;
 		}
 
-		// We couldn't find a fieldset to add the field to so we are adding it at root level
+		// We couldn't find a fieldset to add the field. Now we are checking, if we have set only a group
+		if (!empty($group))
+		{
+			// Roberto condition
+			$fields = &$this->findGroup($group);
+
+			// If an appropriate fields element was found for the group, add the element.
+			if (isset($fields[0]) && ($fields[0] instanceof SimpleXMLElement))
+			{
+				self::addNode($fields[0], $element);
+			}
+
+			// Synchronize any paths found in the load.
+			$this->syncPaths();
+
+			return true;
+		}
+
+		// We couldn't find a parent so we are adding it at root level
 
 		// Add field to the form.
 		self::addNode($this->xml, $element);


### PR DESCRIPTION
Pull Request for Issue #15977 

### Summary of Changes
Added a condition to cover a use case that was possible before 3.7.0. It is wasting time to discuss if this is a use case that was intended, I think it wasn't. Anyway this patch with allow the use case.


### Testing Instructions
#### Preparations

We can do JFormObject manipulations in the template, this is easier for testing. So in a vanilla Joomla installation:

1. Go to the template folder of protostar and create a directory html/com_users/remind
2. Copy the default.php file form components/com_users/views/remind/tmpl/ to the directory created.
3. Change the file components/com_users/models/form/remind.xml so that it contains the following content:

```xml
<?xml version="1.0" encoding="utf-8"?>
<form>
	<fields name="custom_fields" />
</form>
```

#### Tests

* Add the following code to the default.php in html/com_users/remind (template)
```php
// create and add a field
$form = $this->form;

$xml = '<field type="text" name="test-field" label="Test field" />';
$form->setField(new \simpleXmlElement($xml), 'custom_fields');

echo "#<div style='text-align:left;font_size:1.2em;'><pre>";
print_r($form->getField('test-field', 'custom_fields'));
echo "</pre></div>#";
```

* Go to the front page and click on "Forgot your username?"

#### Without Patch
You don't see output for the field internals

#### With Patch
You see output for the field internals

**Don't expect to see the field in the form, that's not the way forms have to be defined so that the  output can be dynamically created.**
 
