### PR TITLE
Fix for #11070 (tag-category) - Improve also views newsfeed-category …

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -4733,6 +4733,14 @@ a.badge:focus {
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+	.tag-category input#filter-search,
+	.newsfeed-category input#filter-search {
+		width: auto;
+		margin-bottom: 9px;
+	}
+	.category-list input#filter-search {
+		width: auto;
+	}
 	.media .pull-left,
 	.media .pull-right {
 		float: none;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -4733,6 +4733,14 @@ a.badge:focus {
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+	.tag-category input#filter-search,
+	.newsfeed-category input#filter-search {
+		width: auto;
+		margin-bottom: 9px;
+	}
+	.category-list input#filter-search {
+		width: auto;
+	}
 	.media .pull-left,
 	.media .pull-right {
 		float: none;

--- a/media/jui/less/responsive-767px-max.less
+++ b/media/jui/less/responsive-767px-max.less
@@ -153,6 +153,16 @@
     }
   }
 
+  // Gracefully displays the filter-search fields and buttons
+  .tag-category input#filter-search,
+  .newsfeed-category input#filter-search {
+    width: auto;
+    margin-bottom: @baseLineHeight / 2;
+  }
+  .category-list input#filter-search {
+    width: auto;
+  }
+
   // Medias
   // Reset float and spacing to stack
   .media .pull-left,

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -4915,6 +4915,14 @@ a.badge:focus {
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+	.tag-category input#filter-search,
+	.newsfeed-category input#filter-search {
+		width: auto;
+		margin-bottom: 9px;
+	}
+	.category-list input#filter-search {
+		width: auto;
+	}
 	.media .pull-left,
 	.media .pull-right {
 		float: none;


### PR DESCRIPTION
…and category-list

Pull Request for Issue #11070.

### Summary of Changes

There is a width issue on the filter-search field. Especially for the tag view, where there are two buttons beside the field. The other filters usually have no button. This is the case for newsfeed-category and category-list.
The width comes from the general rule here:
```
input,
textarea,
.uneditable-input {
	width: 206px;
}
```
https://github.com/joomla/joomla-cms/blob/staging/templates/protostar/css/template.css#L936

### Testing Instructions

» Go to the front-end with latest joomlacms (Test website using the Sample Data TEST to more views).
» In the Menu **All Front End Views**, click on **Tagged items**
» View on small device screen
» Repeat with **Article Category List** and **News Feed Category** menu items

### Expected result

» Filter search is inside the container, and the select limit drop-down gracefully displays on the next line with a margin.

(Test website using the Sample Data TEST to more views).

Tag-category AFTER:
![screen shot 2017-06-12 at 21 50 10](https://issues.joomla.org/uploads/1/7191ff0e5a85e5d76ce0db3636c496cc.png)  

Category-list AFTER:
![screen shot 2017-06-12 at 21 50 26](https://issues.joomla.org/uploads/1/f2cb9e678f39633c76e1676c6dc3d74f.png)  

Newsfeed-category AFTER:
![screen shot 2017-06-12 at 21 50 42](https://issues.joomla.org/uploads/1/dfdc0aadcf93aa2608ba4e713ee06745.png)  

### Actual result

The filter search and the buttons are a bit outside the container on a small device.
On Mac Firefox/Chrome, the issue is there until 328px wide. Fixed above.

Tag-category BEFORE:
![screen shot 2017-06-12 at 21 53 30](https://issues.joomla.org/uploads/1/47c672a03f273fb04bc885e5ca582ef8.png)

Category-list BEFORE:
![screen shot 2017-06-12 at 21 52 39](https://issues.joomla.org/uploads/1/07ceee246d5572ab0161134c7df6380b.png)

Newsfeed-category BEFORE:
![screen shot 2017-06-12 at 21 52 16](https://issues.joomla.org/uploads/1/a01b0de9f6bfddafaf71a33c2f8df2d3.png)
