### PR TITLE
[4.0] Array to php 5.4+ notation [Unit Tests 2: database suite]

### DIFF
--- a/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseDriverMysqliTest.php
@@ -25,10 +25,10 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function dataTestEscape()
 	{
-		return array(
-			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
-		);
+		return [
+			["'%_abc123", false, '\\\'%_abc123'],
+			["'%_abc123", true, '\\\'\\%\_abc123']
+		];
 	}
 
 	/**
@@ -40,11 +40,11 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function dataTestQuoteName()
 	{
-		return array(
-			array('protected`title', null, '`protected``title`'),
-			array('protected"title', null, '`protected"title`'),
-			array('protected]title', null, '`protected]title`'),
-		);
+		return [
+			['protected`title', null, '`protected``title`'],
+			['protected"title', null, '`protected"title`'],
+			['protected]title', null, '`protected]title`'],
+		];
 	}
 
 	/**
@@ -56,7 +56,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function dataTestTransactionRollback()
 	{
-		return array(array(null, 0), array('transactionSavepoint', 1));
+		return [[null, 0], ['transactionSavepoint', 1]];
 	}
 
 	/**
@@ -92,7 +92,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$objCompFour->start_date = '1980-04-18 00:00:00';
 		$objCompFour->description = 'four';
 
-		return array(array(array($objCompOne, $objCompTwo, $objCompThree, $objCompFour)));
+		return [[[$objCompOne, $objCompTwo, $objCompThree, $objCompFour]]];
 	}
 
 	/**
@@ -104,13 +104,16 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function dataTestLoadNextRow()
 	{
-		return array(
-			array(
-				array(
-					array(1, 'Testing', '1980-04-18 00:00:00', 'one'),
-					array(2, 'Testing2', '1980-04-18 00:00:00', 'one'),
-					array(3, 'Testing3', '1980-04-18 00:00:00', 'three'),
-					array(4, 'Testing4', '1980-04-18 00:00:00', 'four'))));
+		return [
+			[
+				[
+					[1, 'Testing', '1980-04-18 00:00:00', 'one'],
+					[2, 'Testing2', '1980-04-18 00:00:00', 'one'],
+					[3, 'Testing3', '1980-04-18 00:00:00', 'three'],
+					[4, 'Testing4', '1980-04-18 00:00:00', 'four']
+				]
+			]
+		];
 	}
 
 	/**
@@ -275,7 +278,12 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function testGetTableColumns()
 	{
-		$tableCol = array('id' => 'int unsigned', 'title' => 'varchar', 'start_date' => 'datetime', 'description' => 'text');
+		$tableCol = [
+			'id'          => 'int unsigned',
+			'title'       => 'varchar',
+			'start_date'  => 'datetime',
+			'description' => 'text'
+		];
 
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest'),
@@ -331,12 +339,12 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		$this->assertThat(
 			self::$driver->getTableColumns('jos_dbtest', false),
 			$this->equalTo(
-				array(
-					'id' => $id,
-					'title' => $title,
-					'start_date' => $start_date,
+				[
+					'id'          => $id,
+					'title'       => $title,
+					'start_date'  => $start_date,
 					'description' => $description
-				)
+				]
 			),
 			__LINE__
 		);
@@ -405,7 +413,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadAssoc();
 
-		$this->assertThat($result, $this->equalTo(array('title' => 'Testing')), __LINE__);
+		$this->assertThat($result, $this->equalTo(['title' => 'Testing']), __LINE__);
 	}
 
 	/**
@@ -425,7 +433,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 
 		$this->assertThat(
 			$result,
-			$this->equalTo(array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4'))),
+			$this->equalTo([['title' => 'Testing'], ['title' => 'Testing2'], ['title' => 'Testing3'], ['title' => 'Testing4']]),
 			__LINE__
 		);
 	}
@@ -445,7 +453,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadColumn();
 
-		$this->assertThat($result, $this->equalTo(array('Testing', 'Testing2', 'Testing3', 'Testing4')), __LINE__);
+		$this->assertThat($result, $this->equalTo(['Testing', 'Testing2', 'Testing3', 'Testing4']), __LINE__);
 	}
 
 	/**
@@ -647,7 +655,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadObjectList();
 
-		$expected = array();
+		$expected = [];
 
 		$objCompare = new stdClass;
 		$objCompare->id = 1;
@@ -721,7 +729,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+		$expected = [3, 'Testing3', '1980-04-18 00:00:00', 'three'];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -742,7 +750,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+		$expected = [[1, 'Testing', '1980-04-18 00:00:00', 'one'], [2, 'Testing2', '1980-04-18 00:00:00', 'one']];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -781,7 +789,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'));
+		$expected = [[1, 'Testing', '1980-04-18 00:00:00', 'one']];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -803,7 +811,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($query, 0, 1);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'));
+		$expected = [[1, 'Testing', '1980-04-18 00:00:00', 'one']];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -857,7 +865,7 @@ class JDatabaseDriverMysqliTest extends TestCaseDatabaseMysqli
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+		$expected = ['6', 'testTitle', '1970-01-01 00:00:00', 'testDescription'];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseExporterMysqliTest.php
@@ -36,54 +36,54 @@ class JDatabaseExporterMysqliTest extends TestCase
 		$this->dbo->expects($this->any())
 			->method('getTableColumns')
 			->willReturn(
-				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
+				[
+					'id' => (object) [
+						'Field'      => 'id',
+						'Type'       => 'int(11) unsigned',
+						'Collation'  => null,
+						'Null'       => 'NO',
+						'Key'        => 'PRI',
+						'Default'    => '',
+						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
+						'Comment'    => '',
+					],
+					'title' => (object) [
+						'Field'      => 'title',
+						'Type'       => 'varchar(255)',
+						'Collation'  => 'utf8_general_ci',
+						'Null'       => 'NO',
+						'Key'        => '',
+						'Default'    => '',
+						'Extra'      => '',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-				)
+						'Comment'    => '',
+					],
+				]
 			);
 
 		$this->dbo->expects($this->any())
 			->method('getTableKeys')
-			->willReturn(array(
-				(object) array(
-					'Table' => 'jos_test',
-					'Non_unique' => '0',
-					'Key_name' => 'PRIMARY',
+			->willReturn([
+				(object) [
+					'Table'        => 'jos_test',
+					'Non_unique'   => '0',
+					'Key_name'     => 'PRIMARY',
 					'Seq_in_index' => '1',
-					'Column_name' => 'id',
-					'Collation' => 'A',
-					'Cardinality' => '2695',
-					'Sub_part' => '',
-					'Packed' => '',
-					'Null' => '',
-					'Index_type' => 'BTREE',
-					'Comment' => '',
-				)
-			));
+					'Column_name'  => 'id',
+					'Collation'    => 'A',
+					'Cardinality'  => '2695',
+					'Sub_part'     => '',
+					'Packed'       => '',
+					'Null'         => '',
+					'Index_type'   => 'BTREE',
+					'Comment'      => '',
+				]
+			]);
 
 		$this->dbo->expects($this->any())
 			->method('loadObjectList')
-			->willReturnCallback(array($this, 'callbackLoadObjectList'));
+			->willReturnCallback([$this, 'callbackLoadObjectList']);
 	}
 
 	/**
@@ -107,7 +107,7 @@ class JDatabaseExporterMysqliTest extends TestCase
 	 */
 	public function callbackLoadObjectList()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -204,14 +204,14 @@ class JDatabaseExporterMysqliTest extends TestCase
 			->withStructure(true);
 
 		$this->assertEquals(
-			array(
+			[
 				'  <table_structure name="#__test">',
 				'   <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 				'   <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />',
 				'   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" ' .
 				'Null="" Index_type="BTREE" Comment="" />',
 				'  </table_structure>'
-			),
+			],
 			TestReflection::invoke($instance, 'buildXmlStructure')
 		);
 	}
@@ -287,7 +287,7 @@ class JDatabaseExporterMysqliTest extends TestCase
 		);
 
 		$this->assertSame(
-			array('jos_foobar'),
+			['jos_foobar'],
 			TestReflection::getValue($instance, 'from'),
 			'The from method should convert a string input to an array.'
 		);

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -28,7 +28,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	/**
 	 * @var    array  Selected sample data for tests.
 	 */
