### PR TITLE
[com_fields] Use the name attribute for save as copy

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -109,7 +109,7 @@ class FieldsModelField extends JModelAdmin
 
 			if ($data['title'] == $origTable->title)
 			{
-				list($title, $name) = $this->generateNewTitle($data['group_id'], $data['alias'], $data['title']);
+				list($title, $name) = $this->generateNewTitle($data['group_id'], $data['name'], $data['title']);
 				$data['title'] = $title;
 				$data['label'] = $title;
 				$data['name'] = $name;


### PR DESCRIPTION
Pull Request for Issue #15654.

### Summary of Changes
This pr fixes the save as copy action for a field.

### Testing Instructions
- Create a custom field
- Save it
- Click on the "Save as Copy" button

### Expected result
A new field is created with the same title, label and name with an appended number.

### Actual result
It doesn't save and throws an error.