### PR TITLE
[4.0] Fix installer -> discover view

### DIFF
--- a/libraries/src/CMS/Installer/Installer.php
+++ b/libraries/src/CMS/Installer/Installer.php
@@ -2296,7 +2296,7 @@ class Installer extends \JAdapter
 				}
 			}
 
-			$adapters[] = str_ireplace('.php', '', $fileName);
+			$adapters[] = $name;
 		}
 
 		// Add any custom adapters if specified


### PR DESCRIPTION
Access "Extension" -> "Discover". You get an error "The ComponentAdapter install adapter does not exist."

The faulty method is `\Joomla\CMS\Installer\Installer::getAdapters` which is supposed to return the type of the adapters ('component', 'module', ...) but currently returns the filename without suffix ('componentadapter', 'moduleadapter') .

### Summary of Changes
Just returning the already existing `$name` instead of working again from the `$filename`.


### Testing Instructions
Access the discover view and make sure it works.


### Expected result
working view


### Actual result
Error


### Documentation Changes Required
None
