### PR TITLE
[4.0] Remove indentation from some sidebar items

### DIFF
--- a/administrator/modules/mod_menu/preset/enabled.php
+++ b/administrator/modules/mod_menu/preset/enabled.php
@@ -92,12 +92,12 @@ if ($user->authorise('core.manage', 'com_users'))
 		$this->addSeparator();
 		$this->addChild(
 				new JMenuNode(
-						JText::_('MOD_MENU_FIELDS'), 'index.php?option=com_fields&context=com_users.user', 'class:fields')
+						JText::_('MOD_MENU_FIELDS'), 'index.php?option=com_fields&context=com_users.user')
 				);
 
 		$this->addChild(
 				new JMenuNode(
-						JText::_('MOD_MENU_FIELDS_GROUP'), 'index.php?option=com_fields&view=groups&context=com_users.user', 'class:category')
+						JText::_('MOD_MENU_FIELDS_GROUP'), 'index.php?option=com_fields&view=groups&context=com_users.user')
 				);
 	}
 
@@ -243,7 +243,7 @@ if ($user->authorise('core.manage', 'com_content'))
 		$this->getParent();
 	}
 
-	$this->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured', 'class:featured'));
+	$this->addChild(new JMenuNode(JText::_('MOD_MENU_COM_CONTENT_FEATURED'), 'index.php?option=com_content&view=featured'));
 
 	if ($comFieldsEnabled && JComponentHelper::getParams('com_content')->get('custom_fields_enable', '1'))
 	{


### PR DESCRIPTION
### Summary of Changes

Since the merge from staging, some of the sidebar menu items had an icon which shouldn't be there in J4. This PR just remove the icon to prevent indentation.

