### PR TITLE
Ignore the "Show Options" setting for the custom fields

### DIFF
--- a/layouts/joomla/edit/fieldset.php
+++ b/layouts/joomla/edit/fieldset.php
@@ -23,7 +23,7 @@ if (empty($fieldSet))
 $ignoreFields = $displayData->get('ignore_fields') ? : array();
 $extraFields = $displayData->get('extra_fields') ? : array();
 
-if ($displayData->get('show_options', 1))
+if (!empty($displayData->showOptions) || $displayData->get('show_options', 1))
 {
 	if (isset($extraFields[$name]))
 	{

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -35,67 +35,99 @@ if (!empty($displayData->configFieldsets))
 	$configFieldsets = $displayData->configFieldsets ?: array();
 }
 
-if ($displayData->get('show_options', 1))
+// Handle the hidden fieldsets when show_options is set false
+if (!$displayData->get('show_options', 1))
 {
-	foreach ($fieldSets as $name => $fieldSet)
-	{
-		// Ensure any fieldsets we don't want to show are skipped (including repeating formfield fieldsets)
-		if ((isset($fieldSet->repeat) && $fieldSet->repeat === true)
-			|| in_array($name, $ignoreFieldsets)
-			|| (!empty($configFieldsets) && in_array($name, $configFieldsets, true))
-			|| (!empty($hiddenFieldsets) && in_array($name, $hiddenFieldsets, true))
-		)
-		{
-			continue;
-		}
-
-		if (!empty($fieldSet->label))
-		{
-			$label = JText::_($fieldSet->label);
-		}
-		else
-		{
-			$label = strtoupper('JGLOBAL_FIELDSET_' . $name);
-			if (JText::_($label) === $label)
-			{
-				$label = strtoupper($app->input->get('option') . '_' . $name . '_FIELDSET_LABEL');
-			}
-			$label = JText::_($label);
-		}
-
-		echo JHtml::_('bootstrap.addTab', $tabName, 'attrib-' . $name, $label);
-
-		if (isset($fieldSet->description) && trim($fieldSet->description))
-		{
-			echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
-		}
-
-		$displayData->fieldset = $name;
-		echo JLayoutHelper::render('joomla.edit.fieldset', $displayData);
-
-		echo JHtml::_('bootstrap.endTab');
-	}
-}
-else
-{
+	// The HTML buffer
 	$html   = array();
+
+	// Hide the whole buffer
 	$html[] = '<div style="display:none;">';
+
+	// Loop over the fieldsets
 	foreach ($fieldSets as $name => $fieldSet)
 	{
+		// Check if the fieldset should be ignored
 		if (in_array($name, $ignoreFieldsets, true))
 		{
 			continue;
 		}
 
+		// If it is a hidden fieldset, render the inputs
 		if (in_array($name, $hiddenFieldsets))
 		{
+			// Loop over the fields
 			foreach ($form->getFieldset($name) as $field)
 			{
+				// Add only the input on the buffer
 				$html[] = $field->input;
 			}
+
+			// Make sure the fieldset is not rendered twice
+			$ignoreFieldsets[] = $name;
+		}
+
+		// Check if it is the correct fieldset to ignore
+		if (strpos($name, 'basic') === 0)
+		{
+			// Ignore only the fieldsets which are defined by the options not the custom fields ones
+			$ignoreFieldsets[] = $name;
 		}
 	}
+
+	// Close the container
 	$html[] = '</div>';
 
+	// Echo the hidden fieldsets
 	echo implode('', $html);
+}
+
+// Loop again over the fieldsets
+foreach ($fieldSets as $name => $fieldSet)
+{
+	// Ensure any fieldsets we don't want to show are skipped (including repeating formfield fieldsets)
+	if ((isset($fieldSet->repeat) && $fieldSet->repeat === true)
+		|| in_array($name, $ignoreFieldsets)
+		|| (!empty($configFieldsets) && in_array($name, $configFieldsets, true))
+		|| (!empty($hiddenFieldsets) && in_array($name, $hiddenFieldsets, true))
+	)
+	{
+		continue;
+	}
+
+	// Determine the label
+	if (!empty($fieldSet->label))
+	{
+		$label = JText::_($fieldSet->label);
+	}
+	else
+	{
+		$label = strtoupper('JGLOBAL_FIELDSET_' . $name);
+		if (JText::_($label) === $label)
+		{
+			$label = strtoupper($app->input->get('option') . '_' . $name . '_FIELDSET_LABEL');
+		}
+		$label = JText::_($label);
+	}
+
+	// Start the tab
+	echo JHtml::_('bootstrap.addTab', $tabName, 'attrib-' . $name, $label);
+
+	// Include the description when available
+	if (isset($fieldSet->description) && trim($fieldSet->description))
+	{
+		echo '<p class="alert alert-info">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
+	}
+
+	// The name of the fieldset to render
+	$displayData->fieldset = $name;
+
+	// Force to show the options
+	$displayData->showOptions = true;
+
+	// Render the fieldset
+	echo JLayoutHelper::render('joomla.edit.fieldset', $displayData);
+
+	// End the tab
+	echo JHtml::_('bootstrap.endTab');
 }


### PR DESCRIPTION
Pull Request for Issue #15473.

### Summary of Changes
If the "Show Article Options" flag is set to no, then the custom fields are hidden as well. More infroamtion can be found in the issue #15473.
![image](https://user-images.githubusercontent.com/251072/27073709-12f7acfe-5025-11e7-9472-9db6851273da.png)

This pr changes the logic to only hide the "Options" tab when editing an article, the custom fields will still be displayed. This means that only fieldsets with the name basic are not displayed anymore with this pr, every other will still. So there is NO configuration setting to hide all additional fieldsets like before the patch.
Additionally the code got a bit of inline documentation as it starts to become more and more complex.

### Testing Instructions
- Create a custom field for articles
- In the article options set the "Show Article Options" flag to NO
- Edit an article

### Expected result
Only the Options tab is hidden. The Fields tab is displayed.

### Actual result
The Fields tab is hidden.