### PR TITLE
[4.0] Array to php 5.4+ notation [Site templates]

### DIFF
--- a/templates/aurora/component.php
+++ b/templates/aurora/component.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 JHtml::_('bootstrap.framework');
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template.css', ['version' => 'auto', 'relative' => true]);
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 //JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/templates/aurora/error.php
+++ b/templates/aurora/error.php
@@ -104,17 +104,17 @@ else
 					</a>
 					<div class="header-search float-right">
 						<?php // Display position-0 modules ?>
-						<?php echo $this->getBuffer('modules', 'position-0', array('style' => 'none')); ?>
+						<?php echo $this->getBuffer('modules', 'position-0', ['style' => 'none']); ?>
 					</div>
 				</div>
 			</header>
 			<div class="navigation">
 				<?php // Display position-1 modules ?>
-				<?php echo $this->getBuffer('modules', 'position-1', array('style' => 'none')); ?>
+				<?php echo $this->getBuffer('modules', 'position-1', ['style' => 'none']); ?>
 			</div>
 			<!-- Banner -->
 			<div class="banner">
-				<?php echo $this->getBuffer('modules', 'banner', array('style' => 'xhtml')); ?>
+				<?php echo $this->getBuffer('modules', 'banner', ['style' => 'xhtml']); ?>
 			</div>
 			<div class="row">
 				<div id="content" class="col-md-12">
@@ -177,7 +177,7 @@ else
 	<div class="footer">
 		<div class="container<?php echo ($params->get('fluidContainer') ? '-fluid' : ''); ?>">
 			<hr>
-			<?php echo $this->getBuffer('modules', 'footer', array('style' => 'none')); ?>
+			<?php echo $this->getBuffer('modules', 'footer', ['style' => 'none']); ?>
 			<p class="float-right">
 				<a href="#top" id="back-top">
 					<?php echo JText::_('TPL_AURORA_BACKTOTOP'); ?>
@@ -188,6 +188,6 @@ else
 			</p>
 		</div>
 	</div>
-	<?php echo $this->getBuffer('modules', 'debug', array('style' => 'none')); ?>
+	<?php echo $this->getBuffer('modules', 'debug', ['style' => 'none']); ?>
 </body>
 </html>

--- a/templates/aurora/html/layouts/joomla/form/field/contenthistory.php
+++ b/templates/aurora/html/layouts/joomla/form/field/contenthistory.php
@@ -47,14 +47,14 @@ extract($displayData);
 echo JHtml::_(
 	'bootstrap.renderModal',
 	'versionsModal',
-	array(
+	[
 		'url'    => $link,
 		'title'  => $label,
 		'height' => '300px',
 		'width'  => '800px',
 		'footer' => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
-			. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
-	)
+			. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>',
+	]
 );
 
 ?>

