### PR TITLE
[4.0] Array to php 5.4+ notation [Build/Cli/Includes folders]

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -14,7 +14,7 @@ require_once JPATH_LIBRARIES . '/bootstrap.php';
 // Set system error handling
 JError::setErrorHandling(E_NOTICE, 'message');
 JError::setErrorHandling(E_WARNING, 'message');
-JError::setErrorHandling(E_ERROR, 'message', array('JError', 'customErrorPage'));
+JError::setErrorHandling(E_ERROR, 'message', ['JError', 'customErrorPage']);
 
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')

--- a/build/build.php
+++ b/build/build.php
@@ -72,34 +72,34 @@ echo "Create list of changed files from git repository.\n";
  * So we add the index file for each top-level directory.
  * Note: If we add new top-level directories or files, be sure to include them here.
  */
-$filesArray = array(
+$filesArray = [
 	"administrator/index.php\n" => true,
-	"cache/index.html\n" => true,
-	"cli/index.html\n" => true,
-	"components/index.html\n" => true,
-	"images/index.html\n" => true,
-	"includes/index.html\n" => true,
-	"language/index.html\n" => true,
-	"layouts/index.html\n" => true,
-	"libraries/index.html\n" => true,
-	"media/index.html\n" => true,
-	"modules/index.html\n" => true,
-	"plugins/index.html\n" => true,
-	"templates/index.html\n" => true,
-	"tmp/index.html\n" => true,
-	"htaccess.txt\n" => true,
-	"index.php\n" => true,
-	"LICENSE.txt\n" => true,
-	"README.txt\n" => true,
-	"robots.txt.dist\n" => true,
-	"web.config.txt\n" => true
-);
+	"cache/index.html\n"        => true,
+	"cli/index.html\n"          => true,
+	"components/index.html\n"   => true,
+	"images/index.html\n"       => true,
+	"includes/index.html\n"     => true,
+	"language/index.html\n"     => true,
+	"layouts/index.html\n"      => true,
+	"libraries/index.html\n"    => true,
+	"media/index.html\n"        => true,
+	"modules/index.html\n"      => true,
+	"plugins/index.html\n"      => true,
+	"templates/index.html\n"    => true,
+	"tmp/index.html\n"          => true,
+	"htaccess.txt\n"            => true,
+	"index.php\n"               => true,
+	"LICENSE.txt\n"             => true,
+	"README.txt\n"              => true,
+	"robots.txt.dist\n"         => true,
+	"web.config.txt\n"          => true,
+];
 
 /*
  * Here we set the files/folders which should not be packaged at any time
  * These paths are from the repository root without the leading slash
  */
