### PR TITLE
put multiple versions of the same  tag

### DIFF
--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -423,8 +423,9 @@ class JDocument
 	 */
 	public function setMetaData($name, $content, $attribute = 'name')
 	{
-		//Pop the element off the end of array if target function expects a string or this http_equiv parameter.
-		if(is_array($content) && (in_array($name, array('generator', 'description')) || !is_string($attribute))){
+		// Pop the element off the end of array if target function expects a string or this http_equiv parameter.
+		if (is_array($content) && (in_array($name, array('generator', 'description')) || !is_string($attribute)))
+		{
 			$content = array_pop($content);
 		}
 		

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -414,7 +414,7 @@ class JDocument
 	 * Sets or alters a meta tag.
 	 *
 	 * @param   string  $name       Name of the meta HTML tag
-	 * @param   string  $content    Value of the meta HTML tag
+	 * @param   mixed   $content    Value of the meta HTML tag as array or string
 	 * @param   string  $attribute  Attribute to use in the meta HTML tag
 	 *
 	 * @return  JDocument instance of $this to allow chaining
@@ -423,12 +423,17 @@ class JDocument
 	 */
 	public function setMetaData($name, $content, $attribute = 'name')
 	{
+		//Pop the element off the end of array if target function expects a string or this http_equiv parameter.
+		if(is_array($content) && (in_array($name, array('generator', 'description')) || !is_string($attribute))){
+			$content = array_pop($content);
+		}
+		
 		// B/C old http_equiv parameter.
 		if (!is_string($attribute))
 		{
 			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
-
+		
 		if ($name == 'generator')
 		{
 			$this->setGenerator($content);

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -434,7 +434,7 @@ class JDocument
 		{
 			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
-		
+
 		if ($name == 'generator')
 		{
 			$this->setGenerator($content);

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -428,7 +428,7 @@ class JDocument
 		{
 			$content = array_pop($content);
 		}
-		
+
 		// B/C old http_equiv parameter.
 		if (!is_string($attribute))
 		{

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -94,7 +94,17 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				}
 				elseif ($type != 'http-equiv' && !empty($content))
 				{
-					$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+					if(is_array($content))
+					{
+						foreach($content as $value)
+						{
+							$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+						}
+					}
+					else
+					{
+						$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
+					}
 				}
 			}
 		}

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -94,9 +94,9 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 				}
 				elseif ($type != 'http-equiv' && !empty($content))
 				{
-					if(is_array($content))
+					if (is_array($content))
 					{
-						foreach($content as $value)
+						foreach ($content as $value)
 						{
 							$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
 						}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changed the type of the parameter $content from a string to an array in the setMetaData method of the JDocument class.
This will allow you to add multiple identical tags with different values. For example og:image (http://ogp.me/#array)

### Testing Instructions
Call in your code
`JFactory::getDocument()->setMetaData("og:image", array("/image1.jpg", "/image2.jpg", "/image3.jpg"), 'property');`


### Expected result
View the source of the page in the browser.
You should see the following code in head:
`	<meta property="og:image" content="/image1.jpg" />
	<meta property="og:image" content="/image2.jpg" />
	<meta property="og:image" content="/image3.jpg" />`

### Documentation Changes Required
https://api.joomla.org/cms-3/classes/JDocument.html#method_setMetaData
Replace this:
> $content   string   Value of the meta HTML tag
with this:

> $content   mixed   Value of the meta HTML tag as array or string
