### PR TITLE
[4.0] Service factory for the Toolbar API, other tweaks

### DIFF
--- a/installation/application/app.php
+++ b/installation/application/app.php
@@ -40,6 +40,7 @@ JLoader::register('JRouterInstallation', __DIR__ . '/router.php');
 JFactory::$container = (new \Joomla\DI\Container)
 	->registerServiceProvider(new InstallationServiceProviderApplication)
 	->registerServiceProvider(new InstallationServiceProviderSession)
+	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Toolbar)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database);

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -588,7 +588,8 @@ abstract class JFactory
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
-			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session);
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Toolbar);
 
 		return $container;
 	}

--- a/libraries/src/CMS/Service/Provider/Toolbar.php
+++ b/libraries/src/CMS/Service/Provider/Toolbar.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Toolbar\ContainerAwareToolbarFactory;
+use Joomla\CMS\Toolbar\ToolbarFactoryInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the application's toolbar dependency
+ *
+ * @since  4.0
+ */
+class Toolbar implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('toolbar.factory', ToolbarFactoryInterface::class)
+			->alias(ContainerAwareToolbarFactory::class, ToolbarFactoryInterface::class)
+			->share(
+				ToolbarFactoryInterface::class,
+				function (Container $container)
+				{
+					$factory = new ContainerAwareToolbarFactory;
+					$factory->setContainer($container);
+
+					return $factory;
+				},
+				true
+			);
+	}
+}

--- a/libraries/src/CMS/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/CMS/Toolbar/ContainerAwareToolbarFactory.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Toolbar;
+
+defined('_JEXEC') or die;
+
+use Joomla\DI\ContainerAwareInterface;
+use Joomla\DI\ContainerAwareTrait;
+
+/**
+ * Default factory for creating toolbar objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, ContainerAwareInterface
+{
+	use ContainerAwareTrait;
+
+	/**
+	 * Creates a new toolbar button.
+	 *
+	 * @param   Toolbar  $toolbar  The Toolbar instance to attach to the button
+	 * @param   string   $type     Button Type
+	 *
+	 * @return  ToolbarButton
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function createButton(Toolbar $toolbar, $type)
+	{
+		$buttonClass = $this->loadButtonClass($type);
+
+		if (!$buttonClass)
+		{
+			$dirs = $toolbar->getButtonPath();
+
+			$file = \JFilterInput::getInstance()->clean(str_replace('_', DIRECTORY_SEPARATOR, strtolower($type)) . '.php', 'path');
+
+			jimport('joomla.filesystem.path');
+
+			if ($buttonFile = \JPath::find($dirs, $file))
+			{
+				include_once $buttonFile;
+			}
+			else
+			{
+				\JLog::add(\JText::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile), \JLog::WARNING, 'jerror');
+
+				throw new \InvalidArgumentException(\JText::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile));
+			}
+		}
+
+		if (!class_exists($buttonClass))
+		{
+			throw new \InvalidArgumentException(sprintf('Class `%1$s` does not exist, could not create a toolbar button.'));
+		}
+
+		// Check for a possible service from the container otherwise manually instantiate the class
+		if ($this->getContainer()->has($buttonClass))
+		{
+			return $this->getContainer()->get($buttonClass);
+		}
+
+		return new $buttonClass($toolbar);
+	}
+
+	/**
+	 * Creates a new Toolbar object.
+	 *
+	 * @param   string  $name  The toolbar name.
+	 *
+	 * @return  Toolbar
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createToolbar($name = 'toolbar')
+	{
+		return new Toolbar($name, $this->getContainer());
+	}
+
+	/**
+	 * Load the button class including the deprecated ones.
+	 *
+	 * @param   string  $type  Button Type
+	 *
+	 * @return  string|null
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function loadButtonClass($type)
+	{
+		$buttonClasses = [
+			'Joomla\\CMS\\Toolbar\\Button\\' . ucfirst($type) . 'Button',
+			// @deprecated __DEPLOY_VERSION__
+			'JToolbarButton' . ucfirst($type),
+		];
+
+		foreach ($buttonClasses as $buttonClass)
+		{
+			if (!class_exists($buttonClass))
+			{
+				continue;
+			}
+
+			return $buttonClass;
+		}
+
+		return null;
+	}
+}

--- a/libraries/src/CMS/Toolbar/Toolbar.php
+++ b/libraries/src/CMS/Toolbar/Toolbar.php
@@ -56,27 +56,54 @@ class Toolbar
 	protected static $instances = array();
 
 	/**
+	 * Factory for creating Toolbar API objects
+	 *
+	 * @var    ToolbarFactoryInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $factory;
+
+	/**
 	 * Constructor
 	 *
-	 * @param   string  $name  The toolbar name.
+	 * @param   string                   $name     The toolbar name.
+	 * @param   ToolbarFactoryInterface  $factory  The toolbar factory.
 	 *
 	 * @since   1.5
 	 */
