### PR TITLE
Fix invalid parsing UTF-8 attribute value

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -1103,7 +1103,7 @@ class JFilterInput extends InputFilter
 				// We have a closing quote, convert its byte position to a UTF-8 string length, using non-multibyte substr()
 				$stringBeforeQuote = substr($attributeValueRemainder, 0, $matches[0][1]);
 				$closeQuoteChars = StringHelper::strlen($stringBeforeQuote);
-				$nextAfter = $nextBefore + $matches[0][1];
+				$nextAfter = $nextBefore + $closeQuoteChars;
 			}
 			else
 			{

--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -1294,6 +1294,12 @@ class JFilterInputTest extends \PHPUnit\Framework\TestCase
 				'<img src="xxx" height="zzz" />',
 				'Test empty alt attribute'
 			),
+			'infinte_loop_c' => array(
+				'string',
+				'<hr title="Äußerungen" class="system-pagebreak" alt="Äußerungen" />',
+				'<hr title="Äußerungen" class="system-pagebreak" alt="Äußerungen" />',
+				'Test correct position of close quote in UTF-8 value'
+			),
 			'quotes_in_text' => array(
 				'string',
 				$quotesInText1,


### PR DESCRIPTION
Pull Request for Issue #16112

### Summary of Changes
- Fix invalid parsing - use correct UTF-8 offset converted from `preg_match`
- This PR **does not** fix the performance issue

### Testing Instructions
Unit test done it.
Please code review. 


### Expected result
Unit test pass


### Actual result
Without the fix and with new unit test travis will hung up.


### Documentation Changes Required
No

### Note
Although I did this fix I'm not a fan of using any mb_ function in this methods. 
I wish to remove it from filter code. I wish to find a more time to complete it in another PR.