### PR TITLE
Don't delete children if we iterate over all of them anyway

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -1119,7 +1119,7 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			// Iterate the items to delete each one.
 			foreach ($ids as $menuid)
 			{
-				if (!$table->delete((int) $menuid))
+				if (!$table->delete((int) $menuid, false))
 				{
 					$this->setError($table->getError());
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/15929.

During installation of a component, all existing menuitems of that component are deleted and recreated afterwards.
This is done by fetching all menuitems of said component using a database query and then iterating over each of them and deleting it using JTableNested::delete().
That method takes a second option argument which defaults to true and makes sure that children are deleted as well.
Now that is nice but since we are iterating over all menuitems, it means that in the first iteration the parent is deleted and all successive deletes of the children fail and generate an error that _getNode can't find the item.

The difference between J3.7 and J4 is that in J3.7 the errors are pushed into $this->_errors but neither the return value (`false`) nor that error array is ever checked afterwards.
In J4 a warning is raised and thus those errors suddenly become visible.

### Summary of Changes
This changes the call so it doesn't delete the children.

### Testing Instructions
In J3 there isn't much you can test beside that menuitems are deleted/recreated as expected after updating an extension with a submenu (eg SermonSpeaker https://www.sermonspeaker.net/download/sermonspeaker-component/sermonspeaker-component-5-6-2/com_sermonspeaker-zip.zip).

In J4 this will prevent the error messages mentioned in the above issue.


### Expected result
Component updates as expected


### Actual result
Component updates as expected


### Documentation Changes Required
None