### PR TITLE
[4.0] Array to php 5.4+ notation [Plugins 2: Editors, Editors-XTD, Extension and Fields]

### DIFF
--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -51,12 +51,12 @@ class PlgButtonArticle extends JPlugin
 			$button->link = $link;
 			$button->text = JText::_('PLG_ARTICLE_BUTTON_ARTICLE');
 			$button->name = 'file-add';
-			$button->options = array(
+			$button->options = [
 				'height'     => '300px',
 				'width'      => '800px',
 				'bodyHeight' => '70',
 				'modalWidth' => '80',
-			);
+			];
 
 			return $button;
 		}

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -45,18 +45,18 @@ class PlgButtonContact extends JPlugin
 			$link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;'
 				. JSession::getFormToken() . '=1&amp;editor=' . $name;
 
-		$button = new JObject;
-		$button->modal   = true;
-		$button->class = 'btn btn-secondary';
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
-		$button->name    = 'address';
-		$button->options = array(
-			'height' => '300px',
-			'width'  => '800px',
-			'bodyHeight'  => '70',
-			'modalWidth'  => '80',
-		);
+			$button = new JObject;
+			$button->modal   = true;
+			$button->class = 'btn btn-secondary';
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
+			$button->name    = 'address';
+			$button->options = [
+				'height'     => '300px',
+				'width'      => '800px',
+				'bodyHeight' => '70',
+				'modalWidth' => '80',
+			];
 
 			return $button;
 		}

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -65,12 +65,12 @@ class PlgButtonImage extends JPlugin
 			$button->link    = $link;
 			$button->text    = JText::_('PLG_IMAGE_BUTTON_IMAGE');
 			$button->name    = 'pictures';
-			$button->options = array(
+			$button->options = [
 				'height'     => '300px',
 				'width'      => '800px',
 				'bodyHeight' => '70',
 				'modalWidth' => '80',
-			);
+			];
 
 			return $button;
 		}

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -43,22 +43,22 @@ class PlgButtonMenu extends JPlugin
 		if ($user->authorise('core.create', 'com_menus')
 			|| $user->authorise('core.edit', 'com_menus'))
 		{
-		$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;'
-			. JSession::getFormToken() . '=1&amp;editor=' . $name;
+			$link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;'
+				. JSession::getFormToken() . '=1&amp;editor=' . $name;
 
-		$button          = new JObject;
-		$button->modal   = true;
-		$button->link    = $link;
-		$button->text    = JText::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
-		$button->name    = 'share-alt';
-		$button->options = array(
-			'height' => '300px',
-			'width'  => '800px',
-			'bodyHeight'  => '70',
-			'modalWidth'  => '80',
-		);
+			$button          = new JObject;
+			$button->modal   = true;
+			$button->link    = $link;
+			$button->text    = JText::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
+			$button->name    = 'share-alt';
+			$button->options = [
+				'height'     => '300px',
+				'width'      => '800px',
+				'bodyHeight' => '70',
+				'modalWidth' => '80',
+			];
 
-		return $button;
+			return $button;
 		}
 	}
 }

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -53,12 +53,12 @@ class PlgButtonModule extends JPlugin
 			$button->link    = $link;
 			$button->text    = JText::_('PLG_MODULE_BUTTON_MODULE');
 			$button->name    = 'file-add';
-			$button->options = array(
+			$button->options = [
 				'height'     => '300px',
 				'width'      => '800px',
 				'bodyHeight' => '70',
 				'modalWidth' => '80',
-			);
+			];
 
 			return $button;
 		}

--- a/plugins/editors-xtd/pagebreak/pagebreak.php
+++ b/plugins/editors-xtd/pagebreak/pagebreak.php
@@ -50,12 +50,12 @@ class PlgButtonPagebreak extends JPlugin
 			$button->link    = $link;
 			$button->text    = JText::_('PLG_EDITORSXTD_PAGEBREAK_BUTTON_PAGEBREAK');
 			$button->name    = 'copy';
-			$button->options = array(
+			$button->options = [
 				'height'     => '300px',
 				'width'      => '300px',
 				'bodyHeight' => '70',
 				'modalWidth' => '80',
-			);
+			];
 
 			return $button;
 		}

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -45,15 +45,15 @@ class PlgButtonReadmore extends JPlugin
 
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
 		$getContent = $getContentResult['result'][0];
