### PR TITLE
Too broad for mobile view

### DIFF
--- a/templates/system/css/offline.css
+++ b/templates/system/css/offline.css
@@ -20,7 +20,7 @@ img  {
 
 #frame {
 	margin: 20px auto;
-	max-width: 400px;
+	max-width: 270px;
 	padding: 20px;
 }
 


### PR DESCRIPTION
400px is too wide for mobile view
The text then falls outside the screen