### PR TITLE
[ libraries / joomla] Type-safe comparisons #1

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -1071,7 +1071,7 @@ class JAccess
 		$user      = JUser::getInstance($userId);
 		$root_user = JFactory::getConfig()->get('root_user');
 
-		if ($root_user && ($root_user == $user->username || $root_user == $user->id))
+		if ($root_user && ($root_user === $user->username || $root_user == $user->id))
 		{
 			// Find the super user levels.
 			foreach (self::$viewLevels as $level => $rule)

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -446,7 +446,7 @@ class JApplicationDaemon extends JApplicationCli
 		$file = $this->config->get('application_pid_file');
 
 		// Change the user id for the process id file if necessary.
-		if ($uid && (fileowner($file) != $uid) && (!@ chown($file, $uid)))
+		if ($uid && (fileowner($file) !== $uid) && (!@ chown($file, $uid)))
 		{
 			JLog::add('Unable to change user ownership of the process id file.', JLog::ERROR);
 
@@ -454,7 +454,7 @@ class JApplicationDaemon extends JApplicationCli
 		}
 
 		// Change the group id for the process id file if necessary.
-		if ($gid && (filegroup($file) != $gid) && (!@ chgrp($file, $gid)))
+		if ($gid && (filegroup($file) !== $gid) && (!@ chgrp($file, $gid)))
 		{
 			JLog::add('Unable to change group ownership of the process id file.', JLog::ERROR);
 
@@ -468,7 +468,7 @@ class JApplicationDaemon extends JApplicationCli
 		}
 
 		// Change the user id for the process necessary.
-		if ($uid && (posix_getuid($file) != $uid) && (!@ posix_setuid($uid)))
+		if ($uid && (posix_getuid($file) !== $uid) && (!@ posix_setuid($uid)))
 		{
 			JLog::add('Unable to change user ownership of the proccess.', JLog::ERROR);
 
@@ -476,7 +476,7 @@ class JApplicationDaemon extends JApplicationCli
 		}
 
 		// Change the group id for the process necessary.
-		if ($gid && (posix_getgid($file) != $gid) && (!@ posix_setgid($gid)))
+		if ($gid && (posix_getgid($file) !== $gid) && (!@ posix_setgid($gid)))
 		{
 			JLog::add('Unable to change group ownership of the proccess.', JLog::ERROR);
 
@@ -746,7 +746,7 @@ class JApplicationDaemon extends JApplicationCli
 		}
 
 		// Only read the pid for the parent file.
-		if ($this->parentId == $this->processId)
+		if ($this->parentId === $this->processId)
 		{
 			// Read the contents of the process id file as an integer.
 			$fp = fopen($this->config->get('application_pid_file'), 'r');

--- a/libraries/joomla/application/web.php
+++ b/libraries/joomla/application/web.php
@@ -306,7 +306,7 @@ class JApplicationWeb extends JApplicationBase
 		}
 
 		// If gzip compression is enabled in configuration and the server is compliant, compress the output.
-		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') != 'ob_gzhandler'))
+		if ($this->get('gzip') && !ini_get('zlib.output_compression') && (ini_get('output_handler') !== 'ob_gzhandler'))
 		{
 			$this->compress();
 		}
@@ -394,7 +394,7 @@ class JApplicationWeb extends JApplicationBase
 		// Iterate through the encodings and attempt to compress the data using any found supported encodings.
 		foreach ($encodings as $encoding)
 		{
-			if (($supported[$encoding] == 'gz') || ($supported[$encoding] == 'deflate'))
+			if (($supported[$encoding] === 'gz') || ($supported[$encoding] === 'deflate'))
 			{
 				// Verify that the server supports gzip compression before we attempt to gzip encode the data.
 				// @codeCoverageIgnoreStart
@@ -406,7 +406,7 @@ class JApplicationWeb extends JApplicationBase
 
 				// Attempt to gzip encode the data with an optimal level 4.
 				$data = $this->getBody();
-				$gzdata = gzencode($data, 4, ($supported[$encoding] == 'gz') ? FORCE_GZIP : FORCE_DEFLATE);
+				$gzdata = gzencode($data, 4, ($supported[$encoding] === 'gz') ? FORCE_GZIP : FORCE_DEFLATE);
 
 				// If there was a problem encoding the data just try the next encoding scheme.
 				// @codeCoverageIgnoreStart
@@ -518,7 +518,7 @@ class JApplicationWeb extends JApplicationBase
 			$prefix = $uri->toString(array('scheme', 'user', 'pass', 'host', 'port'));
 
 			// We just need the prefix since we have a path relative to the root.
-			if ($url[0] == '/')
+			if ($url[0] === '/')
 			{
 				$url = $prefix . $url;
 			}
@@ -665,7 +665,7 @@ class JApplicationWeb extends JApplicationBase
                  * If ($keys && $replace) it's a replacement and previous have been deleted
                  * if($keys && !in_array...) it's a multiple value header
                  */
-		$single = in_array($name, $this->singleValueResponseHeaders);
+		$single = in_array($name, $this->singleValueResponseHeaders, true);
 		if ($value && (!$keys || ($keys && ($replace || !$single))))
 		{
 			// Add the header to the internal array.
@@ -717,7 +717,7 @@ class JApplicationWeb extends JApplicationBase
 			$val = array();
 			foreach ($this->response->headers as $header)
 			{
-				if ('status' == strtolower($header['name']))
+				if ('status' === strtolower($header['name']))
 				{
 					// 'status' headers indicate an HTTP status, and need to be handled slightly differently
 					$this->header('HTTP/1.1 ' . (int) $header['value'], true);
@@ -871,7 +871,7 @@ class JApplicationWeb extends JApplicationBase
 	protected function detectRequestUri()
 	{
 		// First we need to detect the URI scheme.
-		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+		if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) !== 'off'))
 		{
 			$scheme = 'https://';
 		}
@@ -1002,7 +1002,7 @@ class JApplicationWeb extends JApplicationBase
 	 */
 	public function isSSLConnection()
 	{
-		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION');
+		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] === 'on')) || getenv('SSL_PROTOCOL_VERSION');
 	}
 
 	/**
@@ -1089,7 +1089,7 @@ class JApplicationWeb extends JApplicationBase
 		$session = JSession::getInstance($handler, $options);
 		$session->initialise($this->input, $this->dispatcher);
 
-		if ($session->getState() == 'expired')
+		if ($session->getState() === 'expired')
 		{
 			$session->restart();
 		}
@@ -1149,7 +1149,7 @@ class JApplicationWeb extends JApplicationBase
 		// Check to see if an explicit base URI has been set.
 		$siteUri = trim($this->get('site_uri'));
 
-		if ($siteUri != '')
+		if ($siteUri !== '')
 		{
 			$uri = JUri::getInstance($siteUri);
 			$path = $uri->toString(array('path'));

--- a/libraries/joomla/application/web/router/base.php
+++ b/libraries/joomla/application/web/router/base.php
@@ -49,34 +49,34 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		foreach ($pattern as $segment)
 		{
 			// Match a splat with no variable.
-			if ($segment == '*')
+			if ($segment === '*')
 			{
 				$regex[] = '.*';
 			}
 			// Match a splat and capture the data to a named variable.
-			elseif ($segment[0] == '*')
+			elseif ($segment[0] === '*')
 			{
 				$vars[] = substr($segment, 1);
 				$regex[] = '(.*)';
 			}
 			// Match an escaped splat segment.
-			elseif ($segment[0] == '\\' && $segment[1] == '*')
+			elseif ($segment[0] === '\\' && $segment[1] === '*')
 			{
 				$regex[] = '\*' . preg_quote(substr($segment, 2));
 			}
 			// Match an unnamed variable without capture.
-			elseif ($segment == ':')
+			elseif ($segment === ':')
 			{
 				$regex[] = '[^/]*';
 			}
 			// Match a named variable and capture the data.
-			elseif ($segment[0] == ':')
+			elseif ($segment[0] === ':')
 			{
 				$vars[] = substr($segment, 1);
 				$regex[] = '([^/]*)';
 			}
 			// Match a segment with an escaped variable character prefix.
-			elseif ($segment[0] == '\\' && $segment[1] == ':')
+			elseif ($segment[0] === '\\' && $segment[1] === ':')
 			{
 				$regex[] = preg_quote(substr($segment, 1));
 			}
@@ -136,7 +136,7 @@ class JApplicationWebRouterBase extends JApplicationWebRouter
 		$route = trim(parse_url($route, PHP_URL_PATH), ' /');
 
 		// If the route is empty then simply return the default route.  No parsing necessary.
-		if ($route == '')
+		if ($route === '')
 		{
 			return $this->default;
 		}

--- a/libraries/joomla/application/web/router/rest.php
+++ b/libraries/joomla/application/web/router/rest.php
@@ -124,7 +124,7 @@ class JApplicationWebRouterRest extends JApplicationWebRouterBase
 		}
 
 		// Check if request method is POST
-		if ($this->methodInPostRequest == true && strcmp(strtoupper($this->input->server->getMethod()), 'POST') === 0)
+		if ($this->methodInPostRequest === true && strcmp(strtoupper($this->input->server->getMethod()), 'POST') === 0)
 		{
 			// Get the method from input
 			$postMethod = $this->input->get->getWord('_method');

--- a/libraries/joomla/archive/archive.php
+++ b/libraries/joomla/archive/archive.php
@@ -43,7 +43,7 @@ class JArchive
 		$ext = JFile::getExt(strtolower($archivename));
 
 		// Check if a tar is embedded...gzip/bzip2 can just be plain files!
-		if (JFile::getExt(JFile::stripExt(strtolower($archivename))) == 'tar')
+		if (JFile::getExt(JFile::stripExt(strtolower($archivename))) === 'tar')
 		{
 			$untar = true;
 		}

--- a/libraries/joomla/archive/tar.php
+++ b/libraries/joomla/archive/tar.php
@@ -97,7 +97,7 @@ class JArchiveTar implements JArchiveExtractable
 		{
 			$type = strtolower($this->_metadata[$i]['type']);
 
-			if ($type == 'file' || $type == 'unix file')
+			if ($type === 'file' || $type === 'unix file')
 			{
 				$buffer = $this->_metadata[$i]['data'];
 				$path = JPath::clean($destination . '/' . $this->_metadata[$i]['name']);
@@ -224,7 +224,7 @@ class JArchiveTar implements JArchiveExtractable
 						(($mode & 0x100) ? 'x' : '-') . (($mode & 0x040) ? 'r' : '-') . (($mode & 0x020) ? 'w' : '-') . (($mode & 0x010) ? 'x' : '-') .
 						(($mode & 0x004) ? 'r' : '-') . (($mode & 0x002) ? 'w' : '-') . (($mode & 0x001) ? 'x' : '-');
 				}
-				elseif (chr($info['typeflag']) == 'L' && $info['filename'] == '././@LongLink')
+				elseif (chr($info['typeflag']) === 'L' && $info['filename'] === '././@LongLink')
 				{
 					// GNU tar ././@LongLink support - the filename is actually in the contents,
 					// setting a variable here so we can test in the next loop

--- a/libraries/joomla/authentication/authentication.php
+++ b/libraries/joomla/authentication/authentication.php
@@ -157,7 +157,7 @@ class JAuthentication extends JObject
 			// Make sure we haven't already attached this array as an observer
 			foreach ($this->observers as $check)
 			{
-				if (is_array($check) && $check['event'] == $observer['event'] && $check['handler'] == $observer['handler'])
+				if (is_array($check) && $check['event'] === $observer['event'] && $check['handler'] === $observer['handler'])
 				{
 					return;
 				}

--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -171,7 +171,7 @@ class JAdapter extends JObject
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			if (!$file->isFile() || $file->getExtension() != 'php')
+			if (!$file->isFile() || $file->getExtension() !== 'php')
 			{
 				continue;
 			}

--- a/libraries/joomla/cache/cache.php
+++ b/libraries/joomla/cache/cache.php
@@ -107,7 +107,7 @@ class JCache
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			if (!$file->isFile() || $file->getExtension() != 'php' || $fileName == 'helper.php')
+			if (!$file->isFile() || $file->getExtension() !== 'php' || $fileName === 'helper.php')
 			{
 				continue;
 			}
@@ -627,7 +627,7 @@ class JCache
 						$newvalue = array_map('unserialize', $newvalue);
 
 						// Special treatment for script and style declarations.
-						if (($now == 'script' || $now == 'style') && is_array($newvalue) && is_array($options['headerbefore'][$now]))
+						if (($now === 'script' || $now === 'style') && is_array($newvalue) && is_array($options['headerbefore'][$now]))
 						{
 							foreach ($newvalue as $type => $currentScriptStr)
 							{

--- a/libraries/joomla/cache/controller/page.php
+++ b/libraries/joomla/cache/controller/page.php
@@ -63,7 +63,7 @@ class JCacheControllerPage extends JCacheController
 		{
 			$etag = stripslashes($_SERVER['HTTP_IF_NONE_MATCH']);
 
-			if ($etag == $id)
+			if ($etag === $id)
 			{
 				$browserCache = isset($this->options['browsercache']) ? $this->options['browsercache'] : false;
 

--- a/libraries/joomla/cache/storage/apc.php
+++ b/libraries/joomla/cache/storage/apc.php
@@ -83,7 +83,7 @@ class JCacheStorageApc extends JCacheStorage
 
 			$namearr = explode('-', $name);
 
-			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+			if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 			{
 				$group = $namearr[2];
 
@@ -173,7 +173,7 @@ class JCacheStorageApc extends JCacheStorage
 				$internalKey = $key['key'];
 			}
 
-			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group')
 			{
 				apc_delete($internalKey);
 			}

--- a/libraries/joomla/cache/storage/apcu.php
+++ b/libraries/joomla/cache/storage/apcu.php
@@ -83,7 +83,7 @@ class JCacheStorageApcu extends JCacheStorage
 
 			$namearr = explode('-', $name);
 
-			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+			if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 			{
 				$group = $namearr[2];
 
@@ -181,7 +181,7 @@ class JCacheStorageApcu extends JCacheStorage
 				$internalKey = $key['key'];
 			}
 
-			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group')
 			{
 				apcu_delete($internalKey);
 			}

--- a/libraries/joomla/cache/storage/file.php
+++ b/libraries/joomla/cache/storage/file.php
@@ -261,7 +261,7 @@ class JCacheStorageFile extends JCacheStorage
 		$return = true;
 		$folder = $group;
 
-		if (trim($folder) == '')
+		if (trim($folder) === '')
 		{
 			$mode = 'notgroup';
 		}
@@ -653,7 +653,7 @@ class JCacheStorageFile extends JCacheStorage
 
 		while (($file = readdir($handle)) !== false)
 		{
-			if (($file != '.') && ($file != '..') && (!in_array($file, $exclude)) && (!$excludefilter || !preg_match($excludefilter, $file)))
+			if (($file !== '.') && ($file !== '..') && (!in_array($file, $exclude, true)) && (!$excludefilter || !preg_match($excludefilter, $file)))
 			{
 				$dir   = $path . '/' . $file;
 				$isDir = is_dir($dir);
@@ -743,7 +743,7 @@ class JCacheStorageFile extends JCacheStorage
 
 		while (($file = readdir($handle)) !== false)
 		{
-			if (($file != '.') && ($file != '..')
+			if (($file !== '.') && ($file !== '..')
 				&& (!in_array($file, $exclude))
 				&& (empty($excludefilter_string) || !preg_match($excludefilter_string, $file)))
 			{

--- a/libraries/joomla/cache/storage/memcache.php
+++ b/libraries/joomla/cache/storage/memcache.php
@@ -174,7 +174,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 				$namearr = explode('-', $key->name);
 
-				if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+				if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 				{
 					$group = $namearr[2];
 
@@ -262,7 +262,7 @@ class JCacheStorageMemcache extends JCacheStorage
 		{
 			foreach ($index as $key => $value)
 			{
-				if ($value->name == $cache_id)
+				if ($value->name === $cache_id)
 				{
 					unset($index[$key]);
 					static::$_db->set($this->_hash . '-index', $index, 0, 0);
@@ -304,7 +304,7 @@ class JCacheStorageMemcache extends JCacheStorage
 
 			foreach ($index as $key => $value)
 			{
-				if (strpos($value->name, $prefix) === 0 xor $mode != 'group')
+				if (strpos($value->name, $prefix) === 0 xor $mode !== 'group')
 				{
 					static::$_db->delete($value->name);
 					unset($index[$key]);

--- a/libraries/joomla/cache/storage/memcached.php
+++ b/libraries/joomla/cache/storage/memcached.php
@@ -79,7 +79,7 @@ class JCacheStorageMemcached extends JCacheStorage
 			static::$_db = new Memcached($this->_hash);
 			$servers = static::$_db->getServerList();
 
-			if ($servers && ($servers[0]['host'] != $host || $servers[0]['port'] != $port))
+			if ($servers && ($servers[0]['host'] !== $host || $servers[0]['port'] !== (int) $port))
 			{
 				static::$_db->resetServerList();
 				$servers = array();
@@ -193,7 +193,7 @@ class JCacheStorageMemcached extends JCacheStorage
 
 				$namearr = explode('-', $key->name);
 
-				if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+				if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 				{
 					$group = $namearr[2];
 
@@ -281,7 +281,7 @@ class JCacheStorageMemcached extends JCacheStorage
 		{
 			foreach ($index as $key => $value)
 			{
-				if ($value->name == $cache_id)
+				if ($value->name === $cache_id)
 				{
 					unset($index[$key]);
 					static::$_db->set($this->_hash . '-index', $index, 0);
@@ -323,7 +323,7 @@ class JCacheStorageMemcached extends JCacheStorage
 
 			foreach ($index as $key => $value)
 			{
-				if (strpos($value->name, $prefix) === 0 xor $mode != 'group')
+				if (strpos($value->name, $prefix) === 0 xor $mode !== 'group')
 				{
 					static::$_db->delete($value->name);
 					unset($index[$key]);

--- a/libraries/joomla/cache/storage/redis.php
+++ b/libraries/joomla/cache/storage/redis.php
@@ -59,7 +59,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	protected function getConnection()
 	{
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return false;
 		}
@@ -169,7 +169,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function contains($id, $group)
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -190,7 +190,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function get($id, $group, $checkTime = true)
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -207,7 +207,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function getAll()
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -222,7 +222,7 @@ class JCacheStorageRedis extends JCacheStorage
 			{
 				$namearr = explode('-', $key);
 
-				if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+				if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 				{
 					$group = $namearr[2];
 
@@ -257,7 +257,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function store($id, $group, $data)
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -279,7 +279,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function remove($id, $group)
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -302,7 +302,7 @@ class JCacheStorageRedis extends JCacheStorage
 	 */
 	public function clean($group, $mode = null)
 	{
-		if (static::isConnected() == false)
+		if (static::isConnected() === false)
 		{
 			return false;
 		}
@@ -318,12 +318,12 @@ class JCacheStorageRedis extends JCacheStorage
 
 		foreach ($allKeys as $key)
 		{
-			if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode == 'group')
+			if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode === 'group')
 			{
 				static::$_redis->delete($key);
 			}
 
-			if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode != 'group')
+			if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode !== 'group')
 			{
 				static::$_redis->delete($key);
 			}

