### PR TITLE
Fix Stylesheet Mime type keeping b/c

### DIFF
--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -18,7 +18,7 @@
 			label="JTOOLBAR_VERSIONS"
 			id="contenthistory"
 			data-typeAlias="com_content.article"
-		 />
+		/>
 
 		<field
 			name="asset_id"
@@ -97,7 +97,7 @@
 			extension="com_content"
 			class="inputbox"
 			required="true"
-		</field>
+		/>
 
 		<field
 			name="created"
@@ -179,7 +179,7 @@
 			class="inputbox"
 			multiple="true"
 			size="45"
-		</field>
+		/>
 
 		<field
 			name="metakey"
@@ -323,7 +323,7 @@
 		<field
 			name="targeta"
 			type="hidden"
-			/>
+		/>
 
 		<field
 			name="urlb"
@@ -373,56 +373,57 @@
 			type="hidden"
 		/>
 	</fields>
-		<fields name="metadata">
-			<fieldset name="jmetadata"
-				label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
+	<fields name="metadata">
+		<fieldset 
+			name="jmetadata"
+			label="JGLOBAL_FIELDSET_METADATA_OPTIONS">
 
-					<field 
-						name="robots"
-						type="hidden"
-						label="JFIELD_METADATA_ROBOTS_LABEL"
-						description="JFIELD_METADATA_ROBOTS_DESC"
-						filter="unset"
-						labelclass="control-label"
-						>
-						<option value="">JGLOBAL_USE_GLOBAL</option>
-						<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
-						<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
-						<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
-						<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
-					</field>
+				<field 
+					name="robots"
+					type="hidden"
+					label="JFIELD_METADATA_ROBOTS_LABEL"
+					description="JFIELD_METADATA_ROBOTS_DESC"
+					filter="unset"
+					labelclass="control-label"
+					>
+					<option value="">JGLOBAL_USE_GLOBAL</option>
+					<option value="index, follow">JGLOBAL_INDEX_FOLLOW</option>
+					<option value="noindex, follow">JGLOBAL_NOINDEX_FOLLOW</option>
+					<option value="index, nofollow">JGLOBAL_INDEX_NOFOLLOW</option>
+					<option value="noindex, nofollow">JGLOBAL_NOINDEX_NOFOLLOW</option>
+				</field>
 
-					<field 
-						name="author"
-						type="hidden"
-						label="JAUTHOR"
-						description="JFIELD_METADATA_AUTHOR_DESC"
-						filter="unset"
-						size="20"
-						labelclass="control-label"
-					/>
+				<field 
+					name="author"
+					type="hidden"
+					label="JAUTHOR"
+					description="JFIELD_METADATA_AUTHOR_DESC"
+					filter="unset"
+					size="20"
+					labelclass="control-label"
+				/>
 
-					<field 
-						name="rights"
-						type="hidden"
-						label="JFIELD_META_RIGHTS_LABEL"
-						description="JFIELD_META_RIGHTS_DESC"
-						filter="unset"
-						required="false"
-						labelclass="control-label"
-					/>
+				<field 
+					name="rights"
+					type="hidden"
+					label="JFIELD_META_RIGHTS_LABEL"
+					description="JFIELD_META_RIGHTS_DESC"
+					filter="unset"
+					required="false"
+					labelclass="control-label"
+				/>
 
-					<field 
-						name="xreference"
-						type="hidden"
-						label="COM_CONTENT_FIELD_XREFERENCE_LABEL"
-						description="COM_CONTENT_FIELD_XREFERENCE_DESC"
-						filter="unset"
-						class="inputbox"
-						size="20"
-						labelclass="control-label" 
-					/>
+				<field 
+					name="xreference"
+					type="hidden"
+					label="COM_CONTENT_FIELD_XREFERENCE_LABEL"
+					description="COM_CONTENT_FIELD_XREFERENCE_DESC"
+					filter="unset"
+					class="inputbox"
+					size="20"
+					labelclass="control-label" 
+				/>
 
