### PR TITLE
[4.0] Fix Ajax permissions - calculated settings

### DIFF
--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -231,7 +231,7 @@ class JFormFieldRules extends JFormField
 		$groups = $this->getUserGroups();
 
 		// Ajax request data.
-		$ajaxUri = JRoute::_('index.php?option=com_config&task=config.store&format=json&' . JSession::getFormToken() . '=1');
+		$ajaxUri = JRoute::_('index.php?option=com_config&task=application.store&format=json&' . JSession::getFormToken() . '=1');
 
 		// Prepare output
 		$html = array();


### PR DESCRIPTION
Pull Request for Issue #16565.

### Summary of Changes
This small PR fixes the issue #16565. The issue happens because com_config was re-written use namespace MVC, so the URL for store permissions using AJAX needs to be updated.

### Testing Instructions
1. Install Joomla 4
2. Apply patch, confirm the issue sorted

