### PR TITLE
Modules Manager: no need to filter or display language when filtering by administrator

### DIFF
--- a/administrator/components/com_modules/models/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/models/forms/moduleadmin.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fieldset>
+		<field name="id" type="text"
+			label="JGLOBAL_FIELD_ID_LABEL"
+			description="JGLOBAL_FIELD_ID_DESC"
+			default="0"
+			readonly="true"
+		/>
+
+		<field name="title" type="text"
+			description="COM_MODULES_FIELD_TITLE_DESC"
+			label="JGLOBAL_TITLE"
+			class="input-xxlarge input-large-text"
+			size="40"
+			maxlength="100"
+			required="true"
+		/>
+
+		<field name="note" type="text"
+			description="COM_MODULES_FIELD_NOTE_DESC"
+			label="COM_MODULES_FIELD_NOTE_LABEL"
+			maxlength="255"
+			size="40"
+			class="span12"
+		/>
+
+		<field name="module" type="hidden"
+			description="COM_MODULES_FIELD_MODULE_DESC"
+			label="COM_MODULES_FIELD_MODULE_LABEL"
+			readonly="readonly"
+			size="20"
+		/>
+
+		<field name="showtitle" type="radio"
+			class="btn-group btn-group-yesno"
+			default="1"
+			description="COM_MODULES_FIELD_SHOWTITLE_DESC"
+			label="COM_MODULES_FIELD_SHOWTITLE_LABEL"
+			size="1"
+		>
+			<option value="1">JSHOW</option>
+			<option value="0">JHIDE</option>
+		</field>
+
+		<field name="published" type="list"
+			class="chzn-color-state"
+			default="1"
+			description="COM_MODULES_FIELD_PUBLISHED_DESC"
+			label="JSTATUS"
+			size="1"
+		>
+			<option value="1">JPUBLISHED</option>
+			<option value="0">JUNPUBLISHED</option>
+			<option value="-2">JTRASHED</option>
+		</field>
+
+		<field
+			name="publish_up"
+			type="calendar"
+			label="COM_MODULES_FIELD_PUBLISH_UP_LABEL"
+			description="COM_MODULES_FIELD_PUBLISH_UP_DESC"
+			filter="user_utc"
+			translateformat="true"
+			showtime="true"
+			size="22"
+		/>
+
+		<field
+			name="publish_down"
+			type="calendar"
+			label="COM_MODULES_FIELD_PUBLISH_DOWN_LABEL"
+			description="COM_MODULES_FIELD_PUBLISH_DOWN_DESC"
+			filter="user_utc"
+			translateformat="true"
+			showtime="true"
+			size="22"
+		/>
+
+		<field name="client_id" type="hidden"
+			description="COM_MODULES_FIELD_CLIENT_ID_DESC"
+			label="COM_MODULES_FIELD_CLIENT_ID_LABEL"
+			readonly="true"
+			size="1"
+		/>
+
+		<field name="position" type="moduleposition"
+			default=""
+			description="COM_MODULES_FIELD_POSITION_DESC"
+			label="COM_MODULES_FIELD_POSITION_LABEL"
+			maxlength="50"
+		/>
+
+		<field name="access" type="accesslevel"
+			description="JFIELD_ACCESS_DESC"
+			label="JFIELD_ACCESS_LABEL"
+			size="1"
+		/>
+
+		<field name="ordering" type="moduleorder"
+			linked="position"
+			description="JFIELD_ORDERING_DESC"
+			label="JFIELD_ORDERING_LABEL"
+		/>
+
+		<field name="content" type="editor"
+			buttons="true"
+			description="COM_MODULES_FIELD_CONTENT_DESC"
+			filter="JComponentHelper::filterText"
+			label="COM_MODULES_FIELD_CONTENT_LABEL"
+			hide="readmore,pagebreak,module"
+		/>
+
+		<field name="assignment" type="hidden" />
+
+		<field name="assigned" type="hidden" />
+
+		<field name="asset_id" type="hidden"
+			filter="unset"
+		/>
+
+		<field name="rules" type="rules"
+			label="JFIELD_RULES_LABEL"
+			translate_label="false"
+			filter="rules"
+			component="com_modules"
+			section="module"
+			validate="rules"
+		/>
+	</fieldset>
+</form>

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -538,7 +538,14 @@ class ModulesModelModule extends JModelAdmin
 		$this->setState('item.module', $module);
 
 		// Get the form.
-		$form = $this->loadForm('com_modules.module', 'module', array('control' => 'jform', 'load_data' => $loadData));
+		if ($clientId == 1)
+		{
+			$form = $this->loadForm('com_modules.module.admin', 'moduleadmin', array('control' => 'jform', 'load_data' => $loadData), true);
+		}
+		else
+		{
+			$form = $this->loadForm('com_modules.module', 'module', array('control' => 'jform', 'load_data' => $loadData), true);
+		}
 
 		if (empty($form))
 		{

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -23,7 +23,7 @@ if ($saveOrder)
 	$saveOrderingUrl = 'index.php?option=com_modules&task=modules.saveOrderAjax&tmpl=component';
 	JHtml::_('sortablelist.sortable', 'moduleList', 'adminForm', strtolower($listDirn), $saveOrderingUrl);
 }
-$colSpan = $clientId === 1 ? 9 : 10;
+$colSpan = $clientId === 1 ? 8 : 10;
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_modules'); ?>" method="post" name="adminForm" id="adminForm">
 <?php if (!empty( $this->sidebar)) : ?>
@@ -65,9 +65,11 @@ $colSpan = $clientId === 1 ? 9 : 10;
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'ag.title', $listDirn, $listOrder); ?>
 						</th>
+						<?php if ($clientId === 0) : ?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
 						</th>
+						<?php endif; ?>
 						<th width="1%" class="nowrap center hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -181,9 +183,11 @@ $colSpan = $clientId === 1 ? 9 : 10;
 						<td class="small hidden-phone">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
+						<?php if ($clientId === 0) : ?>
 						<td class="small hidden-phone">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>
+						<?php endif; ?>
 						<td class="hidden-phone">
 							<?php echo (int) $item->id; ?>
 						</td>

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -48,11 +48,14 @@ class ModulesViewModules extends JViewLegacy
 			return false;
 		}
 
-		// We do not need the Page filter when filtering by administrator
+		// We do not need the Page and the Language filters when filtering by administrator
 		if ($this->state->get('client_id') == 1)
 		{
 			unset($this->activeFilters['menuitem']);
 			$this->filterForm->removeField('menuitem', 'filter');
+
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
 		}
 
 		// We don't need the toolbar in the modal window.


### PR DESCRIPTION
Follow up on https://github.com/joomla/joomla-cms/pull/16118

### Summary of Changes
As title says


### Testing Instructions
Make sure you use latest staging or patch first with #16118 
Patch.


### Expected result
No more language search tools filter as well as language column in the list when filtering by administrator

![screen shot 2017-05-19 at 12 20 04](https://cloud.githubusercontent.com/assets/869724/26244034/64dc5f60-3c8e-11e7-9efc-1c05adf4dc58.png)

@franz-wohlkoenig @AlexRed 
@rdeutz 