### PR TITLE
[4.0] Array to php 5.4+ notation [Plugins 3: FileSystem, Finder, Installer, Media-Action, QuickIcon and Search]

### DIFF
--- a/plugins/filesystem/local/adapter/adapter.php
+++ b/plugins/filesystem/local/adapter/adapter.php
@@ -120,11 +120,11 @@ class MediaFileAdapterLocal implements MediaFileAdapterInterface
 		// Check if the path points to a file
 		if (is_file($basePath))
 		{
-			return array($this->getPathInformation($basePath));
+			return [$this->getPathInformation($basePath)];
 		}
 
 		// The data to return
-		$data = array();
+		$data = [];
 
 		// Read the folders
 		foreach (JFolder::folders($basePath, $filter) as $folder)

--- a/plugins/finder/categories/categories.php
+++ b/plugins/finder/categories/categories.php
@@ -368,7 +368,7 @@ class PlgFinderCategories extends FinderIndexerAdapter
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias)

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -424,7 +424,7 @@ class PlgFinderContacts extends FinderIndexerAdapter
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias);
@@ -433,7 +433,7 @@ class PlgFinderContacts extends FinderIndexerAdapter
 		$case_when_category_alias .= $query->charLength('c.alias', '!=', '0');
 		$case_when_category_alias .= ' THEN ';
 		$c_id = $query->castAsChar('c.id');
-		$case_when_category_alias .= $query->concatenate(array($c_id, 'c.alias'), ':');
+		$case_when_category_alias .= $query->concatenate([$c_id, 'c.alias'], ':');
 		$case_when_category_alias .= ' ELSE ';
 		$case_when_category_alias .= $c_id . ' END as catslug';
 		$query->select($case_when_category_alias)

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -353,7 +353,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias);
@@ -362,7 +362,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 		$case_when_category_alias .= $query->charLength('c.alias', '!=', '0');
 		$case_when_category_alias .= ' THEN ';
 		$c_id = $query->castAsChar('c.id');
-		$case_when_category_alias .= $query->concatenate(array($c_id, 'c.alias'), ':');
+		$case_when_category_alias .= $query->concatenate([$c_id, 'c.alias'], ':');
 		$case_when_category_alias .= ' ELSE ';
 		$case_when_category_alias .= $c_id . ' END as catslug';
 		$query->select($case_when_category_alias)

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -343,7 +343,7 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias);
@@ -352,7 +352,7 @@ class PlgFinderNewsfeeds extends FinderIndexerAdapter
 		$case_when_category_alias .= $query->charLength('c.alias', '!=', '0');
 		$case_when_category_alias .= ' THEN ';
 		$c_id = $query->castAsChar('c.id');
-		$case_when_category_alias .= $query->concatenate(array($c_id, 'c.alias'), ':');
+		$case_when_category_alias .= $query->concatenate([$c_id, 'c.alias'], ':');
 		$case_when_category_alias .= ' ELSE ';
 		$case_when_category_alias .= $c_id . ' END as catslug';
 		$query->select($case_when_category_alias)

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -305,7 +305,7 @@ class PlgFinderTags extends FinderIndexerAdapter
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias)

--- a/plugins/installer/folderinstaller/folderinstaller.php
+++ b/plugins/installer/folderinstaller/folderinstaller.php
@@ -32,7 +32,7 @@ class PlgInstallerFolderInstaller extends JPlugin
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		$tab            = array();
+		$tab            = [];
 		$tab['name']    = 'folder';
 		$tab['label']   = JText::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT');
 

--- a/plugins/installer/packageinstaller/packageinstaller.php
+++ b/plugins/installer/packageinstaller/packageinstaller.php
@@ -33,7 +33,7 @@ class PlgInstallerPackageInstaller extends JPlugin
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		$tab            = array();
+		$tab            = [];
 		$tab['name']    = 'package';
 		$tab['label']   = JText::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_PACKAGE_FILE');
 