-		JHtml::_('script', 'com_content/admin-article-readmore.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'com_content/admin-article-readmore.min.js', ['version' => 'auto', 'relative' => true]);
 
 		// Pass some data to javascript
 		JFactory::getDocument()->addScriptOptions(
 			'xtd-readmore',
-			array(
+			[
 				'editor' => $getContent,
 				'exists' => JText::_('PLG_READMORE_ALREADY_EXISTS', true),
-			)
+			]
 		);
 
 		$button = new JObject;

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -32,12 +32,12 @@ class PlgEditorCodemirror extends JPlugin
 	 *
 	 * @var array
 	 */
-	protected $modeAlias = array(
+	protected $modeAlias = [
 			'html' => 'htmlmixed',
 			'ini'  => 'properties',
-			'json' => array('name' => 'javascript', 'json' => true),
+			'json' => ['name' => 'javascript', 'json' => true],
 			'scss' => 'css',
-		);
+		];
 
 	/**
 	 * Initialises the Editor.
@@ -63,9 +63,9 @@ class PlgEditorCodemirror extends JPlugin
 		JPluginHelper::importPlugin('editors_codemirror');
 
 		// At this point, params can be modified by a plugin before going to the layout renderer.
-		JFactory::getApplication()->triggerEvent('onCodeMirrorBeforeInit', array(&$this->params));
+		JFactory::getApplication()->triggerEvent('onCodeMirrorBeforeInit', [&$this->params]);
 
-		$displayData = (object) array('params'  => $this->params);
+		$displayData = (object) ['params'  => $this->params];
 
 		// We need to do output buffering here because layouts may actually 'echo' things which we do not want.
 		ob_start();
@@ -93,7 +93,7 @@ class PlgEditorCodemirror extends JPlugin
 		JLayoutHelper::render('editors.codemirror.styles', $displayData, __DIR__ . '/layouts');
 		ob_end_clean();
 
-		JFactory::getApplication()->triggerEvent('onCodeMirrorAfterInit', array(&$this->params));
+		JFactory::getApplication()->triggerEvent('onCodeMirrorAfterInit', [&$this->params]);
 	}
 
 	/**
@@ -183,7 +183,7 @@ class PlgEditorCodemirror extends JPlugin
 	 * @return  string  HTML
 	 */
 	public function onDisplay(
-		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
+		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = [])
 	{
 		$id = empty($id) ? $name : $id;
 
@@ -215,10 +215,10 @@ class PlgEditorCodemirror extends JPlugin
 		// Add styling to the active line.
 		if ($this->params->get('selectionMatches', false))
 		{
-			$options->highlightSelectionMatches = array(
-					'showToken' => true,
-					'annotateScrollbar' => true,
-				);
+			$options->highlightSelectionMatches = [
+				'showToken'         => true,
+				'annotateScrollbar' => true,
+			];
 		}
 
 		// Do we use line numbering?
@@ -248,11 +248,11 @@ class PlgEditorCodemirror extends JPlugin
 		{
 			$options->theme = $theme;
 
-			JHtml::_('stylesheet', $this->params->get('basePath', 'media/editors/codemirror/') . 'theme/' . $theme . '.css', array('version' => 'auto'));
+			JHtml::_('stylesheet', $this->params->get('basePath', 'media/editors/codemirror/') . 'theme/' . $theme . '.css', ['version' => 'auto']);
 		}
 
 		// Special options for tagged modes (xml/html).
-		if (in_array($options->mode, array('xml', 'htmlmixed', 'htmlembedded', 'php')))
+		if (in_array($options->mode, ['xml', 'htmlmixed', 'htmlembedded', 'php']))
 		{
 			// Autogenerate closing tags (html/xml only).
 			$options->autoCloseTags = (boolean) $this->params->get('autoCloseTags', true);
@@ -262,7 +262,7 @@ class PlgEditorCodemirror extends JPlugin
 		}
 
 		// Special options for non-tagged modes.
-		if (!in_array($options->mode, array('xml', 'htmlmixed', 'htmlembedded')))
+		if (!in_array($options->mode, ['xml', 'htmlmixed', 'htmlembedded']))
 		{
 			// Autogenerate closing brackets.
 			$options->autoCloseBrackets = (boolean) $this->params->get('autoCloseBrackets', true);
@@ -276,7 +276,7 @@ class PlgEditorCodemirror extends JPlugin
 		// Vim Keybindings.
 		$options->vimMode = (boolean) $this->params->get('vimKeyBinding', 0);
 
-		$displayData = (object) array(
+		$displayData = (object) [
 				'options' => $options,
 				'params'  => $this->params,
 				'name'    => $name,
@@ -285,14 +285,14 @@ class PlgEditorCodemirror extends JPlugin
 				'rows'    => $row,
 				'content' => $content,
 				'buttons' => $buttons
-			);
+			];
 
 		// At this point, displayData can be modified by a plugin before going to the layout renderer.
-		$results = JFactory::getApplication()->triggerEvent('onCodeMirrorBeforeDisplay', array(&$displayData));
+		$results = JFactory::getApplication()->triggerEvent('onCodeMirrorBeforeDisplay', [&$displayData]);
 
-		$results[] = JLayoutHelper::render('editors.codemirror.element', $displayData, __DIR__ . '/layouts', array('debug' => JDEBUG));
+		$results[] = JLayoutHelper::render('editors.codemirror.element', $displayData, __DIR__ . '/layouts', ['debug' => JDEBUG]);
 
-		foreach (JFactory::getApplication()->triggerEvent('onCodeMirrorAfterDisplay', array(&$displayData)) as $result)
+		foreach (JFactory::getApplication()->triggerEvent('onCodeMirrorAfterDisplay', [&$displayData]) as $result)
 		{
 			$results[] = $result;
 		}

--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -65,7 +65,7 @@ class PlgEditorCodemirror extends JPlugin
 		// At this point, params can be modified by a plugin before going to the layout renderer.
 		JFactory::getApplication()->triggerEvent('onCodeMirrorBeforeInit', [&$this->params]);
 
-		$displayData = (object) ['params'  => $this->params];
+		$displayData = (object) ['params' => $this->params];
 
 		// We need to do output buffering here because layouts may actually 'echo' things which we do not want.
 		ob_start();

--- a/plugins/editors/codemirror/fonts.php
+++ b/plugins/editors/codemirror/fonts.php
@@ -39,7 +39,7 @@ class JFormFieldFonts extends JFormFieldList
 	protected function getOptions()
 	{
 		$fonts = json_decode(file_get_contents(__DIR__ . '/fonts.json'));
-		$options = array();
+		$options = [];
 
 		foreach ($fonts as $key => $info)
 		{

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -16,12 +16,12 @@ $modePath = $params->get('modePath', 'media/vendor/codemirror/mode/%N/%N');
 $extJS    = JDEBUG ? '.js' : '.min.js';
 $extCSS   = JDEBUG ? '.css' : '.min.css';
 
-JHtml::_('script', $basePath . 'lib/codemirror' . $extJS, array('version' => 'auto'));
-JHtml::_('script', $basePath . 'lib/addons' . $extJS, array('version' => 'auto'));
-JHtml::_('stylesheet', $basePath . 'lib/codemirror' . $extCSS, array('version' => 'auto'));
-JHtml::_('stylesheet', $basePath . 'lib/addons' . $extCSS, array('version' => 'auto'));
+JHtml::_('script', $basePath . 'lib/codemirror' . $extJS, ['version' => 'auto']);
+JHtml::_('script', $basePath . 'lib/addons' . $extJS, ['version' => 'auto']);
+JHtml::_('stylesheet', $basePath . 'lib/codemirror' . $extCSS, ['version' => 'auto']);
+JHtml::_('stylesheet', $basePath . 'lib/addons' . $extCSS, ['version' => 'auto']);
 
-$fskeys          = $params->get('fullScreenMod', array());
+$fskeys          = $params->get('fullScreenMod', []);
 $fskeys[]        = $params->get('fullScreen', 'F10');
 $fullScreenCombo = implode('-', $fskeys);
 $fsCombo         = json_encode($fullScreenCombo);

--- a/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/styles.php
@@ -29,7 +29,7 @@ $g                   = hexdec($color{3} . $color{4});
 $b                   = hexdec($color{5} . $color{6});
 $highlightMatchColor = 'rgba(' . $r . ', ' . $g . ', ' . $b . ', .5)';
 
-JHtml::_('stylesheet', 'editors/codemirror/codemirror.css', array('version' => 'auto', 'relative' => true));
+JHtml::_('stylesheet', 'editors/codemirror/codemirror.css', ['version' => 'auto', 'relative' => true]);
 
 JFactory::getDocument()->addStyleDeclaration(
 <<<CSS

--- a/plugins/editors/none/none.php
+++ b/plugins/editors/none/none.php
@@ -28,7 +28,7 @@ class PlgEditorNone extends JPlugin
 	 */
 	public function onInit()
 	{
-		JHtml::_('script', 'editors/none/none.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'editors/none/none.min.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -106,7 +106,7 @@ class PlgEditorNone extends JPlugin
 	 * @return  string
 	 */
 	public function onDisplay($name, $content, $width, $height, $col, $row, $buttons = true,
-		$id = null, $asset = null, $author = null, $params = array())
+		$id = null, $asset = null, $author = null, $params = [])
 	{
 		if (empty($id))
 		{

--- a/plugins/editors/tinymce/field/skins.php
+++ b/plugins/editors/tinymce/field/skins.php
@@ -33,7 +33,7 @@ class JFormFieldSkins extends JFormFieldList
 	 */
 	public function getOptions()
 	{
-		$options = array();
+		$options = [];
 
 		$directories = glob(JPATH_ROOT . '/media/vendor/tinymce/skins' . '/*', GLOB_ONLYDIR);
 
@@ -57,13 +57,13 @@ class JFormFieldSkins extends JFormFieldList
 	 */
 	protected function getInput()
 	{
-		$html = array();
+		$html = [];
 
 		// Get the field options.
 		$options = (array) $this->getOptions();
-		$attrbs  = array(
+		$attrbs  = [
 			'class' => 'custom-select'
-		);
+		];
 
 		// Create a regular list.
 		$html[] = JHtml::_('select.genericlist', $options, $this->name, $attrbs, 'value', 'text', $this->value, $this->id);

--- a/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -40,7 +40,7 @@ class JFormFieldTinymceBuilder extends JFormField
 	 * @var    array
 	 * @since  3.7.0
 	 */
-	protected $layoutData = array();
+	protected $layoutData = [];
 
 	/**
 	 * Method to get the data to be passed to the layout for rendering.
@@ -62,20 +62,20 @@ class JFormFieldTinymceBuilder extends JFormField
 
 		if (empty($data['value']))
 		{
-			$data['value'] = array();
+			$data['value'] = [];
 		}
 
 		// Get the plugin
 		require_once JPATH_PLUGINS . '/editors/tinymce/tinymce.php';
 
-		$menus = array(
-			'edit'   => array('label' => 'Edit'),
-			'insert' => array('label' => 'Insert'),
-			'view'   => array('label' => 'View'),
-			'format' => array('label' => 'Format'),
-			'table'  => array('label' => 'Table'),
-			'tools'  => array('label' => 'Tools'),
-		);
+		$menus = [
+			'edit'   => ['label' => 'Edit'],
+			'insert' => ['label' => 'Insert'],
+			'view'   => ['label' => 'View'],
+			'format' => ['label' => 'Format'],
+			'table'  => ['label' => 'Table'],
+			'tools'  => ['label' => 'Tools'],
+		];
 
 		$data['menus']         = $menus;
 		$data['menubarSource'] = array_keys($menus);
@@ -91,7 +91,7 @@ class JFormFieldTinymceBuilder extends JFormField
 		}
 
 		// Prepare the forms for each set
-		$setsForms  = array();
+		$setsForms  = [];
 		$formsource = JPATH_PLUGINS . '/editors/tinymce/form/setoptions.xml';
 
 		// Preload an old params for B/C
@@ -109,7 +109,7 @@ class JFormFieldTinymceBuilder extends JFormField
 		}
 
 		// Collect already used groups
-		$groupsInUse = array();
+		$groupsInUse = [];
 
 		// Prepare the Set forms, for the set options
 		foreach (array_keys($data['setsNames']) as $num)
@@ -117,7 +117,7 @@ class JFormFieldTinymceBuilder extends JFormField
 			$formname = 'set.form.' . $num;
 			$control  = $this->name . '[setoptions][' . $num . ']';
 
-			$setsForms[$num] = JForm::getInstance($formname, $formsource, array('control' => $control));
+			$setsForms[$num] = JForm::getInstance($formname, $formsource, ['control' => $control]);
 
 			// Check whether we already have saved values or it first time or even old params
 			if (empty($this->value['setoptions'][$num]))
@@ -129,12 +129,12 @@ class JFormFieldTinymceBuilder extends JFormField
 				 * Set 0: for Administrator, Editor, Super Users (4,7,8)
 				 * Set 1: for Registered, Manager (2,6), all else are public
 				 */
-				$formValues->access = !$num ? array(4,7,8) : ($num === 1 ? array(2,6) : array());
+				$formValues->access = !$num ? [4, 7, 8] : ($num === 1 ? [2, 6] : []);
 
 				// Assign Public to the new Set, but only when it not in use already
 				if (empty($formValues->access) && !in_array(1, $groupsInUse))
 				{
-					$formValues->access = array(1);
+					$formValues->access = [1];
 				}
 			}
 			else

--- a/plugins/editors/tinymce/field/uploaddirs.php
+++ b/plugins/editors/tinymce/field/uploaddirs.php
@@ -71,7 +71,7 @@ class JFormFieldUploaddirs extends JFormFieldFolderList
 	 */
 	protected function getInput()
 	{
-		$html = array();
+		$html = [];
 
 		// Get the field options.
 		$options = (array) $this->getOptions();

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -51,8 +51,8 @@ class PlgEditorTinymce extends JPlugin
 	public function onInit()
 	{
 		JHtml::_('behavior.core');
-		JHtml::_('script', $this->_basePath . '/tinymce.min.js', array('version' => 'auto'));
-		JHtml::_('script', 'editors/tinymce/tinymce.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', $this->_basePath . '/tinymce.min.js', ['version' => 'auto']);
+		JHtml::_('script', 'editors/tinymce/tinymce.min.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -136,7 +136,7 @@ class PlgEditorTinymce extends JPlugin
 	 * @return  string
 	 */
 	public function onDisplay(
-		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
+		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = [])
 	{
 		$app = JFactory::getApplication();
 
@@ -163,7 +163,7 @@ class PlgEditorTinymce extends JPlugin
 		$id            = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
 		$nameGroup     = explode('[', preg_replace('/\[\]|\]/', '', $name));
 		$fieldName     = end($nameGroup);
-		$scriptOptions = array();
+		$scriptOptions = [];
 
 		// Check for existing options
 		$doc     = JFactory::getDocument();
@@ -207,7 +207,7 @@ class PlgEditorTinymce extends JPlugin
 
 			if (!empty($btns['names']))
 			{
-				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', array('version' => 'auto', 'relative' => true), array('defer' => 'defer'));
+				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', ['version' => 'auto', 'relative' => true], ['defer' => 'defer']);
 			}
 
 			// Set editor to readonly mode
@@ -239,13 +239,13 @@ class PlgEditorTinymce extends JPlugin
 		$levelParams      = new Joomla\Registry\Registry;
 		$extraOptions     = new stdClass;
 		$toolbarParams    = new stdClass;
-		$extraOptionsAll  = $this->params->get('configuration.setoptions', array());
-		$toolbarParamsAll = $this->params->get('configuration.toolbars', array());
+		$extraOptionsAll  = $this->params->get('configuration.setoptions', []);
+		$toolbarParamsAll = $this->params->get('configuration.toolbars', []);
 
 		// Get configuration depend from User group
 		foreach ($extraOptionsAll as $set => $val)
 		{
-			$val->access = empty($val->access) ? array() : $val->access;
+			$val->access = empty($val->access) ? [] : $val->access;
 
 			// Check whether User in one of allowed group
 			foreach ($val->access as $group)
@@ -386,10 +386,10 @@ class PlgEditorTinymce extends JPlugin
 
 			$ignore_filter = $filter === false;
 
-			$tagBlacklist  = !empty($filter->tagBlacklist) ? $filter->tagBlacklist : array();
-			$attrBlacklist = !empty($filter->attrBlacklist) ? $filter->attrBlacklist : array();
-			$tagArray      = !empty($filter->tagArray) ? $filter->tagArray : array();
-			$attrArray     = !empty($filter->attrArray) ? $filter->attrArray : array();
+			$tagBlacklist  = !empty($filter->tagBlacklist) ? $filter->tagBlacklist : [];
+			$attrBlacklist = !empty($filter->attrBlacklist) ? $filter->attrBlacklist : [];
+			$tagArray      = !empty($filter->tagArray) ? $filter->tagArray : [];
+			$attrArray     = !empty($filter->attrArray) ? $filter->attrArray : [];
 
 			$invalid_elements  = implode(',', array_merge($tagBlacklist, $attrBlacklist, $tagArray, $attrArray));
 
@@ -425,18 +425,18 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		// Set of always available plugins
-		$plugins  = array(
+		$plugins  = [
 			'autolink',
 			'lists',
 			'save',
 			'colorpicker',
 			'importcss',
-		);
+		];
 
 		// Allowed elements
-		$elements = array(
+		$elements = [
 			'hr[id|title|alt|class|width|size|noshade]',
-		);
+		];
 
 		if ($extended_elements)
 		{
@@ -474,10 +474,10 @@ class PlgEditorTinymce extends JPlugin
 			$levelParams->loadArray($preset);
 		}
 
-		$menubar         = (array) $levelParams->get('menu', array());
-		$toolbar1        = (array) $levelParams->get('toolbar1', array());
-		$toolbar2        = (array) $levelParams->get('toolbar2', array());
-		$externalPlugins = array();
+		$menubar         = (array) $levelParams->get('menu', []);
+		$toolbar1        = (array) $levelParams->get('toolbar1', []);
+		$toolbar2        = (array) $levelParams->get('toolbar2', []);
+		$externalPlugins = [];
 
 		// Make an easy way to check which button is enabled
 		$allButtons = array_merge($toolbar1, $toolbar2);
@@ -493,7 +493,7 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		// Template
-		$templates = array();
+		$templates = [];
 
 		if (!empty($allButtons['template']))
 		{
@@ -504,22 +504,22 @@ class PlgEditorTinymce extends JPlugin
 				$str = file_get_contents(JPATH_ROOT . "/media/vendor/tinymce/templates/template_list.js");
 
 				// Find from one [ to the last ]
-				$matches = array();
+				$matches = [];
 				preg_match_all('/\[.*\]/', $str, $matches);
 
 				// Set variables
 				foreach ($matches['0'] as $match)
 				{
-					$values = array();
+					$values = [];
 					preg_match_all('/\".*\"/', $match, $values);
 					$result       = trim($values['0']['0'], '"');
 					$final_result = explode(',', $result);
 
-					$templates[] = array(
-						'title' => trim($final_result['0'], ' " '),
+					$templates[] = [
+						'title'       => trim($final_result['0'], ' " '),
 						'description' => trim($final_result['2'], ' " '),
-						'url' => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
-					);
+						'url'         => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
+					];
 				}
 
 			}
@@ -545,18 +545,18 @@ class PlgEditorTinymce extends JPlugin
 							$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
 						}
 
-						$templates[] = array(
-							'title' => $title,
+						$templates[] = [
+							'title'       => $title,
 							'description' => $description,
-							'url' => JUri::root(true) . '/media/vendor/tinymce/templates/' . $filename . '.html',
-						);
+							'url'         => JUri::root(true) . '/media/vendor/tinymce/templates/' . $filename . '.html',
+						];
 					}
 				}
 			}
 		}
 
 		// Check for extra plugins, from the setoptions form
-		foreach (array('wordcount' => 1, 'advlist' => 1, 'autosave' => 1, 'contextmenu' => 1) as $pName => $def)
+		foreach (['wordcount' => 1, 'advlist' => 1, 'autosave' => 1, 'contextmenu' => 1] as $pName => $def)
 		{
 			if ($levelParams->get($pName, $def))
 			{
@@ -626,57 +626,57 @@ class PlgEditorTinymce extends JPlugin
 		// Build the final options set
 		$scriptOptions = array_merge(
 			$scriptOptions,
-			array(
-			'suffix'  => '.min',
-			'baseURL' => JUri::root(true) . '/media/vendor/tinymce',
-			'directionality' => $text_direction,
-			'language' => $langPrefix,
-			'autosave_restore_when_empty' => false,
-			'skin'   => $skin,
-			'theme'  => $theme,
-			'schema' => 'html5',
+			[
+				'suffix'                      => '.min',
+				'baseURL'                     => JUri::root(true) . '/media/vendor/tinymce',
+				'directionality'              => $text_direction,
+				'language'                    => $langPrefix,
+				'autosave_restore_when_empty' => false,
+				'skin'                        => $skin,
+				'theme'                       => $theme,
+				'schema'                      => 'html5',
 
-			// Toolbars
-			'menubar'  => empty($menubar)  ? false : implode(' ', array_unique($menubar)),
-			'toolbar1' => empty($toolbar1) ? null  : implode(' ', $toolbar1),
-			'toolbar2' => empty($toolbar2) ? null  : implode(' ', $toolbar2),
+				// Toolbars
+				'menubar'  => empty($menubar)  ? false : implode(' ', array_unique($menubar)),
+				'toolbar1' => empty($toolbar1) ? null  : implode(' ', $toolbar1),
+				'toolbar2' => empty($toolbar2) ? null  : implode(' ', $toolbar2),
 
-			'plugins'  => implode(',', array_unique($plugins)),
+				'plugins'  => implode(',', array_unique($plugins)),
 
-			// Cleanup/Output
-			'inline_styles'    => true,
-			'gecko_spellcheck' => true,
-			'entity_encoding'  => $levelParams->get('entity_encoding', 'raw'),
-			'verify_html'      => !$ignore_filter,
+				// Cleanup/Output
+				'inline_styles'    => true,
+				'gecko_spellcheck' => true,
+				'entity_encoding'  => $levelParams->get('entity_encoding', 'raw'),
+				'verify_html'      => !$ignore_filter,
 
-			'valid_elements'          => $valid_elements,
-			'extended_valid_elements' => implode(',', $elements),
-			'invalid_elements'        => $invalid_elements,
+				'valid_elements'          => $valid_elements,
+				'extended_valid_elements' => implode(',', $elements),
+				'invalid_elements'        => $invalid_elements,
 
-			// URL
-			'relative_urls'      => (bool) $levelParams->get('relative_urls', true),
-			'remove_script_host' => false,
+				// URL
+				'relative_urls'      => (bool) $levelParams->get('relative_urls', true),
+				'remove_script_host' => false,
 
-			// Layout
-			'content_css'        => $content_css,
-			'document_base_url'  => JUri::root(true) . '/',
-			'paste_data_images'  => $allowImgPaste,
-			'importcss_append'   => true,
-			'image_title'        => true,
-			'height'             => $html_height,
-			'width'              => $html_width,
-			'resize'             => $resizing,
-			'templates'          => $templates,
-			'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
-			'external_plugins'   => empty($externalPlugins) ? null  : $externalPlugins,
+				// Layout
+				'content_css'        => $content_css,
+				'document_base_url'  => JUri::root(true) . '/',
+				'paste_data_images'  => $allowImgPaste,
+				'importcss_append'   => true,
+				'image_title'        => true,
+				'height'             => $html_height,
+				'width'              => $html_width,
+				'resize'             => $resizing,
+				'templates'          => $templates,
+				'image_advtab'       => (bool) $levelParams->get('image_advtab', false),
+				'external_plugins'   => empty($externalPlugins) ? null  : $externalPlugins,
 
-			// Drag and drop specific
-			'dndEnabled' => $dragdrop,
-			'dndPath'    => JUri::root() . 'media/editors/tinymce/js/dragdrop/plugin.min.js',
+				// Drag and drop specific
+				'dndEnabled' => $dragdrop,
+				'dndPath'    => JUri::root() . 'media/editors/tinymce/js/dragdrop/plugin.min.js',
 
-			// Disable TinyMCE Branding
-			'branding'	=> false,
-			)
+				// Disable TinyMCE Branding
+				'branding'	=> false,
+			]
 		);
 
 		if ($levelParams->get('newlines'))
@@ -694,21 +694,21 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['forced_root_block'] = 'p';
 		}
 
-		$scriptOptions['rel_list'] = array(
-			array('title' => 'Alternate', 'value' => 'alternate'),
-			array('title' => 'Author', 'value' => 'author'),
-			array('title' => 'Bookmark', 'value' => 'bookmark'),
-			array('title' => 'Help', 'value' => 'help'),
-			array('title' => 'License', 'value' => 'license'),
-			array('title' => 'Lightbox', 'value' => 'lightbox'),
-			array('title' => 'Next', 'value' => 'next'),
-			array('title' => 'No Follow', 'value' => 'nofollow'),
-			array('title' => 'No Referrer', 'value' => 'noreferrer'),
-			array('title' => 'Prefetch', 'value' => 'prefetch'),
-			array('title' => 'Prev', 'value' => 'prev'),
-			array('title' => 'Search', 'value' => 'search'),
-			array('title' => 'Tag', 'value' => 'tag'),
-		);
+		$scriptOptions['rel_list'] = [
+			['title' => 'Alternate', 'value' => 'alternate'],
+			['title' => 'Author', 'value' => 'author'],
+			['title' => 'Bookmark', 'value' => 'bookmark'],
+			['title' => 'Help', 'value' => 'help'],
+			['title' => 'License', 'value' => 'license'],
+			['title' => 'Lightbox', 'value' => 'lightbox'],
+			['title' => 'Next', 'value' => 'next'],
+			['title' => 'No Follow', 'value' => 'nofollow'],
+			['title' => 'No Referrer', 'value' => 'noreferrer'],
+			['title' => 'Prefetch', 'value' => 'prefetch'],
+			['title' => 'Prev', 'value' => 'prev'],
+			['title' => 'Search', 'value' => 'search'],
+			['title' => 'Tag', 'value' => 'tag'],
+		];
 
 		/**
 		 * Shrink the buttons if not on a mobile or if mobile view is off.
@@ -767,8 +767,8 @@ class PlgEditorTinymce extends JPlugin
 		$buttons       = $buttonsResult['result'];
 
 		// Init the arrays for the buttons
-		$tinyBtns  = array();
-		$btnsNames = array();
+		$tinyBtns  = [];
+		$btnsNames = [];
 
 		// Build the script
 		foreach ($buttons as $i => $button)
@@ -865,10 +865,10 @@ class PlgEditorTinymce extends JPlugin
 			}
 		}
 
-		return array(
+		return [
 			'names'  => $btnsNames,
 			'script' => $tinyBtns
-		);
+		];
 	}
 
 	/**
@@ -887,14 +887,14 @@ class PlgEditorTinymce extends JPlugin
 
 		$filters = $config->get('filters');
 
-		$blackListTags       = array();
-		$blackListAttributes = array();
+		$blackListTags       = [];
+		$blackListAttributes = [];
 
-		$customListTags       = array();
-		$customListAttributes = array();
+		$customListTags       = [];
+		$customListAttributes = [];
 
-		$whiteListTags       = array();
-		$whiteListAttributes = array();
+		$whiteListTags       = [];
+		$whiteListAttributes = [];
 
 		$whiteList  = false;
 		$blackList  = false;
@@ -930,8 +930,8 @@ class PlgEditorTinymce extends JPlugin
 				// Preprocess the tags and attributes.
 				$tags           = explode(',', $filterData->filter_tags);
 				$attributes     = explode(',', $filterData->filter_attributes);
-				$tempTags       = array();
-				$tempAttributes = array();
+				$tempTags       = [];
+				$tempAttributes = [];
 
 				foreach ($tags as $tag)
 				{
@@ -999,7 +999,7 @@ class PlgEditorTinymce extends JPlugin
 			// Custom blacklist precedes Default blacklist
 			if ($customList)
 			{
-				$filter = JFilterInput::getInstance(array(), array(), 1, 1);
+				$filter = JFilterInput::getInstance([], [], 1, 1);
 
 				// Override filter's default blacklist tags and attributes
 				if ($customListTags)
@@ -1060,73 +1060,73 @@ class PlgEditorTinymce extends JPlugin
 	{
 		// See https://www.tinymce.com/docs/demo/full-featured/
 		// And https://www.tinymce.com/docs/plugins/
-		$buttons = array(
+		$buttons = [
 
 			// General buttons
-			'|'              => array('label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_SEPARATOR'), 'text' => '|'),
+			'|'              => ['label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_SEPARATOR'), 'text' => '|'],
 
-			'undo'           => array('label' => 'Undo'),
-			'redo'           => array('label' => 'Redo'),
+			'undo'           => ['label' => 'Undo'],
+			'redo'           => ['label' => 'Redo'],
 
-			'bold'           => array('label' => 'Bold'),
-			'italic'         => array('label' => 'Italic'),
-			'underline'      => array('label' => 'Underline'),
-			'strikethrough'  => array('label' => 'Strikethrough'),
-			'styleselect'    => array('label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_STYLESELECT'), 'text' => 'Formats'),
-			'formatselect'   => array('label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FORMATSELECT'), 'text' => 'Paragraph'),
-			'fontselect'     => array('label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FONTSELECT'), 'text' => 'Font Family'),
-			'fontsizeselect' => array('label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FONTSIZESELECT'), 'text' => 'Font Sizes'),
+			'bold'           => ['label' => 'Bold'],
+			'italic'         => ['label' => 'Italic'],
+			'underline'      => ['label' => 'Underline'],
+			'strikethrough'  => ['label' => 'Strikethrough'],
+			'styleselect'    => ['label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_STYLESELECT'), 'text' => 'Formats'],
+			'formatselect'   => ['label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FORMATSELECT'), 'text' => 'Paragraph'],
+			'fontselect'     => ['label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FONTSELECT'), 'text' => 'Font Family'],
+			'fontsizeselect' => ['label' => JText::_('PLG_TINY_TOOLBAR_BUTTON_FONTSIZESELECT'), 'text' => 'Font Sizes'],
 
-			'alignleft'     => array('label' => 'Align left'),
-			'aligncenter'   => array('label' => 'Align center'),
-			'alignright'    => array('label' => 'Align right'),
-			'alignjustify'  => array('label' => 'Justify'),
+			'alignleft'     => ['label' => 'Align left'],
+			'aligncenter'   => ['label' => 'Align center'],
+			'alignright'    => ['label' => 'Align right'],
+			'alignjustify'  => ['label' => 'Justify'],
 
-			'outdent'       => array('label' => 'Decrease indent'),
-			'indent'        => array('label' => 'Increase indent'),
+			'outdent'       => ['label' => 'Decrease indent'],
+			'indent'        => ['label' => 'Increase indent'],
 
-			'bullist'       => array('label' => 'Bullet list'),
-			'numlist'       => array('label' => 'Numbered list'),
+			'bullist'       => ['label' => 'Bullet list'],
+			'numlist'       => ['label' => 'Numbered list'],
 
-			'link'          => array('label' => 'Insert/edit link', 'plugin' => 'link'),
-			'unlink'        => array('label' => 'Remove link', 'plugin' => 'link'),
+			'link'          => ['label' => 'Insert/edit link', 'plugin' => 'link'],
+			'unlink'        => ['label' => 'Remove link', 'plugin' => 'link'],
 
-			'subscript'     => array('label' => 'Subscript'),
-			'superscript'   => array('label' => 'Superscript'),
-			'blockquote'    => array('label' => 'Blockquote'),
+			'subscript'     => ['label' => 'Subscript'],
+			'superscript'   => ['label' => 'Superscript'],
+			'blockquote'    => ['label' => 'Blockquote'],
 
-			'cut'           => array('label' => 'Cut'),
-			'copy'          => array('label' => 'Copy'),
-			'paste'         => array('label' => 'Paste', 'plugin' => 'paste'),
-			'pastetext'     => array('label' => 'Paste as text', 'plugin' => 'paste'),
-			'removeformat'  => array('label' => 'Clear formatting'),
+			'cut'           => ['label' => 'Cut'],
+			'copy'          => ['label' => 'Copy'],
+			'paste'         => ['label' => 'Paste', 'plugin' => 'paste'],
+			'pastetext'     => ['label' => 'Paste as text', 'plugin' => 'paste'],
+			'removeformat'  => ['label' => 'Clear formatting'],
 
 			// Buttons from the plugins
-			'forecolor'      => array('label' => 'Text color', 'plugin' => 'textcolor'),
-			'backcolor'      => array('label' => 'Background color', 'plugin' => 'textcolor'),
-			'anchor'         => array('label' => 'Anchor', 'plugin' => 'anchor'),
-			'hr'             => array('label' => 'Horizontal line', 'plugin' => 'hr'),
-			'ltr'            => array('label' => 'Left to right', 'plugin' => 'directionality'),
-			'rtl'            => array('label' => 'Right to left', 'plugin' => 'directionality'),
-			'code'           => array('label' => 'Source code', 'plugin' => 'code'),
-			'codesample'     => array('label' => 'Insert/Edit code sample', 'plugin' => 'codesample'),
-			'table'          => array('label' => 'Table', 'plugin' => 'table'),
-			'charmap'        => array('label' => 'Special character', 'plugin' => 'charmap'),
-			'visualchars'    => array('label' => 'Show invisible characters', 'plugin' => 'visualchars'),
-			'visualblocks'   => array('label' => 'Show blocks', 'plugin' => 'visualblocks'),
-			'nonbreaking'    => array('label' => 'Nonbreaking space', 'plugin' => 'nonbreaking'),
-			'emoticons'      => array('label' => 'Emoticons', 'plugin' => 'emoticons'),
-			'image'          => array('label' => 'Insert/edit image', 'plugin' => 'image'),
-			'media'          => array('label' => 'Insert/edit video', 'plugin' => 'media'),
-			'pagebreak'      => array('label' => 'Page break', 'plugin' => 'pagebreak'),
-			'print'          => array('label' => 'Print', 'plugin' => 'print'),
-			'preview'        => array('label' => 'Preview', 'plugin' => 'preview'),
-			'fullscreen'     => array('label' => 'Fullscreen', 'plugin' => 'fullscreen'),
-			'template'       => array('label' => 'Insert template', 'plugin' => 'template'),
-			'searchreplace'  => array('label' => 'Find and replace', 'plugin' => 'searchreplace'),
-			'insertdatetime' => array('label' => 'Insert date/time', 'plugin' => 'insertdatetime'),
-			// 'spellchecker'   => array('label' => 'Spellcheck', 'plugin' => 'spellchecker'),
-		);
+			'forecolor'      => ['label' => 'Text color', 'plugin' => 'textcolor'],
+			'backcolor'      => ['label' => 'Background color', 'plugin' => 'textcolor'],
+			'anchor'         => ['label' => 'Anchor', 'plugin' => 'anchor'],
+			'hr'             => ['label' => 'Horizontal line', 'plugin' => 'hr'],
+			'ltr'            => ['label' => 'Left to right', 'plugin' => 'directionality'],
+			'rtl'            => ['label' => 'Right to left', 'plugin' => 'directionality'],
+			'code'           => ['label' => 'Source code', 'plugin' => 'code'],
+			'codesample'     => ['label' => 'Insert/Edit code sample', 'plugin' => 'codesample'],
+			'table'          => ['label' => 'Table', 'plugin' => 'table'],
+			'charmap'        => ['label' => 'Special character', 'plugin' => 'charmap'],
+			'visualchars'    => ['label' => 'Show invisible characters', 'plugin' => 'visualchars'],
+			'visualblocks'   => ['label' => 'Show blocks', 'plugin' => 'visualblocks'],
+			'nonbreaking'    => ['label' => 'Nonbreaking space', 'plugin' => 'nonbreaking'],
+			'emoticons'      => ['label' => 'Emoticons', 'plugin' => 'emoticons'],
+			'image'          => ['label' => 'Insert/edit image', 'plugin' => 'image'],
+			'media'          => ['label' => 'Insert/edit video', 'plugin' => 'media'],
+			'pagebreak'      => ['label' => 'Page break', 'plugin' => 'pagebreak'],
+			'print'          => ['label' => 'Print', 'plugin' => 'print'],
+			'preview'        => ['label' => 'Preview', 'plugin' => 'preview'],
+			'fullscreen'     => ['label' => 'Fullscreen', 'plugin' => 'fullscreen'],
+			'template'       => ['label' => 'Insert template', 'plugin' => 'template'],
+			'searchreplace'  => ['label' => 'Find and replace', 'plugin' => 'searchreplace'],
+			'insertdatetime' => ['label' => 'Insert date/time', 'plugin' => 'insertdatetime'],
+			// 'spellchecker'   => ['label' => 'Spellcheck', 'plugin' => 'spellchecker'],
+		];
 
 		return $buttons;
 	}
@@ -1140,22 +1140,22 @@ class PlgEditorTinymce extends JPlugin
 	 */
 	public static function getToolbarPreset()
 	{
-		$preset = array();
+		$preset = [];
 
-		$preset['simple'] = array(
-			'menu' => array(),
-			'toolbar1' => array(
-				'bold', 'underline', 'strikethrough', '|',
+		$preset['simple'] = [
+			'menu'     => [],
+			'toolbar1' => [
+				'bold','underline', 'strikethrough', '|',
 				'undo', 'redo', '|',
 				'bullist', 'numlist', '|',
 				'pastetext'
-			),
-			'toolbar2' => array(),
-		);
+			],
+			'toolbar2' => [],
+		];
 
-		$preset['medium'] = array(
-			'menu' => array('edit', 'insert', 'view', 'format', 'table', 'tools'),
-			'toolbar1' => array(
+		$preset['medium'] = [
+			'menu'     => ['edit', 'insert', 'view', 'format', 'table', 'tools'],
+			'toolbar1' => [
 				'bold', 'italic', 'underline', 'strikethrough', '|',
 				'alignleft', 'aligncenter', 'alignright', 'alignjustify', '|',
 				'formatselect', '|',
@@ -1166,13 +1166,13 @@ class PlgEditorTinymce extends JPlugin
 				'hr', 'table', '|',
 				'subscript', 'superscript', '|',
 				'charmap', 'pastetext' , 'preview'
-			),
-			'toolbar2' => array(),
+			],
+			'toolbar2' => [],
 		);
 
-		$preset['advanced'] = array(
-			'menu'     => array('edit', 'insert', 'view', 'format', 'table', 'tools'),
-			'toolbar1' => array(
+		$preset['advanced'] = [
+			'menu'     => ['edit', 'insert', 'view', 'format', 'table', 'tools'],
+			'toolbar1' => [
 				'bold', 'italic', 'underline', 'strikethrough', '|',
 				'alignleft', 'aligncenter', 'alignright', 'alignjustify', '|',
 				'styleselect', '|',
@@ -1191,8 +1191,8 @@ class PlgEditorTinymce extends JPlugin
 				'cut', 'copy', 'paste', 'pastetext', '|',
 				'visualchars', 'visualblocks', 'nonbreaking', 'blockquote', 'template', '|',
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat',
-			),
-			'toolbar2' => array(),
+			],
+			'toolbar2' => [],
 		);
 
 		return $preset;
@@ -1240,7 +1240,7 @@ class PlgEditorTinymce extends JPlugin
 	 * @deprecated 4.0
 	 */
 	private function onDisplayLegacy(
-		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = array())
+		$name, $content, $width, $height, $col, $row, $buttons = true, $id = null, $asset = null, $author = null, $params = [])
 	{
 		if (empty($id))
 		{
@@ -1250,7 +1250,7 @@ class PlgEditorTinymce extends JPlugin
 		$id            = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
 		$nameGroup     = explode('[', preg_replace('/\[\]|\]/', '', $name));
 		$fieldName     = end($nameGroup);
-		$scriptOptions = array();
+		$scriptOptions = [];
 
 		// Check for existing options
 		$doc     = JFactory::getDocument();
@@ -1294,7 +1294,7 @@ class PlgEditorTinymce extends JPlugin
 
 			if (!empty($btns['names']))
 			{
-				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', array('version' => 'auto', 'relative' => true), array('defer' => 'defer'));
+				JHtml::_('script', 'editors/tinymce/tiny-close.min.js', ['version' => 'auto', 'relative' => true], ['defer' => 'defer']);
 			}
 
 			// Set editor to readonly mode
@@ -1448,10 +1448,10 @@ class PlgEditorTinymce extends JPlugin
 
 			$ignore_filter = $filter === false;
 
-			$tagBlacklist  = !empty($filter->tagBlacklist) ? $filter->tagBlacklist : array();
-			$attrBlacklist = !empty($filter->attrBlacklist) ? $filter->attrBlacklist : array();
-			$tagArray      = !empty($filter->tagArray) ? $filter->tagArray : array();
-			$attrArray     = !empty($filter->attrArray) ? $filter->attrArray : array();
+			$tagBlacklist  = !empty($filter->tagBlacklist) ? $filter->tagBlacklist : [];
+			$attrBlacklist = !empty($filter->attrBlacklist) ? $filter->attrBlacklist : [];
+			$tagArray      = !empty($filter->tagArray) ? $filter->tagArray : [];
+			$attrArray     = !empty($filter->attrArray) ? $filter->attrArray : [];
 
 			$invalid_elements  = implode(',', array_merge($tagBlacklist, $attrBlacklist, $tagArray, $attrArray));
 
@@ -1515,12 +1515,12 @@ class PlgEditorTinymce extends JPlugin
 			$resizing = false;
 		}
 
-		$toolbar1_add   = array();
-		$toolbar2_add   = array();
-		$toolbar3_add   = array();
-		$toolbar4_add   = array();
-		$elements       = array();
-		$plugins        = array(
+		$toolbar1_add   = [];
+		$toolbar2_add   = [];
+		$toolbar3_add   = [];
+		$toolbar4_add   = [];
+		$elements       = [];
+		$plugins        = [
 			'autolink',
 			'lists',
 			'image',
@@ -1533,7 +1533,8 @@ class PlgEditorTinymce extends JPlugin
 			'save',
 			'textcolor',
 			'colorpicker',
-			'importcss');
+			'importcss'
+		];
 		$toolbar1_add[] = 'bold';
 		$toolbar1_add[] = 'italic';
 		$toolbar1_add[] = 'underline';
@@ -1740,7 +1741,7 @@ class PlgEditorTinymce extends JPlugin
 
 		// Template
 		$template = $this->params->get('template', 1);
-		$templates = array();
+		$templates = [];
 
 		if (isset($access[$template]))
 		{
@@ -1754,22 +1755,22 @@ class PlgEditorTinymce extends JPlugin
 				$str = file_get_contents(JPATH_ROOT . "/media/editors/tinymce/templates/template_list.js");
 
 				// Find from one [ to the last ]
-				$matches = array();
+				$matches = [];
 				preg_match_all('/\[.*\]/', $str, $matches);
 
 				// Set variables
 				foreach ($matches['0'] as $match)
 				{
-					$values = array();
+					$values = [];
 					preg_match_all('/\".*\"/', $match, $values);
 					$result       = trim($values["0"]["0"], '"');
 					$final_result = explode(',', $result);
 
-					$templates[] = array(
-						'title' => trim($final_result['0'], ' " '),
+					$templates[] = [
+						'title'       => trim($final_result['0'], ' " '),
 						'description' => trim($final_result['2'], ' " '),
-						'url' => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
-					);
+						'url'         => JUri::root(true) . '/' . trim($final_result['1'], ' " '),
+					];
 				}
 
 			}
@@ -1795,11 +1796,11 @@ class PlgEditorTinymce extends JPlugin
 							$description = JText::_('PLG_TINY_TEMPLATE_' . strtoupper($filename) . '_DESC');
 						}
 
-						$templates[] = array(
-							'title' => $title,
+						$templates[] = [
+							'title'       => $title,
 							'description' => $description,
-							'url' => JUri::root(true) . '/media/editors/tinymce/templates/' . $filename . '.html',
-						);
+							'url'         => JUri::root(true) . '/media/editors/tinymce/templates/' . $filename . '.html',
+						];
 					}
 				}
 			}
@@ -1882,7 +1883,7 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		// Drag and drop Images
-		$externalPlugins = array();
+		$externalPlugins = [];
 		$allowImgPaste   = false;
 		$dragdrop        = $this->params->get('drag_drop', 1);
 
@@ -1922,15 +1923,15 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['mediaUploadPath'] = $tempPath;
 			$scriptOptions['uploadUri']       = $uploadUrl;
 
-			$externalPlugins = array(
-				array('jdragdrop' => JUri::root() . '/media/editors/tinymce/js/plugins/dragdrop/plugin.min.js'),
-			);
+			$externalPlugins = [
+				['jdragdrop' => JUri::root() . '/media/editors/tinymce/js/plugins/dragdrop/plugin.min.js'],
+			];
 		}
 
-			$externalPlugins = array(
-				array('jdragdrop' => ($app->isClient('site') ? JUri::root(false)  : str_replace('/administrator', JUri::root(false)))
-						. '/media/editors/tinymce/js/plugins/jdragdrop/plugin.min.js')
-				);
+			$externalPlugins = [
+				['jdragdrop' => ($app->isClient('site') ? JUri::root(false) : str_replace('/administrator', JUri::root(false)))
+						. '/media/editors/tinymce/js/plugins/jdragdrop/plugin.min.js']
+			];
 
 		// Prepare config variables
 		$plugins  = implode(',', $plugins);
@@ -1947,32 +1948,32 @@ class PlgEditorTinymce extends JPlugin
 
 		$scriptOptions = array_merge(
 			$scriptOptions,
-			array(
-			'suffix'  => '.min',
-			'baseURL' => JUri::root(true) . '/media/editors/tinymce',
-			'directionality' => $text_direction,
-			'language' => $langPrefix,
-			'autosave_restore_when_empty' => false,
-			'skin'   => $skin,
-			'theme'  => $theme,
-			'schema' => 'html5',
+			[
+				'suffix'                      => '.min',
+				'baseURL'                     => JUri::root(true) . '/media/editors/tinymce',
+				'directionality'              => $text_direction,
+				'language'                    => $langPrefix,
+				'autosave_restore_when_empty' => false,
+				'skin'                        => $skin,
+				'theme'                       => $theme,
+				'schema'                      => 'html5',
 
-			// Cleanup/Output
-			'inline_styles'    => true,
-			'gecko_spellcheck' => true,
-			'entity_encoding'  => $this->params->get('entity_encoding', 'raw'),
-			'verify_html'      => !$ignore_filter,
+				// Cleanup/Output
+				'inline_styles'    => true,
+				'gecko_spellcheck' => true,
+				'entity_encoding'  => $this->params->get('entity_encoding', 'raw'),
+				'verify_html'      => !$ignore_filter,
 
-			// URL
-			'relative_urls'      => (bool) $this->params->get('relative_urls', true),
-			'remove_script_host' => false,
+				// URL
+				'relative_urls'      => (bool) $this->params->get('relative_urls', true),
+				'remove_script_host' => false,
 
-			// Layout
-			'content_css'        => $content_css,
-			'document_base_url'  => JUri::root(true) . '/',
-			'paste_data_images'  => $allowImgPaste,
-			'externalPlugins'    => json_encode($externalPlugins),
-		)
+				// Layout
+				'content_css'        => $content_css,
+				'document_base_url'  => JUri::root(true) . '/',
+				'paste_data_images'  => $allowImgPaste,
+				'externalPlugins'    => json_encode($externalPlugins),
+			]
 		);
 
 		if ($this->params->get('newlines'))
@@ -2040,21 +2041,21 @@ class PlgEditorTinymce extends JPlugin
 				$scriptOptions['external_plugins']  = $externalPlugins;
 				$scriptOptions['toolbar1'] = $toolbar1;
 				$scriptOptions['removed_menuitems'] = 'newdocument';
-				$scriptOptions['rel_list'] = array(
-					array('title' => 'Alternate', 'value' => 'alternate'),
-					array('title' => 'Author', 'value' => 'author'),
-					array('title' => 'Bookmark', 'value' => 'bookmark'),
-					array('title' => 'Help', 'value' => 'help'),
-					array('title' => 'License', 'value' => 'license'),
-					array('title' => 'Lightbox', 'value' => 'lightbox'),
-					array('title' => 'Next', 'value' => 'next'),
-					array('title' => 'No Follow', 'value' => 'nofollow'),
-					array('title' => 'No Referrer', 'value' => 'noreferrer'),
-					array('title' => 'Prefetch', 'value' => 'prefetch'),
-					array('title' => 'Prev', 'value' => 'prev'),
-					array('title' => 'Search', 'value' => 'search'),
-					array('title' => 'Tag', 'value' => 'tag'),
-				);
+				$scriptOptions['rel_list'] = [
+					['title' => 'Alternate', 'value' => 'alternate'],
+					['title' => 'Author', 'value' => 'author'],
+					['title' => 'Bookmark', 'value' => 'bookmark'],
+					['title' => 'Help', 'value' => 'help'],
+					['title' => 'License', 'value' => 'license'],
+					['title' => 'Lightbox', 'value' => 'lightbox'],
+					['title' => 'Next', 'value' => 'next'],
+					['title' => 'No Follow', 'value' => 'nofollow'],
+					['title' => 'No Referrer', 'value' => 'noreferrer'],
+					['title' => 'Prefetch', 'value' => 'prefetch'],
+					['title' => 'Prev', 'value' => 'prev'],
+					['title' => 'Search', 'value' => 'search'],
+					['title' => 'Tag', 'value' => 'tag'],
+				];
 				$scriptOptions['importcss_append'] = true;
 				$scriptOptions['image_advtab']     = $image_advtab;
 				$scriptOptions['height']    = $html_height;

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -1168,7 +1168,7 @@ class PlgEditorTinymce extends JPlugin
 				'charmap', 'pastetext' , 'preview'
 			],
 			'toolbar2' => [],
-		);
+		];
 
 		$preset['advanced'] = [
 			'menu'     => ['edit', 'insert', 'view', 'format', 'table', 'tools'],
@@ -1193,7 +1193,7 @@ class PlgEditorTinymce extends JPlugin
 				'print', 'preview', 'codesample', 'insertdatetime', 'removeformat',
 			],
 			'toolbar2' => [],
-		);
+		];
 
 		return $preset;
 	}

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -65,7 +65,7 @@ class PlgExtensionJoomla extends JPlugin
 		{
 			$query->clear()
 				->insert('#__update_sites')
-				->columns(array($db->quoteName('name'), $db->quoteName('type'), $db->quoteName('location'), $db->quoteName('enabled')))
+				->columns([$db->quoteName('name'), $db->quoteName('type'), $db->quoteName('location'), $db->quoteName('enabled')])
 				->values($db->quote($name) . ', ' . $db->quote($type) . ', ' . $db->quote($location) . ', ' . (int) $enabled);
 			$db->setQuery($query);
 
@@ -93,7 +93,7 @@ class PlgExtensionJoomla extends JPlugin
 				// Link this extension to the relevant update site
 				$query->clear()
 					->insert('#__update_sites_extensions')
-					->columns(array($db->quoteName('update_site_id'), $db->quoteName('extension_id')))
+					->columns([$db->quoteName('update_site_id'), $db->quoteName('extension_id')])
 					->values($update_site_id . ', ' . $this->eid);
 				$db->setQuery($query);
 				$db->execute();
@@ -239,7 +239,7 @@ class PlgExtensionJoomla extends JPlugin
 		}
 		else
 		{
-			$children = array();
+			$children = [];
 		}
 
 		if (count($children))

--- a/plugins/extension/namespacemap/namespacemap.php
+++ b/plugins/extension/namespacemap/namespacemap.php
@@ -36,7 +36,7 @@ class PlgExtensionNamespacemap extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	public function __construct(&$subject, $config = array())
+	public function __construct(&$subject, $config = [])
 	{
 		$this->fileCreator = new JNamespacePsr4Map;
 

--- a/plugins/fields/checkboxes/tmpl/checkboxes.php
+++ b/plugins/fields/checkboxes/tmpl/checkboxes.php
@@ -16,7 +16,7 @@ if ($fieldValue === '' || $fieldValue === null)
 }
 
 $fieldValue = (array) $fieldValue;
-$texts      = array();
+$texts      = [];
 $options    = $this->getOptionsFromField($field);
 
 foreach ($options as $value => $name)

--- a/plugins/fields/editor/editor.php
+++ b/plugins/fields/editor/editor.php
@@ -37,7 +37,7 @@ class PlgFieldsEditor extends \Joomla\Component\Fields\Administrator\Plugin\Fiel
 		}
 
 		$fieldNode->setAttribute('buttons', $field->fieldparams->get('buttons', 0) ? 'true' : 'false');
-		$fieldNode->setAttribute('hide', implode(',', $field->fieldparams->get('hide', array())));
+		$fieldNode->setAttribute('hide', implode(',', $field->fieldparams->get('hide', [])));
 
 		return $fieldNode;
 	}

--- a/plugins/fields/list/tmpl/list.php
+++ b/plugins/fields/list/tmpl/list.php
@@ -16,7 +16,7 @@ if ($fieldValue == '')
 }
 
 $fieldValue = (array) $fieldValue;
