### PR TITLE
Set correct Isis default link color

### DIFF
--- a/administrator/templates/isis/templateDetails.xml
+++ b/administrator/templates/isis/templateDetails.xml
@@ -57,12 +57,12 @@
 				label="TPL_ISIS_COLOR_HEADER_LABEL"
 				description="TPL_ISIS_COLOR_HEADER_DESC" />
 
-				<field name="sidebarColor" class="" type="color" default="#0088CC"
+				<field name="sidebarColor" class="" type="color" default="#3071a9"
 				validate="color"
 				label="TPL_ISIS_COLOR_SIDEBAR_LABEL"
 				description="TPL_ISIS_COLOR_SIDEBAR_DESC" />
 
-				<field name="linkColor" class="" type="color" default="#0088CC"
+				<field name="linkColor" class="" type="color" default="#3071a9"
 				validate="color"
 				label="TPL_ISIS_COLOR_LINK_LABEL"
 				description="TPL_ISIS_COLOR_LINK_DESC" />


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Sets the default link color in the Isis XML to match that of the template CSS (#3071a9 - https://github.com/joomla/joomla-cms/blob/staging/administrator/templates/isis/css/template.css#L199)

### Testing Instructions
Code review

### Documentation Changes Required
None
