### PR TITLE
[4.0] Wrap com_config nav-items (tabs)

### DIFF
--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -48,7 +48,7 @@ JFactory::getDocument()->addScriptDeclaration(
 		<div class="col-md-10" id="config">
 
 			<?php if ($this->fieldsets): ?>
-			<ul class="nav nav-tabs" id="configTabs">
+			<ul class="nav nav-tabs flex-wrap" id="configTabs">
 				<?php foreach ($this->fieldsets as $name => $fieldSet) : ?>
 					<?php $dataShowOn = ''; ?>
 					<?php if (!empty($fieldSet->showon)) : ?>


### PR DESCRIPTION
Pull Request for Issue #16558 .

### Summary of Changes
Allows com_config tabs to wrap on smaller screen sizes. 

Note: On even smaller mobile device screens sizes there is other issues which will be addressed at a later stage.


### Testing Instructions
See #16558. Apply patch and navigate to Global Config -> Articles. Reduce screen size. Ensure tabs wrap to a second line.

![tabs](https://user-images.githubusercontent.com/2803503/26898886-5053c556-4bc5-11e7-8d9e-6d700ff1efbe.png)
