### PR TITLE
Use the JLogEntry class

### DIFF
--- a/libraries/src/Joomla/CMS/Log/Log.php
+++ b/libraries/src/Joomla/CMS/Log/Log.php
@@ -159,7 +159,8 @@ class Log
 		// If the entry object isn't a LogEntry object let's make one.
 		if (!($entry instanceof LogEntry))
 		{
-			$entry = new LogEntry((string) $entry, $priority, $category, $date);
+			// We need here to use JLogEntry, otherwise the class don't get loaded, aaargh
+			$entry = new \JLogEntry((string) $entry, $priority, $category, $date);
 		}
 
 		static::$instance->addLogEntry($entry);


### PR DESCRIPTION
Pull Request for Issue #16315 and #16311.

### Summary of Changes
`class_alias` is actually not loading the alias class. Additionally when you have typed function arguments and `instanceof` calls, the class is also not loaded. Because the logger is called very early it can lead to a situation that the class `JLogEntry`is not loaded but a logger which is not namespaced requires still `JLogEntry` and then we get an error like:
_Argument 1 passed to PlgSystemDebug::logger() must be an instance of JLogEntry, instance of Joomla\CMS\Log\LogEntry given_

This pr is a workaround to use `JLogEntry`instead of the namespaced class.

### Testing Instructions
- Enable debugging in Joomla configuration
- Enable in the debug plugin Logging
![image](https://cloud.githubusercontent.com/assets/251072/26557558/ab3dd3fa-44a2-11e7-9964-de54ee934821.png)

### Expected result
No Error is thrown.

### Actual result
Error is thrown.