### PR TITLE
[4.0] Fix fields SQL query

### DIFF
--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -214,40 +214,7 @@ class FieldsModelFields extends JModelList
 			$categories = array_unique($categories);
 
 			// Join over the assigned categories
-			$query->join('LEFT', $db->quoteName('#__fields_categories') . ' AS fc ON fc.field_id = a.id')
-				->group(
-					array(
-						'a.id',
-						'a.title',
-						'a.alias',
-						'a.checked_out',
-						'a.checked_out_time',
-						'a.note',
-						'a.state',
-						'a.access',
-						'a.created_time',
-						'a.created_user_id',
-						'a.ordering',
-						'a.language',
-						'a.fieldparams',
-						'a.params',
-						'a.type',
-						'a.default_value',
-						'a.context',
-						'a.group_id',
-						'a.label',
-						'a.description',
-						'a.required',
-						'l.title',
-						'l.image',
-						'uc.name',
-						'ag.title',
-						'ua.name',
-						'g.title',
-						'g.access',
-						'g.state'
-					)
-				);
+			$query->join('LEFT', $db->quoteName('#__fields_categories') . ' AS fc ON fc.field_id = a.id');
 
 			if (in_array('0', $categories))
 			{
@@ -337,7 +304,7 @@ class FieldsModelFields extends JModelList
 		$listOrdering  = $this->state->get('list.ordering', 'a.ordering');
 		$orderDirn     = $this->state->get('list.direction', 'DESC');
 
-		$query->order($db->escape($listOrdering) . ' ' . $db->escape($orderDirn));		
+		$query->order($db->escape($listOrdering) . ' ' . $db->escape($orderDirn));
 
 		return $query;
 	}


### PR DESCRIPTION
Pull Request for Joomla 3 pr #16192.

### Summary of Changes
Fields are not displayed in the article form because of an SQL query. This pr is the Joomla 4 fix of #16192.

### Testing Instructions
- Create a custom field for articles
- Edit an article

### Expected result
Fields tab should be displayed.

### Actual result
No fields tab is displayed.