### PR TITLE
[3.8] Load the alias class when the original is loaded

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -257,7 +257,12 @@ abstract class JLoader
 		// If the class is registered include the file.
 		if (isset(self::$classes[$key]))
 		{
-			include_once self::$classes[$key];
+			$found = (bool) include_once self::$classes[$key];
+
+			if ($found)
+			{
+				self::loadAliasFor($class);
+			}
 
 			// If the class doesn't exists, we probably have a class alias available
 			if (!class_exists($class, false))
@@ -537,7 +542,14 @@ abstract class JLoader
 					// We check for class_exists to handle case-sensitive file systems
 					if (file_exists($classFilePath) && !class_exists($class, false))
 					{
-						return (bool) include_once $classFilePath;
+						$found = (bool) include_once $classFilePath;
+
+						if ($found)
+						{
+							self::loadAliasFor($class);
+						}
+
+						return $found;
 					}
 				}
 			}
@@ -592,7 +604,14 @@ abstract class JLoader
 					// We check for class_exists to handle case-sensitive file systems
 					if (file_exists($classFilePath) && !class_exists($class, false))
 					{
-						return (bool) include_once $classFilePath;
+						$found = (bool) include_once $classFilePath;
+
+						if ($found)
+						{
+							self::loadAliasFor($class);
+						}
+
+						return $found;
 					}
 				}
 			}
@@ -698,7 +717,14 @@ abstract class JLoader
 			// Load the file if it exists.
 			if (file_exists($path))
 			{
-				return include $path;
+				$found = (bool) include_once $path;
+
+				if ($found)
+				{
+					self::loadAliasFor($class);
+				}
+
+				return $found;
 			}
 
 			// Backwards compatibility patch
@@ -712,12 +738,42 @@ abstract class JLoader
 				// Load the file if it exists.
 				if (file_exists($path))
 				{
-					return include $path;
+					$found = (bool) include_once $path;
+
+					if ($found)
+					{
+						self::loadAliasFor($class);
+					}
+
+					return $found;
 				}
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Loads the aliases for the given class.
+	 *
+	 * @param   string  $class  The class.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private static function loadAliasFor($class)
+	{
+		if (!key_exists($class, self::$classAliasesInverse))
+		{
+			return;
+		}
+
+		foreach (self::$classAliasesInverse[$class] as $alias)
+		{
+			// Force auto-load of the alias class
+			class_exists($alias, true);
+		}
 	}
 
 	/**

--- a/libraries/src/Joomla/CMS/Log/Log.php
+++ b/libraries/src/Joomla/CMS/Log/Log.php
@@ -159,8 +159,7 @@ class Log
 		// If the entry object isn't a LogEntry object let's make one.
 		if (!($entry instanceof LogEntry))
 		{
-			// We need here to use JLogEntry, otherwise the class don't get loaded, aaargh
-			$entry = new \JLogEntry((string) $entry, $priority, $category, $date);
+			$entry = new LogEntry((string) $entry, $priority, $category, $date);
 		}
 
 		static::$instance->addLogEntry($entry);

--- a/tests/unit/stubs/loaderoveralias/jloaderaliasstub.php
+++ b/tests/unit/stubs/loaderoveralias/jloaderaliasstub.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @package    Joomla.Platform
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+class JLoaderAliasStub
+{
+}

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -60,6 +60,7 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 		self::$cache['prefixes']   = TestReflection::getValue('JLoader', 'prefixes');
 		self::$cache['namespaces'] = TestReflection::getValue('JLoader', 'namespaces');
 		self::$cache['classAliases'] = TestReflection::getValue('JLoader', 'classAliases');
+		self::$cache['classAliasesInverse'] = TestReflection::getValue('JLoader', 'classAliasesInverse');
 	}
 
 	/**
@@ -77,6 +78,7 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 		TestReflection::setValue('JLoader', 'prefixes', self::$cache['prefixes']);
 		TestReflection::setValue('JLoader', 'namespaces', self::$cache['namespaces']);
 		TestReflection::setValue('JLoader', 'classAliases', self::$cache['classAliases']);
+		TestReflection::setValue('JLoader', 'classAliasesInverse', self::$cache['classAliasesInverse']);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -93,7 +93,7 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 			'jfactory' => array('joomla.jfactory', null, null, false, 'JFactory does not exist so should not load properly', true),
 			'fred.factory' => array('fred.factory', null, null, false, 'fred.factory does not exist', true),
 			'bogus' => array('bogusload', JPATH_TEST_STUBS, '', true, 'bogusload.php should load properly', false),
-			'helper' => array('joomla.user.helper', null, '', true, 'userhelper should load properly', true));
+			'class.loader' => array('cms.class.loader', null, '', true, 'class loader should load properly', true));
 	}
 
 	/**
@@ -277,6 +277,28 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 		// Check if really the override is used
 		$this->assertEquals('Original Override Class', $newClass->getName());
 		$this->assertEquals('Original Override Class', $oldClass->getName());
+	}
+
+	/**
+	 * Tests the JLoader::registerAlias method if the alias is loaded when the base class is loaded.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testAliasInstanceOf()
+	{
+		// Normally register the class
+		JLoader::register('JLoaderAliasStub', JPATH_TEST_STUBS . '/loaderoveralias/jloaderaliasstub.php');
+
+		// Register the alias
+		JLoader::registerAlias('JLoaderAliasStubAlias', 'JLoaderAliasStub');
+
+		$object = new JLoaderAliasStub;
+
+		$this->assertTrue(
+			$object instanceof JLoaderAliasStubAlias
+		);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -280,7 +280,7 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
-	 * Tests the JLoader::registerAlias method if the alias is loaded when the base class is loaded.
+	 * Tests the JLoader::registerAlias method if the alias is loaded when the original class is loaded.
 	 *
 	 * @return  void
 	 *

--- a/tests/unit/suites/libraries/joomla/log/JLogTest.php
+++ b/tests/unit/suites/libraries/joomla/log/JLogTest.php
@@ -7,8 +7,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE
  */
 
-require_once __DIR__ . '/stubs/log/inspector.php';
-
 /**
  * Test class for JLog.
  *
@@ -18,6 +16,19 @@ require_once __DIR__ . '/stubs/log/inspector.php';
  */
 class JLogTest extends \PHPUnit\Framework\TestCase
 {
+	/**
+	 * Overrides the parent setUp method.
+	 *
+	 * @return  void
+	 *
+	 * @see     \PHPUnit\Framework\TestCase::setUp()
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function setUp()
+	{
+		require_once __DIR__ . '/stubs/log/inspector.php';
+	}
+
 	/**
 	 * Overrides the parent tearDown method.
 	 *


### PR DESCRIPTION
Pull Request for Issue #16315 and #16311 and is improving the workaround in #16342.

### Summary of Changes
`class_alias` is actually not loading the alias class. Additionally when you have typed function arguments and `instanceof` calls, the class is also not loaded. This pr is loading the alias classes when a class is loaded in `JLoader`. It requires that the alias are registered before the original class is loaded.

### Testing Instructions
- Reverert patch from #16342.
- Enable debugging in Joomla configuration
- Enable in the debug plugin Logging
![image](https://cloud.githubusercontent.com/assets/251072/26557558/ab3dd3fa-44a2-11e7-9964-de54ee934821.png)

### Expected result
No Error is thrown.

### Actual result
Error is thrown.