### PR TITLE
[B/C] Page filtering missing for Modules manager

### DIFF
--- a/administrator/components/com_modules/models/forms/filter_modules.xml
+++ b/administrator/components/com_modules/models/forms/filter_modules.xml
@@ -52,7 +52,6 @@
 			type="menuitem"
 			label="COM_MODULES_OPTION_SELECT_PAGE"
 			disable="separator,alias,heading,url"
-			showon="client_id:0"
 			onchange="this.form.submit();"
 			>
 			<option	value="">COM_MODULES_OPTION_SELECT_PAGE</option>

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -48,6 +48,13 @@ class ModulesViewModules extends JViewLegacy
 			return false;
 		}
 
+		// We do not need the Page filter when filtering by administrator
+		if ($this->state->get('client_id') == 1)
+		{
+			unset($this->activeFilters['menuitem']);
+			$this->filterForm->removeField('menuitem', 'filter');
+		}
+
 		// We don't need the toolbar in the modal window.
 		if ($this->getLayout() !== 'modal')
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15621

### Summary of Changes
`showon` does not work for search Tools filters.
Solution: unsetting the page filter when filtering by administrator


### After patch one should get

![module_page_filter](https://cloud.githubusercontent.com/assets/869724/26238609/1e2f4bcc-3c7a-11e7-85e1-39e5b2bb0fcb.gif)
