### PR TITLE
Admin menu missing

### DIFF
--- a/administrator/components/com_associations/views/associations/tmpl/default.xml
+++ b/administrator/components/com_associations/views/associations/tmpl/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="COM_ASSOCIATIONS">
+		<message>
+			<![CDATA[COM_ASSOCIATIONS_XML_DESCRIPTION]]>
+		</message>
+	</layout>
+</metadata>

--- a/administrator/components/com_redirect/views/links/tmpl/default.xml
+++ b/administrator/components/com_redirect/views/links/tmpl/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="COM_REDIRECT">
+		<message>
+			<![CDATA[COM_REDIRECT_XML_DESCRIPTION]]>
+		</message>
+	</layout>
+</metadata>

--- a/administrator/components/com_search/views/searches/tmpl/default.xml
+++ b/administrator/components/com_search/views/searches/tmpl/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="COM_SEARCH_SEARCH_VIEW_DEFAULT_TITLE">
+		<message>
+			<![CDATA[COM_SEARCH_SEARCH_VIEW_DEFAULT_DESC]]>
+		</message>
+	</layout>
+</metadata>

--- a/administrator/components/com_tags/views/tags/tmpl/default.xml
+++ b/administrator/components/com_tags/views/tags/tmpl/default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<metadata>
+	<layout title="COM_TAGS_TAGS_VIEW_DEFAULT_TITLE">
+		<message>
+			<![CDATA[COM_TAGS_TAGS_VIEW_DEFAULT_DESC]]>
+		</message>
+	</layout>
+</metadata>


### PR DESCRIPTION
Custom Admin Menu - missing options  …
With the new ability to create your own admin menu some components were missed.

This PR adds com_tags, multilingual associations, com_redirect and com_search

To test - first confirm that you can not create an admin menu for these 4 components
Apply the PR and make sure that you can create an admin menu of these 4 components and that they work