### PR TITLE
mod_users_latest Remove not existent param/variable

### DIFF
--- a/modules/mod_users_latest/mod_users_latest.php
+++ b/modules/mod_users_latest/mod_users_latest.php
@@ -14,7 +14,6 @@ JLoader::register('ModUsersLatestHelper', __DIR__ . '/helper.php');
 
 $shownumber      = $params->get('shownumber', 5);
 $names           = ModUsersLatestHelper::getUsers($params);
-$linknames       = $params->get('linknames', 0);
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_users_latest', $params->get('layout', 'default'));


### PR DESCRIPTION
Remove the unused parameter/variable linknames this was removed from the xml in 2011 https://github.com/joomla/joomla-cms/commit/557beb01135345e7c3aae822d5e0ad9340919bcd however was left in this php file
Pull Request for Issue # .

### Summary of Changes
Removed reference to non existent parameter 

### Testing Instructions
Check the following files for any reference
https://github.com/joomla/joomla-cms/blob/staging/modules/mod_users_latest/helper.php
https://github.com/joomla/joomla-cms/blob/staging/modules/mod_users_latest/mod_users_latest.php
https://github.com/joomla/joomla-cms/blob/staging/modules/mod_users_latest/mod_users_latest.xml
https://github.com/joomla/joomla-cms/blob/staging/modules/mod_users_latest/tmpl/default.php

Search repository for linknames

Confirm no changes to the module