-	public function __construct($name = 'toolbar')
+	public function __construct($name = 'toolbar', ToolbarFactoryInterface $factory = null)
 	{
-		$this->_name = $name;
+		$this->_name   = $name;
+
+		// At 5.0, require the factory to be injected
+		if (!$factory)
+		{
+			\JLog::add(
+				sprintf(
+					'As of Joomla! 5.0, a %1$s must be provided to a %2$s object when creating it.',
+					ToolbarFactoryInterface::class,
+					get_class($this)
+				),
+				\JLog::WARNING,
+				'deprecated'
+			);
+
+			$factory = new ContainerAwareToolbarFactory;
+			$factory->setContainer(\JFactory::getContainer());
+		}
+
+		$this->setFactory($factory);
 
 		// Set base path to find buttons.
-		$this->_buttonPath[] = __DIR__ . '/button';
+		$this->_buttonPath[] = __DIR__ . '/Button';
 	}
 
 	/**
-	 * Returns the global Toolbar object, only creating it if it
-	 * doesn't already exist.
+	 * Returns the global Toolbar object, only creating it if it doesn't already exist.
 	 *
 	 * @param   string  $name  The name of the toolbar.
 	 *
-	 * @return  Toolbar  The JToolbar object.
+	 * @return  Toolbar  The Toolbar object.
 	 *
 	 * @since   1.5
 	 */
@@ -84,10 +111,26 @@ class Toolbar
 	{
 		if (empty(self::$instances[$name]))
 		{
-			self::$instances[$name] = new static($name);
+			self::$instances[$name] = \JFactory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar('name');
 		}
 
 		return self::$instances[$name];
+	}
+
+	/**
+	 * Set the factory instance
+	 *
+	 * @param   ToolbarFactoryInterface  $factory  The factory instance
+	 *
+	 * @return  $this
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setFactory(ToolbarFactoryInterface $factory)
+	{
+		$this->factory = $factory;
+
+		return $this;
 	}
 
 	/**
@@ -227,81 +270,19 @@ class Toolbar
 			return false;
 		}
 
-		$buttonClass = $this->loadButtonClass($type);
-
-		if (!$buttonClass)
+		// For B/C, catch the exceptions thrown by the factory
+		try
 		{
-			if (isset($this->_buttonPath))
-			{
-				$dirs = $this->_buttonPath;
-			}
-			else
-			{
-				$dirs = array();
-			}
-
-			$file = \JFilterInput::getInstance()->clean(str_replace('_', DIRECTORY_SEPARATOR, strtolower($type)) . '.php', 'path');
-
-			jimport('joomla.filesystem.path');
-
-			if ($buttonFile = \JPath::find($dirs, $file))
-			{
-				include_once $buttonFile;
-			}
-			else
-			{
-				\JLog::add(\JText::sprintf('JLIB_HTML_BUTTON_NO_LOAD', $buttonClass, $buttonFile), \JLog::WARNING, 'jerror');
-
-				return false;
-			}
+			$this->_buttons[$signature] = $this->factory->createButton($this, $type);
 		}
-
-		if (!class_exists($buttonClass))
+		catch (\InvalidArgumentException $e)
 		{
+			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+
 			return false;
 		}
 
-		// Check for a possible service from the container otherwise manually instantiate the class
-		if (\JFactory::getContainer()->exists($buttonClass))
-		{
-			$this->_buttons[$signature] = \JFactory::getContainer()->get($buttonClass);
-		}
-		else
-		{
-			$this->_buttons[$signature] = new $buttonClass($this);
-		}
-
 		return $this->_buttons[$signature];
-	}
-
-	/**
-	 * Load the button class including the deprecated ones.
-	 *
-	 * @param   string  $type  Button Type
-	 *
-	 * @return  string|null
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	private function loadButtonClass($type)
-	{
-		$buttonClasses = array(
-			'Joomla\\CMS\\Toolbar\\Button\\' . ucfirst($type) . 'Button',
-			// @deprecated __DEPLOY_VERSION__
-			'JToolbarButton' . ucfirst($type),
-		);
-
-		foreach ($buttonClasses as $buttonClass)
-		{
-			if (!class_exists($buttonClass))
-			{
-				continue;
-			}
-
-			return $buttonClass;
-		}
-
-		return null;
 	}
 
 	/**
@@ -316,9 +297,22 @@ class Toolbar
 	 * @param   mixed  $path  Directory or directories to search.
 	 *
 	 * @return  void
+	 *
+	 * @deprecated  5.0  ToolbarButton classes should be autoloaded
 	 */
 	public function addButtonPath($path)
 	{
+		\JLog::add(
+			sprintf(
+				'Registering lookup paths for toolbar buttons is deprecated and will be removed in Joomla 5.0.'
+				. ' %1$s objects should be autoloaded or a custom %2%s implementation supporting path lookups provided.',
+				ToolbarButton::class,
+				ToolbarFactoryInterface::class
+			),
+			\JLog::WARNING,
+			'deprecated'
+		);
+
 		// Just force path to array.
 		settype($path, 'array');
 
@@ -338,5 +332,27 @@ class Toolbar
 			// Add to the top of the search dirs.
 			array_unshift($this->_buttonPath, $dir);
 		}
