### PR TITLE
fix populatestate method of category model for com_contact

### DIFF
--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -248,7 +248,9 @@ class ContactModelCategory extends JModelList
 		$this->setState('list.start', $limitstart);
 
 		// Optional filter text
-		$this->setState('list.filter', $app->input->getString('filter-search'));
+                $itemid =$app->input->get('Itemid', 0, 'int');
+                $search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
+		$this->setState('list.filter', $search);
 
 		// Get list ordering default from the parameters
 		$menuParams = new Registry;

--- a/components/com_contact/models/category.php
+++ b/components/com_contact/models/category.php
@@ -248,7 +248,7 @@ class ContactModelCategory extends JModelList
 		$this->setState('list.start', $limitstart);
 
 		// Optional filter text
-                $itemid =$app->input->get('Itemid', 0, 'int');
+                $itemid = $app->input->get('Itemid', 0, 'int');
                 $search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
 		$this->setState('list.filter', $search);
 


### PR DESCRIPTION
populatestate method of category model for com_contact was not using the user session data for the value of filter-search so pagination always failed to remember the value

fixes issue #9273

### Summary of Changes
Use $app->getUserStateFromRequest instead of $app->input->get to fetch the filter value
