### PR TITLE
modal_menu: Displaying the correct placeholder from the option

### DIFF
--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -24,7 +24,7 @@ class JFormFieldModal_Menu extends JFormField
 	 * @since   3.7.0
 	 */
 	protected $type = 'Modal_Menu';
-	
+
 	/**
 	 * Determinate, if the select button is shown
 	 *
@@ -32,7 +32,7 @@ class JFormFieldModal_Menu extends JFormField
 	 * @since   3.7.0
 	 */
 	protected $allowSelect = true;
-	
+
 	/**
 	 * Determinate, if the clear button is shown
 	 *
@@ -40,7 +40,7 @@ class JFormFieldModal_Menu extends JFormField
 	 * @since   3.7.0
 	 */
 	protected $allowClear = true;
-	
+
 	/**
 	 * Determinate, if the create button is shown
 	 *
@@ -48,7 +48,7 @@ class JFormFieldModal_Menu extends JFormField
 	 * @since   3.7.0
 	 */
 	protected $allowNew = false;
-	
+
 	/**
 	 * Determinate, if the edit button is shown
 	 *
@@ -218,7 +218,20 @@ class JFormFieldModal_Menu extends JFormField
 			}
 		}
 
-		$title = empty($title) ? JText::_('COM_MENUS_SELECT_A_MENUITEM') : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+		// Placeholder if option is present or not
+		if (empty($title))
+ 		{
+			if ($this->element->option && (string) $this->element->option['value'] == '')
+			{
+				$title_holder = JText::_($this->element->option, true);
+			}
+			else
+			{
+				$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
+			}
+		}
+
+		$title = empty($title) ? $title_holder : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
 
 		// The current menu item display field.
 		$html  = '<span class="input-append">';
@@ -359,8 +372,18 @@ class JFormFieldModal_Menu extends JFormField
 		// Note: class='required' for client side validation.
 		$class = $this->required ? ' class="required modal-value"' : '';
 
+		// Placeholder if option is present or not when clearing field
+		if ($this->element->option && (string) $this->element->option['value'] == '')
+		{
+			$title_holder = JText::_($this->element->option, true);
+		}
+		else
+		{
+			$title_holder = JText::_('COM_MENUS_SELECT_A_MENUITEM', true);
+		}
+
 		$html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-			. '" data-text="' . htmlspecialchars(JText::_('COM_MENUS_SELECT_A_MENUITEM', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
+			. '" data-text="' . htmlspecialchars($title_holder, ENT_COMPAT, 'UTF-8') . '" value="' . $value . '" />';
 
 		return $html;
 	}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16421

### Summary of Changes
Adding conditionals to display the default placeholder with null value defined in the field Option

### Testing Instructions
Edit an item which contains a choice for a menu item field using the `modal_menu` type.

1. Creating a `Menu Item Alias`. Choosing the menu item to alias to.
2. Creating a `Create Article` menu item. Choosing the menu item `Submission Redirect` in Options.
3. Creating a `Login Form` menu item. Choosing the `Menu Item Login Redirect` and `Menu Item Logout Redirect` in the Options.
4. Creating a `Logout` menu item. Choosing the `Logout Redirection Page` in the Options.
5. Editing the Site `Login Form` module. Choosing the `Login Redirection Page` and the `Logout Redirection Page`.
6. Editing the Site `Menu` module. Choosing the `Base Item`.

The xml code for the `Menu` module is for example
```
				<field
					name="base"
					type="modal_menu"
					label="MOD_MENU_FIELD_ACTIVE_LABEL"
					description="MOD_MENU_FIELD_ACTIVE_DESC"
					select="true"
					new="true"
					edit="true"
					clear="true"
					>
					<option value="">JCURRENT</option>
				</field>
```

In each case, select a menu item in the modal. Then `Clear` that menu item.


### Expected result for the placeholder value
1. `Select a Menu Item`
2. `Default`
3. `Default` for both
4. `Default`
5. `Default` for both
6. `Current`


### Actual result
All have `Select a Menu Item`


Patch and test again. Do not forget to choose a menu item and Clear to confirm that the correct value is displayed.

Here is an example —after patch— concerning the original issue with `Menu` module.

![menumodalfield](https://cloud.githubusercontent.com/assets/869724/26751661/f444a976-483e-11e7-9bf6-3c7af0c96951.gif)

@epidote

