### PR TITLE
[4.0] Array to php 5.4+ notation [Layouts]

### DIFF
--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -22,16 +22,16 @@ $className = substr($extension, 4);
 $app = JFactory::getApplication();
 
 $category->text = $category->description;
-$app->triggerEvent('onContentPrepare', array($extension . '.categories', &$category, &$params, 0));
+$app->triggerEvent('onContentPrepare', [$extension . '.categories', &$category, &$params, 0]);
 $category->description = $category->text;
 
-$results = $app->triggerEvent('onContentAfterTitle', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentAfterTitle', [$extension . '.categories', &$category, &$params, 0]);
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentBeforeDisplay', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentBeforeDisplay', [$extension . '.categories', &$category, &$params, 0]);
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentAfterDisplay', array($extension . '.categories', &$category, &$params, 0));
+$results = $app->triggerEvent('onContentAfterDisplay', [$extension . '.categories', &$category, &$params, 0]);
 $afterDisplayContent = trim(implode("\n", $results));
 
 /**

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -15,7 +15,7 @@ defined('JPATH_BASE') or die;
 	<?php echo JText::_('JASSOCIATIONS'); ?>
 	<?php foreach ($associations as $association) : ?>
 		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
-			<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
+			<?php $flag = JHtml::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, ['title' => $association['language']->title_native], true); ?>
 			&nbsp;<a href="<?php echo JRoute::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
 		<?php else : ?>
 			<?php $class = 'label label-association label-' . $association['language']->sef; ?>

--- a/layouts/joomla/content/info_block/author.php
+++ b/layouts/joomla/content/info_block/author.php
@@ -14,7 +14,7 @@ defined('JPATH_BASE') or die;
 	<?php $author = ($displayData['item']->created_by_alias ?: $displayData['item']->author); ?>
 	<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
 	<?php if (!empty($displayData['item']->contact_link ) && $displayData['params']->get('link_author') == true) : ?>
-		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author, array('itemprop' => 'url'))); ?>
+		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', JHtml::_('link', $displayData['item']->contact_link, $author, ['itemprop' => 'url'])); ?>
 	<?php else : ?>
 		<?php echo JText::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
 	<?php endif; ?>

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -30,7 +30,7 @@ defined('JPATH_BASE') or die;
 			if ($field->showon)
 			{
 				JHtml::_('jquery.framework');
-				JHtml::_('script', 'system/cms.min.js', array('version' => 'auto', 'relative' => true));
+				JHtml::_('script', 'system/cms.min.js', ['version' => 'auto', 'relative' => true]);
 				$datashowon = ' data-showon=\'' . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . '\'';
 			}
 			?>

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -10,17 +10,17 @@
 defined('JPATH_BASE') or die;
 
 $form     = $displayData->getForm();
-$options  = array(
+$options  = [
 	'formControl' => $form->getFormControl(),
 	'hidden'      => (int) ($form->getValue('language', null, '*') === '*'),
-);
+];
 
 JHtml::_('behavior.core');
 JHtml::_('jquery.framework');
 JText::script('JGLOBAL_ASSOC_NOT_POSSIBLE');
 JText::script('JGLOBAL_ASSOCIATIONS_RESET_WARNING');
 JFactory::getDocument()->addScriptOptions('system.associations.edit', $options);
-JHtml::_('script', 'system/associations-edit.min.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'system/associations-edit.min.js', ['version' => 'auto', 'relative' => true]);
 
 // JLayout for standard handling of associations fields in the administrator items edit screens.
 echo $form->renderFieldset('item_associations');

--- a/layouts/joomla/edit/fieldset.php
+++ b/layouts/joomla/edit/fieldset.php
@@ -20,8 +20,8 @@ if (empty($fieldSet))
 	return;
 }
 
-$ignoreFields = $displayData->get('ignore_fields') ? : array();
-$extraFields = $displayData->get('extra_fields') ? : array();
+$ignoreFields = $displayData->get('ignore_fields') ? : [];
+$extraFields = $displayData->get('extra_fields') ? : [];
 
 if ($displayData->get('show_options', 1))
 {
@@ -40,7 +40,7 @@ if ($displayData->get('show_options', 1))
 		}
 	}
 
-	$html = array();
+	$html = [];
 
 	foreach ($fieldSet as $field)
 	{
@@ -51,7 +51,7 @@ if ($displayData->get('show_options', 1))
 }
 else
 {
-	$html = array();
+	$html = [];
 	$html[] = '<div style="display:none;">';
 	foreach ($fieldSet as $field)
 	{

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -64,6 +64,6 @@ if ($count)
 	JHtml::_('bootstrap.tooltip');
 	JHtml::_('bootstrap.popover');
 
-	JHtml::_('stylesheet', 'system/frontediting.css', array('version' => 'auto', 'relative' => true));
-	JHtml::_('script', 'system/frontediting.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('stylesheet', 'system/frontediting.css', ['version' => 'auto', 'relative' => true]);
+	JHtml::_('script', 'system/frontediting.min.js', ['version' => 'auto', 'relative' => true]);
 }

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -23,10 +23,10 @@ if ($component === 'com_categories')
 
 $saveHistory = JComponentHelper::getParams($component)->get('save_history', 0);
 
-$fields = $displayData->get('fields') ?: array(
-	array('parent', 'parent_id'),
-	array('published', 'state', 'enabled'),
-	array('category', 'catid'),
+$fields = $displayData->get('fields') ?: [
+	['parent', 'parent_id'],
+	['published', 'state', 'enabled'],
+	['category', 'catid'],
 	'featured',
 	'sticky',
 	'access',
@@ -34,16 +34,16 @@ $fields = $displayData->get('fields') ?: array(
 	'tags',
 	'note',
 	'version_note',
-);
+];
 
-$hiddenFields = $displayData->get('hidden_fields') ?: array();
+$hiddenFields = $displayData->get('hidden_fields') ?: [];
 
 if (!$saveHistory)
 {
 	$hiddenFields[] = 'version_note';
 }
 
-$html   = array();
+$html   = [];
 $html[] = '<fieldset class="form-vertical form-no-margin">';
 
 foreach ($fields as $field)

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -18,21 +18,21 @@ if (empty($fieldSets))
 	return;
 }
 
-$ignoreFieldsets = $displayData->get('ignore_fieldsets') ?: array();
-$ignoreFields    = $displayData->get('ignore_fields') ?: array();
-$extraFields     = $displayData->get('extra_fields') ?: array();
+$ignoreFieldsets = $displayData->get('ignore_fieldsets') ?: [];
+$ignoreFields    = $displayData->get('ignore_fields') ?: [];
+$extraFields     = $displayData->get('extra_fields') ?: [];
 $tabName         = $displayData->get('tab_name') ?: 'myTab';
 
 if (!empty($displayData->hiddenFieldsets))
 {
 	// These are required to preserve data on save when fields are not displayed.
-	$hiddenFieldsets = $displayData->hiddenFieldsets ?: array();
+	$hiddenFieldsets = $displayData->hiddenFieldsets ?: [];
 }
 
 if (!empty($displayData->configFieldsets))
 {
 	// These are required to configure showing and hiding fields in the editor.
-	$configFieldsets = $displayData->configFieldsets ?: array();
+	$configFieldsets = $displayData->configFieldsets ?: [];
 }
 
 if ($displayData->get('show_options', 1))
@@ -78,7 +78,7 @@ if ($displayData->get('show_options', 1))
 }
 else
 {
-	$html   = array();
+	$html   = [];
 	$html[] = '<div style="display:none;">';
 	foreach ($fieldSets as $name => $fieldSet)
 	{

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -12,20 +12,20 @@ defined('JPATH_BASE') or die;
 $app = JFactory::getApplication();
 $form = $displayData->getForm();
 
-$fields = $displayData->get('fields') ?: array(
+$fields = $displayData->get('fields') ?: [
 	'publish_up',
 	'publish_down',
-	array('created', 'created_time'),
-	array('created_by', 'created_user_id'),
+	['created', 'created_time'],
+	['created_by', 'created_user_id'],
 	'created_by_alias',
-	array('modified', 'modified_time'),
-	array('modified_by', 'modified_user_id'),
+	['modified', 'modified_time'],
+	['modified_by', 'modified_user_id'],
 	'version',
 	'hits',
 	'id'
-);
+];
 
-$hiddenFields = $displayData->get('hidden_fields') ?: array();
+$hiddenFields = $displayData->get('hidden_fields') ?: [];
 
 foreach ($fields as $field)
 {

--- a/layouts/joomla/editors/buttons/modal.php
+++ b/layouts/joomla/editors/buttons/modal.php
@@ -22,13 +22,13 @@ $href     = '#' . str_replace(' ', '', $button->get('text')) . 'Modal';
 $link     = ($button->get('link')) ? JUri::base() . $button->get('link') : null;
 $onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 $title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
-$options  = is_array($button->get('options')) ? $button->get('options') : array();
+$options  = is_array($button->get('options')) ? $button->get('options') : [];
 
 // Create the modal
 echo JHtml::_(
 	'bootstrap.renderModal',
 	str_replace(' ', '', $button->get('text')) . 'Modal',
-	array(
+	[
 		'url'    => $link,
 		'title'  => $title,
 		'height' => array_key_exists('height', $options) ? $options['height'] : '400px',
@@ -37,5 +37,5 @@ echo JHtml::_(
 		'modalWidth'  => array_key_exists('modalWidth', $options) ? $options['modalWidth'] : '80',
 		'footer' => '<button class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">'
 			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
-	)
+	]
 );

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -63,7 +63,7 @@ $document = JFactory::getDocument();
 $inputvalue = '';
 
 // Build the attributes array.
-$attributes = array();
+$attributes = [];
 
 empty($size)      ? null : $attributes['size'] = $size;
 empty($maxlength) ? null : $attributes['maxlength'] = $maxLength;
@@ -98,7 +98,7 @@ $cssFileExt = ($direction === 'rtl') ? '-rtl.css' : '.css';
 JHtml::_('script', $localesPath, false, true, false, false, true);
 JHtml::_('script', $helperPath, false, true, false, false, true);
 JHtml::_('script', 'system/fields/calendar.min.js', false, true, false, false, true);
-JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, array(), true);
+JHtml::_('stylesheet', 'system/fields/calendar' . $cssFileExt, [], true);
 ?>
 <div class="field-calendar">
 	<?php if (!$readonly && !$disabled) : ?>

--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -75,7 +75,7 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 
 			$oid        = $id . $i;
 			$value      = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-			$attributes = array_filter(array($checked, $optionClass, $disabled, $onchange, $onclick));
+			$attributes = array_filter([$checked, $optionClass, $disabled, $onchange, $onclick]);
 		?>
 		<div class="form-check form-check-inline">
 			<label for="<?php echo $oid; ?>" class="form-check-label">

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -45,7 +45,7 @@ extract($displayData);
  * @var   array    $control         Is this field checked?
  */
 
