### PR TITLE
Smart-Search indexing with inline elements

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -61,8 +61,9 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
 
 		// This fixes issues such as '<h1>Title</h1><p>Paragraph</p>'
-		// being transformed into 'TitleParagraph' with no space.
-		$input = str_replace('>', '> ', $input);
+		// being transformed into 'TitleParagraph' with no space
+		// and issues such as '<b>T</b>itle' not being indexed as Title.
+		$input = str_replace('><', '> <', $input);
 
 		// Strip HTML tags.
 		$input = strip_tags($input);

--- a/administrator/components/com_finder/helpers/indexer/parser/html.php
+++ b/administrator/components/com_finder/helpers/indexer/parser/html.php
@@ -60,9 +60,11 @@ class FinderIndexerParserHtml extends FinderIndexerParser
 		// Convert entities equivalent to spaces to actual spaces.
 		$input = str_replace(array('&nbsp;', '&#160;'), ' ', $input);
 
-		// This fixes issues such as '<h1>Title</h1><p>Paragraph</p>'
-		// being transformed into 'TitleParagraph' with no space
-		// and issues such as '<b>T</b>itle' not being indexed as Title.
+		/** 
+		* This fixes issues such as '<h1>Title</h1><p>Paragraph</p>'
+		* being transformed into 'TitleParagraph' with no space
+		* and issues such as '<b>T</b>itle' not being indexed as Title.
+		*/
 		$input = str_replace('><', '> <', $input);
 
 		// Strip HTML tags.


### PR DESCRIPTION
Create an article with the following markup

```
<p><b>D</b>octor <b>W</b>ho</p>
<h1>Title</h1><p>Paragraph</p>
```

run smart search to create an index and then use the smart search module or component on the front end to perform the following searches

1. Doctor
2. Title

## Expected behaviour
Doctor and Title are found

## Actual behaviour
Only title is found because it has been indexed as D and octor

## Apply PR
Both Doctor and Title are found

The search for title should result in Title paragraph with a space between them - this is test is to ensure that existing functionality before this pr has not been changed

Pull Request for Issue #7927 .
