### PR TITLE
[4.0] Array to php 5.4+ notation [Site/Admin Language]

### DIFF
--- a/administrator/language/en-GB/en-GB.localise.php
+++ b/administrator/language/en-GB/en-GB.localise.php
@@ -28,15 +28,15 @@ abstract class En_GBLocalise
 	{
 		if ($count == 0)
 		{
-			return array('0');
+			return ['0'];
 		}
 		elseif ($count == 1)
 		{
-			return array('1');
+			return ['1'];
 		}
 		else
 		{
-			return array('MORE');
+			return ['MORE'];
 		}
 	}
 
@@ -49,7 +49,7 @@ abstract class En_GBLocalise
 	 */
 	public static function getIgnoredSearchWords()
 	{
-		return array('and', 'in', 'on');
+		return ['and', 'in', 'on'];
 	}
 
 	/**

--- a/language/en-GB/en-GB.localise.php
+++ b/language/en-GB/en-GB.localise.php
@@ -28,15 +28,15 @@ abstract class En_GBLocalise
 	{
 		if ($count == 0)
 		{
-			return array('0');
+			return ['0'];
 		}
 		elseif ($count == 1)
 		{
-			return array('1');
+			return ['1'];
 		}
 		else
 		{
-			return array('MORE');
+			return ['MORE'];
 		}
 	}
 
@@ -49,7 +49,7 @@ abstract class En_GBLocalise
 	 */
 	public static function getIgnoredSearchWords()
 	{
-		return array('and', 'in', 'on');
+		return ['and', 'in', 'on'];
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in site/admin language.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.