### PR TITLE
Fix site (frontend) menus of menu type "main" or "menu" and admin (backend) main menu being destroyed by 3.7.x update

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -26,7 +26,7 @@ UPDATE `#__menu_types`
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we con't care because either
+-- If there is a record in the menutype table we don't care because either
 -- it has client_id 1, then it is ok, or it does not exist (which is the normal
 -- case for the standard main menu).
 UPDATE `#__menu`

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -1,2 +1,42 @@
 -- Sync menutype for admin menu and set client_id correct
-UPDATE `#__menu` SET `menutype` = 'main', `client_id` = 1  WHERE `menutype` = 'main' OR `menutype` = 'menu';
+
+-- Note: This file had to be modified with Joomla 3.7.3 because the
+-- original version made site menus disappear if there were menu types
+-- "main" or "menu" defined for the site.
+
+-- Step 1: If there is any user-defined menu and menu type "main" for the site
+-- (client_id = 0), then change the menu type for the menu, any module and the
+-- menu type to something hopefully not being used yet.
+UPDATE `#__menu`
+   SET `menutype` = 'main_is_reserved'
+ WHERE `client_id` = 0
+   AND `menutype` = 'main'
+   AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `client_id` = 0 AND `menutype` = 'main') > 0;
+
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"menutype":"main"','"menutype":"main_is_reserved"')
+ WHERE `client_id` = 0
+   AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `client_id` = 0 AND `menutype` = 'main') > 0;
+
+UPDATE `#__menu_types`
+   SET `menutype` = 'main_is_reserved'
+ WHERE `client_id` = 0 
+   AND `menutype` = 'main';
+
+-- Step 2: What remains now are the main menu items, possibly with wrong
+-- client_id if there was nothing hit by step 1 because there was no record in
+-- the menu types table with client_id = 0.
+-- If there is a record in the menutype table we con't care because either
+-- it has client_id 1, then it is ok, or it does not exist (which is the normal
+-- case for the standard main menu).
+UPDATE `#__menu`
+   SET `client_id` = 1
+ WHERE `menutype` = 'main';
+
+-- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
+-- menu type "menu" for either admin or site.
+UPDATE `#__menu`
+   SET `menutype` = 'main',
+       `client_id` = 1
+ WHERE `menutype` = 'menu'
+   AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `menutype` = 'menu') = 0;

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -26,17 +26,39 @@ UPDATE `#__menu_types`
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we don't care because either
--- it has client_id 1, then it is ok, or it does not exist (which is the normal
--- case for the standard main menu).
 UPDATE `#__menu`
    SET `client_id` = 1
  WHERE `menutype` = 'main';
 
--- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
--- menu type "menu" for either admin or site.
+-- Step 3: If we have menu items for the admin using menutype = "menu" and
+-- having correct client_id = 1, we can be sure they belong to the admin menu
+-- and so rename the menutype.
+UPDATE `#__menu`
+   SET `menutype` = 'main'
+ WHERE `client_id` = 1 
+   AND `menutype` = 'menu';
+
+-- Step 4: If there is no user-defined menu type "menu" for the site, we can
+-- assume that any menu items for that menu type belong to the admin.
+-- Fix the client_id for those as it was done with the original version of this
+-- schema update script here.
 UPDATE `#__menu`
    SET `menutype` = 'main',
        `client_id` = 1
  WHERE `menutype` = 'menu'
-   AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `menutype` = 'menu') = 0;
+   AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `client_id` = 0 AND `menutype` = 'menu') = 0;
+
+-- Step 5: For the standard admin menu items of menutype "main" there is no record
+-- in the menutype table on a clean Joomla installation. If there is one, it is a
+-- mistake and it should be deleted, but here we rename it so the admin can see
+-- it and delete it then. This is also to be done with menu type "menu" for the
+-- admin which we renamed before in step 3.
+UPDATE `#__menu_types`
+   SET `menutype` = 'main_to_be_deleted'
+ WHERE `client_id` = 1
+   AND `menutype` = 'main';
+
+UPDATE `#__menu_types`
+   SET `menutype` = 'menu_to_be_deleted'
+ WHERE `client_id` = 1
+   AND `menutype` = 'menu';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -26,17 +26,39 @@ UPDATE "#__menu_types"
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we don't care because either
--- it has client_id 1, then it is ok, or it does not exist (which is the normal
--- case for the standard main menu).
 UPDATE "#__menu"
    SET "client_id" = 1
