### PR TITLE
[com_fields] Allow multiple values for the integer field

### DIFF
--- a/plugins/fields/integer/tmpl/integer.php
+++ b/plugins/fields/integer/tmpl/integer.php
@@ -18,7 +18,7 @@ if ($value == '')
 
 if (is_array($value))
 {
-	$value = implode(', ', (int) $value);
+	$value = implode(', ', array_map('intval', $value));
 }
 else
 {

--- a/plugins/fields/integer/tmpl/integer.php
+++ b/plugins/fields/integer/tmpl/integer.php
@@ -18,7 +18,11 @@ if ($value == '')
 
 if (is_array($value))
 {
-	$value = implode(', ', $value);
+	$value = implode(', ', (int) $value);
+}
+else
+{
+	$value = (int) $value;
 }
 
-echo (int) $value;
+echo $value;


### PR DESCRIPTION
### Summary of Changes

Before this PR it was impossible to render multiple integer values, but the field allows you to select multiple integer values. This is a bug in com_fields

### Testing Instructions

Create a custom integerfield
make sure Multiple = Yes
Edit content, select several integers in the custom field

### Expected result

When rendered you see all the integers you selected in a comma separated string (_this is what the com_fields/integer field was designed to do with multiples, Im not changing the "feature" Im fixing the bug._)

### Actual result

A single integer is rendered because integer.php casts the resultant comma separated string to a (int)

After this PR a correctly rendered comma separated string is rendered

### Documentation Changes Required

None