### PR TITLE
[4.0] Adding a.modified to the association group_by

### DIFF
--- a/administrator/components/com_content/Model/Articles.php
+++ b/administrator/components/com_content/Model/Articles.php
@@ -193,6 +193,7 @@ class Articles extends ListModel
 			'a.created',
 			'a.created_by',
 			'a.created_by_alias',
+			'a.modified',
 			'a.ordering',
 			'a.featured',
 			'a.language',


### PR DESCRIPTION
On a multilingual site, when associations are enabled, the articles model will throw an error because the group_by clause doesn't contain all selected columns. Which is a requirement in MySQL strict mode.

### Summary of Changes
Adds the missing `a.modified` column to the group


### Testing Instructions
* Make sure you have at least two languages installed (french should work) and associations are enabled
* Try accessing the articles manager


### Expected result
Article list


### Actual result
Error page


### Documentation Changes Required
None