- WHERE "menutype" = 'main';
+ WHERE `menutype` = 'main';
 
--- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
--- menu type "menu" for either admin or site.
+-- Step 3: If we have menu items for the admin using menutype = "menu" and
+-- having correct client_id = 1, we can be sure they belong to the admin menu
+-- and so rename the menutype.
+UPDATE "#__menu"
+   SET "menutype" = 'main'
+ WHERE "client_id" = 1 
+   AND "menutype" = 'menu';
+
+-- Step 4: If there is no user-defined menu type "menu" for the site, we can
+-- assume that any menu items for that menu type belong to the admin.
+-- Fix the client_id for those as it was done with the original version of this
+-- schema update script here.
 UPDATE "#__menu"
    SET "menutype" = 'main',
        "client_id" = 1
  WHERE "menutype" = 'menu'
-   AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "menutype" = 'menu') = 0;
+   AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "client_id" = 0 AND "menutype" = 'menu') > 0;
+
+-- Step 5: For the standard admin menu items of menutype "main" there is no record
+-- in the menutype table on a clean Joomla installation. If there is one, it is a
+-- mistake and it should be deleted, but here we rename it so the admin can see
+-- it and delete it then. This is also to be done with menu type "menu" for the
+-- admin which we renamed before in step 3.
+UPDATE "#__menu_types"
+   SET "menutype" = 'main_to_be_deleted'
+ WHERE "client_id" = 1
+   AND "menutype" = 'main';
+
+UPDATE "#__menu_types"
+   SET "menutype" = 'menu_to_be_deleted'
+ WHERE "client_id" = 1
+   AND "menutype" = 'menu';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -1,3 +1,42 @@
 -- Sync menutype for admin menu and set client_id correct
-UPDATE "#__menu" SET "client_id" = 1 WHERE "menutype" = 'main' OR "menutype" = 'menu';
-UPDATE "#__menu" SET "menutype" = 'main' WHERE "menutype" = 'main' OR "menutype" = 'menu';
+
+-- Note: This file had to be modified with Joomla 3.7.3 because the
+-- original version made site menus disappear if there were menu types
+-- "main" or "menu" defined for the site.
+
+-- Step 1: If there is any user-defined menu and menu type "main" for the site
+-- (client_id = 0), then change the menu type for the menu, any module and the
+-- menu type to something hopefully not being used yet.
+UPDATE "#__menu"
+   SET "menutype" = 'main_is_reserved'
+ WHERE "client_id" = 0
+   AND "menutype" = 'main'
+   AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "client_id" = 0 AND "menutype" = 'main') > 0;
+
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"menutype":"main"','"menutype":"main_is_reserved"')
+ WHERE "client_id" = 0
+   AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "client_id" = 0 AND "menutype" = 'main') > 0;
+
+UPDATE "#__menu_types"
+   SET "menutype" = 'main_is_reserved'
+ WHERE "client_id" = 0 
+   AND "menutype" = 'main';
+
+-- Step 2: What remains now are the main menu items, possibly with wrong
+-- client_id if there was nothing hit by step 1 because there was no record in
+-- the menu types table with client_id = 0.
+-- If there is a record in the menutype table we con't care because either
+-- it has client_id 1, then it is ok, or it does not exist (which is the normal
+-- case for the standard main menu).
+UPDATE "#__menu"
+   SET "client_id" = 1
+ WHERE "menutype" = 'main';
+
+-- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
+-- menu type "menu" for either admin or site.
+UPDATE "#__menu"
+   SET "menutype" = 'main',
+       "client_id" = 1
+ WHERE "menutype" = 'menu'
+   AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "menutype" = 'menu') = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -26,7 +26,7 @@ UPDATE "#__menu_types"
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we con't care because either
+-- If there is a record in the menutype table we don't care because either
 -- it has client_id 1, then it is ok, or it does not exist (which is the normal
 -- case for the standard main menu).
 UPDATE "#__menu"

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -28,7 +28,7 @@ UPDATE "#__menu_types"
 -- the menu types table with client_id = 0.
 UPDATE "#__menu"
    SET "client_id" = 1
