### PR TITLE
Travis-CI Tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
     - php: 7.1
-      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
     - php: 5.3
       env: INSTALL_APC="yes"
     - php: 5.4
@@ -26,7 +26,7 @@ matrix:
     - php: 5.6
       env: INSTALL_APCU="yes"
     - php: nightly
-      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
   allow_failures:
     - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
   fast_finish: true
   include:
     - php: 7.0
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     - php: 7.1
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     - php: 5.3
       env: INSTALL_APC="yes"
     - php: 5.4
@@ -26,7 +26,7 @@ matrix:
     - php: 5.6
       env: INSTALL_APCU="yes"
     - php: nightly
-      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no"
+      env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
   allow_failures:
     - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
       env: INSTALL_APCU="yes"
     - php: 5.6
       env: INSTALL_APCU="yes"
+    - php: nightly
+      env: INSTALL_APCU="yes" INSTALL_APCU_BC_BETA="no" INSTALL_MEMCACHE="no" INSTALL_MEMCACHED="no" INSTALL_REDIS="no" # Disabled apcu_bc install until https://github.com/travis-ci/travis-ci/issues/5207 is resolved
+  allow_failures:
+    - php: nightly
 
 services:
   - memcache

--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -27,5 +27,5 @@ if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add "$BASE/build/travis/
 if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
 if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
-if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
+if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_REDIS == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/redis.ini"; fi

--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -7,8 +7,8 @@ BASE="$1"
 # Abort travis execution if setup fails
 set -e
 
-# Disable xdebug on php 7.0.* and lower.
-if [[ ( $TRAVIS_PHP_VERSION = 5.* ) || ( $TRAVIS_PHP_VERSION = 7.0 ) ]]; then phpenv config-rm xdebug.ini; fi
+# Disable xdebug.
+phpenv config-rm xdebug.ini || echo "xdebug not available"
 
 # Make sure all dev dependencies are installed
 composer install

--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -28,5 +28,4 @@ if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add "$BASE/build/travis
 if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu-beta && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
-if [[ $INSTALL_APCU_BC_BETA == "yes" ]]; then printf "\n" | pecl install apcu_bc-beta; fi
 if [[ $INSTALL_REDIS == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/redis.ini"; fi


### PR DESCRIPTION
### Summary of Changes

- Always attempt to disable XDebug with a simpler conditional
- Add a test run for the PHP nightly build, this will basically have us always testing against PHP's master branch going forward (main benefit here is we can test earlier with the latest PHP builds and be more aware if changes in new versions will affect us)
- Remove trying to install `apcu_bc` PECL extension, it's just broken
- Turns back on Memcached and Redis tests on PHP 7

### Testing Instructions

CI still works and review