### PR TITLE
Mysql: Synch data type of column checked_out_time in menu table with same column in other tables

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-03.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.3-2017-06-03.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__menu` MODIFY `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'The time the menu item was checked out.';

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -1347,7 +1347,7 @@ CREATE TABLE IF NOT EXISTS `#__menu` (
   `level` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'The relative level in the tree.',
   `component_id` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to #__extensions.id',
   `checked_out` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'FK to #__users.id',
-  `checked_out_time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'The time the menu item was checked out.',
+  `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00' COMMENT 'The time the menu item was checked out.',
   `browserNav` tinyint(4) NOT NULL DEFAULT 0 COMMENT 'The click behaviour of the link.',
   `access` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'The access level required to view the menu item.',
   `img` varchar(255) NOT NULL COMMENT 'The image of the menu item.',


### PR DESCRIPTION
Redo of Pull Request #11527 .

### Summary of Changes

This PR changes the data type of column `checked_out_time` in table `#__menu` from timestamp to datetime so it is equal to the data type of all other `checked_out_time` columns.

It is a redo of PR #11527 , which was missing the schema update but elsewhere was OK.

So almost all credits should go to the author of PR #11527 , @wmchris .

For some reasons PR #11527 shows something like "unknown branch", and there is no reaction of the author to my post there, so I thought I should make a redo.

There is nothing to be done for MS SQL or Postgresql since for these the data types are already consistent for the `checked_out_time` column.

### Testing Instructions

By code review (should be sufficient):
Check in installation/sql/myssql/joomla.sql of current staging that all columns `checked_out_time` are of type "datetime" except the one of table `#__menu` which is of type "timestamp". But the default value and the not null condition are same as for other `checked_out_time` columns.
Check that this PR fixes this and keeps the comment for the column, and it adds a correct schema update sql script for mysql only which results in the same change as in joomla.sql.

Real test (for paranoids):
Copy the schema update "3.7.3-2017-06-03.sql" from this PR to the correct location of a Joomla 3.7.2 or 3.7.3-dev (current staging) or apply this PR with the patchtester component.
Then go to "Extensions -> Manage -> Database" in the backend and - using the "Fix" button - fix the 2 database problems being shown, telling there is no column `checked_out_time` of type "datetime" in the menu table and that the schema is not up to date.
It should work without any SQL error, and after that the data type has changed (check in PHPmyAdmin).
To revert this patch, in addition to either removing the "3.7.3-2017-06-03.sql" or reverting the patch with patchtester you have to change back the data type of the column in PHPmyAdmin.

### Expected result

Data type of all columns `checked_out_time` of Joomla core database tables is the same (datetime).

### Actual result

Data type of all columns `checked_out_time` of Joomla core database tables is the same (datetime), except of the `#__menu` table, where it is timestamp but with a default value suitable for datetime.

### Documentation Changes Required

None.