### PR TITLE
[com_fields] Respect the ordering of field groups when showing the field tabs

### DIFF
--- a/administrator/components/com_fields/models/groups.php
+++ b/administrator/components/com_fields/models/groups.php
@@ -121,13 +121,7 @@ class FieldsModelGroups extends JModelList
 		$user = JFactory::getUser();
 
 		// Select the required fields from the table.
-		$query->select(
-			$this->getState(
-				'list.select',
-				'a.id, a.title, a.checked_out, a.checked_out_time, a.note' .
-				', a.state, a.access, a.created, a.created_by, a.ordering, a.language'
-			)
-		);
+		$query->select($this->getState('list.select', 'a.*'));
 		$query->from('#__fields_groups AS a');
 
 		// Join over the language


### PR DESCRIPTION
Pull Request for Issue #16420.

### Summary of Changes
The Field group tabs should be shown in their respective order when editing an article.

### Testing Instructions
- Create a field group with the name "A Test"
- Create a field group with the name "B Test"
- Create a field group with the name "C Test"
- Reorder the groups
- Create for every group a custom field

### Expected result
The tabs are shown in the order of groups.

### Actual result
The tabs are shown in some random order.