### PR TITLE
On search results, highlight searched word in item title - issue #11996

### DIFF
--- a/components/com_search/views/search/tmpl/default_results.php
+++ b/components/com_search/views/search/tmpl/default_results.php
@@ -16,10 +16,10 @@ defined('_JEXEC') or die;
 		<?php echo $this->pagination->limitstart + $result->count . '. '; ?>
 		<?php if ($result->href) : ?>
 			<a href="<?php echo JRoute::_($result->href); ?>"<?php if ($result->browsernav == 1) : ?> target="_blank"<?php endif; ?>>
-				<?php echo $this->escape($result->title); ?>
+				<?php echo $result->title; ?>
 			</a>
 		<?php else : ?>
-			<?php echo $this->escape($result->title); ?>
+			<?php echo $result->title; ?>
 		<?php endif; ?>
 	</dt>
 	<?php if ($result->section) : ?>

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -267,6 +267,7 @@ class SearchViewSearch extends JViewLegacy
 					$created = '';
 				}
 
+				$result->title   = StringHelper::str_ireplace($needle, $hl1 . $needle . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
 				$result->text    = JHtml::_('content.prepare', $result->text, '', 'com_search.search');
 				$result->created = $created;
 				$result->count   = $i + 1;


### PR DESCRIPTION
Pull Request for Issue #11996 .

### Summary of Changes

Highlight a search result title, instead of only highlighting them in an article snippet.

### Testing Instructions

See Issue #11996.

On stock Joomla, with sample data, search for the word "Joomla". 

### Expected result

At least one article has the word "Joomla" only in its title. This instance of "joomla" should be highlighted. Other instances in article snippets should still be highlighed.

### Documentation Changes Required

#jab17
