### PR TITLE
Fix for keeping menu item type on save and new.…

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -261,10 +261,10 @@ class MenusControllerItem extends JControllerForm
 		$context  = 'com_menus.edit.item';
 
         // Set the menutype should we need it.
-        if($data['menutype'] !== '')
-        {
-            $app->input->set('menutype', $data['menutype']);
-        }
+		if ($data['menutype'] !== '')
+		{
+			$app->input->set('menutype', $data['menutype']);
+		}
 
 		// Determine the name of the primary key for the data.
 		if (empty($key))

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -260,6 +260,12 @@ class MenusControllerItem extends JControllerForm
 		$task     = $this->getTask();
 		$context  = 'com_menus.edit.item';
 
+        // Set the menutype should we need it.
+        if($data['menutype'] !== '')
+        {
+            $app->input->set('menutype', $data['menutype']);
+        }
+
 		// Determine the name of the primary key for the data.
 		if (empty($key))
 		{

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -260,7 +260,7 @@ class MenusControllerItem extends JControllerForm
 		$task     = $this->getTask();
 		$context  = 'com_menus.edit.item';
 
-        // Set the menutype should we need it.
+		// Set the menutype should we need it.
 		if ($data['menutype'] !== '')
 		{
 			$app->input->set('menutype', $data['menutype']);

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -546,6 +546,7 @@ class MenusControllerItem extends JControllerForm
 		}
 
 		unset($data['request']);
+		
 		$data['type'] = $title;
 
 		if ($this->input->get('fieldtype') == 'type')


### PR DESCRIPTION
Pull Request for Issue #15447  .

Set menu item type on save, so when using save and new for instance the menu item type is passed through again. 