### PR TITLE
Fix Voting php warning on blog category pages

### DIFF
--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -20,7 +20,12 @@ defined('_JEXEC') or die;
  * @var   string   $path     Path to this file
  */
 
-$rating = (int) @$row->rating;
+if ($context=='com_content.categories')
+{
+	return;
+}
+
+$rating = (int) $row->rating;
 
 $img = '';
 

--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
  * @var   string   $path     Path to this file
  */
 
-if ($context=='com_content.categories')
+if ($context == 'com_content.categories')
 {
 	return;
 }

--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -27,12 +27,11 @@ if ($context == 'com_content.categories')
 
 $rating = (int) $row->rating;
 
-$img = '';
-
 // Look for images in template if available
 $starImageOn  = JHtml::_('image', 'system/rating_star.png', JText::_('PLG_VOTE_STAR_ACTIVE'), null, true);
 $starImageOff = JHtml::_('image', 'system/rating_star_blank.png', JText::_('PLG_VOTE_STAR_INACTIVE'), null, true);
 
+$img = '';
 for ($i = 0; $i < $rating; $i++)
 {
 	$img .= $starImageOn;


### PR DESCRIPTION
Pull Request for Issue #16203


Create a Blog item menu, create some article for the blog. Enable Show Voting in the blog menu item.

PHP Notice: Undefined property: JCategoryNode::$rating_count in ../plugins/content/vote/tmpl/rating.php on line 45

Replaced PR https://github.com/joomla/joomla-cms/pull/16204