### PR TITLE
[4.0] Disable TinyMCE Branding

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -673,6 +673,9 @@ class PlgEditorTinymce extends JPlugin
 			// Drag and drop specific
 			'dndEnabled' => $dragdrop,
 			'dndPath'    => JUri::root() . 'media/editors/tinymce/js/dragdrop/plugin.min.js',
+
+			// Disaable TinyMCE Branding
+			'branding'	=> false,
 			)
 		);
 


### PR DESCRIPTION
TinyMCE 4.6 now displays its own branding in the content area. This PR uses the provided API (https://www.tinymce.com/docs/configure/editor-appearance/#branding) to remove the branding seen below

<img width="382" alt="screenshotr16-48-16" src="https://cloud.githubusercontent.com/assets/1296369/26592560/07d3633a-4559-11e7-82fd-907b6bad1f19.png">

