### PR TITLE
[4.0] Array to php 5.4+ notation [Administrator templates]

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -17,19 +17,19 @@ $this->setHtml5(true);
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
-JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', array('version' => 'auto'));
+JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.min.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.min.css', ['version' => 'auto', 'relative' => true]);
 
 // Load optional RTL Bootstrap CSS
 JHtml::_('bootstrap.loadCss', false, $this->direction);
 
 // Load specific language related CSS
-JHtml::_('stylesheet', 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css', ['version' => 'auto']);
 
 // Load custom.css
-JHtml::_('stylesheet', 'custom.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'custom.css', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <!DOCTYPE html>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -19,19 +19,19 @@ $input           = $app->input;
 
 // Add JavaScript
 JHtml::_('bootstrap.framework');
-JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', array('version' => 'auto'));
-JHtml::_('script', 'template.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
+JHtml::_('script', 'template.js', ['version' => 'auto', 'relative' => true]);
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.min.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') . '.min.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('stylesheet', 'user.css', ['version' => 'auto', 'relative' => true]);
 
 // Load specific language related CSS
 $languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (file_exists($languageCss) && filesize($languageCss) > 0)
 {
-	JHtml::_('stylesheet', $languageCss, array('version' => 'auto'));
+	JHtml::_('stylesheet', $languageCss, ['version' => 'auto']);
 }
 
 // Load custom.css
@@ -39,7 +39,7 @@ $customCss = 'templates/' . $this->template . '/css/custom.css';
 
 if (file_exists($customCss) && filesize($customCss) > 0)
 {
-	JHtml::_('stylesheet', $customCss, array('version' => 'auto'));
+	JHtml::_('stylesheet', $customCss, ['version' => 'auto']);
 }
 
 // Detecting Active Variables
@@ -129,12 +129,12 @@ $doc->setMetaData('theme-color', '#1c3d5c');
 							<?php
 								try
 								{
-									$messagesModel = new \Joomla\Component\Postinstall\Administrator\Model\Messages(array('ignore_request' => true));
+									$messagesModel = new \Joomla\Component\Postinstall\Administrator\Model\Messages(['ignore_request' => true]);
 									$messages      = $messagesModel->getItems();
 								}
 								catch (RuntimeException $e)
 								{
-									$messages = array();
+									$messages = [];
 
 									// Still render the error message from the Exception object
 									JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -16,17 +16,17 @@ $lang = JFactory::getLanguage();
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 JHtml::_('bootstrap.tooltip');
-JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', array('version' => 'auto'));
+JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
 
 // Add Stylesheets
-JHtml::_('stylesheet', 'template.min.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'template.min.css', ['version' => 'auto', 'relative' => true]);
 
 // Load specific language related CSS
 $languageCss = 'language/' . $lang->getTag() . '/' . $lang->getTag() . '.css';
 
 if (file_exists($languageCss) && filesize($languageCss) > 0)
 {
-	JHtml::_('stylesheet', $languageCss, array('version' => 'auto'));
+	JHtml::_('stylesheet', $languageCss, ['version' => 'auto']);
 }
 
 // Load custom.css
@@ -34,7 +34,7 @@ $customCss = 'templates/' . $this->template . '/css/custom.css';
 
 if (file_exists($customCss) && filesize($customCss) > 0)
 {
-	JHtml::_('stylesheet', $customCss, array('version' => 'auto'));
+	JHtml::_('stylesheet', $customCss, ['version' => 'auto']);
 }
 
 // Detecting Active Variables

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -15,7 +15,7 @@ defined('_JEXEC') or die;
 $this->setHtml5(true);
 
 // Add html5 shiv
-JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
+JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in administrator templates.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.