### PR TITLE
[4.0] Array to php 5.4+ notation [Plugins 5: System]

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -33,11 +33,11 @@ class PlgSystemCache extends JPlugin
 		parent::__construct($subject, $config);
 
 		// Set the language in the class.
-		$options = array(
+		$options = [
 			'defaultgroup' => 'page',
 			'browsercache' => $this->params->get('browsercache', false),
 			'caching'      => false,
-		);
+		];
 
 		$this->_cache     = JCache::getInstance('page', $options);
 		$this->_cache_key = JUri::getInstance()->toString();
@@ -128,7 +128,7 @@ class PlgSystemCache extends JPlugin
 	protected function isExcluded()
 	{
 		// Check if menu items have been excluded
-		if ($exclusions = $this->params->get('exclude_menu_items', array()))
+		if ($exclusions = $this->params->get('exclude_menu_items', []))
 		{
 			// Get the current menu item
 			$active = JFactory::getApplication()->getMenu()->getActive();
@@ -143,13 +143,13 @@ class PlgSystemCache extends JPlugin
 		if ($exclusions = $this->params->get('exclude', ''))
 		{
 			// Normalize line endings
-			$exclusions = str_replace(array("\r\n", "\r"), "\n", $exclusions);
+			$exclusions = str_replace(["\r\n", "\r"], "\n", $exclusions);
 
 			// Split them
 			$exclusions = explode("\n", $exclusions);
 
 			// Get current path to match against
-			$path = JUri::getInstance()->toString(array('path', 'query', 'fragment'));
+			$path = JUri::getInstance()->toString(['path', 'query', 'fragment']);
 
 			// Loop through each pattern
 			if ($exclusions)

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -40,7 +40,7 @@ class PlgSystemDebug extends JPlugin
 	 * @var    array
 	 * @since  3.1
 	 */
-	private $logEntries = array();
+	private $logEntries = [];
 
 	/**
 	 * Holds SHOW PROFILES of queries.
@@ -48,7 +48,7 @@ class PlgSystemDebug extends JPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $sqlShowProfiles = array();
+	private $sqlShowProfiles = [];
 
 	/**
 	 * Holds all SHOW PROFILE FOR QUERY n, indexed by n-1.
@@ -56,7 +56,7 @@ class PlgSystemDebug extends JPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $sqlShowProfileEach = array();
+	private $sqlShowProfileEach = [];
 
 	/**
 	 * Holds all EXPLAIN EXTENDED for all queries.
@@ -64,7 +64,7 @@ class PlgSystemDebug extends JPlugin
 	 * @var    array
 	 * @since  3.1.2
 	 */
-	private $explains = array();
+	private $explains = [];
 
 	/**
 	 * Holds total amount of executed queries.
@@ -88,7 +88,7 @@ class PlgSystemDebug extends JPlugin
 	 * @var    callable[]
 	 * @since  3.7.0
 	 */
-	private static $displayCallbacks = array();
+	private static $displayCallbacks = [];
 
 	/**
 	 * Constructor.
@@ -105,13 +105,13 @@ class PlgSystemDebug extends JPlugin
 		// Log the deprecated API.
 		if ($this->params->get('log-deprecated'))
 		{
-			JLog::addLogger(array('text_file' => 'deprecated.php'), JLog::ALL, array('deprecated'));
+			JLog::addLogger(['text_file' => 'deprecated.php'], JLog::ALL, ['deprecated']);
 		}
 
 		// Log everything (except deprecated APIs, these are logged separately with the option above).
 		if ($this->params->get('log-everything'))
 		{
-			JLog::addLogger(array('text_file' => 'everything.php'), JLog::ALL, array('deprecated', 'databasequery'), true);
+			JLog::addLogger(['text_file' => 'everything.php'], JLog::ALL, ['deprecated', 'databasequery'], true);
 		}
 
 		// Get the application if not done by JPlugin. This may happen during upgrades from Joomla 2.5.
@@ -142,7 +142,7 @@ class PlgSystemDebug extends JPlugin
 		{
 			$priority = 0;
 
-			foreach ($this->params->get('log_priorities', array()) as $p)
+			foreach ($this->params->get('log_priorities', []) as $p)
 			{
 				$const = 'JLog::' . strtoupper($p);
 
@@ -158,12 +158,12 @@ class PlgSystemDebug extends JPlugin
 			$categories = array_filter(preg_split('/[^A-Z0-9_\.-]/i', $this->params->get('log_categories', '')));
 			$mode = $this->params->get('log_category_mode', 0);
 
-			JLog::addLogger(array('logger' => 'callback', 'callback' => array($this, 'logger')), $priority, $categories, $mode);
+			JLog::addLogger(['logger' => 'callback', 'callback' => [$this, 'logger']], $priority, $categories, $mode);
 		}
 
 		// Prepare disconnect handler for SQL profiling.
 		$db = JFactory::getDbo();
-		$db->addDisconnectHandler(array($this, 'mysqlDisconnectHandler'));
+		$db->addDisconnectHandler([$this, 'mysqlDisconnectHandler']);
 
 		// Log deprecated class aliases
 		foreach (JLoader::getDeprecatedAliases() as $deprecation)
@@ -194,15 +194,15 @@ class PlgSystemDebug extends JPlugin
 		// Only if debugging or language debug is enabled.
 		if ((JDEBUG || $this->debugLang) && $this->isAuthorisedDisplayDebug())
 		{
-			JHtml::_('stylesheet', 'plg_system_debug/debug.css', array('version' => 'auto', 'relative' => true));
-			JHtml::_('script', 'plg_system_debug/debug.min.js', array('version' => 'auto', 'relative' => true));
+			JHtml::_('stylesheet', 'plg_system_debug/debug.css', ['version' => 'auto', 'relative' => true]);
+			JHtml::_('script', 'plg_system_debug/debug.min.js', ['version' => 'auto', 'relative' => true]);
 		}
 
 		// Only if debugging is enabled for SQL query popovers.
 		if (JDEBUG && $this->isAuthorisedDisplayDebug())
 		{
 			JHtml::_('bootstrap.tooltip');
-			JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'top'));
+			JHtml::_('bootstrap.popover', '.hasPopover', ['placement' => 'top']);
 		}
 	}
 
@@ -253,7 +253,7 @@ class PlgSystemDebug extends JPlugin
 		// Load language.
 		$this->loadLanguage();
 
-		$html = array();
+		$html = [];
 
 		$html[] = '<div id="system-debug" class="profiler">';
 
@@ -400,7 +400,7 @@ class PlgSystemDebug extends JPlugin
 	 *
 	 * @since   2.5
 	 */
-	protected function display($item, array $errors = array())
+	protected function display($item, array $errors = [])
 	{
 		$title = JText::_('PLG_DEBUG_' . strtoupper($item));
 
@@ -418,7 +418,7 @@ class PlgSystemDebug extends JPlugin
 			return __METHOD__ . ' -- Unknown method: ' . $fncName . '<br>';
 		}
 
-		$html = array();
+		$html = [];
 
 		$js = "Joomla.toggleContainer('dbg_container_" . $item . "');";
 
@@ -450,7 +450,7 @@ class PlgSystemDebug extends JPlugin
 	{
 		$title = JText::_('PLG_DEBUG_' . strtoupper($name));
 
-		$html = array();
+		$html = [];
 
 		$js = "toggleContainer('dbg_container_" . $name . "');";
 
@@ -488,7 +488,7 @@ class PlgSystemDebug extends JPlugin
 			$session = $this->app->getSession()->all();
 		}
 
-		$html = array();
+		$html = [];
 		static $id;
 
 		if (!is_array($session))
@@ -561,7 +561,7 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function displayErrors()
 	{
-		$html = array();
+		$html = [];
 
 		$html[] = '<ol>';
 
@@ -597,13 +597,13 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function displayProfileInformation()
 	{
-		$html = array();
+		$html = [];
 
-		$htmlMarks = array();
+		$htmlMarks = [];
 
 		$totalTime = 0;
 		$totalMem = 0;
-		$marks = array();
+		$marks = [];
 
 		foreach (JProfiler::getInstance('Application')->getMarks() as $mark)
 		{
@@ -621,12 +621,12 @@ class PlgSystemDebug extends JPlugin
 				$mark->label
 			);
 
-			$marks[] = (object) array(
-				'time' => $mark->time,
+			$marks[] = (object) [
+				'time'   => $mark->time,
 				'memory' => $mark->memory,
-				'html' => $htmlMark,
-				'tip' => $mark->label
-			);
+				'html'   => $htmlMark,
+				'tip'    => $mark->label
+			];
 		}
 
 		$avgTime = $totalTime / count($marks);
@@ -669,17 +669,17 @@ class PlgSystemDebug extends JPlugin
 			$barClass .= " progress-$barClass";
 			$barClassMem .= " progress-$barClassMem";
 
-			$bars[] = (object) array(
+			$bars[] = (object) [
 				'width' => round($mark->time / ($totalTime / 100), 4),
 				'class' => $barClass,
-				'tip' => $mark->tip . ' ' . round($mark->time, 2) . ' ms'
-			);
+				'tip'   => $mark->tip . ' ' . round($mark->time, 2) . ' ms'
+			];
 
-			$barsMem[] = (object) array(
+			$barsMem[] = (object) [
 				'width' => round((float) $mark->memory / ($totalMem / 100), 4),
 				'class' => $barClassMem,
-				'tip' => $mark->tip . ' ' . round($mark->memory, 3) . '  MB',
-			);
+				'tip'   => $mark->tip . ' ' . round($mark->memory, 3) . '  MB',
+			];
 
 			$htmlMarks[] = '<div>' . str_replace('badge-time', $labelClass, str_replace('badge-memory', $labelClassMem, $mark->html)) . '</div>';
 		}
@@ -786,15 +786,15 @@ class PlgSystemDebug extends JPlugin
 			return null;
 		}
 
-		$timings = $db->getTimings();
+		$timings    = $db->getTimings();
 		$callStacks = $db->getCallStacks();
 
 		$db->setDebug(false);
 
-		$selectQueryTypeTicker = array();
-		$otherQueryTypeTicker = array();
+		$selectQueryTypeTicker = [];
+		$otherQueryTypeTicker  = [];
 
-		$timing = array();
+		$timing  = [];
 		$maxtime = 0;
 
 		if (isset($timings[0]))
@@ -809,8 +809,8 @@ class PlgSystemDebug extends JPlugin
 				{
 					if (isset($timings[$id * 2 + 1]))
 					{
-						// Compute the query time: $timing[$k] = array( queryTime, timeBetweenQueries ).
-						$timing[$id] = array(($timings[$id * 2 + 1] - $timings[$id * 2]) * 1000, $id > 0 ? ($timings[$id * 2] - $timings[$id * 2 - 1]) * 1000 : 0);
+						// Compute the query time: $timing[$k] = [queryTime, timeBetweenQueries].
+						$timing[$id] =[($timings[$id * 2 + 1] - $timings[$id * 2]) * 1000, $id > 0 ? ($timings[$id * 2] - $timings[$id * 2 - 1]) * 1000 : 0];
 						$maxtime = max($maxtime, $timing[$id]['0']);
 					}
 				}
@@ -822,10 +822,10 @@ class PlgSystemDebug extends JPlugin
 			$totalBargraphTime = 1;
 		}
 
-		$bars = array();
-		$info = array();
+		$bars = [];
+		$info = [];
 		$totalQueryTime = 0;
-		$duplicates = array();
+		$duplicates = [];
 
 		foreach ($log as $id => $query)
 		{
@@ -833,7 +833,7 @@ class PlgSystemDebug extends JPlugin
 
 			if (!isset($duplicates[$did]))
 			{
-				$duplicates[$did] = array();
+				$duplicates[$did] = [];
 			}
 
 			$duplicates[$did][] = $id;
@@ -911,18 +911,18 @@ class PlgSystemDebug extends JPlugin
 					$barWidth = $minWidth;
 				}
 
-				$bars[$id] = (object) array(
+				$bars[$id] = (object) [
 					'class' => $barClass,
 					'width' => $barWidth,
-					'pre' => $barPre,
-					'tip' => sprintf('%.2f&nbsp;ms', $queryTime)
-				);
-				$info[$id] = (object) array(
-					'class' => $labelClass,
-					'explain' => $explain,
-					'profile' => $profile,
+					'pre'   => $barPre,
+					'tip'   => sprintf('%.2f&nbsp;ms', $queryTime)
+				];
+				$info[$id] = (object) [
+					'class'       => $labelClass,
+					'explain'     => $explain,
+					'profile'     => $profile,
 					'hasWarnings' => $hasWarnings
-				);
+				];
 			}
 		}
 
