### PR TITLE
Changes to display atom feeds correctly

### DIFF
--- a/libraries/joomla/feed/parser/atom.php
+++ b/libraries/joomla/feed/parser/atom.php
@@ -200,5 +200,41 @@ class JFeedParserAtom extends JFeedParser
 		$entry->title       = (string) $el->title;
 		$entry->updatedDate = (string) $el->updated;
 		$entry->content     = (string) $el->summary;
+
+		if (!$entry->content)
+		{
+			$entry->content = (string) $el->content;
+		}
+
+		if (filter_var($entry->uri, FILTER_VALIDATE_URL) === false && !is_null($el->link) && $el->link)
+		{
+			$link = $el->link;
+			if (is_array($link))
+			{
+				$link = $this->bestLinkForUri($link);
+			}
+			$uri = (string)$link['href'];
+			if ($uri)
+			{
+				$entry->uri = $uri;
+			}
+		}
+	}
+	private function bestLinkForUri(array $links)
+	{
+		//if there is more than one link, then find the most appropriate one and return it.
+		$linkPrefs = array('', 'self', 'alternate');
+		foreach ($linkPrefs as $pref)
+		{
+			foreach ($links as $link)
+			{
+				$rel = (string)$link['rel'];
+				if ($rel === $pref)
+				{
+					return $link;
+				}
+			}
+		}
+		return array_shift($links);
 	}
 }

--- a/libraries/joomla/feed/parser/atom.php
+++ b/libraries/joomla/feed/parser/atom.php
@@ -224,7 +224,7 @@ class JFeedParserAtom extends JFeedParser
 	/**
 	 * If there is more than one <link> in the feed entry, find the most appropriate one and return it.
 	 *
-	 * @param   array             $links  Array of <link> elements from the feed entry.
+	 * @param   array  $links  Array of <link> elements from the feed entry.
 	 *
 	 * @return  SimpleXMLElement
 	 */

--- a/libraries/joomla/feed/parser/atom.php
+++ b/libraries/joomla/feed/parser/atom.php
@@ -213,22 +213,29 @@ class JFeedParserAtom extends JFeedParser
 			{
 				$link = $this->bestLinkForUri($link);
 			}
-			$uri = (string)$link['href'];
+			$uri = (string) $link['href'];
 			if ($uri)
 			{
 				$entry->uri = $uri;
 			}
 		}
 	}
+
+	/**
+	 * If there is more than one <link> in the feed entry, find the most appropriate one and return it.
+	 *
+	 * @param   array             $links  Array of <link> elements from the feed entry.
+	 *
+	 * @return  SimpleXMLElement
+	 */
 	private function bestLinkForUri(array $links)
 	{
-		//if there is more than one link, then find the most appropriate one and return it.
 		$linkPrefs = array('', 'self', 'alternate');
 		foreach ($linkPrefs as $pref)
 		{
 			foreach ($links as $link)
 			{
-				$rel = (string)$link['rel'];
+				$rel = (string) $link['rel'];
 				if ($rel === $pref)
 				{
 					return $link;


### PR DESCRIPTION
Pull Request for Issue #15348.

### Summary of Changes

Per the issue #15348, there are issues when displaying some Atom feeds in Joomla.

1. For some feeds (examples: https://code.tutsplus.com/categories/php.atom, http://planet.debian.org/atom.xml ), the feed is rendered in Joomla with only the titles, and no content.

    This is due to the feed items not containing a `summary` element. It does, however have a `content` element. I have therefore made a change to the feed parser such that if the `summary` is found to be missing, it will fall-back to using the `content` instead.

2. For many Atom feeds (examples: https://www.gov.uk/government/organisations/home-office.atom, https://www.theregister.co.uk/headlines.atom), when the feed items are displayed in Joomla, the title link points to the main feed URL instead of the URL for the article. In fact most Atom feeds that I've tried exhibit this behaviour.

    This is due to the fact that the Atom feed parser is assuming that the `id` element in each feed item will contain a valid URL for the source article. This is not usually the case; the `id` element generally does contain a unique identifier, but it is often not a URL. The actual URL that we should be linking to is usually contained within a `link` element within the item.

    I have therefore made changes to the feed parser such that if the ID is found not to contain a valid URL, then we fall-back to the `link` elements.

    Most feeds only have a single `link` element per item, but this change also takes into account the fact that some feeds may have multiple `link` elements per item, distinguished by different `rel` attributes. In this case, the parser will attempt to find the best one to use -- this is generally the one without a `rel` attribute at all or with `rel="alternate"`. NB: I have not found any live feeds that triggered this code, but I used the [example XML on Wikipedia](https://en.wikipedia.org/wiki/Atom_%28standard%29) as a reference.

### Testing Instructions

* Create a newsfeed category in Joomla and a menu entry to display it.
* Add a selection of Atom newsfeeds to the category as you can find. You should include the four feeds referenced above as they are known to demonstrate the issues, but finding others to test as well may be helpful.

### Expected result

* With the changes in place, TutsPlus and Debian feeds show the item contents as well as just the headlines.

* With the changes in place, the headlines in the Home Office and The Register feeds can be clicked to link to the articles.

### Actual result

* Before the changes, TutsPlus and Debian feeds only show headlines.

* Before the changes, clicking article headlines on the Home Office and The Register feeds takes you to the atom newsfeed itself rather than the article.

### Documentation Changes Required

None.