### PR TITLE
If view "not found" then send 404 Not Found, not 500 Internal Server Error

### DIFF
--- a/libraries/legacy/controller/legacy.php
+++ b/libraries/legacy/controller/legacy.php
@@ -846,19 +846,7 @@ class JControllerLegacy extends JObject
 			}
 			else
 			{
-				$response = 500;
-
-				/*
-				 * With URL rewriting enabled on the server, all client requests for non-existent files are being
-				 * forwarded to Joomla.  Return a 404 response here and assume the client was requesting a non-existent
-				 * file for which there is no view type that matches the file's extension (the most likely scenario).
-				 */
-				if (JFactory::getApplication()->get('sef_rewrite'))
-				{
-					$response = 404;
-				}
-
-				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND', $name, $type, $prefix), $response);
+				throw new Exception(JText::sprintf('JLIB_APPLICATION_ERROR_VIEW_NOT_FOUND', $name, $type, $prefix), 404);
 			}
 		}
 


### PR DESCRIPTION
Currently if you go to a nonexisting faked url with an invalid view you get a `500 Internal Server` Status response with `view not found` message

It would be more appropriate to give a `404 Not Found` status for a `view not found` error. 

http://joomla-cms/index.php?option=com_content&view=nonsuch

We already do this if SEF enabled (E.g.https://www.joomla.org/index.php?option=com_content&view=nonsuch gives a 404),  there is no reason (that i can see) that we would not also do it if SEF was not enabled . 