### PR TITLE
Remove the JToolBar alias registration

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -147,7 +147,6 @@ JLoader::registerAlias('JUcmContent',                       '\\Joomla\\CMS\\Ucm\
 JLoader::registerAlias('JUcmType',                          '\\Joomla\\CMS\\Ucm\\UcmType', '4.0');
 
 JLoader::registerAlias('JToolbar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
-JLoader::registerAlias('JToolBar',                          '\\Joomla\\CMS\\Toolbar\\Toolbar', '4.0');
 JLoader::registerAlias('JToolbarHelper',                    '\\Joomla\\CMS\\Toolbar\\ToolbarHelper', '4.0');
 JLoader::registerAlias('JToolbarButton',                    '\\Joomla\\CMS\\Toolbar\\ToolbarButton', '4.0');
 JLoader::registerAlias('JToolbarButtonConfirm',             '\\Joomla\\CMS\\Toolbar\\Button\\ConfirmButton', '4.0');


### PR DESCRIPTION
Pull Request for Issue #16025.

### Summary of Changes
Removes the warning
_Warning: Cannot declare class JToolBar, because the name is already in use in /j4/libraries/loader.php on line 769_