### PR TITLE
Set a new category if one doesn't exist.

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -417,8 +417,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		{
 			if (count($options) === 0)
 			{
+
 				//All Categories have been deleted, so we need a new delete (This will create on save if selected)
-				$options[0]            = new stdClass();
+				$options[0]            = new stdClass;
 				$options[0]->value     = 'Uncategorised';
 				$options[0]->text      = 'uncategorised';
 				$options[0]->level     = '1';

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -417,7 +417,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		{
 			if (count($options) === 0)
 			{
-				// All Categories have been deleted, so we need a new delete (This will create on save if selected)
+				// All Categories have been deleted, so we need a new category (This will create on save if selected).
 				$options[0]            = new stdClass;
 				$options[0]->value     = 'Uncategorised';
 				$options[0]->text      = 'uncategorised';

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -425,6 +425,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				$options[0]->published = '1';
 				$options[0]->lft       = '1';
 			}
+
 			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
 		}
 

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -420,7 +420,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				// All Categories have been deleted, so we need a new category (This will create on save if selected).
 				$options[0]            = new stdClass;
 				$options[0]->value     = 'Uncategorised';
-				$options[0]->text      = 'uncategorised';
+				$options[0]->text      = 'Uncategorised';
 				$options[0]->level     = '1';
 				$options[0]->published = '1';
 				$options[0]->lft       = '1';

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -417,8 +417,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		{
 			if (count($options) === 0)
 			{
-
-				//All Categories have been deleted, so we need a new delete (This will create on save if selected)
+				// All Categories have been deleted, so we need a new delete (This will create on save if selected)
 				$options[0]            = new stdClass;
 				$options[0]->value     = 'Uncategorised';
 				$options[0]->text      = 'uncategorised';

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -415,6 +415,16 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		else
 			// Create a regular list.
 		{
+			if (count($options) === 0)
+			{
+				//All Categories have been deleted, so we need a new delete (This will create on save if selected)
+				$options[0]            = new stdClass();
+				$options[0]->value     = 'Uncategorised';
+				$options[0]->text      = 'uncategorised';
+				$options[0]->level     = '1';
+				$options[0]->published = '1';
+				$options[0]->lft       = '1';
+			}
 			$html[] = JHtml::_('select.genericlist', $options, $this->name, trim($attr), 'value', 'text', $this->value, $this->id);
 		}
 

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -413,8 +413,8 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			}
 		}
 		else
-			// Create a regular list.
 		{
+			// Create a regular list.
 			if (count($options) === 0)
 			{
 				// All Categories have been deleted, so we need a new category (This will create on save if selected).


### PR DESCRIPTION
Pull Request for Issue #15151. @brianteeman 

Just sets the original uncategorized category as the default selected. If you save, category is created. You can type a new category to create to proceed article creation.

Apply the patch, you can now create an article. IF not selecting a category it is placed in Uncategorized. 

Otherwise you can type a new category name and hit return, then save article and the new category and article is created.