### PR TITLE
Rescue mode using $root_user in configuration.php

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -1064,9 +1064,12 @@ class JAccess
 			}
 		}
 
+		// Initialise the authorised array.
+		$authorised = array(1);
+
 		// Check for the recovery mode setting and return early.
-		$user      = JFactory::getUser($userId);
-		$root_user = JFactory::getApplication()->get('root_user');
+		$user      = JUser::getInstance($userId);
+		$root_user = JFactory::getConfig()->get('root_user');
 
 		if ($root_user && ($root_user == $user->username || $root_user == $user->id))
 		{
@@ -1075,7 +1078,7 @@ class JAccess
 			{
 				foreach ($rule as $id)
 				{
-					if ($id > 0 && JAccess::checkGroup($id, 'core.admin'))
+					if ($id > 0 && self::checkGroup($id, 'core.admin'))
 					{
 						$authorised[] = $level;
 						break;
@@ -1083,14 +1086,11 @@ class JAccess
 				}
 			}
 
-			return $authorised = array_keys(self::$viewLevels);
+			return $authorised;
 		}
 
 		// Get all groups that the user is mapped to recursively.
 		$groups = self::getGroupsByUser($userId);
-
-		// Initialise the authorised array.
-		$authorised = array(1);
 
 		// Find the authorised levels.
 		foreach (self::$viewLevels as $level => $rule)


### PR DESCRIPTION
Rescue mode using $root_user in configuration.php does not work as expected. This is because the authorised view levels are still not assigned to the raised privilege user.

For details see #15957

### Summary of Changes
`JAccess::getAuthorisedViewLevels($userId)` changed to return super user access level for the `$root_user` 

### Testing Instructions
* Add `public $root_user = 'a_normal_user_username';`
* Login with this user in the backend.

### Expected result
The entire backend should be accessible like a super user.

### Actual result
Most of the part are inaccessible. 

### Documentation Changes Required
None