### PR TITLE
[4.0] Impossible to create new Menu Type

### DIFF
--- a/libraries/src/CMS/Table/MenuType.php
+++ b/libraries/src/CMS/Table/MenuType.php
@@ -52,7 +52,7 @@ class MenuType extends Table
 			return false;
 		}
 
-		$this->menutype = JApplicationHelper::stringURLSafe($this->menutype);
+		$this->menutype = \JApplicationHelper::stringURLSafe($this->menutype);
 
 		if (empty($this->menutype))
 		{


### PR DESCRIPTION
Try creating a new Menu (Menu type)
Error is `Class 'Joomla\CMS\Table\JApplicationHelper' not found`

Patch and retest