### PR TITLE
[4.0] Fix JToolbar being declared twice

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -146,7 +146,6 @@ JLoader::registerAlias('JUcmBase',                          '\\Joomla\\CMS\\Ucm\
 JLoader::registerAlias('JUcmContent',                       '\\Joomla\\CMS\\Ucm\\UcmContent', '4.0');
 JLoader::registerAlias('JUcmType',                          '\\Joomla\\CMS\\Ucm\\UcmType', '4.0');
 
-JLoader::registerAlias('JToolbar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
 JLoader::registerAlias('JToolBar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
 JLoader::registerAlias('JToolbarHelper',                    '\\Joomla\\CMS\\Toolbar\\ToolbarHelper', '4.0');
 JLoader::registerAlias('JToolbarButton',                    '\\Joomla\\CMS\\Toolbar\\ToolbarButton', '4.0');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR fixes the following PHP error:

> Warning: Cannot declare class JToolBar, because the name is already in use in \libraries\loader.php on line 769

@wilsonge @laoneo rebase for 3.8 or ok in 4.0?

