### PR TITLE
Allow setting model state to disable loading tags data

### DIFF
--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -98,8 +98,13 @@ class ContactModelCategory extends JModelList
 			{
 				$item->params = new Registry($item->params);
 			}
-			$this->tags = new JHelperTags;
-			$this->tags->getItemTags('com_contact.contact', $item->id);
+
+			// Some contexts may not use tags data at all, so we allow callers to disable loading tag data
+			if ($this->getState('load_tags', true))
+			{
+				$this->tags = new JHelperTags;
+				$this->tags->getItemTags('com_contact.contact', $item->id);
+			}
 		}
 
 		return $items;

--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -241,8 +241,12 @@ class ContactModelContact extends JModelForm
 				$registry = new Registry($data->metadata);
 				$data->metadata = $registry;
 
-				$data->tags = new JHelperTags;
-				$data->tags->getItemTags('com_contact.contact', $data->id);
+				// Some contexts may not use tags data at all, so we allow callers to disable loading tag data
+				if ($this->getState('load_tags', true))
+				{
+					$data->tags = new JHelperTags;
+					$data->tags->getItemTags('com_contact.contact', $data->id);
+				}
 
 				// Compute access permissions.
 				if (($access = $this->getState('filter.access')))

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -655,8 +655,8 @@ class ContentModelArticles extends JModelList
 				}
 			}
 
-			// Get the tags
-			if ($item->params->get('show_tags'))
+			// Some contexts may not use tags data at all, so we allow callers to disable loading tag data
+			if ($this->getState('load_tags', $item->params->get('show_tags', '1')))
 			{
 				$item->tags = new JHelperTags;
 				$item->tags->getItemTags('com_content.article', $item->id);

--- a/components/com_newsfeeds/models/category.php
+++ b/components/com_newsfeeds/models/category.php
@@ -93,9 +93,12 @@ class NewsfeedsModelCategory extends JModelList
 				$params->loadString($item->params);
 			}
 
-			// Get the tags
-			$item->tags = new JHelperTags;
-			$item->tags->getItemTags('com_newsfeeds.newsfeed', $item->id);
+			// Some contexts may not use tags data at all, so we allow callers to disable loading tag data
+			if ($this->getState('load_tags', true))
+			{
+				$item->tags = new JHelperTags;
+				$item->tags->getItemTags('com_newsfeeds.newsfeed', $item->id);
+			}
 		}
 
 		return $items;

--- a/components/com_users/models/profile.php
+++ b/components/com_users/models/profile.php
@@ -395,8 +395,12 @@ class UsersModelProfile extends JModelForm
 			return false;
 		}
 
-		$user->tags = new JHelperTags;
-		$user->tags->getTagIds($user->id, 'com_users.user');
+		// Some contexts may not use tags data at all, so we allow callers to disable loading tag data
+		if ($this->getState('load_tags', true))
+		{
+			$user->tags = new JHelperTags;
+			$user->tags->getTagIds($user->id, 'com_users.user');
+		}
 
 		return $user->id;
 	}

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -50,6 +50,9 @@ abstract class ModArticlesCategoryHelper
 		$articles->setState('list.limit', (int) $params->get('count', 0));
 		$articles->setState('filter.published', 1);
 
+		// This module does not use tags data
+		$articles->setState('load_tags', false);
+
 		// Access filter
 		$access     = !JComponentHelper::getParams('com_content')->get('show_noauth');
 		$authorised = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -49,6 +49,9 @@ abstract class ModArticlesLatestHelper
 		$model->setState('list.limit', (int) $params->get('count', 5));
 		$model->setState('filter.published', 1);
 
+		// This module does not use tags data
+		$model->setState('load_tags', false);
+
 		// Access filter
 		$access     = !JComponentHelper::getParams('com_content')->get('show_noauth');
 		$authorised = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -44,6 +44,9 @@ abstract class ModArticlesNewsHelper
 		$model->setState('list.limit', (int) $params->get('count', 5));
 		$model->setState('filter.published', 1);
 
+		// This module does not use tags data
+		$model->setState('load_tags', false);
+
 		// Access filter
 		$access     = !JComponentHelper::getParams('com_content')->get('show_noauth');
 		$authorised = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -46,6 +46,9 @@ abstract class ModArticlesPopularHelper
 		$model->setState('filter.published', 1);
 		$model->setState('filter.featured', $params->get('show_front', 1) == 1 ? 'show' : 'hide');
 
+		// This module does not use tags data
+		$model->setState('load_tags', false);
+
 		// Access filter
 		$access = !JComponentHelper::getParams('com_content')->get('show_noauth');
 		$authorised = JAccess::getAuthorisedViewLevels(JFactory::getUser()->get('id'));


### PR DESCRIPTION
Pull Request for Issue #16274

### Summary of Changes

A slightly different approach to #10519 this allows someone using our component models which load tags data to disable the loading of that data by setting the model state.  This doesn't introduce any new params to the UI, it is solely geared toward cases where the models outside of the "normal" component view context.  Since the tags data is not used in certain article modules, there will not be a query for that data.

### Testing Instructions

See #16274 and #10519 for additional context and instructions.

### Documentation Changes Required

Note the new model state parameter.