### PR TITLE
[4.0] Add Context as selector to SearchTools

### DIFF
--- a/administrator/components/com_fields/models/forms/filter_fields.xml
+++ b/administrator/components/com_fields/models/forms/filter_fields.xml
@@ -4,6 +4,7 @@
 		<field
 			name="context"
 			type="fieldcontexts"
+			filtermode="selector"
 			onchange="this.form.submit();"
 		/>
 	</fieldset>

--- a/administrator/components/com_fields/models/forms/filter_groups.xml
+++ b/administrator/components/com_fields/models/forms/filter_groups.xml
@@ -4,6 +4,7 @@
 		<field
 			name="context"
 			type="fieldcontexts"
+			filtermode="selector"
 			onchange="this.form.submit();"
 		/>
 	</fieldset>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -41,16 +41,7 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-				<div id="filter-bar" class="js-stools clearfix">
-					<div class="js-stools-container-list hidden-md-down">
-						<div class="hidden-sm-down">
-							<div class="js-stools-field-list">
-								<?php echo $this->filterForm->getField('context')->input; ?>
-							</div>
-						</div>
-					</div>
-				</div>
-				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">
 						<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -46,16 +46,7 @@ if ($saveOrder)
 		</div>
 		<div class="col-md-10">
 			<div id="j-main-container" class="j-main-container">
-				<div id="filter-bar" class="js-stools clearfix">
-					<div class="js-stools-container-list hidden-md-down">
-						<div class="hidden-sm-down">
-							<div class="js-stools-field-list">
-								<?php echo $this->filterForm->getField('context')->input; ?>
-							</div>
-						</div>
-					</div>
-				</div>
-				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
+				<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-warning alert-no-items">
 						<?php echo JText::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>


### PR DESCRIPTION
Pull Request for Issue #16542 .

### Summary of Changes
Moves the context for fields and fieldgroups into the searchtool, similar to the client selector inthe templatestyle manager.


### Testing Instructions
Test that fields and fieldgroups manager work as expected when changing the context.
That field should also be on the same line as the other search tools.

### Expected result
Field is part of the search tools "bar"

### Actual result
Field is on a separated line



### Documentation Changes Required
None