-	protected $sample = array(
+	protected $sample = [
 		'xml-id-field' =>
 			'<field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 		'xml-title-field' =>
@@ -37,7 +37,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			'<field Field="body" Type="mediumtext" Null="NO" Key="" Default="" Extra="" />',
 		'xml-primary-key' =>
 			'<key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />',
-	);
+	];
 
 	/**
 	 * Sets up the testing conditions
@@ -47,7 +47,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	public function setup()
 	{
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverMysqli')
-					->setMethods(array(
+					->setMethods([
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -56,8 +56,8 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
-					->setConstructorArgs(array())
+					])
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
@@ -78,30 +78,30 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('getTableColumns')
 			->will(
 			$this->returnValue(
-				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
+				[
+					'id' => (object) [
+						'Field'      => 'id',
+						'Type'       => 'int(11) unsigned',
+						'Collation'  => null,
+						'Null'       => 'NO',
+						'Key'        => 'PRI',
+						'Default'    => '',
+						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
+						'Comment'    => '',
+					],
+					'title' => (object) [
+						'Field'      => 'title',
+						'Type'       => 'varchar(255)',
+						'Collation'  => 'utf8_general_ci',
+						'Null'       => 'NO',
+						'Key'        => '',
+						'Default'    => '',
+						'Extra'      => '',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-				)
+						'Comment'    => '',
+					],
+				]
 			)
 		);
 
@@ -111,22 +111,22 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('getTableKeys')
 			->will(
 			$this->returnValue(
-				array(
-					(object) array(
-						'Table' => 'jos_test',
-						'Non_unique' => '0',
-						'Key_name' => 'PRIMARY',
+				[
+					(object) [
+						'Table'        => 'jos_test',
+						'Non_unique'   => '0',
+						'Key_name'     => 'PRIMARY',
 						'Seq_in_index' => '1',
-						'Column_name' => 'id',
-						'Collation' => 'A',
-						'Cardinality' => '2695',
-						'Sub_part' => '',
-						'Packed' => '',
-						'Null' => '',
-						'Index_type' => 'BTREE',
-						'Comment' => '',
-					)
-				)
+						'Column_name'  => 'id',
+						'Collation'    => 'A',
+						'Cardinality'  => '2695',
+						'Sub_part'     => '',
+						'Packed'       => '',
+						'Null'         => '',
+						'Index_type'   => 'BTREE',
+						'Comment'      => '',
+					]
+				]
 			)
 		);
 
@@ -136,7 +136,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('quoteName')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackQuoteName')
+				[$this, 'callbackQuoteName']
 			)
 		);
 
@@ -146,7 +146,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('quote')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackQuote')
+				[$this, 'callbackQuote']
 			)
 		);
 
@@ -156,7 +156,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('setQuery')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackSetQuery')
+				[$this, 'callbackSetQuery']
 			)
 		);
 
@@ -166,7 +166,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			->method('loadObjectList')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
+				[$this, 'callbackLoadObjectList']
 			)
 		);
 	}
@@ -192,7 +192,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function callbackLoadObjectList()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -247,41 +247,41 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 		$k2 = '<key Table="#__test" Non_unique="0" Key_name="idx_title" Seq_in_index="1"' .
 			' Column_name="title" Collation="A" Null="" Index_type="BTREE" Comment="" />';
 
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . '</table_structure>'),
-				array(),
+				[],
 				'getAlterTableSQL should not change anything.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $f3 . $k1 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` ADD COLUMN `alias` varchar(255) NOT NULL DEFAULT ''",
-				),
+				],
 				'getAlterTableSQL should add the new alias column.'
 			),
-			array(
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` ADD UNIQUE KEY `idx_title` (`title`)",
-				),
+				],
 				'getAlterTableSQL should add the new key.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $k1 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` DROP COLUMN `title`",
-				),
+				],
 				'getAlterTableSQL should remove the title column.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` DROP PRIMARY KEY",
-				),
+				],
 				'getAlterTableSQL should drop the old primary key.'
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -291,29 +291,29 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function dataGetColumnSql()
 	{
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-id-field']
 				),
 				"`id` int(11) unsigned NOT NULL DEFAULT '' AUTO_INCREMENT",
 				'Typical primary key field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-title-field']
 				),
 				"`title` varchar(50) NOT NULL DEFAULT ''",
 				'Typical text field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-body-field']
 				),
 				"`body` mediumtext NOT NULL",
 				'Typical blob field',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -323,18 +323,18 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function dataGetKeySql()
 	{
-		return array(
-			array(
+		return [
+			[
 				// Keys come in arrays.
-				array(
+				[
 					new SimpleXmlElement(
 						$this->sample['xml-primary-key']
 					),
-				),
+				],
 				"primary key  (`id`)",
 				'Typical primary key index',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -454,7 +454,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getAddKeySQL', 'jos_test', array(new SimpleXmlElement($this->sample['xml-primary-key']))),
+			TestReflection::invoke($instance, 'getAddKeySQL', 'jos_test', [new SimpleXmlElement($this->sample['xml-primary-key'])]),
 			$this->equalTo(
 				"ALTER TABLE `jos_test` ADD PRIMARY KEY  (`id`)"
 			),
@@ -583,17 +583,17 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 	{
 		$instance = new JDatabaseImporterMysqli;
 
-		$o1 = (object) array('Key_name' => 'id', 'foo' => 'bar1');
-		$o2 = (object) array('Key_name' => 'id', 'foo' => 'bar2');
-		$o3 = (object) array('Key_name' => 'title', 'foo' => 'bar3');
+		$o1 = (object) ['Key_name' => 'id', 'foo' => 'bar1'];
+		$o2 = (object) ['Key_name' => 'id', 'foo' => 'bar2'];
+		$o3 = (object) ['Key_name' => 'title', 'foo' => 'bar3'];
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getKeyLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getKeyLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => [$o3]
+				]
 			),
 			'getKeyLookup, using array input, did not yield the expected result.'
 		);
@@ -603,12 +603,12 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 		$o3 = new SimpleXmlElement('<key Key_name="title" foo="bar3" />');
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getKeyLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getKeyLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => ]$o3]
+				]
 			),
 			'getKeyLookup, using SimpleXmlElement input, did not yield the expected result.'
 		);

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -259,7 +259,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 					"ALTER TABLE `jos_test` ADD COLUMN `alias` varchar(255) NOT NULL DEFAULT ''",
 				],
 				'getAlterTableSQL should add the new alias column.'
-			),
+			],
 			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
 				[

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseImporterMysqliTest.php
@@ -607,7 +607,7 @@ class JDatabaseImporterMysqliTest extends \PHPUnit\Framework\TestCase
 			$this->equalTo(
 				[
 					'id'    => [$o1, $o2],
-					'title' => ]$o3]
+					'title' => [$o3]
 				]
 			),
 			'getKeyLookup, using SimpleXmlElement input, did not yield the expected result.'

--- a/tests/unit/suites/database/driver/mysqli/JDatabaseIteratorMysqliTest.php
+++ b/tests/unit/suites/database/driver/mysqli/JDatabaseIteratorMysqliTest.php
@@ -25,83 +25,83 @@ class JDatabaseIteratorMysqliTest extends TestCaseDatabaseMysqli
 	 */
 	public function casesForEachData()
 	{
-		return array(
+		return [
 			// Testing 'stdClass' type without specific index, offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				0,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2'),
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2'],
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, limit=2 without specific index or offset
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				2,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, offset=2 without specific index or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				20,
 				2,
-				array(
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title, id',
 				'#__dbtest',
 				'title',
 				'stdClass',
 				0,
 				0,
-				array(
-					'Testing' => (object) array('title' => 'Testing', 'id' => '1'),
-					'Testing2' => (object) array('title' => 'Testing2', 'id' => '2'),
-					'Testing3' => (object) array('title' => 'Testing3', 'id' => '3'),
-					'Testing4' => (object) array('title' => 'Testing4', 'id' => '4')
-				),
+				[
+					'Testing'  => (object) ['title' => 'Testing', 'id' => '1'],
+					'Testing2' => (object) ['title' => 'Testing2', 'id' => '2'],
+					'Testing3' => (object) ['title' => 'Testing3', 'id' => '3'],
+					'Testing4' => (object) ['title' => 'Testing4', 'id' => '4']
+				],
 				null,
-			),
+			],
 
 			// Testing 'UnexistingClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				'title',
 				'UnexistingClass',
 				0,
 				0,
-				array(),
+				[],
 				'InvalidArgumentException',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseDriverPdomysqlTest.php
@@ -25,10 +25,10 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	 */
 	public function dataTestEscape()
 	{
-		return array(
-			array("'%_abc123", false, '\\\'%_abc123'),
-			array("'%_abc123", true, '\\\'\\%\_abc123')
-		);
+		return [
+			["'%_abc123", false, '\\\'%_abc123'],
+			["'%_abc123", true, '\\\'\\%\_abc123']
+		];
 	}
 
 	/**
@@ -40,11 +40,11 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	 */
 	public function dataTestQuoteName()
 	{
-		return array(
-			array('protected`title', null, '`protected``title`'),
-			array('protected"title', null, '`protected"title`'),
-			array('protected]title', null, '`protected]title`'),
-		);
+		return [
+			['protected`title', null, '`protected``title`'],
+			['protected"title', null, '`protected"title`'],
+			['protected]title', null, '`protected]title`'],
+		];
 	}
 
 	/**
@@ -56,7 +56,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	 */
 	public function dataTestTransactionRollback()
 	{
-		return array(array(null, 0), array('transactionSavepoint', 1));
+		return [[null, 0], ['transactionSavepoint', 1]];
 	}
 
 	/**
@@ -272,7 +272,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 	 */
 	public function testGetTableColumns()
 	{
-		$tableCol = array('id' => 'int unsigned', 'title' => 'varchar', 'start_date' => 'datetime', 'description' => 'text');
+		$tableCol = ['id' => 'int unsigned', 'title' => 'varchar', 'start_date' => 'datetime', 'description' => 'text'];
 
 		$this->assertThat(
 			self::$driver->getTableColumns('#__dbtest'),
@@ -328,12 +328,12 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		$this->assertThat(
 			self::$driver->getTableColumns('#__dbtest', false),
 			$this->equalTo(
-				array(
-					'id' => $id,
-					'title' => $title,
-					'start_date' => $start_date,
+				[
+					'id'          => $id,
+					'title'       => $title,
+					'start_date'  => $start_date,
 					'description' => $description
-				)
+				]
 			),
 			__LINE__
 		);
@@ -417,9 +417,9 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		$this->assertThat(
 			$result,
 			$this->equalTo(
-				array(
+				[
 					'title' => 'Testing'
-				)),
+				]),
 				__LINE__
 			);
 	}
@@ -441,7 +441,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 
 		$this->assertThat(
 			$result,
-			$this->equalTo(array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4'))),
+			$this->equalTo([['title' => 'Testing'], ['title' => 'Testing2'], ['title' => 'Testing3'], ['title' => 'Testing4']]),
 			__LINE__
 		);
 	}
@@ -463,7 +463,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 
 		$this->assertThat(
 			$result,
-			$this->equalTo(array('Testing', 'Testing2', 'Testing3', 'Testing4')),
+			$this->equalTo(['Testing', 'Testing2', 'Testing3', 'Testing4']),
 			__LINE__
 		);
 	}
@@ -537,7 +537,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadObjectList();
 
-		$expected = array();
+		$expected = [];
 
 		$objCompare              = new stdClass;
 		$objCompare->id          = 1;
@@ -619,7 +619,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00', 'three');
+		$expected = [3, 'Testing3', '1980-04-18 00:00:00', 'three'];
 
 		$this->assertThat(
 			$result,
@@ -644,7 +644,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one'));
+		$expected = [[1, 'Testing', '1980-04-18 00:00:00', 'one'], [2, 'Testing2', '1980-04-18 00:00:00', 'one']];
 
 		$this->assertThat(
 			$result,
@@ -747,7 +747,7 @@ class JDatabaseDriverPdomysqlTest extends TestCaseDatabasePdomysql
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array('6', 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+		$expected = ['6', 'testTitle', '1970-01-01 00:00:00', 'testDescription'];
 
 		$this->assertThat(
 			$result,

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -76,7 +76,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
 						'Comment'    => '',
-					),
+					],
 					(object) [
 						'Field'      => 'title',
 						'Type'       => 'varchar(255)',

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseExporterPdomysqlTest.php
@@ -35,7 +35,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
-					->setMethods(array(
+					->setMethods([
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -43,8 +43,8 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'quoteName',
 						'loadObjectList',
 						'setQuery',
-					))
-					->setConstructorArgs(array())
+					])
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
@@ -65,30 +65,30 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('getTableColumns')
 			->will(
 			$this->returnValue(
-				array(
-					(object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
+				[
+					(object) [
+						'Field'      => 'id',
+						'Type'       => 'int(11) unsigned',
+						'Collation'  => null,
+						'Null'       => 'NO',
+						'Key'        => 'PRI',
+						'Default'    => '',
+						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
+						'Comment'    => '',
 					),
-					(object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
+					(object) [
+						'Field'      => 'title',
+						'Type'       => 'varchar(255)',
+						'Collation'  => 'utf8_general_ci',
+						'Null'       => 'NO',
+						'Key'        => '',
+						'Default'    => '',
+						'Extra'      => '',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-				)
+						'Comment'    => '',
+					],
+				]
 			)
 		);
 
@@ -98,22 +98,22 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('getTableKeys')
 			->will(
 			$this->returnValue(
-				array(
-					(object) array(
-						'Table' => 'jos_test',
-						'Non_unique' => '0',
-						'Key_name' => 'PRIMARY',
+				[
+					(object) [
+						'Table'        => 'jos_test',
+						'Non_unique'   => '0',
+						'Key_name'     => 'PRIMARY',
 						'Seq_in_index' => '1',
-						'Column_name' => 'id',
-						'Collation' => 'A',
-						'Cardinality' => '2695',
-						'Sub_part' => '',
-						'Packed' => '',
-						'Null' => '',
-						'Index_type' => 'BTREE',
-						'Comment' => '',
-					)
-				)
+						'Column_name'  => 'id',
+						'Collation'    => 'A',
+						'Cardinality'  => '2695',
+						'Sub_part'     => '',
+						'Packed'       => '',
+						'Null'         => '',
+						'Index_type'   => 'BTREE',
+						'Comment'      => '',
+					]
+				]
 			)
 		);
 
@@ -123,7 +123,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('quoteName')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackQuoteName')
+				[$this, 'callbackQuoteName']
 			)
 		);
 
@@ -133,7 +133,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('setQuery')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackSetQuery')
+				[$this, 'callbackSetQuery']
 			)
 		);
 
@@ -143,7 +143,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('loadObjectList')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
+				[$this, 'callbackLoadObjectList']
 			)
 		);
 	}
