### PR TITLE
[4.0] JError and JTableMenu aren't namespaced (yet)

### DIFF
--- a/libraries/src/CMS/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/CMS/Installer/Adapter/ComponentAdapter.php
@@ -1106,7 +1106,7 @@ class ComponentAdapter extends InstallerAdapter
 	{
 		$db = $this->parent->getDbo();
 
-		/** @var  JTableMenu  $table */
+		/** @var  \JTableMenu  $table */
 		$table = Table::getInstance('menu');
 
 		// Get the ids of the menu items
@@ -1131,7 +1131,7 @@ class ComponentAdapter extends InstallerAdapter
 			{
 				if (!$table->delete((int) $menuid))
 				{
-					JError::raiseWarning(1, $table->getError());
+					\JError::raiseWarning(1, $table->getError());
 
 					$result = false;
 				}
@@ -1323,7 +1323,7 @@ class ComponentAdapter extends InstallerAdapter
 	{
 		$db = $this->parent->getDbo();
 
-		/** @var  JTableMenu  $table */
+		/** @var  \JTableMenu  $table */
 		$table  = Table::getInstance('menu');
 
 		try
@@ -1332,7 +1332,7 @@ class ComponentAdapter extends InstallerAdapter
 		}
 		catch (\InvalidArgumentException $e)
 		{
-			JLog::add($e->getMessage(), JLog::WARNING, 'jerror');
+			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
 
 			return false;
 		}
@@ -1356,13 +1356,13 @@ class ComponentAdapter extends InstallerAdapter
 			if (!$menu_id)
 			{
 				// Oops! Could not get the menu ID. Go back and rollback changes.
-				JError::raiseWarning(1, $table->getError());
+				\JError::raiseWarning(1, $table->getError());
 
 				return false;
 			}
 			else
 			{
-				/** @var  JTableMenu $temporaryTable */
+				/** @var  \JTableMenu $temporaryTable */
 				$temporaryTable = Table::getInstance('menu');
 				$temporaryTable->delete($menu_id, true);
 				$temporaryTable->rebuild($data['parent_id']);


### PR DESCRIPTION
`Joomla\CMS\Installer\Adapter\ComponentAdapter` has some calls to JError and JLog which aren't marked being from "root" namespace.
Also fixing some doc blocks to `\JTableMenu`

### Summary of Changes
Adds the leading `\` to the calls.


### Testing Instructions
Install or update a component and you get an error that the Error class isn't found about every second time.


### Expected result
No errors or at least a message


### Actual result
Fatal Error

This could be merged by review I think as the error is obvious. Pinging @laoneo for review.