### PR TITLE
[4.0] Fix com_tags view not found error

### DIFF
--- a/administrator/components/com_tags/Controller/Controller.php
+++ b/administrator/components/com_tags/Controller/Controller.php
@@ -20,6 +20,14 @@ use Joomla\CMS\Controller\Controller as BaseController;
 class Controller extends BaseController
 {
 	/**
+	 * The default view.
+	 *
+	 * @var    string
+	 * @since  1.6
+	 */
+	protected $default_view = 'tags';
+	
+	/**
 	 * Method to display a view.
 	 *
 	 * @param   boolean  $cachable   If true, the view output will be cached

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -95,9 +95,9 @@ JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
 JLoader::registerAlias('JAdministrator', 'JApplicationAdministrator');
 JLoader::registerAlias('JSite', 'JApplicationSite');
 
-//JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
-//$extensionPsr4Loader = new JNamespacePsr4Map;
-//$extensionPsr4Loader->ensureMapFileExists();
+// JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+// $extensionPsr4Loader = new JNamespacePsr4Map;
+// $extensionPsr4Loader->ensureMapFileExists();
 
 // Can be removed when the move of all core fields to namespace is finished
 \Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/joomla/form/fields');

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -95,9 +95,9 @@ JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
 JLoader::registerAlias('JAdministrator', 'JApplicationAdministrator');
 JLoader::registerAlias('JSite', 'JApplicationSite');
 
-// JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
-// $extensionPsr4Loader = new JNamespacePsr4Map;
-// $extensionPsr4Loader->ensureMapFileExists();
+/* JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+   $extensionPsr4Loader = new JNamespacePsr4Map;
+   $extensionPsr4Loader->ensureMapFileExists(); */
 
 // Can be removed when the move of all core fields to namespace is finished
 \Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/joomla/form/fields');

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -95,9 +95,9 @@ JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
 JLoader::registerAlias('JAdministrator', 'JApplicationAdministrator');
 JLoader::registerAlias('JSite', 'JApplicationSite');
 
-/* JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
-   $extensionPsr4Loader = new JNamespacePsr4Map;
-   $extensionPsr4Loader->ensureMapFileExists(); */
+//JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+//$extensionPsr4Loader = new JNamespacePsr4Map;
+//$extensionPsr4Loader->ensureMapFileExists();
 
 // Can be removed when the move of all core fields to namespace is finished
 \Joomla\CMS\Form\FormHelper::addFieldPath(JPATH_LIBRARIES . '/joomla/form/fields');

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -23,6 +23,11 @@ class JNamespacePsr4Map
 	 */
 	protected $file = '';
 
+	/**
+	 * Class constructor
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
 	public function __construct()
 	{
 		$this->file = JPATH_LIBRARIES . '/autoload_psr4.php';

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -24,7 +24,7 @@ class JNamespacePsr4Map
 	protected $file = '';
 
 	/**
-	 * Class constructor
+	 * Constructor. For PHP 5.5 compatibility we must set the file property like this
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */


### PR DESCRIPTION
Pull Request for Issue #16438.

### Summary of Changes
This PR fix view not found error reported at https://github.com/joomla/joomla-cms/issues/16438

### Testing Instructions
1. Follow the issue description, see the error
2. Apply patch, confirm that the error is fixed

### Additional comments

We actually should not have to set default_view in controller like this.  When default_view is not provided, it should be default to component name (which is tags in this case).  If https://github.com/joomla/joomla-cms/pull/15301 is reviewed, it should help solving this requirement