### PR TITLE
[com_fields] Ensure there are correct spaces in tag if attributes not used

### DIFF
--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -19,7 +19,11 @@ $attributes = '';
 
 if (!JUri::isInternal($value))
 {
-	$attributes = 'rel="nofollow noopener noreferrer" target="_blank"';
+	$attributes = ' rel="nofollow noopener noreferrer" target="_blank"';
 }
 
-echo '<a href="' . htmlspecialchars($value) . '" ' . $attributes . '>' . htmlspecialchars($value) . '</a>';
+echo sprintf('<a href="%s"%s>%s</a>',
+	htmlspecialchars($value),
+	$attributes,
+	htmlspecialchars($value)
+);


### PR DESCRIPTION
### Summary of Changes

If the link was internal, the resultant output would be

```html
<a href="http://example.com/internal" >http://example.com/internal</a>
```

note the extra space

### Expected result

```html
<a href="http://example.com/internal">http://example.com/internal</a>
```