@@ -958,7 +958,7 @@ class PlgSystemDebug extends JPlugin
 		}
 
 		$memoryUsageNow = memory_get_usage();
-		$list = array();
+		$list = [];
 
 		foreach ($log as $id => $query)
 		{
@@ -1100,9 +1100,9 @@ class PlgSystemDebug extends JPlugin
 				$htmlProfile = ($info[$id]->profile ? $info[$id]->profile : JText::_('PLG_DEBUG_NO_PROFILE'));
 
 				$htmlAccordions = JHtml::_(
-					'bootstrap.startAccordion', 'dbg_query_' . $id, array(
+					'bootstrap.startAccordion', 'dbg_query_' . $id, [
 						'active' => $info[$id]->hasWarnings ? ('dbg_query_explain_' . $id) : ''
-					)
+					]
 				);
 
 				$htmlAccordions .= JHtml::_('bootstrap.addSlide', 'dbg_query_' . $id, JText::_('PLG_DEBUG_EXPLAIN'), 'dbg_query_explain_' . $id)
@@ -1127,7 +1127,7 @@ class PlgSystemDebug extends JPlugin
 
 				if (isset($duplicates[$did]))
 				{
-					$dups = array();
+					$dups = [];
 
 					foreach ($duplicates[$did] as $dup)
 					{
@@ -1182,7 +1182,7 @@ class PlgSystemDebug extends JPlugin
 			$this->totalQueries = $db->getCount();
 		}
 
-		$html = array();
+		$html = [];
 
 		$html[] = '<h4>' . JText::sprintf('PLG_DEBUG_QUERIES_LOGGED', $this->totalQueries)
 			. sprintf(' <span class="badge ' . $labelClass . '">%.2f&nbsp;ms</span>', $totalQueryTime) . '</h4><br>';
@@ -1194,7 +1194,7 @@ class PlgSystemDebug extends JPlugin
 
 			foreach ($duplicates as $dups)
 			{
-				$links = array();
+				$links = [];
 
 				foreach ($dups as $dup)
 				{
@@ -1227,7 +1227,7 @@ class PlgSystemDebug extends JPlugin
 
 			arsort($selectQueryTypeTicker);
 
-			$list = array();
+			$list = [];
 
 			foreach ($selectQueryTypeTicker as $query => $occurrences)
 			{
@@ -1245,7 +1245,7 @@ class PlgSystemDebug extends JPlugin
 
 			arsort($otherQueryTypeTicker);
 
-			$list = array();
+			$list = [];
 
 			foreach ($otherQueryTypeTicker as $query => $occurrences)
 			{
@@ -1273,7 +1273,7 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function renderBars(&$bars, $class = '', $id = null)
 	{
-		$html = array();
+		$html = [];
 
 		foreach ($bars as $i => $bar)
 		{
@@ -1321,7 +1321,7 @@ class PlgSystemDebug extends JPlugin
 			return null;
 		}
 
-		$html = array();
+		$html = [];
 
 		$html[] = '<table class="table table-striped dbg-query-table">';
 		$html[] = '<thead>';
@@ -1335,7 +1335,7 @@ class PlgSystemDebug extends JPlugin
 		$html[] = '</tr>';
 		$html[] = '</thead>';
 		$html[] = '<tbody>';
-		$durations = array();
+		$durations = [];
 
 		foreach ($table as $tr)
 		{
@@ -1477,16 +1477,16 @@ class PlgSystemDebug extends JPlugin
 				}
 				else
 				{
-					$this->sqlShowProfileEach[0] = array(array('Error' => 'MySql have_profiling = off'));
+					$this->sqlShowProfileEach[0] = [['Error' => 'MySql have_profiling = off']];
 				}
 			}
 			catch (Exception $e)
 			{
-				$this->sqlShowProfileEach[0] = array(array('Error' => $e->getMessage()));
+				$this->sqlShowProfileEach[0] = [['Error' => $e->getMessage()]];
 			}
 		}
 
-		if (in_array($db->getServerType(), array('mysql', 'postgresql')))
+		if (in_array($db->getServerType(), ['mysql', 'postgresql']))
 		{
 			$log = $db->getLog();
 
@@ -1503,7 +1503,7 @@ class PlgSystemDebug extends JPlugin
 					}
 					catch (Exception $e)
 					{
-						$this->explains[$k] = array(array('Error' => $e->getMessage()));
+						$this->explains[$k] = [['Error' => $e->getMessage()]];
 					}
 				}
 			}
@@ -1526,7 +1526,7 @@ class PlgSystemDebug extends JPlugin
 			return '<p>' . JText::_('JNONE') . '</p>';
 		}
 
-		$html = array();
+		$html = [];
 
 		$html[] = '<ul>';
 
@@ -1549,7 +1549,7 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function displayLanguageFilesLoaded()
 	{
-		$html = array();
+		$html = [];
 
 		$html[] = '<ul>';
 
@@ -1596,7 +1596,7 @@ class PlgSystemDebug extends JPlugin
 
 		ksort($orphans, SORT_STRING);
 
-		$guesses = array();
+		$guesses = [];
 
 		foreach ($orphans as $key => $occurance)
 		{
@@ -1607,7 +1607,7 @@ class PlgSystemDebug extends JPlugin
 
 				if (!isset($guesses[$file]))
 				{
-					$guesses[$file] = array();
+					$guesses[$file] = [];
 				}
 
 				// Prepare the key.
@@ -1654,7 +1654,7 @@ class PlgSystemDebug extends JPlugin
 			}
 		}
 
-		$html = array();
+		$html = [];
 
 		foreach ($guesses as $file => $keys)
 		{
@@ -1682,7 +1682,7 @@ class PlgSystemDebug extends JPlugin
 
 		$query = preg_replace($newlineKeywords, '<br>&#160;&#160;\\0', $query);
 
-		$regex = array(
+		$regex = [
 
 			// Tables are identified by the prefix.
 			'/(=)/' => '<b class="dbg-operator">$1</b>',
@@ -1693,7 +1693,7 @@ class PlgSystemDebug extends JPlugin
 			// Tables are identified by the prefix.
 			'/(' . JFactory::getDbo()->getPrefix() . '[a-z_0-9]+)/' => '<span class="dbg-table">$1</span>'
 
-		);
+		];
 
 		$query = preg_replace(array_keys($regex), array_values($regex), $query);
 
@@ -1715,7 +1715,7 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function renderBacktrace($error)
 	{
-		return JLayoutHelper::render('joomla.error.backtrace', array('backtrace' => $error->getTrace()));
+		return JLayoutHelper::render('joomla.error.backtrace', ['backtrace' => $error->getTrace()]);
 	}
 
 	/**
@@ -1759,16 +1759,16 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function displayLogs()
 	{
-		$priorities = array(
+		$priorities = [
 			JLog::EMERGENCY => '<span class="badge badge-important">EMERGENCY</span>',
-			JLog::ALERT => '<span class="badge badge-important">ALERT</span>',
-			JLog::CRITICAL => '<span class="badge badge-important">CRITICAL</span>',
-			JLog::ERROR => '<span class="badge badge-important">ERROR</span>',
-			JLog::WARNING => '<span class="badge badge-warning">WARNING</span>',
-			JLog::NOTICE => '<span class="badge badge-info">NOTICE</span>',
-			JLog::INFO => '<span class="badge badge-info">INFO</span>',
-			JLog::DEBUG => '<span class="badge">DEBUG</span>'
-		);
+			JLog::ALERT     => '<span class="badge badge-important">ALERT</span>',
+			JLog::CRITICAL  => '<span class="badge badge-important">CRITICAL</span>',
+			JLog::ERROR     => '<span class="badge badge-important">ERROR</span>',
+			JLog::WARNING   => '<span class="badge badge-warning">WARNING</span>',
+			JLog::NOTICE    => '<span class="badge badge-info">NOTICE</span>',
+			JLog::INFO      => '<span class="badge badge-info">INFO</span>',
+			JLog::DEBUG     => '<span class="badge">DEBUG</span>',
+		];
 
 		$out = '';
 
@@ -1838,7 +1838,7 @@ class PlgSystemDebug extends JPlugin
 			}
 
 			// Don't show everything logs if not selected.
-			if (!$showEverything && !in_array($entry->category, array('deprecated', 'databasequery')))
+			if (!$showEverything && !in_array($entry->category, ['deprecated', 'databasequery']))
 			{
 				continue;
 			}
@@ -1849,7 +1849,7 @@ class PlgSystemDebug extends JPlugin
 
 			if ($entry->callStack)
 			{
-				$out .= JHtml::_('bootstrap.startAccordion', 'dbg_logs_' . $count, array('active' => ''));
+				$out .= JHtml::_('bootstrap.startAccordion', 'dbg_logs_' . $count, ['active' => '']);
 				$out .= JHtml::_('bootstrap.addSlide', 'dbg_logs_' . $count, JText::_('PLG_DEBUG_CALL_STACK'), 'dbg_logs_backtrace_' . $count);
 				$out .= $this->renderCallStack($entry->callStack);
 				$out .= JHtml::_('bootstrap.endSlide');
@@ -1874,7 +1874,7 @@ class PlgSystemDebug extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	protected function renderCallStack(array $callStack = array())
+	protected function renderCallStack(array $callStack = [])
 	{
 		$htmlCallStack = '';
 

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -597,13 +597,11 @@ class PlgSystemDebug extends JPlugin
 	 */
 	protected function displayProfileInformation()
 	{
-		$html = [];
-
+		$html      = [];
 		$htmlMarks = [];
-
 		$totalTime = 0;
-		$totalMem = 0;
-		$marks = [];
+		$totalMem  = 0;
+		$marks     = [];
 
 		foreach (JProfiler::getInstance('Application')->getMarks() as $mark)
 		{
@@ -810,22 +808,22 @@ class PlgSystemDebug extends JPlugin
 					if (isset($timings[$id * 2 + 1]))
 					{
 						// Compute the query time: $timing[$k] = [queryTime, timeBetweenQueries].
-						$timing[$id] =[($timings[$id * 2 + 1] - $timings[$id * 2]) * 1000, $id > 0 ? ($timings[$id * 2] - $timings[$id * 2 - 1]) * 1000 : 0];
-						$maxtime = max($maxtime, $timing[$id]['0']);
+						$timing[$id] = [($timings[$id * 2 + 1] - $timings[$id * 2]) * 1000, $id > 0 ? ($timings[$id * 2] - $timings[$id * 2 - 1]) * 1000 : 0];
+						$maxtime     = max($maxtime, $timing[$id]['0']);
 					}
 				}
 			}
 		}
 		else
 		{
-			$startTime = null;
+			$startTime         = null;
 			$totalBargraphTime = 1;
 		}
 
-		$bars = [];
-		$info = [];
+		$bars           = [];
+		$info           = [];
 		$totalQueryTime = 0;
-		$duplicates = [];
+		$duplicates     = [];
 
 		foreach ($log as $id => $query)
 		{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -40,7 +40,7 @@ class PlgSystemFields extends JPlugin
 	 *
 	 * @since   3.7.0
 	 */
-	public function onContentAfterSave($context, $item, $isNew, $data = array())
+	public function onContentAfterSave($context, $item, $isNew, $data = [])
 	{
 		// Check if data is an array and the item has an id
 		if (!is_array($data) || empty($item->id))
@@ -77,10 +77,10 @@ class PlgSystemFields extends JPlugin
 		}
 
 		// Get the fields data
-		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : array();
+		$fieldsData = !empty($data['com_fields']) ? $data['com_fields'] : [];
 
 		// Loading the model
-		$model = new \Joomla\Component\Fields\Administrator\Model\Field(array('ignore_request' => true));
+		$model = new \Joomla\Component\Fields\Administrator\Model\Field(['ignore_request' => true]);
 
 		// Loop over the fields
 		foreach ($fields as $field)
@@ -121,7 +121,7 @@ class PlgSystemFields extends JPlugin
 		$task = JFactory::getApplication()->input->getCmd('task');
 
 		// Skip fields save when we activate a user, because we will lose the saved data
-		if (in_array($task, array('activate', 'block', 'unblock')))
+		if (in_array($task, ['activate', 'block', 'unblock']))
 		{
 			return true;
 		}
@@ -153,7 +153,7 @@ class PlgSystemFields extends JPlugin
 
 		$context = $parts[0] . '.' . $parts[1];
 
-		$model = new \Joomla\Component\Fields\Administrator\Model\Field(array('ignore_request' => true));
+		$model = new \Joomla\Component\Fields\Administrator\Model\Field(['ignore_request' => true]);
 		$model->cleanupValues($context, $item->id);
 
 		return true;
@@ -218,7 +218,7 @@ class PlgSystemFields extends JPlugin
 		$input = JFactory::getApplication()->input;
 
 		// If we are on the save command we need the actual data
-		$jformData = $input->get('jform', array(), 'array');
+		$jformData = $input->get('jform', [], 'array');
 
 		if ($jformData && !$data)
 		{
@@ -342,11 +342,11 @@ class PlgSystemFields extends JPlugin
 			return FieldsHelper::render(
 				$context,
 				'fields.render',
-				array(
-					'item'            => $item,
-					'context'         => $context,
-					'fields'          => $fields
-				)
+				[
+					'item'    => $item,
+					'context' => $context,
+					'fields'  => $fields,
+				]
 			);
 		}
 
@@ -375,7 +375,7 @@ class PlgSystemFields extends JPlugin
 		$fields = FieldsHelper::getFields($parts[0] . '.' . $parts[1], $item, true);
 
 		// Adding the fields to the object
-		$item->jcfields = array();
+		$item->jcfields = [];
 
 		foreach ($fields as $key => $field)
 		{

--- a/plugins/system/highlight/highlight.php
+++ b/plugins/system/highlight/highlight.php
@@ -64,7 +64,7 @@ class PlgSystemHighlight extends JPlugin
 		// Clean the terms array.
 		$filter     = JFilterInput::getInstance();
 
-		$cleanTerms = array();
+		$cleanTerms = [];
 
 		foreach ($terms as $term)
 		{

--- a/plugins/system/languagecode/languagecode.php
+++ b/plugins/system/languagecode/languagecode.php
@@ -43,19 +43,19 @@ class PlgSystemLanguagecode extends JPlugin
 			if ($new_code)
 			{
 				// Replace the new code in the HTML document.
-				$patterns = array(
+				$patterns = [
 					chr(1) . '(<html.*\s+xml:lang=")(' . $code . ')(".*>)' . chr(1) . 'i',
 					chr(1) . '(<html.*\s+lang=")(' . $code . ')(".*>)' . chr(1) . 'i',
-				);
-				$replace = array(
+				];
+				$replace = [
 					'${1}' . strtolower($new_code) . '${3}',
 					'${1}' . strtolower($new_code) . '${3}'
-				);
+				];
 			}
 			else
 			{
-				$patterns = array();
-				$replace  = array();
+				$patterns = [];
+				$replace  = [];
 			}
 
 			// Replace codes in <link hreflang="" /> attributes.

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -132,20 +132,20 @@ class PlgSystemLanguageFilter extends JPlugin
 			$router = $this->app->getRouter();
 
 			// Attach build rules for language SEF.
-			$router->attachBuildRule(array($this, 'preprocessBuildRule'), JRouter::PROCESS_BEFORE);
-			$router->attachBuildRule(array($this, 'buildRule'), JRouter::PROCESS_DURING);
+			$router->attachBuildRule([$this, 'preprocessBuildRule'], JRouter::PROCESS_BEFORE);
+			$router->attachBuildRule([$this, 'buildRule'], JRouter::PROCESS_DURING);
 
 			if ($this->mode_sef)
 			{
-				$router->attachBuildRule(array($this, 'postprocessSEFBuildRule'), JRouter::PROCESS_AFTER);
+				$router->attachBuildRule([$this, 'postprocessSEFBuildRule'], JRouter::PROCESS_AFTER);
 			}
 			else
 			{
-				$router->attachBuildRule(array($this, 'postprocessNonSEFBuildRule'), JRouter::PROCESS_AFTER);
+				$router->attachBuildRule([$this, 'postprocessNonSEFBuildRule'], JRouter::PROCESS_AFTER);
 			}
 
 			// Attach parse rules for language SEF.
-			$router->attachParseRule(array($this, 'parseRule'), JRouter::PROCESS_DURING);
+			$router->attachParseRule([$this, 'parseRule'], JRouter::PROCESS_DURING);
 		}
 	}
 
@@ -366,7 +366,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					// Empty parts array when "index.php" is the only part left.
 					if (count($parts) === 1 && $parts[0] === 'index.php')
 					{
-						$parts = array();
+						$parts = [];
 					}
 
 					$uri->setPath(implode('/', $parts));
@@ -462,7 +462,7 @@ class PlgSystemLanguageFilter extends JPlugin
 					$uri->setPath('index.php/' . $uri->getPath());
 				}
 
-				$redirectUri = $uri->base() . $uri->toString(array('path', 'query', 'fragment'));
+				$redirectUri = $uri->base() . $uri->toString(['path', 'query', 'fragment']);
 			}
 			else
 			{
@@ -491,7 +491,7 @@ class PlgSystemLanguageFilter extends JPlugin
 		}
 
 		// We have found our language and now need to set the cookie and the language value in our system
-		$array = array('lang' => $lang_code);
+		$array              = ['lang' => $lang_code];
 		$this->current_lang = $lang_code;
 
 		// Set the request var.
@@ -606,7 +606,7 @@ class PlgSystemLanguageFilter extends JPlugin
 	 *
 	 * @since   1.5
 	 */
-	public function onUserLogin($user, $options = array())
+	public function onUserLogin($user, $options = [])
 	{
 		$menu = $this->app->getMenu();
 
@@ -737,7 +737,7 @@ class PlgSystemLanguageFilter extends JPlugin
 			$active                = $menu->getActive();
 			$levels                = JFactory::getUser()->getAuthorisedViewLevels();
 			$remove_default_prefix = $this->params->get('remove_default_prefix', 0);
-			$server                = JUri::getInstance()->toString(array('scheme', 'host', 'port'));
+			$server                = JUri::getInstance()->toString(['scheme', 'host', 'port']);
 			$is_home               = false;
 			$currentInternalUrl    = 'index.php?' . http_build_query($this->app->getRouter()->getVars());
 
@@ -762,9 +762,9 @@ class PlgSystemLanguageFilter extends JPlugin
 			$cName = StringHelper::ucfirst(StringHelper::str_ireplace('com_', '', $option)) . 'HelperAssociation';
 			JLoader::register($cName, JPath::clean(JPATH_COMPONENT_SITE . '/helpers/association.php'));
 
-			if (class_exists($cName) && is_callable(array($cName, 'getAssociations')))
+			if (class_exists($cName) && is_callable([$cName, 'getAssociations']))
 			{
-				$cassociations = call_user_func(array($cName, 'getAssociations'));
+				$cassociations = call_user_func([$cName, 'getAssociations']);
 			}
 
 			// For each language...
@@ -819,7 +819,7 @@ class PlgSystemLanguageFilter extends JPlugin
 
 				foreach ($languages as $i => &$language)
 				{
-					$doc->addHeadLink($server . $language->link, 'alternate', 'rel', array('hreflang' => $i));
+					$doc->addHeadLink($server . $language->link, 'alternate', 'rel', ['hreflang' => $i]);
 				}
 
 				// Add x-default language tag

--- a/plugins/system/log/log.php
+++ b/plugins/system/log/log.php
@@ -27,7 +27,7 @@ class PlgSystemLog extends JPlugin
 	 */
 	public function onUserLoginFailure($response)
 	{
-		$errorlog = array();
+		$errorlog = [];
 
 		switch ($response['status'])
 		{
@@ -55,7 +55,7 @@ class PlgSystemLog extends JPlugin
 				break;
 		}
 
-		JLog::addLogger(array(), JLog::INFO);
+		JLog::addLogger([], JLog::INFO);
 		JLog::add($errorlog['comment'], JLog::INFO, $errorlog['status']);
 	}
 }

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -60,7 +60,7 @@ class PlgSystemLogout extends JPlugin
 			$this->app->input->cookie->set($hash, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 
 			// Set the error handler for E_ALL to be the class handleError method.
-			JError::setErrorHandling(E_ALL, 'callback', array('PlgSystemLogout', 'handleError'));
+			JError::setErrorHandling(E_ALL, 'callback', ['PlgSystemLogout', 'handleError']);
 		}
 	}
 
