### PR TITLE
[4.0] Array to php 5.4+ notation [Plugins 1: Authentication, Behaviour, Captcha and Content]

### DIFF
--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -103,7 +103,7 @@ class PlgAuthenticationCookie extends JPlugin
 
 		// Find the matching record if it exists.
 		$query = $this->db->getQuery(true)
-			->select($this->db->quoteName(array('user_id', 'token', 'series', 'time')))
+			->select($this->db->quoteName(['user_id', 'token', 'series', 'time']))
 			->from($this->db->quoteName('#__user_keys'))
 			->where($this->db->quoteName('series') . ' = ' . $this->db->quote($series))
 			->where($this->db->quoteName('uastring') . ' = ' . $this->db->quote($cookieName))
@@ -166,7 +166,7 @@ class PlgAuthenticationCookie extends JPlugin
 
 		// Make sure there really is a user with this name and get the data for the session.
 		$query = $this->db->getQuery(true)
-			->select($this->db->quoteName(array('id', 'username', 'password')))
+			->select($this->db->quoteName(['id', 'username', 'password']))
 			->from($this->db->quoteName('#__users'))
 			->where($this->db->quoteName('username') . ' = ' . $this->db->quote($results[0]->user_id))
 			->where($this->db->quoteName('requireReset') . ' = 0');

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -42,12 +42,12 @@ class PlgAuthenticationGMail extends JPlugin
 
 		$success = false;
 
-		$curlParams = array(
+		$curlParams = [
 			'follow_location' => true,
-			'transport.curl'  => array(
+			'transport.curl'  => [
 				CURLOPT_SSL_VERIFYPEER => $this->params->get('verifypeer', 1)
-			),
-		);
+			],
+		];
 
 		$transportParams = new Registry($curlParams);
 
@@ -111,9 +111,9 @@ class PlgAuthenticationGMail extends JPlugin
 			}
 		}
 
