### PR TITLE
[4.0] Add preflight/postflight hooks to uninstall

### DIFF
--- a/libraries/src/CMS/Installer/InstallerAdapter.php
+++ b/libraries/src/CMS/Installer/InstallerAdapter.php
@@ -1203,6 +1203,17 @@ abstract class InstallerAdapter
 
 		try
 		{
+			$this->triggerManifestScript('preflight');
+		}
+		catch (\RuntimeException $e)
+		{
+			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+
+			return false;
+		}
+
+		try
+		{
 			$this->triggerManifestScript('uninstall');
 		}
 		catch (\RuntimeException $e)
@@ -1256,6 +1267,18 @@ abstract class InstallerAdapter
 		try
 		{
 			$retval |= $this->finaliseUninstall();
+		}
+		catch (\RuntimeException $e)
+		{
+			\JLog::add($e->getMessage(), \JLog::WARNING, 'jerror');
+
+			$retval = false;
+		}
+
+		// And now we run the postflight
+		try
+		{
+			$this->triggerManifestScript('postflight');
 		}
 		catch (\RuntimeException $e)
 		{


### PR DESCRIPTION
Pull Request for Issue #16166

### Summary of Changes

In 3.x, only plugins make `preflight` available to extension scripts during the uninstall process and none make `postflight` available.  This PR will make those hooks available in 4.0.

### Testing Instructions

An extension's install script, when the extension is uninstalled, can act on the `preflight`, `uninstall`, and `postflight` hooks.

### Documentation Changes Required

- For plugins, where the `uninstall` hooks is triggered is now actually different.  In 3.x, `uninstall` is triggered after the SQL queries are performed (if any), inconsistent with the other adapters which are doing it before.  This is a B/C concern.
- All extensions implementing `preflight` and `postflight` will now have to check the install route (given as one of the method parameters) and not assume they only apply in an install/update context.

### Discussion Points

The current implementation triggers both `preflight` and `uninstall` immediately, this seems a bit illogical to trigger two hooks back-to-back when nothing else has happened in the middle.  I think moving `uninstall` somewhere in the middle (after SQL and before files is where it is for plugins in 3.x) may make sense, but there may be other options as well.