### PR TITLE
[4.0] Array to php 5.4+ notation [Installation]

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -117,7 +117,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 		{
 			ksort($orphans, SORT_STRING);
 
-			$guesses = array();
+			$guesses = [];
 
 			foreach ($orphans as $key => $occurance)
 			{
@@ -252,7 +252,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 	 */
 	protected function fetchConfigurationData($file = '', $class = 'JConfig')
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -308,7 +308,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 			return false;
 		}
 
-		$ret = array();
+		$ret = [];
 
 		$ret['language']   = (string) $xml->forceLang;
 		$ret['helpurl']    = (string) $xml->helpurl;
@@ -330,7 +330,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 	 */
 	public function getLocaliseAdmin($db = false)
 	{
-		$langfiles = array();
+		$langfiles = [];
 
 		// If db connection, fetch them from the database.
 		if ($db)
@@ -387,7 +387,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 	 *
 	 * @since   3.1
 	 */
-	protected function initialiseApp($options = array())
+	protected function initialiseApp($options = [])
 	{
 		// Get the localisation information provided in the localise.xml file.
 		$forced = $this->getLocalise();
@@ -479,14 +479,14 @@ final class InstallationApplicationWeb extends JApplicationCms
 			$type = $this->input->get('format', 'html', 'word');
 			$date = new JDate('now');
 
-			$attributes = array(
+			$attributes = [
 				'charset'      => 'utf-8',
 				'lineend'      => 'unix',
 				'tab'          => "\t",
 				'language'     => $lang->getTag(),
 				'direction'    => $lang->isRtl() ? 'rtl' : 'ltr',
 				'mediaversion' => md5($date->format('YmdHi')),
-			);
+			];
 
 			$document = JDocument::getInstance($type, $attributes);
 
@@ -512,12 +512,12 @@ final class InstallationApplicationWeb extends JApplicationCms
 	{
 		$file = $this->input->getCmd('tmpl', 'index');
 
-		$options = array(
-			'template' => 'template',
-			'file' => $file . '.php',
+		$options = {
+			'template'  => 'template',
+			'file'      => $file . '.php',
 			'directory' => JPATH_THEMES,
-			'params' => '{}',
-		);
+			'params'    => '{}',
+		];
 
 		// Parse the document.
 		$this->document->parse($options);
@@ -568,7 +568,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 	 *
 	 * @since   3.1
 	 */
-	public function setCfg(array $vars = array(), $namespace = 'config')
+	public function setCfg(array $vars = [], $namespace = 'config')
 	{
 		$this->config->loadArray($vars, $namespace);
 	}

--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -512,7 +512,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 	{
 		$file = $this->input->getCmd('tmpl', 'index');
 
-		$options = {
+		$options = [
 			'template'  => 'template',
 			'file'      => $file . '.php',
 			'directory' => JPATH_THEMES,

--- a/installation/controller/detectftproot.php
+++ b/installation/controller/detectftproot.php
@@ -33,7 +33,7 @@ class InstallationControllerDetectftproot extends JControllerBase
 		JSession::checkToken() or $app->sendJsonResponse(new Exception(JText::_('JINVALID_TOKEN'), 403));
 
 		// Get the data
-		$data = $app->input->post->get('jform', array(), 'array');
+		$data = $app->input->post->get('jform', [], 'array');
 
 		// Store the options in the session.
 		$vars = (new InstallationModelSetup)->storeOptions($data);

--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -92,7 +92,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 		}
 
 		// Check if user has activated the multilingual site
-		$data = $this->getInput()->post->get('jform', array(), 'array');
+		$data = $this->getInput()->post->get('jform', [], 'array');
 
 		if ((int) $data['activateMultilanguage'])
 		{
@@ -122,7 +122,7 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 			JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_menus/tables/');
 
 			$siteLanguages       = $model->getInstalledlangsFrontend();
-			$groupedAssociations = array();
+			$groupedAssociations = [];
 
 			foreach ($siteLanguages as $siteLang)
 			{

--- a/installation/controller/verifyftpsettings.php
+++ b/installation/controller/verifyftpsettings.php
@@ -36,7 +36,7 @@ class InstallationControllerVerifyftpsettings extends JControllerBase
 		$model = new InstallationModelSetup;
 
 		// Get the data
-		$data = $app->input->post->get('jform', array(), 'array');
+		$data = $app->input->post->get('jform', [], 'array');
 
 		// Store the options in the session.
 		$vars = $model->storeOptions($data);

--- a/installation/form/field/language.php
+++ b/installation/form/field/language.php
@@ -75,12 +75,12 @@ class InstallationFormFieldLanguage extends JFormFieldList
 
 		if (!$options || $options  instanceof Exception)
 		{
-			$options = array();
+			$options = [];
 		}
 		// Sort languages by name
 		else
 		{
-			usort($options, array($this, '_sortLanguages'));
+			usort($options, [$this, '_sortLanguages']);
 		}
 
 		// Set the default value from the native language.

--- a/installation/form/field/prefix.php
+++ b/installation/form/field/prefix.php
@@ -46,7 +46,7 @@ class InstallationFormFieldPrefix extends JFormField
 		}
 
 		// If a prefix is already set, use it instead.
-		$session = JFactory::getSession()->get('setup.options', array());
+		$session = JFactory::getSession()->get('setup.options', []);
 
 		if (empty($session['db_prefix']))
 		{

--- a/installation/form/field/sample.php
+++ b/installation/form/field/sample.php
@@ -34,7 +34,7 @@ class InstallationFormFieldSample extends JFormFieldRadio
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = [];
 		$type    = $this->form->getValue('db_type');
 
 		// Some database drivers share DDLs; point these drivers to the correct parent

--- a/installation/helper/database.php
+++ b/installation/helper/database.php
@@ -37,15 +37,15 @@ abstract class InstallationHelperDatabase
 		if (!$db)
 		{
 			// Build the connection options array.
-			$options = array(
-				'driver' => $driver,
-				'host' => $host,
-				'user' => $user,
+			$options = [
+				'driver'   => $driver,
+				'host'     => $host,
+				'user'     => $user,
 				'password' => $password,
 				'database' => $database,
-				'prefix' => $prefix,
-				'select' => $select,
-			);
+				'prefix'   => $prefix,
+				'select'   => $select,
+			];
 
 			// Get a database object.
 			$db = JDatabaseDriver::getInstance($options);

--- a/installation/html/helper.php
+++ b/installation/html/helper.php
@@ -28,7 +28,7 @@ class InstallationHtmlHelper
 		$path   = JPATH_CONFIGURATION . '/configuration.php';
 		$useftp = file_exists($path) ? !is_writable($path) : !is_writable(JPATH_CONFIGURATION . '/');
 
-		$tabs   = array();
+		$tabs   = [];
 		$tabs[] = 'site';
 		$tabs[] = 'database';
 
@@ -39,7 +39,7 @@ class InstallationHtmlHelper
 
 		$tabs[] = 'summary';
 
-		$html = array();
+		$html = [];
 		$html[] = '<ul class="nav nav-tabs mb-1">';
 
 		foreach ($tabs as $tab)
@@ -61,12 +61,12 @@ class InstallationHtmlHelper
 	 */
 	public static function stepbarlanguages()
 	{
-		$tabs = array();
+		$tabs = [];
 		$tabs[] = 'languages';
 		$tabs[] = 'defaultlanguage';
 		$tabs[] = 'complete';
 
-		$html = array();
+		$html = [];
 		$html[] = '<ul class="nav nav-tabs mb-1">';
 
 		foreach ($tabs as $tab)

--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -147,7 +147,7 @@ class InstallationModelConfiguration extends JModelBase
 		$registry->set('shared_session', 0);
 
 		// Generate the configuration class string buffer.
-		$buffer = $registry->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));
+		$buffer = $registry->toString('PHP', ['class' => 'JConfig', 'closingtag' => false]);
 
 		// Build the configuration file path.
 		$path = JPATH_CONFIGURATION . '/configuration.php';
@@ -291,8 +291,9 @@ class InstallationModelConfiguration extends JModelBase
 		}
 		else
 		{
-			$columns = array(
-				$db->quoteName('id'), $db->quoteName('name'),
+			$columns = [
+				$db->quoteName('id'),
+				$db->quoteName('name'),
 				$db->quoteName('username'),
 				$db->quoteName('email'),
 				$db->quoteName('password'),
@@ -302,7 +303,7 @@ class InstallationModelConfiguration extends JModelBase
 				$db->quoteName('lastvisitDate'),
 				$db->quoteName('activation'),
 				$db->quoteName('params')
-			);
+			];
 			$query->clear()
 				->insert('#__users', true)
 				->columns($columns)
@@ -346,7 +347,7 @@ class InstallationModelConfiguration extends JModelBase
 		{
 			$query->clear()
 				->insert($db->quoteName('#__user_usergroup_map'), false)
-				->columns(array($db->quoteName('user_id'), $db->quoteName('group_id')))
+				->columns([$db->quoteName('user_id'), $db->quoteName('group_id')])
 				->values($db->quote($userId) . ', 8');
 		}
 

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -244,14 +244,14 @@ class InstallationModelDatabase extends JModelBase
 				 * Now we're really getting insane here; we're going to try building a new JDatabaseDriver instance without the database name
 				 * in order to trick the connection into creating the database
 				 */
-				$altDBoptions = array(
+				$altDBoptions = [
 					'driver'   => $options->db_type,
 					'host'     => $options->db_host,
 					'user'     => $options->db_user,
 					'password' => $options->db_pass,
 					'prefix'   => $options->db_prefix,
 					'select'   => $options->db_select,
-				);
+				];
 
 				$altDB = JDatabaseDriver::getInstance($altDBoptions);
 
@@ -549,10 +549,10 @@ class InstallationModelDatabase extends JModelBase
 		$query->clear()
 			->insert($db->quoteName('#__schemas'))
 			->columns(
-				array(
+				[
 					$db->quoteName('extension_id'),
 					$db->quoteName('version_id')
-				)
+				]
 			)
 			->values('700, ' . $db->quote($version));
 		$db->setQuery($query);
@@ -623,7 +623,7 @@ class InstallationModelDatabase extends JModelBase
 		if (in_array($options->language, $languages['admin']) || in_array($options->language, $languages['site']))
 		{
 			// Build the language parameters for the language manager.
-			$params = array();
+			$params = [];
 
 			// Set default administrator/site language to sample data values.
 			$params['administrator'] = 'en-GB';
@@ -798,19 +798,19 @@ class InstallationModelDatabase extends JModelBase
 		$userId = self::getUserId();
 
 		// Update all core tables created_by fields of the tables with the random user id.
-		$updatesArray = array(
-			'#__banners'         => array('created_by', 'modified_by'),
-			'#__categories'      => array('created_user_id', 'modified_user_id'),
-			'#__contact_details' => array('created_by', 'modified_by'),
-			'#__content'         => array('created_by', 'modified_by'),
-			'#__fields'          => array('created_user_id', 'modified_by'),
-			'#__finder_filters'  => array('created_by', 'modified_by'),
-			'#__newsfeeds'       => array('created_by', 'modified_by'),
-			'#__tags'            => array('created_user_id', 'modified_user_id'),
-			'#__ucm_content'     => array('core_created_user_id', 'core_modified_user_id'),
-			'#__ucm_history'     => array('editor_user_id'),
-			'#__user_notes'      => array('created_user_id', 'modified_user_id'),
-		);
+		$updatesArray = [
+			'#__banners'         => ['created_by', 'modified_by'],
+			'#__categories'      => ['created_user_id', 'modified_user_id'],
+			'#__contact_details' => ['created_by', 'modified_by'],
+			'#__content'         => ['created_by', 'modified_by'],
+			'#__fields'          => ['created_user_id', 'modified_by'],
+			'#__finder_filters'  => ['created_by', 'modified_by'],
+			'#__newsfeeds'       => ['created_by', 'modified_by'],
+			'#__tags'            => ['created_user_id', 'modified_user_id'],
+			'#__ucm_content'     => ['core_created_user_id', 'core_modified_user_id'],
+			'#__ucm_history'     => ['editor_user_id'],
+			'#__user_notes'      => ['created_user_id', 'modified_user_id'],
+		];
 
 		foreach ($updatesArray as $table => $fields)
 		{
@@ -852,26 +852,26 @@ class InstallationModelDatabase extends JModelBase
 		$nullDate    = $db->getNullDate();
 
 		// Update all core tables date fields of the tables with the current date.
-		$updatesArray = array(
-			'#__banners'             => array('publish_up', 'publish_down', 'reset', 'created', 'modified'),
-			'#__banner_tracks'       => array('track_date'),
-			'#__categories'          => array('created_time', 'modified_time'),
-			'#__contact_details'     => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__content'             => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__contentitem_tag_map' => array('tag_date'),
-			'#__fields'              => array('created_time', 'modified_time'),
-			'#__finder_filters'      => array('created', 'modified'),
-			'#__finder_links'        => array('indexdate', 'publish_start_date', 'publish_end_date', 'start_date', 'end_date'),
-			'#__messages'            => array('date_time'),
-			'#__modules'             => array('publish_up', 'publish_down'),
-			'#__newsfeeds'           => array('publish_up', 'publish_down', 'created', 'modified'),
-			'#__redirect_links'      => array('created_date', 'modified_date'),
-			'#__tags'                => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
-			'#__ucm_content'         => array('core_created_time', 'core_modified_time', 'core_publish_up', 'core_publish_down'),
-			'#__ucm_history'         => array('save_date'),
-			'#__users'               => array('registerDate', 'lastvisitDate', 'lastResetTime'),
-			'#__user_notes'          => array('publish_up', 'publish_down', 'created_time', 'modified_time'),
-		);
+		$updatesArray = [
+			'#__banners'             => ['publish_up', 'publish_down', 'reset', 'created', 'modified'],
+			'#__banner_tracks'       => ['track_date'],
+			'#__categories'          => ['created_time', 'modified_time'],
+			'#__contact_details'     => ['publish_up', 'publish_down', 'created', 'modified'],
+			'#__content'             => ['publish_up', 'publish_down', 'created', 'modified'],
+			'#__contentitem_tag_map' => ['tag_date'],
+			'#__fields'              => ['created_time', 'modified_time'],
+			'#__finder_filters'      => ['created', 'modified'],
+			'#__finder_links'        => ['indexdate', 'publish_start_date', 'publish_end_date', 'start_date', 'end_date'],
+			'#__messages'            => ['date_time'],
+			'#__modules'             => ['publish_up', 'publish_down'],
+			'#__newsfeeds'           => ['publish_up', 'publish_down', 'created', 'modified'],
+			'#__redirect_links'      => ['created_date', 'modified_date'],
+			'#__tags'                => ['publish_up', 'publish_down', 'created_time', 'modified_time'],
+			'#__ucm_content'         => ['core_created_time', 'core_modified_time', 'core_publish_up', 'core_publish_down'],
+			'#__ucm_history'         => ['save_date'],
+			'#__users'               => ['registerDate', 'lastvisitDate', 'lastResetTime'],
+			'#__user_notes'          => ['publish_up', 'publish_down', 'created_time', 'modified_time'],
+		];
 
 		foreach ($updatesArray as $table => $fields)
 		{
@@ -1132,8 +1132,8 @@ class InstallationModelDatabase extends JModelBase
 	 */
 	protected function splitQueries($query)
 	{
-		$buffer    = array();
-		$queries   = array();
+		$buffer    = [];
+		$queries   = [];
 		$in_string = false;
 
 		// Trim any whitespace.

--- a/installation/model/ftp.php
+++ b/installation/model/ftp.php
@@ -34,7 +34,7 @@ class InstallationModelFtp extends JModelBase
 
 		// Connect and login to the FTP server.
 		// Use binary transfer mode to be able to compare files.
-		@$ftp = JClientFtp::getInstance($options->get('ftp_host'), $options->get('ftp_port'), array('type' => FTP_BINARY));
+		@$ftp = JClientFtp::getInstance($options->get('ftp_host'), $options->get('ftp_port'), ['type' => FTP_BINARY]);
 
 		// Check to make sure FTP is connected and authenticated.
 		if (!$ftp->isConnected())
@@ -82,8 +82,8 @@ class InstallationModelFtp extends JModelBase
 		}
 
 		// Check to see if Joomla is installed at the FTP current working directory.
-		$paths = array();
-		$known = array('administrator', 'components', 'installation', 'language', 'libraries', 'plugins');
+		$paths = [];
+		$known = ['administrator', 'components', 'installation', 'language', 'libraries', 'plugins'];
 
 		if (count(array_diff($known, $cwdFolders)) == 0)
 		{
@@ -220,7 +220,7 @@ class InstallationModelFtp extends JModelBase
 		}
 
 		// Verify valid root path, part one.
-		$checkList = array('robots.txt', 'index.php');
+		$checkList = ['robots.txt', 'index.php'];
 
 		if (count(array_diff($checkList, $rootList)))
 		{

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -101,12 +101,12 @@ class InstallationModelLanguages extends JModelBase
 			 * In #__update_sites_extensions you should have this extension_id linked
 			 * to the Accredited Translations Repo.
 			 */
-			$updater->findUpdates(array($extId), 0);
+			$updater->findUpdates([$extId], 0);
 
 			$query = $db->getQuery(true);
 
 			// Select the required fields from the updates table.
-			$query->select($db->qn(array('update_id', 'name', 'element', 'version')))
+			$query->select($db->qn(['update_id', 'name', 'element', 'version']))
 				->from($db->qn('#__updates'))
 				->order($db->qn('name'));
 
@@ -115,12 +115,12 @@ class InstallationModelLanguages extends JModelBase
 
 			if (!$list || $list instanceof Exception)
 			{
-				$list = array();
+				$list = [];
 			}
 		}
 		else
 		{
-			$list = array();
+			$list = [];
 		}
 
 		return $list;
@@ -307,7 +307,7 @@ class InstallationModelLanguages extends JModelBase
 		$langlist = $this->getLanguageList($client->id);
 
 		// Compute all the languages.
-		$data = array();
+		$data = [];
 
 		foreach ($langlist as $lang)
 		{
@@ -342,7 +342,7 @@ class InstallationModelLanguages extends JModelBase
 			$data[]           = $row;
 		}
 
-		usort($data, array($this, 'compareLanguages'));
+		usort($data, [$this, 'compareLanguages']);
 
 		return $data;
 	}
@@ -363,7 +363,7 @@ class InstallationModelLanguages extends JModelBase
 		$query = $db->getQuery(true);
 
 		// Select field element from the extensions table.
-		$query->select($db->qn(array('element', 'name')))
+		$query->select($db->qn(['element', 'name']))
 			->from($db->qn('#__extensions'))
 			->where($db->qn('type') . ' = ' . $db->q('language'))
 			->where($db->qn('state') . ' = 0')
@@ -444,7 +444,7 @@ class InstallationModelLanguages extends JModelBase
 		$params->set($client->name, $language);
 
 		$table = JTable::getInstance('extension');
-		$id    = $table->find(array('element' => 'com_languages'));
+		$id    = $table->find(['element' => 'com_languages']);
 
 		// Load
 		if (!$table->load($id))
@@ -484,7 +484,7 @@ class InstallationModelLanguages extends JModelBase
 	 */
 	public function getOptions()
 	{
-		return JFactory::getSession()->get('setup.options', array());
+		return JFactory::getSession()->get('setup.options', []);
 	}
 
 	/**
@@ -510,7 +510,7 @@ class InstallationModelLanguages extends JModelBase
 
 		try
 		{
-			$form = JForm::getInstance('jform', $view, array('control' => 'jform'));
+			$form = JForm::getInstance('jform', $view, ['control' => 'jform']);
 		}
 		catch (Exception $e)
 		{
@@ -609,7 +609,7 @@ class InstallationModelLanguages extends JModelBase
 		JTable::addIncludePath(JPATH_LIBRARIES . '/legacy/table/');
 		$tableModule = JTable::getInstance('Module', 'JTable');
 
-		$moduleData  = array(
+		$moduleData  = [
 			'id'        => 0,
 			'title'     => 'Language Switcher',
 			'note'      => '',
@@ -625,8 +625,8 @@ class InstallationModelLanguages extends JModelBase
 			'client_id' => 0,
 			'language'  => '*',
 			'published' => 1,
-			'rules'     => array(),
-		);
+			'rules'     => [],
+		];
 
 		// Bind the data.
 		if (!$tableModule->bind($moduleData))
@@ -667,7 +667,7 @@ class InstallationModelLanguages extends JModelBase
 		// Add Module in Module menus.
 		$query->clear()
 			->insert($db->qn('#__modules_menu'))
-			->columns(array($db->qn('moduleid'), $db->qn('menuid')))
+			->columns([$db->qn('moduleid'), $db->qn('menuid')])
 			->values($moduleId . ', 0');
 		$db->setQuery($query);
 
@@ -702,7 +702,7 @@ class InstallationModelLanguages extends JModelBase
 		// For each content language.
 		foreach ($siteLanguages as $siteLang)
 		{
-			if ($tableLanguage->load(array('lang_code' => $siteLang->language, 'published' => 0)))
+			if ($tableLanguage->load(['lang_code' => $siteLang->language, 'published' => 0]))
 			{
 				if (!$tableLanguage->publish())
 				{
@@ -785,7 +785,7 @@ class InstallationModelLanguages extends JModelBase
 			$nativeLanguageName = $itemLanguage->name;
 		}
 
-		$langData = array(
+		$langData = [
 			'lang_id'      => 0,
 			'lang_code'    => $itemLanguage->language,
 			'title'        => $itemLanguage->name,
@@ -797,7 +797,7 @@ class InstallationModelLanguages extends JModelBase
 			'description'  => '',
 			'metakey'      => '',
 			'metadesc'     => '',
-		);
+		];
 
 		// Bind the data.
 		if (!$tableLanguage->bind($langData))
@@ -844,12 +844,12 @@ class InstallationModelLanguages extends JModelBase
 		// Add Menu Group.
 		$tableMenu = JTable::getInstance('Type', 'JTableMenu');
 
-		$menuData = array(
+		$menuData = [
 			'id'          => 0,
 			'menutype'    => 'mainmenu-' . strtolower($itemLanguage->language),
 			'title'       => 'Main Menu (' . $itemLanguage->language . ')',
 			'description' => 'The main menu for the site in language ' . $itemLanguage->name,
-		);
+		];
 
 		// Bind the data.
 		if (!$tableMenu->bind($menuData))
@@ -891,7 +891,7 @@ class InstallationModelLanguages extends JModelBase
 		$title = $newlanguage->_('COM_LANGUAGES_HOMEPAGE');
 		$alias = 'home_' . $itemLanguage->language;
 
-		$menuItem = array(
+		$menuItem = [
 			'title'        => $title,
 			'alias'        => $alias,
 			'menutype'     => 'mainmenu-' . strtolower($itemLanguage->language),
@@ -913,7 +913,7 @@ class InstallationModelLanguages extends JModelBase
 				. '"menu-anchor_css":"","menu_image":"","show_page_heading":1,"page_title":"","page_heading":"",'
 				. '"pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}',
 			'language'     => $itemLanguage->language,
-		);
+		];
 
 		// Bind the data.
 		if (!$tableItem->bind($menuItem))
@@ -958,7 +958,7 @@ class InstallationModelLanguages extends JModelBase
 		$tableModule = JTable::getInstance('Module', 'JTable');
 		$title = 'Main menu ' . $itemLanguage->language;
 
-		$moduleData = array(
+		$moduleData = [
 			'id'        => 0,
 			'title'     => $title,
 			'note'      => '',
@@ -973,8 +973,8 @@ class InstallationModelLanguages extends JModelBase
 			'client_id' => 0,
 			'language'  => $itemLanguage->language,
 			'published' => 1,
-			'rules' => array(),
-		);
+			'rules'     => [],
+		];
 
 		// Bind the data.
 		if (!$tableModule->bind($moduleData))
@@ -1085,7 +1085,7 @@ class InstallationModelLanguages extends JModelBase
 		// Initialize a new category.
 		$category = JTable::getInstance('Category');
 
-		$data = array(
+		$data = [
 			'extension'       => 'com_content',
 			'title'           => $title . ' (' . strtolower($itemLanguage->language) . ')',
 			'description'     => '',
@@ -1098,9 +1098,9 @@ class InstallationModelLanguages extends JModelBase
 			'created_time'    => JFactory::getDate()->toSql(),
 			'created_user_id' => (int) $this->getAdminId(),
 			'language'        => $itemLanguage->language,
-			'rules'           => array(),
+			'rules'           => [],
 			'parent_id'       => 1,
-		);
+		];
 
 		// Set the location in the tree.
 		$category->setLocation(1, 'last-child');
@@ -1151,7 +1151,7 @@ class InstallationModelLanguages extends JModelBase
 		// Initialize a new article.
 		$article = JTable::getInstance('Content');
 
-		$data = array(
+		$data = [
 			'title'            => $title . ' (' . strtolower($itemLanguage->language) . ')',
 			'introtext'        => '<p>Lorem ipsum ad his scripta blandit partiendo, eum fastidii accumsan euripidis'
 										. ' in, eum liber hendrerit an. Qui ut wisi vocibus suscipiantur, quo dicit'
@@ -1161,8 +1161,8 @@ class InstallationModelLanguages extends JModelBase
 										. 'equidem dolores. Quo no falli viris intellegam, ut fugit veritus placerat'
 										. 'per. Ius id vidit volumus mandamus, vide veritus democritum te nec, ei eos'
 										. 'debet libris consulatu.</p>',
-			'images'           => json_encode(array()),
-			'urls'             => json_encode(array()),
+			'images'           => json_encode([]),
+			'urls'             => json_encode([]),
 			'state'            => 1,
 			'created'          => $currentDate,
 			'created_by'       => (int) $this->getAdminId(),
@@ -1176,9 +1176,9 @@ class InstallationModelLanguages extends JModelBase
 			'metadesc'         => '',
 			'language'         => $itemLanguage->language,
 			'featured'         => 1,
-			'attribs'          => array(),
-			'rules'            => array(),
-		);
+			'attribs'          => [],
+			'rules'            => [],
+		];
 
 		// Bind the data to the table
 		if (!$article->bind($data))

--- a/installation/model/setup.php
+++ b/installation/model/setup.php
@@ -25,7 +25,7 @@ class InstallationModelSetup extends JModelBase
 	 */
 	public function getOptions()
 	{
-		return JFactory::getSession()->get('setup.options', array());
+		return JFactory::getSession()->get('setup.options', []);
 	}
 
 	/**
@@ -80,7 +80,7 @@ class InstallationModelSetup extends JModelBase
 
 		try
 		{
-			$form = JForm::getInstance('jform', $view, array('control' => 'jform'));
+			$form = JForm::getInstance('jform', $view, ['control' => 'jform']);
 		}
 		catch (Exception $e)
 		{
@@ -113,7 +113,7 @@ class InstallationModelSetup extends JModelBase
 	public function checkForm($page = 'site')
 	{
 		// Get the posted values from the request and validate them.
-		$data   = JFactory::getApplication()->input->post->get('jform', array(), 'array');
+		$data   = JFactory::getApplication()->input->post->get('jform', [], 'array');
 		$return = $this->validate($data, $page);
 
 		// Attempt to save the data before validation.
@@ -166,7 +166,7 @@ class InstallationModelSetup extends JModelBase
 
 		if (!$list || $list instanceof Exception)
 		{
-			$list = array();
+			$list = [];
 		}
 
 		return $list;
@@ -214,7 +214,7 @@ class InstallationModelSetup extends JModelBase
 	 */
 	public function getPhpOptions()
 	{
-		$options = array();
+		$options = [];
 
 		// Check the PHP Version.
 		$option = new stdClass;
@@ -331,7 +331,7 @@ class InstallationModelSetup extends JModelBase
 	 */
 	public function getPhpSettings()
 	{
-		$settings = array();
+		$settings = [];
 
 		// Check for safe mode.
 		$setting = new stdClass;

--- a/installation/service/provider/session.php
+++ b/installation/service/provider/session.php
@@ -49,10 +49,10 @@ class InstallationServiceProviderSession implements ServiceProviderInterface
 					$lifetime = (($app->get('lifetime')) ? $app->get('lifetime') * 60 : 900);
 
 					// Initialize the options for the Session object.
-					$options = array(
+					$options = [
 						'name'   => $name,
 						'expire' => $lifetime
-					);
+					];
 
 					// Set up the storage handler
 					$handler = new FilesystemHandler(JPATH_INSTALLATION . '/sessions');
@@ -62,7 +62,7 @@ class InstallationServiceProviderSession implements ServiceProviderInterface
 					$storage = new JoomlaStorage($input, $handler);
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');
-					$dispatcher->addListener('onAfterSessionStart', array($app, 'afterSessionStart'));
+					$dispatcher->addListener('onAfterSessionStart', [$app, 'afterSessionStart']);
 
 					$session = new JSession($storage, $dispatcher, $options);
 					$session->addValidator(new AddressValidator($input, $session));

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -26,11 +26,11 @@ JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.core');
 
 // Add installation js
-JHtml::_('script', 'installation/template/js/installation.js', array('version' => 'auto'));
+JHtml::_('script', 'installation/template/js/installation.js', ['version' => 'auto']);
 
 // Add Stylesheets
 JHtml::_('bootstrap.loadCss', true, $this->direction);
-JHtml::_('stylesheet', 'installation/template/css/template.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'installation/template/css/template.css', ['version' => 'auto']);
 
 // Load JavaScript message titles
 JText::script('ERROR');
@@ -50,7 +50,7 @@ JText::script('INSTL_PROCESS_BUSY');
 JText::script('INSTL_FTP_SETTINGS_CORRECT');
 
 // Add script options
-$this->addScriptOptions('system.installation', array('url' => JRoute::_('index.php')));
+$this->addScriptOptions('system.installation', ['url' => JRoute::_('index.php')]);
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/installation/view/install/html.php
+++ b/installation/view/install/html.php
@@ -38,7 +38,7 @@ class InstallationViewInstallHtml extends JViewHtml
 	 * @var    array
 	 * @since  3.1
 	 */
-	protected $tasks = array();
+	protected $tasks = [];
 
 	/**
 	 * Method to render the view.


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in installation.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.