### PR TITLE
JAB17 Allow to change J! version against which updates will be checked

### DIFF
--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -318,8 +318,10 @@ class JUpdate extends JObject
 				if (isset($this->currentUpdate->targetplatform->name)
 					&& $product == $this->currentUpdate->targetplatform->name
 					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) 
+					    || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) 
+					    || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					$phpMatch = false;
 

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -319,9 +319,9 @@ class JUpdate extends JObject
 					&& $product == $this->currentUpdate->targetplatform->name
 					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) 
-						|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) 
-						|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
+					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					$phpMatch = false;
 

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -319,9 +319,9 @@ class JUpdate extends JObject
 					&& $product == $this->currentUpdate->targetplatform->name
 					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) 
-					    || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+						|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) 
-					    || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
+						|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					$phpMatch = false;
 

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -317,9 +317,9 @@ class JUpdate extends JObject
 				 */
 				if (isset($this->currentUpdate->targetplatform->name)
 					&& $product == $this->currentUpdate->targetplatform->name
-					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', JVERSION)
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || JVersion::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || JVersion::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
+					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					$phpMatch = false;
 


### PR DESCRIPTION
JAB17 make it happen.

### Summary of Changes

Allow to pass version of Joomla into the method which checks weather an update is compatible.
This changes are needed by Joomla Update component to tell if your extensions have a compatible update for Joomla version to which you are going to update or upgrade.

It is a task which we are implementing on JAB 2017 with @wilsonge 

### Testing Instructions

$update = new JUpdate();
$update->set('jversion.full', '3.7.2');
$update->set('jversion.dev_level', '2');
$update->loadFromXML('https://update.joomla.org/core/extensions/com_joomlaupdate.xml');
$download_url = $update->get('downloadurl');

Above update server has an update only for Joomla 3.6
so $download_url->_data is empty as there is no update for Joomla 3.7.2

When you will change
$update->set('jversion.full', '3.6.0');
$update->set('jversion.dev_level', '0');
then $download_url->_data will contain a download URL.

### Expected result

Allow to check if there is an update for a specific version of Joomla

### Actual result

It is possible to check if there is an update only for current version of Joomla.

### Documentation Changes Required

None
