### PR TITLE
JAB17 Allow to check 3rd party extensions compatibility before J! upgrade

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1040,7 +1040,7 @@ ENDDATA;
 			return array();
 		}
 
-		// return variable
+		// Return variable
 		$extensions_compatibility = array(
 			'compatible' => array(),
 			'not_compatible' => array(),
@@ -1087,9 +1087,9 @@ ENDDATA;
 	/**
 	 * Get an array with URL's to update servers for a given extension ID
 	 *
-	 * @param    int  $extension_id  The extension ID
+	 * @param   int  $extension_id  The extension ID
 	 * 
-	 * @return   array  An array with URL's
+	 * @return  array  An array with URL's
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
@@ -1100,9 +1100,10 @@ ENDDATA;
 
 		$query->select($db->qn('us.location'))
 			->from($db->qn('#__update_sites', 'us'))
-			->leftJoin($db->qn('#__update_sites_extensions', 'e')
+			->leftJoin(
+				$db->qn('#__update_sites_extensions', 'e')
 				. ' ON ' . $db->qn('e.update_site_id') . ' = ' . $db->qn('us.update_site_id')
-				  )
+			)
 			->where($db->qn('e.extension_id') . ' = ' . (int) $extension_id);
 
 		$db->setQuery($query);

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -999,7 +999,7 @@ ENDDATA;
 	/**
 	 * Method to get a list with 3rd party extensions, sorted by compatibility
 	 *
-	 * @param   string $latest_version The Joomla! version to test against
+	 * @param   string  $latest_version  The Joomla! version to test against
 	 *
 	 * @return  array  An array of data items.
 	 *
@@ -1025,8 +1025,8 @@ ENDDATA;
 	/**
 	 * Method to filter 3rd party extensions by the compatibility versions
 	 *
-	 * @param   array $extensions The items to check as an object list. See getExtensions().
-	 * @param   string $latest_version The Joomla! version to test against
+	 * @param   array   $extensions      The items to check as an object list. See getExtensions().
+	 * @param   string  $latest_version  The Joomla! version to test against
 	 *
 	 * @return  array  An array of data items.
 	 *
@@ -1040,7 +1040,7 @@ ENDDATA;
 			return array();
 		}
 
-		//return variable
+		// return variable
 		$extensions_compatibility = array(
 			'compatible' => array(),
 			'not_compatible' => array(),
@@ -1064,7 +1064,7 @@ ENDDATA;
 
 			foreach ($locations as $location)
 			{
-				$update = new JUpdate();
+				$update = new JUpdate;
 				$update->set('jversion.full', $version[1]);
 				$update->set('jversion.dev_level', $version[2]);
 				$update->loadFromXML($location);
@@ -1087,9 +1087,9 @@ ENDDATA;
 	/**
 	 * Get an array with URL's to update servers for a given extension ID
 	 *
-	 * @param $extension_id
+	 * @param    int  $extension_id  The extension ID
 	 * 
-	 * @return array
+	 * @return   array  An array with URL's
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
@@ -1101,8 +1101,9 @@ ENDDATA;
 		$query->select($db->qn('us.location'))
 			->from($db->qn('#__update_sites', 'us'))
 			->leftJoin($db->qn('#__update_sites_extensions', 'e')
-				. ' ON ' . $db->qn('e.update_site_id') . ' = ' . $db->qn('us.update_site_id'))
-			->where($db->qn('e.extension_id') . ' = ' . (int)$extension_id);
+				. ' ON ' . $db->qn('e.update_site_id') . ' = ' . $db->qn('us.update_site_id')
+				  )
+			->where($db->qn('e.extension_id') . ' = ' . (int) $extension_id);
 
 		$db->setQuery($query);
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1001,9 +1001,9 @@ ENDDATA;
 	 *
 	 * @param   string $latest_version The Joomla! version to test against
 	 *
-	 * @return  mixed  An array of data items.
+	 * @return  array  An array of data items.
 	 *
-	 * @since   3.8.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getExtensions($latest_version)
 	{
@@ -1030,12 +1030,13 @@ ENDDATA;
 	 *
 	 * @return  array  An array of data items.
 	 *
-	 * @since   3.8.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	private function checkCompatibility($extensions, $latest_version)
 	{
 		// If empty, return the current value
-		if (empty($extensions) || !is_array($extensions)) {
+		if (empty($extensions) || !is_array($extensions))
+		{
 			return array();
 		}
 
@@ -1050,18 +1051,19 @@ ENDDATA;
 
 		preg_match('/^(\d+\.\d+\.(\d+))/', $latest_version, $version);
 
-		foreach ($extensions as $extension) {
-
+		foreach ($extensions as $extension)
+		{
 			$locations = $this->getUpdateSitesLocations($extension->extension_id);
 
 			// If there are no update servers then we do not know if there is a compatible update
-			if (empty($locations)) {
+			if (empty($locations))
+			{
 				$extensions_compatibility['na'][] = $extension;
 				continue;
 			}
 
-			foreach ($locations as $location) {
-
+			foreach ($locations as $location)
+			{
 				$update = new JUpdate();
 				$update->set('jversion.full', $version[1]);
 				$update->set('jversion.dev_level', $version[2]);
@@ -1069,7 +1071,8 @@ ENDDATA;
 
 				// If there is a download URL then there is probably a compatible update
 				$download_url = $update->get('downloadurl');
-				if (!empty($download_url) && !empty($download_url->_data)) {
+				if (!empty($download_url) && !empty($download_url->_data))
+				{
 					$extensions_compatibility['compatible'][] = $extension;
 					continue 2;
 				}
@@ -1088,7 +1091,7 @@ ENDDATA;
 	 * 
 	 * @return array
 	 *
-	 * @since 3.8.0
+	 * @since __DEPLOY_VERSION__
 	 */
 	private function getUpdateSitesLocations($extension_id)
 	{

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -997,7 +997,7 @@ ENDDATA;
 	}
 
 	/**
-	 * Method to get a list with 3rd party extensions, sorted by compatibility
+	 * Method to get a list of 3rd party extensions, sorted by compatibility
 	 *
 	 * @param   string  $latest_version  The Joomla! version to test against
 	 *
@@ -1085,11 +1085,11 @@ ENDDATA;
 	}
 
 	/**
-	 * Get an array with URL's to update servers for a given extension ID
+	 * Get an array with URLs to update servers for a given extension ID
 	 *
 	 * @param   int  $extension_id  The extension ID
 	 * 
-	 * @return  array  An array with URL's
+	 * @return  array  An array with URLs
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1018,7 +1018,7 @@ ENDDATA;
 			->leftJoin($db->qn('#__extensions', 'e2') . ' ON e1.extension_id = e2.package_id')
 			->where('e1.' . $db->qn('protected') . ' = 0')
 			->where('e1.' . $db->qn('type') . ' <> ' . $db->q('language'))
-			->where('e2.' . $db->qn('type') . ' IS NULL OR e2.' . $db->qn('type') . ' <> ' . $db->q('language'));
+			->where('(e2.' . $db->qn('type') . ' IS NULL OR e2.' . $db->qn('type') . ' <> ' . $db->q('language') . ')');
 
 		// Add condition to exclude core extensions if not already excluded before
 		foreach ($coreExtensions as $coreExtension)

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1007,13 +1007,25 @@ ENDDATA;
 	 */
 	public function getExtensions($latest_version)
 	{
-		$db = $this->getDbo();
+		$coreExtensions = JExtensionHelper::getCoreExtensions();
+
+		$db    = $this->getDbo();
 		$query = $db->getQuery(true);
 
 		$query->select('*')
 			->from($db->qn('#__extensions'))
-			->where($db->qn('protected') . ' = ' . $db->q('0'))
-			->where($db->qn('extension_id') . ' > ' . $db->q('9999'));
+			->where($db->qn('protected') . ' = ' . $db->q('0'));
+
+		// Add condition to exclude core extensions
+		foreach ($coreExtensions as $coreExtension)
+		{
+			$query->where(
+				'(' . $db->qn('type') . ' <> ' . $db->q($extension[0])
+				. ' OR ' . $db->qn('element') . ' <> ' . $db->q($extension[1])
+				. ' OR ' . $db->qn('folder') . ' <> ' . $db->q($extension[2])
+				. ' OR ' . $db->qn('client_id') . ' <> ' . $extension[3] . ')'
+			);
+		}
 
 		$db->setQuery($query);
 

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1014,7 +1014,7 @@ ENDDATA;
 
 		$query->select('*')
 			->from($db->qn('#__extensions'))
-			->where($db->qn('protected') . ' = ' . $db->q('0'));
+			->where($db->qn('protected') . ' = 0');
 
 		// Add condition to exclude core extensions
 		foreach ($coreExtensions as $coreExtension)


### PR DESCRIPTION
JAB17 make it happen!

### Summary of Changes

Added methods to check 3rd party extensions (except languages) compatibility before J! upgrade.
This code is based on: https://github.com/nicksavov/joomla-cms/tree/2.5.x-with-pre-upgrade-check

It is a task which we are implementing on JAB 2017 with @wilsonge 

After applying a similar code to the above brunch it gives a following result where the compatibility is not checked against the manifest data stored in Joomla but against the update server of the extension.

But this PR is only a small part which has to be migrated from above brunch to J!3. The remaining part of code should have been done by other JAB17 team members and committed in another PR.

So do not expect to get the result as on this screen shot. It is only a visualization of whole feature.

![screenshot-127 0 0 1-2017-06-04-08-56-08](https://cloud.githubusercontent.com/assets/977916/26759652/33de5b02-4904-11e7-9964-4474cc0e0f29.png)

### Testing Instructions

Here are testing instructions for this PR, but it would be easier to test it when the remaining PRs will be committed.

Install the extension on your Joomla https://extensions.joomla.org/extensions/extension/site-management/seo-a-metadata/link-with-article-images-on-facebook/
Call the method getExtensions from the class JoomlaupdateModelDefault with an argument:
* '3.7.2' - there is  an update server and an update, so it is compatible
* '3.8.0' - there is an update server but there is no update, so it is not compatible
* '3.7.2' - remove the update server from database, there is no update server, so the result is NA.

In the file administrator/components/com_joomlaupdate/views/default/view.html.php
after `$model = $this->getModel();`
add this code with one of above arguments: `var_dump($model->getExtensions('3.7.2')); die;`

Core extensions and (core and 3rd party) language extensions and language packs are excluded from the check for compatibility.

Some more test examples: https://github.com/joomla/joomla-cms/pull/16494#issuecomment-313920961

### Expected result

You will get an array with extensions grouped into categories and above extension will be in following category for each scenario:
* compatible
* not_compatible
* na

### Actual result

No results as this feature does not exist

### Documentation Changes Required

None