--- a/plugins/installer/urlinstaller/urlinstaller.php
+++ b/plugins/installer/urlinstaller/urlinstaller.php
@@ -32,7 +32,7 @@ class PlgInstallerUrlInstaller extends JPlugin
 	 */
 	public function onInstallerAddInstallationTab()
 	{
-		$tab            = array();
+		$tab            = [];
 		$tab['name']    = 'url';
 		$tab['label']   = JText::_('PLG_INSTALLER_URLINSTALLER_TEXT');
 

--- a/plugins/media-action/crop/crop.php
+++ b/plugins/media-action/crop/crop.php
@@ -29,7 +29,7 @@ class PlgMediaActionCrop extends MediaActionPlugin
 	{
 		parent::loadJs();
 
-		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -43,6 +43,6 @@ class PlgMediaActionCrop extends MediaActionPlugin
 	{
 		parent::loadCss();
 
-		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', array('version' => 'auto', 'relative' => true));
+		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', ['version' => 'auto', 'relative' => true]);
 	}
 }

--- a/plugins/media-action/resize/resize.php
+++ b/plugins/media-action/resize/resize.php
@@ -29,7 +29,7 @@ class PlgMediaActionResize extends MediaActionPlugin
 	{
 		parent::loadJs();
 
-		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -43,6 +43,6 @@ class PlgMediaActionResize extends MediaActionPlugin
 	{
 		parent::loadCss();
 
-		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', array('version' => 'auto', 'relative' => true));
+		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', ['version' => 'auto', 'relative' => true]);
 	}
 }

--- a/plugins/media-action/rotate/rotate.php
+++ b/plugins/media-action/rotate/rotate.php
@@ -29,7 +29,7 @@ class PlgMediaActionRotate extends MediaActionPlugin
 	{
 		parent::loadJs();
 
-		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'vendor/cropperjs/cropper.min.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -43,6 +43,6 @@ class PlgMediaActionRotate extends MediaActionPlugin
 	{
 		parent::loadCss();
 
-		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', array('version' => 'auto', 'relative' => true));
+		JHtml::_('stylesheet', 'vendor/cropperjs/cropper.min.css', ['version' => 'auto', 'relative' => true]);
 	}
 }

--- a/plugins/quickicon/extensionupdate/extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/extensionupdate.php
@@ -39,14 +39,14 @@ class PlgQuickiconExtensionupdate extends JPlugin
 	{
 		if ($context !== $this->params->get('context', 'mod_quickicon') || !JFactory::getUser()->authorise('core.manage', 'com_installer'))
 		{
-			return array();
+			return [];
 		}
 
 		$token    = JSession::getFormToken() . '=1';
-		$options  = array(
-			'url' => JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token,
+		$options  = [
+			'url'     => JUri::base() . 'index.php?option=com_installer&view=update&task=update.find&' . $token,
 			'ajaxUrl' => JUri::base() . 'index.php?option=com_installer&view=update&task=update.ajax&' . $token,
-		);
+		];
 
 		JFactory::getDocument()->addScriptOptions('js-extensions-update', $options);
 
@@ -57,17 +57,17 @@ class PlgQuickiconExtensionupdate extends JPlugin
 		JText::script('PLG_QUICKICON_EXTENSIONUPDATE_ERROR', true);
 
 		JHtml::_('behavior.core');
-		JHtml::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'plg_quickicon_extensionupdate/extensionupdatecheck.js', ['version' => 'auto', 'relative' => true]);
 
-		return array(
-			array(
+		return [
+			[
 				'link'  => 'index.php?option=com_installer&view=update&task=update.find&' . $token,
 				'image' => 'asterisk',
 				'icon'  => 'header/icon-48-extension.png',
 				'text'  => JText::_('PLG_QUICKICON_EXTENSIONUPDATE_CHECKING'),
 				'id'    => 'plg_quickicon_extensionupdate',
 				'group' => 'MOD_QUICKICON_MAINTENANCE'
-			)
-		);
+			]
+		];
 	}
 }

--- a/plugins/quickicon/joomlaupdate/joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/joomlaupdate.php
@@ -77,7 +77,7 @@ class PlgQuickiconJoomlaupdate extends CMSPlugin implements SubscriberInterface
 		);
 
 		JHtml::_('behavior.core');
