### PR TITLE
[4.0] [com_associations] Fix JFactory class not found

### DIFF
--- a/administrator/components/com_associations/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/Helper/AssociationsHelper.php
@@ -654,7 +654,7 @@ class AssociationsHelper extends ContentHelper
 	 */
 	public static function getLanguagefilterPluginId()
 	{
-		$db    = JFactory::getDbo();
+		$db    = \JFactory::getDbo();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('extension_id'))
 			->from($db->quoteName('#__extensions'))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Visiting com_associations in the backend was throwing a PHP error regarding JFactory not being found.

### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

