### PR TITLE
Use setcookie to solve php session warning

### DIFF
--- a/libraries/joomla/session/handler/joomla.php
+++ b/libraries/joomla/session/handler/joomla.php
@@ -97,10 +97,11 @@ class JSessionHandlerJoomla extends JSessionHandlerNative
 		 * In order to kill the session altogether, such as to log the user out, the session id
 		 * must also be unset. If a cookie is used to propagate the session id (default behavior),
 		 * then the session cookie must be deleted.
+		 * We need to use setcookie here or we will get a warning in some session handlers (ex: files).
 		 */
 		if (isset($_COOKIE[$session_name]))
 		{
-			$this->input->cookie->set($session_name, '', 1);
+			setcookie($session_name, '', 1);
 		}
 
 		parent::clear();


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16477.

### Summary of Changes

PHP Files handler (and maybe other handlers) emit a warning when clearing the session.
This PR try to solves that.

### Testing Instructions

1. Use latest staging
2. Login in backend
3. Set the session handler to PHP (files handler)
4. Set session timeout to 1 minute (for faster test)
5. Wait around a minute
6. Refresh the page you will get a php warning

Apply path and try again, should work.

### Expected result

Working as usual.

### Actual result

`Warning: session_start(): The session id is too long or contains illegal characters, valid characters are a-z, A-Z, 0-9 and '-,' in /path/to/joomla/staging/libraries/joomla/session/handler/native.php on line 260`

### Documentation Changes Required

None

@mbabker @wilsonge please check.