### PR TITLE
Sort configuration.php properties in alphabetical order

### DIFF
--- a/libraries/vendor/joomla/registry/src/Format/Php.php
+++ b/libraries/vendor/joomla/registry/src/Format/Php.php
@@ -36,7 +36,11 @@ class Php extends AbstractRegistryFormat
 		// Build the object variables string
 		$vars = '';
 
-		foreach (get_object_vars($object) as $k => $v)
+		// Save the object properties in alphabetical order
+		$data = get_object_vars($object);
+		ksort($data, SORT_NATURAL | SORT_FLAG_CASE );
+
+		foreach ($data as $k => $v)
 		{
 			if (is_scalar($v))
 			{


### PR DESCRIPTION
### Summary of Changes

For those of us that daily have to edit configuration.php files manually, the current ordering of the object properties is random 

Some items are together, but other items (like db host user password) are spread throughout the file.

Joomla doesnt care what order the properties are in

But people like me who daily edit manually configuration.php files, having the properties in a a-z order would greatly help workflow. 

### Testing Instructions

Apply patch, save Joomla Global Config, see that configuration.php contents are now in a-z order. 

### Documentation Changes Required

None.

Full b/c, no issues there. 