### PR TITLE
Silence PHP Notice on no items tagged

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -116,8 +116,7 @@ class TagsViewTag extends JViewLegacy
 		}
 
 		// Categories store the images differently so lets re-map it so the display is correct
-		$count = count($items);
-		if ($count > 0 && $items && $items[0]->type_alias === 'com_content.category')
+		if ($items && $items[0]->type_alias === 'com_content.category')
 		{
 			foreach ($items as $row)
 			{

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -117,7 +117,7 @@ class TagsViewTag extends JViewLegacy
 
 		// Categories store the images differently so lets re-map it so the display is correct
 		$count = count($items);
-		if ($count > 0 && $items[0]->type_alias === 'com_content.category')
+		if ($count > 0 && $items && $items[0]->type_alias === 'com_content.category')
 		{
 			foreach ($items as $row)
 			{


### PR DESCRIPTION
Pull Request for Issue #16067 .

### Summary of Changes

Dont run code block when there are no items linked to a tag

### Testing Instructions

Install Joomla,
Create a tag
go to front end and load that tags page with url like
http://joomla-cms/index.php?option=com_tags&view=tag&id=3

### Expected result

No PHP notices

### Actual result

PHP notice

`Notice: Trying to get property of non-object in .../components/com_tags/views/tag/view.html.php 
on line 120`

### Documentation Changes Required

None