### PR TITLE
Remove Alias for observer classes which got removed.

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -62,9 +62,6 @@ JLoader::registerAlias('JTableContenthistory',              '\\Joomla\\CMS\\Tabl
 JLoader::registerAlias('JTableContenttype',                 '\\Joomla\\CMS\\Table\\ContentType', '4.0');
 JLoader::registerAlias('JTableCorecontent',                 '\\Joomla\\CMS\\Table\\CoreContent', '4.0');
 JLoader::registerAlias('JTableUcm',                         '\\Joomla\\CMS\\Table\\Ucm', '4.0');
-JLoader::registerAlias('JTableObserver',                    '\\Joomla\\CMS\\Table\\Observer\\AbstractObserver', '4.0');
-JLoader::registerAlias('JTableObserverContenthistory',      '\\Joomla\\CMS\\Table\\Observer\\ContentHistory', '4.0');
-JLoader::registerAlias('JTableObserverTags',                '\\Joomla\\CMS\\Table\\Observer\\Tags', '4.0');
 
 JLoader::registerAlias('JAccess',                           '\\Joomla\\CMS\\Access\\Access', '4.0');
 JLoader::registerAlias('JAccessRule',                       '\\Joomla\\CMS\\Access\\Rule', '4.0');


### PR DESCRIPTION
While testing the stubGenerator PR from Michael I found that we register alias for classes that no longer exist in 4.0.

### Summary of Changes
This removes the class mapping for the three observer classes that got removed.


### Testing Instructions
Not much to test here. Review should be enough since those classes just don't exist anymore.

### Documentation Changes Required
The removing of the observer classes has to be documented as B/C break, but I hope that's already done by the PR which actually removed the oberserver 😄 