### PR TITLE
Fixes merging off session data when using two browser tabs with two separate …

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -597,7 +597,7 @@ class MenusModelItem extends JModelAdmin
 		$itemData = (array) $this->getItem();
 		$sessionData = (array) JFactory::getApplication()->getUserState('com_menus.edit.item.data', array());
 
-		// Only merge if there is a session and item ID.
+		// Only merge if there is a session and itemId or itemid is null.
 		if (isset($sessionData['id']) && isset($itemData['id']) && $sessionData['id'] === $itemData['id']
 			|| is_null($itemData['id']))
 		{

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -592,8 +592,21 @@ class MenusModelItem extends JModelAdmin
 	 */
 	protected function loadFormData()
 	{
-		// Check the session for previously entered form data.
-		$data = array_merge((array) $this->getItem(), (array) JFactory::getApplication()->getUserState('com_menus.edit.item.data', array()));
+
+		// Check the session for previously entered form data, providing it has an ID and it is the same.
+		$itemData = (array) $this->getItem();
+		$sessionData = (array) JFactory::getApplication()->getUserState('com_menus.edit.item.data', array());
+
+		// Only merge if there is a session and item ID.
+		if (isset($sessionData['id']) && isset($itemData['id']) && $sessionData['id'] === $itemData['id']
+			|| is_null($itemData['id']))
+		{
+			$data = array_merge($itemData, $sessionData);
+		}
+		else
+		{
+			$data = $itemData;
+		}
 
 		// For a new menu item, pre-select some filters (Status, Language, Access) in edit form if those have been selected in Menu Manager
 		if ($this->getItem()->id == 0)
@@ -674,8 +687,10 @@ class MenusModelItem extends JModelAdmin
 		// If the link has been set in the state, possibly changing link type.
 		if ($link = $this->getState('item.link'))
 		{
+
 			// Check if we are changing away from the actual link type.
-			if (MenusHelper::getLinkKey($table->link) != MenusHelper::getLinkKey($link))
+			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id !== (int) $this->getState('item.id')
+				|| MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && is_null($table->id))
 			{
 				$table->link = $link;
 			}

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1690,7 +1690,7 @@ class MenusModelItem extends JModelAdmin
 	public function publish(&$pks, $value = 1)
 	{
 		$table = $this->getTable();
-		$pks = (array) $pks;
+		$pks   = (array) $pks;
 
 		// Default menu item existence checks.
 		if ($value != 1)


### PR DESCRIPTION
Fixes merging off session data when using two tabs with two separate menu items.

Pull Request for Issue #12222  .

### Summary of Changes
Setting conditions for if the item id is null and also if the itemid is equal to that of reloaded item.

This pull request fixes all but 1 scenario which IMHO cannot be solved. You cannot create two new menu items at the same time and reload each expecting it to loading the session data. Unless you were to start tagging unique session stores per browser instance. But it is very unlikely you would be creating two new menu items simultaneously and refreshing one of them before save.

### Testing Instructions
Without patch,open up two menu items, on menu item 1 change the Menu Item Type say from article to article list, DO NOT SAVE. Refresh menu item 2 and it will load menu item 1's data.

### Expected result

To refresh the page instance it's own data.

### Actual result

it loads the previous menu items data from session
