### PR TITLE
[4.0] Fixing issue with the installation of non-namespaced extensions

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-19-03.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-19-03.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `#__extensions` ADD namespace VARCHAR(500) NULL DEFAULT NULL AFTER params;
+ALTER TABLE `#__extensions` ADD namespace VARCHAR(500) NOT NULL DEFAULT '' AFTER params;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-19.sql
@@ -1,1 +1,1 @@
-ALTER TABLE ""#__extensions" ADD "namespace"" VARCHAR(500) NULL DEFAULT NULL AFTER "params";
+ALTER TABLE ""#__extensions" ADD "namespace"" VARCHAR(500) NOT NULL DEFAULT '' AFTER "params";

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -468,7 +468,7 @@ CREATE TABLE IF NOT EXISTS `#__extensions` (
   `protected` tinyint(3) NOT NULL DEFAULT 0,
   `manifest_cache` text NOT NULL,
   `params` text NOT NULL,
-  `namespace` varchar(500) DEFAULT NULL,
+  `namespace` varchar(500) NOT NULL DEFAULT '',
   `checked_out` int(10) unsigned NOT NULL DEFAULT 0,
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `ordering` int(11) DEFAULT 0,

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -479,7 +479,7 @@ CREATE TABLE IF NOT EXISTS "#__extensions" (
   "protected" smallint DEFAULT 0 NOT NULL,
   "manifest_cache" text NOT NULL,
   "params" text NOT NULL,
-  "namespace" varchar(500) DEFAULT NULL,
+  "namespace" varchar(500) NOT NULL DEFAULT '',
   "checked_out" integer DEFAULT 0 NOT NULL,
   "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "ordering" bigint DEFAULT 0,


### PR DESCRIPTION
Pull Request for Issue #16430 .

### Summary of Changes

Fixes the null issue when installing old non-namespaced extensions

### Testing Instructions

Install a none-namespaced extension, it should work in J4

### Expected result

Old extensions install fine

### Actual result

Old installations give you an SQL error

### Documentation Changes Required

None