-			</fieldset>
-		</fields>
+		</fieldset>
+	</fields>
 </form>

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -654,7 +654,7 @@ class JDocument
 			// Old mime type parameter.
 			if (!empty($argList[1]))
 			{
-				$attribs['mime'] = $argList[1];
+				$attribs['type'] = $argList[1];
 			}
 
 			// Old media parameter.

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -643,7 +643,7 @@ class JDocument
 	public function addStyleSheet($url, $options = array(), $attribs = array())
 	{
 		// B/C before 3.7.0
-		if (!is_array($options) && (!is_array($attribs) || $attribs === array()))
+		if (is_string($options))
 		{
 			JLog::add('The addStyleSheet method signature used has changed, use (url, options, attributes) instead.', JLog::WARNING, 'deprecated');
 

--- a/libraries/joomla/document/feed.php
+++ b/libraries/joomla/document/feed.php
@@ -212,7 +212,7 @@ class JDocumentFeed extends JDocument
 		// Generate stylesheet links
 		foreach ($this->_styleSheets as $src => $attr)
 		{
-			$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";
+			$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['type'] . "\"?>\n";
 		}
 
 		// Render the feed

--- a/libraries/joomla/document/feed.php
+++ b/libraries/joomla/document/feed.php
@@ -211,7 +211,7 @@ class JDocumentFeed extends JDocument
 		// Generate stylesheet links
 		foreach ($this->_styleSheets as $src => $attr)
 		{
-			// b/c before 3.7.0
+			// Ensure b/c before 3.7.0
 			if (array_key_exists('mime', $attr))
 			{
 				$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";

--- a/libraries/joomla/document/feed.php
+++ b/libraries/joomla/document/feed.php
@@ -204,22 +204,15 @@ class JDocumentFeed extends JDocument
 
 		$this->setMimeEncoding($renderer->getContentType());
 
-		// Output - Generate prolog
+		// Output
+		// Generate prolog
 		$data = "<?xml version=\"1.0\" encoding=\"" . $this->_charset . "\"?>\n";
 		$data .= "<!-- generator=\"" . $this->getGenerator() . "\" -->\n";
 
 		// Generate stylesheet links
 		foreach ($this->_styleSheets as $src => $attr)
 		{
-			// Ensure b/c before 3.7.0
-			if (array_key_exists('mime', $attr))
-			{
-				$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";
-			}
-			else
-			{
-				$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['type'] . "\"?>\n";
-			}
+			$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";
 		}
 
 		// Render the feed

--- a/libraries/joomla/document/feed.php
+++ b/libraries/joomla/document/feed.php
@@ -204,15 +204,22 @@ class JDocumentFeed extends JDocument
 
 		$this->setMimeEncoding($renderer->getContentType());
 
-		// Output
-		// Generate prolog
+		// Output - Generate prolog
 		$data = "<?xml version=\"1.0\" encoding=\"" . $this->_charset . "\"?>\n";
 		$data .= "<!-- generator=\"" . $this->getGenerator() . "\" -->\n";
 
 		// Generate stylesheet links
 		foreach ($this->_styleSheets as $src => $attr)
 		{
-			$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";
+			// b/c before 3.7.0
+			if (array_key_exists('mime', $attr))
+			{
+				$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['mime'] . "\"?>\n";
+			}
+			else
+			{
+				$data .= "<?xml-stylesheet href=\"$src\" type=\"" . $attr['type'] . "\"?>\n";
+			}
 		}
 
 		// Render the feed


### PR DESCRIPTION
Pull Request for Issue #16266.

### Summary of Changes

Ensure b/c and ensure mime type is set on XML Stylesheets in RSS Feeds without PHP undefined index error. 


### Steps to replicate,

 - Edit /libraries/joomla/document/feed.php
 - On Line 206 (or anywhere in the render function, this is just to break it) add code:

```php
// 3/4 style with no options or attribs
$this->addStyleSheet('/media/system/css/modal.css');
```

or 

```php
// 3 with mime specified
$this->addStyleSheet('/media/system/css/modal.css','text/css');
```

or 

```php
// Joomla 4 with type specified
$this->addStyleSheet('/media/system/css/modal.css',array(),array('type'=>'text/css'));
```


 - View any RSS feed created by your Joomla site (mine: E.g.: index.php?option=com_content&view=featured&Itemid=109&format=feed&type=rss)

 - see error message in the RSS of:

![screen shot 2017-05-26 at 22 18 05](https://cloud.githubusercontent.com/assets/400092/26513021/38daa2e0-4261-11e7-8ae3-00118155176d.png)

Then Apply this PR, 

### Expected result

No error


@810 