@@ -172,7 +172,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function callbackLoadObjectList()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -324,14 +324,14 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		$this->assertThat(
 			TestReflection::invoke($instance, 'buildXmlStructure'),
 			$this->equalTo(
-				array(
+				[
 					'  <table_structure name="#__test">',
 					'   <field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 					'   <field Field="title" Type="varchar(255)" Null="NO" Key="" Default="" Extra="" />',
 					'   <key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" ' .
 					'Null="" Index_type="BTREE" Comment="" />',
 					'  </table_structure>'
-				)
+				]
 			),
 			'buildXmlStructure has not returned the expected result.'
 		);
@@ -470,7 +470,7 @@ class JDatabaseExporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 			$this->assertThat(
 				TestReflection::getValue($instance, 'from'),
-				$this->equalTo(array('jos_foobar')),
+				$this->equalTo(['jos_foobar']),
 				'The from method should convert a string input to an array.'
 			);
 		}

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseImporterPdomysqlTest.php
@@ -32,7 +32,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	 * @var    array  Selected sample data for tests.
 	 * @since  3.4
 	 */
-	protected $sample = array(
+	protected $sample = [
 		'xml-id-field' =>
 			'<field Field="id" Type="int(11) unsigned" Null="NO" Key="PRI" Default="" Extra="auto_increment" />',
 		'xml-title-field' =>
@@ -41,7 +41,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			'<field Field="body" Type="mediumtext" Null="NO" Key="" Default="" Extra="" />',
 		'xml-primary-key' =>
 			'<key Table="#__test" Non_unique="0" Key_name="PRIMARY" Seq_in_index="1" Column_name="id" Collation="A" Null="" Index_type="BTREE" Comment="" />',
-	);
+	];
 
 	/**
 	 * Sets up the testing conditions
@@ -56,7 +56,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPdomysql')
-					->setMethods(array(
+					->setMethods([
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -65,8 +65,8 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
-					->setConstructorArgs(array())
+					])
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
@@ -87,30 +87,30 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('getTableColumns')
 			->will(
 			$this->returnValue(
-				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'int(11) unsigned',
-						'Collation' => null,
-						'Null' => 'NO',
-						'Key' => 'PRI',
-						'Default' => '',
-						'Extra' => 'auto_increment',
+				[
+					'id' => (object) [
+						'Field'      => 'id',
+						'Type'       => 'int(11) unsigned',
+						'Collation'  => null,
+						'Null'       => 'NO',
+						'Key'        => 'PRI',
+						'Default'    => '',
+						'Extra'      => 'auto_increment',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'varchar(255)',
-						'Collation' => 'utf8_general_ci',
-						'Null' => 'NO',
-						'Key' => '',
-						'Default' => '',
-						'Extra' => '',
+						'Comment'    => '',
+					],
+					'title' => (object) [
+						'Field'      => 'title',
+						'Type'       => 'varchar(255)',
+						'Collation'  => 'utf8_general_ci',
+						'Null'       => 'NO',
+						'Key'        => '',
+						'Default'    => '',
+						'Extra'      => '',
 						'Privileges' => 'select,insert,update,references',
-						'Comment' => '',
-					),
-				)
+						'Comment'    => '',
+					],
+				]
 			)
 		);
 
@@ -120,22 +120,22 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('getTableKeys')
 			->will(
 			$this->returnValue(
-				array(
-					(object) array(
-						'Table' => 'jos_test',
-						'Non_unique' => '0',
-						'Key_name' => 'PRIMARY',
+				[
+					(object) [
+						'Table'        => 'jos_test',
+						'Non_unique'   => '0',
+						'Key_name'     => 'PRIMARY',
 						'Seq_in_index' => '1',
-						'Column_name' => 'id',
-						'Collation' => 'A',
-						'Cardinality' => '2695',
-						'Sub_part' => '',
-						'Packed' => '',
-						'Null' => '',
-						'Index_type' => 'BTREE',
-						'Comment' => '',
-					)
-				)
+						'Column_name'  => 'id',
+						'Collation'    => 'A',
+						'Cardinality'  => '2695',
+						'Sub_part'     => '',
+						'Packed'       => '',
+						'Null'         => '',
+						'Index_type'   => 'BTREE',
+						'Comment'      => '',
+					]
+				]
 			)
 		);
 
@@ -145,7 +145,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('quoteName')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackQuoteName')
+				[$this, 'callbackQuoteName']
 			)
 		);
 
@@ -155,7 +155,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('quote')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackQuote')
+				[$this, 'callbackQuote']
 			)
 		);
 
@@ -165,7 +165,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('setQuery')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackSetQuery')
+				[$this, 'callbackSetQuery']
 			)
 		);
 
@@ -175,7 +175,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 			->method('loadObjectList')
 			->will(
 			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
+				[$this, 'callbackLoadObjectList']
 			)
 		);
 	}
@@ -204,7 +204,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function callbackLoadObjectList()
 	{
-		return array();
+		return [];
 	}
 
 	/**
@@ -267,41 +267,41 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		$k2 = '<key Table="#__test" Non_unique="0" Key_name="idx_title" Seq_in_index="1"' .
 			' Column_name="title" Collation="A" Null="" Index_type="BTREE" Comment="" />';
 
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . '</table_structure>'),
-				array(),
+				[],
 				'getAlterTableSQL should not change anything.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $f3 . $k1 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` ADD COLUMN `alias` varchar(255) NOT NULL DEFAULT ''",
-				),
+				],
 				'getAlterTableSQL should add the new alias column.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` ADD UNIQUE KEY `idx_title` (`title`)",
-				),
+				],
 				'getAlterTableSQL should add the new key.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $k1 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` DROP COLUMN `title`",
-				),
+				],
 				'getAlterTableSQL should remove the title column.'
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . '</table_structure>'),
-				array(
+				[
 					"ALTER TABLE `jos_test` DROP PRIMARY KEY",
-				),
+				],
 				'getAlterTableSQL should drop the old primary key.'
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -313,29 +313,29 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function dataGetColumnSql()
 	{
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-id-field']
 				),
 				"`id` int(11) unsigned NOT NULL DEFAULT '' AUTO_INCREMENT",
 				'Typical primary key field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-title-field']
 				),
 				"`title` varchar(50) NOT NULL DEFAULT ''",
 				'Typical text field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$this->sample['xml-body-field']
 				),
 				"`body` mediumtext NOT NULL",
 				'Typical blob field',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -347,18 +347,18 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function dataGetKeySql()
 	{
-		return array(
-			array(
+		return [
+			[
 				// Keys come in arrays.
-				array(
+				[
 					new SimpleXmlElement(
 						$this->sample['xml-primary-key']
 					),
-				),
+				],
 				"primary key  (`id`)",
 				'Typical primary key index',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -544,7 +544,7 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		$instance->setDbo($this->dbo);
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getAddKeySQL', 'jos_test', array(new SimpleXmlElement($this->sample['xml-primary-key']))),
+			TestReflection::invoke($instance, 'getAddKeySQL', 'jos_test', [new SimpleXmlElement($this->sample['xml-primary-key'])]),
 			$this->equalTo(
 				"ALTER TABLE `jos_test` ADD PRIMARY KEY  (`id`)"
 			),
@@ -702,17 +702,17 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 	{
 		$instance = new JDatabaseImporterPdomysql;
 
-		$o1 = (object) array('Key_name' => 'id', 'foo' => 'bar1');
-		$o2 = (object) array('Key_name' => 'id', 'foo' => 'bar2');
-		$o3 = (object) array('Key_name' => 'title', 'foo' => 'bar3');
+		$o1 = (object) ['Key_name' => 'id', 'foo' => 'bar1'];
+		$o2 = (object) ['Key_name' => 'id', 'foo' => 'bar2'];
+		$o3 = (object) ['Key_name' => 'title', 'foo' => 'bar3'];
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getKeyLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getKeyLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => [$o3]
+				]
 			),
 			'getKeyLookup, using array input, did not yield the expected result.'
 		);
@@ -722,12 +722,12 @@ class JDatabaseImporterPdomysqlTest extends \PHPUnit\Framework\TestCase
 		$o3 = new SimpleXmlElement('<key Key_name="title" foo="bar3" />');
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getKeyLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getKeyLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => [$o3]
+				]
 			),
 			'getKeyLookup, using SimpleXmlElement input, did not yield the expected result.'
 		);

--- a/tests/unit/suites/database/driver/pdomysql/JDatabaseIteratorPdomysqlTest.php
+++ b/tests/unit/suites/database/driver/pdomysql/JDatabaseIteratorPdomysqlTest.php
@@ -25,83 +25,83 @@ class JDatabaseIteratorPdomysqlTest extends TestCaseDatabasePdomysql
 	 */
 	public function casesForEachData()
 	{
-		return array(
+		return [
 			// Testing 'stdClass' type without specific index, offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				0,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2'),
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2'],
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, limit=2 without specific index or offset
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				2,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, offset=2 without specific index or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				20,
 				2,
-				array(
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title, id',
 				'#__dbtest',
 				'title',
 				'stdClass',
 				0,
 				0,
-				array(
-					'Testing' => (object) array('title' => 'Testing', 'id' => '1'),
-					'Testing2' => (object) array('title' => 'Testing2', 'id' => '2'),
-					'Testing3' => (object) array('title' => 'Testing3', 'id' => '3'),
-					'Testing4' => (object) array('title' => 'Testing4', 'id' => '4')
-				),
+				[
+					'Testing'  => (object) ['title' => 'Testing', 'id' => '1'],
+					'Testing2' => (object) ['title' => 'Testing2', 'id' => '2'],
+					'Testing3' => (object) ['title' => 'Testing3', 'id' => '3'],
+					'Testing4' => (object) ['title' => 'Testing4', 'id' => '4']
+				],
 				null,
-			),
+			],
 
 			// Testing 'UnexistingClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				'title',
 				'UnexistingClass',
 				0,
 				0,
-				array(),
+				[],
 				'InvalidArgumentException',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -47,7 +47,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 			/* ' will be escaped and become '' */
 			["'%_abc123", false], ["'%_abc123", true],
 			/* ' and \ will be escaped: the first become '', the latter \\ */
-			["\'%_abc123", false] ["\'%_abc123", true]
+			["\'%_abc123", false], ["\'%_abc123", true]
 		];
 	}
 
