### PR TITLE
[4.0] Array to php 5.4+ notation [Plugins 4: TwoFactorAuth and User]

### DIFF
--- a/plugins/twofactorauth/totp/totp.php
+++ b/plugins/twofactorauth/totp/totp.php
@@ -69,10 +69,10 @@ class PlgTwofactorauthTotp extends JPlugin
 			return false;
 		}
 
-		return (object) array(
+		return (object) [
 			'method' => $this->methodName,
 			'title'  => JText::_('PLG_TWOFACTORAUTH_TOTP_METHOD_TITLE')
-		);
+		];
 	}
 
 	/**
@@ -122,10 +122,10 @@ class PlgTwofactorauthTotp extends JPlugin
 		$html = @ob_get_clean();
 
 		// Return the form contents
-		return array(
+		return [
 			'method' => $this->methodName,
 			'form'   => $html
-		);
+		];
 	}
 
 	/**
@@ -150,7 +150,7 @@ class PlgTwofactorauthTotp extends JPlugin
 		$input = JFactory::getApplication()->input;
 
 		// Load raw data
-		$rawData = $input->get('jform', array(), 'array');
+		$rawData = $input->get('jform', [], 'array');
 
 		if (!isset($rawData['twofactor']['totp']))
 		{
@@ -213,13 +213,13 @@ class PlgTwofactorauthTotp extends JPlugin
 		}
 
 		// Check succeedeed; return an OTP configuration object
-		$otpConfig = (object) array(
+		$otpConfig = (object) [
 			'method'   => 'totp',
-			'config'   => array(
+			'config'   => [
 				'code' => $data['key']
-			),
-			'otep'     => array()
-		);
+			],
+			'otep'     => []
+		];
 
 		return $otpConfig;
 	}

--- a/plugins/twofactorauth/yubikey/yubikey.php
+++ b/plugins/twofactorauth/yubikey/yubikey.php
@@ -68,10 +68,10 @@ class PlgTwofactorauthYubikey extends JPlugin
 			return false;
 		}
 
-		return (object) array(
+		return (object) [
 			'method' => $this->methodName,
 			'title'  => JText::_('PLG_TWOFACTORAUTH_YUBIKEY_METHOD_TITLE'),
-		);
+		];
 	}
 
 	/**
@@ -111,10 +111,10 @@ class PlgTwofactorauthYubikey extends JPlugin
 		$html = @ob_get_clean();
 
 		// Return the form contents
-		return array(
+		return [
 			'method' => $this->methodName,
 			'form'   => $html,
-		);
+		];
 	}
 
 	/**
@@ -139,7 +139,7 @@ class PlgTwofactorauthYubikey extends JPlugin
 		$input = JFactory::getApplication()->input;
 
 		// Load raw data
-		$rawData = $input->get('jform', array(), 'array');
+		$rawData = $input->get('jform', [], 'array');
 
 		if (!isset($rawData['twofactor']['yubikey']))
 		{
@@ -179,13 +179,13 @@ class PlgTwofactorauthYubikey extends JPlugin
 		$yubikey      = substr($data['securitycode'], 0, -32);
 
 		// Check succeedeed; return an OTP configuration object
-		$otpConfig    = (object) array(
+		$otpConfig    = (object) [
 			'method'  => $this->methodName,
-			'config'  => array(
+			'config'  => [
 				'yubikey' => $yubikey
-			),
-			'otep'    => array()
-		);
+			],
+			'otep'    => []
+		];
 
 		return $otpConfig;
 	}
@@ -249,13 +249,13 @@ class PlgTwofactorauthYubikey extends JPlugin
 	 */
 	public function validateYubikeyOtp($otp)
 	{
-		$server_queue = array(
+		$server_queue = [
 			'api.yubico.com',
 			'api2.yubico.com',
 			'api3.yubico.com',
 			'api4.yubico.com',
 			'api5.yubico.com',
-		);
+		];
 
 		shuffle($server_queue);
 
@@ -315,7 +315,7 @@ class PlgTwofactorauthYubikey extends JPlugin
 
 		// Parse response
 		$lines = explode("\n", $response->body);
-		$data  = array();
+		$data  = [];
 
 		foreach ($lines as $line)
 		{

--- a/plugins/user/contactcreator/contactcreator.php
+++ b/plugins/user/contactcreator/contactcreator.php
@@ -80,7 +80,7 @@ class PlgUserContactCreator extends JPlugin
 			 * Try to pre-load a contact for this user. Apparently only possible if other plugin creates it
 			 * Note: $user_id is cleaned above
 			 */
-			if (!$contact->load(array('user_id' => (int) $user_id)))
+			if (!$contact->load(['user_id' => (int) $user_id]))
 			{
 				$contact->published = $this->params->get('autopublish', 0);
 			}
@@ -107,10 +107,10 @@ class PlgUserContactCreator extends JPlugin
 			if (!empty($autowebpage))
 			{
 				// Search terms
-				$search_array = array('[name]', '[username]', '[userid]', '[email]');
+				$search_array = ['[name]', '[username]', '[userid]', '[email]'];
 
 				// Replacement terms, urlencoded
-				$replace_array = array_map('urlencode', array($user['name'], $user['username'], $user['id'], $user['email']));
+				$replace_array = array_map('urlencode', [$user['name'], $user['username'], $user['id'], $user['email']]);
 
 				// Now replace it in together
 				$contact->webpage = str_replace($search_array, $replace_array, $autowebpage);
@@ -142,7 +142,7 @@ class PlgUserContactCreator extends JPlugin
 	{
 		$table = $this->getContactTable();
 
-		while ($table->load(array('alias' => $alias, 'catid' => $categoryId)))
+		while ($table->load(['alias' => $alias, 'catid' => $categoryId]))
 		{
 			if ($name === $table->name)
 			{
@@ -152,7 +152,7 @@ class PlgUserContactCreator extends JPlugin
 			$alias = StringHelper::increment($alias, 'dash');
 		}
 
-		return array($name, $alias);
+		return [$name, $alias];
 	}
 
 	/**

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -185,7 +185,7 @@ class PlgUserJoomla extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	public function onUserLogin($user, $options = array())
+	public function onUserLogin($user, $options = [])
 	{
 		$instance = $this->_getUser($user, $options);
 
@@ -283,7 +283,7 @@ class PlgUserJoomla extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	public function onUserLogout($user, $options = array())
+	public function onUserLogout($user, $options = [])
 	{
 		$my      = JFactory::getUser();
 		$session = JFactory::getSession();
@@ -351,7 +351,7 @@ class PlgUserJoomla extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	protected function _getUser($user, $options = array())
+	protected function _getUser($user, $options = [])
 	{
 		$instance = JUser::getInstance();
 		$id = (int) JUserHelper::getUserId($user['username']);
@@ -375,8 +375,8 @@ class PlgUserJoomla extends JPlugin
 		$instance->password_clear = $user['password_clear'];
 
 		// Result should contain an email (check).
-		$instance->email = $user['email'];
-		$instance->groups = array($defaultUserGroup);
+		$instance->email  = $user['email'];
+		$instance->groups = [$defaultUserGroup];
 
 		// If autoregister is set let's register the user
 		$autoregister = isset($options['autoregister']) ? $options['autoregister'] : $this->params->get('autoregister', 1);

--- a/plugins/user/profile/field/dob.php
+++ b/plugins/user/profile/field/dob.php
@@ -53,7 +53,7 @@ class JFormFieldDob extends JFormFieldCalendar
 			if ($app->isClient('administrator') || $view === 'profile' || $view === 'registration')
 			{
 				$layout = new JLayoutFile('plugins.user.profile.fields.dob');
-				$info   = $layout->render(array('text' => $text));
+				$info   = $layout->render(['text' => $text]);
 				$label  = $info . $label;
 			}
 		}

--- a/plugins/user/profile/field/tos.php
+++ b/plugins/user/profile/field/tos.php
@@ -82,7 +82,7 @@ class JFormFieldTos extends JFormFieldRadio
 		{
 			JLoader::register('ContentHelperRoute', JPATH_BASE . '/components/com_content/helpers/route.php');
 
-			$attribs          = array();
+			$attribs          = [];
 			$attribs['class'] = 'modal';
 			$attribs['rel']   = '{handler: \'iframe\', size: {x:800, y:500}}';
 

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -436,7 +436,7 @@ class PlgUserProfile extends JPlugin
 			$usedOrdering = $db->loadColumn();
 
 			$tuples = [];
-			$order = 1;
+			$order  = 1;
 
 			foreach ($data['profile'] as $k => $v)
 			{

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -61,7 +61,7 @@ class PlgUserProfile extends JPlugin
 	public function onContentPrepareData($context, $data)
 	{
 		// Check we are manipulating a valid form.
-		if (!in_array($context, array('com_users.profile', 'com_users.user', 'com_users.registration', 'com_admin.profile')))
+		if (!in_array($context, ['com_users.profile', 'com_users.user', 'com_users.registration', 'com_admin.profile']))
 		{
 			return true;
 		}
@@ -76,10 +76,10 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 				$query = $db->getQuery(true)
 					->select(
-						array(
+						[
 							$db->qn('profile_key'),
 							$db->qn('profile_value'),
-						)
+						]
 					)
 					->from('#__user_profiles')
 					->where($db->qn('user_id') . ' = ' . $db->q((int) $userId))
@@ -90,7 +90,7 @@ class PlgUserProfile extends JPlugin
 				$results = $db->loadRowList();
 
 				// Merge the profile data.
-				$data->profile = array();
+				$data->profile = [];
 
 				foreach ($results as $v)
 				{
@@ -106,22 +106,22 @@ class PlgUserProfile extends JPlugin
 
 			if (!JHtml::isRegistered('users.url'))
 			{
-				JHtml::register('users.url', array(__CLASS__, 'url'));
+				JHtml::register('users.url', [__CLASS__, 'url']);
 			}
 
 			if (!JHtml::isRegistered('users.calendar'))
 			{
-				JHtml::register('users.calendar', array(__CLASS__, 'calendar'));
+				JHtml::register('users.calendar', [__CLASS__, 'calendar']);
 			}
 
 			if (!JHtml::isRegistered('users.tos'))
 			{
-				JHtml::register('users.tos', array(__CLASS__, 'tos'));
+				JHtml::register('users.tos', [__CLASS__, 'tos']);
 			}
 
 			if (!JHtml::isRegistered('users.dob'))
 			{
-				JHtml::register('users.dob', array(__CLASS__, 'dob'));
+				JHtml::register('users.dob', [__CLASS__, 'dob']);
 			}
 		}
 
@@ -232,7 +232,7 @@ class PlgUserProfile extends JPlugin
 		// Check we are manipulating a valid form.
 		$name = $form->getName();
 
-		if (!in_array($name, array('com_admin.profile', 'com_users.user', 'com_users.profile', 'com_users.registration')))
+		if (!in_array($name, ['com_admin.profile', 'com_users.user', 'com_users.profile', 'com_users.registration']))
 		{
 			return true;
 		}
@@ -241,7 +241,7 @@ class PlgUserProfile extends JPlugin
 		JForm::addFormPath(__DIR__ . '/profiles');
 		$form->loadFile('profile', false);
 
-		$fields = array(
+		$fields = [
 			'address1',
 			'address2',
 			'city',
@@ -254,7 +254,7 @@ class PlgUserProfile extends JPlugin
 			'aboutme',
 			'dob',
 			'tos',
-		);
+		];
 
 		// Change fields description when displayed in frontend or backend profile editing
 		$app = JFactory::getApplication();
@@ -435,7 +435,7 @@ class PlgUserProfile extends JPlugin
 			$db->setQuery($query);
 			$usedOrdering = $db->loadColumn();
 
-			$tuples = array();
+			$tuples = [];
 			$order = 1;
 
 			foreach ($data['profile'] as $k => $v)


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in TwoFactorAuth and User plugins.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.