### PR TITLE
Set variable (type) in case of an empty requests

### DIFF
--- a/libraries/joomla/input/json.php
+++ b/libraries/joomla/input/json.php
@@ -47,11 +47,11 @@ class JInputJSON extends JInput
 		if (is_null($source))
 		{
 			$this->_raw = file_get_contents('php://input');
-			$this->data = json_decode($this->_raw, true);
+			$this->data = json_decode($this->_raw, true) ?: array();
 		}
 		else
 		{
-			$this->data = & $source;
+			$this->data = &$source;
 		}
 
 		// Set the options for the class.

--- a/libraries/joomla/input/json.php
+++ b/libraries/joomla/input/json.php
@@ -47,7 +47,12 @@ class JInputJSON extends JInput
 		if (is_null($source))
 		{
 			$this->_raw = file_get_contents('php://input');
-			$this->data = json_decode($this->_raw, true) ?: array();
+			$this->data = json_decode($this->_raw, true);
+
+			if (!is_array($this->data))
+			{
+				$this->data = array();
+			}
 		}
 		else
 		{


### PR DESCRIPTION
### Summary of Changes
If you want to process raw post data send to an (open) api, you probably would use something similar to this.: `$payload = $this->input->json->getArray();`

This is fine when (valid) data was send. In case of an empty request though, a null value is passed to `JInput::getArrayRecursive()`, which results in the following warning:
> Warning: Invalid argument supplied for foreach() in [...]\libraries\joomla\input\input.php on line 230

### Testing Instructions
First, create a test controller "foobar" with the following content in e.g. `/components/com_users/controllers/foobar.php`
```
<?php

defined('_JEXEC') or die;

class UsersControllerFoobar extends JControllerLegacy
{
	public function foobar()
	{
        $payload = $this->input->json->getArray();

		print_r($payload);

		JFactory::getApplication()->close();
	}
}
```
Send a POST request with the content type "application/json" to that controller and leave out the payload / data. It shouldn't matter if you use curl, your browser console and / or an addons to do that.

### Expected result
The expected result would be an empty array.

### Actual result
The warning mentioned above appears.