@@ -135,7 +135,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 			['jos_dbtest', 'test', '"jos_dbtest" AS "test"'],
 			['public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'],
 			['joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'],
-			[['joomla_ut', 'dbtest'), ['j_ut', 'tst'], ['"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"']],
+			[['joomla_ut', 'dbtest'], ['j_ut', 'tst'], ['"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"']],
 			[
 				['joomla_ut.dbtest', 'public.dbtest'],
 				['j_ut_db', 'pub_tst'],

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseDriverPostgresqlTest.php
@@ -24,13 +24,14 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestEscape()
 	{
-		return array(
+		return [
 			/* ' will be escaped and become '' */
-			array("'%_abc123", false, '\'\'%_abc123'),
-			array("'%_abc123", true, '\'\'\%\_abc123'),
+			["'%_abc123", false, '\'\'%_abc123'],
+			["'%_abc123", true, '\'\'\%\_abc123'],
 			/* ' and \ will be escaped: the first become '', the latter \\ */
-			array("\'%_abc123", false, '\\\\\'\'%_abc123'),
-			array("\'%_abc123", true, '\\\\\'\'\%\_abc123'));
+			["\'%_abc123", false, '\\\\\'\'%_abc123'],
+			["\'%_abc123", true, '\\\\\'\'\%\_abc123']
+		];
 	}
 
 	/**
@@ -42,11 +43,12 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestGetEscaped()
 	{
-		return array(
+		return [
 			/* ' will be escaped and become '' */
-			array("'%_abc123", false), array("'%_abc123", true),
+			["'%_abc123", false], ["'%_abc123", true],
 			/* ' and \ will be escaped: the first become '', the latter \\ */
-			array("\'%_abc123", false), array("\'%_abc123", true));
+			["\'%_abc123", false] ["\'%_abc123", true]
+		];
 	}
 
 	/**
@@ -58,7 +60,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestTransactionRollback()
 	{
-		return array(array(null, 0), array('transactionSavepoint', 1));
+		return [[null, 0], ['transactionSavepoint', 1]];
 	}
 
 	/**
@@ -74,7 +76,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$obj->db_user = 'testName';
 		$obj->db_name = 'testDb';
 
-		return array(array($obj, false), array($obj, true));
+		return [[$obj, false], [$obj, true]];
 	}
 
 	/**
@@ -86,19 +88,20 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestReplacePrefix()
 	{
-		return array(
+		return [
 			/* no prefix inside, no change */
-			array('SELECT * FROM table', '#__', 'SELECT * FROM table'),
+			['SELECT * FROM table', '#__', 'SELECT * FROM table'],
 			/* the prefix inside double quote has to be changed */
-			array('SELECT * FROM "#__table"', '#__', 'SELECT * FROM "jos_table"'),
+			['SELECT * FROM "#__table"', '#__', 'SELECT * FROM "jos_table"'],
 			/* the prefix inside single quote hasn't to be changed */
-			array('SELECT * FROM \'#__table\'', '#__', 'SELECT * FROM \'#__table\''),
+			['SELECT * FROM \'#__table\'', '#__', 'SELECT * FROM \'#__table\''],
 			/* mixed quote case */
-			array('SELECT * FROM \'#__table\', "#__tableSecond"', '#__', 'SELECT * FROM \'#__table\', "jos_tableSecond"'),
+			['SELECT * FROM \'#__table\', "#__tableSecond"', '#__', 'SELECT * FROM \'#__table\', "jos_tableSecond"'],
 			/* the prefix used in sequence name (single quote) has to be changed */
-			array('SELECT * FROM currval(\'#__table_id_seq\'::regclass)', '#__', 'SELECT * FROM currval(\'jos_table_id_seq\'::regclass)'),
+			['SELECT * FROM currval(\'#__table_id_seq\'::regclass)', '#__', 'SELECT * FROM currval(\'jos_table_id_seq\'::regclass)'],
 			/* using another prefix */
-			array('SELECT * FROM "#!-_table"', '#!-_', 'SELECT * FROM "jos_table"'));
+			['SELECT * FROM "#!-_table"', '#!-_', 'SELECT * FROM "jos_table"']
+		];
 	}
 
 	/**
@@ -110,42 +113,46 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestQuoteName()
 	{
-		return array(
+		return [
 			/* test escape double quote */
-			array('protected`title', null, '"protected`title"'),
-			array('protected"title', null, '"protected""title"'),
-			array('protected]title', null, '"protected]title"'),
+			['protected`title', null, '"protected`title"'],
+			['protected"title', null, '"protected""title"'],
+			['protected]title', null, '"protected]title"'],
 			/* no dot inside var */
-			array('jos_dbtest', null, '"jos_dbtest"'),
+			['jos_dbtest', null, '"jos_dbtest"'],
 			/* a dot inside var */
-			array('public.jos_dbtest', null, '"public"."jos_dbtest"'),
+			['public.jos_dbtest', null, '"public"."jos_dbtest"'],
 			/* two dot inside var */
-			array('joomla_ut.public.jos_dbtest', null, '"joomla_ut"."public"."jos_dbtest"'),
+			['joomla_ut.public.jos_dbtest', null, '"joomla_ut"."public"."jos_dbtest"'],
 			/* using an array */
-			array(array('joomla_ut', 'dbtest'), null, array('"joomla_ut"', '"dbtest"')),
+			[['joomla_ut', 'dbtest'], null, ['"joomla_ut"', '"dbtest"']],
 			/* using an array with dotted name */
-			array(array('joomla_ut.dbtest', 'public.dbtest'), null, array('"joomla_ut"."dbtest"', '"public"."dbtest"')),
+			[['joomla_ut.dbtest', 'public.dbtest'], null, ['"joomla_ut"."dbtest"', '"public"."dbtest"']],
 			/* using an array with two dot in name */
-			array(array('joomla_ut.public.dbtest', 'public.dbtest.col'), null, array('"joomla_ut"."public"."dbtest"', '"public"."dbtest"."col"')),
+			[['joomla_ut.public.dbtest', 'public.dbtest.col'], null, ['"joomla_ut"."public"."dbtest"', '"public"."dbtest"."col"']],
 
 			/*** same tests with AS part ***/
