### PR TITLE
[com_fields] Define the catid for the mail fields

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -72,6 +72,8 @@ class ContactViewContact extends JViewLegacy
 		$item = $this->get('Item');
 		$state = $this->get('State');
 
+		$app->setUserState('com_contact.contact.data', array('catid' => $item->catid));
+
 		$this->form = $this->get('Form');
 
  		$params = $state->get('params');
@@ -108,7 +110,7 @@ class ContactViewContact extends JViewLegacy
 		{
 			// Get Category Model data
 			$categoryModel = JModelLegacy::getInstance('Category', 'ContactModel', array('ignore_request' => true));
-			
+
 			$categoryModel->setState('category.id', $item->catid);
 			$categoryModel->setState('list.ordering', 'a.name');
 			$categoryModel->setState('list.direction', 'asc');


### PR DESCRIPTION
Pull Request for Issue #16574.

### Summary of Changes
When a "Contact - Mail" custom field is assigned to a category, then on the front only the fields in the contact form should be shown where the actual contact belongs to.

### Testing Instructions
- Create a contact category A
- Create a contact category B
- Create a contact A for category A
- Create a contact B for category B
- Create a Mail custom field with the title A and assign it to category A
- Create a Mail custom field with the title B and assign it to category B
- Create a menu item for contact A
- Create a menu item for contact B

### Expected result
- When opening contact A on the front only the custom field A should be shown below the contact form.
- When opening contact B on the front only the custom field B should be shown below the contact form.

### Actual result
- When opening contact A on the front the custom field A and B are shown below the contact form.
- When opening contact B on the front the custom field A and B are shown below the contact form.