### PR TITLE
[4.0] Service factory for the Menu API

### DIFF
--- a/installation/application/app.php
+++ b/installation/application/app.php
@@ -41,6 +41,7 @@ JFactory::$container = (new \Joomla\DI\Container)
 	->registerServiceProvider(new InstallationServiceProviderApplication)
 	->registerServiceProvider(new InstallationServiceProviderSession)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Toolbar)
+	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Menu)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database);

--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -588,6 +588,7 @@ abstract class JFactory
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Menu)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Toolbar);
 

--- a/libraries/src/CMS/Menu/AbstractMenu.php
+++ b/libraries/src/CMS/Menu/AbstractMenu.php
@@ -105,23 +105,7 @@ abstract class AbstractMenu
 
 		if (empty(self::$instances[$client]))
 		{
-			// Create a Menu object
-			$classname = 'JMenu' . ucfirst($client);
-
-			if (!class_exists($classname))
-			{
-				throw new \Exception(\JText::sprintf('JLIB_APPLICATION_ERROR_MENU_LOAD', $client), 500);
-			}
-
-			// Check for a possible service from the container otherwise manually instantiate the class
-			if (\JFactory::getContainer()->exists($classname))
-			{
-				self::$instances[$client] = \JFactory::getContainer()->get($classname);
-			}
-			else
-			{
-				self::$instances[$client] = new $classname($options);
-			}
+			self::$instances[$client] = \JFactory::getContainer()->get(MenuFactoryInterface::class)->createMenu($client, $options);
 		}
 
 		return self::$instances[$client];

--- a/libraries/src/CMS/Menu/MenuFactory.php
+++ b/libraries/src/CMS/Menu/MenuFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Menu;
+
+defined('_JEXEC') or die;
+
+/**
+ * Default factory for creating Menu objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class MenuFactory implements MenuFactoryInterface
+{
+	/**
+	 * Creates a new Menu object for the requested format.
+	 *
+	 * @param   string  $client   The name of the client
+	 * @param   array   $options  An associative array of options
+	 *
+	 * @return  AbstractMenu
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function createMenu($client, array $options = [])
+	{
+		// Create a Menu object
+		$classname = __NAMESPACE__ . '\\' . ucfirst(strtolower($client)) . 'Menu';
+
+		if (!class_exists($classname))
+		{
+			throw new \InvalidArgumentException(\JText::sprintf('JLIB_APPLICATION_ERROR_MENU_LOAD', $client), 500);
+		}
+
+		return new $classname($options);
+	}
+}

--- a/libraries/src/CMS/Menu/MenuFactoryInterface.php
+++ b/libraries/src/CMS/Menu/MenuFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Menu;
+
+defined('_JEXEC') or die;
+
+/**
+ * Interface defining a factory which can create Menu objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface MenuFactoryInterface
+{
+	/**
+	 * Creates a new Menu object for the requested format.
+	 *
+	 * @param   string  $client   The name of the client
+	 * @param   array   $options  An associative array of options
+	 *
+	 * @return  AbstractMenu
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function createMenu($client, array $options = []);
+}

--- a/libraries/src/CMS/Service/Provider/Menu.php
+++ b/libraries/src/CMS/Service/Provider/Menu.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Menu\MenuFactory;
+use Joomla\CMS\Menu\MenuFactoryInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the application's menu dependency
+ *
+ * @since  4.0
+ */
+class Menu implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('menu.factory', MenuFactoryInterface::class)
+			->alias(MenuFactory::class, MenuFactoryInterface::class)
+			->share(
+				MenuFactoryInterface::class,
+				function (Container $container)
+				{
+					return new MenuFactory;
+				},
+				true
+			);
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Following other pull requests, this creates a service factory for creating menu objects.

### Testing Instructions

The CMS still works by default, developers are able to inject a custom service factory into the container to implement custom logic for creating menu objects