--- a/templates/aurora/html/layouts/joomla/form/field/media.php
+++ b/templates/aurora/html/layouts/joomla/form/field/media.php
@@ -108,14 +108,14 @@ $url    = ($readonly ? ''
 	// Render the modal
 	echo JHtml::_('bootstrap.renderModal',
 		'imageModal_'. $id,
-		array(
+		[
 			'title' => JText::_('JLIB_FORM_CHANGE_IMAGE'),
 			'closeButton' => true,
-			'footer' => '<a class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>'
-		)
+			'footer' => '<a class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>',
+		]
 	);
 
-	JHtml::_('script', 'media/mediafield.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('script', 'media/mediafield.min.js', ['version' => 'auto', 'relative' => true]);
 	?>
 	<?php if ($showPreview && $showAsTooltip) : ?>
 	<div class="input-prepend input-append">

--- a/templates/aurora/html/layouts/joomla/form/field/user.php
+++ b/templates/aurora/html/layouts/joomla/form/field/user.php
@@ -60,7 +60,7 @@ if (JText::_('JLIB_FORM_SELECT_USER') === htmlspecialchars($userName, ENT_COMPAT
 
 if (!$readonly)
 {
-	JHtml::_('script', 'system/fields/fielduser.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('script', 'system/fields/fielduser.min.js', ['version' => 'auto', 'relative' => true]);
 }
 ?>
 <?php // Create a dummy text field with the user name. ?>
@@ -87,11 +87,11 @@ if (!$readonly)
 			<?php echo JHtml::_(
 				'bootstrap.renderModal',
 				'userModal_' . $id,
-				array(
+				[
 					'title'  => JText::_('JLIB_FORM_CHANGE_USER'),
 					'closeButton' => true,
-					'footer' => '<a type="button" class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>'
-				)
+					'footer' => '<a type="button" class="btn" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>',
+				]
 			); ?>
 		<?php endif; ?>
 	</div>

--- a/templates/aurora/html/layouts/joomla/system/message.php
+++ b/templates/aurora/html/layouts/joomla/system/message.php
@@ -11,7 +11,12 @@ defined('_JEXEC') or die;
 
 $msgList = $displayData['msgList'];
 
-$alert = array('error' => 'alert-danger', 'warning' => '', 'notice' => 'alert-info', 'message' => 'alert-success');
+$alert = [
+	'error'   => 'alert-danger',
+	'warning' => '',
+	'notice'  => 'alert-info',
+	'message' => 'alert-success',
+];
 ?>
 <div id="system-message-container">
 	<?php if (is_array($msgList) && !empty($msgList)) : ?>

--- a/templates/aurora/index.php
+++ b/templates/aurora/index.php
@@ -28,16 +28,16 @@ $sitename = $app->get('sitename');
 JHtml::_('bootstrap.framework');
 
 // Add template js
-JHtml::_('script', 'template.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'template.js', ['version' => 'auto', 'relative' => true]);
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template.css', ['version' => 'auto', 'relative' => true]);
 
 // Check for a custom CSS file
-JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'user.css', ['version' => 'auto', 'relative' => true]);
 
 // Check for a custom js file
-JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'user.js', ['version' => 'auto', 'relative' => true]);
 
 // Load optional RTL Bootstrap CSS
 //JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/templates/aurora/offline.php
+++ b/templates/aurora/offline.php
@@ -23,11 +23,11 @@ $fullWidth = 1;
 JHtml::_('bootstrap.framework');
 
 // Add template js
-JHtml::_('script', 'template.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'template.js', ['version' => 'auto', 'relative' => true]);
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('stylesheet', 'offline.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('stylesheet', 'offline.css', ['version' => 'auto', 'relative' => true]);
 
 // Template color
 if ($this->params->get('templateColor'))
@@ -53,10 +53,10 @@ if ($this->params->get('templateColor'))
 }
 
 // Check for a custom CSS file
-JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'user.css', ['version' => 'auto', 'relative' => true]);
 
 // Check for a custom js file
-JHtml::_('script', 'user.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'user.js', ['version' => 'auto', 'relative' => true]);
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -15,10 +15,10 @@ defined('_JEXEC') or die;
 $this->setHtml5(true);
 
 // Add html5 shiv
-JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
+JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 
 // Styles
-JHtml::_('stylesheet', 'general.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'general.css', ['version' => 'auto', 'relative' => true]);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -17,17 +17,17 @@ $app = JFactory::getApplication();
 $this->setHtml5(true);
 
 // Add html5 shiv
-JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
+JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 
 // Styles
-JHtml::_('stylesheet', 'templates/system/css/offline.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'templates/system/css/offline.css', ['version' => 'auto']);
 
 if ($this->direction === 'rtl')
 {
-	JHtml::_('stylesheet', 'templates/system/css/offline_rtl.css', array('version' => 'auto'));
+	JHtml::_('stylesheet', 'templates/system/css/offline_rtl.css', ['version' => 'auto']);
 }
 
-JHtml::_('stylesheet', 'templates/system/css/general.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'templates/system/css/general.css', ['version' => 'auto']);
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 does nto support php 5.3 anymore, use php 5.4+ array notation in site templates.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.