### PR TITLE
[4.0] Remove JObject API use in install adapters

### DIFF
--- a/libraries/src/CMS/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/CMS/Installer/Adapter/LanguageAdapter.php
@@ -479,7 +479,7 @@ class LanguageAdapter extends InstallerAdapter
 		// Set the extensions name
 		$name = (string) $this->getManifest()->name;
 		$name = \JFilterInput::getInstance()->clean($name, 'cmd');
-		$this->set('name', $name);
+		$this->name = $name;
 
 		// Get the Language tag [ISO tag, eg. en-GB]
 		$tag = (string) $xml->tag;
@@ -492,7 +492,7 @@ class LanguageAdapter extends InstallerAdapter
 			return false;
 		}
 
-		$this->set('tag', $tag);
+		$this->tag = $tag;
 
 		// Set the language installation path
 		$this->parent->setPath('extension_site', $basePath . '/language/' . $tag);

--- a/libraries/src/CMS/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/CMS/Installer/Adapter/ModuleAdapter.php
@@ -594,7 +594,7 @@ class ModuleAdapter extends InstallerAdapter
 				$this->parent->manifestClass = new $classname($this);
 
 				// And set this so we can copy it later
-				$this->set('manifest_script', $manifestScript);
+				$this->manifest_script = $manifestScript;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes

Uses of the `JObject` API crept back into the install adapters after I refactored them to not extend that class.  This removes the scope creep.

### Testing Instructions

Updating languages and uninstalling modules works.

Fixes https://github.com/joomla/joomla-cms/issues/15631