### PR TITLE
[4.0] Correcting mod_languages css

### DIFF
--- a/media/mod_languages/css/template.css
+++ b/media/mod_languages/css/template.css
@@ -18,6 +18,7 @@ div.mod-languages ul.lang-block li {
 
 div.mod-languages img {
 	border:none;
+	display:inline-block;
 }
 
 div.mod-languages a {


### PR DESCRIPTION
Create a multingual site.
Display the language switcher module in frontend (sidebar-right).

Params for the module:

![screen shot 2017-06-14 at 15 58 44](https://user-images.githubusercontent.com/869724/27136093-a3c32362-511a-11e7-9377-c8abbbbeec1c.png)

Before patch
![screen shot 2017-06-14 at 15 56 16](https://user-images.githubusercontent.com/869724/27136129-beed30d8-511a-11e7-84aa-d8547119c8fe.png)

After patch
![screen shot 2017-06-14 at 15 55 06](https://user-images.githubusercontent.com/869724/27136136-c6a2daf8-511a-11e7-852f-4e2e5e1c27e1.png)

Note: it may need more as, here, the param `Line Height` is now useless.