### PR TITLE
[4.0] Fix com joomlaupdate

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2348,8 +2348,7 @@ class JoomlaInstallerScript
 	 */
 	private function cleanJoomlaCache()
 	{
-		JModelLegacy::addIncludePath(JPATH_ROOT . '/administrator/components/com_cache/models');
-		$model = JModelLegacy::getInstance('cache', 'CacheModel');
+		$model = new \Joomla\Component\Cache\Administrator\Model\Cache;
 
 		// Clean frontend cache
 		$model->clean();

--- a/administrator/components/com_joomlaupdate/Controller/Update.php
+++ b/administrator/components/com_joomlaupdate/Controller/Update.php
@@ -197,7 +197,7 @@ class Update extends Controller
 
 		$model->cleanUp();
 
-		$url = 'index.php?option=com_joomlaupdate&view=default&layout=complete';
+		$url = 'index.php?option=com_joomlaupdate&view=joomlaupdate&layout=complete';
 		$this->setRedirect($url);
 
 		try


### PR DESCRIPTION
Pull Request for Issue #16376 .

### Summary of Changes
This PR fixes the issue #16376. com_cache was namespaced, so the code in JoomlaInstallerScript of com_admin needs to call the namespace class

Also, the default view in com_joomlaupdate was renamed to joomlaupdate (because Default could not be used in class name), so the the update controller in that component needs to be updated to the new view name

### Testing Instructions
1. Follow the issue description to see the issue
2. Apply patch, confirm that the issue fixed

I already tested it myself, so maybe it could be merged by code review to save time of testers