-		$headers = array(
+		$headers = [
 			'Authorization' => 'Basic ' . base64_encode($credentials['username'] . ':' . $credentials['password'])
-		);
+		];
 
 		try
 		{
@@ -175,12 +175,12 @@ class PlgAuthenticationGMail extends JPlugin
 
 		// Extra security checks with existing local accounts
 		$db                  = JFactory::getDbo();
-		$localUsernameChecks = array(strstr($email, '@', true), $email);
+		$localUsernameChecks = [strstr($email, '@', true), $email];
 
 		$query = $db->getQuery(true)
 			->select('id, activation, username, email, block')
 			->from('#__users')
-			->where('username IN(' . implode(',', array_map(array($db, 'quote'), $localUsernameChecks)) . ')'
+			->where('username IN(' . implode(',', array_map([$db, 'quote'], $localUsernameChecks)) . ')'
 				. ' OR email = ' . $db->quote($email)
 			);
 

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -105,7 +105,7 @@ class PlgAuthenticationJoomla extends JPlugin
 			}
 
 			/** @var \Joomla\Component\Users\Administrator\Model\User $model */
-			$model = new User(array('ignore_request' => true));
+			$model = new User(['ignore_request' => true]);
 
 			// Load the user's OTP (one time password, a.k.a. two factor auth) configuration
 			if (!array_key_exists('otp_config', $options))
@@ -147,7 +147,7 @@ class PlgAuthenticationJoomla extends JPlugin
 			// Try to validate the OTP
 			JPluginHelper::importPlugin('twofactorauth');
 
-			$otpAuthReplies = JFactory::getApplication()->triggerEvent('onUserTwofactorAuthenticate', array($credentials, $options));
+			$otpAuthReplies = JFactory::getApplication()->triggerEvent('onUserTwofactorAuthenticate', [$credentials, $options]);
 
 			$check = false;
 
@@ -199,7 +199,7 @@ class PlgAuthenticationJoomla extends JPlugin
 				if (in_array($otep, $otpConfig->otep))
 				{
 					// Remove the OTEP from the array
-					$otpConfig->otep = array_diff($otpConfig->otep, array($otep));
+					$otpConfig->otep = array_diff($otpConfig->otep, [$otep]);
 
 					$model->setOtpConfig($result->id, $otpConfig);
 

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -33,7 +33,7 @@ class PlgAuthenticationLdap extends JPlugin
 	{
 		$userdetails = null;
 		$success = 0;
-		$userdetails = array();
+		$userdetails = [];
 
 		// For JLog
 		$response->type = 'LDAP';

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -31,7 +31,7 @@ class PlgBehaviourTaggable extends JPlugin
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(&$subject, $config = array())
+	public function __construct(&$subject, $config = [])
 	{
 		$this->allowLegacyListeners = false;
 
@@ -115,7 +115,7 @@ class PlgBehaviourTaggable extends JPlugin
 		$tagsHelper            = $table->tagsHelper;
 		$tagsHelper->typeAlias = $typeAlias;
 
-		$newTags = isset($table->newTags) ? $table->newTags : array();
+		$newTags = isset($table->newTags) ? $table->newTags : [];
 
 		if (empty($newTags))
 		{
@@ -173,7 +173,7 @@ class PlgBehaviourTaggable extends JPlugin
 		$tagsHelper            = $table->tagsHelper;
 		$tagsHelper->typeAlias = $typeAlias;
 
-		$newTags = isset($table->newTags) ? $table->newTags : array();
+		$newTags = isset($table->newTags) ? $table->newTags : [];
 
 		if (empty($newTags))
 		{

--- a/plugins/behaviour/versionable/versionable.php
+++ b/plugins/behaviour/versionable/versionable.php
@@ -31,7 +31,7 @@ class PlgBehaviourVersionable extends JPlugin
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function __construct(&$subject, $config = array())
+	public function __construct(&$subject, $config = [])
 	{
 		$this->allowLegacyListeners = false;
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -59,7 +59,7 @@ class PlgCaptchaRecaptcha extends JPlugin
 		else
 		{
 			// Load callback first for browser compatibility
-			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', array('version' => 'auto', 'relative' => true));
+			JHtml::_('script', 'plg_captcha_recaptcha/recaptcha.min.js', ['version' => 'auto', 'relative' => true]);
 
 			$file = 'https://www.google.com/recaptcha/api.js?onload=JoomlaInitReCaptcha2&render=explicit&hl=' . JFactory::getLanguage()->getTag();
 			JHtml::_('script', $file);
@@ -172,12 +172,12 @@ class PlgCaptchaRecaptcha extends JPlugin
 			case '1.0':
 				$response = $this->_recaptcha_http_post(
 					'www.google.com', '/recaptcha/api/verify',
-					array(
+					[
 						'privatekey' => $privatekey,
 						'remoteip'   => $remoteip,
 						'challenge'  => $challenge,
-						'response'   => $response
-					)
+						'response'   => $response,
+					]
 				);
 
 				$answers = explode("\n", $response[1]);
@@ -291,9 +291,9 @@ class PlgCaptchaRecaptcha extends JPlugin
 	{
 		$language = JFactory::getLanguage();
 
-		$tag = explode('-', $language->getTag());
-		$tag = $tag[0];
-		$available = array('en', 'pt', 'fr', 'de', 'nl', 'ru', 'es', 'tr');
+		$tag       = explode('-', $language->getTag());
+		$tag       = $tag[0];
+		$available = ['en', 'pt', 'fr', 'de', 'nl', 'ru', 'es', 'tr'];
 
 		if (in_array($tag, $available))
 		{

--- a/plugins/content/contact/contact.php
+++ b/plugins/content/contact/contact.php
@@ -38,7 +38,7 @@ class PlgContentContact extends JPlugin
 	 */
 	public function onContentPrepare($context, &$row, $params, $page = 0)
 	{
-		$allowed_contexts = array('com_content.category', 'com_content.article', 'com_content.featured');
+		$allowed_contexts = ['com_content.category', 'com_content.article', 'com_content.featured'];
 
 		if (!in_array($context, $allowed_contexts))
 		{
@@ -82,7 +82,7 @@ class PlgContentContact extends JPlugin
 	 */
 	protected function getContactId($created_by)
 	{
-		static $contacts = array();
+		static $contacts = [];
 
 		if (isset($contacts[$created_by]))
 		{

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -67,8 +67,8 @@ class PlgContentFields extends JPlugin
 
 			$context    = $parts[0] . '.' . $parts[1];
 			$fields     = FieldsHelper::getFields($context, $item, true);
-			$fieldsById = array();
-			$groups     = array();
+			$fieldsById = [];
+			$groups     = [];
 
 			// Rearranging fields in arrays for easier lookup later.
 			foreach ($fields as $field)
@@ -93,11 +93,11 @@ class PlgContentFields extends JPlugin
 						$output = FieldsHelper::render(
 							$context,
 							'field.' . $layout,
-							array(
+							[
 								'item'    => $item,
 								'context' => $context,
 								'field'   => $fieldsById[$id]
-							)
+							]
 						);
 					}
 				}
@@ -118,11 +118,11 @@ class PlgContentFields extends JPlugin
 						$output = FieldsHelper::render(
 							$context,
 							'fields.' . $layout,
-							array(
+							[
 								'item'    => $item,
 								'context' => $context,
 								'fields'  => $renderFields
-							)
+							]
 						);
 					}
 				}

--- a/plugins/content/finder/finder.php
+++ b/plugins/content/finder/finder.php
@@ -34,7 +34,7 @@ class PlgContentFinder extends JPlugin
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderAfterSave event.
-		JFactory::getApplication()->triggerEvent('onFinderAfterSave', array($context, $article, $isNew));
+		JFactory::getApplication()->triggerEvent('onFinderAfterSave', [$context, $article, $isNew]);
 	}
 
 	/**
@@ -54,7 +54,7 @@ class PlgContentFinder extends JPlugin
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderBeforeSave event.
-		JFactory::getApplication()->triggerEvent('onFinderBeforeSave', array($context, $article, $isNew));
+		JFactory::getApplication()->triggerEvent('onFinderBeforeSave', [$context, $article, $isNew]);
 	}
 
 	/**
@@ -73,7 +73,7 @@ class PlgContentFinder extends JPlugin
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderAfterDelete event.
-		JFactory::getApplication()->triggerEvent('onFinderAfterDelete', array($context, $article));
+		JFactory::getApplication()->triggerEvent('onFinderAfterDelete', [$context, $article]);
 	}
 
 	/**
@@ -95,7 +95,7 @@ class PlgContentFinder extends JPlugin
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderChangeState event.
-		JFactory::getApplication()->triggerEvent('onFinderChangeState', array($context, $pks, $value));
+		JFactory::getApplication()->triggerEvent('onFinderChangeState', [$context, $pks, $value]);
 	}
 
 	/**
@@ -116,6 +116,6 @@ class PlgContentFinder extends JPlugin
 		JPluginHelper::importPlugin('finder');
 
 		// Trigger the onFinderCategoryChangeState event.
-		JFactory::getApplication()->triggerEvent('onFinderCategoryChangeState', array($extension, $pks, $value));
+		JFactory::getApplication()->triggerEvent('onFinderCategoryChangeState', [$extension, $pks, $value]);
 	}
 }

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -82,11 +82,11 @@ class PlgContentJoomla extends JPlugin
 				$receiver = JUser::getInstance($user_id);
 				$lang = JLanguage::getInstance($receiver->getParam('admin_language', $default_language), $debug);
 				$lang->load('com_content');
-				$message = array(
+				$message = [
 					'user_id_to' => $user_id,
-					'subject' => $lang->_('COM_CONTENT_NEW_ARTICLE'),
-					'message' => sprintf($lang->_('COM_CONTENT_ON_NEW_CONTENT'), $user->get('name'), $article->title)
-				);
+					'subject'    => $lang->_('COM_CONTENT_NEW_ARTICLE'),
+					'message'    => sprintf($lang->_('COM_CONTENT_ON_NEW_CONTENT'), $user->get('name'), $article->title)
+				];
 				$model_message = new Message;
 				$result = $model_message->save($message);
 			}
@@ -124,13 +124,13 @@ class PlgContentJoomla extends JPlugin
 		// Default to true if not a core extension
 		$result = true;
 
-		$tableInfo = array(
-			'com_banners' => array('table_name' => '#__banners'),
-			'com_contact' => array('table_name' => '#__contact_details'),
-			'com_content' => array('table_name' => '#__content'),
-			'com_newsfeeds' => array('table_name' => '#__newsfeeds'),
-			'com_weblinks' => array('table_name' => '#__weblinks')
-		);
+		$tableInfo = [
+			'com_banners'   => ['table_name' => '#__banners'],
+			'com_contact'   => ['table_name' => '#__contact_details'],
+			'com_content'   => ['table_name' => '#__content'],
+			'com_newsfeeds' => ['table_name' => '#__newsfeeds'],
+			'com_weblinks'  => ['table_name' => '#__weblinks'],
+		];
 
 		// Now check to see if this is a known core extension
 		if (isset($tableInfo[$extension]))
@@ -235,7 +235,7 @@ class PlgContentJoomla extends JPlugin
 
 		// First element in tree is the current category, so we can skip that one
 		unset($childCategoryTree[0]);
-		$childCategoryIds = array();
+		$childCategoryIds = [];
 
 		foreach ($childCategoryTree as $node)
 		{

--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -17,9 +17,9 @@ defined('_JEXEC') or die;
  */
 class PlgContentLoadmodule extends JPlugin
 {
-	protected static $modules = array();
+	protected static $modules = [];
 
-	protected static $mods = array();
+	protected static $mods = [];
 
 	/**
 	 * Plugin that loads module positions within content
@@ -135,7 +135,7 @@ class PlgContentLoadmodule extends JPlugin
 		$document = JFactory::getDocument();
 		$renderer = $document->loadRenderer('module');
 		$modules  = JModuleHelper::getModules($position);
-		$params   = array('style' => $style);
+		$params   = ['style' => $style];
 		ob_start();
 
 		foreach ($modules as $module)
@@ -175,7 +175,7 @@ class PlgContentLoadmodule extends JPlugin
 			$mod  = JModuleHelper::getModule($name, $title);
 		}
 
-		$params = array('style' => $style);
+		$params = ['style' => $style];
 		ob_start();
 
 		if ($mod->id)

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -103,7 +103,7 @@ class PlgContentPagebreak extends JPlugin
 		$this->loadLanguage();
 
 		// Find all instances of plugin and put in $matches.
-		$matches = array();
+		$matches = [];
 		preg_match_all($regex, $row->text, $matches, PREG_SET_ORDER);
 
 		if ($showall && $this->params->get('showall', 1))

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -125,11 +125,11 @@ class PlgContentPagenavigation extends JPlugin
 			$query = $db->getQuery(true);
 
 			$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-				. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+				. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 				. ' ELSE a.id END AS slug';
 
 			$case_when1 = ' CASE WHEN ' . $query->charLength('cc.alias', '!=', '0')
-				. ' THEN ' . $query->concatenate(array($query->castAsChar('cc.id'), 'cc.alias'), ':')
+				. ' THEN ' . $query->concatenate([$query->castAsChar('cc.id'), 'cc.alias'], ':')
 				. ' ELSE cc.id END AS catslug';
 
 			$query->select('a.id, a.title, a.catid, a.language')
@@ -154,7 +154,7 @@ class PlgContentPagenavigation extends JPlugin
 			// This check needed if incorrect Itemid is given resulting in an incorrect result.
 			if (!is_array($list))
 			{
-				$list = array();
+				$list = [];
 			}
 
 			reset($list);

--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -24,7 +24,7 @@ $uri = clone JUri::getInstance();
 $uri->setVar('hitcount', '0');
 
 // Create option list for voting select box
-$options = array();
+$options = [];
 
 for ($i = 1; $i < 6; $i++)
 {


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in Authentication, Behaviour, Captcha and Content plugins.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.