### PR TITLE
[4.0] Use new event object for fetching quick icons

### DIFF
--- a/administrator/modules/mod_quickicon/event.php
+++ b/administrator/modules/mod_quickicon/event.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  mod_quickicon
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Event\AbstractEvent;
+
+/**
+ * Event object for retrieving pluggable quick icons
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class GetQuickIconsEvent extends AbstractEvent
+{
+	/**
+	 * The event context
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $context;
+
+	/**
+	 * Get the event context
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getContext()
+	{
+		return $this->context;
+	}
+
+	/**
+	 * Set the event context
+	 *
+	 * @param   string  $context  The event context
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setContext($context)
+	{
+		$this->context = $context;
+
+		return $context;
+	}
+}

--- a/administrator/modules/mod_quickicon/helper.php
+++ b/administrator/modules/mod_quickicon/helper.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+JLoader::register('GetQuickIconsEvent', __DIR__ . '/event.php');
+
 /**
  * Helper for mod_quickicon
  *
@@ -87,7 +89,10 @@ abstract class ModQuickIconHelper
 			// Include buttons defined by published quickicon plugins
 			JPluginHelper::importPlugin('quickicon');
 			$app = JFactory::getApplication();
-			$arrays = (array) $app->triggerEvent('onGetIcons', array($context));
+			$arrays = (array) $app->triggerEvent(
+				'onGetIcons',
+				new GetQuickIconsEvent('onGetIcons', ['context' => $context])
+			);
 
 			foreach ($arrays as $response)
 			{


### PR DESCRIPTION
### Summary of Changes

4.0 ships with the Framework event dispatcher which uses an event object based approach with the legacy implementation of events through `JEvent` and `JEventDispatcher` in 3.x is still supported throughout the 4.x lifecycle.  This allows the CMS to work in a "mixed" state where plugins can listen to events with both syntaxes and events can be dispatched through both syntaxes.

As a demonstration of this, the `onGetIcons` event dispatched from the admin `mod_quickicon` is converted to dispatching a `GetQuickIconsEvent` event object versus the legacy way of dispatching events with a plain array of arguments.  The advantage of using event objects is you now have a more crystal clear expectation of what you're getting when an event is dispatched; since your listener is now receiving a PHP class object, it will have an API that can followed to determine what the event arguments are and what types of data exist in them.

Plugins, through our event package's `Joomla\Event\SubscriberInterface`, can now also explicitly declare the events that they support and can map those listeners to any method in the class.  I've changed the Joomla! Update quick icon plugin to make use of this new structure, demonstrating the subscriber implementation and how a listener receives an event object versus the event arguments as method parameters.

I've purposefully not touched the other quick icon plugins to demonstrate how the compatibility layer just works.

### Testing Instructions

With this patch applied, the Joomla update check icon should still display correctly on the admin dashboard.

### Documentation Changes Required

N/A