### PR TITLE
[libraries] - legacy categories  move group by

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -290,14 +290,6 @@ class JCategories
 			$query->select('COUNT(i.' . $db->quoteName($this->_key) . ') AS numitems');
 		}
 
-		// Group by
-		$query->group(
-			'c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
-			 c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-			 c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
-			 c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version'
-		);
-
 		// Get the results
 		$db->setQuery($query);
 		$results = $db->loadObjectList('id');


### PR DESCRIPTION
### Summary of Changes
group by is not necessary cause we have no function in the select


### Testing Instructions
1. enable debug plugin
2. go to the home page 
3. click on debug database tab
4. look fro this query  #__categories 
![nopleaseno](https://user-images.githubusercontent.com/181681/27196797-31886850-520c-11e7-99c7-9b95970f1567.PNG)
5. apply th pr
you should see this one 
![yespleaseyes](https://user-images.githubusercontent.com/181681/27196927-ab2cc052-520c-11e7-95b2-e04a978600a2.PNG)
no more group by





### Expected result
no group by


### Actual result
unneeded group by


### Documentation Changes Required

