### PR TITLE
Limit memory used by tokeniser

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -71,12 +71,29 @@ class FinderIndexerHelper
 	public static function tokenize($input, $lang, $phrase = false)
 	{
 		static $cache;
+
+		// Instantiate a cache object.
+		if ($cache === null)
+		{
+			$options = array(
+				'defaultgroup' => __METHOD__,
+				'storage'	   => 'memory',
+				);
+			$cache = JCache::getInstance('', $options);
+			$cache->setCaching(true);
+		}
+
 		$store = StringHelper::strlen($input) < 128 ? md5($input . '::' . $lang . '::' . $phrase) : null;
 
 		// Check if the string has been tokenized already.
-		if ($store && isset($cache[$store]))
+		if ($store)
 		{
-			return $cache[$store];
+			$tokens = $cache->get($store);
+
+			if ($tokens)
+			{
+				return $tokens;
+			}
 		}
 
 		$tokens = array();
@@ -199,9 +216,10 @@ class FinderIndexerHelper
 
 		if ($store)
 		{
-			$cache[$store] = count($tokens) > 1 ? $tokens : array_shift($tokens);
+			$data = count($tokens) > 1 ? $tokens : array_shift($tokens);
+			$cache->store($data, $store);
 
-			return $cache[$store];
+			return $data;
 		}
 		else
 		{

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -90,11 +90,13 @@ class JCache
 	/**
 	 * Get the storage handlers
 	 *
+	 * @param   boolean  $persistentOnly  If true only return persistent storage handlers.
+	 *
 	 * @return  array
 	 *
 	 * @since   11.1
 	 */
-	public static function getStores()
+	public static function getStores($persistentOnly = false)
 	{
 		$handlers = array();
 
@@ -122,7 +124,7 @@ class JCache
 			}
 
 			// Sweet!  Our class exists, so now we just need to know if it passes its test method.
-			if ($class::isSupported())
+			if ($class::isSupported() && (!$persistentOnly || $class::isPersistent()))
 			{
 				// Connector names should not have file extensions.
 				$handlers[] = str_ireplace('.php', '', $fileName);

--- a/libraries/joomla/cache/storage.php
+++ b/libraries/joomla/cache/storage.php
@@ -305,6 +305,18 @@ class JCacheStorage
 	}
 
 	/**
+	 * Test to see if stored data is persistent across requests.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isPersistent()
+	{
+		return true;
+	}
+
+	/**
 	 * Test to see if the storage handler is available.
 	 *
 	 * @return  boolean

--- a/libraries/joomla/cache/storage/memory.php
+++ b/libraries/joomla/cache/storage/memory.php
@@ -1,0 +1,275 @@
+<?php
+/**
+ * @package     Joomla.Platform
+ * @subpackage  Cache
+ *
+ * @copyright   Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Native PHP in-memory cache storage handler.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class JCacheStorageMemory extends JCacheStorage
+{
+	/**
+	 * Cache buffers.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $buffers = array();
+
+	/**
+	 * Maximum number of buffers permitted.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $maxBuffers = 0;
+
+	/**
+	 * A simple integer that stands in for a clock to indicate how old an item is.
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $clock = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   array  $options  Optional parameters
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct($options = array())
+	{
+		parent::__construct($options);
+
+		$this->maxBuffers = isset($options['maxBuffers']) ? $options['maxBuffers'] : 100;
+	}
+
+	/**
+	 * Get cached data by ID and group.
+	 *
+	 * @param   string   $id         The cache data ID
+	 * @param   string   $group      The cache data group
+	 * @param   boolean  $checkTime  True to verify cache time expiration threshold
+	 *
+	 * @return  mixed  Boolean false on failure or a cached data object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function get($id, $group, $checkTime = true)
+	{
+		if (!isset($this->buffers[$group][$id]))
+		{
+			return false;
+		}
+
+		// Update the clock to show when the entry was last used.
+		$this->buffers[$group][$id]['clock'] = $this->clock++;
+
+		return unserialize($this->buffers[$group][$id]['value']);
+	}
+
+	/**
+	 * Get all cached data
+	 *
+	 * @return  mixed  Boolean false on failure or a cached data object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getAll()
+	{
+		return $this->buffers;
+	}
+
+	/**
+	 * Store the data to cache by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 * @param   string  $data   The data to store in cache
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function store($id, $group, $data)
+	{
+		// If we have enough room, store the data.
+		if (!isset($this->buffers[$group]) || count($this->buffers[$group]) < $this->maxBuffers)
+		{
+			$this->buffers[$group][$id] = array(
+				'clock' => $this->clock++,
+				'value' => serialize($data),
+				);
+
+			return true;
+		}
+
+		$lru = 0;
+		$min = $this->clock;
+
+		// Find the least recently-used item.
+		foreach ($this->buffers[$group] as $key => $entry)
+		{
+			if ($entry['clock'] < $min)
+			{
+				$lru = $key;
+				$min = $entry['clock'];
+			}
+		}
+
+		// Remove the least-recently used item.
+		unset($this->buffers[$group][$lru]);
+
+		// Insert the new item.
+		$this->buffers[$group][$id] = array(
+			'clock' => $this->clock++,
+			'value' => serialize($data),
+			);
+
+		return true;
+	}
+
+	/**
+	 * Remove a cached data entry by ID and group
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function remove($id, $group)
+	{
+		if (!isset($this->buffers[$group][$id]))
+		{
+			return false;
+		}
+
+		unset($this->buffers[$group][$id]);
+
+		return true;
+	}
+
+	/**
+	 * Clean cache for a group given a mode.
+	 *
+	 * group mode    : cleans all cache in the group
+	 * notgroup mode : cleans all cache not in the group
+	 *
+	 * @param   string  $group  The cache data group
+	 * @param   string  $mode   The mode for cleaning cache [group|notgroup]
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function clean($group, $mode = null)
+	{
+		// Clear the specified group.
+		if ($mode == 'group')
+		{
+			unset($this->buffers[$group]);
+
+			return true;
+		}
+
+		// Not a valid mode.
+		if ($mode != 'notgroup')
+		{
+			return false;
+		}
+
+		// Clear all buffers except the one specified.
+		foreach ($this->buffers as $key => $buffer)
+		{
+			if ($key != $group)
+			{
+				unset($this->buffers[$key]);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Garbage collect expired cache data
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function gc()
+	{
+		return true;
+	}
+
+	/**
+	 * Test to see if the storage handler is available.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isSupported()
+	{
+		return true;
+	}
+
+	/**
+	 * Test to see if stored data is persistent across requests.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isPersistent()
+	{
+		return false;
+	}
+
+	/**
+	 * Lock cached item
+	 *
+	 * @param   string   $id        The cache data ID
+	 * @param   string   $group     The cache data group
+	 * @param   integer  $locktime  Cached item max lock time
+	 *
+	 * @return  mixed  Boolean false if locking failed or an object containing properties locked and locklooped
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function lock($id, $group, $locktime)
+	{
+		$returning = new stdClass;
+		$returning->locklooped = false;
+		$returning->locked = false;
+
+		return $returning;
+	}
+
+	/**
+	 * Unlock cached item
+	 *
+	 * @param   string  $id     The cache data ID
+	 * @param   string  $group  The cache data group
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function unlock($id, $group = null)
+	{
+		return true;
+	}
+}


### PR DESCRIPTION
Note: This replaces and is the same as #12649 but without the branch merge that I was unable to recover from.  It includes the suggestions by @nikosdion such that the new memory cache handler is not listed in global configuration.
### Summary of Changes
Running the Smart Search indexer on a medium-sized site often results in "out of memory" failures which can only be addressed by running the CLI indexer with more memory allocated, like this:

`php -d memory_limit=256M finder_indexer.php`

However, this option is not usually available for web-based indexing.

It turns out that the problem is largely due to the tokeniser attempting to reduce execution time by caching all previous tokenisations under 128 bytes long.  This PR addresses that issue by limiting the number of cached tokenisations to 100.  Note: the number could be made configurable, but I am doubtful of the benefit to be gained so that is not part of this PR.

Hat tip to @mahagr for pointing out the problem with the tokeniser.

Since this might conceivably be of use elsewhere, the fix has been implemented by adding a new storage class to the JCache library.  The new JCacheStorageMemory class uses a regular PHP array to store cached items.  A maxBuffers option allows you to define the maximum number of items to cache (default 100).  If an attempt is made to store a new item when the cache is already full, the least recently used item will be deleted to make room.
### Testing Instructions

Find or construct a site with enough content that the CLI indexer fails with an out of memory error.  As a rough guide you'll probably need over 1,000 articles to trigger the error.  The size of the articles doesn't matter much because tokenisations of strings more than 128 bytes long are not cached and most articles are likely to be longer than that.

Apply the PR and run the indexer again.  Hopefully you won't get the out of memory error!

Alternatively, since #12679 and #12680 have now been merged, simply look at the amount of memory used.

I am aware that unit tests need to be added for JCacheStorageMemory and I'd appreciate help in writing them.
### Documentation Changes Required

None.
