### PR TITLE
[4.0] Load autoload_psr4.php and some minor fixes

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -87,16 +87,48 @@ class JNamespacePsr4Map
 
 			if (file_exists(JPATH_ADMINISTRATOR . '/components/' . $element))
 			{
-				$elements[$baseNamespace . '\\\\Administrator'] = array('/administrator/components/' . $element);
+				$elements[$baseNamespace . '\\\\Administrator\\\\'] = array('/administrator/components/' . $element);
 			}
 
 			if (file_exists(JPATH_ROOT . '/components/' . $element))
 			{
-				$elements[$baseNamespace . '\\\\Site'] = array('/components/' . $element);
+				$elements[$baseNamespace . '\\\\Site\\\\'] = array('/components/' . $element);
 			}
 		}
 
 		$this->writeNamespaceFile($elements);
+
+		return true;
+	}
+
+	/**
+	 * Load the PSR4 file
+	 *
+	 * @return  bool
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function load()
+	{
+		if (!$this->exists())
+		{
+			// We can't continue here
+			if (!JFactory::getDbo()->connected())
+			{
+				return false;
+			}
+
+			$this->create();
+		}
+
+		$map = require $this->file;
+
+		$loader = include JPATH_LIBRARIES . '/vendor/autoload.php';
+
+		foreach ($map as $namespace => $path)
+		{
+			$loader->setPsr4($namespace, $path);
+		}
 
 		return true;
 	}
@@ -114,6 +146,7 @@ class JNamespacePsr4Map
 	{
 		$content   = array();
 		$content[] = "<?php";
+		$content[] = 'defined(\'_JEXEC\') or die;';
 		$content[] = 'return array(';
 
 		foreach ($elements as $namespace => $paths)

--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -316,6 +316,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	public function execute()
 	{
+		$this->createExtensionNamespaceMap();
+
 		PluginHelper::importPlugin('system');
 
 		// Trigger the onBeforeExecute event.
@@ -1023,8 +1025,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	protected function render()
 	{
-		$this->createExtensionNamespaceMap();
-
 		// Setup the document options.
 		$this->docOptions['template'] = $this->get('theme');
 		$this->docOptions['file']     = $this->get('themeFile', 'index.php');

--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -140,8 +140,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		{
 			$this->config->set('session_name', $this->getName());
 		}
-
-		$this->createExtensionNamespaceMap();
 	}
 
 	/**
@@ -1025,6 +1023,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	 */
 	protected function render()
 	{
+		$this->createExtensionNamespaceMap();
+
 		// Setup the document options.
 		$this->docOptions['template'] = $this->get('theme');
 		$this->docOptions['file']     = $this->get('themeFile', 'index.php');

--- a/libraries/src/CMS/Application/ExtensionNamespaceMapper.php
+++ b/libraries/src/CMS/Application/ExtensionNamespaceMapper.php
@@ -30,6 +30,6 @@ trait ExtensionNamespaceMapper
 	{
 		JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
 		$extensionPsr4Loader = new \JNamespacePsr4Map;
-		$extensionPsr4Loader->ensureMapFileExists();
+		$extensionPsr4Loader->load();
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #16616 

### Summary of Changes

* Move the namespace map creation / loading to render method in CMSApplication (as suggested by Michael), this should fix the installer issues
* Load the generated namespace map file
* Minor fixes in the namespace file

### Testing Instructions

Make sure you delete the old autoload_psr4.php in libraries before.

Check that libraries/autoload_psr4.php is generated and paths are loaded.

### Expected result

Installation works

### Actual result

Installation is broken on default SQL credentials

### Documentation Changes Required

Probably