### PR TITLE
[4.0] Fix com_menu searchtools being auto expanded

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -40,8 +40,6 @@ $formSelector = !empty($data['options']['formSelector']) ? $data['options']['for
 
 // Load search tools
 JHtml::_('searchtools.form', $formSelector, $data['options']);
-
-$filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilters ? ' js-stools-container-filters-visible' : '';
 ?>
 <div class="js-stools clearfix">
 	<div class="clearfix">
@@ -53,7 +51,7 @@ $filtersClass = isset($data['view']->activeFilters) && $data['view']->activeFilt
 		</div>
 	</div>
 	<!-- Filters div -->
-	<div class="js-stools-container-filters hidden-xs-down clearfix<?php echo $filtersClass; ?>">
+	<div class="js-stools-container-filters hidden-xs-down clearfix">
 		<?php echo JLayoutHelper::render('joomla.searchtools.default.filters', $data); ?>
 	</div>
 </div>


### PR DESCRIPTION
Pull Request for Issue #16346

### Summary of Changes

This PR ensures that the searchtools in com_menu do not auto expand. Same as other components.


