### PR TITLE
Fix a problem with older Joomla versions language packs registration and update sites rebuild

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -328,7 +328,8 @@ class InstallerModelUpdatesites extends InstallerModel
 						$query = $db->getQuery(true)
 							->select($db->quoteName('extension_id'))
 							->from($db->quoteName('#__extensions'))
-							->where($db->quoteName('name') . ' = ' . $db->quote($manifest->name))
+							->where( '(' . $db->quoteName('name') . ' = ' . $db->quote($manifest->name) .
+								' OR ' . $db->quoteName('name') . ' = ' . $db->quote($manifest->packagename) . ')' )
 							->where($db->quoteName('type') . ' = ' . $db->quote($manifest['type']))
 							->where($db->quoteName('extension_id') . ' NOT IN (' . $joomlaCoreExtensionIds . ')')
 							->where($db->quoteName('state') . ' != -1');

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -328,8 +328,10 @@ class InstallerModelUpdatesites extends InstallerModel
 						$query = $db->getQuery(true)
 							->select($db->quoteName('extension_id'))
 							->from($db->quoteName('#__extensions'))
-							->where( '(' . $db->quoteName('name') . ' = ' . $db->quote($manifest->name) .
-								' OR ' . $db->quoteName('name') . ' = ' . $db->quote($manifest->packagename) . ')' )
+							->where('(' 
+								. $db->quoteName('name') . ' = ' . $db->quote($manifest->name) 
+								. ' OR ' . $db->quoteName('name') . ' = ' . $db->quote($manifest->packagename) 
+								. ')' )
 							->where($db->quoteName('type') . ' = ' . $db->quote($manifest['type']))
 							->where($db->quoteName('extension_id') . ' NOT IN (' . $joomlaCoreExtensionIds . ')')
 							->where($db->quoteName('state') . ' != -1');


### PR DESCRIPTION
Language packs installed under older Joomla versions are registered in the database under their package name, not under their name and since rebuild function fails on them.

e.g. package with 
```
  <name>Afrikaans (South Africa)</name>
  <packagename>af-ZA</packagename>
```

has name column in #_extensions table set as 	af-ZA and since existing update sites rebuild fails.

### Testing Instructions
Set language package name in  #_extensions to its packagename. Hit rebuild on update servers.


### Expected result
Update server from this package is on the list.


### Actual result
Update server from this package is not on the list of update servers.


### Documentation Changes Required

