### PR TITLE
Ensure identity is always loaded in site and admin apps

### DIFF
--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -553,6 +553,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 				// TODO - This creates an implicit hard requirement on the JApplicationCms constructor
 				static::$instances[$name] = new $classname(null, null, null, $container);
 			}
+
+			static::$instances[$name]->loadIdentity(\JFactory::getUser());
 		}
 
 		return static::$instances[$name];


### PR DESCRIPTION
### Summary of Changes
Ensures the identity of the currently logged in user is always loaded into the application

Required for Yves PR

Note this might have side-affects on custom web applications that use `CMSApplication`?

### Documentation Changes Required
Document that CMS Applications will now have the identity loaded when the class is created by the singleton creator
