### PR TITLE
[4.0] Array to php 5.4+ notation [Site Modules]

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -65,7 +65,7 @@ class ModArchiveHelper
 		$itemid = (isset($item) && !empty($item->id)) ? '&Itemid=' . $item->id : '';
 
 		$i     = 0;
-		$lists = array();
+		$lists = [];
 
 		foreach ($rows as $row)
 		{

--- a/modules/mod_articles_categories/helper.php
+++ b/modules/mod_articles_categories/helper.php
@@ -27,7 +27,7 @@ abstract class ModArticlesCategoriesHelper
 	 */
 	public static function getList(&$params)
 	{
-		$options               = array();
+		$options               = [];
 		$options['countItems'] = $params->get('numitems', 0);
 
 		$categories = JCategories::getInstance('Content', $options);

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -38,7 +38,7 @@ abstract class ModArticlesCategoryHelper
 	public static function getList(&$params)
 	{
 		// Get an instance of the generic articles model
-		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', ['ignore_request' => true]);
 
 		// Set application parameters in model
 		$app       = JFactory::getApplication();
@@ -69,10 +69,10 @@ abstract class ModArticlesCategoryHelper
 					switch ($view)
 					{
 						case 'category' :
-							$catids = array($app->input->getInt('id'));
+							$catids = [$app->input->getInt('id')];
 							break;
 						case 'categories' :
-							$catids = array($app->input->getInt('id'));
+							$catids = [$app->input->getInt('id')];
 							break;
 						case 'article' :
 							if ($params->get('show_on_article_page', 1))
@@ -83,17 +83,17 @@ abstract class ModArticlesCategoryHelper
 								if (!$catid)
 								{
 									// Get an instance of the generic article model
-									$article = JModelLegacy::getInstance('Article', 'ContentModel', array('ignore_request' => true));
+									$article = JModelLegacy::getInstance('Article', 'ContentModel', ['ignore_request' => true]);
 
 									$article->setState('params', $appParams);
 									$article->setState('filter.published', 1);
 									$article->setState('article.id', (int) $article_id);
 									$item   = $article->getItem();
-									$catids = array($item->catid);
+									$catids = [$item->catid];
 								}
 								else
 								{
-									$catids = array($catid);
+									$catids = [$catid];
 								}
 							}
 							else
@@ -130,13 +130,13 @@ abstract class ModArticlesCategoryHelper
 			if ($params->get('show_child_category_articles', 0) && (int) $params->get('levels', 0) > 0)
 			{
 				// Get an instance of the generic categories model
-				$categories = JModelLegacy::getInstance('Categories', 'ContentModel', array('ignore_request' => true));
+				$categories = JModelLegacy::getInstance('Categories', 'ContentModel', ['ignore_request' => true]);
 				$categories->setState('params', $appParams);
 				$levels = $params->get('levels', 1) ?: 9999;
 				$categories->setState('filter.get_children', $levels);
 				$categories->setState('filter.published', 1);
 				$categories->setState('filter.access', $access);
-				$additional_catids = array();
+				$additional_catids = [];
 
 				foreach ($catids as $catid)
 				{
@@ -321,7 +321,7 @@ abstract class ModArticlesCategoryHelper
 	 */
 	public static function _cleanIntrotext($introtext)
 	{
-		$introtext = str_replace(array('<p>','</p>'), ' ', $introtext);
+		$introtext = str_replace(['<p>', '</p>'], ' ', $introtext);
 		$introtext = strip_tags($introtext, '<a><em><strong>');
 		$introtext = trim($introtext);
 
@@ -391,7 +391,7 @@ abstract class ModArticlesCategoryHelper
 	 */
 	public static function groupBy($list, $fieldName, $article_grouping_direction, $fieldNameToKeep = null)
 	{
-		$grouped = array();
+		$grouped = [];
 
 		if (!is_array($list))
 		{
@@ -400,14 +400,14 @@ abstract class ModArticlesCategoryHelper
 				return $grouped;
 			}
 
-			$list = array($list);
+			$list = [$list];
 		}
 
 		foreach ($list as $key => $item)
 		{
 			if (!isset($grouped[$item->$fieldName]))
 			{
-				$grouped[$item->$fieldName] = array();
+				$grouped[$item->$fieldName] = [];
 			}
 
 			if ($fieldNameToKeep === null)
@@ -441,7 +441,7 @@ abstract class ModArticlesCategoryHelper
 	 */
 	public static function groupByDate($list, $type = 'year', $article_grouping_direction, $month_year_format = 'F Y')
 	{
-		$grouped = array();
+		$grouped = [];
 
 		if (!is_array($list))
 		{
@@ -450,7 +450,7 @@ abstract class ModArticlesCategoryHelper
 				return $grouped;
 			}
 
-			$list = array($list);
+			$list = [$list];
 		}
 
 		foreach ($list as $key => $item)
@@ -462,7 +462,7 @@ abstract class ModArticlesCategoryHelper
 
 					if (!isset($grouped[$month_year]))
 					{
-						$grouped[$month_year] = array();
+						$grouped[$month_year] = [];
 					}
 
 					$grouped[$month_year][$key] = $item;
@@ -474,7 +474,7 @@ abstract class ModArticlesCategoryHelper
 
 					if (!isset($grouped[$year]))
 					{
-						$grouped[$year] = array();
+						$grouped[$year] = [];
 					}
 
 					$grouped[$year][$key] = $item;

--- a/modules/mod_articles_latest/helper.php
+++ b/modules/mod_articles_latest/helper.php
@@ -38,7 +38,7 @@ abstract class ModArticlesLatestHelper
 		$db = JFactory::getDbo();
 
 		// Get an instance of the generic articles model
-		$model = new Articles(array('ignore_request' => true));
+		$model = new Articles(['ignore_request' => true]);
 
 		// Set application parameters in model
 		$app       = JFactory::getApplication();
@@ -56,7 +56,7 @@ abstract class ModArticlesLatestHelper
 		$model->setState('filter.access', $access);
 
 		// Category filter
-		$model->setState('filter.category_id', $params->get('catid', array()));
+		$model->setState('filter.category_id', $params->get('catid', []));
 
 		// User filter
 		$userId = JFactory::getUser()->get('id');
@@ -97,13 +97,13 @@ abstract class ModArticlesLatestHelper
 		}
 
 		// Set ordering
-		$order_map = array(
-			'm_dsc' => 'a.modified DESC, a.created',
+		$order_map = [
+			'm_dsc'  => 'a.modified DESC, a.created',
 			'mc_dsc' => 'CASE WHEN (a.modified = ' . $db->quote($db->getNullDate()) . ') THEN a.created ELSE a.modified END',
-			'c_dsc' => 'a.created',
-			'p_dsc' => 'a.publish_up',
+			'c_dsc'  => 'a.created',
+			'p_dsc'  => 'a.publish_up',
 			'random' => $db->getQuery(true)->Rand(),
-		);
+		];
 
 		$ordering = ArrayHelper::getValue($order_map, $params->get('ordering'), 'a.publish_up');
 		$dir      = 'DESC';

--- a/modules/mod_articles_news/helper.php
+++ b/modules/mod_articles_news/helper.php
@@ -32,7 +32,7 @@ abstract class ModArticlesNewsHelper
 	public static function getList(&$params)
 	{
 		// Get an instance of the generic articles model
-		$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+		$model = JModelLegacy::getInstance('Articles', 'ContentModel', ['ignore_request' => true]);
 
 		// Set application parameters in model
 		$app       = JFactory::getApplication();
@@ -50,7 +50,7 @@ abstract class ModArticlesNewsHelper
 		$model->setState('filter.access', $access);
 
 		// Category filter
-		$model->setState('filter.category_id', $params->get('catid', array()));
+		$model->setState('filter.category_id', $params->get('catid', []));
 
 		// Filter by language
 		$model->setState('filter.language', $app->getLanguageFilter());
@@ -118,15 +118,15 @@ abstract class ModArticlesNewsHelper
 			if ($triggerEvents)
 			{
 				$item->text = '';
-				$app->triggerEvent('onContentPrepare', array ('com_content.article', &$item, &$params, 1));
+				$app->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$params, 1]);
 
-				$results                 = $app->triggerEvent('onContentAfterTitle', array('com_content.article', &$item, &$params, 1));
+				$results                 = $app->triggerEvent('onContentAfterTitle', ['com_content.article', &$item, &$params, 1]);
 				$item->afterDisplayTitle = trim(implode("\n", $results));
 
-				$results                    = $app->triggerEvent('onContentBeforeDisplay', array('com_content.article', &$item, &$params, 1));
+				$results                    = $app->triggerEvent('onContentBeforeDisplay', ['com_content.article', &$item, &$params, 1]);
 				$item->beforeDisplayContent = trim(implode("\n", $results));
 
-				$results                   = $app->triggerEvent('onContentAfterDisplay', array('com_content.article', &$item, &$params, 1));
+				$results                   = $app->triggerEvent('onContentAfterDisplay', ['com_content.article', &$item, &$params, 1]);
 				$item->afterDisplayContent = trim(implode("\n", $results));
 			}
 			else

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -33,7 +33,7 @@ abstract class ModArticlesPopularHelper
 	public static function getList(&$params)
 	{
 		// Get an instance of the generic articles model
-		$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+		$model = JModelLegacy::getInstance('Articles', 'ContentModel', ['ignore_request' => true]);
 
 		// Set application parameters in model
 		$app = JFactory::getApplication();
@@ -52,7 +52,7 @@ abstract class ModArticlesPopularHelper
 		$model->setState('filter.access', $access);
 
 		// Category filter
-		$model->setState('filter.category_id', $params->get('catid', array()));
+		$model->setState('filter.category_id', $params->get('catid', []));
 
 		// Date filter
 		$date_filtering = $params->get('date_filtering', 'off');

--- a/modules/mod_banners/Helper/ModBannersHelper.php
+++ b/modules/mod_banners/Helper/ModBannersHelper.php
@@ -32,9 +32,9 @@ class ModBannersHelper
 		$app      = \JFactory::getApplication();
 		$keywords = explode(',', $document->getMetaData('keywords'));
 
-		$model = new Banners(array('ignore_request' => true));
+		$model = new Banners(['ignore_request' => true]);
 		$model->setState('filter.client_id', (int) $params->get('cid'));
-		$model->setState('filter.category_id', $params->get('catid', array()));
+		$model->setState('filter.category_id', $params->get('catid', []));
 		$model->setState('list.limit', (int) $params->get('count', 1));
 		$model->setState('list.start', 0);
 		$model->setState('filter.ordering', $params->get('ordering'));

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -23,7 +23,7 @@ $baseurl = JUri::base();
 		<?php $link = JRoute::_('index.php?option=com_banners&task=click&id=' . $item->id); ?>
 		<?php if ($item->type == 1) : ?>
 			<?php // Text based banners ?>
-			<?php echo str_replace(array('{CLICKURL}', '{NAME}'), array($link, $item->name), $item->custombannercode); ?>
+			<?php echo str_replace(['{CLICKURL}', '{NAME}'], [$link, $item->name], $item->custombannercode); ?>
 		<?php else : ?>
 			<?php $imageurl = $item->params->get('imageurl'); ?>
 			<?php $width = $item->params->get('width'); ?>

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -47,7 +47,7 @@ class ModBreadCrumbsHelper
 		$count = count($items);
 
 		// Don't use $items here as it references JPathway properties directly
-		$crumbs = array();
+		$crumbs = [];
 
 		for ($i = 0; $i < $count; $i ++)
 		{

--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -36,7 +36,7 @@ class ModFinderHelper
 		// Determine if there is an item id before routing.
 		$needId = !JUri::getInstance($route)->getVar('Itemid');
 
-		$fields = array();
+		$fields = [];
 		$uri = JUri::getInstance(JRoute::_($route));
 		$uri->delVar('q');
 
@@ -73,7 +73,7 @@ class ModFinderHelper
 		$filter  = JFilterInput::getInstance();
 
 		// Get the static taxonomy filters.
-		$options = array();
+		$options = [];
 		$options['filter'] = ($request->get('f', 0, 'int') !== 0) ? $request->get('f', '', 'int') : $params->get('searchfilter');
 		$options['filter'] = $filter->clean($options['filter'], 'int');
 

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -43,8 +43,8 @@ else
 	$output .= $input;
 }
 
-JHtml::_('stylesheet', 'vendor/awesomplete/awesomplete.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('script', 'com_finder/finder.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'vendor/awesomplete/awesomplete.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('script', 'com_finder/finder.js', ['version' => 'auto', 'relative' => true]);
 
 JText::script('MOD_FINDER_SEARCH_VALUE', true);
 
@@ -53,8 +53,8 @@ JText::script('MOD_FINDER_SEARCH_VALUE', true);
  */
 if ($params->get('show_autosuggest', 1))
 {
-	JHtml::_('script', 'vendor/awesomplete/awesomplete.min.js', array('version' => 'auto', 'relative' => true));
-	JFactory::getDocument()->addScriptOptions('finder-search', array('url' => JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component')));
+	JHtml::_('script', 'vendor/awesomplete/awesomplete.min.js', ['version' => 'auto', 'relative' => true]);
+	JFactory::getDocument()->addScriptOptions('finder-search', ['url' => JRoute::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component')]);
 }
 ?>
 

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -38,7 +38,7 @@ abstract class ModLanguagesHelper
 		$active		= $menu->getActive();
 
 		// Get menu home items
-		$homes = array();
+		$homes = [];
 		$homes['*'] = $menu->getDefault('*');
 
 		foreach ($languages as $item)
@@ -65,9 +65,9 @@ abstract class ModLanguagesHelper
 			$class = str_replace('com_', '', $app->input->get('option')) . 'HelperAssociation';
 			JLoader::register($class, JPATH_COMPONENT_SITE . '/helpers/association.php');
 
-			if (class_exists($class) && is_callable(array($class, 'getAssociations')))
+			if (class_exists($class) && is_callable([$class, 'getAssociations']))
 			{
-				$cassociations = call_user_func(array($class, 'getAssociations'));
+				$cassociations = call_user_func([$class, 'getAssociations']);
 			}
 		}
 
@@ -129,7 +129,7 @@ abstract class ModLanguagesHelper
 					{
 						if ($language->active)
 						{
-							$language->link = JUri::getInstance()->toString(array('path', 'query'));
+							$language->link = JUri::getInstance()->toString(['path', 'query']);
 						}
 						else
 						{

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('stylesheet', 'mod_languages/template.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'mod_languages/template.css', ['version' => 'auto', 'relative' => true]);
 
 if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 {
@@ -37,7 +37,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 				<a href="#" data-toggle="dropdown" class="btn dropdown-toggle">
 					<span class="caret"></span>
 					<?php if ($language->image) : ?>
-						&nbsp;<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+						&nbsp;<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native], true); ?>
 					<?php endif; ?>
 					<?php echo $language->title_native; ?>
 				</a>
@@ -49,7 +49,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo $language->link; ?>">
 					<?php if ($language->image) : ?>
-						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native], true); ?>
 					<?php endif; ?>
 					<?php echo $language->title_native; ?>
 				</a>
@@ -66,7 +66,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 			<a href="<?php echo $language->link; ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
-					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native], true); ?>
 				<?php else : ?>
 					<span class="label"><?php echo strtoupper($language->sef); ?></span>
 				<?php endif; ?>

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -51,7 +51,7 @@ class ModMenuHelper
 			$end            = (int) $params->get('endLevel');
 			$showAll        = $params->get('showAllChildren');
 			$items          = $menu->getItems('menutype', $params->get('menutype'));
-			$hidden_parents = array();
+			$hidden_parents = [];
 			$lastitem       = 0;
 
 			if ($items)

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-$attributes = array();
+$attributes = [];
 
 if ($item->anchor_title)
 {

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-$attributes = array();
+$attributes = [];
 
 if ($item->anchor_title)
 {

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -86,8 +86,8 @@ class ModRandomImageHelper
 	public static function getImages(&$params, $folder)
 	{
 		$type   = $params->get('type', 'jpg');
-		$files  = array();
-		$images = array();
+		$files  = [];
+		$images = [];
 
 		$dir = JPATH_BASE . '/' . $folder;
 
@@ -149,6 +149,6 @@ class ModRandomImageHelper
 			$folder = str_replace(JPATH_BASE, '', $folder);
 		}
 
-		return str_replace(array('\\', '/'), DIRECTORY_SEPARATOR, $folder);
+		return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $folder);
 	}
 }

--- a/modules/mod_random_image/tmpl/default.php
+++ b/modules/mod_random_image/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 <?php if ($link) : ?>
 <a href="<?php echo $link; ?>">
 <?php endif; ?>
-	<?php echo JHtml::_('image', $image->folder . '/' . $image->name, $image->name, array('width' => $image->width, 'height' => $image->height)); ?>
+	<?php echo JHtml::_('image', $image->folder . '/' . $image->name, $image->name, ['width' => $image->width, 'height' => $image->height]); ?>
 <?php if ($link) : ?>
 </a>
 <?php endif; ?>

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -38,13 +38,13 @@ abstract class ModRelatedItemsHelper
 
 		// Get an instance of the generic articles model
 		JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_content/models');
-		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+		$articles = JModelLegacy::getInstance('Articles', 'ContentModel', ['ignore_request' => true]);
 
 		if ($articles === false)
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-			return array();
+			return [];
 		}
 
 		// Set application parameters in model
@@ -60,7 +60,7 @@ abstract class ModRelatedItemsHelper
 
 		$nullDate = $db->getNullDate();
 		$now      = $date->toSql();
-		$related  = array();
+		$related  = [];
 		$query    = $db->getQuery(true);
 
 		if ($option === 'com_content' && $view === 'article' && $id)
@@ -79,12 +79,12 @@ abstract class ModRelatedItemsHelper
 			{
 				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-				return array();
+				return [];
 			}
 
 			// Explode the meta keys on a comma
 			$keys  = explode(',', $metakey);
-			$likes = array();
+			$likes = [];
 
 			// Assemble any non-blank word(s)
 			foreach ($keys as $key)
@@ -113,7 +113,7 @@ abstract class ModRelatedItemsHelper
 				$case_when .= $query->charLength('a.alias', '!=', '0');
 				$case_when .= ' THEN ';
 				$a_id = $query->castAsChar('a.id');
-				$case_when .= $query->concatenate(array($a_id, 'a.alias'), ':');
+				$case_when .= $query->concatenate([$a_id, 'a.alias'], ':');
 				$case_when .= ' ELSE ';
 				$case_when .= $a_id . ' END as slug';
 
@@ -125,7 +125,7 @@ abstract class ModRelatedItemsHelper
 					->where('a.state = 1')
 					->where('a.access IN (' . $groups . ')');
 
-				$wheres = array();
+				$wheres = [];
 
 				foreach ($likes as $keyword)
 				{
@@ -152,12 +152,12 @@ abstract class ModRelatedItemsHelper
 				{
 					JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-					return array();
+					return [];
 				}
 
 				if (count($temp))
 				{
-					$articles_ids = array();
+					$articles_ids = [];
 
 					foreach ($temp as $row)
 					{

--- a/modules/mod_related_items/mod_related_items.php
+++ b/modules/mod_related_items/mod_related_items.php
@@ -17,7 +17,7 @@ $cacheparams->cachemode = 'safeuri';
 $cacheparams->class = 'ModRelatedItemsHelper';
 $cacheparams->method = 'getList';
 $cacheparams->methodparams = $params;
-$cacheparams->modeparams = array('id' => 'int', 'Itemid' => 'int');
+$cacheparams->modeparams = ['id' => 'int', 'Itemid' => 'int'];
 
 $list = JModuleHelper::moduleCache($module, $params, $cacheparams);
 

--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -21,12 +21,12 @@ if ($params->get('opensearch', 1))
 
 	$ostitle = $params->get('opensearch_title', JText::_('MOD_SEARCH_SEARCHBUTTON_TEXT') . ' ' . $app->get('sitename'));
 	$doc->addHeadLink(
-			JUri::getInstance()->toString(array('scheme', 'host', 'port'))
+			JUri::getInstance()->toString(['scheme', 'host', 'port'])
 			. JRoute::_('&option=com_search&format=opensearch'), 'search', 'rel',
-			array(
+			[
 				'title' => htmlspecialchars($ostitle, ENT_COMPAT, 'UTF-8'),
-				'type' => 'application/opensearchdescription+xml'
-			)
+				'type'  => 'application/opensearchdescription+xml',
+			]
 		);
 }
 

--- a/modules/mod_stats/helper.php
+++ b/modules/mod_stats/helper.php
@@ -27,7 +27,7 @@ class ModStatsHelper
 	{
 		$app        = JFactory::getApplication();
 		$db         = JFactory::getDbo();
-		$rows       = array();
+		$rows       = [];
 		$query      = $db->getQuery(true);
 		$serverinfo = $params->get('serverinfo');
 		$siteinfo   = $params->get('siteinfo');
@@ -145,7 +145,7 @@ class ModStatsHelper
 		// Include additional data defined by published system plugins
 		JPluginHelper::importPlugin('system');
 
-		$arrays = (array) $app->triggerEvent('onGetStats', array('mod_stats'));
+		$arrays = (array) $app->triggerEvent('onGetStats', ['mod_stats']);
 
 		foreach ($arrays as $response)
 		{

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -40,15 +40,15 @@ abstract class ModTagsPopularHelper
 
 		$query = $db->getQuery(true)
 			->select(
-				array(
+				[
 					'MAX(' . $db->quoteName('tag_id') . ') AS tag_id',
 					' COUNT(*) AS count', 'MAX(t.title) AS title',
 					'MAX(' . $db->quoteName('t.access') . ') AS access',
 					'MAX(' . $db->quoteName('t.alias') . ') AS alias',
 					'MAX(' . $db->quoteName('t.params') . ') AS params',
-				)
+				]
 			)
-			->group($db->quoteName(array('tag_id', 'title', 'access', 'alias')))
+			->group($db->quoteName(['tag_id', 'title', 'access', 'alias']))
 			->from($db->quoteName('#__contentitem_tag_map', 'm'))
 			->where($db->quoteName('t.access') . ' IN (' . $groups . ')');
 
@@ -101,13 +101,13 @@ abstract class ModTagsPopularHelper
 				$query->order('count DESC');
 				$equery = $db->getQuery(true)
 					->select(
-						array(
+						[
 							'a.tag_id',
 							'a.count',
 							'a.title',
 							'a.access',
 							'a.alias',
-						)
+						]
 					)
 					->from('(' . (string) $query . ') AS a')
 					->order('a.title' . ' ' . $order_direction);
@@ -128,7 +128,7 @@ abstract class ModTagsPopularHelper
 		}
 		catch (RuntimeException $e)
 		{
-			$results = array();
+			$results = [];
 			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -63,18 +63,18 @@ abstract class ModTagssimilarHelper
 
 		$query = $db->getQuery(true)
 			->select(
-			array(
+			[
 				$db->quoteName('m.core_content_id'),
 				$db->quoteName('m.content_item_id'),
 				$db->quoteName('m.type_alias'),
-					'COUNT( ' . $db->quoteName('tag_id') . ') AS ' . $db->quoteName('count'),
+				'COUNT( ' . $db->quoteName('tag_id') . ') AS ' . $db->quoteName('count'),
 				$db->quoteName('ct.router'),
 				$db->quoteName('cc.core_title'),
 				$db->quoteName('cc.core_alias'),
 				$db->quoteName('cc.core_catid'),
 				$db->quoteName('cc.core_language'),
-				$db->quoteName('cc.core_params')
-				)
+				$db->quoteName('cc.core_params'),
+			]
 		);
 
 		$query->from($db->quoteName('#__contentitem_tag_map', 'm'));
@@ -113,8 +113,17 @@ abstract class ModTagssimilarHelper
 
 		$query->group(
 			$db->quoteName(
-				array('m.core_content_id', 'm.content_item_id', 'm.type_alias', 'ct.router', 'cc.core_title',
-				'cc.core_alias', 'cc.core_catid', 'cc.core_language', 'cc.core_params')
+				[
+					'm.core_content_id',
+					'm.content_item_id',
+					'm.type_alias',
+					'ct.router',
+					'cc.core_title',
+					'cc.core_alias',
+					'cc.core_catid',
+					'cc.core_language',
+					'cc.core_params',
+				]
 			)
 		);
 
@@ -146,7 +155,7 @@ abstract class ModTagssimilarHelper
 		}
 		catch (RuntimeException $e)
 		{
-			$results = array();
+			$results = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 

--- a/modules/mod_tags_similar/mod_tags_similar.php
+++ b/modules/mod_tags_similar/mod_tags_similar.php
@@ -17,7 +17,7 @@ $cacheparams->cachemode = 'safeuri';
 $cacheparams->class = 'ModTagssimilarHelper';
 $cacheparams->method = 'getList';
 $cacheparams->methodparams = $params;
-$cacheparams->modeparams = array('id' => 'array', 'Itemid' => 'int');
+$cacheparams->modeparams = ['id' => 'array', 'Itemid' => 'int'];
 
 $list = JModuleHelper::moduleCache($module, $params, $cacheparams);
 

--- a/modules/mod_users_latest/helper.php
+++ b/modules/mod_users_latest/helper.php
@@ -32,7 +32,7 @@ class ModUsersLatestHelper
 	{
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select($db->quoteName(array('a.id', 'a.name', 'a.username', 'a.registerDate')))
+			->select($db->quoteName(['a.id', 'a.name', 'a.username', 'a.registerDate']))
 			->order($db->quoteName('a.registerDate') . ' DESC')
 			->from('#__users AS a');
 		$user = JFactory::getUser();
@@ -43,7 +43,7 @@ class ModUsersLatestHelper
 
 			if (empty($groups))
 			{
-				return array();
+				return [];
 			}
 
 			$query->join('LEFT', '#__user_usergroup_map AS m ON m.user_id = a.id')
@@ -62,7 +62,7 @@ class ModUsersLatestHelper
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-			return array();
+			return [];
 		}
 	}
 }

--- a/modules/mod_whosonline/helper.php
+++ b/modules/mod_whosonline/helper.php
@@ -28,7 +28,7 @@ class ModWhosonlineHelper
 		$db = JFactory::getDbo();
 
 		// Calculate number of guests and users
-		$result	     = array();
+		$result	     = [];
 		$user_array  = 0;
 		$guest_array = 0;
 
@@ -47,7 +47,7 @@ class ModWhosonlineHelper
 		catch (RuntimeException $e)
 		{
 			// Don't worry be happy
-			$sessions = array();
+			$sessions = [];
 		}
 
 		if (count($sessions))
@@ -89,11 +89,11 @@ class ModWhosonlineHelper
 
 		$db    = JFactory::getDbo();
 		$query = $db->getQuery(true)
-			->select($db->quoteName(array('a.username', 'a.userid', 'a.client_id')))
+			->select($db->quoteName(['a.username', 'a.userid', 'a.client_id']))
 			->from('#__session AS a')
 			->where($db->quoteName('a.userid') . ' != 0')
 			->where($db->quoteName('a.client_id') . ' ' . $whereCondition)
-			->group($db->quoteName(array('a.username', 'a.userid', 'a.client_id')));
+			->group($db->quoteName(['a.username', 'a.userid', 'a.client_id']));
 
 		$user = JFactory::getUser();
 
@@ -103,7 +103,7 @@ class ModWhosonlineHelper
 
 			if (empty($groups))
 			{
-				return array();
+				return [];
 			}
 
 			$query->join('LEFT', '#__user_usergroup_map AS m ON m.user_id = a.userid')
@@ -120,7 +120,7 @@ class ModWhosonlineHelper
 		}
 		catch (RuntimeException $e)
 		{
-			return array();
+			return [];
 		}
 	}
 }

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'com_wrapper/iframe-height.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <iframe <?php echo $load; ?>
 	id="blockrandom"


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in site modules.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.