### PR TITLE
[4.0] Array to php 5.4+ notation [Administrator Modules]

### DIFF
--- a/administrator/modules/mod_latest/mod_latest.php
+++ b/administrator/modules/mod_latest/mod_latest.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\Component\Content\Administrator\Model\Articles;
 use Joomla\Module\Latest\Administrator\Helper\ModLatestHelper;
 
-$list = ModLatestHelper::getList($params, new Articles(array('ignore_request' => true)));
+$list = ModLatestHelper::getList($params, new Articles(['ignore_request' => true]));
 
 if ($params->get('automatic_title', 0))
 {

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -60,7 +60,7 @@ abstract class ModLoginHelper
 	public static function getReturnUri()
 	{
 		$uri    = JUri::getInstance();
-		$return = 'index.php' . $uri->toString(array('query'));
+		$return = 'index.php' . $uri->toString(['query']);
 
 		if ($return != 'index.php?option=com_login')
 		{

--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -50,7 +50,7 @@ abstract class ModMenuHelper
 		}
 		catch (RuntimeException $e)
 		{
-			$result = array();
+			$result = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED') . ' ' . $e->getMessage(), 'danger');
 		}
 
@@ -68,13 +68,13 @@ abstract class ModMenuHelper
 	 *
 	 * @since   1.6
 	 */
-	public static function getComponents($authCheck = true, $enabledOnly = false, $exclude = array())
+	public static function getComponents($authCheck = true, $enabledOnly = false, $exclude = [])
 	{
 		$lang   = JFactory::getLanguage();
 		$user   = JFactory::getUser();
 		$db     = JFactory::getDbo();
 		$query  = $db->getQuery(true);
-		$result = array();
+		$result = [];
 
 		// Prepare the query.
 		$query->select('m.id, m.title, m.alias, m.link, m.parent_id, m.img, e.element, m.menutype')
@@ -110,7 +110,7 @@ abstract class ModMenuHelper
 		}
 		catch (RuntimeException $e)
 		{
-			$components = array();
+			$components = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'danger');
 		}
 
@@ -130,7 +130,7 @@ abstract class ModMenuHelper
 
 					if (!isset($result[$component->id]->submenu))
 					{
-						$result[$component->id]->submenu = array();
+						$result[$component->id]->submenu = [];
 					}
 
 					// If the root menu link is empty, add it in.
@@ -207,7 +207,7 @@ abstract class ModMenuHelper
 		}
 		catch (RuntimeException $e)
 		{
-			$menuItems = array();
+			$menuItems = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 
@@ -226,7 +226,7 @@ abstract class ModMenuHelper
 	 */
 	public static function parseItems($menuItems, $authCheck = true)
 	{
-		$result = array();
+		$result = [];
 		$user   = JFactory::getUser();
 		$lang   = JFactory::getLanguage();
 		$levels = $user->getAuthorisedViewLevels();
@@ -278,7 +278,7 @@ abstract class ModMenuHelper
 			}
 
 			$menuitem->text    = $lang->hasKey($menuitem->title) ? JText::_($menuitem->title) : $menuitem->title;
-			$menuitem->submenu = array();
+			$menuitem->submenu = [];
 
 			$result[$menuitem->parent_id][$menuitem->id] = $menuitem;
 		}
@@ -286,7 +286,7 @@ abstract class ModMenuHelper
 		// Do an early exit if there are no top level menu items.
 		if (!isset($result[1]))
 		{
-			return array();
+			return [];
 		}
 
 		// Put the items under respective parent menu items.

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -178,7 +178,7 @@ class JAdminCssMenu
 		echo '<li' . $class . ' role="menuitem" ' . $ariaPopup . '>';
 
 		// Print a link if it exists
-		$linkClass = array();
+		$linkClass = [];
 		$dataToggle = '';
 
 		if ($this->_current->hasChildren())
@@ -266,7 +266,7 @@ class JAdminCssMenu
 		// Initialise the known classes array if it does not exist
 		if (!is_array($classes))
 		{
-			$classes = array();
+			$classes = [];
 		}
 
 		$html = '';
