### PR TITLE
Add truncate class and implement in popular articles module

### DIFF
--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -18,13 +18,13 @@ JHtml::_('bootstrap.tooltip');
 			<?php $hits = (int) $item->hits; ?>
 			<?php $hits_class = ($hits >= 10000 ? 'important' : ($hits >= 1000 ? 'warning' : ($hits >= 100 ? 'info' : ''))); ?>
 			<div class="row-fluid">
-				<div class="span8">
+				<div class="span8 truncate">
 					<span class="badge badge-<?php echo $hits_class; ?> hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JGLOBAL_HITS'); ?>"><?php echo $item->hits; ?></span>
 					<?php if ($item->checked_out) : ?>
 							<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time); ?>
 					<?php endif; ?>
 
-					<strong class="row-title break-word">
+					<strong class="row-title" title="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
 						<?php if ($item->link) : ?>
 							<a href="<?php echo $item->link; ?>">
 								<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?></a>

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7037,6 +7037,11 @@ h6 {
 	font-size: 12px;
 	line-height: 14px;
 }
+.truncate {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7037,6 +7037,11 @@ h6 {
 	font-size: 12px;
 	line-height: 14px;
 }
+.truncate {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
 .chzn-container .chzn-drop {
 	border-radius: 0 0 3px 3px;
 }

--- a/administrator/templates/isis/less/blocks/_global.less
+++ b/administrator/templates/isis/less/blocks/_global.less
@@ -84,3 +84,9 @@ h6 {
 	font-size: 12px;
 	line-height: 14px;
 }
+
+.truncate {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}


### PR DESCRIPTION
Partial Pull Request for Issue #12648

### Summary of Changes

This adds a `.truncate` class to Isis to truncate long text.  To fix the issue with the popular articles module wrapping text, this truncate class is implemented.

### Testing Instructions

Generate an article with a long title, get it to show up in the popular articles backend module, and have the module display in the admin dashboard with a `span6` option so the module is somewhat smaller.  Pre-patch, you should get an awkward looking break.  Post-patch, the title will truncate and using the `title` attribute when hovering over the text it'll show the full non-truncated text.

### Expected result

Should look something like the first item in this image

<img width="519" alt="screen shot 2017-05-24 at 9 30 41 pm" src="https://cloud.githubusercontent.com/assets/368545/26433495/a75a294c-40c8-11e7-9bee-090032381fad.png">

### Documentation Changes Required

If we have the CSS documented anywhere, add that.

Anyone who thinks they can do this better than me is welcome, I can barely write anything that's not PHP 😉 