### PR TITLE
[4.0] Stop sticky toolbar jump on scroll

### DIFF
--- a/administrator/templates/atum/js/template.js
+++ b/administrator/templates/atum/js/template.js
@@ -317,7 +317,7 @@
 			var subhead = document.getElementById('subhead');
 
 			if (subhead) {
-				var scrollTop = (window.pageYOffset || subhead.scrollTop)  - (subhead.clientTop || 40);
+				var scrollTop = (window.pageYOffset || subhead.scrollTop)  - (subhead.clientTop || 0);
 
 				if (scrollTop >= navTop && !isFixed) {
 					isFixed = true;


### PR DESCRIPTION
Pull Request for Issue #15989 .

### Summary of Changes
Stops the toolbar from jumping to sticky on scroll


### Testing Instructions
Apply patch and navigate to page containing toolbar. Slowly scroll down.


### Before
Toolbar jumps to sticky/fixed position

### After
Toolbars sticks/fixes position smoothly (as it hits the top of the viewport.

### Documentation Changes Required
None
