### PR TITLE
[4.0] Add support for Hound

### DIFF
--- a/hound.yml
+++ b/hound.yml
@@ -1,0 +1,10 @@
+fail_on_violations: true
+
+scss:
+  config_file: .scss-lint.yml
+
+jshint:
+  enabled: false
+
+ruby:
+  enabled: false


### PR DESCRIPTION
This PR adds the `yaml` file to support Hound, which we can use for those who don't want to download/use Ruby for SCSS linting.

Hound will automatically comment on PR's and report any SCSS violations. At some point in the future, we can also use this for Javascript too, but for the time being, I've disabled it.

@mbabker once merged, could you please activate HoundCI for the repo: https://houndci.com