### PR TITLE
[4.0] Add namespace prefix of own custom fields to article form

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
-	<fieldset addfieldprefix="Joomla\Component\Categories\Administrator\Field">
+	<fieldset addfieldprefix="Joomla\Component\Content\Administrator\Field">
 		<field 
 			name="id" 
 			type="text" 
@@ -76,6 +76,7 @@
 			class="advancedSelect"
 			label="JCATEGORY"
 			description="JFIELD_CATEGORY_DESC"
+			addfieldprefix="Joomla\Component\Categories\Administrator\Field"
 			required="true"
 			default=""
 		/>


### PR DESCRIPTION
When associations are enabled, the article form uses a custom field `Modal_Article` to select the article.
Due to the now namespaced field the form can't no longer find the field and displays a textfield instead.

### Summary of Changes
Adds the fieldprefix of com_content to the article form. The prefix from com_categories which is needed for the catid field is moved to that specific field.
@laoneo With the old way, the "own" fieldpath is already automatically preregistered. But with namespaces that isn't the case. Do you think it's possible (and should we?) to register that automatically as well? Otherwise extensions need to specify it in each of their XMLs if they use custom fields, like I do with this PR.

### Testing Instructions
* Make sure you have a multilingual setup where associations are enabled
* Edit an article and try to assign another article.
* Make sure both the category select field and the article select field are working as expected.

### Expected result
A field which allows to select an article from a modal


### Actual result
Textfield


### Documentation Changes Required
None
