### PR TITLE
Fix custom fields without a fieldgroup not being displayed

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -409,8 +409,8 @@ class FieldsHelper
 		$model->setState('filter.context', $context);
 
 		/**
-		 * $model->getItems() would only return existant groups, but we also
-		 * have the 'default' group with id 0 with isn't existant in the database,
+		 * $model->getItems() would only return existing groups, but we also
+		 * have the 'default' group with id 0 which is not in the database,
 		 * so we create it virtually here.
 		 */
 		$defaultGroup = new \stdClass;

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -408,8 +408,17 @@ class FieldsHelper
 		$model = JModelLegacy::getInstance('Groups', 'FieldsModel', array('ignore_request' => true));
 		$model->setState('filter.context', $context);
 
+		// $model->getItems() would only return existant groups, but we also
+		// have the 'default' group with id 0 with isn't existant in the database,
+		// so we create it virtually here.
+		$defaultGroup = new \stdClass();
+		$defaultGroup->id = 0;
+		$defaultGroup->title = '';
+		$defaultGroup->description = '';
+		$iterateGroups = array_merge(array($defaultGroup), $model->getItems());
+
 		// Looping through the groups
-		foreach ($model->getItems() as $group)
+		foreach ($iterateGroups as $group)
 		{
 			if (empty($fieldsPerGroup[$group->id]))
 			{

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -408,10 +408,12 @@ class FieldsHelper
 		$model = JModelLegacy::getInstance('Groups', 'FieldsModel', array('ignore_request' => true));
 		$model->setState('filter.context', $context);
 
-		// $model->getItems() would only return existant groups, but we also
-		// have the 'default' group with id 0 with isn't existant in the database,
-		// so we create it virtually here.
-		$defaultGroup = new \stdClass();
+		/**
+		 * $model->getItems() would only return existant groups, but we also
+		 * have the 'default' group with id 0 with isn't existant in the database,
+		 * so we create it virtually here.
+		 */
+		$defaultGroup = new \stdClass;
 		$defaultGroup->id = 0;
 		$defaultGroup->title = '';
 		$defaultGroup->description = '';


### PR DESCRIPTION
Commit 193e39c5b82c6cfd689e09a22f33becadf1cbeee introduced the usage of FieldsModelGroups::getItems() when getting the fieldgroups (and hence their fieldset in the backend editing layout) for the fields.

Unfortunately, that commit also introduced a bug, by which custom fields without a field group won't get displayed anymore. This PR fixes this issue.

This should get into the 3.7.3 release, as else the functionality of custom fields is broken.