### PR TITLE
Allow to use tinymce params

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -199,7 +199,7 @@ class PlgEditorTinymce extends JPlugin
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';
 
-		if($options['tinyMCE'][$fieldName])
+		if ($options['tinyMCE'][$fieldName])
 		{
 			$options['tinyMCE'][$fieldName] = array_merge($options['tinyMCE'][$fieldName], $params);
 		}
@@ -1278,7 +1278,7 @@ class PlgEditorTinymce extends JPlugin
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';
 
-		if($options['tinyMCE'][$fieldName])
+		if ($options['tinyMCE'][$fieldName])
 		{
 			$options['tinyMCE'][$fieldName] = array_merge($options['tinyMCE'][$fieldName], $params);
 		}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -199,6 +199,15 @@ class PlgEditorTinymce extends JPlugin
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';
 
+		if($options['tinyMCE'][$fieldName])
+		{
+			$options['tinyMCE'][$fieldName] = array_merge($options['tinyMCE'][$fieldName], $params);
+		}
+		else
+		{
+			$options['tinyMCE'][$fieldName] = $params;
+		}
+
 		// Prepare the instance specific options, actually the ext-buttons
 		if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
 		{
@@ -1268,6 +1277,15 @@ class PlgEditorTinymce extends JPlugin
 		$editor .= JLayoutHelper::render('joomla.tinymce.textarea', $textarea);
 		$editor .= $this->_toogleButton($id);
 		$editor .= '</div>';
+
+		if($options['tinyMCE'][$fieldName])
+		{
+			$options['tinyMCE'][$fieldName] = array_merge($options['tinyMCE'][$fieldName], $params);
+		}
+		else
+		{
+			$options['tinyMCE'][$fieldName] = $params;
+		}
 
 		// Prepare instance specific options, actually the ext-buttons
 		if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))


### PR DESCRIPTION
### Summary of Changes
Allow to set tinymce parameters like
```PHP
$options = array(
        'inline'=>true,
        'menubar'=>false,
);
echo $editor->display( 'new_incorrect_feed', '', 500, 170, '20', '10', true, null, null, null, $options )
```

### Testing Instructions
Pass options to the $editor, for example `inline => true`

### Expected result
Tinymce is in inline mode.


### Actual result
Tinymce is not in inline mode.