-if (in_array($format, array('rgb', 'rgba')) && $validate != 'color')
+if (in_array($format, ['rgb', 'rgba']) && $validate != 'color')
 {
 	$alpha = ($format === 'rgba');
 	$placeholder = $alpha ? 'rgba(0, 0, 0, 0.5)' : 'rgb(0, 0, 0)';
@@ -55,7 +55,7 @@ else
 	$placeholder = '#rrggbb';
 }
 
-$inputclass   = ($keywords && ! in_array($format, array('rgb', 'rgba'))) ? ' keywords' : ' ' . $format;
+$inputclass   = ($keywords && ! in_array($format, ['rgb', 'rgba'])) ? ' keywords' : ' ' . $format;
 $class        = ' class="form-control ' . trim('minicolors ' . $class) . ($validate == 'color' ? 'form-control ' : $inputclass) . '"';
 $control      = $control ? ' data-control="' . $control . '"' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
@@ -70,9 +70,9 @@ $autocomplete = ! $autocomplete ? ' autocomplete="off"' : '';
 $direction = $lang->isRTL() ? ' dir="ltr" style="text-align:right"' : '';
 
 JHtml::_('jquery.framework');
-JHtml::_('script', 'vendor/minicolors/jquery.minicolors.min.js', array('version' => 'auto', 'relative' => true));
-JHtml::_('stylesheet', 'vendor/minicolors/jquery.minicolors.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('script', 'system/fields/color-field-adv-init.min.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'vendor/minicolors/jquery.minicolors.min.js', ['version' => 'auto', 'relative' => true]);
+JHtml::_('stylesheet', 'vendor/minicolors/jquery.minicolors.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('script', 'system/fields/color-field-adv-init.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <input
 	type="text"

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -51,9 +51,9 @@ $readonly = $readonly ? ' readonly' : '';
 
 // Include jQuery
 JHtml::_('jquery.framework');
-JHtml::_('script', 'system/fields/simplecolors.min.js', array('version' => 'auto', 'relative' => true));
-JHtml::_('stylesheet', 'system/simplecolors.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('script', 'system/fields/color-field-init.min.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'system/fields/simplecolors.min.js', ['version' => 'auto', 'relative' => true]);
+JHtml::_('stylesheet', 'system/simplecolors.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('script', 'system/fields/color-field-init.min.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <select data-chosen="true" name="<?php echo $name; ?>" id="<?php echo $id; ?>"<?php
 echo $disabled; ?><?php echo $readonly; ?><?php echo $required; ?><?php echo $class; ?><?php echo $position; ?><?php

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -47,7 +47,7 @@ extract($displayData);
 echo JHtml::_(
 	'bootstrap.renderModal',
 	'versionsModal',
-	array(
+	[
 		'url'    => $link,
 		'title'  => $label,
 		'height' => '100%',
@@ -56,7 +56,7 @@ echo JHtml::_(
 		'bodyHeight'  => '60',
 		'footer' => '<a type="button" class="btn" data-dismiss="modal" aria-hidden="true">'
 			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
-	)
+	]
 );
 
 ?>

--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -48,7 +48,7 @@ extract($displayData);
 $autocomplete = !$autocomplete ? 'autocomplete="off"' : 'autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == 'autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	$spellcheck ? '' : 'spellcheck="false"',
 	!empty($size) ? 'size="' . $size . '"' : '',
 	$disabled ? 'disabled' : '',
@@ -60,7 +60,7 @@ $attributes = array(
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	$required ? 'required aria-required="true"' : '',
 	$autofocus ? 'autofocus' : '',
-);
+];
 ?>
 <input
 	type="email"

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -112,7 +112,7 @@ $url    = ($readonly ? ''
 	// Render the modal
 	echo JHtml::_('bootstrap.renderModal',
 		'imageModal_'. $id,
-		array(
+		[
 			'url'         => $url,
 			'title'       => JText::_('JLIB_FORM_CHANGE_IMAGE'),
 			'closeButton' => true,
@@ -121,10 +121,10 @@ $url    = ($readonly ? ''
 			'modalWidth'  => '80',
 			'bodyHeight'  => '60',
 			'footer'      => '<button class="btn btn-secondary button-save-selected">' . JText::_('JSELECT') . '</button><button class="btn btn-secondary" data-dismiss="modal">' . JText::_('JCANCEL') . '</button>'
-		)
+		]
 	);
 
-	JHtml::_('script', 'system/fields/mediafield.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('script', 'system/fields/mediafield.min.js', ['version' => 'auto', 'relative' => true]);
 	?>
 	<div class="input-group">
 		<?php if ($showPreview && $showAsTooltip) : ?>

--- a/layouts/joomla/form/field/meter.php
+++ b/layouts/joomla/form/field/meter.php
@@ -63,11 +63,11 @@ $data .= 'aria-valuemax="' . $max . '"';
 $data .= ' aria-valuemin="' . $min . '"';
 $data .= ' aria-valuenow="' . $value . '"';
 
-$attributes = array(
+$attributes = [
 	$class,
 	!empty($width) ? ' style="width:' . $width . ';"' : '',
 	$data
-);
+];
 
 $value = ((float) ($value - $min) * 100) / ($max - $min);
 ?>

--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -55,7 +55,7 @@ $attr .= !empty($size) ? ' size="' . $size . '"' : '';
 // Initialize JavaScript field attributes.
 $attr .= !empty($onchange) ? ' onchange="' . $onchange . '"' : '';
 
-JHtml::_('script', 'system/fields/moduleorder.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('script', 'system/fields/moduleorder.js', ['version' => 'auto', 'relative' => true]);
 ?>
 <div
 	id="parent_<?php echo $id; ?>"

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -48,7 +48,7 @@ extract($displayData);
 $autocomplete = !$autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
 	!empty($size) ? 'size="' . $size . '"' : '',
 	$disabled ? 'disabled' : '',
@@ -61,7 +61,7 @@ $attributes = array(
 	$required ? 'required aria-required="true"' : '',
 	$autocomplete,
 	$autofocus ? 'autofocus' : ''
-);
+];
 
 if (is_numeric($value))
 {

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -60,7 +60,7 @@ if ($meter)
 JText::script('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
 JText::script('JFIELD_PASSWORD_INDICATE_COMPLETE');
 
-$attributes = array(
+$attributes = [
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	!$autocomplete ? 'autocomplete="off"' : '',
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
@@ -76,7 +76,7 @@ $attributes = array(
 	!empty($minUppercase) ? 'data-min-uppercase="' . $minUppercase . '"' : '',
 	!empty($minLowercase) ? 'data-min-lowercase="' . $minLowercase . '"' : '',
 	!empty($forcePassword) ? 'data-min-force="' . $forcePassword . '"' : '',
-);
+];
 
 ?>
 <input

--- a/layouts/joomla/form/field/radio.php
+++ b/layouts/joomla/form/field/radio.php
@@ -54,7 +54,7 @@ $dataToggle = (strpos(trim($class), 'btn-group') !== false) ? ' data-toggle="but
 ?>
 <?php // START SWITCHER ?>
 <?php if (strpos(trim($class), 'switcher') !== false) : ?>
-<?php JHtml::_('script', 'system/fields/switcher.js', array('version' => 'auto', 'relative' => true)); ?>
+<?php JHtml::_('script', 'system/fields/switcher.js', ['version' => 'auto', 'relative' => true]); ?>
 <fieldset id="<?php echo $id; ?>"
 	<?php echo $disabled ? 'disabled' : ''; ?>
 	<?php echo $required ? 'required aria-required="true"' : ''; ?>>
@@ -80,7 +80,7 @@ $dataToggle = (strpos(trim($class), 'btn-group') !== false) ? ' data-toggle="but
 					$onchange    = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 					$oid         = $id . $i;
 					$ovalue      = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-					$attributes  = array_filter(array($checked, $optionClass, $disabled, $onchange, $onclick));
+					$attributes  = array_filter([$checked, $optionClass, $disabled, $onchange, $onclick]);
 				?>
 				<?php if ($required) : ?>
 					<?php $attributes[] = 'required aria-required="true"'; ?>
@@ -118,7 +118,7 @@ $dataToggle = (strpos(trim($class), 'btn-group') !== false) ? ' data-toggle="but
 				$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 				$oid        = $id . $i;
 				$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-				$attributes = array_filter(array($checked, $optionClass, $disabled, $onchange, $onclick));
+				$attributes = array_filter([$checked, $optionClass, $disabled, $onchange, $onclick]);
 			?>
 			<?php if ($required) : ?>
 				<?php $attributes[] = 'required aria-required="true"'; ?>

--- a/layouts/joomla/form/field/radiobasic.php
+++ b/layouts/joomla/form/field/radiobasic.php
@@ -71,7 +71,7 @@ $alt    = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 				$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 				$oid        = $id . $i;
 				$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-				$attributes = array_filter(array($checked, $optionClass, $disabled, $onchange, $onclick));
+				$attributes = array_filter([$checked, $optionClass, $disabled, $onchange, $onclick]);
 			?>
 			<?php if ($required) : ?>
 				<?php $attributes[] = 'required aria-required="true"'; ?>

--- a/layouts/joomla/form/field/range.php
+++ b/layouts/joomla/form/field/range.php
@@ -45,7 +45,7 @@ extract($displayData);
  */
 
 // Initialize some field attributes.
-$attributes = array(
+$attributes = [
 	$class ? 'class="form-control ' . $class . '"' : 'class="form-control"',
 	$disabled ? 'disabled' : '',
 	$readonly ? 'readonly' : '',
@@ -54,7 +54,7 @@ $attributes = array(
 	!empty($step) ? 'step="' . $step . '"' : '',
 	!empty($min) ? 'min="' . $min . '"' : '',
 	$autofocus ? 'autofocus' : '',
-);
+];
 
 $value = (float) $value;
 $value = empty($value) ? $min : $value;

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -29,8 +29,8 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	JHtml::_('jquery.ui', array('core', 'sortable'));
-	JHtml::_('script', 'system/fields/subform-repeatable.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('jquery.ui', ['core', 'sortable']);
+	JHtml::_('script', 'system/fields/subform-repeatable.min.js', ['version' => 'auto', 'relative' => true]);
 }
 
 // Build heading
@@ -93,14 +93,14 @@ else
 			<tbody>
 			<?php
 			foreach ($forms as $k => $form) :
-				echo $this->sublayout($sublayout, array('form' => $form, 'basegroup' => $fieldname, 'group' => $fieldname . $k, 'buttons' => $buttons));
+				echo $this->sublayout($sublayout, ['form' => $form, 'basegroup' => $fieldname, 'group' => $fieldname . $k, 'buttons' => $buttons]);
 			endforeach;
 			?>
 			</tbody>
 		</table>
 		<?php if ($multiple) : ?>
 		<script type="text/subform-repeatable-template-section" class="subform-repeatable-template-section">
-		<?php echo $this->sublayout($sublayout, array('form' => $tmpl, 'basegroup' => $fieldname, 'group' => $fieldname . 'X', 'buttons' => $buttons)); ?>
+		<?php echo $this->sublayout($sublayout, ['form' => $tmpl, 'basegroup' => $fieldname, 'group' => $fieldname . 'X', 'buttons' => $buttons]); ?>
 		</script>
 		<?php endif; ?>
 		</div>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -24,7 +24,7 @@ extract($displayData);
 <tr class="subform-repeatable-group" data-base-name="<?php echo $basegroup; ?>" data-group="<?php echo $group; ?>">
 	<?php foreach ($form->getGroup('') as $field) : ?>
 	<td data-column="<?php echo strip_tags($field->label); ?>">
-		<?php echo $field->renderField(array('hiddenLabel' => true)); ?>
+		<?php echo $field->renderField(['hiddenLabel' => true]); ?>
 	</td>
 	<?php endforeach; ?>
 	<?php if (!empty($buttons)) : ?>

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -29,8 +29,8 @@ extract($displayData);
 // Add script
 if ($multiple)
 {
-	JHtml::_('jquery.ui', array('core', 'sortable'));
-	JHtml::_('script', 'system/fields/subform-repeatable.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('jquery.ui', ['core', 'sortable']);
+	JHtml::_('script', 'system/fields/subform-repeatable.min.js', ['version' => 'auto', 'relative' => true]);
 }
 
 $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
@@ -50,12 +50,12 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<?php endif; ?>
 		<?php
 		foreach ($forms as $k => $form) :
-			echo $this->sublayout($sublayout, array('form' => $form, 'basegroup' => $fieldname, 'group' => $fieldname . $k, 'buttons' => $buttons));
+			echo $this->sublayout($sublayout, ['form' => $form, 'basegroup' => $fieldname, 'group' => $fieldname . $k, 'buttons' => $buttons]);
 		endforeach;
 		?>
 		<?php if ($multiple) : ?>
 		<script type="text/subform-repeatable-template-section" class="subform-repeatable-template-section">
-		<?php echo $this->sublayout($sublayout, array('form' => $tmpl, 'basegroup' => $fieldname, 'group' => $fieldname . 'X', 'buttons' => $buttons)); ?>
+		<?php echo $this->sublayout($sublayout, ['form' => $tmpl, 'basegroup' => $fieldname, 'group' => $fieldname . 'X', 'buttons' => $buttons]); ?>
 		</script>
 		<?php endif; ?>
 		</div>

--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -52,7 +52,7 @@ JHtml::_('script', 'system/html5fallback.js', false, true);
 $autocomplete = !$autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	!empty($size) ? 'size="' . $size . '"' : '',
 	$disabled ? 'disabled' : '',
 	$readonly ? 'readonly' : '',
@@ -63,7 +63,7 @@ $attributes = array(
 	$onchange ? ' onchange="' . $onchange . '"' : '',
 	!empty($maxLength) ? $maxLength : '',
 	$required ? 'required aria-required="true"' : '',
-);
+];
 ?>
 <input
 	type="tel"

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -54,7 +54,7 @@ if ($options)
 $autocomplete = !$autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
 	!empty($size) ? 'size="' . $size . '"' : '',
 	$disabled ? 'disabled' : '',
@@ -72,7 +72,7 @@ $attributes = array(
 
 	// @TODO add a proper string here!!!
 	!empty($validationtext) ? 'data-validation-text="' . $validationtext . '"' : '',
-);
+];
 
 $addonBeforeHtml = '<span class="input-group-addon">' . $addonBefore . '</span>';
 $addonAfterHtml  = '<span class="input-group-addon">' . $addonAfter . '</span>';

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -48,7 +48,7 @@ extract($displayData);
 $autocomplete = !$autocomplete ? 'autocomplete="off"' : 'autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == 'autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	$columns ?: '',
 	$rows ?: '',
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
@@ -63,7 +63,7 @@ $attributes = array(
 	$spellcheck ? '' : 'spellcheck="false"',
 	$maxlength ? $maxlength: ''
 
-);
+];
 ?>
 <textarea name="<?php
 echo $name; ?>" id="<?php

--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -47,7 +47,7 @@ extract($displayData);
 $autocomplete = !$autocomplete ? ' autocomplete="off"' : ' autocomplete="' . $autocomplete . '"';
 $autocomplete = $autocomplete == ' autocomplete="on"' ? '' : $autocomplete;
 
-$attributes = array(
+$attributes = [
 	!empty($size) ? ' size="' . $size . '"' : '',
 	$disabled ? ' disabled' : '',
 	$readonly ? ' readonly' : '',
@@ -58,7 +58,7 @@ $attributes = array(
 	$onchange ? ' onchange="' . $onchange . '"' : '',
 	!empty($maxLength) ? $maxLength : '',
 	$required ? ' required aria-required="true"' : '',
-);
+];
 ?>
 <input
 	<?php echo $inputType; ?>

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -48,7 +48,7 @@ extract($displayData);
 if (!$readonly)
 {
 	JHtml::_('behavior.modal', 'a.modal_' . $id);
-	JHtml::_('script', 'system/fields/fielduser.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('script', 'system/fields/fielduser.min.js', ['version' => 'auto', 'relative' => true]);
 }
 
 $uri = new JUri('index.php?option=com_users&view=users&layout=modal&tmpl=component&required=0');
@@ -76,9 +76,13 @@ if ($this->escape($userName) === JText::_('JLIB_FORM_SELECT_USER'))
 	$userName = '';
 }
 
-$inputAttributes = array(
-	'type' => 'text', 'id' => $id, 'class' => 'form-control field-user-input-name', 'value' => $this->escape($userName)
-);
+$inputAttributes = [
+	'type'  => 'text',
+	'id'    => $id,
+	'class' => 'form-control field-user-input-name',
+	'value' => $this->escape($userName),
+];
+
 if ($class)
 {
 	$inputAttributes['class'] .= ' ' . $class;
@@ -113,7 +117,7 @@ if (!$readonly)
 					<?php echo JHtml::_(
 						'bootstrap.renderModal',
 						'userModal_' . $id,
-						array(
+						[
 							'url'         => $uri,
 							'title'       => JText::_('JLIB_FORM_CHANGE_USER'),
 							'closeButton' => true,
@@ -122,7 +126,7 @@ if (!$readonly)
 							'modalWidth'  => 80,
 							'bodyHeight'  => 60,
 							'footer'      => '<a type="button" class="btn btn-secondary" data-dismiss="modal">' . JText::_('JCANCEL') . '</a>'
-						)
+						]
 					); ?>
 				</span>
 			<?php endif; ?>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -22,7 +22,7 @@ extract($displayData);
 if (!empty($options['showonEnabled']))
 {
 	JHtml::_('jquery.framework');
-	JHtml::_('script', 'system/cms.min.js', array('version' => 'auto', 'relative' => true));
+	JHtml::_('script', 'system/cms.min.js', ['version' => 'auto', 'relative' => true]);
 }
 
 $class = empty($options['class']) ? '' : ' ' . $options['class'];

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -22,8 +22,8 @@ defined('JPATH_BASE') or die;
 		'access.assetgrouplist',
 		'batch[assetgroup_id]', '',
 		'class="custom-select"',
-		array(
+		[
 			'title' => JText::_('JLIB_HTML_BATCH_NOCHANGE'),
-			'id' => 'batch-access'
-		)
+			'id'    => 'batch-access'
+		]
 	); ?>

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -19,10 +19,10 @@ defined('JPATH_BASE') or die;
 extract($displayData);
 
 // Create the copy/move options.
-$options = array(
+$options = [
 	JHtml::_('select.option', 'c', JText::_('JLIB_HTML_BATCH_COPY')),
 	JHtml::_('select.option', 'm', JText::_('JLIB_HTML_BATCH_MOVE'))
-);
+];
 ?>
 <label id="batch-choose-action-lbl" for="batch-choose-action"><?php echo JText::_('JLIB_HTML_BATCH_MENU_LABEL'); ?></label>
 <div id="batch-choose-action" class="control-group">

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -22,5 +22,5 @@ echo JHtml::_('tooltipText', 'JLIB_HTML_BATCH_TAG_LABEL', 'JLIB_HTML_BATCH_TAG_L
 </label>
 <select name="batch[tag]" class="custom-select" id="batch-tag-id">
 	<option value=""><?php echo JText::_('JLIB_HTML_BATCH_TAG_NOCHANGE'); ?></option>
-	<?php echo JHtml::_('select.options', JHtml::_('tag.tags', array('filter.published' => array(1))), 'value', 'text'); ?>
+	<?php echo JHtml::_('select.options', JHtml::_('tag.tags', ['filter.published' => [1]]), 'value', 'text'); ?>
 </select>

--- a/layouts/joomla/modal/iframe.php
+++ b/layouts/joomla/modal/iframe.php
@@ -30,10 +30,10 @@ extract($displayData);
  *
  */
 
-$iframeAttributes = array(
+$iframeAttributes = [
 	'class' => 'iframe',
 	'src'   => $params['url']
-);
+];
 
 if (isset($params['title']))
 {

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -35,7 +35,7 @@ extract($displayData);
  *
  */
 
-$modalClasses = array('modal');
+$modalClasses = ['modal'];
 
 if (!isset($params['animation']) || $params['animation'])
 {
@@ -50,10 +50,10 @@ if ($modalWidth && $modalWidth > 0 && $modalWidth <= 100)
 	$modalDialogClass = ' jviewport-width' . $modalWidth;
 }
 
-$modalAttributes = array(
+$modalAttributes = [
 	'tabindex' => '-1',
 	'class'    => 'joomla-modal ' .implode(' ', $modalClasses)
-);
+];
 
 if (isset($params['backdrop']))
 {

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -58,7 +58,7 @@ if ($displayData['active'])
 		$limit = 'limitstart.value=0';
 	}
 
-	$cssClasses = array();
+	$cssClasses = [];
 
 	$title = '';
 

--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 $data = $displayData;
 
 // Receive overridable options
-$data['options'] = !empty($data['options']) ? $data['options'] : array();
+$data['options'] = !empty($data['options']) ? $data['options'] : [];
 
 $noResultsText     = '';
 $hideActiveFilters = false;
@@ -57,7 +57,7 @@ if (isset($data['view']->filterForm) && !empty($data['view']->filterForm))
 }
 
 // Set some basic options.
-$customOptions = array(
+$customOptions = [
 	'filtersHidden'       => isset($data['options']['filtersHidden']) && $data['options']['filtersHidden'] ? $data['options']['filtersHidden'] : $hideActiveFilters,
 	'filterButton'        => isset($data['options']['filterButton']) && $data['options']['filterButton'] ? $data['options']['filterButton'] : $showFilterButton,
 	'defaultLimit'        => isset($data['options']['defaultLimit']) ? $data['options']['defaultLimit'] : JFactory::getApplication()->get('list_limit', 20),
@@ -68,7 +68,7 @@ $customOptions = array(
 	'showNoResults'       => !empty($noResultsText) ? true : false,
 	'noResultsText'       => !empty($noResultsText) ? $noResultsText : '',
 	'formSelector'        => !empty($data['options']['formSelector']) ? $data['options']['formSelector'] : '#adminForm',
-);
+];
 
 // Merge custom options in the options array.
 $data['options'] = array_merge($customOptions, $data['options']);

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -14,7 +14,7 @@ use Joomla\Registry\Registry;
 $data = $displayData;
 
 // Receive overridable options
-$data['options'] = !empty($data['options']) ? $data['options'] : array();
+$data['options'] = !empty($data['options']) ? $data['options'] : [];
 
 if (is_array($data['options']))
 {
@@ -42,7 +42,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				<div class="input-group">
 					<?php echo $filters['filter_search']->input; ?>
 					<?php if ($filters['filter_search']->description) : ?>
-						<?php JHtmlBootstrap::tooltip('#filter_search', array('title' => JText::_($filters['filter_search']->description))); ?>
+						<?php JHtmlBootstrap::tooltip('#filter_search', ['title' => JText::_($filters['filter_search']->description)]); ?>
 					<?php endif; ?>
 					<span class="input-group-btn">
 						<button type="submit" class="btn btn-secondary hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>">

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -20,7 +20,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<?php $dataShowOn = ''; ?>
 			<?php if ($field->showon) : ?>
 				<?php JHtml::_('jquery.framework'); ?>
-				<?php JHtml::_('script', 'system/cms.min.js', array('version' => 'auto', 'relative' => true)); ?>
+				<?php JHtml::_('script', 'system/cms.min.js', ['version' => 'auto', 'relative' => true]); ?>
 				<?php $dataShowOn = " data-showon='" . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . "'"; ?>
 			<?php endif; ?>
 			<div class="js-stools-field-filter"<?php echo $dataShowOn; ?>>

--- a/layouts/joomla/toolbar/apply.php
+++ b/layouts/joomla/toolbar/apply.php
@@ -17,7 +17,7 @@ if (preg_match('/Joomla.submitbutton/', $displayData['doTask']))
 	$ctrls = str_replace("')", '', $ctrls);
 	$ctrls = str_replace(";", '', $ctrls);
 
-	$options = array('task' => $ctrls);
+	$options = ['task' => $ctrls];
 	JFactory::getDocument()->addScriptOptions('keySave', $options);
 }
 

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -27,7 +27,7 @@ $text     = isset($displayData['text']) ? $displayData['text'] : '';
 // Render the modal
 echo JHtml::_('bootstrap.renderModal',
 	'modal_'. $selector,
-	array(
+	[
 		'url'         => $displayData['doTask'],
 		'title'       => $text,
 		'height'      => '100%',
@@ -41,7 +41,7 @@ echo JHtml::_('bootstrap.renderModal',
 						. '<button class="btn btn-success" type="button"'
 						. ' onclick="jQuery(\'#modal_downloadModal iframe\').contents().find(\'#exportBtn\').click();">'
 						. JText::_("COM_BANNERS_TRACKS_EXPORT") . '</button>',
-	)
+	]
 );
 ?>
 <button onclick="jQuery('#modal_<?php echo $selector; ?>').modal('show')" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -14,7 +14,7 @@ extract($displayData);
 echo JHtml::_(
 	'bootstrap.renderModal',
 	'versionsModal',
-	array(
+	[
 		'url'    => "index.php?option=com_contenthistory&amp;view=history&amp;layout=modal&amp;tmpl=component&amp;item_id="
 			. (int) $displayData['itemId']. "&amp;type_id=" . $displayData['typeId'] . "&amp;type_alias=" . $displayData['typeAlias']
 			. "&amp;" . JSession::getFormToken() . "=1",
@@ -25,7 +25,7 @@ echo JHtml::_(
 		'bodyHeight'  => '60',
 		'footer' => '<a type="button" class="btn btn-secondary" data-dismiss="modal" aria-hidden="true">'
 			. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</a>'
-	)
+	]
 );
 
 ?>

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -52,22 +52,22 @@ extract($displayData);
  */
 
 JHtml::_('behavior.core');
-JHtml::_('jquery.ui', array('core', 'sortable'));
-JHtml::_('stylesheet', 'media/vendor/tinymce/skins/lightgray/skin.min.css', array('version' => 'auto', 'relative' => false));
-JHtml::_('stylesheet', 'editors/tinymce/tinymce-builder.css', array('version' => 'auto', 'relative' => true));
-JHtml::_('script', 'editors/tinymce/tinymce-builder.js', array('version' => 'auto', 'relative' => true));
+JHtml::_('jquery.ui', ['core', 'sortable']);
+JHtml::_('stylesheet', 'media/vendor/tinymce/skins/lightgray/skin.min.css', ['version' => 'auto', 'relative' => false]);
+JHtml::_('stylesheet', 'editors/tinymce/tinymce-builder.css', ['version' => 'auto', 'relative' => true]);
+JHtml::_('script', 'editors/tinymce/tinymce-builder.js', ['version' => 'auto', 'relative' => true]);
 
 if ($languageFile)
 {
-	JHtml::_('script', $languageFile, array('version' => 'auto', 'relative' => false));
+	JHtml::_('script', $languageFile, ['version' => 'auto', 'relative' => false]);
 }
 
-JFactory::getDocument()->addScriptOptions('plg_editors_tinymce_builder', array(
+JFactory::getDocument()->addScriptOptions('plg_editors_tinymce_builder', [
 		'menus'         => $menus,
 		'buttons'       => $buttons,
 		'toolbarPreset' => $toolbarPreset,
 		'formControl'   => $name . '[toolbars]',
-	)
+	]
 );
 
 ?>
@@ -110,11 +110,11 @@ JFactory::getDocument()->addScriptOptions('plg_editors_tinymce_builder', array(
 	<?php // Render tab content for each set ?>
 	<div class="tab-content">
 		<?php
-		$presetButtonClases = array(
+		$presetButtonClases = [
 			'simple'   => 'btn-success',
 			'medium'   => 'btn-info',
 			'advanced' => 'btn-warning',
-		);
+		];
 		foreach ( $setsNames as $num => $title ) :
 
 			// Check whether the values exists, and if empty then use from preset
@@ -138,9 +138,9 @@ JFactory::getDocument()->addScriptOptions('plg_editors_tinymce_builder', array(
 			}
 
 			// Take existing values
-			$valMenu = empty($value['toolbars'][$num]['menu'])     ? array() : $value['toolbars'][$num]['menu'];
-			$valBar1 = empty($value['toolbars'][$num]['toolbar1']) ? array() : $value['toolbars'][$num]['toolbar1'];
-			$valBar2 = empty($value['toolbars'][$num]['toolbar2']) ? array() : $value['toolbars'][$num]['toolbar2'];
+			$valMenu = empty($value['toolbars'][$num]['menu'])     ? [] : $value['toolbars'][$num]['menu'];
+			$valBar1 = empty($value['toolbars'][$num]['toolbar1']) ? [] : $value['toolbars'][$num]['toolbar1'];
+			$valBar2 = empty($value['toolbars'][$num]['toolbar2']) ? [] : $value['toolbars'][$num]['toolbar2'];
 		?>
 			<div class="tab-pane <?php echo $num === $setsAmount - 1 ? 'active' : ''; ?>" id="set-<?php echo $num; ?>">
 				<div class="btn-toolbar float-right">
@@ -179,7 +179,7 @@ JFactory::getDocument()->addScriptOptions('plg_editors_tinymce_builder', array(
 				</div>
 
 				<?php // Render the form for extra options ?>
-				<?php echo $this->sublayout('setoptions', array('form' => $setsForms[$num])); ?>
+				<?php echo $this->sublayout('setoptions', ['form' => $setsForms[$num]]); ?>
 			</div>
 		<?php endforeach; ?>
 	</div>


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in layouts.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.