-		JHtml::_('script', 'plg_quickicon_joomlaupdate/jupdatecheck.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'plg_quickicon_joomlaupdate/jupdatecheck.js', ['version' => 'auto', 'relative' => true]);
 
 		// Add the icon to the result array
 		$result = $event->getArgument('result', []);

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -106,30 +106,30 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 	 */
 	private function getPhpSupport()
 	{
-		$phpSupportData = array(
-			'5.5' => array(
+		$phpSupportData = [
+			'5.5' => [
 				'security' => '2015-07-10',
 				'eos'      => '2016-07-21'
-			),
-			'5.6' => array(
+			],
+			'5.6' => [
 				'security' => '2016-12-31',
 				'eos'      => '2018-12-31'
-			),
-			'7.0' => array(
+			],
+			'7.0' => [
 				'security' => '2017-12-03',
 				'eos'      => '2018-12-03'
-			),
-			'7.1' => array(
+			],
+			'7.1' => [
 				'security' => '2018-12-01',
 				'eos'      => '2019-12-01'
-			),
-		);
+			],
+		];
 
 		// Fill our return array with default values
-		$supportStatus = array(
+		$supportStatus = [
 			'status'  => self::PHP_SUPPORTED,
 			'message' => null,
-		);
+		];
 
 		// Check the PHP version's support status using the minor version
 		$activePhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -35,9 +35,9 @@ class PlgSearchCategories extends JPlugin
 	 */
 	public function onContentSearchAreas()
 	{
-		static $areas = array(
+		static $areas = [
 			'categories' => 'PLG_SEARCH_CATEGORIES_CATEGORIES'
-		);
+		];
 
 		return $areas;
 	}
@@ -69,14 +69,14 @@ class PlgSearchCategories extends JPlugin
 		{
 			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
 			{
-				return array();
+				return [];
 			}
 		}
 
 		$sContent = $this->params->get('search_content', 1);
 		$sArchived = $this->params->get('search_archived', 1);
 		$limit = $this->params->def('search_limit', 50);
-		$state = array();
+		$state = [];
 
 		if ($sContent)
 		{
@@ -90,14 +90,14 @@ class PlgSearchCategories extends JPlugin
 
 		if (empty($state))
 		{
-			return array();
+			return [];
 		}
 
 		$text = trim($text);
 
 		if ($text === '')
 		{
-			return array();
+			return [];
 		}
 
 		/* TODO: The $where variable does not seem to be used at all
@@ -105,7 +105,7 @@ class PlgSearchCategories extends JPlugin
 		{
 			case 'exact':
 				$text = $db->quote('%' . $db->escape($text, true) . '%', false);
-				$wheres2 = array();
+				$wheres2 = [];
 				$wheres2[] = 'a.title LIKE ' . $text;
 				$wheres2[] = 'a.description LIKE ' . $text;
 				$where = '(' . implode(') OR (', $wheres2) . ')';
@@ -115,11 +115,11 @@ class PlgSearchCategories extends JPlugin
 			case 'all';
 			default:
 				$words = explode(' ', $text);
-				$wheres = array();
+				$wheres = [];
 				foreach ($words as $word)
 				{
 					$word = $db->quote('%' . $db->escape($word, true) . '%', false);
-					$wheres2 = array();
+					$wheres2 = [];
 					$wheres2[] = 'a.title LIKE ' . $word;
 					$wheres2[] = 'a.description LIKE ' . $word;
 					$wheres[] = implode(' OR ', $wheres2);
@@ -147,7 +147,7 @@ class PlgSearchCategories extends JPlugin
 		$query = $db->getQuery(true);
 
 		$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 			. ' ELSE a.id END AS slug';
 
 		$query->select('a.title, a.description AS text, a.created_time AS created')
@@ -175,18 +175,18 @@ class PlgSearchCategories extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
-			$rows = array();
+			$rows = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 
-		$return = array();
+		$return = [];
 
 		if ($rows)
 		{
 			foreach ($rows as $i => $row)
 			{
 
-				if (searchHelper::checkNoHtml($row, $searchText, array('name', 'title', 'text')))
+				if (searchHelper::checkNoHtml($row, $searchText, ['name', 'title', 'text']))
 				{
 					$row->href = ContentHelperRoute::getCategoryRoute($row->slug);
 					$row->section = JText::_('JCATEGORY');

--- a/plugins/search/categories/categories.php
+++ b/plugins/search/categories/categories.php
@@ -73,10 +73,10 @@ class PlgSearchCategories extends JPlugin
 			}
 		}
 
-		$sContent = $this->params->get('search_content', 1);
+		$sContent  = $this->params->get('search_content', 1);
 		$sArchived = $this->params->get('search_archived', 1);
-		$limit = $this->params->def('search_limit', 50);
-		$state = [];
+		$limit     = $this->params->def('search_limit', 50);
+		$state     = [];
 
 		if ($sContent)
 		{

--- a/plugins/search/contacts/contacts.php
+++ b/plugins/search/contacts/contacts.php
@@ -33,9 +33,9 @@ class PlgSearchContacts extends JPlugin
 	 */
 	public function onContentSearchAreas()
 	{
-		static $areas = array(
+		static $areas = [
 			'contacts' => 'PLG_SEARCH_CONTACTS_CONTACTS'
-		);
+		];
 
 		return $areas;
 	}
@@ -68,14 +68,14 @@ class PlgSearchContacts extends JPlugin
 		{
 			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
 			{
-				return array();
+				return [];
 			}
 		}
 
 		$sContent  = $this->params->get('search_content', 1);
 		$sArchived = $this->params->get('search_archived', 1);
 		$limit     = $this->params->def('search_limit', 50);
-		$state     = array();
+		$state     = [];
 
 		if ($sContent)
 		{
@@ -89,14 +89,14 @@ class PlgSearchContacts extends JPlugin
 
 		if (empty($state))
 		{
-			return array();
+			return [];
 		}
 
 		$text = trim($text);
 
 		if ($text === '')
 		{
-			return array();
+			return [];
 		}
 
 		$section = JText::_('PLG_SEARCH_CONTACTS_CONTACTS');
@@ -123,19 +123,19 @@ class PlgSearchContacts extends JPlugin
 		$query = $db->getQuery(true);
 
 		$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 			. ' ELSE a.id END AS slug';
 
 		$case_when1 = ' CASE WHEN ' . $query->charLength('c.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('c.id'), 'c.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('c.id'), 'c.alias'], ':')
 			. ' ELSE c.id END AS catslug';
 
 		$query->select('a.name AS title')
 			->select($db->quote('') . ' AS created, a.con_position, a.misc')
 			->select($case_when)
 			->select($case_when1)
-			->select($query->concatenate(array('a.name', 'a.con_position', 'a.misc'), ',') . ' AS text')
-			->select($query->concatenate(array($db->quote($section), 'c.title'), ' / ') . ' AS section')
+			->select($query->concatenate(['a.name', 'a.con_position', 'a.misc'], ',') . ' AS text')
+			->select($query->concatenate([$db->quote($section), 'c.title'], ' / ') . ' AS section')
 			->select($db->quote('2') . ' AS browsernav')
 			->from($db->quoteName('#__contact_details', 'a'))
 			->innerJoin($db->quoteName('#__categories', 'c') . ' ON c.id = a.catid')
@@ -164,7 +164,7 @@ class PlgSearchContacts extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
-			$rows = array();
+			$rows = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -25,9 +25,9 @@ class PlgSearchContent extends JPlugin
 	 */
 	public function onContentSearchAreas()
 	{
-		static $areas = array(
+		static $areas = [
 			'content' => 'JGLOBAL_ARTICLES'
-		);
+		];
 
 		return $areas;
 	}
@@ -63,7 +63,7 @@ class PlgSearchContent extends JPlugin
 		{
 			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
 			{
-				return array();
+				return [];
 			}
 		}
 
@@ -79,14 +79,14 @@ class PlgSearchContent extends JPlugin
 
 		if ($text === '')
 		{
-			return array();
+			return [];
 		}
 
 		switch ($phrase)
 		{
 			case 'exact':
 				$text      = $db->quote('%' . $db->escape($text, true) . '%', false);
-				$wheres2   = array();
+				$wheres2   = [];
 				$wheres2[] = 'a.title LIKE ' . $text;
 				$wheres2[] = 'a.introtext LIKE ' . $text;
 				$wheres2[] = 'a.fulltext LIKE ' . $text;
@@ -100,12 +100,12 @@ class PlgSearchContent extends JPlugin
 			case 'any':
 			default:
 				$words = explode(' ', $text);
-				$wheres = array();
+				$wheres = [];
 
 				foreach ($words as $word)
 				{
 					$word      = $db->quote('%' . $db->escape($word, true) . '%', false);
-					$wheres2   = array();
+					$wheres2   = [];
 					$wheres2[] = 'LOWER(a.title) LIKE LOWER(' . $word . ')';
 					$wheres2[] = 'LOWER(a.introtext) LIKE LOWER(' . $word . ')';
 					$wheres2[] = 'LOWER(a.fulltext) LIKE LOWER(' . $word . ')';
@@ -143,7 +143,7 @@ class PlgSearchContent extends JPlugin
 				break;
 		}
 
-		$rows = array();
+		$rows = [];
 		$query = $db->getQuery(true);
 
 		// Search articles.
@@ -152,15 +152,15 @@ class PlgSearchContent extends JPlugin
 			$query->clear();
 
 			$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-				. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+				. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 				. ' ELSE a.id END AS slug';
 
 			$case_when1 = ' CASE WHEN ' . $query->charLength('c.alias', '!=', '0')
-				. ' THEN ' . $query->concatenate(array($query->castAsChar('c.id'), 'c.alias'), ':')
+				. ' THEN ' . $query->concatenate([$query->castAsChar('c.id'), 'c.alias'], ':')
 				. ' ELSE c.id END AS catslug';
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created, a.language, a.catid')
-				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
+				->select($query->concatenate(['a.introtext', 'a.fulltext']) . ' AS text')
 				->select('c.title AS section')
 				->select($case_when)
 				->select($case_when1)
@@ -199,7 +199,7 @@ class PlgSearchContent extends JPlugin
 			}
 			catch (RuntimeException $e)
 			{
-				$list = array();
+				$list = [];
 				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 			}
 			$limit -= count($list);
@@ -221,15 +221,15 @@ class PlgSearchContent extends JPlugin
 			$query->clear();
 
 			$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 			. ' ELSE a.id END AS slug';
 
 			$case_when1 = ' CASE WHEN ' . $query->charLength('c.alias', '!=', '0')
-				. ' THEN ' . $query->concatenate(array($query->castAsChar('c.id'), 'c.alias'), ':')
+				. ' THEN ' . $query->concatenate([$query->castAsChar('c.id'), 'c.alias'], ':')
 				. ' ELSE c.id END AS catslug';
 
 			$query->select('a.title AS title, a.metadesc, a.metakey, a.created AS created')
-				->select($query->concatenate(array('a.introtext', 'a.fulltext')) . ' AS text')
+				->select($query->concatenate(['a.introtext', 'a.fulltext']) . ' AS text')
 				->select($case_when)
 				->select($case_when1)
 				->select('c.title AS section')
@@ -267,7 +267,7 @@ class PlgSearchContent extends JPlugin
 			}
 			catch (RuntimeException $e)
 			{
-				$list3 = array();
+				$list3 = [];
 				JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 			}
 
@@ -291,13 +291,13 @@ class PlgSearchContent extends JPlugin
 			$rows[] = $list3;
 		}
 
-		$results = array();
+		$results = [];
 
 		if (count($rows))
 		{
 			foreach ($rows as $row)
 			{
-				$new_row = array();
+				$new_row = [];
 
 				foreach ($row as $article)
 				{
@@ -311,7 +311,7 @@ class PlgSearchContent extends JPlugin
 					$db->setQuery($query);
 					$article->jcfields = implode(',', $db->loadColumn());
 
-					if (SearchHelper::checkNoHtml($article, $searchText, array('text', 'title', 'jcfields', 'metadesc', 'metakey')))
+					if (SearchHelper::checkNoHtml($article, $searchText, ['text', 'title', 'jcfields', 'metadesc', 'metakey']))
 					{
 						$new_row[] = $article;
 					}

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -143,7 +143,7 @@ class PlgSearchContent extends JPlugin
 				break;
 		}
 
-		$rows = [];
+		$rows  = [];
 		$query = $db->getQuery(true);
 
 		// Search articles.

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -33,9 +33,9 @@ class PlgSearchNewsfeeds extends JPlugin
 	 */
 	public function onContentSearchAreas()
 	{
-		static $areas = array(
+		static $areas = [
 			'newsfeeds' => 'PLG_SEARCH_NEWSFEEDS_NEWSFEEDS'
-		);
+		];
 
 		return $areas;
 	}
@@ -66,14 +66,14 @@ class PlgSearchNewsfeeds extends JPlugin
 		{
 			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
 			{
-				return array();
+				return [];
 			}
 		}
 
 		$sContent = $this->params->get('search_content', 1);
 		$sArchived = $this->params->get('search_archived', 1);
 		$limit = $this->params->def('search_limit', 50);
-		$state = array();
+		$state = [];
 
 		if ($sContent)
 		{
@@ -87,21 +87,21 @@ class PlgSearchNewsfeeds extends JPlugin
 
 		if (empty($state))
 		{
-			return array();
+			return [];
 		}
 
 		$text = trim($text);
 
 		if ($text === '')
 		{
-			return array();
+			return [];
 		}
 
 		switch ($phrase)
 		{
 			case 'exact':
 				$text = $db->quote('%' . $db->escape($text, true) . '%', false);
-				$wheres2 = array();
+				$wheres2 = [];
 				$wheres2[] = 'a.name LIKE ' . $text;
 				$wheres2[] = 'a.link LIKE ' . $text;
 				$where = '(' . implode(') OR (', $wheres2) . ')';
@@ -111,12 +111,12 @@ class PlgSearchNewsfeeds extends JPlugin
 			case 'any':
 			default:
 				$words = explode(' ', $text);
-				$wheres = array();
+				$wheres = [];
 
 				foreach ($words as $word)
 				{
 					$word = $db->quote('%' . $db->escape($word, true) . '%', false);
-					$wheres2 = array();
+					$wheres2 = [];
 					$wheres2[] = 'a.name LIKE ' . $word;
 					$wheres2[] = 'a.link LIKE ' . $word;
 					$wheres[] = implode(' OR ', $wheres2);
@@ -148,18 +148,18 @@ class PlgSearchNewsfeeds extends JPlugin
 		$query = $db->getQuery(true);
 
 		$case_when = ' CASE WHEN ' . $query->charLength('a.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('a.id'), 'a.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('a.id'), 'a.alias'], ':')
 			. ' ELSE a.id END AS slug';
 
 		$case_when1 = ' CASE WHEN ' . $query->charLength('c.alias', '!=', '0')
-			. ' THEN ' . $query->concatenate(array($query->castAsChar('c.id'), 'c.alias'), ':')
+			. ' THEN ' . $query->concatenate([$query->castAsChar('c.id'), 'c.alias'], ':')
 			. ' ELSE c.id END AS catslug';
 
 		$query->select('a.name AS title')
 			->select($db->quote('') . ' AS created, a.link AS text')
 			->select($case_when)
 			->select($case_when1)
-			->select($query->concatenate(array($db->quote($searchNewsfeeds), 'c.title'), ' / ') . ' AS section')
+			->select($query->concatenate([$db->quote($searchNewsfeeds), 'c.title'], ' / ') . ' AS section')
 			->select($db->quote('1') . ' AS browsernav')
 			->from($db->quoteName('#__newsfeeds', 'a'))
 			->innerJoin($db->quoteName('#__categories', 'c') . ' ON c.id = a.catid')
@@ -182,7 +182,7 @@ class PlgSearchNewsfeeds extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
-			$rows = array();
+			$rows = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 

--- a/plugins/search/newsfeeds/newsfeeds.php
+++ b/plugins/search/newsfeeds/newsfeeds.php
@@ -70,10 +70,10 @@ class PlgSearchNewsfeeds extends JPlugin
 			}
 		}
 
-		$sContent = $this->params->get('search_content', 1);
+		$sContent  = $this->params->get('search_content', 1);
 		$sArchived = $this->params->get('search_archived', 1);
-		$limit = $this->params->def('search_limit', 50);
-		$state = [];
+		$limit     = $this->params->def('search_limit', 50);
+		$state     = [];
 
 		if ($sContent)
 		{
@@ -100,26 +100,26 @@ class PlgSearchNewsfeeds extends JPlugin
 		switch ($phrase)
 		{
 			case 'exact':
-				$text = $db->quote('%' . $db->escape($text, true) . '%', false);
-				$wheres2 = [];
+				$text      = $db->quote('%' . $db->escape($text, true) . '%', false);
+				$wheres2   = [];
 				$wheres2[] = 'a.name LIKE ' . $text;
 				$wheres2[] = 'a.link LIKE ' . $text;
-				$where = '(' . implode(') OR (', $wheres2) . ')';
+				$where     = '(' . implode(') OR (', $wheres2) . ')';
 				break;
 
 			case 'all':
 			case 'any':
 			default:
-				$words = explode(' ', $text);
+				$words  = explode(' ', $text);
 				$wheres = [];
 
 				foreach ($words as $word)
 				{
-					$word = $db->quote('%' . $db->escape($word, true) . '%', false);
-					$wheres2 = [];
+					$word      = $db->quote('%' . $db->escape($word, true) . '%', false);
+					$wheres2   = [];
 					$wheres2[] = 'a.name LIKE ' . $word;
 					$wheres2[] = 'a.link LIKE ' . $word;
-					$wheres[] = implode(' OR ', $wheres2);
+					$wheres[]  = implode(' OR ', $wheres2);
 				}
 
 				$where = '(' . implode(($phrase === 'all' ? ') AND (' : ') OR ('), $wheres) . ')';

--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -35,9 +35,9 @@ class PlgSearchTags extends JPlugin
 	 */
 	public function onContentSearchAreas()
 	{
-		static $areas = array(
+		static $areas = [
 			'tags' => 'PLG_SEARCH_TAGS_TAGS'
-		);
+		];
 
 		return $areas;
 	}
@@ -72,7 +72,7 @@ class PlgSearchTags extends JPlugin
 		{
 			if (!array_intersect($areas, array_keys($this->onContentSearchAreas())))
 			{
-				return array();
+				return [];
 			}
 		}
 
@@ -80,7 +80,7 @@ class PlgSearchTags extends JPlugin
 
 		if ($text === '')
 		{
-			return array();
+			return [];
 		}
 
 		$text = $db->quote('%' . $db->escape($text, true) . '%', false);
@@ -113,7 +113,7 @@ class PlgSearchTags extends JPlugin
 		$case_when_item_alias .= $query->charLength('a.alias', '!=', '0');
 		$case_when_item_alias .= ' THEN ';
 		$a_id                  = $query->castAsChar('a.id');
-		$case_when_item_alias .= $query->concatenate(array($a_id, 'a.alias'), ':');
+		$case_when_item_alias .= $query->concatenate([$a_id, 'a.alias'], ':');
 		$case_when_item_alias .= ' ELSE ';
 		$case_when_item_alias .= $a_id . ' END as slug';
 		$query->select($case_when_item_alias);
@@ -147,7 +147,7 @@ class PlgSearchTags extends JPlugin
 		}
 		catch (RuntimeException $e)
 		{
-			$rows = array();
+			$rows = [];
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 		}
 


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in FileSystem, Finder, Installer, Media-Action, QuickIcon and Search plugins.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.