@@ -367,7 +367,7 @@ class JAdminCssMenu
 					}
 					else
 					{
-						$missing = array();
+						$missing = [];
 
 						if ($rMenu)
 						{
@@ -388,7 +388,7 @@ class JAdminCssMenu
 						$uri->setVar('recover_menu', 1);
 
 						$table = JTable::getInstance('MenuType');
-						$table->load(array('menutype' => $menutype));
+						$table->load(['menutype' => $menutype]);
 						$mType = $table->get('title', $menutype);
 
 						$msg = JText::sprintf('MOD_MENU_IMPORTANT_ITEMS_INACCESSIBLE_LIST_WARNING', $mType, implode(', ', $missing), $uri);
@@ -430,7 +430,7 @@ class JAdminCssMenu
 			}
 			elseif ($item->type == 'container')
 			{
-				$exclude    = (array) $item->params->get('hideitems') ?: array();
+				$exclude    = (array) $item->params->get('hideitems') ?: [];
 				$components = ModMenuHelper::getComponents(true, false, $exclude);
 
 				// Exclude if it is a container type menu item, and has no children.
@@ -551,7 +551,7 @@ class JMenuNode
 	 *
 	 * @var  array
 	 */
-	protected $_children = array();
+	protected $_children = [];
 
 	/**
 	 * Constructor for the class.
@@ -576,11 +576,11 @@ class JMenuNode
 		{
 			$uri    = new JUri($link);
 			$params = $uri->getQuery(true);
-			$parts  = array();
+			$parts  = [];
 
 			foreach ($params as $value)
 			{
-				$parts[] = str_replace(array('.', '_'), '-', $value);
+				$parts[] = str_replace(['.', '_'], '-', $value);
 			}
 
 			$this->id = implode('-', $parts);

--- a/administrator/modules/mod_menu/preset/enabled.php
+++ b/administrator/modules/mod_menu/preset/enabled.php
@@ -151,7 +151,7 @@ if ($user->authorise('core.manage', 'com_menus'))
 
 	// Menu Types
 	$menuTypes = ModMenuHelper::getMenus();
-	$menuTypes = ArrayHelper::sortObjects($menuTypes, isset($menuTypes[0]->client_id) ? array('client_id', 'title') : 'title', 1, false);
+	$menuTypes = ArrayHelper::sortObjects($menuTypes, isset($menuTypes[0]->client_id) ? ['client_id', 'title'] : 'title', 1, false);
 
 	foreach ($menuTypes as $mti => $menuType)
 	{
@@ -173,13 +173,13 @@ if ($user->authorise('core.manage', 'com_menus'))
 		elseif ($menuType->home > 1)
 		{
 			$titleicon = ' <span>'
-				. JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, array('title' => JText::_('MOD_MENU_HOME_MULTIPLE')), true)
+				. JHtml::_('image', 'mod_languages/icon-16-language.png', $menuType->home, ['title' => JText::_('MOD_MENU_HOME_MULTIPLE')], true)
 				. '</span>';
 		}
 		elseif ($menuType->image && JHtml::_('image', 'mod_languages/' . $menuType->image . '.gif', null, null, true, true))
 		{
 			$titleicon = ' <span>' .
-				JHtml::_('image', 'mod_languages/' . $menuType->image . '.gif', $alt, array('title' => $menuType->title_native), true) . '</span>';
+				JHtml::_('image', 'mod_languages/' . $menuType->image . '.gif', $alt, ['title' => $menuType->title_native], true) . '</span>';
 		}
 		else
 		{

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 // Include jQuery
 JHtml::_('jquery.framework');
 
-JHtml::_('script', 'mod_multilangstatus/admin-multilangstatus.min.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'mod_multilangstatus/admin-multilangstatus.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 
 <li class="px-2 multilanguage">
@@ -24,7 +24,7 @@ JHtml::_('script', 'mod_multilangstatus/admin-multilangstatus.min.js', array('ve
 <?php echo JHtml::_(
 	'bootstrap.renderModal',
 	'multiLangModal',
-	array(
+	[
 		'title'      => JText::_('MOD_MULTILANGSTATUS'),
 		'url'        => JRoute::_('index.php?option=com_languages&view=multilangstatus&tmpl=component'),
 		'height'     => '400px',
@@ -32,5 +32,5 @@ JHtml::_('script', 'mod_multilangstatus/admin-multilangstatus.min.js', array('ve
 		'bodyHeight' => 70,
 		'modalWidth' => 80,
 		'footer'     => '<a class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">' . JText::_('JTOOLBAR_CLOSE') . '</a>',
-	)
+	]
 );

--- a/administrator/modules/mod_popular/mod_popular.php
+++ b/administrator/modules/mod_popular/mod_popular.php
@@ -14,7 +14,7 @@ use Joomla\Component\Content\Administrator\Model\Articles;
 // Include the mod_popular functions only once.
 JLoader::register('ModPopularHelper', __DIR__ . '/helper.php');
 
-$list = ModPopularHelper::getList($params, new Articles(array('ignore_request' => true)));
+$list = ModPopularHelper::getList($params, new Articles(['ignore_request' => true]));
 
 // Get module data.
 if ($params->get('automatic_title', 0))

--- a/administrator/modules/mod_quickicon/helper.php
+++ b/administrator/modules/mod_quickicon/helper.php
@@ -79,7 +79,7 @@ abstract class ModQuickIconHelper
 						'access' => ['core.manage', 'com_modules'],
 						'group'  => 'MOD_QUICKICON_STRUCTURE'
 					]
-				);
+				];
 			}
 			else
 			{

--- a/administrator/modules/mod_quickicon/helper.php
+++ b/administrator/modules/mod_quickicon/helper.php
@@ -23,7 +23,7 @@ abstract class ModQuickIconHelper
 	 *
 	 * @since   1.6
 	 */
-	protected static $buttons = array();
+	protected static $buttons = [];
 
 	/**
 	 * Helper method to return button list.
@@ -50,40 +50,40 @@ abstract class ModQuickIconHelper
 				// Load mod_quickicon language file in case this method is called before rendering the module
 				JFactory::getLanguage()->load('mod_quickicon');
 
-				self::$buttons[$key] = array(
-					array(
+				self::$buttons[$key] = [
+					[
 						'link'   => JRoute::_('index.php?option=com_content&task=article.add'),
 						'image'  => 'fa fa-pencil-square',
 						'text'   => JText::_('MOD_QUICKICON_ADD_NEW_ARTICLE'),
-						'access' => array('core.manage', 'com_content', 'core.create', 'com_content'),
+						'access' => ['core.manage', 'com_content', 'core.create', 'com_content'],
 						'group'  => 'MOD_QUICKICON_CONTENT',
-					),
-					array(
+					],
+					[
 						'link'   => JRoute::_('index.php?option=com_media'),
 						'image'  => 'fa fa-file-image-o',
 						'text'   => JText::_('MOD_QUICKICON_MEDIA_MANAGER'),
-						'access' => array('core.manage', 'com_media'),
+						'access' => ['core.manage', 'com_media'],
 						'group'  => 'MOD_QUICKICON_CONTENT',
-					),
-					array(
+					],
+					[
 						'link'   => JRoute::_('index.php?option=com_config'),
 						'image'  => 'fa fa-cog',
 						'text'   => JText::_('MOD_QUICKICON_GLOBAL_CONFIGURATION'),
-						'access' => array('core.manage', 'com_config', 'core.admin', 'com_config'),
+						'access' => ['core.manage', 'com_config', 'core.admin', 'com_config'],
 						'group'  => 'MOD_QUICKICON_CONFIGURATION',
-					),
-					array(
+					],
+					[
 						'link'   => JRoute::_('index.php?option=com_modules'),
 						'image'  => 'fa fa-cube',
 						'text'   => JText::_('MOD_QUICKICON_MODULE_MANAGER'),
-						'access' => array('core.manage', 'com_modules'),
+						'access' => ['core.manage', 'com_modules'],
 						'group'  => 'MOD_QUICKICON_STRUCTURE'
-					)
+					]
 				);
 			}
 			else
 			{
-				self::$buttons[$key] = array();
+				self::$buttons[$key] = [];
 			}
 
 			// Include buttons defined by published quickicon plugins
@@ -98,13 +98,13 @@ abstract class ModQuickIconHelper
 			{
 				foreach ($response as $icon)
 				{
-					$default = array(
+					$default = [
 						'link'   => null,
 						'image'  => 'cog',
 						'text'   => null,
 						'access' => true,
 						'group'  => 'MOD_QUICKICON_EXTENSIONS',
-					);
+					];
 					$icon = array_merge($default, $icon);
 
 					if (!is_null($icon['link']) && !is_null($icon['text']))

--- a/administrator/modules/mod_stats_admin/helper.php
+++ b/administrator/modules/mod_stats_admin/helper.php
@@ -29,7 +29,7 @@ class ModStatsHelper
 	{
 		$app   = JFactory::getApplication();
 		$db    = JFactory::getDbo();
-		$rows  = array();
+		$rows  = [];
 		$query = $db->getQuery(true);
 
 		$serverinfo = $params->get('serverinfo');
@@ -115,7 +115,7 @@ class ModStatsHelper
 		JPluginHelper::importPlugin('system');
 
 		$app    = JFactory::getApplication();
-		$arrays = (array) $app->triggerEvent('onGetStats', array('mod_stats_admin'));
+		$arrays = (array) $app->triggerEvent('onGetStats', ['mod_stats_admin']);
 
 		foreach ($arrays as $response)
 		{

--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 $hideLinks = $input->getBool('hidemainmenu');
 $task      = $input->getCmd('task');
-$output    = array();
+$output    = [];
 
 // Print logged in user count based on the shared session state
 if (JFactory::getConfig()->get('shared_session', '0'))


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in administrator modules.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.