### PR TITLE
[4.0] Move toolbar buttons to left

### DIFF
--- a/administrator/components/com_categories/View/Categories/Html.php
+++ b/administrator/components/com_categories/View/Categories/Html.php
@@ -216,11 +216,6 @@ class Html extends HtmlView
 			\JToolbarHelper::custom('categories.rebuild', 'refresh.png', 'refresh_f2.png', 'JTOOLBAR_REBUILD', false);
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			\JToolbarHelper::preferences($component);
-		}
-
 		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete', $component))
 		{
 			\JToolbarHelper::deleteList('JGLOBAL_CONFIRM_DELETE', 'categories.delete', 'JTOOLBAR_EMPTY_TRASH');
@@ -228,6 +223,11 @@ class Html extends HtmlView
 		elseif ($canDo->get('core.edit.state'))
 		{
 			\JToolbarHelper::trash('categories.trash');
+		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			\JToolbarHelper::preferences($component);
 		}
 
 		// Compute the ref_key if it does exist in the component

--- a/administrator/components/com_fields/View/Fields/Html.php
+++ b/administrator/components/com_fields/View/Fields/Html.php
@@ -181,11 +181,6 @@ class Html extends HtmlView
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			ToolbarHelper::preferences($component);
-		}
-
 		if ($this->state->get('filter.state') == -2 && $canDo->get('core.delete', $component))
 		{
 			ToolbarHelper::deleteList('', 'fields.delete', 'JTOOLBAR_EMPTY_TRASH');
@@ -193,6 +188,11 @@ class Html extends HtmlView
 		elseif ($canDo->get('core.edit.state'))
 		{
 			ToolbarHelper::trash('fields.trash');
+		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			ToolbarHelper::preferences($component);
 		}
 
 		ToolbarHelper::help('JHELP_COMPONENTS_FIELDS_FIELDS');

--- a/administrator/components/com_fields/View/Groups/Html.php
+++ b/administrator/components/com_fields/View/Groups/Html.php
@@ -184,11 +184,6 @@ class Html extends HtmlView
 			$bar->appendButton('Custom', $dhtml, 'batch');
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			ToolbarHelper::preferences($component);
-		}
-
 		if ($this->state->get('filter.state') == -2 && $canDo->get('core.delete', $component))
 		{
 			ToolbarHelper::deleteList('', 'groups.delete', 'JTOOLBAR_EMPTY_TRASH');
@@ -196,6 +191,11 @@ class Html extends HtmlView
 		elseif ($canDo->get('core.edit.state'))
 		{
 			ToolbarHelper::trash('groups.trash');
+		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			ToolbarHelper::preferences($component);
 		}
 
 		ToolbarHelper::help('JHELP_COMPONENTS_FIELDS_FIELD_GROUPS');

--- a/administrator/components/com_finder/View/Filters/Html.php
+++ b/administrator/components/com_finder/View/Filters/Html.php
@@ -139,20 +139,21 @@ class Html extends HtmlView
 			ToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			ToolbarHelper::preferences('com_finder');
-		}
-
 		ToolbarHelper::divider();
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
 		ToolbarHelper::divider();
-		ToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_SEARCH_FILTERS');
 
 		if ($canDo->get('core.delete'))
 		{
 			ToolbarHelper::deleteList('', 'filters.delete');
 			ToolbarHelper::divider();
 		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			ToolbarHelper::preferences('com_finder');
+		}
+
+		ToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_SEARCH_FILTERS');
 	}
 }

--- a/administrator/components/com_finder/View/Index/Html.php
+++ b/administrator/components/com_finder/View/Index/Html.php
@@ -156,11 +156,6 @@ class Html extends HtmlView
 			ToolbarHelper::unpublishList('index.unpublish');
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			ToolbarHelper::preferences('com_finder');
-		}
-
 		$toolbar->appendButton('Popup', 'bars', 'COM_FINDER_STATISTICS', 'index.php?option=com_finder&view=statistics&tmpl=component', 550, 350);
 
 		if ($canDo->get('core.delete'))
@@ -171,6 +166,11 @@ class Html extends HtmlView
 		if ($canDo->get('core.edit.state'))
 		{
 			ToolbarHelper::trash('index.purge', 'COM_FINDER_INDEX_TOOLBAR_PURGE', false);
+		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			ToolbarHelper::preferences('com_finder');
 		}
 
 		ToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_INDEXED_CONTENT');

--- a/administrator/components/com_finder/View/Maps/Html.php
+++ b/administrator/components/com_finder/View/Maps/Html.php
@@ -134,11 +134,6 @@ class Html extends HtmlView
 			ToolbarHelper::divider();
 		}
 
-		if ($canDo->get('core.admin') || $canDo->get('core.options'))
-		{
-			ToolbarHelper::preferences('com_finder');
-		}
-
 		ToolbarHelper::divider();
 		Toolbar::getInstance('toolbar')->appendButton(
 			'Popup',
@@ -149,12 +144,18 @@ class Html extends HtmlView
 			350
 		);
 		ToolbarHelper::divider();
-		ToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_CONTENT_MAPS');
 
 		if ($canDo->get('core.delete'))
 		{
 			ToolbarHelper::deleteList('', 'maps.delete');
 			ToolbarHelper::divider();
 		}
+
+		if ($canDo->get('core.admin') || $canDo->get('core.options'))
+		{
+			ToolbarHelper::preferences('com_finder');
+		}
+
+		ToolbarHelper::help('JHELP_COMPONENTS_FINDER_MANAGE_CONTENT_MAPS');
 	}
 }


### PR DESCRIPTION
There is currently some inconsistency in where the "Trash" and some other toolbar buttons appear. I don't think this is intentional.

### Summary of Changes
Moves the buttons so they are aligned left and only the "Options" and "Help" buttons are right floated.


### Testing Instructions
Check categories view and see the Trash button on the right.
After applying this PR the buttons are on the left block, leaving only the Options and Help buttons on the right.

Other affected views are the list views in Fields and Smart Search.

### Documentation Changes Required
None