### PR TITLE
[3.7.3] Remove autosave from tinymce & language deprecation

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/en-GB.plg_editors_tinymce.ini
@@ -90,6 +90,7 @@ PLG_TINY_FIELD_RESIZING_DESC="Enable/disable the resizing of the editor area (ve
 PLG_TINY_FIELD_RESIZING_LABEL="Resizing"
 PLG_TINY_FIELD_RTL_DESC="Show or hide the RTL button."
 PLG_TINY_FIELD_RTL_LABEL="Directionality"
+; The two following strings are deprecated
 PLG_TINY_FIELD_SAVEWARNING_DESC="Gives warning if you cancel without saving changes."
 PLG_TINY_FIELD_SAVEWARNING_LABEL="Save Warning"
 PLG_TINY_FIELD_SEARCH-REPLACE_DESC="Show or hide the Search &amp; Replace button."

--- a/plugins/editors/tinymce/form/setoptions.xml
+++ b/plugins/editors/tinymce/form/setoptions.xml
@@ -272,18 +272,6 @@
     </field>
 
     <field
-        name="autosave"
-        type="radio"
-        label="PLG_TINY_FIELD_SAVEWARNING_LABEL"
-        description="PLG_TINY_FIELD_SAVEWARNING_DESC"
-        class="btn-group btn-group-yesno"
-        default="1"
-        >
-        <option value="1">JON</option>
-        <option value="0">JOFF</option>
-    </field>
-
-    <field
         name="contextmenu"
         type="radio"
         label="PLG_TINY_FIELD_CONTEXTMENU_LABEL"


### PR DESCRIPTION
Pull Request for Issue #14488

### Summary of Changes

The PR was a zero file changes merge. https://github.com/joomla/joomla-cms/pull/14488/files This PR reapplys the chagens and deprecated the two language strings.

### Testing Instructions

go to the tinymce options and confirm the autosave option is gone.

### Expected result

autosave option is gone.

### Actual result

autosave option is still there

### Documentation Changes Required

Nothing.