### PR TITLE
Fix notices on Contact form

### DIFF
--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -66,13 +66,17 @@ $tparams = $this->item->params;
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
 	<?php $presentation_style = $tparams->get('presentation_style'); ?>
+    <?php $accordionStarted = true; ?>
+	<?php $tabSetStarted = true; ?>
 
 	<?php if ($this->params->get('show_info', 1)) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'basic-details')); ?>
+            <?php $accordionStarted = true; ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic-details')); ?>
+			<?php $tabSetStarted = true; ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'basic-details', JText::_('COM_CONTACT_DETAILS')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_DETAILS') . '</h3>'; ?>
@@ -109,8 +113,20 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
+            <?php if(!$accordionStarted)
+			{
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-form'));
+			    $accordionStarted = true;
+			}
+            ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
+			<?php if(!$tabSetStarted)
+			{
+			    echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-form'));
+				$tabSetStarted = true;
+			}
+            ?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-form', JText::_('COM_CONTACT_EMAIL_FORM')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_EMAIL_FORM') . '</h3>'; ?>
@@ -131,8 +147,20 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
+			<?php if(!$accordionStarted)
+			{
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-articles'));
+				$accordionStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
+			<?php if(!$tabSetStarted)
+			{
+				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-articles'));
+				$tabSetStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-articles', JText::_('JGLOBAL_ARTICLES')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('JGLOBAL_ARTICLES') . '</h3>'; ?>
@@ -149,8 +177,20 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
+			<?php if(!$accordionStarted)
+			{
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-profile'));
+				$accordionStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
+			<?php if(!$tabSetStarted)
+			{
+				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-profile'));
+				$tabSetStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-profile', JText::_('COM_CONTACT_PROFILE')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_PROFILE') . '</h3>'; ?>
@@ -171,8 +211,20 @@ $tparams = $this->item->params;
 
 	<?php if ($this->contact->misc && $tparams->get('show_misc')) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
+			<?php if(!$accordionStarted)
+			{
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-misc'));
+				$accordionStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
+			<?php if(!$tabSetStarted)
+			{
+				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-misc'));
+				$tabSetStarted = true;
+			}
+			?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-misc', JText::_('COM_CONTACT_OTHER_INFORMATION')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_OTHER_INFORMATION') . '</h3>'; ?>
@@ -200,9 +252,9 @@ $tparams = $this->item->params;
 		<?php endif; ?>
 	<?php endif; ?>
 
-	<?php if ($presentation_style === 'sliders') : ?>
+	<?php if ($accordionStarted) : ?>
 		<?php echo JHtml::_('bootstrap.endAccordion'); ?>
-	<?php elseif ($presentation_style === 'tabs') : ?>
+	<?php elseif ($tabSetStarted) : ?>
 		<?php echo JHtml::_('bootstrap.endTabSet'); ?>
 	<?php endif; ?>
 

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -115,7 +115,7 @@ $tparams = $this->item->params;
 		<?php if ($presentation_style === 'sliders') : ?>
             <?php if(!$accordionStarted)
 			{
-				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-form'));
+			    echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-form'));
 			    $accordionStarted = true;
 			}
             ?>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -66,8 +66,8 @@ $tparams = $this->item->params;
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
 	<?php $presentation_style = $tparams->get('presentation_style'); ?>
-    <?php $accordionStarted = true; ?>
-	<?php $tabSetStarted = true; ?>
+    	<?php $accordionStarted = false; ?>
+	<?php $tabSetStarted = false; ?>
 
 	<?php if ($this->params->get('show_info', 1)) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -123,7 +123,7 @@ $tparams = $this->item->params;
 		<?php elseif ($presentation_style === 'tabs') : ?>
 			<?php if (!$tabSetStarted)
 			{
-			    echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-form'));
+				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-form'));
 				$tabSetStarted = true;
 			}
 			?>

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -66,13 +66,13 @@ $tparams = $this->item->params;
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
 	<?php $presentation_style = $tparams->get('presentation_style'); ?>
-    	<?php $accordionStarted = false; ?>
+	<?php $accordionStarted = false; ?>
 	<?php $tabSetStarted = false; ?>
 
 	<?php if ($this->params->get('show_info', 1)) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
 			<?php echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'basic-details')); ?>
-            <?php $accordionStarted = true; ?>
+			<?php $accordionStarted = true; ?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
 			<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'basic-details')); ?>
