### PR TITLE
Added check for menu router, when adding in a default itemid.

### DIFF
--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -135,7 +135,7 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 
 		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
 		// otherwise it can end up in a redirect loop.
-		if (!empty($default->id) && $active->home !== 1 && in_array($default->access, $levels))
+		if (!empty($default->id) && ($active && $active->home !== 1 && in_array($default->access, $levels)))
 		{
 			$query['Itemid'] = $default->id;
 		}

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -130,7 +130,11 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		// If not found, return language specific home link
 		$default = $this->router->menu->getDefault($language);
 
-		if (!empty($default->id))
+		//Get the current users access levels
+		$levels = JAccess::getAuthorisedViewLevels(JFactory::getUser()->id);
+		//Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
+		//otherwise it can end up in a redirect loop.
+		if (!empty($default->id) && $active->home !== 1 && in_array($default->access, $levels))
 		{
 			$query['Itemid'] = $default->id;
 		}

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -131,7 +131,7 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		$default = $this->router->menu->getDefault($language);
 
 		// Get the current users access levels
-		$levels = JAccess::getAuthorisedViewLevels(JFactory::getUser()->id);
+		$levels = JFactory::getUser()->getAuthorisedViewLevels();
 
 		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
 		// otherwise it can end up in a redirect loop.

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -133,7 +133,8 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		// Get the current users access levels
 		$levels = JAccess::getAuthorisedViewLevels(JFactory::getUser()->id);
 
-		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item, otherwise it can end up in a redirect loop.
+		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
+		// otherwise it can end up in a redirect loop.
 		if (!empty($default->id) && $active->home !== 1 && in_array($default->access, $levels))
 		{
 			$query['Itemid'] = $default->id;

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -117,7 +117,7 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 			}
 		}
 
-		// Check if the active menuitem matches the requested language
+		// Check if the active menu item matches the requested language
 		$active = $this->router->menu->getActive();
 
 		if ($active && $active->component == 'com_' . $this->router->getName()
@@ -130,10 +130,10 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		// If not found, return language specific home link
 		$default = $this->router->menu->getDefault($language);
 
-		// Get the current users access levels
+		// Get the current user's access levels
 		$levels = JFactory::getUser()->getAuthorisedViewLevels();
 
-		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
+		// Make sure there is a menu item ID, check it is the home menu, and the user can actually access this menu item,
 		// otherwise it can end up in a redirect loop.
 		if (!empty($default->id) && ($active && $active->home !== 1 && in_array($default->access, $levels)))
 		{

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -132,8 +132,8 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 
 		// Get the current users access levels
 		$levels = JAccess::getAuthorisedViewLevels(JFactory::getUser()->id);
-		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
-		// otherwise it can end up in a redirect loop.
+
+		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item, otherwise it can end up in a redirect loop.
 		if (!empty($default->id) && $active->home !== 1 && in_array($default->access, $levels))
 		{
 			$query['Itemid'] = $default->id;

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -130,10 +130,10 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 		// If not found, return language specific home link
 		$default = $this->router->menu->getDefault($language);
 
-		//Get the current users access levels
+		// Get the current users access levels
 		$levels = JAccess::getAuthorisedViewLevels(JFactory::getUser()->id);
-		//Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
-		//otherwise it can end up in a redirect loop.
+		// Make sure there is an menu item ID, check it is the home menu, and the user can actually access this menu item,
+		// otherwise it can end up in a redirect loop.
 		if (!empty($default->id) && $active->home !== 1 && in_array($default->access, $levels))
 		{
 			$query['Itemid'] = $default->id;


### PR DESCRIPTION
Pull Request for Issue #15730.

### Summary of Changes

Add check that current is not the homepage menu itemid, then check the user has access before applying the Itemid. 

### Testing Instructions

Before patch, set the homepage as a 'Registered' Access level menu on a blank install. And access the menu, any menu item will do.


### Expected result

You are redirected to a login page.

### Actual result

You end up in a redirect loop.

### Documentation Changes Required

