### PR TITLE
[4.0]Update and fix InstallerHelper accordingly to processHeaders

### DIFF
--- a/libraries/src/CMS/Installer/InstallerHelper.php
+++ b/libraries/src/CMS/Installer/InstallerHelper.php
@@ -73,7 +73,7 @@ abstract class InstallerHelper
 
 		// Parse the Content-Disposition header to get the file name
 		if (isset($response->headers['Content-Disposition'])
-			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'], $parts))
+			&& preg_match("/\s*filename\s?=\s?(.*)/", $response->headers['Content-Disposition'][0], $parts))
 		{
 			$flds = explode(';', $parts[1]);
 			$target = trim($flds[0], '"');


### PR DESCRIPTION
### Summary of Changes
The InstallerHelper class must be updated to evaluate correctly header values based on the new processHeaders function contained in the class \Joomla\Http\AbstractTransport


### Expected result
Header value evaluated correctly in:
$response->headers['Content-Disposition']


### Actual result
The header value is assigned to an array thus requiring:
$response->headers['Content-Disposition'][0]
to access it.