- WHERE `menutype` = 'main';
+ WHERE "menutype" = 'main';
 
 -- Step 3: If we have menu items for the admin using menutype = "menu" and
 -- having correct client_id = 1, we can be sure they belong to the admin menu

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -25,7 +25,7 @@ UPDATE [#__menu_types]
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we con't care because either
+-- If there is a record in the menutype table we don't care because either
 -- it has client_id 1, then it is ok, or it does not exist (which is the normal
 -- case for the standard main menu).
 UPDATE [#__menu]

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -1,6 +1,46 @@
 -- Sync menutype for admin menu and set client_id correct
-UPDATE [#__menu] SET [client_id] = 1 WHERE [menutype] = 'main' OR [menutype] = 'menu';
-UPDATE [#__menu] SET [menutype] = 'main' WHERE [menutype] = 'main' OR [menutype] = 'menu';
+-- Note: This change had to be modified with Joomla 3.7.3 because the
+-- original version made site menus disappear if there were menu types
+-- "main" or "menu" defined for the site.
+
+-- Step 1: If there is any user-defined menu and menu type "main" for the site
+-- (client_id = 0), then change the menu type for the menu, any module and the
+-- menu type to something hopefully not being used yet.
+UPDATE [#__menu]
+   SET [menutype] = 'main_is_reserved'
+ WHERE [client_id] = 0
+   AND [menutype] = 'main'
+   AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [client_id] = 0 AND [menutype] = 'main') > 0;
+
+UPDATE [#__modules]
+   SET [params] = REPLACE([params],'"menutype":"main"','"menutype":"main_is_reserved"')
+ WHERE [client_id] = 0
+   AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [client_id] = 0 AND [menutype] = 'main') > 0;
+
+UPDATE [#__menu_types]
+   SET [menutype] = 'main_is_reserved'
+ WHERE [client_id] = 0 
+   AND [menutype] = 'main';
+
+-- Step 2: What remains now are the main menu items, possibly with wrong
+-- client_id if there was nothing hit by step 1 because there was no record in
+-- the menu types table with client_id = 0.
+-- If there is a record in the menutype table we con't care because either
+-- it has client_id 1, then it is ok, or it does not exist (which is the normal
+-- case for the standard main menu).
+UPDATE [#__menu]
+   SET [client_id] = 1
+ WHERE [menutype] = 'main';
+
+-- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
+-- menu type "menu" for either admin or site.
+UPDATE [#__menu]
+   SET [menutype] = 'main',
+       [client_id] = 1
+ WHERE [menutype] = 'menu'
+   AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [menutype] = 'menu') = 0;
+
+-- End sync menutype for admin menu and set client_id correct
 
 SET IDENTITY_INSERT #__extensions  ON;
 

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -25,20 +25,42 @@ UPDATE [#__menu_types]
 -- Step 2: What remains now are the main menu items, possibly with wrong
 -- client_id if there was nothing hit by step 1 because there was no record in
 -- the menu types table with client_id = 0.
--- If there is a record in the menutype table we don't care because either
--- it has client_id 1, then it is ok, or it does not exist (which is the normal
--- case for the standard main menu).
 UPDATE [#__menu]
    SET [client_id] = 1
  WHERE [menutype] = 'main';
 
--- Step 3: Synch menu type "menu" correct client_id if there is no user-defined
--- menu type "menu" for either admin or site.
+-- Step 3: If we have menu items for the admin using menutype = "menu" and
+-- having correct client_id = 1, we can be sure they belong to the admin menu
+-- and so rename the menutype.
+UPDATE [#__menu]
+   SET [menutype] = 'main'
+ WHERE [client_id] = 1 
+   AND [menutype] = 'menu';
+
+-- Step 4: If there is no user-defined menu type "menu" for the site, we can
+-- assume that any menu items for that menu type belong to the admin.
+-- Fix the client_id for those as it was done with the original version of this
+-- schema update script here.
 UPDATE [#__menu]
    SET [menutype] = 'main',
        [client_id] = 1
  WHERE [menutype] = 'menu'
-   AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [menutype] = 'menu') = 0;
+   AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [client_id] = 0 AND [menutype] = 'menu') > 0;
+
+-- Step 5: For the standard admin menu items of menutype "main" there is no record
+-- in the menutype table on a clean Joomla installation. If there is one, it is a
+-- mistake and it should be deleted, but here we rename it so the admin can see
+-- it and delete it then. This is also to be done with menu type "menu" for the
+-- admin which we renamed before in step 3.
+UPDATE [#__menu_types]
+   SET [menutype] = 'main_to_be_deleted'
+ WHERE [client_id] = 1
+   AND [menutype] = 'main';
+
+UPDATE [#__menu_types]
+   SET [menutype] = 'menu_to_be_deleted'
+ WHERE [client_id] = 1
+   AND [menutype] = 'menu';
 
 -- End sync menutype for admin menu and set client_id correct
 


### PR DESCRIPTION
Pull Request for Issues #15671 , #15719 , #16643 and #16732 .

Replaces PR #15695  .

### Summary of Changes

With PR #13619 by @rdeutz a schema update was introduced which tried to fix incorrect client_id of the main menu for the admin client and change menu type "menu" to "main" to fix some inconsistency remaining on some installations which have been sequentially updated since very old Joomla versions.

Starting with version 2.5, the menu types "menu" and "main" have been reserved so users were not allowed to create such menus and menu items. Since 3.7.0 only menutype "main" is reserved for the main admin menu. But in some cases it is possible to have menus and menu items with those reserved types, e.g. if having sequentially updated the installation since very old version.

PR #13619 did not care about that, and so it caused site (frontend) menus to disappear, which has caused rumors in the support forums.

PR #15695 by @alikon tried to fix that, but the discussions in that PR have shown that it was not as easy as it looked like in the first moment.

After I proposed a solution in the discussion, @alikon encouraged me to make a PR from my proposal, and here it is now.

It fixes the problem by renaming the menu type "main" for site menus before setting the correct client ID for the main menu, and by renaming a present admin menu type "menu" to "main" only if it is not a used-defined menu type.

The fix is done in the original schema update from PR #13619 and not in a new schema update, because these had to be updated anyway in order to be correct for updating 3.6.5 and earlier versions, and for later versions nothign can be done. If anyone already has run into the trouble by updating to 3.7.0, he/she had to fix the menus manually with database tools or fall back to the pre-update version, otherwise he/she will still be lost, and there is no easy way to fix the messed up menus after the problem has come. Therefore there are no new schema updates provided by this PR here.

More details about the issue and how it could be fixed can be found here in German language: [http://www.joomlaportal.de/joomla-3-x-installation/328656-nach-upgrade-auf-3-7-menu-verschwunden-2.html#post1640779](http://www.joomlaportal.de/joomla-3-x-installation/328656-nach-upgrade-auf-3-7-menu-verschwunden-2.html#post1640779 "http://www.joomlaportal.de/joomla-3-x-installation/328656-nach-upgrade-auf-3-7-menu-verschwunden-2.html#post1640779"). This was also the inspiration for how to do it in my PR.

### Testing Instructions

**Preconditions:**

Either have been hit by issue #15671 or #15719 and have a backup of the Joomla! from _before_ it was updated to 3.7.0 or later and therefore hit by the issue, and have test system where you have restored that backup.

Or prepare as described in @alikon 's [comment below](https://issues.joomla.org/tracker/joomla-cms/16577#event-286991 "https://issues.joomla.org/tracker/joomla-cms/16577#event-286991").

Then execute as described in the [same comment](https://issues.joomla.org/tracker/joomla-cms/16577#event-286991 "https://issues.joomla.org/tracker/joomla-cms/16577#event-286991") by @alikon .

### Expected result

The update is performed without any errors. No menu has disappeared in on site (frontend) or admin (backend).

### Actual result

The update is performed without any errors, but the site (frontend) menus with menu type "main" and "menu" have disappeared from site, and backend menus were sometimes messed up, too. Details see in @alikon 's [comment](https://issues.joomla.org/tracker/joomla-cms/16577#event-286991 "https://issues.joomla.org/tracker/joomla-cms/16577#event-286991").

### Documentation Changes Required

None.