### PR TITLE
Fix shortDays array order

### DIFF
--- a/media/system/js/fields/calendar-locales/pt.js
+++ b/media/system/js/fields/calendar-locales/pt.js
@@ -4,7 +4,7 @@ window.JoomlaCalLocale = {
 	wk : "sem",
 	time : "Hora:",
 	days : ["Domingo", "Segunda-feira", "Terça-feira", "Quarta-feira", "Quinta-feira", "Sexta-feira", "Sábado"],
-	shortDays : ["Seg", "Ter", "Qua", "Qui", "Sex", "Sab", "Dom"],
+	shortDays : ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sab"],
 	months : ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
 	shortMonths : ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
 	AM : "AM",


### PR DESCRIPTION
shortDays array was displaying Monday (Seg) as the first day of the week, however the calendar displays Sunday as the first day, so the shortDays must be changed accordingly.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

