### PR TITLE
[com_fields] Create a node for the default value

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -160,12 +160,17 @@ abstract class FieldsPlugin extends JPlugin
 		// Set the attributes
 		$node->setAttribute('name', $field->name);
 		$node->setAttribute('type', $field->type);
-		$node->setAttribute('default', $field->default_value);
 		$node->setAttribute('label', $field->label);
 		$node->setAttribute('description', $field->description);
 		$node->setAttribute('class', $field->params->get('class'));
 		$node->setAttribute('hint', $field->params->get('hint'));
 		$node->setAttribute('required', $field->required ? 'true' : 'false');
+
+		if ($field->default_value)
+		{
+			$defaultNode = $node->appendChild(new DOMElement('default'));
+			$defaultNode->appendChild(new DOMCdataSection($field->default_value));
+		}
 
 		// Combine the two params
 		$params = clone $this->params;


### PR DESCRIPTION
Follow up Pull Request for PR #12451.

### Summary of Changes
Changes custom fields to use the new default value node. This pr requires #12451 to be merged, test ONLY when #12451 is in staging!!

### Testing Instructions
- Create an editor field
- Set `<b>Hello Joomla</b>` as default value
- Set the filter to raw
- Save the field
- Edit an article

### Expected result
The editor custom field is prefilled with _Hello Joomla_ in bold.

### Actual result
The editor custom field is prefilled with _Hello Joomla_ in bold.