### PR TITLE
Update phpversioncheck.php

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -175,10 +175,11 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 				);
 			}
 
-			// If the version is still supported, check if it has reached security support only
-			$phpSecurityOnlyDate = new JDate($phpSupportData[$activePhpVersion]['security']);
+			// If the version is still supported, check if it has reached eol minus 3 month
+			$interval = new DateInterval('P3M');
+			$phpEndOfSupport->sub($interval);
 
-			if (!$phpNotSupported && $today > $phpSecurityOnlyDate)
+			if (!$phpNotSupported && $today > $phpEndOfSupport)
 			{
 				$supportStatus['status']  = self::PHP_SECURITY_ONLY;
 				$supportStatus['message'] = JText::sprintf(


### PR DESCRIPTION
Pull Request for Issue #14571 .
Summary of Changes

Message for nearing eol appears three month before eol.
Testing Instructions

If you have PHP 5.6 the quickicon message should disappear. Changing the 3 month into e.g. 23 month, anything more than the real remaining time, should make the message appear again.

$interval = new DateInterval('P3M'); // line 179, message gone
$interval = new DateInterval('P23M'); // message appears