@@ -113,20 +113,20 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
-            <?php if(!$accordionStarted)
+			<?php if (!$accordionStarted)
 			{
-			    echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-form'));
-			    $accordionStarted = true;
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-form'));
+				$accordionStarted = true;
 			}
-            ?>
+			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
-			<?php if(!$tabSetStarted)
+			<?php if (!$tabSetStarted)
 			{
 			    echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-form'));
 				$tabSetStarted = true;
 			}
-            ?>
+			?>
 			<?php echo JHtml::_('bootstrap.addTab', 'myTab', 'display-form', JText::_('COM_CONTACT_EMAIL_FORM')); ?>
 		<?php elseif ($presentation_style === 'plain') : ?>
 			<?php echo '<h3>' . JText::_('COM_CONTACT_EMAIL_FORM') . '</h3>'; ?>
@@ -147,7 +147,7 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
-			<?php if(!$accordionStarted)
+			<?php if (!$accordionStarted)
 			{
 				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-articles'));
 				$accordionStarted = true;
@@ -155,7 +155,7 @@ $tparams = $this->item->params;
 			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
-			<?php if(!$tabSetStarted)
+			<?php if (!$tabSetStarted)
 			{
 				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-articles'));
 				$tabSetStarted = true;
@@ -177,7 +177,7 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
-			<?php if(!$accordionStarted)
+			<?php if (!$accordionStarted)
 			{
 				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-profile'));
 				$accordionStarted = true;
@@ -185,7 +185,7 @@ $tparams = $this->item->params;
 			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
-			<?php if(!$tabSetStarted)
+			<?php if (!$tabSetStarted)
 			{
 				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-profile'));
 				$tabSetStarted = true;
@@ -211,7 +211,7 @@ $tparams = $this->item->params;
 
 	<?php if ($this->contact->misc && $tparams->get('show_misc')) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
-			<?php if(!$accordionStarted)
+			<?php if (!$accordionStarted)
 			{
 				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-misc'));
 				$accordionStarted = true;
@@ -219,7 +219,7 @@ $tparams = $this->item->params;
 			?>
 			<?php echo JHtml::_('bootstrap.addSlide', 'slide-contact', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
-			<?php if(!$tabSetStarted)
+			<?php if (!$tabSetStarted)
 			{
 				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-misc'));
 				$tabSetStarted = true;


### PR DESCRIPTION
Notice errors are displayed when "Contact information" is disabled, and either Slides or Tabs display format is used.

### Summary of Changes
When displaying com_contact "contact" view, using either Tabs or Sliders display format, multiple notices are thrown by PHP, if "Contact information" is disabled. It happens because the Accordion or the Tab set is only created when "Contact information" is displayed, and therefore is missing if "Contact information" is hidden.

This PR tracks the opening of Accordion and Tab set, and make to open then if it has not been done yet.


### Testing Instructions
1. Create a com_contact menu item of type **Single contact**
2. Under **Contact display options**, select **Sliders** as the Display format.
3. Under **Contact display options**, set **Contact information** to **Hide**
4. In Joomla configuration, set **Error reporting** to **Maximum**
5. Visit the front end using that menu item

6. Perform the same test when selecting **Tabs** as the Display format


### Expected result

The contact form with no error.

### Actual result

You will get notices `errors:

````
Notice: Undefined index: JHtmlBootstrap::startAccordion in  /src/main/libraries/cms/html/bootstrap.php on line 687

Notice: Undefined index: JHtmlBootstrap::startAccordion in /src/main/libraries/cms/html/bootstrap.php on line 688

Notice: Undefined index: JHtmlBootstrap::startAccordion in /src/main/libraries/cms/html/bootstrap.php on line 689
````
### Documentation Changes Required

