### PR TITLE
TinyMCE parameters: displaying background color icon correctly

### DIFF
--- a/media/editors/tinymce/js/tinymce-builder.js
+++ b/media/editors/tinymce/js/tinymce-builder.js
@@ -200,7 +200,7 @@
             $btn.html('<span class="mce-txt">' + tinymce.translate(info.label) + '</span> <i class="mce-caret"></i>');
         } else {
             $element.addClass('mce-btn-small');
-            $btn.html(info.text ? tinymce.translate(info.text) : '<span class="mce-ico mce-i-' + name + '"></span>');
+            $btn.html(info.text ? tinymce.translate(info.text) : '<i class="mce-ico mce-i-' + name + '"></i>');
         }
 
         return $element;


### PR DESCRIPTION
Pull Request for Issue #15370

### Summary of Changes
The plugin loads the skin.min.css where we have 
```
i.mce-i-backcolor {
    background: #bbb none repeat scroll 0 0;
    text-shadow: none;
}
```
which can't be loaded as the code uses `<span>`

changed to `<i>`

### Testing Instructions
Edit the TinyMCE plugin

Before patch we get
![screen shot 2017-06-15 at 11 02 35](https://user-images.githubusercontent.com/869724/27173982-ba9f632a-51ba-11e7-8292-d7bf2d2d358d.png)

After patch we have
![screen shot 2017-06-15 at 10 56 44](https://user-images.githubusercontent.com/869724/27173990-c45830cc-51ba-11e7-9865-044b791a9def.png)
