### PR TITLE
Remove (int) since value is filtered already

### DIFF
--- a/libraries/cms/module/helper.php
+++ b/libraries/cms/module/helper.php
@@ -377,13 +377,13 @@ abstract class JModuleHelper
 	public static function getModuleList()
 	{
 		$app = JFactory::getApplication();
-		$Itemid = $app->input->getInt('Itemid');
+		$Itemid = $app->input->getInt('Itemid', 0);
 		$groups = implode(',', JFactory::getUser()->getAuthorisedViewLevels());
 		$lang = JFactory::getLanguage()->getTag();
 		$clientId = (int) $app->getClientId();
 
 		// Build a cache ID for the resulting data object
-		$cacheId = $groups . $clientId . (int) $Itemid;
+		$cacheId = $groups . $clientId . $Itemid;
 
 		$db = JFactory::getDbo();
 
@@ -402,7 +402,7 @@ abstract class JModuleHelper
 			->where('(m.publish_down = ' . $db->quote($nullDate) . ' OR m.publish_down >= ' . $db->quote($now) . ')')
 			->where('m.access IN (' . $groups . ')')
 			->where('m.client_id = ' . $clientId)
-			->where('(mm.menuid = ' . (int) $Itemid . ' OR mm.menuid <= 0)');
+			->where('(mm.menuid = ' . $Itemid . ' OR mm.menuid <= 0)');
 
 		// Filter by language
 		if ($app->isClient('site') && $app->getLanguageFilter())


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Simple remove (int) since value of $Itemid is filtered already by getInt(). If set default value to 0, then ```$app->input->getInt('Itemid', 0)``` never returns other than int, so explicit type conversion is not necessary.

### Testing Instructions
Code review.

### Expected result

### Actual result

### Documentation Changes Required
Not needed.
