### PR TITLE
[tags] If we count false it returns 1 and not zero

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -117,7 +117,7 @@ class TagsViewTag extends JViewLegacy
 
 		// Categories store the images differently so lets re-map it so the display is correct
 		$count = count($items);
-		if ($count > 0 && $items[0]->type_alias === 'com_content.category')
+		if ($count > 1 && $items[0]->type_alias === 'com_content.category')
 		{
 			foreach ($items as $row)
 			{


### PR DESCRIPTION
Pull Request for Issue #14747

### Summary of Changes

$var = count(false) => 1 see: http://php.net/manual/en/function.count.php

@tonypartridge please check this too as this comes from #14747 

### Testing Instructions

- enable maximal error reporting
- add one article
- add one tag to a article
- access the article from the frontend
- get the URL for the list of the tagged articles
- untag the tag from the article
- see the error in the frontend `Notice: Trying to get property of non-object in JRoot\components\com_tags\views\tag\view.html.php on line 120`

### Expected result

No error just the `No matching items were found.` message

### Actual result

The `No matching items were found.` plus a PHP notice: ``Notice: Trying to get property of non-object in JRoot\components\com_tags\views\tag\view.html.php on line 120``

### Documentation Changes Required

none