### PR TITLE
[fix] Username is case sensitive in com_joomlaupdate login

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -901,7 +901,7 @@ ENDDATA;
 		$username = isset($credentials['username']) ? $credentials['username'] : null;
 		$user     = JFactory::getUser();
 
-		if ($user->username != $username)
+		if (strtolower($user->username) != strtolower($username))
 		{
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue #12593

### Summary of Changes

Make sure user name is not case sensitive in com_joomlaupdate

### Testing Instructions

Upload a Joomla! package in com_joomlaupdate. When it asks for credential, enter correct credentials but use different case for username (e.g. if your username is admin, enter Admin)

### Expected result

Confirmation successful, installation proceeds.

### Actual result

403 Access Forbidden error.

### Documentation Changes Required

None