-$texts      = array();
+$texts      = [];
 $options    = $this->getOptionsFromField($field);
 
 foreach ($options as $value => $name)

--- a/plugins/fields/radio/tmpl/radio.php
+++ b/plugins/fields/radio/tmpl/radio.php
@@ -16,7 +16,7 @@ if ($value == '')
 }
 
 $value   = (array) $value;
-$texts   = array();
+$texts   = [];
 $options = $this->getOptionsFromField($field);
 
 foreach ($options as $optionValue => $optionText)

--- a/plugins/fields/sql/sql.php
+++ b/plugins/fields/sql/sql.php
@@ -56,7 +56,7 @@ class PlgFieldsSql extends FieldsListPlugin
 	 *
 	 * @since   3.7.0
 	 */
-	public function onContentBeforeSave($context, $item, $isNew, $data = array())
+	public function onContentBeforeSave($context, $item, $isNew, $data = [])
 	{
 		// Only work on new SQL fields
 		if ($context != 'com_fields.field' || !isset($item->type) || $item->type != 'sql' || !$isNew)

--- a/plugins/fields/sql/tmpl/sql.php
+++ b/plugins/fields/sql/tmpl/sql.php
@@ -45,7 +45,7 @@ catch (Exception $e)
 	$items = $db->loadObjectlist();
 }
 
-$texts = array();
+$texts = [];
 
 foreach ($items as $item)
 {

--- a/plugins/fields/user/tmpl/user.php
+++ b/plugins/fields/user/tmpl/user.php
@@ -16,7 +16,7 @@ if ($value == '')
 }
 
 $value = (array) $value;
-$texts = array();
+$texts = [];
 
 foreach ($value as $userId)
 {

--- a/plugins/fields/usergrouplist/tmpl/usergrouplist.php
+++ b/plugins/fields/usergrouplist/tmpl/usergrouplist.php
@@ -18,7 +18,7 @@ if ($value == '')
 JLoader::register('UsersHelper', JPATH_ADMINISTRATOR . '/components/com_users/helpers/users.php');
 
 $value  = (array) $value;
-$texts  = array();
+$texts  = [];
 $groups = UsersHelper::getGroups();
 
 foreach ($groups as $group)


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in Editors, Editors-XTD, Extension and Fields plugins.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.