### PR TITLE
[4.0] Fix breadcrumbs module

### DIFF
--- a/language/en-GB/en-GB.mod_breadcrumbs.ini
+++ b/language/en-GB/en-GB.mod_breadcrumbs.ini
@@ -6,8 +6,6 @@
 MOD_BREADCRUMBS="Breadcrumbs"
 MOD_BREADCRUMBS_FIELD_HOMETEXT_DESC="This text will be shown as Home entry. If the field is left empty, it will use the default value from the mod_breadcrumbs.ini language file."
 MOD_BREADCRUMBS_FIELD_HOMETEXT_LABEL="Text for Home Entry"
-MOD_BREADCRUMBS_FIELD_SEPARATOR_DESC="A text separator."
-MOD_BREADCRUMBS_FIELD_SEPARATOR_LABEL="Text Separator"
 MOD_BREADCRUMBS_FIELD_SHOWHERE_DESC="Show or hide &quot;You are here&quot; text in the pathway."
 MOD_BREADCRUMBS_FIELD_SHOWHERE_LABEL="Show &quot;You are here&quot;"
 MOD_BREADCRUMBS_FIELD_SHOWHOME_DESC="Show or hide the Home element in the pathway."

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.php
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.php
@@ -16,8 +16,6 @@ JLoader::register('ModBreadCrumbsHelper', __DIR__ . '/helper.php');
 $list  = ModBreadCrumbsHelper::getList($params);
 $count = count($list);
 
-// Set the default separator
-$separator = ModBreadCrumbsHelper::setSeparator($params->get('separator'));
 $moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_breadcrumbs', $params->get('layout', 'default'));

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.xml
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.xml
@@ -25,14 +25,47 @@
 				<field
 					name="showHere"
 					type="radio"
-					class="switcher"
 					label="MOD_BREADCRUMBS_FIELD_SHOWHERE_LABEL"
 					description="MOD_BREADCRUMBS_FIELD_SHOWHERE_DESC"
+					class="switcher"
 					default="1"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
+
+				<field
+					name="showHome"
+					type="radio"
+					label="MOD_BREADCRUMBS_FIELD_SHOWHOME_LABEL"
+					description="MOD_BREADCRUMBS_FIELD_SHOWHOME_DESC"
+					class="switcher"
+					default="1"
+					>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+
+				<field
+					name="homeText"
+					type="text"
+					label="MOD_BREADCRUMBS_FIELD_HOMETEXT_LABEL"
+					description="MOD_BREADCRUMBS_FIELD_HOMETEXT_DESC"
+					showon="showHome:1"
+				/>
+
+				<field
+					name="showLast"
+					type="radio"
+					label="MOD_BREADCRUMBS_FIELD_SHOWLAST_LABEL"
+					description="MOD_BREADCRUMBS_FIELD_SHOWLAST_DESC"
+					default="1"
+					class="switcher"
+					>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+
 			</fieldset>
 		</fields>
 	</config>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -14,12 +14,12 @@ JHtml::_('bootstrap.tooltip');
 
 <ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
 	<?php if ($params->get('showHere', 1)) : ?>
-		<li>
+		<li class="float-left">
 			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;
 		</li>
 	<?php else : ?>
-		<li class="active">
-			<span class="divider icon-location"></span>
+		<li class="float-left">
+			<span class="divider fa fa-location" aria-hidden="true"></span>
 		</li>
 	<?php endif; ?>
 
@@ -45,29 +45,19 @@ JHtml::_('bootstrap.tooltip');
 	// Generate the trail
 	foreach ($list as $key => $item) :
 		if ($key !== $last_item_key) :
+			if (!empty($item->link)) :
+				$breadcrumbItem = '<a itemprop="item" href="' . $item->link . '" class="pathway"><span itemprop="name">' . $item->name . '</span></a>';
+			else :
+				$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
+			endif;
 			// Render all but last item - along with separator ?>
-			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-				<?php if (!empty($item->link)) : ?>
-					<a itemprop="item" href="<?php echo $item->link; ?>" class="pathway"><span itemprop="name"><?php echo $item->name; ?></span></a>
-				<?php else : ?>
-					<span itemprop="name">
-						<?php echo $item->name; ?>
-					</span>
-				<?php endif; ?>
-
-				<?php if (($key !== $penult_item_key) || $show_last) : ?>
-					<span class="divider">
-						<?php echo $separator; ?>
-					</span>
-				<?php endif; ?>
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="breadcrumb-item"><?php echo $breadcrumbItem; ?>
 				<meta itemprop="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php elseif ($show_last) :
+			$breadcrumbItem = '<span itemprop="name">' . $item->name . '</span>';
 			// Render last item if reqd. ?>
-			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="active">
-				<span itemprop="name">
-					<?php echo $item->name; ?>
-				</span>
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="breadcrumb-item active"><?php echo $breadcrumbItem; ?>
 				<meta itemprop="position" content="<?php echo $key + 1; ?>">
 			</li>
 		<?php endif;


### PR DESCRIPTION
Pull Request for Issue #16392

### Summary of Changes

This PR fixes the breadcrumbs styling and also adds back in the parameters I accidentally removed months ago.

I've also removed the `separator` parameter as BS4 breadcrumbs separators are now done using the `::before` pseudo selector.

### Testing Instructions

Use the breadcrumbs module and ensure the styling is ok.

