### PR TITLE
[4.0] Factory service for creating JDocument objects

### DIFF
--- a/installation/application/app.php
+++ b/installation/application/app.php
@@ -40,6 +40,7 @@ JLoader::register('JRouterInstallation', __DIR__ . '/router.php');
 JFactory::$container = (new \Joomla\DI\Container)
 	->registerServiceProvider(new InstallationServiceProviderApplication)
 	->registerServiceProvider(new InstallationServiceProviderSession)
+	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database);
 

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -9,6 +9,9 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Document\Factory;
+use Joomla\CMS\Document\FactoryInterface;
+
 /**
  * Document class, provides an easy interface to parse and display a document
  *
@@ -215,6 +218,14 @@ class JDocument
 	protected $mediaVersion = null;
 
 	/**
+	 * Factory for creating JDocument API objects
+	 *
+	 * @var    FactoryInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $factory;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param   array  $options  Associative array of options
@@ -262,6 +273,15 @@ class JDocument
 		{
 			$this->setMediaVersion($options['mediaversion']);
 		}
+
+		if (array_key_exists('factory', $options))
+		{
+			$this->setFactory($options['factory']);
+		}
+		else
+		{
+			$this->setFactory(new Factory);
+		}
 	}
 
 	/**
@@ -274,7 +294,6 @@ class JDocument
 	 * @return  object  The document object.
 	 *
 	 * @since   11.1
-	 * @todo    This should allow custom class prefixes to be configured somehow
 	 */
 	public static function getInstance($type = 'html', $attributes = array())
 	{
@@ -282,51 +301,26 @@ class JDocument
 
 		if (empty(self::$instances[$signature]))
 		{
-			$type  = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
-			$ntype = null;
-
-			// Determine the path and class
-			$class = 'JDocument' . ucfirst($type);
-
-			if (!class_exists($class))
-			{
-				// @deprecated 4.0 - JDocument objects should be autoloaded instead
-				$path = __DIR__ . '/' . $type . '/' . $type . '.php';
-
-				JLoader::register($class, $path);
-
-				if (class_exists($class))
-				{
-					JLog::add('Non-autoloadable JDocument subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-				}
-				// Default to the raw format
-				else
-				{
-					$ntype = $type;
-					$class = 'JDocumentRaw';
-				}
-			}
-
-			// Check for a possible service from the container otherwise manually instantiate the class
-			if (JFactory::getContainer()->exists($class))
-			{
-				$instance = JFactory::getContainer()->get($class);
-			}
-			else
-			{
-				$instance = new $class($attributes);
-			}
-
-			self::$instances[$signature] = $instance;
-
-			if (!is_null($ntype))
-			{
-				// Set the type to the Document type originally requested
-				$instance->setType($ntype);
-			}
+			self::$instances[$signature] = JFactory::getContainer()->get(FactoryInterface::class)->createDocument($type, $attributes);
 		}
 
 		return self::$instances[$signature];
+	}
+
+	/**
+	 * Set the factory instance
+	 *
+	 * @param   FactoryInterface  $factory  The factory instance
+	 *
+	 * @return  JDocument
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFactory(FactoryInterface $factory)
+	{
+		$this->factory = $factory;
+
+		return $this;
 	}
 
 	/**
@@ -1182,37 +1176,7 @@ class JDocument
 	 */
 	public function loadRenderer($type)
 	{
-		// New class name format adds the format type to the class name
-		$class = 'JDocumentRenderer' . ucfirst($this->getType()) . ucfirst($type);
-
-		if (!class_exists($class))
-		{
-			// "Legacy" class name structure
-			$class = 'JDocumentRenderer' . $type;
-
-			if (!class_exists($class))
-			{
-				// @deprecated 4.0 - Non-autoloadable class support is deprecated, only log a message though if a file is found
-				$path = __DIR__ . '/' . $this->getType() . '/renderer/' . $type . '.php';
-
-				if (!file_exists($path))
-				{
-					throw new RuntimeException('Unable to load renderer class', 500);
-				}
-
-				JLoader::register($class, $path);
-
-				JLog::add('Non-autoloadable JDocumentRenderer subclasses are deprecated, support will be removed in 4.0.', JLog::WARNING, 'deprecated');
-
-				// If the class still doesn't exist after including the path, we've got issues
-				if (!class_exists($class))
-				{
-					throw new RuntimeException('Unable to load renderer class', 500);
-				}
-			}
-		}
-
-		return new $class($this);
+		return $this->factory->createRenderer($this, $type);
 	}
 
 	/**

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -587,6 +587,7 @@ abstract class JFactory
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Application)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session);
 
 		return $container;

--- a/libraries/src/CMS/Document/Factory.php
+++ b/libraries/src/CMS/Document/Factory.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Document;
+
+defined('_JEXEC') or die;
+
+/**
+ * Default factory for creating JDocument objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class Factory implements FactoryInterface
+{
+	/**
+	 * Creates a new JDocument object for the requested format.
+	 *
+	 * @param   string  $type        The document type to instantiate
+	 * @param   array   $attributes  Array of attributes
+	 *
+	 * @return  \JDocument
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createDocument($type = 'html', array $attributes = array())
+	{
+		$type  = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
+		$ntype = null;
+
+		// Determine the path and class
+		$class = '\\JDocument' . ucfirst($type);
+
+		if (!class_exists($class))
+		{
+			$ntype = $type;
+			$class = '\\JDocumentRaw';
+		}
+
+		// Inject this factory into the document unless one was provided
+		if (!isset($attributes['factory']))
+		{
+			$attributes['factory'] = $this;
+		}
+
+		$instance = new $class($attributes);
+
+		if (!is_null($ntype))
+		{
+			// Set the type to the Document type originally requested
+			$instance->setType($ntype);
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Creates a new renderer object.
+	 *
+	 * @param   \JDocument  $document  The JDocument instance to attach to the renderer
+	 * @param   string      $type      The renderer type to instantiate
+	 *
+	 * @return  \JDocumentRenderer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createRenderer(\JDocument $document, $type)
+	{
+		// New class name format adds the format type to the class name
+		$class = '\\JDocumentRenderer' . ucfirst($document->getType()) . ucfirst($type);
+
+		if (!class_exists($class))
+		{
+			// "Legacy" class name structure
+			$class = '\\JDocumentRenderer' . $type;
+
+			if (!class_exists($class))
+			{
+				throw new \RuntimeException('Unable to load renderer class', 500);
+			}
+		}
+
+		return new $class($document);
+	}
+}

--- a/libraries/src/CMS/Document/FactoryInterface.php
+++ b/libraries/src/CMS/Document/FactoryInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Document;
+
+defined('_JEXEC') or die;
+
+/**
+ * Interface defining a factory which can create JDocument objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface FactoryInterface
+{
+	/**
+	 * Creates a new JDocument object for the requested format.
+	 *
+	 * @param   string  $type        The document type to instantiate
+	 * @param   array   $attributes  Array of attributes
+	 *
+	 * @return  \JDocument
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createDocument($type = 'html', array $attributes = array());
+
+	/**
+	 * Creates a new renderer object.
+	 *
+	 * @param   \JDocument  $document  The JDocument instance to attach to the renderer
+	 * @param   string      $type      The renderer type to instantiate
+	 *
+	 * @return  \JDocumentRenderer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createRenderer(\JDocument $document, $type);
+}

--- a/libraries/src/CMS/Service/Provider/Document.php
+++ b/libraries/src/CMS/Service/Provider/Document.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Document\Factory;
+use Joomla\CMS\Document\FactoryInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the application's database dependency
+ *
+ * @since  4.0
+ */
+class Document implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('document.factory', FactoryInterface::class)
+			->alias(Factory::class, FactoryInterface::class)
+			->share(
+				FactoryInterface::class,
+				function (Container $container)
+				{
+					return new Factory;
+				},
+				true
+			);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Our API has some hardcoded conventions as it relates to creating classes in a lot of places and it takes a lot of hackish behavior to be able to do things like replace core services with a custom implementation (one example would be in extensions which replace the JDocument HTML renderer objects with custom implementations).  This PR demonstrates a way around this limitation which can allow us to move in a direction where developers would replace services without overloading core classes.

For the JDocument API, a new service factory class is introduced to replace the inner logic of the `JDocument::getInstance()` and `JDocument::loadRenderer()` methods.  This factory lives in our DI container and an extension can replace the factory definition with any object implementing the `Joomla\CMS\Document\FactoryInterface`, giving them greater flexibility in the creation of `JDocument` and `JDocumentRenderer` objects.  More about how to work with the DI container and this method of service overloading can be found in the [Framework repository README](https://github.com/joomla-framework/di/blob/master/README.md).

Eventually, this should be able to cause `JDocument::getInstance()` to be deprecated in favor of using the service factory.  The CMS web application class and `JFactory` would still be aware of the global singleton document object (the one that gets created and used by default right now), and `JDocument` would lose its stateful `getInstance()` singleton factory and `$instances` container.

### Testing Instructions

For general users, the CMS should continue to function as it did without this PR.  For developers, they should be able to overload the factory service in the container by either setting a new service or extending (decorating) the existing implementation.  As a quick example, this could be used for an `onAfterInitialise` event to replace the factory service in the container.

```php

use Joomla\CMS\Document\FactoryInterface;
use Joomla\DI\Container;

public function onAfterInitialise()
{
    JFactory::getContainer()->extend('document.factory', function (FactoryInterface $originalFactory, Container $container) {
        // This would be the spot where you return your custom FactoryInterface implementation, but maybe that is dependent on a certain extension being enabled
        if (JComponentHelper::isEnabled('com_custommodules') {
            // This will completely replace the original implementation now
            return new CustomFactory;
        }

        // Maybe your custom service depends on a component, and when that component isn't available, you just use the original implementation
        if (!JComponentHelper::isEnabled('com_custommodules') {
            return $originalFactory;
        }

        // Perhaps you defined your custom factory as another service container key, so get that if it is available
        if ($container->exists('my.custom.factory')) {
            return $container->get('my.custom.factory');
        }

        // Or, you could just implement a decorator pattern where your custom implementation receives the original implementation as an argument
        return new DecoratingFactory($originalFactory);
    });
}
```

`JDocument::setFactory()` is also added which would enable a developer to replace the factory implementation used in a given `JDocument` instance.  The factory can also be passed into `JDocument` through its constructor, setting the `factory` key on the options array.

### Documentation Changes Required

Document the new service and this approach to overloading core services.