### PR TITLE
Fixes language loading for system plugins in Language Filter plugin

### DIFF
--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -479,7 +479,10 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($language->getPaths() as $extension => $files)
 			{
-				$newLang->load($extension);
+				if($newLang->load($extension) == false)
+				{
+					$newLang->load($extension, JPATH_ADMINISTRATOR);
+				}
 			}
 
 			JFactory::$language = $newLang;

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -479,7 +479,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 			foreach ($language->getPaths() as $extension => $files)
 			{
-				if($newLang->load($extension) == false)
+				if ($newLang->load($extension) == false)
 				{
 					$newLang->load($extension, JPATH_ADMINISTRATOR);
 				}

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -475,18 +475,25 @@ class PlgSystemLanguageFilter extends JPlugin
 
 		if ($language->getTag() != $lang_code)
 		{
-			$newLang = JLanguage::getInstance($lang_code);
+			$language_new = JLanguage::getInstance($lang_code);
 
 			foreach ($language->getPaths() as $extension => $files)
 			{
-				if ($newLang->load($extension) == false)
+				if (strpos($extension, 'plg_system') !== false)
 				{
-					$newLang->load($extension, JPATH_ADMINISTRATOR);
+					$extension_name = substr($extension, 11);
+
+					$language_new->load($extension, JPATH_ADMINISTRATOR)
+					|| $language_new->load($extension, JPATH_PLUGINS . '/system/' . $extension_name);
+
+					continue;
 				}
+
+				$language_new->load($extension);
 			}
 
-			JFactory::$language = $newLang;
-			$this->app->loadLanguage($newLang);
+			JFactory::$language = $language_new;
+			$this->app->loadLanguage($language_new);
 		}
 
 		// Create a cookie.


### PR DESCRIPTION
Encountered a bug in the Language Filter plugin that prevents the loading of the correct language files for system plugins. This bug was reported by a user of my plugin EasyCalcCheck Plus. All system plugins (also core) are affected.

In the beginning of the process the language files from the plugins are loaded properly using \JPlugin::loadLanguage (with correct path: JPATH_ADMINISTRATOR). But once the language is switched in the frontend, all language files are reloaded in the plugin Language Filter ($newLang->load($extension)) but the problem is that the path for the plugins is not set to JPATH_ADMINISTRATOR but the default parameter is used (JPATH_BASE).

Result is:

<img width="744" alt="i336 cimgpsh_orig" src="https://cloud.githubusercontent.com/assets/1976103/26522541/8e42628e-4303-11e7-9e3c-8fc06795da19.png">

Since the languages files of plugins are stored in the administrator's language folder, wrong paths are used to find the languages files. You see that the paths are not correct (site language folder) and the result is false (obviously).

This leads to non-translated strings after the language switch. A reload of the page will load the proper translation strings.

The problem is that you cannot reload the correct translations later with \JPlugin::loadLanguage because it checks whether the loading of the language file was already processed.

Additional information: The system plugin has to use the "protected $autoloadLanguage = true" property or load the \JPlugin::loadLanguage function before the Language Filter plugin triggers the language switch.

### Summary of Changes

The change is quite simple. If the language file could not be loaded, we try to load the file with the JPATH_ADMINISTRATOR attribute. This will only happen, if the files of plugins have to be loaded. With the correct path the files will be loaded properly and are available directly after the language switch.

### Testing Instructions

The easiest way to test it is to create a multilingual website and install my plugin EasyCalcCheck Plus (https://extensions.joomla.org/extensions/extension/access-a-security/site-security/easycalccheck-plus/). Create a menu entry for each language to the registration form of the core user component. Open the page and change the language with the language module.

### Expected result

The strings are translated properly directly after the language switch.

<img width="422" alt="image" src="https://cloud.githubusercontent.com/assets/1976103/26522652/49c22d68-4305-11e7-9ffa-3984160642d7.png">

### Actual result

The language strings are not translated since the Language Filter plugin does not load the correct strings (wrong path to language files of plugins).

<img width="597" alt="image" src="https://cloud.githubusercontent.com/assets/1976103/26522664/8570f970-4305-11e7-897a-f3248552ac4c.png">

### Documentation Changes Required

No changes required. No B/C breaks.