### PR TITLE
Remove white shadow from status bar

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8425,11 +8425,11 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 }
 #status {
 	background: #ebebeb;
-	border-top: 1px solid #d4d4d4;
+	border-top: 1px solid #dedede;
 	padding: 4px 10px;
-	-webkit-box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
-	-moz-box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
-	box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
+	-webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
+	-moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
+	box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
 	color: #626262;
 }
 #status .btn-group {

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8425,11 +8425,11 @@ html[dir=rtl] .quick-icons .nav-list [class*=" icon-"] {
 }
 #status {
 	background: #ebebeb;
-	border-top: 1px solid #d4d4d4;
+	border-top: 1px solid #dedede;
 	padding: 4px 10px;
-	-webkit-box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
-	-moz-box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
-	box-shadow: 0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6);
+	-webkit-box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
+	-moz-box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
+	box-shadow: 0 0 3px rgba(0, 0, 0, 0.08);
 	color: #626262;
 }
 #status .btn-group {

--- a/administrator/templates/isis/less/blocks/_status.less
+++ b/administrator/templates/isis/less/blocks/_status.less
@@ -2,9 +2,9 @@
 
 #status {
 	background: #ebebeb;
-	border-top: 1px solid #d4d4d4;
+	border-top: 1px solid #dedede;
 	padding: 4px 10px;
-	.box-shadow(~"0px 1px 0px rgba(255, 255, 255, 0.8) inset, 0px -15px 15px rgba(255, 255, 255, 0.6)");
+	.box-shadow(~"0 0 3px rgba(0, 0, 0, 0.08)");
 	color: #626262;
 
 	.btn-group {


### PR DESCRIPTION
Pull Request for Issue #16160 .

### Summary of Changes
Remove the large white shadow from the footer status bar.


### Testing Instructions
Apply patch and check that the shadow in #16160 has been removed.


### Expected result



### Actual result



### Documentation Changes Required

