### PR TITLE
Fixed the typehint for quote functions in `JDatabaseDriver`

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -14,8 +14,8 @@ defined('JPATH_PLATFORM') or die;
  *
  * @since  12.1
  *
- * @method      string  q()   q($text, $escape = true)  Alias for quote method
- * @method      string  qn()  qn($name, $as = null)     Alias for quoteName method
+ * @method   string|array  q()   q($text, $escape = true)  Alias for quote method
+ * @method   string|array  qn()  qn($name, $as = null)     Alias for quoteName method
  */
 abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 {


### PR DESCRIPTION
### Summary of Changes
Changed the typehint of quote function from string to string and array to reflect actual function return type

### Testing Instructions
Code review


### Documentation Changes Required
Update typehint

