### PR TITLE
Prevent double amp encoding

### DIFF
--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -49,4 +49,4 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink)), $linktype, $attributes);
+echo JHtml::_('link', JFilterOutput::ampReplace($item->flink), $linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,4 +50,4 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8')), $linktype, $attributes);
+echo JHtml::_('link', JFilterOutput::ampReplace($item->flink), $linktype, $attributes);


### PR DESCRIPTION
Pull Request for Issue #16088 .

### Summary of Changes

fix the double amp issue

### Steps to reproduce the issue

Updated from 3.7.0. to 3.7.1
Turn SEF off in Joomla config.
Create menu items to category blog

### Expected result

Something like
`index.php?option=com_content&view=categories&id=50&Itemid=288`

### Actual result

double ampsands 

`index.php?option=com_content&amp;view=categories&amp;id=50& amp;Itemid=288`