### PR TITLE
[4.0] Fix default filter state in backend list views

### DIFF
--- a/administrator/components/com_banners/Model/Banners.php
+++ b/administrator/components/com_banners/Model/Banners.php
@@ -140,7 +140,7 @@ class Banners extends ListModel
 			->join('LEFT', $db->quoteName('#__banner_clients', 'cl') . ' ON cl.id = a.cid');
 
 		// Filter by published state
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_banners/Model/Clients.php
+++ b/administrator/components/com_banners/Model/Clients.php
@@ -128,7 +128,7 @@ class Clients extends ListModel
 			->join('LEFT', '#__users AS uc ON uc.id=a.checked_out');
 
 		// Filter by published state
-		$published = $this->getState('filter.state');
+		$published = (string) $this->getState('filter.state');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_categories/Model/Categories.php
+++ b/administrator/components/com_categories/Model/Categories.php
@@ -213,7 +213,7 @@ class Categories extends ListModel
 		}
 
 		// Filter by published state
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_contact/Model/Contacts.php
+++ b/administrator/components/com_contact/Model/Contacts.php
@@ -263,7 +263,7 @@ class Contacts extends ListModel
 		}
 
 		// Filter by published state
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_content/Model/Articles.php
+++ b/administrator/components/com_content/Model/Articles.php
@@ -240,7 +240,7 @@ class Articles extends ListModel
 		}
 
 		// Filter by published state
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_languages/Model/Languages.php
+++ b/administrator/components/com_languages/Model/Languages.php
@@ -123,7 +123,7 @@ class Languages extends ListModel
 			->join('LEFT', $db->quoteName('#__menu') . ' AS l  ON  l.language = a.lang_code AND l.home=1  AND l.language <> ' . $db->quote('*'));
 
 		// Filter on the published state.
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_newsfeeds/Model/Newsfeeds.php
+++ b/administrator/components/com_newsfeeds/Model/Newsfeeds.php
@@ -224,7 +224,7 @@ class Newsfeeds extends ListModel
 		}
 
 		// Filter by published state.
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_plugins/Model/Plugins.php
+++ b/administrator/components/com_plugins/Model/Plugins.php
@@ -231,7 +231,7 @@ class Plugins extends ListModel
 		}
 
 		// Filter by published state.
-		$published = $this->getState('filter.enabled');
+		$published = (string) $this->getState('filter.enabled');
 
 		if (is_numeric($published))
 		{

--- a/administrator/components/com_redirect/Model/Links.php
+++ b/administrator/components/com_redirect/Model/Links.php
@@ -146,7 +146,7 @@ class Links extends ListModel
 		$query->from($db->quoteName('#__redirect_links', 'a'));
 
 		// Filter by published state
-		$state = $this->getState('filter.state');
+		$state = (string) $this->getState('filter.state');
 
 		if (is_numeric($state))
 		{

--- a/administrator/components/com_tags/Model/Tags.php
+++ b/administrator/components/com_tags/Model/Tags.php
@@ -176,7 +176,7 @@ class Tags extends ListModel
 		}
 
 		// Filter by published state
-		$published = $this->getState('filter.published');
+		$published = (string) $this->getState('filter.published');
 
 		if (is_numeric($published))
 		{


### PR DESCRIPTION
Pull Request for Issue #16366.

### Summary of Changes
This PR fix the default filter state in backend list views. It causes by the changes in PR https://github.com/joomla/joomla-cms/pull/15455 . Now, the first time you visit the page (articles list for example), the $published value has value null instead of '' (empty string) like before, so this line return false https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/Model/Articles.php#L249 , no filter is applied and all articles are being shown.

This PR just cast type of $published to string to solve the issue.

### Testing Instructions
1. Install Joomla 4, confirm the issue described at https://github.com/joomla/joomla-cms/issues/16366

2. Apply patch, confirm the issue fixed