-			array('jos_dbtest', 'test', '"jos_dbtest" AS "test"'),
-			array('public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'),
-			array('joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'),
-			array(array('joomla_ut', 'dbtest'), array('j_ut', 'tst'), array('"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"')),
-			array(
-				array('joomla_ut.dbtest', 'public.dbtest'),
-				array('j_ut_db', 'pub_tst'),
-				array('"joomla_ut"."dbtest" AS "j_ut_db"', '"public"."dbtest" AS "pub_tst"')),
-			array(
-				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
-				array('j_ut_p_db', 'pub_tst_col'),
-				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col" AS "pub_tst_col"')),
+			['jos_dbtest', 'test', '"jos_dbtest" AS "test"'],
+			['public.jos_dbtest', 'tst', '"public"."jos_dbtest" AS "tst"'],
+			['joomla_ut.public.jos_dbtest', 'tst', '"joomla_ut"."public"."jos_dbtest" AS "tst"'],
+			[['joomla_ut', 'dbtest'), ['j_ut', 'tst'], ['"joomla_ut" AS "j_ut"', '"dbtest" AS "tst"']],
+			[
+				['joomla_ut.dbtest', 'public.dbtest'],
+				['j_ut_db', 'pub_tst'],
+				['"joomla_ut"."dbtest" AS "j_ut_db"', '"public"."dbtest" AS "pub_tst"']
+			],
+			[
+				['joomla_ut.public.dbtest', 'public.dbtest.col'],
+				['j_ut_p_db', 'pub_tst_col'],
+				['"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col" AS "pub_tst_col"']
+			],
 			/* last test but with one null inside array */
-			array(
-				array('joomla_ut.public.dbtest', 'public.dbtest.col'),
-				array('j_ut_p_db', null),
-				array('"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col"')));
+			[
+				['joomla_ut.public.dbtest', 'public.dbtest.col'],
+				['j_ut_p_db', null],
+				['"joomla_ut"."public"."dbtest" AS "j_ut_p_db"', '"public"."dbtest"."col"']
+			]
+		];
 	}
 
 	/**
@@ -181,7 +188,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$objCompFour->start_date = '1980-04-18 00:00:00';
 		$objCompFour->description = 'four';
 
-		return array(array(array($objCompOne, $objCompTwo, $objCompThree, $objCompFour)));
+		return [[[$objCompOne, $objCompTwo, $objCompThree, $objCompFour]]];
 	}
 
 	/**
@@ -193,13 +200,16 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function dataTestLoadNextRow()
 	{
-		return array(
-			array(
-				array(
-					array(1, 'Testing', '1980-04-18 00:00:00', 'one'),
-					array(2, 'Testing2', '1980-04-18 00:00:00', 'one'),
-					array(3, 'Testing3', '1980-04-18 00:00:00', 'three'),
-					array(4, 'Testing4', '1980-04-18 00:00:00', 'four'))));
+		return [
+			[
+				[
+					[1, 'Testing', '1980-04-18 00:00:00', 'one'],
+					[2, 'Testing2', '1980-04-18 00:00:00', 'one'],
+					[3, 'Testing3', '1980-04-18 00:00:00', 'three'],
+					[4, 'Testing4', '1980-04-18 00:00:00', 'four']
+				]
+			]
+		];
 	}
 
 	/**
@@ -300,7 +310,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testGetTableColumns()
 	{
-		$tableCol = array('id' => 'integer', 'title' => 'character varying', 'start_date' => 'timestamp without time zone', 'description' => 'text');
+		$tableCol = ['id' => 'integer', 'title' => 'character varying', 'start_date' => 'timestamp without time zone', 'description' => 'text'];
 
 		$this->assertEquals($tableCol, self::$driver->getTableColumns('jos_dbtest'));
 
@@ -346,7 +356,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$description->comments = '';
 
 		$this->assertEquals(
-			array('id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description),
+			['id' => $id, 'title' => $title, 'start_date' => $start_date, 'description' => $description],
 			self::$driver->getTableColumns('jos_dbtest', false)
 		);
 	}
@@ -382,7 +392,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$id->isUnique = 'f';
 		$id->Query = 'CREATE INDEX jos_assets_idx_parent_id ON jos_assets USING btree (parent_id)';
 
-		$this->assertEquals(array($pkey, $id, $lftrgt, $asset), self::$driver->getTableKeys('jos_assets'));
+		$this->assertEquals([$pkey, $id, $lftrgt, $asset], self::$driver->getTableKeys('jos_assets'));
 	}
 
 	/**
@@ -415,7 +425,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 			$seq->cycle_option = null;
 		}
 
-		$this->assertEquals(array($seq), self::$driver->getTableSequences('jos_dbtest'));
+		$this->assertEquals([$seq], self::$driver->getTableSequences('jos_dbtest'));
 	}
 
 	/**
@@ -427,17 +437,17 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function testGetTableList()
 	{
-		$expected = array(
-			"0" => "jos_assets",
-			"1" => "jos_categories",
-			"2" => "jos_content",
-			"3" => "jos_core_log_searches",
-			"4" => "jos_dbtest",
-			"5" => "jos_extensions",
-			"6" => "jos_languages",
-			"7" => "jos_log_entries",
-			"8" => "jos_menu",
-			"9" => "jos_menu_types",
+		$expected = [
+			"0"  => "jos_assets",
+			"1"  => "jos_categories",
+			"2"  => "jos_content",
+			"3"  => "jos_core_log_searches",
+			"4"  => "jos_dbtest",
+			"5"  => "jos_extensions",
+			"6"  => "jos_languages",
+			"7"  => "jos_log_entries",
+			"8"  => "jos_menu",
+			"9"  => "jos_menu_types",
 			"10" => "jos_modules",
 			"11" => "jos_modules_menu",
 			"12" => "jos_schemas",
@@ -450,7 +460,8 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 			"19" => "jos_user_usergroup_map",
 			"20" => "jos_usergroups",
 			"21" => "jos_users",
-			"22" => "jos_viewlevels");
+			"22" => "jos_viewlevels"
+		];
 
 		$result = self::$driver->getTableList();
 
@@ -603,7 +614,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadAssoc();
 
-		$this->assertEquals(array('title' => 'Testing'), $result);
+		$this->assertEquals(['title' => 'Testing'], $result);
 	}
 
 	/**
@@ -622,7 +633,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		$result = self::$driver->loadAssocList();
 
 		$this->assertEquals(
-			array(array('title' => 'Testing'), array('title' => 'Testing2'), array('title' => 'Testing3'), array('title' => 'Testing4')),
+			[['title' => 'Testing'], ['title' => 'Testing2'], ['title' => 'Testing3'], ['title' => 'Testing4']],
 			$result
 		);
 	}
@@ -642,7 +653,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadColumn();
 
-		$this->assertEquals(array('Testing', 'Testing2', 'Testing3', 'Testing4'), $result);
+		$this->assertEquals(['Testing', 'Testing2', 'Testing3', 'Testing4'], $result);
 	}
 
 	/**
@@ -844,7 +855,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadObjectList();
 
-		$expected = array();
+		$expected = [];
 
 		$objCompare = new stdClass;
 		$objCompare->id = 1;
@@ -917,7 +928,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$this->assertEquals(array(3, 'Testing3', '1980-04-18 00:00:00', 'three'), $result);
+		$this->assertEquals([3, 'Testing3', '1980-04-18 00:00:00', 'three'], $result);
 	}
 
 	/**
@@ -936,7 +947,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$this->assertEquals(array(array(1, 'Testing', '1980-04-18 00:00:00', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00', 'one')), $result);
+		$this->assertEquals([[1, 'Testing', '1980-04-18 00:00:00', 'one'], [2, 'Testing2', '1980-04-18 00:00:00', 'one']], $result);
 	}
 
 	/**
@@ -999,19 +1010,19 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 	public function testSqlValue()
 	{
 		// Array of columns' description as that returned by getTableColumns
-		$tablCol = array(
-			'id' => 'integer',
-			'charVar' => 'character varying',
+		$tablCol = [
+			'id'        => 'integer',
+			'charVar'   => 'character varying',
 			'timeStamp' => 'timestamp without time zone',
-			'nullDate' => 'timestamp without time zone',
-			'txt' => 'text',
-			'boolTrue' => 'boolean',
+			'nullDate'  => 'timestamp without time zone',
+			'txt'       => 'text',
+			'boolTrue'  => 'boolean',
 			'boolFalse' => 'boolean',
-			'num' => 'numeric,',
-			'nullInt' => 'integer'
-		);
+			'num'       => 'numeric,',
+			'nullInt'   => 'integer'
+		];
 
-		$values = array();
+		$values = [];
 
 		// Object containing fields of integer, character varying, timestamp and text type
 		$tst = new JObject;
@@ -1091,7 +1102,7 @@ class JDatabaseDriverPostgresqlTest extends TestCaseDatabasePostgresql
 		self::$driver->setQuery($queryCheck);
 		$result = self::$driver->loadRow();
 
-		$expected = array(6, 'testTitle', '1970-01-01 00:00:00', 'testDescription');
+		$expected = [6, 'testTitle', '1970-01-01 00:00:00', 'testDescription'];
 
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseExporterPostgresqlTest.php
@@ -38,7 +38,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 	protected function setup()
 	{
 		// Set up the database object mock.
-		$this->dbo = $this->getMockDatabase('Postgresql', array('getTableSequences'), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', ['getTableSequences'], '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->dbo->expects($this->any())
 			->method('getPrefix')
@@ -47,48 +47,48 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$this->dbo->expects($this->any())
 			->method('getTableColumns')
 			->willReturn(
-				array(
-					(object) array(
+				[
+					(object) [
 						'column_name' => 'id',
-						'type' => 'integer',
-						'null' => 'NO',
-						'default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
-						'comments' => '',
-					),
-					(object) array(
+						'type'        => 'integer',
+						'null'        => 'NO',
+						'default'     => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+						'comments'    => '',
+					],
+					(object) [
 						'column_name' => 'title',
-						'type' => 'character varying(50)',
-						'null' => 'NO',
-						'default' => 'NULL',
-						'comments' => '',
-					),
-					(object) array(
+						'type'        => 'character varying(50)',
+						'null'        => 'NO',
+						'default'     => 'NULL',
+						'comments'    => '',
+					],
+					(object) [
 						'column_name' => 'start_date',
-						'type' => 'timestamp without time zone',
-						'null' => 'NO',
-						'default' => 'NULL',
-						'comments' => '',
-					),
-					(object) array(
+						'type'        => 'timestamp without time zone',
+						'null'        => 'NO',
+						'default'     => 'NULL',
+						'comments'    => '',
+					],
+					(object) [
 						'column_name' => 'description',
-						'type' => 'text',
-						'null' => 'NO',
-						'default' => 'NULL',
-						'comments' => '',
-					)
-				)
+						'type'        => 'text',
+						'null'        => 'NO',
+						'default'     => 'NULL',
+						'comments'    => '',
+					]
+				]
 			);
 
 		$this->dbo->expects($this->any())
 			->method('getTableKeys')
-			->willReturn(array(
-				(object) array(
-					'idxName' => 'jos_dbtest_pkey',
+			->willReturn([
+				(object) [
+					'idxName'   => 'jos_dbtest_pkey',
 					'isPrimary' => 'TRUE',
-					'isUnique' => 'TRUE',
-					'Query' => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
-				)
-			));
+					'isUnique'  => 'TRUE',
+					'Query'     => 'ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)',
+				]
+			]);
 
 		// Check if database is at least 9.1.0
 		$this->dbo->expects($this->any())
@@ -110,29 +110,29 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		$this->dbo->expects($this->any())
 			->method('getTableSequences')
 			->willReturn(
-				array(
-					(object) array(
-						'sequence' => 'jos_dbtest_id_seq',
-						'schema' => 'public',
-						'table' => 'jos_dbtest',
-						'column' => 'id',
-						'data_type' => 'bigint',
-						'start_value' => $start_val,
+				[
+					(object) [
+						'sequence'      => 'jos_dbtest_id_seq',
+						'schema'        => 'public',
+						'table'         => 'jos_dbtest',
+						'column'        => 'id',
+						'data_type'     => 'bigint',
+						'start_value'   => $start_val,
 						'minimum_value' => '1',
 						'maximum_value' => '9223372036854775807',
-						'increment' => '1',
-						'cycle_option' => 'NO',
-					)
-				)
+						'increment'     => '1',
+						'cycle_option'  => 'NO',
+					]
+				]
 			);
 
 		$this->dbo->expects($this->any())
 			->method('loadObjectList')
-			->willReturn(array());
+			->willReturn([]);
 
 		$this->dbo->expects($this->any())
 			->method('getTableList')
-			->willReturn(array('jos_dbtest'));
+			->willReturn(['jos_dbtest']);
 	}
 
 	/**
@@ -310,7 +310,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		}
 
 		$this->assertEquals(
-			array(
+			[
 				'  <table_structure name="#__test">',
 				'   <sequence Name="jos_dbtest_id_seq" Schema="public" Table="jos_dbtest" Column="id" Type="bigint" Start_Value="' .
 				$start_val . '" Min_Value="1" Max_Value="9223372036854775807" Increment="1" Cycle_option="NO" />',
@@ -320,7 +320,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 				'   <field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
 				'   <key Index="jos_dbtest_pkey" is_primary="TRUE" is_unique="TRUE" Query="ALTER TABLE "jos_dbtest" ADD PRIMARY KEY (id)" />',
 				'  </table_structure>'
-			),
+			],
 			TestReflection::invoke($instance, 'buildXmlStructure')
 		);
 	}
@@ -395,7 +395,7 @@ class JDatabaseExporterPostgresqlTest extends TestCase
 		);
 
 		$this->assertAttributeEquals(
-			array('jos_foobar'),
+			['jos_foobar'],
 			'from',
 			$instance,
 			'The from method should convert a string input to an array.'

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseImporterPostgresqlTest.php
@@ -32,7 +32,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	{
 		// Set up the database object mock.
 		$this->dbo = $this->getMockBuilder('JDatabaseDriverPostgresql')
-					->setMethods(array(
+					->setMethods([
 						'getErrorNum',
 						'getPrefix',
 						'getTableColumns',
@@ -47,8 +47,8 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 						'loadObjectList',
 						'quote',
 						'setQuery',
-					))
-					->setConstructorArgs(array())
+					])
+					->setConstructorArgs([])
 					->setMockClassName('')
 					->disableOriginalConstructor()
 					->getMock();
@@ -69,22 +69,22 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('getTableColumns')
 		->will(
 			$this->returnValue(
-				array(
-					'id' => (object) array(
-						'Field' => 'id',
-						'Type' => 'integer',
-						'Null' => 'NO',
-						'Default' => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
+				[
+					'id' => (object) [
+						'Field'    => 'id',
+						'Type'     => 'integer',
+						'Null'     => 'NO',
+						'Default'  => 'nextval(\'jos_dbtest_id_seq\'::regclass)',
 						'Comments' => '',
-					),
-					'title' => (object) array(
-						'Field' => 'title',
-						'Type' => 'character varying(50)',
-						'Null' => 'NO',
-						'Default' => 'NULL',
+					],
+					'title' => (object) [
+						'Field'    => 'title',
+						'Type'     => 'character varying(50)',
+						'Null'     => 'NO',
+						'Default'  => 'NULL',
 						'Comments' => '',
-					),
-				)
+					],
+				]
 			)
 		);
 
@@ -94,20 +94,20 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('getTableKeys')
 		->will(
 			$this->returnValue(
-				array(
-					(object) array(
-						'Index' => 'jos_dbtest_pkey',
+				[
+					(object) [
+						'Index'      => 'jos_dbtest_pkey',
 						'is_primary' => 'TRUE',
-						'is_unique' => 'TRUE',
-						'Query' => 'ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)',
-					),
-					(object) array(
-						'Index' => 'jos_dbtest_idx_name',
+						'is_unique'  => 'TRUE',
+						'Query'      => 'ALTER TABLE jos_dbtest ADD PRIMARY KEY (id)',
+					],
+					(object) [
+						'Index'      => 'jos_dbtest_idx_name',
 						'is_primary' => 'FALSE',
-						'is_unique' => 'FALSE',
-						'Query' => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
-					)
-				)
+						'is_unique'  => 'FALSE',
+						'Query'      => 'CREATE INDEX jos_dbtest_idx_name ON jos_dbtest USING btree (name)',
+					]
+				]
 			)
 		);
 
@@ -138,20 +138,20 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('getTableSequences')
 		->will(
 			$this->returnValue(
-			array(
-					(object) array(
-						'Name' => 'jos_dbtest_id_seq',
-						'Schema' => 'public',
-						'Table' => 'jos_dbtest',
-						'Column' => 'id',
-						'Type' => 'bigint',
-						'Start_Value' => $start_val,
-						'Min_Value' => '1',
-						'Max_Value' => '9223372036854775807',
-						'Increment' => '1',
+				[
+					(object) [
+						'Name'         => 'jos_dbtest_id_seq',
+						'Schema'       => 'public',
+						'Table'        => 'jos_dbtest',
+						'Column'       => 'id',
+						'Type'         => 'bigint',
+						'Start_Value'  => $start_val,
+						'Min_Value'    => '1',
+						'Max_Value'    => '9223372036854775807',
+						'Increment'    => '1',
 						'Cycle_option' => 'NO',
-					)
-				)
+					]
+				]
 			)
 		);
 
@@ -161,7 +161,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('quoteName')
 		->will(
 			$this->returnCallback(
-				array($this, 'callbackQuoteName')
+				[$this, 'callbackQuoteName']
 			)
 		);
 
@@ -171,7 +171,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('quote')
 		->will(
 			$this->returnCallback(
-				array($this, 'callbackQuote')
+				[$this, 'callbackQuote']
 			)
 		);
 
@@ -181,7 +181,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('setQuery')
 		->will(
 			$this->returnCallback(
-				array($this, 'callbackSetQuery')
+				[$this, 'callbackSetQuery']
 			)
 		);
 
@@ -191,7 +191,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		->method('loadObjectList')
 		->will(
 			$this->returnCallback(
-				array($this, 'callbackLoadObjectList')
+				[$this, 'callbackLoadObjectList']
 			)
 		);
 	}
@@ -217,7 +217,7 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function callbackLoadObjectList()
 	{
-		return array('');
+		return [''];
 	}
 
 	/**
@@ -289,116 +289,116 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$changeSeq = "CREATE SEQUENCE jos_dbtest_title_seq INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 " .
 			"START 1 NO CYCLE OWNED BY \"public.jos_dbtest.title\"";
 
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement('<table_structure name="#__dbtest">' . $s1 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
-				),
+				[],
 				'getAlterTableSQL should not change anything.'
-			),
-			array(
+			],
+			[
 				// Add col
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $f3 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					'ALTER TABLE "jos_test" ADD COLUMN "alias" character varying(255) NOT NULL DEFAULT \'test\'',
-				),
+				],
 				'getAlterTableSQL should add the new alias column.'
-			),
-			array(
+			],
+			[
 				// Add idx
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k3 . '</table_structure>'),
-				array('CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)',),
+				['CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)',],
 				'getAlterTableSQL should add the new key.'
-			),
-			array(
+			],
+			[
 				// Add unique idx
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $k4 . '</table_structure>'),
-				array(
+				[
 					'CREATE UNIQUE INDEX jos_dbtest_uidx_name ON jos_dbtest USING btree (name)',
-				),
+				],
 				'getAlterTableSQL should add the new unique key.'
-			),
-			array(
+			],
+			[
 				// Add sequence
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					$addSequence,
-				),
+				],
 				'getAlterTableSQL should add the new sequence.'
-			),
-			array(
+			],
+			[
 				// Add pkey
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k2 . $pk . '</table_structure>'),
-				array(
+				[
 					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
-				),
+				],
 				'getAlterTableSQL should add the new sequence.'
-			),
-			array(
+			],
+			[
 				// Drop col
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					'ALTER TABLE "jos_test" DROP COLUMN "title"',
-				),
+				],
 				'getAlterTableSQL should remove the title column.'
-			),
-			array(
+			],
+			[
 				// Drop idx
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . '</table_structure>'),
-				array(
+				[
 					"DROP INDEX \"jos_dbtest_idx_name\""
-				),
+				],
 				'getAlterTableSQL should change sequence.'
-			),
-			array(
+			],
+			[
 				// Drop seq
 				new SimpleXmlElement('<table_structure name="#__test">' . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					'DROP SEQUENCE "jos_dbtest_id_seq"',
-				),
+				],
 				'getAlterTableSQL should drop the sequence.'
-			),
-			array(
-			// Drop pkey
+			],
+			[
+				// Drop pkey
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k2 . '</table_structure>'),
-				array(
+				[
 					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"',
-				),
+				],
 				'getAlterTableSQL should drop the old primary key.'
-			),
-			array(
+			],
+			[
 				// Change col
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2_def . $k1 . $k2 . '</table_structure>'),
-				array($changeCol,),
+				[$changeCol,],
 				'getAlterTableSQL should change title field.'
-			),
-			array(
+			],
+			[
 				// Change seq
 				new SimpleXmlElement('<table_structure name="#__test">' . $s2 . $f1 . $f2 . $k1 . $k2 . '</table_structure>'),
-				array(
+				[
 					$changeSeq,
-					"DROP SEQUENCE \"jos_dbtest_id_seq\"",),
+					"DROP SEQUENCE \"jos_dbtest_id_seq\"",
+				],
 				'getAlterTableSQL should change sequence.'
-			),
-			array(
+			],
+			[
 				// Change idx
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $k1 . $k3 . '</table_structure>'),
-				array(
+				[
 					"CREATE INDEX jos_dbtest_idx_title ON jos_dbtest USING btree (title)",
 					'DROP INDEX "jos_dbtest_idx_name"'
-				),
+				],
 				'getAlterTableSQL should change index.'
-			),
-			array(
+			],
+			[
 				// Change pkey
 				new SimpleXmlElement('<table_structure name="#__test">' . $s1 . $f1 . $f2 . $pk . $k2 . '</table_structure>'),
-				array(
+				[
 					'ALTER TABLE jos_dbtest ADD PRIMARY KEY (title)',
 					'ALTER TABLE ONLY "jos_test" DROP CONSTRAINT "jos_dbtest_pkey"'
-				),
+				],
 				'getAlterTableSQL should change primary key.'
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -408,42 +408,43 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function dataGetColumnSql()
 	{
-		$sample = array(
-			'xml-id-field' => '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
+		$sample = [
+			'xml-id-field'    => '<field Field="id" Type="integer" Null="NO" Default="nextval(\'jos_dbtest_id_seq\'::regclass)" Comments="" />',
 			'xml-title-field' => '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
-			'xml-title-def' => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
-			'xml-body-field' => '<field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',);
+			'xml-title-def'   => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
+			'xml-body-field'  => '<field Field="description" Type="text" Null="NO" Default="NULL" Comments="" />',
+		];
 
-		return array(
-			array(
+		return [
+			[
 				new SimpleXmlElement(
 					$sample['xml-id-field']
 				),
 				'"id" serial',
 				'Typical primary key field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$sample['xml-title-field']
 				),
 				'"title" character varying(50) NOT NULL',
 				'Typical text field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$sample['xml-body-field']
 				),
 				'"description" text NOT NULL',
 				'Typical blob field',
-			),
-			array(
+			],
+			[
 				new SimpleXmlElement(
 					$sample['xml-title-def']
 				),
 				'"title" character varying(50) NOT NULL DEFAULT \'this is a test\'',
 				'Typical text field with default value',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -543,10 +544,11 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$instance = new JDatabaseImporterPostgresql;
 		$instance->setDbo($this->dbo);
 
-		$sample = array(
+		$sample = [
 			'xml-title-field' => '<field Field="title" Type="character varying(50)" Null="NO" Default="NULL" Comments="" />',
-			'xml-title-def' => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
-			'xml-int-defnum' => '<field Field="title" Type="integer" Null="NO" Default="0" Comments="" />',);
+			'xml-title-def'   => '<field Field="title" Type="character varying(50)" Null="NO" Default="this is a test" Comments="" />',
+			'xml-int-defnum'  => '<field Field="title" Type="integer" Null="NO" Default="0" Comments="" />',
+		];
 
 		$this->assertThat(
 			TestReflection::invoke($instance, 'getAddColumnSQL', 'jos_test', new SimpleXmlElement($sample['xml-title-field'])),
@@ -787,17 +789,17 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 	{
 		$instance = new JDatabaseImporterPostgresql;
 
-		$o1 = (object) array('Index' => 'id', 'foo' => 'bar1');
-		$o2 = (object) array('Index' => 'id', 'foo' => 'bar2');
-		$o3 = (object) array('Index' => 'title', 'foo' => 'bar3');
+		$o1 = (object) ['Index' => 'id', 'foo' => 'bar1'];
+		$o2 = (object) ['Index' => 'id', 'foo' => 'bar2'];
+		$o3 = (object) ['Index' => 'title', 'foo' => 'bar3'];
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getIdxLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getIdxLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => [$o3]
+				]
 			),
 			'getIdxLookup, using array input, did not yield the expected result.'
 		);
@@ -807,12 +809,12 @@ class JDatabaseImporterPostgresqlTest extends \PHPUnit\Framework\TestCase
 		$o3 = new SimpleXmlElement('<key Index="title" foo="bar3" />');
 
 		$this->assertThat(
-			TestReflection::invoke($instance, 'getIdxLookup', array($o1, $o2, $o3)),
+			TestReflection::invoke($instance, 'getIdxLookup', [$o1, $o2, $o3]),
 			$this->equalTo(
-				array(
-					'id' => array($o1, $o2),
-					'title' => array($o3)
-				)
+				[
+					'id'    => [$o1, $o2],
+					'title' => [$o3]
+				]
 			),
 			'getIdxLookup, using SimpleXmlElement input, did not yield the expected result.'
 		);

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseIteratorPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseIteratorPostgresqlTest.php
@@ -25,82 +25,82 @@ class JDatabaseIteratorPostgresqlTest extends TestCaseDatabasePostgresql
 	 */
 	public function casesForEachData()
 	{
-		return array(
+		return [
 			// Testing 'stdClass' type without specific index, offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				0,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2'),
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2'],
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, limit=2 without specific index or offset
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				2,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, offset=2 without specific index or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				20,
 				2,
-				array(
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title, id',
 				'#__dbtest',
 				'title',
 				'stdClass',
 				0,
 				0,
-				array(
-					'Testing' => (object) array('title' => 'Testing', 'id' => '1'),
-					'Testing2' => (object) array('title' => 'Testing2', 'id' => '2'),
-					'Testing3' => (object) array('title' => 'Testing3', 'id' => '3'),
-					'Testing4' => (object) array('title' => 'Testing4', 'id' => '4')
-				),
+				[
+					'Testing'  => (object) ['title' => 'Testing', 'id' => '1'],
+					'Testing2' => (object) ['title' => 'Testing2', 'id' => '2'],
+					'Testing3' => (object) ['title' => 'Testing3', 'id' => '3'],
+					'Testing4' => (object) ['title' => 'Testing4', 'id' => '4']
+				],
 				null,
-			),
+			],
 
 			// Testing 'UnexistingClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				'title',
 				'UnexistingClass',
 				0,
 				0,
-				array(),
+				[],
 				'InvalidArgumentException',
-			),
+			],
 		);
 	}
 

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseIteratorPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseIteratorPostgresqlTest.php
@@ -101,7 +101,7 @@ class JDatabaseIteratorPostgresqlTest extends TestCaseDatabasePostgresql
 				[],
 				'InvalidArgumentException',
 			],
