### PR TITLE
Bypass viewlevel check for categoryedit field when Superuser

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -143,7 +143,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 		$db = JFactory::getDbo();
 		$user = JFactory::getUser();
-		$groups = implode(',', $user->getAuthorisedViewLevels());
 
 		$query = $db->getQuery(true)
 			->select('DISTINCT a.id AS value, a.title AS text, a.level, a.published, a.lft');
@@ -186,7 +185,12 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		}
 
 		// Filter categories on User Access Level
-		$subQuery->where('access IN (' . $groups . ')');
+		// Filter by access level on categories.
+		if (!$user->authorise('core.admin'))
+		{
+			$groups = implode(',', $user->getAuthorisedViewLevels());
+			$subQuery->where('access IN (' . $groups . ')');
+		}
 
 		$query->from('(' . (string) $subQuery . ') AS a')
 			->join('LEFT', $db->quoteName('#__categories') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
@@ -256,9 +260,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				$options[$i]->text = $options[$i]->text . ' (' . $language . ')';
 			}
 		}
-
-		// Get the current user object.
-		$user = JFactory::getUser();
 
 		// For new items we want a list of categories you are allowed to create in.
 		if ($oldCat == 0)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15960 .

### Summary of Changes
This PR bypassed the access level check introduced with https://github.com/joomla/joomla-cms/pull/12931 for Superusers, similar to how it is done for articles (see https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/models/articles.php#L231-L237)

On a sidenote: I removed a second instance of `$user = JFactory::getUser();` in that method since `$user` at that point already exists.

### Testing Instructions
* Create a category and set it to access level "Guest" (or any other level where SuperUsers aren't part of)
* Edit an article and try assigning that category.

### Expected result
Super Users can assign any category


### Actual result
That "Guest" category isn't available


### Documentation Changes Required
None
