### PR TITLE
Correct mistake for "resolve conflicts" in #15747

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -149,9 +149,9 @@ class ContactViewContact extends JViewLegacy
 		 */
 		$item->email_raw = $item->email_to;
 
-		if ($item->email_to && $params->get('show_email'))
+		if ($item->email_to && $item->params->get('show_email'))
 		{
-			$item->email_to = JHtml::_('email.cloak', $item->email_to, (bool) $params->get('add_mailto_link', true));
+			$item->email_to = JHtml::_('email.cloak', $item->email_to, (bool) $item->params->get('add_mailto_link', true));
 		}
 
 		if ($item->params->get('show_street_address') || $item->params->get('show_suburb') || $item->params->get('show_state')


### PR DESCRIPTION
### Summary of Changes
Correct my mistake for "resolve conflicts" in PR #15747.

I inadvertently resolved the conflicts the wrong way. It should be $item->params->get() instead of $params->get().

### Testing Instructions
Code review: https://github.com/matrikular/joomla-cms/commit/66757d610588b71a6c89589eff2586d6602259e2
