### PR TITLE
Deprecate JGrid

### DIFF
--- a/libraries/joomla/grid/grid.php
+++ b/libraries/joomla/grid/grid.php
@@ -13,6 +13,7 @@ defined('JPATH_PLATFORM') or die;
  * JGrid class to dynamically generate HTML tables
  *
  * @since  11.3
+ * @deprecated 4.0 This class will be removed without any replacement
  */
 class JGrid
 {

--- a/libraries/joomla/grid/grid.php
+++ b/libraries/joomla/grid/grid.php
@@ -12,8 +12,8 @@ defined('JPATH_PLATFORM') or die;
 /**
  * JGrid class to dynamically generate HTML tables
  *
- * @since  11.3
- * @deprecated 4.0 This class will be removed without any replacement
+ * @since       11.3
+ * @deprecated  4.0 This class will be removed without any replacement
  */
 class JGrid
 {


### PR DESCRIPTION
~Namespace grid. Who the heck is still using this class?~

After the discussion in this pr, the `JGrid` class will be deprecated.