### PR TITLE
[libraries] - legacy categories use group by when needed

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -288,15 +288,16 @@ class JCategories
 
 			$query->join('LEFT', $queryjoin);
 			$query->select('COUNT(i.' . $db->quoteName($this->_key) . ') AS numitems');
+			
+			// Group by
+			$query->group(
+				'c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
+				 c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
+				 c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
+				 c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version'
+			);
 		}
 
-		// Group by
-		$query->group(
-			'c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
-			 c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-			 c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
-			 c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version'
-		);
 
 		// Get the results
 		$db->setQuery($query);


### PR DESCRIPTION
### Summary of Changes
group by is  necessary only when we have a function  like `COUNT()`  in the select


### Testing Instructions
1. enable debug plugin
2. creat a menu item of type single  article and set homepage
3. go to the home page 
5. click on debug database tab
6. look for this query  #__categories 
![nopleaseno](https://user-images.githubusercontent.com/181681/27196797-31886850-520c-11e7-99c7-9b95970f1567.PNG)
5. apply th pr
you should see this one 
![yespleaseyes](https://user-images.githubusercontent.com/181681/27196927-ab2cc052-520c-11e7-95b2-e04a978600a2.PNG)
no more group by





### Expected result
no group by


### Actual result
unneeded group by