@@ -74,7 +74,7 @@ class PlgSystemLogout extends JPlugin
 	 *
 	 * @since   1.6
 	 */
-	public function onUserLogout($user, $options = array())
+	public function onUserLogout($user, $options = [])
 	{
 		if ($this->app->isClient('site'))
 		{

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -48,10 +48,10 @@ class PlgSystemRedirect extends JPlugin
 		parent::__construct($subject, $config);
 
 		// Set the JError handler for E_ERROR to be the class' handleError method.
-		JError::setErrorHandling(E_ERROR, 'callback', array('PlgSystemRedirect', 'handleError'));
+		JError::setErrorHandling(E_ERROR, 'callback', ['PlgSystemRedirect', 'handleError']);
 
 		// Register the previously defined exception handler so we can forward errors to it
-		self::$previousExceptionHandler = set_exception_handler(array('PlgSystemRedirect', 'handleException'));
+		self::$previousExceptionHandler = set_exception_handler(['PlgSystemRedirect', 'handleException']);
 	}
 
 	/**
@@ -109,7 +109,7 @@ class PlgSystemRedirect extends JPlugin
 			// Proxy to the previous exception handler if available, otherwise just render the error page
 			if (self::$previousExceptionHandler)
 			{
-				call_user_func_array(self::$previousExceptionHandler, array($error));
+				call_user_func_array(self::$previousExceptionHandler, [$error]);
 			}
 			else
 			{
@@ -119,11 +119,11 @@ class PlgSystemRedirect extends JPlugin
 
 		$uri = JUri::getInstance();
 
-		$url = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
-		$urlRel = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
+		$url = StringHelper::strtolower(rawurldecode($uri->toString(['scheme', 'host', 'port', 'path', 'query', 'fragment'])));
+		$urlRel = StringHelper::strtolower(rawurldecode($uri->toString(['path', 'query', 'fragment'])));
 
-		$urlWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
-		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
+		$urlWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(['scheme', 'host', 'port', 'path', 'fragment'])));
+		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(['path', 'fragment'])));
 
 		// Why is this (still) here?
 		if ((strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http://') !== false))
@@ -163,7 +163,7 @@ class PlgSystemRedirect extends JPlugin
 		}
 
 		$possibleMatches = array_unique(
-			array($url, $urlRel, $urlWithoutQuery, $urlRelWithoutQuery)
+			[$url, $urlRel, $urlWithoutQuery, $urlRelWithoutQuery]
 		);
 
 		foreach ($possibleMatches as $match)
@@ -212,14 +212,14 @@ class PlgSystemRedirect extends JPlugin
 
 			if ((bool) $params->get('collect_urls', true))
 			{
-				$data = (object) array(
-					'id' => 0,
-					'old_url' => $url,
-					'referer' => $app->input->server->getString('HTTP_REFERER', ''),
-					'hits' => 1,
-					'published' => 0,
-					'created_date' => JFactory::getDate()->toSql()
-				);
+				$data = (object) [
+					'id'           => 0,
+					'old_url'      => $url,
+					'referer'      => $app->input->server->getString('HTTP_REFERER', ''),
+					'hits'         => 1,
+					'published'    => 0,
+					'created_date' => JFactory::getDate()->toSql(),
+				];
 
 				try
 				{

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -62,7 +62,7 @@ class PlgSystemRemember extends JPlugin
 			// Check for the cookie
 			if ($this->app->input->cookie->get($cookieName))
 			{
-				$this->app->login(array('username' => ''), array('silent' => true));
+				$this->app->login(['username' => ''], ['silent' => true]);
 			}
 		}
 	}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -67,12 +67,12 @@ class PlgSystemSef extends JPlugin
 			unset($doc->_links[$canonical]);
 
 			// Set the current canonical link but use the SEF system plugin domain field.
-			$canonical = $sefDomain . JUri::getInstance($canonical)->toString(array('path', 'query', 'fragment'));
+			$canonical = $sefDomain . JUri::getInstance($canonical)->toString(['path', 'query', 'fragment']);
 		}
 		// If a canonical html doesn't exists already add a canonical html tag using the SEF plugin domain field.
 		else
 		{
-			$canonical = $sefDomain . JUri::getInstance()->toString(array('path', 'query', 'fragment'));
+			$canonical = $sefDomain . JUri::getInstance()->toString(['path', 'query', 'fragment']);
 		}
 
 		// Add the canonical link.
@@ -117,7 +117,7 @@ class PlgSystemSef extends JPlugin
 
 		// Check for all unknown protocals (a protocol must contain at least one alpahnumeric character followed by a ":").
 		$protocols  = '[a-zA-Z0-9\-]+:';
-		$attributes = array('href=', 'src=', 'srcset=', 'poster=');
+		$attributes = ['href=', 'src=', 'srcset=', 'poster='];
 
 		foreach ($attributes as $attribute)
 		{
@@ -138,7 +138,7 @@ class PlgSystemSef extends JPlugin
 		}
 
 		// Replace all unknown protocols in onmouseover and onmouseout attributes.
-		$attributes = array('onmouseover=', 'onmouseout=');
+		$attributes = ['onmouseover=', 'onmouseout='];
 
 		foreach ($attributes as $attribute)
 		{

--- a/plugins/system/stats/field/base.php
+++ b/plugins/system/stats/field/base.php
@@ -27,10 +27,10 @@ abstract class PlgSystemStatsFormFieldBase extends JFormField
 	{
 		$template = JFactory::getApplication()->getTemplate();
 
-		return array(
+		return [
 			JPATH_ADMINISTRATOR . '/templates/' . $template . '/html/layouts/plugins/system/stats',
 			dirname(__DIR__) . '/layouts',
 			JPATH_SITE . '/layouts'
-		);
+		];
 	}
 }

--- a/plugins/system/stats/field/data.php
+++ b/plugins/system/stats/field/data.php
@@ -47,9 +47,9 @@ class PlgSystemStatsFormFieldData extends PlgSystemStatsFormFieldBase
 
 		JPluginHelper::importPlugin('system', 'stats');
 
-		$result = JFactory::getApplication()->triggerEvent('onGetStatsData', array('stats.field.data'));
+		$result = JFactory::getApplication()->triggerEvent('onGetStatsData', ['stats.field.data']);
 
-		$data['statsData'] = $result ? reset($result) : array();
+		$data['statsData'] = $result ? reset($result) : [];
 
 		return $data;
 	}

--- a/plugins/system/stats/layouts/stats.php
+++ b/plugins/system/stats/layouts/stats.php
@@ -17,7 +17,7 @@ extract($displayData);
  * @var  array  $statsData  Array containing the data that will be sent to the stats server
  */
 
-$versionFields = array('php_version', 'db_version', 'cms_version');
+$versionFields = ['php_version', 'db_version', 'cms_version'];
 ?>
 <table class="table table-striped m-1-b js-pstats-data-details" style="display:none;">
 	<?php foreach ($statsData as $key => $value) : ?>

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -98,7 +98,7 @@ class PlgSystemStats extends JPlugin
 		$this->loadLanguage();
 
 		JHtml::_('jquery.framework');
-		JHtml::_('script', 'plg_system_stats/stats.js', array('version' => 'auto', 'relative' => true));
+		JHtml::_('script', 'plg_system_stats/stats.js', ['version' => 'auto', 'relative' => true]);
 	}
 
 	/**
@@ -127,7 +127,7 @@ class PlgSystemStats extends JPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -154,7 +154,7 @@ class PlgSystemStats extends JPlugin
 			throw new RuntimeException('Unable to save plugin settings', 500);
 		}
 
-		echo json_encode(array('sent' => 0));
+		echo json_encode(['sent' => 0]);
 	}
 
 	/**
@@ -183,7 +183,7 @@ class PlgSystemStats extends JPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -207,10 +207,10 @@ class PlgSystemStats extends JPlugin
 		// User has not selected the mode. Show message.
 		if ((int) $this->params->get('mode') !== static::MODE_ALLOW_ALWAYS)
 		{
-			$data = array(
+			$data = [
 				'sent' => 0,
 				'html' => $this->getRenderer('message')->render($this->getLayoutData())
-			);
+			];
 
 			echo json_encode($data);
 
@@ -224,7 +224,7 @@ class PlgSystemStats extends JPlugin
 
 		$this->sendStats();
 
-		echo json_encode(array('sent' => 1));
+		echo json_encode(['sent' => 1]);
 	}
 
 	/**
@@ -251,7 +251,7 @@ class PlgSystemStats extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	public function debug($layoutId, $data = array())
+	public function debug($layoutId, $data = [])
 	{
 		$data = array_merge($this->getLayoutData(), $data);
 
@@ -267,11 +267,11 @@ class PlgSystemStats extends JPlugin
 	 */
 	protected function getLayoutData()
 	{
-		return array(
+		return [
 			'plugin'       => $this,
 			'pluginParams' => $this->params,
 			'statsData'    => $this->getStatsData()
-		);
+		];
 	}
 
 	/**
@@ -285,10 +285,10 @@ class PlgSystemStats extends JPlugin
 	{
 		$template = JFactory::getApplication()->getTemplate();
 
-		return array(
+		return [
 			JPATH_ADMINISTRATOR . '/templates/' . $template . '/html/layouts/plugins/' . $this->_type . '/' . $this->_name,
 			__DIR__ . '/layouts',
-		);
+		];
 	}
 
 	/**
@@ -318,14 +318,14 @@ class PlgSystemStats extends JPlugin
 	 */
 	private function getStatsData()
 	{
-		return array(
+		return [
 			'unique_id'   => $this->getUniqueId(),
 			'php_version' => PHP_VERSION,
 			'db_type'     => $this->db->name,
 			'db_version'  => $this->db->getVersion(),
 			'cms_version' => JVERSION,
 			'server_os'   => php_uname('s') . ' ' . php_uname('r')
-		);
+		];
 	}
 
 	/**
@@ -418,7 +418,7 @@ class PlgSystemStats extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	public function render($layoutId, $data = array())
+	public function render($layoutId, $data = [])
 	{
 		$data = array_merge($this->getLayoutData(), $data);
 
@@ -463,7 +463,7 @@ class PlgSystemStats extends JPlugin
 			// Update the plugin parameters
 			$result = $this->db->setQuery($query)->execute();
 
-			$this->clearCacheGroups(array('com_plugins'), array(0, 1));
+			$this->clearCacheGroups(['com_plugins'], [0, 1]);
 		}
 		catch (Exception $exc)
 		{
@@ -538,7 +538,7 @@ class PlgSystemStats extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
+	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
 		foreach ($clearGroups as $group)
 		{
@@ -546,10 +546,10 @@ class PlgSystemStats extends JPlugin
 			{
 				try
 				{
-					$options = array(
+					$options = [
 						'defaultgroup' => $group,
 						'cachebase'    => $client_id ? JPATH_ADMINISTRATOR . '/cache' : $this->app->get('cache_path', JPATH_SITE . '/cache')
-					);
+					];
 
 					$cache = JCache::getInstance('callback', $options);
 					$cache->clean();

--- a/plugins/system/updatenotification/postinstall/updatecachetime.php
+++ b/plugins/system/updatenotification/postinstall/updatecachetime.php
@@ -44,7 +44,7 @@ function updatecachetime_postinstall_action()
 	// Save the new parameters back to com_installer
 	$table = JTable::getInstance('extension');
 	$table->load($installer->id);
-	$table->bind(array('params' => $installer->params->toString()));
+	$table->bind(['params' => $installer->params->toString()]);
 
 	// Store the changes
 	if (!$table->store())

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -91,7 +91,7 @@ class PlgSystemUpdatenotification extends JPlugin
 			// Update the plugin parameters
 			$result = $db->setQuery($query)->execute();
 
-			$this->clearCacheGroups(array('com_plugins'), array(0, 1));
+			$this->clearCacheGroups(['com_plugins'], [0, 1]);
 		}
 		catch (Exception $exc)
 		{
@@ -122,7 +122,7 @@ class PlgSystemUpdatenotification extends JPlugin
 
 		// Get any available updates
 		$updater = JUpdater::getInstance();
-		$results = $updater->findUpdates(array($eid), $cache_timeout);
+		$results = $updater->findUpdates([$eid], $cache_timeout);
 
 		// If there are no updates our job is done. We need BOTH this check AND the one below.
 		if (!$results)
@@ -131,7 +131,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		}
 
 		// Get the update model and retrieve the Joomla! core updates
-		$model = new Update(array('ignore_request' => true));
+		$model = new Update(['ignore_request' => true]);
 		$model->setState('filter.extension_id', $eid);
 		$updates = $model->getItems();
 
@@ -170,10 +170,10 @@ class PlgSystemUpdatenotification extends JPlugin
 		 * The plugins should modify the $uri object directly and return null.
 		 */
 