-$doNotPackage = array(
+$doNotPackage = [
 	'.appveyor.yml',
 	'.drone.yml',
 	'.github',
@@ -126,17 +126,17 @@ $doNotPackage = array(
 	// Remove the testing sample data from all packages
 	'installation/sql/mysql/sample_testing.sql',
 	'installation/sql/postgresql/sample_testing.sql',
-);
+];
 
 /*
  * Here we set the files/folders which should not be packaged with patch packages only
  * These paths are from the repository root without the leading slash
  */
-$doNotPatch = array(
+$doNotPatch = [
 	'administrator/logs',
 	'installation',
 	'images',
-);
+];
 
 // For the packages, replace spaces in stability (RC) with underscores
 $packageStability = str_replace(' ', '_', $stability);
@@ -153,7 +153,7 @@ for ($num = $release - 1; $num >= 0; $num--)
 	system($command);
 
 	// $filesArray will hold the array of files to include in diff package
-	$deletedFiles = array();
+	$deletedFiles = [];
 	$files        = file('diffdocs/' . $version . '.' . $num);
 
 	// Loop through and add all files except: tests, installation, build, .git, .travis, travis, phpunit, .md, or images

--- a/build/bump.php
+++ b/build/bump.php
@@ -38,39 +38,38 @@ const PHP_TAB = "\t";
 // File paths.
 $versionFile      = '/libraries/src/Joomla/CMS/Version.php';
 
-$coreXmlFiles     = array(
-			'/administrator/manifests/files/joomla.xml',
-			);
+$coreXmlFiles     = [
+	'/administrator/manifests/files/joomla.xml',
+];
 
-$languageXmlFiles = array(
-			'/language/en-GB/en-GB.xml',
-			'/language/en-GB/install.xml',
-			'/administrator/language/en-GB/en-GB.xml',
-			'/administrator/language/en-GB/install.xml',
-			'/installation/language/en-GB/en-GB.xml',
-			);
+$languageXmlFiles = [
+	'/language/en-GB/en-GB.xml',
+	'/language/en-GB/install.xml',
+	'/administrator/language/en-GB/en-GB.xml',
+	'/administrator/language/en-GB/install.xml',
+	'/installation/language/en-GB/en-GB.xml',
+];
 
 $languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
 
 $antJobFile = '/build.xml';
 
-$readMeFiles = array(
-			'/README.md',
-			'/README.txt',
-			);
+$readMeFiles = [
+	'/README.md',
+	'/README.txt',
+];
 
 // Change copyright date exclusions.
-$directoryLoopExcludeDirectories = array(
-			'/libraries/vendor/',
-			'/libraries/phputf8/',
-			'/libraries/php-encryption/',
-			'/libraries/phpass/',
-			'/libraries/idna_convert/',
-			'/libraries/fof/',
-			);
+$directoryLoopExcludeDirectories = [
+	'/libraries/vendor/',
+	'/libraries/phputf8/',
+	'/libraries/php-encryption/',
+	'/libraries/phpass/',
+	'/libraries/idna_convert/',
+	'/libraries/fof/',
+];
 
-$directoryLoopExcludeFiles = array(
-			);
+$directoryLoopExcludeFiles = [];
 
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
@@ -148,17 +147,17 @@ else
 // Set version properties.
 $versionSubParts = explode('.', $versionParts[0]);
 
-$version = array(
-		'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
-		'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
-		'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
-		'dev_status' => $dev_status,
-		'build'      => '',
-		'reldate'    => date('j-F-Y'),
-		'reltime'    => date('H:i'),
-		'reltz'      => 'GMT',
-		'credate'    => date('F Y'),
-		);
+$version = [
+	'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
+	'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
+	'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
+	'dev_status' => $dev_status,
+	'build'      => '',
+	'reldate'    => date('j-F-Y'),
+	'reltime'    => date('H:i'),
+	'reltz'      => 'GMT',
+	'credate'    => date('F Y'),
+];
 
 // Version Codename.
 if (!empty($opts['c']))

--- a/build/helpTOC.php
+++ b/build/helpTOC.php
@@ -65,7 +65,7 @@ class MediawikiCli extends \Joomla\CMS\Application\CliApplication
 		$this->out('Fetching data from docs wiki', true);
 		$categoryMembers = $mediawiki->categories->getCategoryMembers('Category:Help_screen_' . $version::RELEASE, null, 'max');
 
-		$members = array();
+		$members = [];
 
 		// Loop through the result objects to get every document
 		foreach ($categoryMembers->query->categorymembers as $catmembers)
@@ -89,12 +89,12 @@ class MediawikiCli extends \Joomla\CMS\Application\CliApplication
 		 * Now we start fancy processing so we can get the language key for the titles
 		 */
 
-		$cleanMembers = array();
+		$cleanMembers = [];
 
 		// Strip the namespace prefix off the titles and replace spaces with underscores
 		foreach ($members as $member)
 		{
-			$cleanMembers[] = str_replace(array($namespace, ' '), array('', '_'), $member);
+			$cleanMembers[] = str_replace([$namespace, ' '], ['', '_'], $member);
 		}
 
 		// Make sure we only have an array of unique values before continuing
@@ -104,7 +104,7 @@ class MediawikiCli extends \Joomla\CMS\Application\CliApplication
 		 * Loop through the cleaned up title array and the language strings array to match things up
 		 */
 
-		$matchedMembers = array();
+		$matchedMembers = [];
 
 		foreach ($cleanMembers as $member)
 		{
@@ -123,7 +123,7 @@ class MediawikiCli extends \Joomla\CMS\Application\CliApplication
 		asort($matchedMembers);
 
 		// Now we strip off the JHELP_ prefix from the strings to get usable strings for both COM_ADMIN and JHELP
-		$stripped = array();
+		$stripped = [];
 
 		foreach ($matchedMembers as $member)
 		{
@@ -137,7 +137,7 @@ class MediawikiCli extends \Joomla\CMS\Application\CliApplication
 		// Load the admin com_admin language file
 		$language->load('com_admin', JPATH_ADMINISTRATOR);
 
-		$toc = array();
+		$toc = [];
 
 		foreach ($stripped as $string)
 		{

--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -86,7 +86,7 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 	 * @var    array
 	 * @since  3.3
 	 */
-	private $filters = array();
+	private $filters = [];
 
 	/**
 	 * Entry point for Smart Search CLI script
@@ -271,7 +271,7 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 		// Use the temporary filter information to update the filter taxonomy ids.
 		foreach ($this->filters as $filter_id => $filter)
 		{
-			$tids = array();
+			$tids = [];
 
 			foreach ($filter as $element)
 			{
@@ -356,11 +356,11 @@ class FinderCli extends \Joomla\CMS\Application\CliApplication
 			// Construct a temporary data structure to hold the filter information.
 			foreach ($taxonomies as $taxonomy)
 			{
-				$this->filters[$filter->filter_id][] = array(
+				$this->filters[$filter->filter_id][] = [
 					'filter' => $filter->title,
 					'title'  => $taxonomy->title,
 					'parent' => $taxonomy->parent,
-				);
+				];
 			}
 		}
 

--- a/includes/framework.php
+++ b/includes/framework.php
@@ -14,7 +14,7 @@ require_once JPATH_LIBRARIES . '/bootstrap.php';
 // Set system error handling
 JError::setErrorHandling(E_NOTICE, 'message');
 JError::setErrorHandling(E_WARNING, 'message');
-JError::setErrorHandling(E_ERROR, 'callback', array('JError', 'customErrorPage'));
+JError::setErrorHandling(E_ERROR, 'callback', ['JError', 'customErrorPage']);
 
 // Installation check, and check on removal of the install directory.
 if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in buil/cli and site/admin includes folders.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.