### PR TITLE
[4.0] Store tags is broken

### DIFF
--- a/libraries/extensions.classmap.php
+++ b/libraries/extensions.classmap.php
@@ -12,3 +12,5 @@ defined('_JEXEC') or die;
 // Class map of the core extensions
 JLoader::registerAlias('FieldsPlugin',     '\\Joomla\\Component\\Fields\\Administrator\\Plugin\\FieldsPlugin', '4.0');
 JLoader::registerAlias('FieldsListPlugin', '\\Joomla\\Component\\Fields\\Administrator\\Plugin\\FieldsListPlugin', '4.0');
+
+JLoader::registerAlias('TagsTableTag',     '\\Joomla\\Component\\Tags\\Administrator\\Table\\Tag', '4.0');

--- a/libraries/src/CMS/Helper/TagsHelper.php
+++ b/libraries/src/CMS/Helper/TagsHelper.php
@@ -75,6 +75,11 @@ class TagsHelper extends CMSHelper
 		// Prevent saving duplicate tags
 		$tags = array_unique($tags);
 
+		if (!$tags)
+		{
+			return true;
+		}
+
 		$query = $db->getQuery(true);
 		$query->insert('#__contentitem_tag_map');
 		$query->columns(
@@ -241,9 +246,10 @@ class TagsHelper extends CMSHelper
 					else
 					{
 						// Prepare tag data
-						$tagTable->id = 0;
-						$tagTable->title = $tagText;
-						$tagTable->published = 1;
+						$tagTable->id          = 0;
+						$tagTable->title       = $tagText;
+						$tagTable->published   = 1;
+						$tagTable->description = '';
 
 						// $tagTable->language = property_exists ($item, 'language') ? $item->language : '*';
 						$tagTable->language = '*';

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -115,7 +115,7 @@ class PlgBehaviourTaggable extends JPlugin
 		$tagsHelper            = $table->tagsHelper;
 		$tagsHelper->typeAlias = $typeAlias;
 
-		$newTags = isset($table->newTags) ? $table->newTags : $tagsHelper->tags;
+		$newTags = isset($table->newTags) ? $table->newTags : array();
 
 		if (empty($newTags))
 		{
@@ -173,7 +173,7 @@ class PlgBehaviourTaggable extends JPlugin
 		$tagsHelper            = $table->tagsHelper;
 		$tagsHelper->typeAlias = $typeAlias;
 
-		$newTags = isset($table->newTags) ? $table->newTags : $tagsHelper->tags;
+		$newTags = isset($table->newTags) ? $table->newTags : array();
 
 		if (empty($newTags))
 		{


### PR DESCRIPTION
### Summary of Changes
When editing an article the on the fly tags are not created.

### Testing Instructions
- Edit an article
- Define a tag
- Save the article

### Expected result
Tag will be created and assigned to the article.

### Actual result
Tag is not created and an error is thrown.