### PR TITLE
[4.0] Fix lookup path for installer tmpl

### DIFF
--- a/administrator/components/com_installer/View/Installer/Html.php
+++ b/administrator/components/com_installer/View/Installer/Html.php
@@ -56,7 +56,7 @@ class Html extends HtmlView
 	{
 		parent::__construct($config);
 
-		$this->_addPath('template', $this->_basePath . '/views/installer/tmpl');
+		$this->_addPath('template', $this->_basePath . '/tmpl/installer');
 		$this->_addPath('template', JPATH_THEMES . '/' . \JFactory::getApplication()->getTemplate() . '/html/com_installer/installer');
 	}
 


### PR DESCRIPTION
After installing an extension, you get an error that the layout "default_message" isn't found.
This is due to the moving of the template files out of the views into their own tmpl folder, done with https://github.com/joomla/joomla-cms/pull/16319

### Summary of Changes
Adjusts the lookup path in `Joomla\Component\Installer\Administrator\View\Installer`
@laoneo and @joomdonation please review

### Testing Instructions
Install an extension


### Expected result
Installs


### Actual result
Gives an error


### Documentation Changes Required
None
