### PR TITLE
Add statistics in mod_stats (front end) depending on the event "onGetStats"

### DIFF
--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -116,33 +116,6 @@ class ModStatsHelper
 				$rows[$i]->data  = $items;
 				$i++;
 			}
-
-			if (JComponentHelper::isInstalled('com_weblinks'))
-			{
-				$query->clear()
-					->select('COUNT(id) AS count_links')
-					->from('#__weblinks')
-					->where('state = 1');
-				$db->setQuery($query);
-
-				try
-				{
-					$links = $db->loadResult();
-				}
-				catch (RuntimeException $e)
-				{
-					$links = false;
-				}
-
-				if ($links)
-				{
-					$rows[$i]        = new stdClass;
-					$rows[$i]->title = JText::_('MOD_STATS_WEBLINKS');
-					$rows[$i]->icon  = 'out-2';
-					$rows[$i]->data  = $links;
-					$i++;
-				}
-			}
 		}
 
 		if ($counter)
@@ -167,6 +140,27 @@ class ModStatsHelper
 				$rows[$i] = new stdClass;
 				$rows[$i]->title = JText::_('MOD_STATS_ARTICLES_VIEW_HITS');
 				$rows[$i]->data  = $hits + $increase;
+			}
+		}
+
+		// Include additional data defined by published system plugins
+		JPluginHelper::importPlugin('system');
+
+		$arrays = (array) $app->triggerEvent('onGetStats', array('mod_stats_admin'));
+
+		foreach ($arrays as $response)
+		{
+			foreach ($response as $row)
+			{
+				// We only add a row if the title and data are given
+				if (isset($row['title']) && isset($row['data']))
+				{
+					$rows[$i]        = new stdClass;
+					$rows[$i]->title = $row['title'];
+					$rows[$i]->icon  = isset($row['icon']) ? $row['icon'] : 'info';
+					$rows[$i]->data  = $row['data'];
+					$i++;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
I added showing statistics in mod_stats (front end) depending on the event "onGetStats".  
And I deleted the fix way, web links counted the stats. 
mod_stats_admin used the  event "onGetStats" already.


### Testing Instructions
1. Install web links https://github.com/joomla-extensions/weblinks/releases
2. Create a web link and a menu item for showing the web link per category.
3. Open frond end and click the web link so stats are collected.
4. Create a module that shows statistics in frond end and select hit counter. Select a position for this module and show it on all pages.
5. Navigate to the front page and see, that the stats for web links are shown
6. Navigate to the plugin manager and see, that the plugin System - Web Links is not active

7. Apply my patch and see, that stats are shown if the plugin is active and they are not shown, if the plugin is not active.


### Expected result
If the plugin System - Web Links is not active, there should no stats are shown.


### Actual result
Stats are shown in the front end for the component web links independent of the plugin System - Web Links. 
If another component used the event "onGetStats", these stats are only shown in the back end module
mod_stats_admin and **not** in the frond end module mod_stats.



