### PR TITLE
Add UTF-8 support in Joomla media manager

### DIFF
--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -65,8 +65,8 @@ class JFile
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
-		// Allow uploading UTF-8 filenames in Linux and Windows starting from PHP 7.1
-		$unicode = strtoupper(PHP_OS === 'LINUX') || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
+		// Allow uploading UTF-8 filenames in Windows starting from PHP 7.1 and other OS
+		$unicode = strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
 
 		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -65,7 +65,7 @@ class JFile
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
-		// Allow uploading UTF-8 filenames in Linux
+		// Allow uploading UTF-8 filenames in Linux and Windows starting from PHP 7.1
 		$unicode = strtoupper(PHP_OS === 'LINUX') || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
 
 		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -66,7 +66,7 @@ class JFile
 		$file = rtrim($file, '.');
 
 		// Allow uploading UTF-8 filenames in Linux
-		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
+		$unicode = strtoupper(PHP_OS === 'LINUX') || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
 
 		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -64,8 +64,11 @@ class JFile
 	{
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
-
-		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#u', '#^\.#');
+		
+		// Allow upload UTF-8 file names in Linux
+		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
+		
+		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');
 
 		return trim(preg_replace($regex, '', $file));
 	}

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -65,7 +65,7 @@ class JFile
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
-		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
+		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#u', '#^\.#');
 
 		return trim(preg_replace($regex, '', $file));
 	}

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -64,10 +64,10 @@ class JFile
 	{
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
-		
+
 		// Allow upload UTF-8 file names in Linux
 		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
-		
+
 		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');
 
 		return trim(preg_replace($regex, '', $file));

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -65,7 +65,7 @@ class JFile
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
-		// Allow upload UTF-8 file names in Linux
+		// Allow uploading UTF-8 filenames in Linux
 		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
 
 		$regex = array('#(\.){2,}#', '#[^\w\.\- ]#' . $unicode, '#^\.#');

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -715,8 +715,8 @@ abstract class JFolder
 	 */
 	public static function makeSafe($path)
 	{
-		// Allow uploading UTF-8 filenames in Linux and Windows starting from PHP 7.1
-		$unicode = strtoupper(PHP_OS === 'LINUX') || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
+		// Allow uploading UTF-8 filenames in Windows starting from PHP 7.1 and other OS
+		$unicode = strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN' || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
 
 		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#' . $unicode);
 

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -715,8 +715,8 @@ abstract class JFolder
 	 */
 	public static function makeSafe($path)
 	{
-		// Allow uploading UTF-8 filenames in Linux
-		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
+		// Allow uploading UTF-8 filenames in Linux and Windows starting from PHP 7.1
+		$unicode = strtoupper(PHP_OS === 'LINUX') || version_compare(PHP_VERSION, '7.1', '>=') ? 'u' : '';
 
 		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#' . $unicode);
 

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -715,7 +715,7 @@ abstract class JFolder
 	 */
 	public static function makeSafe($path)
 	{
-		$regex = array('#[^A-Za-z0-9_\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#');
+		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#u');
 
 		return preg_replace($regex, '', $path);
 	}

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -715,7 +715,7 @@ abstract class JFolder
 	 */
 	public static function makeSafe($path)
 	{
-		// Allow upload UTF-8 file names in Linux
+		// Allow uploading UTF-8 filenames in Linux
 		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
 
 		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#' . $unicode);

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -715,7 +715,10 @@ abstract class JFolder
 	 */
 	public static function makeSafe($path)
 	{
-		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#u');
+		// Allow upload UTF-8 file names in Linux
+		$unicode = strtoupper(PHP_OS === 'LINUX') ? 'u' : '';
+
+		$regex = array('#[^\w\\\/\(\)\[\]\{\}\#\$\^\+\.\'~`!@&=;,-]#' . $unicode);
 
 		return preg_replace($regex, '', $path);
 	}


### PR DESCRIPTION
### Summary of Changes

This PR allows to upload UTF-8 filenames with media manager and use the `makeSafe` method for UTF-8 file names:

Windows with PHP >= v7.1 - media manager uploads files with non-ascii names.
Windows with PHP < v7.1 - media manager prevent files with non-ascii names from being uploaded.
Other OS with any PHP version - media manager uploads files with non-ascii names.

### Testing Instructions

Try to upload an image named in any other letters then ASCII, e.g. `файл.jpg`

### Expected result

Image is uploaded

### Actual result

Error (unsupported format)