### PR TITLE
Upgrade PHPPass to v0.5

### DIFF
--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -2,7 +2,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.4 / genuine.
+# Version 0.5 / genuine.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.
@@ -30,7 +30,7 @@ class PasswordHash {
 	var $portable_hashes;
 	var $random_state;
 
-	function PasswordHash($iteration_count_log2, $portable_hashes)
+	function __construct($iteration_count_log2, $portable_hashes)
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
@@ -45,11 +45,16 @@ class PasswordHash {
 			$this->random_state .= getmypid();
 	}
 
+	function PasswordHash($iteration_count_log2, $portable_hashes)
+	{
+		self::__construct($iteration_count_log2, $portable_hashes);
+	}
+
 	function get_random_bytes($count)
 	{
 		$output = '';
 		if (@is_readable('/dev/urandom') &&
-		    ($fh = @fopen('/dev/urandom', 'rb'))) {
+			($fh = @fopen('/dev/urandom', 'rb'))) {
 			$output = fread($fh, $count);
 			fclose($fh);
 		}
@@ -58,9 +63,8 @@ class PasswordHash {
 			$output = '';
 			for ($i = 0; $i < $count; $i += 16) {
 				$this->random_state =
-				    md5(microtime() . $this->random_state);
-				$output .=
-				    pack('H*', md5($this->random_state));
+					md5(microtime() . $this->random_state);
+				$output .= md5($this->random_state, TRUE);
 			}
 			$output = substr($output, 0, $count);
 		}
@@ -104,12 +108,12 @@ class PasswordHash {
 	function crypt_private($password, $setting)
 	{
 		$output = '*0';
-		if (substr($setting, 0, 2) == $output)
+		if (substr($setting, 0, 2) === $output)
 			$output = '*1';
 
 		$id = substr($setting, 0, 3);
 		# We use "$P$", phpBB3 uses "$H$" for the same thing
-		if ($id != '$P$' && $id != '$H$')
+		if ($id !== '$P$' && $id !== '$H$')
 			return $output;
 
 		$count_log2 = strpos($this->itoa64, $setting[3]);
@@ -119,47 +123,22 @@ class PasswordHash {
 		$count = 1 << $count_log2;
 
 		$salt = substr($setting, 4, 8);
-		if (strlen($salt) != 8)
+		if (strlen($salt) !== 8)
 			return $output;
 
-		# We're kind of forced to use MD5 here since it's the only
-		# cryptographic primitive available in all versions of PHP
-		# currently in use.  To implement our own low-level crypto
-		# in PHP would result in much worse performance and
+		# We were kind of forced to use MD5 here since it's the only
+		# cryptographic primitive that was available in all versions
+		# of PHP in use.  To implement our own low-level crypto in PHP
+		# would have resulted in much worse performance and
 		# consequently in lower iteration counts and hashes that are
 		# quicker to crack (by non-PHP code).
-		if (PHP_VERSION >= '5') {
-			$hash = md5($salt . $password, TRUE);
-			do {
-				$hash = md5($hash . $password, TRUE);
-			} while (--$count);
-		} else {
-			$hash = pack('H*', md5($salt . $password));
-			do {
-				$hash = pack('H*', md5($hash . $password));
-			} while (--$count);
-		}
+		$hash = md5($salt . $password, TRUE);
+		do {
+			$hash = md5($hash . $password, TRUE);
+		} while (--$count);
 
 		$output = substr($setting, 0, 12);
 		$output .= $this->encode64($hash, 16);
-
-		return $output;
-	}
-
-	function gensalt_extended($input)
-	{
-		$count_log2 = min($this->iteration_count_log2 + 8, 24);
-		# This should be odd to not reveal weak DES keys, and the
-		# maximum valid value is (2**24 - 1) which is odd anyway.
-		$count = (1 << $count_log2) - 1;
-
-		$output = '_';
-		$output .= $this->itoa64[$count & 0x3f];
-		$output .= $this->itoa64[($count >> 6) & 0x3f];
-		$output .= $this->itoa64[($count >> 12) & 0x3f];
-		$output .= $this->itoa64[($count >> 18) & 0x3f];
-
-		$output .= $this->encode64($input, 3);
 
 		return $output;
 	}
@@ -209,29 +188,20 @@ class PasswordHash {
 	{
 		$random = '';
 
-		if (CRYPT_BLOWFISH == 1 && !$this->portable_hashes) {
+		if (CRYPT_BLOWFISH === 1 && !$this->portable_hashes) {
 			$random = $this->get_random_bytes(16);
 			$hash =
-			    crypt($password, $this->gensalt_blowfish($random));
-			if (strlen($hash) == 60)
-				return $hash;
-		}
-
-		if (CRYPT_EXT_DES == 1 && !$this->portable_hashes) {
-			if (strlen($random) < 3)
-				$random = $this->get_random_bytes(3);
-			$hash =
-			    crypt($password, $this->gensalt_extended($random));
-			if (strlen($hash) == 20)
+				crypt($password, $this->gensalt_blowfish($random));
+			if (strlen($hash) === 60)
 				return $hash;
 		}
 
 		if (strlen($random) < 6)
 			$random = $this->get_random_bytes(6);
 		$hash =
-		    $this->crypt_private($password,
-		    $this->gensalt_private($random));
-		if (strlen($hash) == 34)
+			$this->crypt_private($password,
+				$this->gensalt_private($random));
+		if (strlen($hash) === 34)
 			return $hash;
 
 		# Returning '*' on error is safe here, but would _not_ be safe
@@ -243,10 +213,14 @@ class PasswordHash {
 	function CheckPassword($password, $stored_hash)
 	{
 		$hash = $this->crypt_private($password, $stored_hash);
-		if ($hash[0] == '*')
+		if ($hash[0] === '*')
 			$hash = crypt($password, $stored_hash);
 
-		return $hash == $stored_hash;
+		# This is not constant-time.  In order to keep the code simple,
+		# for timing safety we currently rely on the salts being
+		# unpredictable, which they are at least in the non-fallback
+		# cases (that is, when we use /dev/urandom and bcrypt).
+		return $hash === $stored_hash;
 	}
 }
 


### PR DESCRIPTION
Pull Request for Issue #15985

Upgrade PHPPass to v0.5

### Steps to reproduce the issue

Run unit tests in PHP 71. - see: https://travis-ci.org/joomla/joomla-cms/jobs/231268244

### Expected result

No warnings

### Actual result

`PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; PasswordHash has a deprecated constructor in /home/travis/build/joomla/joomla-cms/libraries/phpass/PasswordHash.php on line 27`
