### PR TITLE
[com_fields] Wrong frontend fields ordering

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -303,7 +303,7 @@ class FieldsModelFields extends JModelList
 
 		// Add the list ordering clause
 		$listOrdering  = $this->state->get('list.ordering', 'a.ordering');
-		$orderDirn     = $this->state->get('list.direction', 'DESC');
+		$orderDirn     = $this->state->get('list.direction', 'ASC');
 
 		$query->order($db->escape($listOrdering) . ' ' . $db->escape($orderDirn));		
 


### PR DESCRIPTION
### Summary of Changes
In the frontend the field ordering is reversed to the backend, because DESC is default instead of ASC.

### Testing Instructions
Create two or more fields and reorder it.

### Expected result
Frontend and Backend ordering are equal.

### Actual result
Frontend ordering is reversed to the backend ordering