-		);
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
+++ b/tests/unit/suites/database/driver/postgresql/JDatabaseQueryPostgresqlTest.php
@@ -39,11 +39,11 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function dataTestNullDate()
 	{
-		return array(
+		return [
 			// Quoted, expected
-			array(true, "'_1970-01-01 00:00:00_'"),
-			array(false, "1970-01-01 00:00:00"),
-		);
+			[true, "'_1970-01-01 00:00:00_'"],
+			[false, "1970-01-01 00:00:00"],
+		];
 	}
 
 	/**
@@ -55,10 +55,10 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function dataTestQuote()
 	{
-		return array(
+		return [
 			// Text, escaped, expected
-			array('text', false, '\'text\''),
-		);
+			['text', false, '\'text\''],
+		];
 	}
 
 	/**
@@ -70,14 +70,14 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function dataTestJoin()
 	{
-		return array(
+		return [
 			// $type, $conditions
-			array('', 		'b ON b.id = a.id'),
-			array('INNER',	'b ON b.id = a.id'),
-			array('OUTER',	'b ON b.id = a.id'),
-			array('LEFT',	'b ON b.id = a.id'),
-			array('RIGHT',	'b ON b.id = a.id'),
-		);
+			['', 		'b ON b.id = a.id'],
+			['INNER',	'b ON b.id = a.id'],
+			['OUTER',	'b ON b.id = a.id'],
+			['LEFT',	'b ON b.id = a.id'],
+			['RIGHT',	'b ON b.id = a.id'],
+		];
 	}
 
 	/**
@@ -128,7 +128,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	{
 		parent::setUp();
 
-		$this->dbo = $this->getMockDatabase('Postgresql', array(), '1970-01-01 00:00:00', 'Y-m-d H:i:s');
+		$this->dbo = $this->getMockDatabase('Postgresql', [], '1970-01-01 00:00:00', 'Y-m-d H:i:s');
 
 		$this->_instance = new JDatabaseQueryPostgresql($this->dbo);
 	}
@@ -531,7 +531,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function testClear_all()
 	{
-		$properties = array(
+		$properties = [
 			'select',
 			'delete',
 			'update',
@@ -551,7 +551,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			'noWait',
 			'offset',
 			'returning',
-		);
+		];
 
 		$q = new JDatabaseQueryPostgresql($this->dbo);
 
@@ -583,7 +583,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function testClear_clause()
 	{
-		$clauses = array(
+		$clauses = [
 			'from',
 			'join',
 			'set',
@@ -599,7 +599,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			'noWait',
 			'offset',
 			'returning',
-		);
+		];
 
 		// Test each clause.
 		foreach ($clauses as $clause)
@@ -642,7 +642,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function testClear_type()
 	{
-		$types = array(
+		$types = [
 			'select',
 			'delete',
 			'update',
@@ -653,9 +653,9 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			'noWait',
 			'offset',
 			'returning',
-		);
+		];
 
-		$clauses = array(
+		$clauses = [
 			'from',
 			'join',
 			'set',
@@ -665,7 +665,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 			'order',
 			'columns',
 			'values',
-		);
+		];
 
 		$q = new JDatabaseQueryPostgresql($this->dbo);
 
@@ -713,9 +713,9 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	{
 		$q = new JDatabaseQueryPostgresql($this->dbo);
 
-		$this->assertEquals('foo || bar', $q->concatenate(array('foo', 'bar')));
+		$this->assertEquals('foo || bar', $q->concatenate(['foo', 'bar']));
 
-		$this->assertEquals("foo || '_ and _' || bar", $q->concatenate(array('foo', 'bar'), ' and '));
+		$this->assertEquals("foo || '_ and _' || bar", $q->concatenate(['foo', 'bar'], ' and '));
 	}
 
 	/**
@@ -1003,7 +1003,7 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 
 		$this->assertEquals('SELECT foo,bar', trim($q->select));
 
-		$q->select(array('goo', 'car'));
+		$q->select(['goo', 'car']);
 
 		$this->assertEquals('SELECT foo,bar,goo,car', trim($q->select));
 	}
@@ -1024,13 +1024,13 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 		$this->assertEquals('WHERE foo = 1', trim($q->where));
 
 		// Add another column.
-		$q->where(array('bar = 2', 'goo = 3'));
+		$q->where(['bar = 2', 'goo = 3']);
 
 		$this->assertEquals('WHERE foo = 1 AND bar = 2 AND goo = 3', trim($q->where));
 
 		// Clear the where
 		$q->clear();
-		$q->where(array('bar = 2', 'goo = 3'), 'OR');
+		$q->where(['bar = 2', 'goo = 3'], 'OR');
 
 		$this->assertEquals('WHERE bar = 2 OR goo = 3', trim($q->where));
 	}
@@ -1180,12 +1180,12 @@ class JDatabaseQueryPostgresqlTest extends TestCase
 	 */
 	public function seedDateAdd()
 	{
-		return array(
+		return [
 			// date, interval, datepart, expected
-			'Add date'		=> array('2008-12-31', '1', 'day', "timestamp '2008-12-31' + interval '1 day'"),
-			'Subtract date'	=> array('2008-12-31', '-1', 'day', "timestamp '2008-12-31' - interval '1 day'"),
-			'Add datetime'	=> array('2008-12-31 23:59:59', '1', 'day', "timestamp '2008-12-31 23:59:59' + interval '1 day'"),
-		);
+			'Add date'		=> ['2008-12-31', '1', 'day', "timestamp '2008-12-31' + interval '1 day'"],
+			'Subtract date'	=> ['2008-12-31', '-1', 'day', "timestamp '2008-12-31' - interval '1 day'"],
+			'Add datetime'	=> ['2008-12-31 23:59:59', '1', 'day', "timestamp '2008-12-31 23:59:59' + interval '1 day'"],
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
+++ b/tests/unit/suites/database/driver/sqlite/JDatabaseQuerySqliteTest.php
@@ -73,13 +73,13 @@ class JDatabaseQuerySqliteTest extends TestCase
 	 */
 	public function seedDateAdd()
 	{
-		return array(
+		return [
 			// date, interval, datepart, expected
-			'Add date'			=> array('2008-12-31', '1', 'DAY', "datetime('2008-12-31', '+1 DAY')"),
-			'Subtract date'		=> array('2008-12-31', '-1', 'DAY', "datetime('2008-12-31', '-1 DAY')"),
-			'Add datetime'		=> array('2008-12-31 23:59:59', '1', 'DAY', "datetime('2008-12-31 23:59:59', '+1 DAY')"),
-			'Add microseconds'	=> array('2008-12-31 23:59:59', '53', 'microseconds', "datetime('2008-12-31 23:59:59', '+0.053 seconds')"),
-		);
+			'Add date'         => ['2008-12-31', '1', 'DAY', "datetime('2008-12-31', '+1 DAY')"],
+			'Subtract date'    => ['2008-12-31', '-1', 'DAY', "datetime('2008-12-31', '-1 DAY')"],
+			'Add datetime'     => ['2008-12-31 23:59:59', '1', 'DAY', "datetime('2008-12-31 23:59:59', '+1 DAY')"],
+			'Add microseconds' => ['2008-12-31 23:59:59', '53', 'microseconds', "datetime('2008-12-31 23:59:59', '+0.053 seconds')"],
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseDriverSqlsrvTest.php
@@ -24,11 +24,11 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 	 */
 	public function dataTestEscape()
 	{
-		return array(
-			array("'%_abc123[]", false, "''%_abc123[]"),
-			array("'%_abc123[]", true, "''[%][_]abc123[[]]"),
-			array("binary\000data", false, "binary' + CHAR(0) + N'data"),
-		);
+		return [
+			["'%_abc123[]", false, "''%_abc123[]"],
+			["'%_abc123[]", true, "''[%][_]abc123[[]]"],
+			["binary\000data", false, "binary' + CHAR(0) + N'data"],
+		];
 	}
 
 	/**
@@ -40,11 +40,11 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 	 */
 	public function dataTestQuoteName()
 	{
-		return array(
-			array('protected`title', null, '[protected`title]'),
-			array('protected"title', null, '[protected"title]'),
-			array('protected]title', null, '[protected]]title]'),
-		);
+		return [
+			['protected`title', null, '[protected`title]'],
+			['protected"title', null, '[protected"title]'],
+			['protected]title', null, '[protected]]title]'],
+		];
 	}
 
 	/**
@@ -203,7 +203,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadAssoc();
 
-		$this->assertThat($result, $this->equalTo(array('title' => 'Testing')), __LINE__);
+		$this->assertThat($result, $this->equalTo(['title' => 'Testing']), __LINE__);
 	}
 
 	/**
@@ -224,12 +224,12 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		$this->assertThat(
 			$result,
 			$this->equalTo(
-				array(
-					array('title' => 'Testing'),
-					array('title' => 'Testing2'),
-					array('title' => 'Testing3'),
-					array('title' => 'Testing4')
-				)
+				[
+					['title' => 'Testing'],
+					['title' => 'Testing2'],
+					['title' => 'Testing3'],
+					['title' => 'Testing4']
+				]
 			),
 			__LINE__
 		);
@@ -250,7 +250,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadColumn();
 
-		$this->assertThat($result, $this->equalTo(array('Testing', 'Testing2', 'Testing3', 'Testing4')), __LINE__);
+		$this->assertThat($result, $this->equalTo(['Testing', 'Testing2', 'Testing3', 'Testing4']), __LINE__);
 	}
 
 	/**
@@ -294,7 +294,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadObjectList();
 
-		$expected = array();
+		$expected = [];
 
 		$objCompare = new \stdClass;
 		$objCompare->id = 1;
@@ -367,7 +367,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRow();
 
-		$expected = array(3, 'Testing3', '1980-04-18 00:00:00.000', 'three');
+		$expected = [3, 'Testing3', '1980-04-18 00:00:00.000', 'three'];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}
@@ -388,7 +388,7 @@ class JDatabaseDriverSqlsrvTest extends TestCaseDatabaseSqlsrv
 		self::$driver->setQuery($query);
 		$result = self::$driver->loadRowList();
 
-		$expected = array(array(1, 'Testing', '1980-04-18 00:00:00.000', 'one'), array(2, 'Testing2', '1980-04-18 00:00:00.000', 'one'));
+		$expected = [[1, 'Testing', '1980-04-18 00:00:00.000', 'one'], [2, 'Testing2', '1980-04-18 00:00:00.000', 'one']];
 
 		$this->assertThat($result, $this->equalTo($expected), __LINE__);
 	}

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseIteratorSqlsrvTest.php
@@ -25,83 +25,83 @@ class JDatabaseIteratorSqlsrvTest extends TestCaseDatabaseSqlsrv
 	 */
 	public function casesForEachData()
 	{
-		return array(
+		return [
 			// Testing 'stdClass' type without specific index, offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				0,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2'),
-					(object) array('title' => 'Testing3'),
-					(object) array('title' => 'Testing4')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2'],
+					(object) ['title' => 'Testing3'],
+					(object) ['title' => 'Testing4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, limit=2 without specific index or offset
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				2,
 				0,
-				array(
-					(object) array('title' => 'Testing'),
-					(object) array('title' => 'Testing2')
-				),
+				[
+					(object) ['title' => 'Testing'],
+					(object) ['title' => 'Testing2']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, offset=2 without specific index or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				null,
 				'stdClass',
 				20,
 				2,
-				array(
-					(object) array('title' => 'Testing3', 'RowNumber' => '3'),
-					(object) array('title' => 'Testing4', 'RowNumber' => '4')
-				),
+				[
+					(object) ['title' => 'Testing3', 'RowNumber' => '3'],
+					(object) ['title' => 'Testing4', 'RowNumber' => '4']
+				],
 				null
-			),
+			],
 
 			// Testing 'stdClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title, id',
 				'#__dbtest',
 				'title',
 				'stdClass',
 				0,
 				0,
-				array(
-					'Testing' => (object) array('title' => 'Testing', 'id' => '1'),
-					'Testing2' => (object) array('title' => 'Testing2', 'id' => '2'),
-					'Testing3' => (object) array('title' => 'Testing3', 'id' => '3'),
-					'Testing4' => (object) array('title' => 'Testing4', 'id' => '4')
-				),
+				[
+					'Testing'  => (object) ['title' => 'Testing', 'id' => '1'],
+					'Testing2' => (object) ['title' => 'Testing2', 'id' => '2'],
+					'Testing3' => (object) ['title' => 'Testing3', 'id' => '3'],
+					'Testing4' => (object) ['title' => 'Testing4', 'id' => '4']
+				],
 				null,
-			),
+			],
 
 			// Testing 'UnexistingClass' type, index='title' without specific offset or limit
-			array(
+			[
 				'title',
 				'#__dbtest',
 				'title',
 				'UnexistingClass',
 				0,
 				0,
-				array(),
+				[],
 				'InvalidArgumentException',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
+++ b/tests/unit/suites/database/driver/sqlsrv/JDatabaseQuerySqlsrvTest.php
@@ -73,12 +73,12 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 	 */
 	public function seedDateAdd()
 	{
-		return array(
+		return [
 			// date, interval, datepart, expected
-			'Add date'			=> array('2008-12-31', '1', 'day', "DATEADD('day', '1', '2008-12-31')"),
-			'Subtract date'		=> array('2008-12-31', '-1', 'day', "DATEADD('day', '-1', '2008-12-31')"),
-			'Add datetime'		=> array('2008-12-31 23:59:59', '1', 'day', "DATEADD('day', '1', '2008-12-31 23:59:59')"),
-		);
+			'Add date'      => ['2008-12-31', '1', 'day', "DATEADD('day', '1', '2008-12-31')"],
+			'Subtract date' => ['2008-12-31', '-1', 'day', "DATEADD('day', '-1', '2008-12-31')"],
+			'Add datetime'  => ['2008-12-31 23:59:59', '1', 'day', "DATEADD('day', '1', '2008-12-31 23:59:59')"],
+		];
 	}
 
 	/**
@@ -209,7 +209,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			. ",'sta''tic' 'static'"
 			. ", 1. AS x";
 
-		$expected = array(
+		$expected = [
 			'DISTINCT - [catid] AS [\\"]',
 			'a.id',
 			'a.title AS [a\'title]]x]',
@@ -221,7 +221,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			'++-+ a.end + 1 - 3',
 			"'sta''tic' 'static'",
 			'1. AS x',
-		);
+		];
 
 		$columns = TestReflection::invoke($this->_instance, 'splitSqlExpression', $columns);
 
@@ -238,10 +238,10 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 		$columns = "ALL-[catid] AS []]] "
 			. ', - id';
 
-		$expected = array(
+		$expected = [
 			'ALL - [catid] AS []]]',
 			'- id',
-		);
+		];
 
 		$columns = TestReflection::invoke($this->_instance, 'splitSqlExpression', $columns);
 
@@ -293,7 +293,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			. ','
 		);
 
-		$expected = array(
+		$expected = [
 			'*',
 			'a.*',
 			'id_9',
@@ -320,7 +320,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			'- a.id AS [columnAlias23]',
 			'eNULL',
 			'',
-		);
+		];
 
 		TestReflection::invoke($this->_instance, 'fixSelectAliases');
 
@@ -340,7 +340,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			. ", ++ ix"
 		);
 
-		$expected = array(
+		$expected = [
 			'DISTINCT +++ id',
 			'-+-+- a. [id_9] AS [columnAlias1]',
 			'-+-+- a. [id_9] AS [columnAlias2]',
@@ -348,7 +348,7 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			'-+-+- a.[id_9] AS [columnAlias4]',
 			'+-+ ix AS [columnAlias5]',
 			'++ ix',
-		);
+		];
 
 		TestReflection::invoke($this->_instance, 'fixSelectAliases');
 
@@ -365,12 +365,12 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			. ", [a].[b] + c"
 		);
 
-		$expected = array(
+		$expected = [
 			'DISTINCT -+++ [a]. id AS [columnAlias0]',
 			'[a]. [id_9]',
 			'c ++ [a].[b] AS [columnAlias2]',
 			'[a].[b] + c AS [columnAlias3]',
-		);
+		];
 
 		TestReflection::invoke($this->_instance, 'fixSelectAliases');
 
@@ -385,10 +385,10 @@ class JDatabaseQuerySqlsrvTest extends TestCase
 			. ", ''+a . id_9 'alias'"
 		);
 
-		$expected = array(
+		$expected = [
 			'DISTINCT + id',
 			"'' + a. id_9 AS 'alias'",
-		);
+		];
 
 		TestReflection::invoke($this->_instance, 'fixSelectAliases');
 


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Since 4.0 doesn't support php 5.3 anymore, use php 5.4+ array notation in unit tests databse suite.

### Testing Instructions

Simple code review.
Unit tests (travis) test passed.

### Documentation Changes Required

None.