### PR TITLE
Multilingual associations buttons missing icons

### DIFF
--- a/administrator/components/com_associations/views/association/view.html.php
+++ b/administrator/components/com_associations/views/association/view.html.php
@@ -197,13 +197,13 @@ class AssociationsViewAssociation extends JViewLegacy
 
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')" '
-			. 'class="btn btn-small btn-success"><span class="icon-32-apply icon-white" aria-hidden="true"></span>'
+			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white" aria-hidden="true"></span>'
 			. JText::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button>', 'reference'
 		);
 
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'target\')" '
-			. 'class="btn btn-small btn-success"><span class="icon-32-apply icon-white" aria-hidden="true"></span>'
+			. 'class="btn btn-small btn-success"><span class="icon-apply icon-white" aria-hidden="true"></span>'
 			. JText::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
 		);
 


### PR DESCRIPTION
As seen in the images the code for the icons was incorrect. icon-32=* was only for hathor

## before
<img width="527" alt="screenshotr21-03-32" src="https://cloud.githubusercontent.com/assets/1296369/26326312/865a6550-3f32-11e7-8cd2-9d5e7f70382b.png">


## after
<img width="602" alt="screenshotr21-03-00" src="https://cloud.githubusercontent.com/assets/1296369/26326325/90655fdc-3f32-11e7-9449-3f2d854cdf2f.png">

