### PR TITLE
[4.0] Array to php 5.4+ notation [Unit Tests 1: core folder]

### DIFF
--- a/tests/unit/core/case/cache.php
+++ b/tests/unit/core/case/cache.php
@@ -193,7 +193,7 @@ abstract class TestCaseCache extends TestCase
 	 */
 	public function testCacheLock()
 	{
-		$returning = (object) array('locklooped' => false, 'locked' => true);
+		$returning = (object) ['locklooped' => false, 'locked' => true];
 		$expected  = $this->logicalOr($this->equalTo($returning), $this->isFalse());
 		$result    = $this->handler->lock($this->id, $this->group, 3);
 		$data      = 'testData';

--- a/tests/unit/core/case/database.php
+++ b/tests/unit/core/case/database.php
@@ -46,11 +46,11 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	public static function setUpBeforeClass()
 	{
 		// We always want the default database test case to use an SQLite memory database.
-		$options = array(
-			'driver' => 'sqlite',
+		$options = [
+			'driver'   => 'sqlite',
 			'database' => ':memory:',
-			'prefix' => 'jos_'
-		);
+			'prefix'   => 'jos_'
+		];
 
 		try
 		{
@@ -137,10 +137,10 @@ abstract class TestCaseDatabase extends PHPUnit_Extensions_Database_TestCase
 	{
 		// Required given the use of InnoDB contraints.
 		return new PHPUnit_Extensions_Database_Operation_Composite(
-			array(
+			[
 				PHPUnit_Extensions_Database_Operation_Factory::DELETE_ALL(),
 				PHPUnit_Extensions_Database_Operation_Factory::INSERT()
-			)
+			]
 		);
 	}
 

--- a/tests/unit/core/case/database/mysqli.php
+++ b/tests/unit/core/case/database/mysqli.php
@@ -24,7 +24,7 @@ abstract class TestCaseDatabaseMysqli extends TestCaseDatabase
 	 * @var    array  The JDatabaseDriver options for the connection.
 	 * @since  12.1
 	 */
-	private static $_options = array('driver' => 'mysqli');
+	private static $_options = ['driver' => 'mysqli'];
 
 	/**
 	 * @var    JDatabaseDriverMysqli  The saved database driver to be restored after these tests.

--- a/tests/unit/core/case/database/oracle.php
+++ b/tests/unit/core/case/database/oracle.php
@@ -24,7 +24,7 @@ abstract class TestCaseDatabaseOracle extends TestCaseDatabase
 	 * @var    array  The JDatabaseDriver options for the connection.
 	 * @since  12.1
 	 */
-	private static $_options = array('driver' => 'oracle');
+	private static $_options = ['driver' => 'oracle'];
 
 	/**
 	 * @var    JDatabaseDriverOracle  The saved database driver to be restored after these tests.

--- a/tests/unit/core/case/database/pdomysql.php
+++ b/tests/unit/core/case/database/pdomysql.php
@@ -24,7 +24,7 @@ abstract class TestCaseDatabasePdomysql extends TestCaseDatabase
 	 * @var    array  The JDatabaseDriver options for the connection.
 	 * @since  3.4
 	 */
-	private static $_options = array('driver' => 'pdomysql');
+	private static $_options = ['driver' => 'pdomysql'];
 
 	/**
 	 * @var    JDatabaseDriverPdomysql  The saved database driver to be restored after these tests.

--- a/tests/unit/core/case/database/postgresql.php
+++ b/tests/unit/core/case/database/postgresql.php
@@ -24,7 +24,7 @@ abstract class TestCaseDatabasePostgresql extends TestCaseDatabase
 	 * @var    array  The JDatabaseDriver options for the connection.
 	 * @since  12.1
 	 */
-	private static $_options = array('driver' => 'postgresql');
+	private static $_options = ['driver' => 'postgresql'];
 
 	/**
 	 * @var    JDatabaseDriverPostgresql  The saved database driver to be restored after these tests.

--- a/tests/unit/core/case/database/sqlsrv.php
+++ b/tests/unit/core/case/database/sqlsrv.php
@@ -24,7 +24,7 @@ abstract class TestCaseDatabaseSqlsrv extends TestCaseDatabase
 	 * @var    array  The database driver options for the connection.
 	 * @since  12.1
 	 */
-	private static $options = array('driver' => 'sqlsrv');
+	private static $options = ['driver' => 'sqlsrv'];
 
 	/**
 	 * @var    JDatabaseDriverSqlsrv  The saved database driver to be restored after these tests.

--- a/tests/unit/core/case/trait.php
+++ b/tests/unit/core/case/trait.php
@@ -31,15 +31,15 @@ trait TestCaseTrait
 	 */
 	private $_stashedFactoryState = [
 		'application' => null,
-		'config' => null,
-		'container' => null,
-		'dates' => null,
-		'database' => null,
-		'session' => null,
-		'language' => null,
-		'document' => null,
-		'acl' => null,
-		'mailer' => null
+		'config'      => null,
+		'container'   => null,
+		'dates'       => null,
+		'database'    => null,
+		'session'     => null,
+		'language'    => null,
+		'document'    => null,
+		'acl'         => null,
+		'mailer'      => null
 	];
 
 	/**
@@ -160,7 +160,7 @@ trait TestCaseTrait
 	 *
 	 * @since   3.2
 	 */
-	public function getMockCmsApp($options = array(), $constructor = array())
+	public function getMockCmsApp($options = [], $constructor = [])
 	{
 		// Attempt to load the real class first.
 		class_exists('JApplicationCms');
@@ -192,7 +192,7 @@ trait TestCaseTrait
 	 *
 	 * @since   12.1
 	 */
-	public function getMockDatabase($driver = '', array $extraMethods = array(), $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
+	public function getMockDatabase($driver = '', array $extraMethods = [], $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
 	{
 		// Attempt to load the real class first.
 		class_exists('JDatabaseDriver');
@@ -280,7 +280,7 @@ trait TestCaseTrait
 	 *
 	 * @since   12.1
 	 */
-	public function getMockSession($options = array())
+	public function getMockSession($options = [])
 	{
 		// Attempt to load the real class first.
 		class_exists('JSession');
@@ -297,7 +297,7 @@ trait TestCaseTrait
 	 *
 	 * @since   12.1
 	 */
-	public function getMockWeb($options = array())
+	public function getMockWeb($options = [])
 	{
 		// Attempt to load the real class first.
 		class_exists('JApplicationWeb');
@@ -367,7 +367,7 @@ trait TestCaseTrait
 	 */
 	protected function saveErrorHandlers()
 	{
-		$this->_stashedErrorState = array();
+		$this->_stashedErrorState = [];
 
 		// Handle optional usage of JError until removed.
 		if (class_exists('JError'))
@@ -421,11 +421,11 @@ trait TestCaseTrait
 	 */
 	protected function setErrorCallback($testName)
 	{
-		$callbackHandlers = array(
-			E_NOTICE => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
-			E_WARNING => array('mode' => 'callback', 'options' => array($testName, 'errorCallback')),
-			E_ERROR => array('mode' => 'callback', 'options' => array($testName, 'errorCallback'))
-		);
+		$callbackHandlers = [
+			E_NOTICE  => ['mode' => 'callback', 'options' => [$testName, 'errorCallback']],
+			E_WARNING => ['mode' => 'callback', 'options' => [$testName, 'errorCallback']],
+			E_ERROR   => ['mode' => 'callback', 'options' => [$testName, 'errorCallback']]
+		];
 
 		$this->setErrorHandlers($callbackHandlers);
 	}

--- a/tests/unit/core/helper.php
+++ b/tests/unit/core/helper.php
@@ -40,17 +40,17 @@ class TestHelper
 			return;
 		}
 
-		$deprecations = array(
+		$deprecations = [
 			'phpCount'  => 0,
 			'userCount' => 0,
-			'php'       => array(),
-			'user'      => array(),
-		);
+			'php'       => [],
+			'user'      => [],
+		];
 
 		$deprecationHandler = function ($type, $msg, $file, $line, $context) use (&$deprecations)
 		{
 			// Check if the type is E_DEPRECATED or E_USER_DEPRECATED
-			if (!in_array($type, array(E_DEPRECATED, E_USER_DEPRECATED)))
+			if (!in_array($type, [E_DEPRECATED, E_USER_DEPRECATED]))
 			{
 				return PHPUnit_Util_ErrorHandler::handleError($type, $msg, $file, $line, $context);
 			}
@@ -91,7 +91,7 @@ class TestHelper
 		{
 			restore_error_handler();
 
-			if (array('PHPUnit_Util_ErrorHandler', 'handleError') === $oldErrorHandler)
+			if (['PHPUnit_Util_ErrorHandler', 'handleError'] === $oldErrorHandler)
 			{
 				restore_error_handler();
 				self::register();
@@ -133,7 +133,7 @@ class TestHelper
 					return $b['count'] - $a['count'];
 				};
 
-				foreach (array('php', 'user') as $group)
+				foreach (['php', 'user'] as $group)
 				{
 					if ($deprecations[$group . 'Count'])
 					{
@@ -176,15 +176,15 @@ class TestHelper
 	public static function registerDeprecationLogger()
 	{
 		Log::addLogger(
-			array(
+			[
 				'logger'   => 'callback',
 				'callback' => function (LogEntry $entry)
 				{
 					@trigger_error($entry->message, E_USER_DEPRECATED);
 				},
-			),
+			],
 			Log::ALL,
-			array('deprecated')
+			['deprecated']
 		);
 	}
 
@@ -200,11 +200,11 @@ class TestHelper
 		if (defined('JOOMLA_TEST_LOGGING') && JOOMLA_TEST_LOGGING === 'yes')
 		{
 			Log::addLogger(
-				array(
+				[
 					'logger'         => 'formattedtext',
 					'text_file'      => 'unit_test.php',
 					'text_file_path' => dirname(dirname(__DIR__)) . '/tmp'
-				)
+				]
 			);
 		}
 	}

--- a/tests/unit/core/mock/application/base.php
+++ b/tests/unit/core/mock/application/base.php
@@ -23,7 +23,7 @@ class TestMockApplicationBase
 	 */
 	public static function getMethods()
 	{
-		return array(
+		return [
 			'close',
 			'getIdentity',
 			'registerEvent',
@@ -31,7 +31,7 @@ class TestMockApplicationBase
 			'loadDispatcher',
 			'loadIdentity',
 			'getDispatcher',
-		);
+		];
 	}
 
 	/**
@@ -59,7 +59,7 @@ class TestMockApplicationBase
 
 		$test->assignMockReturns(
 			$mockObject,
-			array('close' => true)
+			['close' => true]
 		);
 
 		return $mockObject;
@@ -75,7 +75,7 @@ class TestMockApplicationBase
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test, $options = array())
+	public static function create($test, $options = [])
 	{
 		// Set expected server variables.
 		if (!isset($_SERVER['HTTP_HOST']))
@@ -89,7 +89,7 @@ class TestMockApplicationBase
 		// Build the mock object & allow Call to original constructor
 		$mockObject = $test->getMockBuilder('JApplicationBase')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->getMock();
 

--- a/tests/unit/core/mock/application/cli.php
+++ b/tests/unit/core/mock/application/cli.php
@@ -24,14 +24,14 @@ class TestMockApplicationCli extends TestMockApplicationBase
 	public static function getMethods()
 	{
 		// Collect all the relevant methods in JApplicationCli.
-		$methods = array(
+		$methods = [
 			'get',
 			'execute',
 			'loadConfiguration',
 			'out',
 			'in',
 			'set',
-		);
+		];
 
 		return array_merge($methods, parent::getMethods());
 	}
@@ -46,7 +46,7 @@ class TestMockApplicationCli extends TestMockApplicationBase
 	 *
 	 * @since   12.2
 	 */
-	public static function create($test, $options = array())
+	public static function create($test, $options = [])
 	{
 		// Create the mock.
 		$mockObject = $test->getMockForAbstractClass(

--- a/tests/unit/core/mock/application/cms.php
+++ b/tests/unit/core/mock/application/cms.php
@@ -24,7 +24,7 @@ class TestMockApplicationCms extends TestMockApplicationWeb
 	public static function getMethods()
 	{
 		// Collect all the relevant methods in JApplicationCms (work in progress).
-		$methods = array(
+		$methods = [
 			'getMenu',
 			'getPathway',
 			'getTemplate',
@@ -36,7 +36,7 @@ class TestMockApplicationCms extends TestMockApplicationWeb
 			'getUserState',
 			'getUserStateFromRequest',
 			'setUserState',
-		);
+		];
 
 		return array_merge($methods, parent::getMethods());
 	}
@@ -79,7 +79,7 @@ class TestMockApplicationCms extends TestMockApplicationWeb
 	 *
 	 * @since   3.2
 	 */
-	public static function create($test, $options = array(), $constructor = array())
+	public static function create($test, $options = [], $constructor = [])
 	{
 		// Set expected server variables.
 		if (!isset($_SERVER['HTTP_HOST']))

--- a/tests/unit/core/mock/application/web.php
+++ b/tests/unit/core/mock/application/web.php
@@ -20,7 +20,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 * @var    array
 	 * @since  12.2
 	 */
-	public static $body = array();
+	public static $body = [];
 
 	/**
 	 * Mock storage for the response headers.
@@ -28,7 +28,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 * @var    array
 	 * @since  3.2
 	 */
-	public static $headers = array();
+	public static $headers = [];
 
 	/**
 	 * Mock storage for the response cache status.
@@ -48,7 +48,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	public static function getMethods()
 	{
 		// Collect all the relevant methods in JApplicationWeb (work in progress).
-		$methods = array(
+		$methods = [
 			'allowCache',
 			'appendBody',
 			'clearHeaders',
@@ -70,7 +70,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 			'setBody',
 			'setHeader',
 			'setSession',
-		);
+		];
 
 		return array_merge($methods, parent::getMethods());
 	}
@@ -106,23 +106,23 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'appendBody' => array((is_callable(array($test, 'mockAppendBody')) ? $test : get_called_class()), 'mockAppendBody'),
-				'getBody' => array((is_callable(array($test, 'mockGetBody')) ? $test : get_called_class()), 'mockGetBody'),
-				'prependBody' => array((is_callable(array($test, 'mockPrependBody')) ? $test : get_called_class()), 'mockPrependBody'),
-				'setBody' => array((is_callable(array($test, 'mockSetBody')) ? $test : get_called_class()), 'mockSetBody'),
-				'getHeaders' => array((is_callable(array($test, 'mockGetHeaders')) ? $test : get_called_class()), 'mockGetHeaders'),
-				'setHeader' => array((is_callable(array($test, 'mockSetHeader')) ? $test : get_called_class()), 'mockSetHeader'),
-				'clearHeaders' => array((is_callable(array($test, 'mockClearHeaders')) ? $test : get_called_class()), 'mockClearHeaders'),
-				'allowCache' => array((is_callable(array($test, 'mockAllowCache')) ? $test : get_called_class()), 'mockAllowCache'),
-			)
+			[
+				'appendBody'   => [(is_callable([$test, 'mockAppendBody']) ? $test : get_called_class()), 'mockAppendBody'],
+				'getBody'      => [(is_callable([$test, 'mockGetBody']) ? $test : get_called_class()), 'mockGetBody'],
+				'prependBody'  => [(is_callable([$test, 'mockPrependBody']) ? $test : get_called_class()), 'mockPrependBody'],
+				'setBody'      => [(is_callable([$test, 'mockSetBody']) ? $test : get_called_class()), 'mockSetBody'],
+				'getHeaders'   => [(is_callable([$test, 'mockGetHeaders']) ? $test : get_called_class()), 'mockGetHeaders'],
+				'setHeader'    => [(is_callable([$test, 'mockSetHeader']) ? $test : get_called_class()), 'mockSetHeader'],
+				'clearHeaders' => [(is_callable([$test, 'mockClearHeaders']) ? $test : get_called_class()), 'mockClearHeaders'],
+				'allowCache'   => [(is_callable([$test, 'mockAllowCache']) ? $test : get_called_class()), 'mockAllowCache'],
+			]
 		);
 
 		// Reset the body storage.
-		static::$body = array();
+		static::$body = [];
 
 		// Reset the headers storage.
-		static::$headers = array();
+		static::$headers = [];
 
 		// Reset the cache storage.
 		static::$cachable = false;
@@ -152,7 +152,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test, $options = array(), $constructor = array())
+	public static function create($test, $options = [], $constructor = [])
 	{
 		// Set expected server variables.
 		if (!isset($_SERVER['HTTP_HOST']))
@@ -234,7 +234,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 */
 	public static function mockSetBody($content)
 	{
-		static::$body = array($content);
+		static::$body = [$content];
 	}
 
 	/**
@@ -282,7 +282,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 		}
 
 		// Add the header to the internal array.
-		static::$headers[] = array('name' => $name, 'value' => $value);
+		static::$headers[] = ['name' => $name, 'value' => $value];
 	}
 
 	/**
@@ -294,7 +294,7 @@ class TestMockApplicationWeb extends TestMockApplicationBase
 	 */
 	public static function mockClearHeaders()
 	{
-		static::$headers = array();
+		static::$headers = [];
 	}
 
 	/**

--- a/tests/unit/core/mock/cache.php
+++ b/tests/unit/core/mock/cache.php
@@ -20,7 +20,7 @@ class TestMockCache
 	 * @var    array
 	 * @since  12.1
 	 */
-	public static $cache = array();
+	public static $cache = [];
 
 	/**
 	 * Creates and instance of the mock JApplication object.
@@ -32,30 +32,30 @@ class TestMockCache
 	 *
 	 * @since   12.1
 	 */
-	public static function create(TestCase $test, $data = array())
+	public static function create(TestCase $test, $data = [])
 	{
 		self::$cache = $data;
 
 		// Collect all the relevant methods in JConfig.
-		$methods = array(
+		$methods = [
 			'get',
 			'store',
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JCache')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'get' => array(get_called_class(), 'mockGet'),
-				'store' => array(get_called_class(), 'mockStore'),
-			)
+			[
+				'get'   => [get_called_class(), 'mockGet'],
+				'store' => [get_called_class(), 'mockStore'],
+			]
 		);
 
 		return $mockObject;

--- a/tests/unit/core/mock/config.php
+++ b/tests/unit/core/mock/config.php
@@ -26,15 +26,15 @@ class TestMockConfig
 	public static function create($test)
 	{
 		// Collect all the relevant methods in JConfig.
-		$methods = array(
+		$methods = [
 			'get',
 			'set'
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JConfig')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();

--- a/tests/unit/core/mock/controller.php
+++ b/tests/unit/core/mock/controller.php
@@ -26,18 +26,18 @@ class TestMockController
 	public static function create($test)
 	{
 		// Collect all the relevant methods in JController.
-		$methods = array(
+		$methods = [
 			'execute',
 			'getApplication',
 			'getInput',
 			'serialize',
 			'unserialize',
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JControllerBase')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();

--- a/tests/unit/core/mock/database/driver.php
+++ b/tests/unit/core/mock/database/driver.php
@@ -35,10 +35,10 @@ class TestMockDatabaseDriver
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test, $driver = '', array $extraMethods = array(), $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
+	public static function create($test, $driver = '', array $extraMethods = [], $nullDate = '0000-00-00 00:00:00', $dateFormat = 'Y-m-d H:i:s')
 	{
 		// Collect all the relevant methods in JDatabaseDriver.
-		$methods = array_merge($extraMethods, array(
+		$methods = array_merge($extraMethods, [
 			'connect',
 			'connected',
 			'disconnect',
@@ -95,33 +95,33 @@ class TestMockDatabaseDriver
 			'transactionStart',
 			'unlockTables',
 			'updateObject',
-		));
+		]);
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JDatabaseDriver' . $driver)
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		// Mock selected methods.
 		$test->assignMockReturns(
-			$mockObject, array(
-				'getNullDate' => $nullDate,
+			$mockObject, [
+				'getNullDate'   => $nullDate,
 				'getDateFormat' => $dateFormat
-			)
+			]
 		);
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'escape' => array((is_callable(array($test, 'mockEscape')) ? $test : __CLASS__), 'mockEscape'),
-				'getQuery' => array((is_callable(array($test, 'mockGetQuery')) ? $test : __CLASS__), 'mockGetQuery'),
-				'quote' => array((is_callable(array($test, 'mockQuote')) ? $test : __CLASS__), 'mockQuote'),
-				'quoteName' => array((is_callable(array($test, 'mockQuoteName')) ? $test : __CLASS__), 'mockQuoteName'),
-				'setQuery' => array((is_callable(array($test, 'mockSetQuery')) ? $test : __CLASS__), 'mockSetQuery'),
-			)
+			[
+				'escape'    => [(is_callable([$test, 'mockEscape']) ? $test : __CLASS__), 'mockEscape'],
+				'getQuery'  => [(is_callable([$test, 'mockGetQuery']) ? $test : __CLASS__), 'mockGetQuery'],
+				'quote'     => [(is_callable([$test, 'mockQuote']) ? $test : __CLASS__), 'mockQuote'],
+				'quoteName' => [(is_callable([$test, 'mockQuoteName']) ? $test : __CLASS__), 'mockQuoteName'],
+				'setQuery'  => [(is_callable([$test, 'mockSetQuery']) ? $test : __CLASS__), 'mockSetQuery'],
+			]
 		);
 
 		return $mockObject;

--- a/tests/unit/core/mock/dispatcher.php
+++ b/tests/unit/core/mock/dispatcher.php
@@ -22,7 +22,7 @@ class TestMockDispatcher
 	 * @var    array
 	 * @since  11.3
 	 */
-	public static $handlers = array();
+	public static $handlers = [];
 
 	/**
 	 * Keeps track of triggers.
@@ -30,7 +30,7 @@ class TestMockDispatcher
 	 * @var    array
 	 * @since  11.3
 	 */
-	public static $triggered = array();
+	public static $triggered = [];
 
 	/**
 	 * Creates and instance of the mock DispatcherInterface object.
@@ -45,18 +45,18 @@ class TestMockDispatcher
 	public static function create($test, $defaults = true)
 	{
 		// Clear the static tracker properties.
-		self::$handlers  = array();
-		self::$triggered = array();
+		self::$handlers  = [];
+		self::$triggered = [];
 
 		// Collect all the relevant methods in DispatcherInterface.
-		$methods = array(
+		$methods = [
 			'addListener',
 			'dispatch',
 			'register',
 			'removeListener',
 			'trigger',
 			'test',
-		);
+		];
 
 		// Create the mock.
 		$mockObject = $test->getMockBuilder(DispatcherInterface::class)
@@ -65,20 +65,20 @@ class TestMockDispatcher
 
 		// Mock selected methods.
 		$test->assignMockReturns(
-			$mockObject, array(
+			$mockObject, [
 				// An additional 'test' method for confirming this object is successfully mocked.
 				'test' => 'ok',
-			)
+			]
 		);
 
 		if ($defaults)
 		{
 			$test->assignMockCallbacks(
 				$mockObject,
-				array(
-					'dispatch'     => array(get_called_class(), 'mockDispatch'),
-					'addListener'  => array(get_called_class(), 'mockRegister'),
-				)
+				[
+					'dispatch'     => [get_called_class(), 'mockDispatch'],
+					'addListener'  => [get_called_class(), 'mockRegister'],
+				]
 			);
 		}
 
@@ -105,7 +105,7 @@ class TestMockDispatcher
 			return self::$handlers[$event];
 		}
 
-		return array();
+		return [];
 	}
 
 	/**

--- a/tests/unit/core/mock/document.php
+++ b/tests/unit/core/mock/document.php
@@ -26,27 +26,27 @@ class TestMockDocument
 	public static function create($test)
 	{
 		// Collect all the relevant methods in JDatabase.
-		$methods = array(
+		$methods = [
 			'parse',
 			'render',
 			'test',
-		);
+		];
 
 		// Create the mock.
 		$mockObject = $test->getMockBuilder('JDocument')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		// Mock selected methods.
 		$test->assignMockReturns(
-			$mockObject, array(
+			$mockObject, [
 				'parse' => $mockObject,
 				// An additional 'test' method for confirming this object is successfully mocked.
-				'test' => 'ok'
-			)
+				'test'  => 'ok'
+			]
 		);
 
 		return $mockObject;

--- a/tests/unit/core/mock/input.php
+++ b/tests/unit/core/mock/input.php
@@ -37,7 +37,7 @@ class TestMockInput
 	 */
 	public function __construct(PHPUnit_Framework_TestCase $test)
 	{
-		self::$inputs = array();
+		self::$inputs = [];
 		self::$test = $test;
 	}
 
@@ -54,7 +54,7 @@ class TestMockInput
 	public function createInput(array $options = null)
 	{
 		// Collect all the relevant methods in JInput.
-		$methods = array(
+		$methods = [
 			'count',
 			'def',
 			'get',
@@ -64,7 +64,7 @@ class TestMockInput
 			'set',
 			'serialize',
 			'unserialize',
-		);
+		];
 
 		// Add custom methods if required for derived application classes.
 		if (isset($options['methods']) && is_array($options['methods']))
@@ -75,19 +75,19 @@ class TestMockInput
 		// Build the mock object.
 		$mockObject = self::$test->getMockBuilder('JInput')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		self::$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'get' => array((is_callable(array(self::$test, 'mockInputGet')) ? self::$test : $this), 'mockInputGet'),
-				'getArray' => array((is_callable(array(self::$test, 'mockInputGetArray')) ? self::$test : $this), 'mockInputGetArray'),
-				'getInt' => array((is_callable(array(self::$test, 'mockInputGetInt')) ? self::$test : $this), 'mockInputGetInt'),
-				'set' => array((is_callable(array(self::$test, 'mockInputSet')) ? self::$test : $this), 'mockInputSet'),
-			)
+			[
+				'get'      => [(is_callable([self::$test, 'mockInputGet']) ? self::$test : $this), 'mockInputGet'],
+				'getArray' => [(is_callable([self::$test, 'mockInputGetArray']) ? self::$test : $this), 'mockInputGetArray'],
+				'getInt'   => [(is_callable([self::$test, 'mockInputGetInt']) ? self::$test : $this), 'mockInputGetInt'],
+				'set'      => [(is_callable([self::$test, 'mockInputSet']) ? self::$test : $this), 'mockInputSet'],
+			]
 		);
 
 		$mockObject->get = $mockObject;
@@ -106,13 +106,13 @@ class TestMockInput
 	 */
 	public function createInputJson()
 	{
-		$mockObject = $this->createInput(array('methods' => array('getRaw')));
+		$mockObject = $this->createInput(['methods' => ['getRaw']]);
 
 		self::$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'getRaw' => array((is_callable(array(self::$test, 'mockInputGetRaw')) ? self::$test : $this), 'mockInputGetRaw'),
-			)
+			[
+				'getRaw' => [(is_callable([self::$test, 'mockInputGetRaw']) ? self::$test : $this), 'mockInputGetRaw'],
+			]
 		);
 
 		return $mockObject;
@@ -146,9 +146,9 @@ class TestMockInput
 	 *
 	 * @since   3.4
 	 */
-	public static function mockInputGetArray(array $vars = array(), $datasource = null)
+	public static function mockInputGetArray(array $vars = [], $datasource = null)
 	{
-		return array();
+		return [];
 	}
 
 	/**

--- a/tests/unit/core/mock/input.php
+++ b/tests/unit/core/mock/input.php
@@ -38,7 +38,7 @@ class TestMockInput
 	public function __construct(PHPUnit_Framework_TestCase $test)
 	{
 		self::$inputs = [];
-		self::$test = $test;
+		self::$test   = $test;
 	}
 
 	/**

--- a/tests/unit/core/mock/language.php
+++ b/tests/unit/core/mock/language.php
@@ -26,36 +26,36 @@ class TestMockLanguage
 	public static function create($test)
 	{
 		// Collect all the relevant methods in JDatabase.
-		$methods = array(
+		$methods = [
 			'_',
 			'getInstance',
 			'getTag',
 			'test',
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JLanguage')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		// Mock selected methods.
 		$test->assignMockReturns(
-			$mockObject, array(
+			$mockObject, [
 				'getInstance' => $mockObject,
-				'getTag' => 'en-GB',
+				'getTag'      => 'en-GB',
 				// An additional 'test' method for confirming this object is successfully mocked.
-				'test' => 'ok',
-			)
+				'test'        => 'ok',
+			]
 		);
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'_' => array(get_called_class(), 'mock_'),
-			)
+			[
+				'_' => [get_called_class(), 'mock_'],
+			]
 		);
 
 		return $mockObject;

--- a/tests/unit/core/mock/menu.php
+++ b/tests/unit/core/mock/menu.php
@@ -14,7 +14,7 @@
  */
 class TestMockMenu
 {
-	protected static $data = array();
+	protected static $data = [];
 
 	/**
 	 * Creates an instance of the mock JMenu object.
@@ -28,7 +28,7 @@ class TestMockMenu
 	public static function create(PHPUnit_Framework_TestCase $test, $setDefault = true, $setActive = false)
 	{
 		// Collect all the relevant methods in JMenu (work in progress).
-		$methods = array(
+		$methods = [
 			'getItem',
 			'setDefault',
 			'getDefault',
@@ -39,12 +39,12 @@ class TestMockMenu
 			'getMenu',
 			'authorise',
 			'load'
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JMenu')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
@@ -57,7 +57,7 @@ class TestMockMenu
 
 		$mockObject->expects($test->any())
 				->method('getItems')
-				->will($test->returnCallback(array(__CLASS__, 'prepareGetItemsData')));
+				->will($test->returnCallback([__CLASS__, 'prepareGetItemsData']));
 
 		$mockObject->expects($test->any())
 				->method('getMenu')
@@ -82,12 +82,12 @@ class TestMockMenu
 
 	protected static function prepareGetItemData()
 	{
-		$return = array();
+		$return = [];
 
 		foreach (self::$data as $id => $item)
 		{
-			$return[] = array($id, $item);
-			$return[] = array((string) $id, $item);
+			$return[] = [$id, $item];
+			$return[] = [(string) $id, $item];
 		}
 
 		return $return;
@@ -95,15 +95,15 @@ class TestMockMenu
 
 	protected static function prepareDefaultData()
 	{
-		$return   = array();
-		$return[] = array('en-GB', self::$data[45]);
+		$return   = [];
+		$return[] = ['en-GB', self::$data[45]];
 
 		return $return;
 	}
 
 	public static function prepareGetItemsData($attributes, $values)
 	{
-		$items = array();
+		$items = [];
 		$attributes = (array) $attributes;
 		$values = (array) $values;
 
@@ -142,7 +142,7 @@ class TestMockMenu
 
 	protected static function createMenuSampleData()
 	{
-		self::$data[42] = (object) array(
+		self::$data[42] = (object) [
 			'id'           => '42',
 			'menutype'     => 'testmenu',
 			'title'        => 'Test1',
@@ -158,10 +158,11 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '0',
 			'component'    => 'com_test',
-			'tree'         => array(42),
-			'query'        => array('option' => 'com_test', 'view' => 'test'));
+			'tree'         => [42],
+			'query'        => ['option' => 'com_test', 'view' => 'test']
+		];
 
-		self::$data[43] = (object) array(
+		self::$data[43] = (object) [
 			'id'           => '43',
 			'menutype'     => 'testmenu',
 			'title'        => 'Test2',
@@ -177,10 +178,11 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '0',
 			'component'    => 'com_test2',
-			'tree'         => array(43),
-			'query'        => array('option' => 'com_test2', 'view' => 'test'));
+			'tree'         => [43],
+			'query'        => ['option' => 'com_test2', 'view' => 'test']
+		];
 
-		self::$data[44] = (object) array(
+		self::$data[44] = (object) [
 			'id'           => '44',
 			'menutype'     => 'testmenu',
 			'title'        => 'Submenu',
@@ -196,10 +198,11 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '43',
 			'component'    => 'com_test2',
-			'tree'         => array(43, 44),
-			'query'        => array('option' => 'com_test2', 'view' => 'test2'));
+			'tree'         => [43, 44],
+			'query'        => ['option' => 'com_test2', 'view' => 'test2']
+		];
 
-		self::$data[45] = (object) array(
+		self::$data[45] = (object) [
 			'id'           => '45',
 			'menutype'     => 'testmenu',
 			'title'        => 'Home',
@@ -215,10 +218,11 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '0',
 			'component'    => 'com_test3',
-			'tree'         => array(43, 44),
-			'query'        => array('option' => 'com_test3', 'view' => 'test3'));
+			'tree'         => [43, 44],
+			'query'        => ['option' => 'com_test3', 'view' => 'test3']
+		];
 
-		self::$data[46] = (object) array(
+		self::$data[46] = (object) [
 			'id'           => '46',
 			'menutype'     => 'testmenu',
 			'title'        => 'Submenu',
@@ -234,10 +238,11 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '42',
 			'component'    => 'com_test',
-			'tree'         => array(42, 46),
-			'query'        => array('option' => 'com_test', 'view' => 'test2'));
+			'tree'         => [42, 46],
+			'query'        => ['option' => 'com_test', 'view' => 'test2']
+		];
 
-		self::$data[47] = (object) array(
+		self::$data[47] = (object) [
 			'id'           => '47',
 			'menutype'     => 'testmenu',
 			'title'        => 'English Test',
@@ -253,9 +258,10 @@ class TestMockMenu
 			'component_id' => '1000',
 			'parent_id'    => '0',
 			'component'    => 'com_test',
-			'query'        => array('option' => 'com_test', 'view' => 'test2'));
+			'query'        => ['option' => 'com_test', 'view' => 'test2']
+		];
 
-	/**	self::$data[48] = (object) array(
+	/**	self::$data[48] = (object) [
 			'id'           => '48',
 			'menutype'     => '',
 			'title'        => '',
@@ -271,9 +277,10 @@ class TestMockMenu
 			'component_id' => '',
 			'parent_id'    => '',
 			'component'    => '',
-			'query'        => array());
+			'query'        => []
+		];
 
-		self::$data[49] = (object) array(
+		self::$data[49] = (object) [
 			'id'           => '49',
 			'menutype'     => '',
 			'title'        => '',
@@ -289,9 +296,10 @@ class TestMockMenu
 			'component_id' => '',
 			'parent_id'    => '',
 			'component'    => '',
-			'query'        => array());
+			'query'        => []
+		];
 
-		self::$data[50] = (object) array(
+		self::$data[50] = (object) [
 			'id'           => '50',
 			'menutype'     => '',
 			'title'        => '',
@@ -307,9 +315,10 @@ class TestMockMenu
 			'component_id' => '',
 			'parent_id'    => '',
 			'component'    => '',
-			'query'        => array());
+			'query'        => []
+		];
 
-		self::$data[51] = (object) array(
+		self::$data[51] = (object) [
 			'id'           => '51',
 			'menutype'     => '',
 			'title'        => '',
@@ -325,6 +334,7 @@ class TestMockMenu
 			'component_id' => '',
 			'parent_id'    => '',
 			'component'    => '',
-			'query'        => array());**/
+			'query'        => []
+		];**/
 	}
 }

--- a/tests/unit/core/mock/menu.php
+++ b/tests/unit/core/mock/menu.php
@@ -103,9 +103,9 @@ class TestMockMenu
 
 	public static function prepareGetItemsData($attributes, $values)
 	{
-		$items = [];
+		$items      = [];
 		$attributes = (array) $attributes;
-		$values = (array) $values;
+		$values     = (array) $values;
 
 		foreach (self::$data as $item)
 		{

--- a/tests/unit/core/mock/rules.php
+++ b/tests/unit/core/mock/rules.php
@@ -26,23 +26,23 @@ class TestMockRules
 	public static function create($test)
 	{
 		// Mock all the public methods.
-		$methods = array(
+		$methods = [
 			'allow',
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JAccessRules')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'allow' => array(get_called_class(), 'mockAllow'),
-			)
+			[
+				'allow' => [get_called_class(), 'mockAllow'],
+			]
 		);
 
 		return $mockObject;

--- a/tests/unit/core/mock/session.php
+++ b/tests/unit/core/mock/session.php
@@ -20,7 +20,7 @@ class TestMockSession
 	 * @var    array
 	 * @since  11.3
 	 */
-	protected static $options = array();
+	protected static $options = [];
 
 	/**
 	 * Gets an option.
@@ -51,7 +51,7 @@ class TestMockSession
 	 *
 	 * @since   11.3
 	 */
-	public static function create($test, $options = array())
+	public static function create($test, $options = [])
 	{
 		if (is_array($options))
 		{
@@ -59,7 +59,7 @@ class TestMockSession
 		}
 
 		// Mock all the public methods.
-		$methods = array(
+		$methods = [
 			'clear',
 			'close',
 			'destroy',
@@ -79,28 +79,28 @@ class TestMockSession
 			'isNew',
 			'restart',
 			'set',
-		);
+		];
 
 		// Build the mock object.
 		$mockObject = $test->getMockBuilder('JSession')
 					->setMethods($methods)
-					->setConstructorArgs(array())
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
 
 		// Mock selected methods.
 		$test->assignMockReturns(
-			$mockObject, array(
+			$mockObject, [
 				'getId' => self::getOption('getId')
-			)
+			]
 		);
 
 		$test->assignMockCallbacks(
 			$mockObject,
-			array(
-				'get' => array(get_called_class(), 'mockGet'),
-			)
+			[
+				'get' => [get_called_class(), 'mockGet'],
+			]
 		);
 
 		return $mockObject;


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in unit tests core folder.

### Testing Instructions

Simple code review.
Unit tests (travis) test passed.

### Documentation Changes Required

None.