### PR TITLE
Do not attempt to send email when no "From Email" set

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -144,25 +144,34 @@ class PlgUserJoomla extends JPlugin
 						$user['password_clear']
 					);
 
-					// Assemble the email data...the sexy way!
-					$mail = JFactory::getMailer()
-						->setSender(
-							array(
-								$this->app->get('mailfrom'),
-								$this->app->get('fromname')
-							)
-						)
-						->addRecipient($user['email'])
-						->setSubject($emailSubject)
-						->setBody($emailBody);
-
-					// Set application language back to default if we changed it
-					if ($userLocale != $defaultLocale)
+					// Check if we have a valid email to send from
+					if (strpos($this->app->get('mailfrom'), '@'))
 					{
-						$lang->setLanguage($defaultLocale);
-					}
 
-					if (!$mail->Send())
+						// Assemble the email data...the sexy way!
+						$mail = JFactory::getMailer()
+							->setSender(
+								array(
+									$this->app->get('mailfrom'),
+									$this->app->get('fromname')
+								)
+							)
+							->addRecipient($user['email'])
+							->setSubject($emailSubject)
+							->setBody($emailBody);
+
+						// Set application language back to default if we changed it
+						if ($userLocale != $defaultLocale)
+						{
+							$lang->setLanguage($defaultLocale);
+						}
+
+						if (!$mail->Send())
+						{
+							$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
+						}
+					}
+					else
 					{
 						$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 					}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -113,7 +113,7 @@ class PlgUserJoomla extends JPlugin
 			return;
 		}
 
-		// check if we have a sensible from email address, if not bail out as mail would not be sent anyway
+		// Check if we have a sensible from email address, if not bail out as mail would not be sent anyway
 		if (strpos($this->app->get('mailfrom'), '@') === false)
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -144,36 +144,27 @@ class PlgUserJoomla extends JPlugin
 						$user['password_clear']
 					);
 
-					// Check if we have a valid email to send from
-					if (strpos($this->app->get('mailfrom'), '@'))
+					// Assemble the email data...
+					$mail = JFactory::getMailer();
+
+					$mail->setSender(
+							array(
+								$this->app->get('mailfrom'),
+								$this->app->get('fromname')
+							)
+						);
+
+					$mail->addRecipient($user['email']);
+					$mail->setSubject($emailSubject);
+					$mail->setBody($emailBody);
+
+					// Set application language back to default if we changed it
+					if ($userLocale != $defaultLocale)
 					{
-
-						// Assemble the email data...
-						$mail = JFactory::getMailer();
-
-						$mail->setSender(
-								array(
-									$this->app->get('mailfrom'),
-									$this->app->get('fromname')
-								)
-							);
-
-						$mail->addRecipient($user['email']);
-						$mail->setSubject($emailSubject);
-						$mail->setBody($emailBody);
-
-						// Set application language back to default if we changed it
-						if ($userLocale != $defaultLocale)
-						{
-							$lang->setLanguage($defaultLocale);
-						}
-
-						if (!$mail->Send())
-						{
-							$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
-						}
+						$lang->setLanguage($defaultLocale);
 					}
-					else
+
+					if (!$mail->Send())
 					{
 						$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 					}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -148,17 +148,19 @@ class PlgUserJoomla extends JPlugin
 					if (strpos($this->app->get('mailfrom'), '@'))
 					{
 
-						// Assemble the email data...the sexy way!
-						$mail = JFactory::getMailer()
-							->setSender(
+						// Assemble the email data...
+						$mail = JFactory::getMailer();
+
+						$mail->setSender(
 								array(
 									$this->app->get('mailfrom'),
 									$this->app->get('fromname')
 								)
-							)
-							->addRecipient($user['email'])
-							->setSubject($emailSubject)
-							->setBody($emailBody);
+							);
+
+						$mail->addRecipient($user['email']);
+						$mail->setSubject($emailSubject);
+						$mail->setBody($emailBody);
 
 						// Set application language back to default if we changed it
 						if ($userLocale != $defaultLocale)

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -114,7 +114,7 @@ class PlgUserJoomla extends JPlugin
 		}
 
 		// check if we have a sensible from email address, if not bail out as mail would not be sent anyway
-		if (strpos($this->app->get('mailfrom'), '@'))
+		if (strpos($this->app->get('mailfrom'), '@') === false)
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 			return;

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -166,7 +166,7 @@ class PlgUserJoomla extends JPlugin
 
 		$retSetRecipient = $mail->addRecipient($user['email']);
 
-		if (!$retSetSender || $retSetRecipient)
+		if (!$retSetSender || !$retSetRecipient)
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 			return;

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -101,13 +101,15 @@ class PlgUserJoomla extends JPlugin
 	{
 		$mail_to_user = $this->params->get('mail_to_user', 1);
 
-		if (!$isnew || !$mail_to_user) {
+		if (!$isnew || !$mail_to_user)
+		{
 			return;
 		}
 
 		// TODO: Suck in the frontend registration emails here as well. Job for a rainy day.
 		// The method check here ensures that if running as a CLI Application we don't get any errors
-		if (method_exists($this->app, 'isClient') && !$this->app->isClient('administrator')) {
+		if (method_exists($this->app, 'isClient') && !$this->app->isClient('administrator'))
+		{
 			return;
 		}
 
@@ -174,11 +176,13 @@ class PlgUserJoomla extends JPlugin
 		$mail->setBody($emailBody);
 
 		// Set application language back to default if we changed it
-		if ($userLocale != $defaultLocale) {
+		if ($userLocale != $defaultLocale)
+		{
 			$lang->setLanguage($defaultLocale);
 		}
 
-		if ($mail->Send() !== true) {
+		if ($mail->Send() !== true)
+		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 		}
 	}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -155,35 +155,23 @@ class PlgUserJoomla extends JPlugin
 			$user['password_clear']
 		);
 
-		$mail = JFactory::getMailer();
-
-		$retSetSender = $mail->setSender(
-			array(
-				$this->app->get('mailfrom'),
-				$this->app->get('fromname')
-			)
+		$res = JFactory::getMailer()->sendMail(
+			$this->app->get('mailfrom'),
+			$this->app->get('fromname'),
+			$user['email'],
+			$emailSubject,
+			$emailBody
 		);
 
-		$retSetRecipient = $mail->addRecipient($user['email']);
-
-		if (!$retSetSender || !$retSetRecipient)
+		if ($res === false)
 		{
 			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
-			return;
 		}
-
-		$mail->setSubject($emailSubject);
-		$mail->setBody($emailBody);
 
 		// Set application language back to default if we changed it
 		if ($userLocale != $defaultLocale)
 		{
 			$lang->setLanguage($defaultLocale);
-		}
-
-		if ($mail->Send() !== true)
-		{
-			$this->app->enqueueMessage(JText::_('JERROR_SENDING_EMAIL'), 'warning');
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue #16093 .

### Summary of Changes

Dont error if there is no from EMAIL in Joomla Global Config, when sending an email.

### Testing Instructions

install Joomla 3.7.1
REMOVE the from name in your global configuration mail settings
Create a new Publisher using the admin console.

### Expected result

No email is sent, no PHP warning given.

### Actual result

> 0 Call to a member function addRecipient() on boolean

### After applying this patch

<img width="577" alt="screen shot 2017-05-18 at 13 09 33" src="https://cloud.githubusercontent.com/assets/400092/26201564/87b2242a-3bcb-11e7-8a4a-c7d07d54f97b.png">


### Documentation Changes Required

(Note: PR quickly created in Github, may need refining) 