--- a/libraries/joomla/cache/storage/wincache.php
+++ b/libraries/joomla/cache/storage/wincache.php
@@ -67,7 +67,7 @@ class JCacheStorageWincache extends JCacheStorage
 			$name    = $key['key_name'];
 			$namearr = explode('-', $name);
 
-			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+			if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 			{
 				$group = $namearr[2];
 
@@ -149,7 +149,7 @@ class JCacheStorageWincache extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['key_name'], $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			if (strpos($key['key_name'], $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group')
 			{
 				wincache_ucache_delete($key['key_name']);
 			}

--- a/libraries/joomla/cache/storage/xcache.php
+++ b/libraries/joomla/cache/storage/xcache.php
@@ -46,7 +46,7 @@ class JCacheStorageXcache extends JCacheStorage
 	public function get($id, $group, $checkTime = true)
 	{
 		// Make sure XCache is configured properly
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return false;
 		}
@@ -73,7 +73,7 @@ class JCacheStorageXcache extends JCacheStorage
 	public function getAll()
 	{
 		// Make sure XCache is configured properly
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return array();
 		}
@@ -88,7 +88,7 @@ class JCacheStorageXcache extends JCacheStorage
 		{
 			$namearr = explode('-', $key['name']);
 
-			if ($namearr !== false && $namearr[0] == $secret && $namearr[1] == 'cache')
+			if ($namearr !== false && $namearr[0] === $secret && $namearr[1] === 'cache')
 			{
 				$group = $namearr[2];
 
@@ -124,7 +124,7 @@ class JCacheStorageXcache extends JCacheStorage
 	public function store($id, $group, $data)
 	{
 		// Make sure XCache is configured properly
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return false;
 		}
@@ -145,7 +145,7 @@ class JCacheStorageXcache extends JCacheStorage
 	public function remove($id, $group)
 	{
 		// Make sure XCache is configured properly
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return false;
 		}
@@ -176,7 +176,7 @@ class JCacheStorageXcache extends JCacheStorage
 	public function clean($group, $mode = null)
 	{
 		// Make sure XCache is configured properly
-		if (static::isSupported() == false)
+		if (static::isSupported() === false)
 		{
 			return true;
 		}
@@ -187,7 +187,7 @@ class JCacheStorageXcache extends JCacheStorage
 
 		foreach ($keys as $key)
 		{
-			if (strpos($key['name'], $secret . '-cache-' . $group . '-') === 0 xor $mode != 'group')
+			if (strpos($key['name'], $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group')
 			{
 				xcache_unset($key['name']);
 			}
@@ -211,7 +211,7 @@ class JCacheStorageXcache extends JCacheStorage
 			$xcache_admin_enable_auth = ini_get('xcache.admin.enable_auth');
 
 			// Some extensions ini variables are reported as strings
-			if ($xcache_admin_enable_auth == 'Off')
+			if ($xcache_admin_enable_auth === 'Off')
 			{
 				return true;
 			}

--- a/libraries/joomla/client/ftp.php
+++ b/libraries/joomla/client/ftp.php
@@ -352,7 +352,7 @@ class JClientFtp
 		}
 
 		// If we are already logged in, continue :)
-		if ($this->_responseCode == 503)
+		if ($this->_responseCode === 503)
 		{
 			return true;
 		}
@@ -608,7 +608,7 @@ class JClientFtp
 	public function chmod($path, $mode)
 	{
 		// If no filename is given, we assume the current directory is the target
-		if ($path == '')
+		if ($path === '')
 		{
 			$path = '.';
 		}
@@ -905,7 +905,7 @@ class JClientFtp
 		fclose($this->_dataconn);
 
 		// Let's try to cleanup some line endings if it is ascii
-		if ($mode == FTP_ASCII)
+		if ($mode === FTP_ASCII)
 		{
 			$os = 'UNIX';
 
@@ -1552,7 +1552,7 @@ class JClientFtp
 		}
 
 		// If only raw output is requested we are done
-		if ($type == 'raw')
+		if ($type === 'raw')
 		{
 			return $data;
 		}
@@ -1564,7 +1564,7 @@ class JClientFtp
 		}
 
 		// If the server returned the number of results in the first response, let's dump it
-		if (strtolower(substr($contents[0], 0, 6)) == 'total ')
+		if (strtolower(substr($contents[0], 0, 6)) === 'total ')
 		{
 			array_shift($contents);
 
@@ -1604,7 +1604,7 @@ class JClientFtp
 		}
 
 		// Here is where it is going to get dirty....
-		if ($osType == 'UNIX' || $osType == 'MAC')
+		if ($osType === 'UNIX' || $osType === 'MAC')
 		{
 			foreach ($contents as $file)
 			{
@@ -1628,18 +1628,18 @@ class JClientFtp
 				}
 
 				// If we just want files, do not add a folder
-				if ($type == 'files' && $tmp_array['type'] == 1)
+				if ($type === 'files' && $tmp_array['type'] == 1)
 				{
 					continue;
 				}
 
 				// If we just want folders, do not add a file
-				if ($type == 'folders' && $tmp_array['type'] == 0)
+				if ($type === 'folders' && $tmp_array['type'] == 0)
 				{
 					continue;
 				}
 
-				if (is_array($tmp_array) && $tmp_array['name'] != '.' && $tmp_array['name'] != '..')
+				if (is_array($tmp_array) && $tmp_array['name'] !== '.' && $tmp_array['name'] !== '..')
 				{
 					$dir_list[] = $tmp_array;
 				}
@@ -1653,7 +1653,7 @@ class JClientFtp
 
 				if (@preg_match($regexp, $file, $regs))
 				{
-					$fType = (int) ($regs[7] == '<DIR>');
+					$fType = (int) ($regs[7] === '<DIR>');
 					$timestamp = strtotime("$regs[3]-$regs[1]-$regs[2] $regs[4]:$regs[5]$regs[6]");
 
 					// $tmp_array['line'] = $regs[0];
@@ -1669,17 +1669,17 @@ class JClientFtp
 					$tmp_array['name'] = $regs[8];
 				}
 				// If we just want files, do not add a folder
-				if ($type == 'files' && $tmp_array['type'] == 1)
+				if ($type === 'files' && $tmp_array['type'] == 1)
 				{
 					continue;
 				}
 				// If we just want folders, do not add a file
-				if ($type == 'folders' && $tmp_array['type'] == 0)
+				if ($type === 'folders' && $tmp_array['type'] == 0)
 				{
 					continue;
 				}
 
-				if (is_array($tmp_array) && $tmp_array['name'] != '.' && $tmp_array['name'] != '..')
+				if (is_array($tmp_array) && $tmp_array['name'] !== '.' && $tmp_array['name'] !== '..')
 				{
 					$dir_list[] = $tmp_array;
 				}
@@ -1828,7 +1828,7 @@ class JClientFtp
 		$this->_responseMsg = $parts[0];
 
 		// If it's not 227, we weren't given an IP and port, which means it failed.
-		if ($this->_responseCode != '227')
+		if ($this->_responseCode !== '227')
 		{
 			JLog::add(JText::sprintf('JLIB_CLIENT_ERROR_JFTP_PASSIVE_IP_OBTAIN', $this->_responseMsg), JLog::WARNING, 'jerror');
 

--- a/libraries/joomla/client/helper.php
+++ b/libraries/joomla/client/helper.php
@@ -58,7 +58,7 @@ class JClientHelper
 			}
 
 			// If user and pass are not set in global config lets see if they are in the session
-			if ($options['enabled'] == true && ($options['user'] == '' || $options['pass'] == ''))
+			if ($options['enabled'] == true && ($options['user'] === '' || $options['pass'] === ''))
 			{
 				$session = JFactory::getSession();
 				$options['user'] = $session->get($client . '.user', null, 'JClientHelper');
@@ -66,7 +66,7 @@ class JClientHelper
 			}
 
 			// If user or pass are missing, disable this client
-			if ($options['user'] == '' || $options['pass'] == '')
+			if ($options['user'] === '' || $options['pass'] === '')
 			{
 				$options['enabled'] = false;
 			}
@@ -168,7 +168,7 @@ class JClientHelper
 			// The client is disabled in global config, so let's pretend we are OK
 			$return = true;
 		}
-		elseif ($options['user'] != '' && $options['pass'] != '')
+		elseif ($options['user'] !== '' && $options['pass'] !== '')
 		{
 			// Login credentials are available in global config
 			$return = true;
@@ -180,7 +180,7 @@ class JClientHelper
 			$user = $session->get($client . '.user', null, 'JClientHelper');
 			$pass = $session->get($client . '.pass', null, 'JClientHelper');
 
-			if ($user != '' && $pass != '')
+			if ($user !== '' && $pass !== '')
 			{
 				$return = true;
 			}
@@ -210,7 +210,7 @@ class JClientHelper
 		$user = $input->post->getString('username', null);
 		$pass = $input->post->getString('password', null);
 
-		if ($user != '' && $pass != '')
+		if ($user !== '' && $pass !== '')
 		{
 			// Add credentials to the session
 			if (self::setCredentials($client, $user, $pass))

--- a/libraries/joomla/crypt/cipher/crypto.php
+++ b/libraries/joomla/crypt/cipher/crypto.php
@@ -30,7 +30,7 @@ class JCryptCipherCrypto implements JCryptCipher
 	public function decrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != 'crypto')
+		if ($key->type !== 'crypto')
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected crypto.');
 		}
@@ -68,7 +68,7 @@ class JCryptCipherCrypto implements JCryptCipher
 	public function encrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != 'crypto')
+		if ($key->type !== 'crypto')
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected crypto.');
 		}

--- a/libraries/joomla/crypt/cipher/mcrypt.php
+++ b/libraries/joomla/crypt/cipher/mcrypt.php
@@ -65,7 +65,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 	public function decrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != $this->keyType)
+		if ($key->type !== $this->keyType)
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
 		}
@@ -90,7 +90,7 @@ abstract class JCryptCipherMcrypt implements JCryptCipher
 	public function encrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != $this->keyType)
+		if ($key->type !== $this->keyType)
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected ' . $this->keyType . '.');
 		}

--- a/libraries/joomla/crypt/cipher/simple.php
+++ b/libraries/joomla/crypt/cipher/simple.php
@@ -31,7 +31,7 @@ class JCryptCipherSimple implements JCryptCipher
 	public function decrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != 'simple')
+		if ($key->type !== 'simple')
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
 		}