+	}
+
+	/**
+	 * Get the lookup paths for button objects
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @deprecated  5.0  ToolbarButton classes should be autoloaded
+	 */
+	public function getButtonPath()
+	{
+		\JLog::add(
+			sprintf(
+				'Lookup paths for %s objects is deprecated and will be removed in Joomla 5.0.',
+				ToolbarButton::class
+			),
+			\JLog::WARNING,
+			'deprecated'
+		);
+
+		return $this->_buttonPath;
 	}
 }

--- a/libraries/src/CMS/Toolbar/ToolbarButton.php
+++ b/libraries/src/CMS/Toolbar/ToolbarButton.php
@@ -15,7 +15,7 @@ defined('JPATH_PLATFORM') or die;
 /**
  * Button base class
  *
- * The JButton is the base class for all JButton types
+ * The base class for all toolbar button types
  *
  * @since  3.0
  */
@@ -33,16 +33,16 @@ abstract class ToolbarButton
 	/**
 	 * reference to the object that instantiated the element
 	 *
-	 * @var    static
+	 * @var    Toolbar
 	 */
 	protected $_parent = null;
 
 	/**
 	 * Constructor
 	 *
-	 * @param   object  $parent  The parent
+	 * @param   Toolbar  $parent  The parent
 	 */
-	public function __construct($parent = null)
+	public function __construct(Toolbar $parent = null)
 	{
 		$this->_parent = $parent;
 	}

--- a/libraries/src/CMS/Toolbar/ToolbarFactoryInterface.php
+++ b/libraries/src/CMS/Toolbar/ToolbarFactoryInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Toolbar;
+
+defined('_JEXEC') or die;
+
+/**
+ * Interface for creating toolbar objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ToolbarFactoryInterface
+{
+	/**
+	 * Creates a new toolbar button.
+	 *
+	 * @param   Toolbar  $toolbar  The Toolbar instance to attach to the button
+	 * @param   string   $type     Button Type
+	 *
+	 * @return  ToolbarButton
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function createButton(Toolbar $toolbar, $type);
+
+	/**
+	 * Creates a new Toolbar object.
+	 *
+	 * @param   string  $name  The toolbar name.
+	 *
+	 * @return  Toolbar
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createToolbar($name = 'toolbar');
+}


### PR DESCRIPTION
### Summary of Changes

Similar to #16259 this creates a service factory for use with creating objects in the Toolbar API.  This should make things a little more flexible as it relates to creating new objects and creating custom objects if needed in extensions.

### Testing Instructions

Fundamentally, this is the same as #16259 for testing.  The CMS by default should continue to function without error, for those looking for advanced integrations they can create and inject new logic.

### Documentation Changes Required

- As of 5.0, when a `Toolbar` object is created a factory must be passed into the constructor; for ease of migration with 4.0 this won't be a required argument
- Typehint and document the correct `Toolbar` object in the `ToolbarButton` constructor, this breaks B/C if anyone were trying something like `new StandardButton(new stdClass);` but since the class internals would break without a `Toolbar` instance and the number of places where one should be direct instantiating a `ToolbarButton` should be minimal (if at all) so it should be a low risk change