### PR TITLE
[com_fields] Order the groups by the ordering column in the groups field

### DIFF
--- a/administrator/components/com_fields/models/fields/fieldgroups.php
+++ b/administrator/components/com_fields/models/fields/fieldgroups.php
@@ -44,6 +44,7 @@ class JFormFieldFieldgroups extends JFormFieldList
 		$query->where('state IN (' . implode(',', $states) . ')');
 		$query->where('context = ' . $db->quote($context));
 		$query->where('access IN (' . implode(',', $viewlevels) . ')');
+		$query->order('ordering asc, id asc');
 
 		$db->setQuery($query);
 		$options = $db->loadObjectList();


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/16663#issuecomment-308122649.

### Summary of Changes
The groups are not ordered according to the ordering.

### Testing Instructions
- Create a field group with the name "A Test"
- Create a field group with the name "B Test"
- Create a field group with the name "C Test"
- Reorder the groups
- Go to Fields and expand the filter
- Select the groups filter drop down
![image](https://user-images.githubusercontent.com/251072/27086634-0a024dec-5053-11e7-803f-b1a0374ef9e0.png)

### Expected result
The groups are ordered with the ordering in the groups manager.

### Actual result
The groups do have a random order, probably by id.