### PR TITLE
Space missing between attributes in xml.

### DIFF
--- a/components/com_content/views/featured/tmpl/default.xml
+++ b/components/com_content/views/featured/tmpl/default.xml
@@ -16,7 +16,8 @@
 			name="featured_categories"
 			type="category"
 			label="COM_CONTENT_FEATURED_CATEGORIES_LABEL"
-			description="COM_CONTENT_FEATURED_CATEGORIES_DESC"extension="com_content"
+			description="COM_CONTENT_FEATURED_CATEGORIES_DESC"
+			extension="com_content"
 			multiple="true"
 			size="10"
 			default=""
@@ -24,21 +25,21 @@
 			<option value="">JOPTION_ALL_CATEGORIES</option>
 			</field>
 
-			<field 
+			<field
 				name="layout_type"
 				type="hidden"
 				default="blog"
 			/>
 
-			<field 
-				name="bloglayout" 
-				type="spacer" 
+			<field
+				name="bloglayout"
+				type="spacer"
 				label="JGLOBAL_SUBSLIDER_BLOG_LAYOUT_LABEL"
 				class="text"
 			/>
 
-			<field 
-				name="num_leading_articles" 
+			<field
+				name="num_leading_articles"
 				type="text"
 				label="JGLOBAL_NUM_LEADING_ARTICLES_LABEL"
 				description="JGLOBAL_NUM_LEADING_ARTICLES_DESC"
@@ -46,8 +47,8 @@
 				size="3"
 			/>
 
-			<field 
-				name="num_intro_articles" 
+			<field
+				name="num_intro_articles"
 				type="text"
 				label="JGLOBAL_NUM_INTRO_ARTICLES_LABEL"
 				description="JGLOBAL_NUM_INTRO_ARTICLES_DESC"
@@ -55,8 +56,8 @@
 				size="3"
 			/>
 
-			<field 
-				name="num_columns" 
+			<field
+				name="num_columns"
 				type="text"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				description="JGLOBAL_NUM_COLUMNS_DESC"
@@ -64,8 +65,8 @@
 				size="3"
 			/>
 
-			<field 
-				name="num_links" 
+			<field
+				name="num_links"
 				type="text"
 				label="JGLOBAL_NUM_LINKS_LABEL"
 				description="JGLOBAL_NUM_LINKS_DESC"
@@ -73,8 +74,8 @@
 				size="3"
 			/>
 
-			<field 
-				name="multi_column_order" 
+			<field
+				name="multi_column_order"
 				type="list"
 				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
 				description="JGLOBAL_MULTI_COLUMN_ORDER_DESC"
@@ -84,8 +85,8 @@
 				<option value="1">JGLOBAL_Across</option>
 			</field>
 
-			<field 
-				name="orderby_pri" 
+			<field
+				name="orderby_pri"
 				type="list"
 				label="JGLOBAL_CATEGORY_ORDER_LABEL"
 				description="JGLOBAL_CATEGORY_ORDER_DESC"
@@ -97,8 +98,8 @@
 				<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
 			</field>
 
-			<field 
-				name="orderby_sec" 
+			<field
+				name="orderby_sec"
 				type="list"
 				label="JGLOBAL_ARTICLE_ORDER_LABEL"
 				description="JGLOBAL_ARTICLE_ORDER_DESC"
@@ -121,8 +122,8 @@
 				<option value="rrank" requires="vote">JGLOBAL_RATINGS_ASC</option>
 			</field>
 
-			<field 
-				name="order_date" 
+			<field
+				name="order_date"
 				type="list"
 				label="JGLOBAL_ORDERING_DATE_LABEL"
 				description="JGLOBAL_ORDERING_DATE_DESC"
@@ -133,8 +134,8 @@
 				<option value="published">JPUBLISHED</option>
 			</field>
 
-			<field 
-				name="show_pagination" 
+			<field
+				name="show_pagination"
 				type="list"
 				label="JGLOBAL_PAGINATION_LABEL"
 				description="JGLOBAL_PAGINATION_DESC"
@@ -145,8 +146,8 @@
 				<option value="2">JGLOBAL_AUTO</option>
 			</field>
 
-			<field 
-				name="show_pagination_results" 
+			<field
+				name="show_pagination_results"
 				type="list"
 				label="JGLOBAL_PAGINATION_RESULTS_LABEL"
 				description="JGLOBAL_PAGINATION_RESULTS_DESC"
@@ -158,8 +159,8 @@
 	</fieldset>
 
 	<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
-			<field 
-				name="show_title" 
+			<field
+				name="show_title"
 				type="list"
 				label="JGLOBAL_SHOW_TITLE_LABEL"
 				description="JGLOBAL_SHOW_TITLE_DESC"
@@ -170,8 +171,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="link_titles" 
+			<field
+				name="link_titles"
 				type="list"
 				label="JGLOBAL_LINKED_TITLES_LABEL"
 				description="JGLOBAL_LINKED_TITLES_DESC"
@@ -182,8 +183,8 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field 
-				name="show_intro" 
+			<field
+				name="show_intro"
 				type="list"
 				label="JGLOBAL_SHOW_INTRO_LABEL"
 				description="JGLOBAL_SHOW_INTRO_DESC"
@@ -220,8 +221,8 @@
 				<option	value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_category" 
+			<field
+				name="show_category"
 				type="list"
 				label="JGLOBAL_SHOW_CATEGORY_LABEL"
 				description="JGLOBAL_SHOW_CATEGORY_DESC"