@@ -72,7 +72,7 @@ class JCryptCipherSimple implements JCryptCipher
 	public function encrypt($data, JCryptKey $key)
 	{
 		// Validate key.
-		if ($key->type != 'simple')
+		if ($key->type !== 'simple')
 		{
 			throw new InvalidArgumentException('Invalid key of type: ' . $key->type . '.  Expected simple.');
 		}

--- a/libraries/joomla/crypt/key.php
+++ b/libraries/joomla/crypt/key.php
@@ -66,7 +66,7 @@ class JCryptKey
 	 */
 	public function __get($name)
 	{
-		if ($name == 'type')
+		if ($name === 'type')
 		{
 			return $this->type;
 		}

--- a/libraries/joomla/crypt/password/simple.php
+++ b/libraries/joomla/crypt/password/simple.php
@@ -132,7 +132,7 @@ class JCryptPasswordSimple implements JCryptPassword
 	public function verify($password, $hash)
 	{
 		// Check if the hash is a blowfish hash.
-		if (substr($hash, 0, 4) == '$2a$' || substr($hash, 0, 4) == '$2y$')
+		if (substr($hash, 0, 4) === '$2a$' || substr($hash, 0, 4) === '$2y$')
 		{
 			$type = '$2a$';
 
@@ -145,7 +145,7 @@ class JCryptPasswordSimple implements JCryptPassword
 		}
 
 		// Check if the hash is an MD5 hash.
-		if (substr($hash, 0, 3) == '$1$')
+		if (substr($hash, 0, 3) === '$1$')
 		{
 			return JCrypt::timingSafeCompare(crypt($password, $hash), $hash);
 		}


### PR DESCRIPTION
### Summary of Changes

Implemented type-safe comparisons in the `libraries / joomla` directory.
For easier reviewing, there is a total of five parts, that cover the `libraries / joomla` directory

This is part 1, which covers directories `access` until  `crypt`


### Testing Instructions

**Code review only**, as those changes should not affect behavior.
Despite the quantity of the changes, it should be fairly easy to review.

Attention to code reviewers:
In order to prevent code-review-fatigue, I only did type safe comparisons, **without applying**:
- formatting
- removal of unnecessary parentheses
- other non-related changes

Please **only** review the correctness of the specific changes, without pointing out any possible formatting issues (unless corrupted by this PR), removal of parentheses and other non-related changes. This will help get this PR reviewed and merged quickly.
If you should find other prospects for type safe comparison in those folders please note them in a review.

Thank you