### PR TITLE
Fix double encode ampersand in contact select list

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -272,10 +272,10 @@ class ContactViewContact extends JViewLegacy
 		{
 			foreach ($contacts as &$contact)
 			{
-				$contact->link = JRoute::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid));
+				$contact->link = JRoute::_(ContactHelperRoute::getContactRoute($contact->slug, $contact->catid), false);
 			}
 
-			$item->link = JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid));
+			$item->link = JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid), false);
 		}
 
 		// Process the content plugins


### PR DESCRIPTION
### Summary of Changes
As @infograf768 mentioned here: https://github.com/joomla/joomla-cms/pull/15973#issuecomment-303954414 there seems to be a bug in the com_contact view that leads to double encoded ampersands being inserted for each link / url of the contact select list.

Because of this, the url isn't recognised correctly and the params aren't merged properly.

### Testing Instructions
- Apply #16264
- Create at least two contacts in the same category and make sure to fill in an email address.
- Create a menu item for those two contacts. 
- Set the "Disable the "Add Mailto: Link" parameter in one of the menu items to "Show", leave the other to "Use Global"
- Set the "Show Contact List" parameter in the com_contact options to "Show"
- Set the "Disable the "Add Mailto: Link" parameter in the com_contact option to "Hide"

### Expected result
Given that at least two contacts are accessible via a menu item, only one contact should have a mailto link attached to the address. This should be the case whether you've selected a contact from the contact list (select) or via a menu item.

Another indicator would be, that the breadcrumb navigation always shows the contacts alias as the last element.

### Actual result
While in @infograf768 test the mailto links were both always on, in mine (after applying #16264), the mailto links for all contacts were always off. Either way, an indication that the params have been merged incorrectly.