@@ -232,8 +233,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="link_category" 
+			<field
+				name="link_category"
 				type="list"
 				label="JGLOBAL_LINK_CATEGORY_LABEL"
 				description="JGLOBAL_LINK_CATEGORY_DESC"
@@ -244,8 +245,8 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field 
-				name="show_parent_category" 
+			<field
+				name="show_parent_category"
 				type="list"
 				label="JGLOBAL_SHOW_PARENT_CATEGORY_LABEL"
 				description="JGLOBAL_SHOW_PARENT_CATEGORY_DESC"
@@ -256,8 +257,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="link_parent_category" 
+			<field
+				name="link_parent_category"
 				type="list"
 				label="JGLOBAL_LINK_PARENT_CATEGORY_LABEL"
 				description="JGLOBAL_LINK_PARENT_CATEGORY_DESC"
@@ -279,8 +280,8 @@
 				<option value="0">JHIDE</option>
 			</field>
 
-			<field 
-				name="show_author" 
+			<field
+				name="show_author"
 				type="list"
 				label="JGLOBAL_SHOW_AUTHOR_LABEL"
 				description="JGLOBAL_SHOW_AUTHOR_DESC"
@@ -291,8 +292,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="link_author" 
+			<field
+				name="link_author"
 				type="list"
 				label="JGLOBAL_LINK_AUTHOR_LABEL"
 				description="JGLOBAL_LINK_AUTHOR_DESC"
@@ -303,8 +304,8 @@
 				<option value="1">JYes</option>
 			</field>
 
-			<field 
-				name="show_create_date" 
+			<field
+				name="show_create_date"
 				type="list"
 				label="JGLOBAL_SHOW_CREATE_DATE_LABEL"
 				description="JGLOBAL_SHOW_CREATE_DATE_DESC"
@@ -315,8 +316,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_modify_date" 
+			<field
+				name="show_modify_date"
 				type="list"
 				label="JGLOBAL_SHOW_MODIFY_DATE_LABEL"
 				description="JGLOBAL_SHOW_MODIFY_DATE_DESC"
@@ -327,8 +328,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_publish_date" 
+			<field
+				name="show_publish_date"
 				type="list"
 				label="JGLOBAL_SHOW_PUBLISH_DATE_LABEL"
 				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
@@ -339,8 +340,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_item_navigation" 
+			<field
+				name="show_item_navigation"
 				type="list"
 				label="JGLOBAL_SHOW_NAVIGATION_LABEL"
 				description="JGLOBAL_SHOW_PUBLISH_DATE_DESC"
@@ -352,7 +353,7 @@
 			</field>
 
 			<field
-				name="show_vote" 
+				name="show_vote"
 				type="list"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				description="JGLOBAL_SHOW_VOTE_DESC"
@@ -385,8 +386,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_icons" 
+			<field
+				name="show_icons"
 				type="list"
 				label="JGLOBAL_SHOW_ICONS_LABEL"
 				description="JGLOBAL_SHOW_ICONS_DESC"
@@ -397,8 +398,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_print_icon" 
+			<field
+				name="show_print_icon"
 				type="list"
 				label="JGLOBAL_SHOW_PRINT_ICON_LABEL"
 				description="JGLOBAL_SHOW_PRINT_ICON_DESC"
@@ -409,8 +410,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_email_icon" 
+			<field
+				name="show_email_icon"
 				type="list"
 				label="JGLOBAL_SHOW_EMAIL_ICON_LABEL"
 				description="JGLOBAL_SHOW_EMAIL_ICON_DESC"
@@ -421,8 +422,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_hits" 
+			<field
+				name="show_hits"
 				type="list"
 				label="JGLOBAL_SHOW_HITS_LABEL"
 				description="JGLOBAL_SHOW_HITS_DESC"
@@ -433,7 +434,7 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
+			<field
 				name="show_tags"
 				type="list"
 				label="COM_CONTENT_FIELD_SHOW_TAGS_LABEL"
@@ -444,8 +445,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="show_noauth" 
+			<field
+				name="show_noauth"
 				type="list"
 				label="JGLOBAL_SHOW_UNAUTH_LINKS_LABEL"
 				description="JGLOBAL_SHOW_UNAUTH_LINKS_DESC"
@@ -458,8 +459,8 @@
 		</fieldset>
 		<fieldset name="integration" label="COM_MENUS_INTEGRATION_FIELDSET_LABEL">
 
-			<field 
-				name="show_feed_link" 
+			<field
+				name="show_feed_link"
 				type="list"
 				label="JGLOBAL_SHOW_FEED_LINK_LABEL"
 				description="JGLOBAL_SHOW_FEED_LINK_DESC"
@@ -469,8 +470,8 @@
 				<option value="1">JSHOW</option>
 			</field>
 
-			<field 
-				name="feed_summary" 
+			<field
+				name="feed_summary"
 				type="list"
 				label="JGLOBAL_FEED_SUMMARY_LABEL"
 				description="JGLOBAL_FEED_SUMMARY_DESC"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added a newline where one was missing.


### Testing Instructions
Open a page that reads `components/com_content/views/featured/tmpl/default.xml` (for example, a menu listing page in the admin which has a "featured articles" type on it). 


### Expected result
The page will render without issue.


### Actual result
Errors from attempting to parse bad xml.


### Documentation Changes Required
Nope.
