### PR TITLE
Prevent Double amp escaping with htmlspecialchars bestpractice

### DIFF
--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -49,4 +49,4 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo JHtml::_('link', JFilterOutput::ampReplace($item->flink), $linktype, $attributes);
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -50,4 +50,4 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo JHtml::_('link', JFilterOutput::ampReplace($item->flink), $linktype, $attributes);
+echo JHtml::_('link', JFilterOutput::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
adding bestpractice for htmlspecialchars because this standard have $double_encode = true by default


### Actual result
links are wihtout &amp; in url


### Documentation Changes Required

modules/mod_menu/tmpl/default_url.php

modules/mod_menu/tmpl/default_component.php