-		JFactory::getApplication()->triggerEvent('onBuildAdministratorLoginURL', array(&$uri));
+		JFactory::getApplication()->triggerEvent('onBuildAdministratorLoginURL', [&$uri]);
 
 		// Let's find out the email addresses to notify
-		$superUsers    = array();
+		$superUsers    = [];
 		$specificEmail = $this->params->get('email', '');
 
 		if (!empty($specificEmail))
@@ -224,7 +224,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		$mailFrom = $jConfig->get('mailfrom');
 		$fromName = $jConfig->get('fromname');
 
-		$substitutions = array(
+		$substitutions = [
 			'[NEWVERSION]'  => $newVersion,
 			'[CURVERSION]'  => $currentVersion,
 			'[SITENAME]'    => $sitename,
@@ -232,7 +232,7 @@ class PlgSystemUpdatenotification extends JPlugin
 			'[LINK]'        => $uri->toString(),
 			'[RELEASENEWS]' => 'https://www.joomla.org/announcements/release-news/',
 			'\\n'           => "\n",
-		);
+		];
 
 		foreach ($substitutions as $k => $v)
 		{
@@ -244,7 +244,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		foreach ($superUsers as $superUser)
 		{
 			$mailer = JFactory::getMailer();
-			$mailer->setSender(array($mailFrom, $fromName));
+			$mailer->setSender([$mailFrom, $fromName]);
 			$mailer->addRecipient($superUser->email);
 			$mailer->setSubject($email_subject);
 			$mailer->setBody($email_body);
@@ -272,7 +272,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		if (!empty($email))
 		{
 			$temp   = explode(',', $email);
-			$emails = array();
+			$emails = [];
 
 			foreach ($temp as $entry)
 			{
@@ -284,18 +284,18 @@ class PlgSystemUpdatenotification extends JPlugin
 		}
 		else
 		{
-			$emails = array();
+			$emails = [];
 		}
 
 		// Get a list of groups which have Super User privileges
-		$ret = array();
+		$ret = [];
 
 		try
 		{
 			$rootId    = JTable::getInstance('Asset', 'JTable')->getRootId();
 			$rules     = JAccess::getAssetRules($rootId)->getData();
 			$rawGroups = $rules['core.admin']->getData();
-			$groups    = array();
+			$groups    = [];
 
 			if (empty($rawGroups))
 			{
@@ -335,7 +335,7 @@ class PlgSystemUpdatenotification extends JPlugin
 				return $ret;
 			}
 
-			$userIDs = array();
+			$userIDs = [];
 
 			foreach ($rawUserIDs as $id)
 			{
@@ -352,11 +352,11 @@ class PlgSystemUpdatenotification extends JPlugin
 		{
 			$query = $db->getQuery(true)
 						->select(
-							array(
+							[
 								$db->qn('id'),
 								$db->qn('username'),
 								$db->qn('email'),
-							)
+							]
 						)->from($db->qn('#__users'))
 						->where($db->qn('id') . ' IN(' . implode(',', $userIDs) . ')')
 						->where($db->qn('block') . ' = 0')
@@ -388,7 +388,7 @@ class PlgSystemUpdatenotification extends JPlugin
 	 *
 	 * @since   3.5
 	 */
-	private function clearCacheGroups(array $clearGroups, array $cacheClients = array(0, 1))
+	private function clearCacheGroups(array $clearGroups, array $cacheClients = [0, 1])
 	{
 		$conf = JFactory::getConfig();
 
@@ -398,11 +398,11 @@ class PlgSystemUpdatenotification extends JPlugin
 			{
 				try
 				{
-					$options = array(
+					$options = [
 						'defaultgroup' => $group,
 						'cachebase'    => $client_id ? JPATH_ADMINISTRATOR . '/cache' :
 							$conf->get('cache_path', JPATH_SITE . '/cache')
-					);
+					];
 
 					$cache = JCache::getInstance('callback', $options);
 					$cache->clean();


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in System plugins.

### Testing Instructions

Simple code review.

### Documentation Changes Required

None.