### PR TITLE
Contact page does not load proper com_user.profile XML

### DIFF
--- a/components/com_contact/models/contact.php
+++ b/components/com_contact/models/contact.php
@@ -386,7 +386,14 @@ class ContactModelContact extends JModelForm
 		$data = $userModel->getItem((int) $contact->user_id);
 
 		JPluginHelper::importPlugin('user');
-		$form = new JForm('com_users.profile');
+
+		// Get the form.
+		JForm::addFormPath(JPATH_SITE . '/components/com_users/models/forms');
+		JForm::addFieldPath(JPATH_SITE . '/components/com_users/models/fields');
+		JForm::addFormPath(JPATH_SITE . '/components/com_users/model/form');
+		JForm::addFieldPath(JPATH_SITE . '/components/com_users/model/field');
+
+		$form = JForm::getInstance('com_users.profile', 'profile');
 
 		// Get the dispatcher.
 		$dispatcher = JEventDispatcher::getInstance();


### PR DESCRIPTION
Pull Request for Issue #8120.

### Summary of Changes
This adds in the right profile XML for the profile linked to a contact. See #8120 for a longer explanation.


### Testing Instructions
1. Create or edit a contact and connect it with a user.
2. Edit the default.php layout of the contact view of com_contact and insert a var_dump($this->item);
3. Access the contact in the frontend and see that the $this->item->profile field contains an empty JForm object.
4. Apply the changes.
5. See that the JForm object now contains some data from the user. 
