### PR TITLE
[ libraries / joomla] Type-safe comparisons #2

### DIFF
--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -204,7 +204,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			if (!$file->isFile() || $file->getExtension() != 'php')
+			if (!$file->isFile() || $file->getExtension() !== 'php')
 			{
 				continue;
 			}
@@ -352,15 +352,15 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			$lenEndString = strlen($endString);
 			$testEnd = substr($sql, $i, $lenEndString);
 
-			if ($current == '"' || $current == "'" || $current2 == '--'
-				|| ($current2 == '/*' && $current3 != '/*!' && $current3 != '/*+')
-				|| ($current == '#' && $current3 != '#__')
-				|| ($comment && $testEnd == $endString))
+			if ($current === '"' || $current === "'" || $current2 === '--'
+				|| ($current2 === '/*' && $current3 !== '/*!' && $current3 !== '/*+')
+				|| ($current === '#' && $current3 !== '#__')
+				|| ($comment && $testEnd === $endString))
 			{
 				// Check if quoted with previous backslash
 				$n = 2;
 
-				while (substr($sql, $i - $n + 1, 1) == '\\' && $n < $i)
+				while (substr($sql, $i - $n + 1, 1) === '\\' && $n < $i)
 				{
 					$n++;
 				}
@@ -389,17 +389,17 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 					else
 					{
 						$open = true;
-						if ($current2 == '--')
+						if ($current2 === '--')
 						{
 							$endString = "\n";
 							$comment = true;
 						}
-						elseif ($current2 == '/*')
+						elseif ($current2 === '/*')
 						{
 							$endString = '*/';
 							$comment = true;
 						}
-						elseif ($current == '#')
+						elseif ($current === '#')
 						{
 							$endString = "\n";
 							$comment = true;
@@ -421,7 +421,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 				$start = $i + 1;
 			}
 
-			if (($current == ';' && !$open) || $i == $end - 1)
+			if (($current === ';' && !$open) || $i == $end - 1)
 			{
 				if ($start <= $i)
 				{
@@ -838,7 +838,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 					 * When the last part of the old collation is not _ci we have a charset_collationType format,
 					 * something like utf8_bin. Therefore the new collation only has *two* parts.
 					 */
-					if ($ci != 'ci')
+					if ($ci !== 'ci')
 					{
 						$newCollation = $charset . '_' . $ci;
 					}
@@ -850,7 +850,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 					continue;
 				}
 
-				$null = $col->Null == 'YES' ? 'NULL' : 'NOT NULL';
+				$null = $col->Null === 'YES' ? 'NULL' : 'NOT NULL';
 				$default = is_null($col->Default) ? '' : "DEFAULT '" . $this->q($col->Default) . "'";
 				$columnMods[] = "MODIFY COLUMN `{$col->Field}` {$col->Type} CHARACTER SET $charset COLLATE $newCollation $null $default";
 			}
@@ -1379,7 +1379,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 			}
 
 			// Ignore any internal fields.
-			if ($k[0] == '_')
+			if ($k[0] === '_')
 			{
 				continue;
 			}
@@ -2009,7 +2009,7 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $sql{$l} == '\\')
+				while ($l >= 0 && $sql{$l} === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;

--- a/libraries/joomla/database/driver/oracle.php
+++ b/libraries/joomla/database/driver/oracle.php
@@ -592,7 +592,7 @@ class JDatabaseDriverOracle extends JDatabaseDriverPdo
 
 				$l = $k - 1;
 
-				while ($l >= 0 && $query{$l} == '\\')
+				while ($l >= 0 && $query{$l} === '\\')
 				{
 					$l--;
 					$escaped = !$escaped;

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -73,7 +73,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		// Get some basic values from the options.
 		$options['driver']  = 'mysql';
 
-		if (!isset($options['charset']) || $options['charset'] == 'utf8')
+		if (!isset($options['charset']) || $options['charset'] === 'utf8')
 		{
 			$options['charset'] = 'utf8mb4';
 		}
@@ -84,7 +84,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		 * us knowing the server version. Because of this chicken and egg issue, we _assume_ it's supported and we'll just
 		 * catch any problems at connection time.
 		 */
-		$this->utf8mb4 = ($options['charset'] == 'utf8mb4');
+		$this->utf8mb4 = ($options['charset'] === 'utf8mb4');
 
 		// Finalize initialisation.
 		parent::__construct($options);

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -909,11 +909,11 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			case 'boolean':
 				$val = 'NULL';
 
-				if ($field_value == 't')
+				if ($field_value === 't')
 				{
 					$val = 'TRUE';
 				}
-				elseif ($field_value == 'f')
+				elseif ($field_value === 'f')
 				{
 					$val = 'FALSE';
 				}
@@ -929,7 +929,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			case 'smallint':
 			case 'serial':
 			case 'numeric,':
-				$val = strlen($field_value) == 0 ? 'NULL' : $field_value;
+				$val = $field_value === '' ? 'NULL' : $field_value;
 				break;
 
 			case 'date':
@@ -1130,7 +1130,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 			}
 
 			// Ignore any internal fields or primary keys with value 0.
-			if (($k[0] == '_') || ($k == $key && (($v === 0) || ($v === '0'))))
+			if (($k[0] === '_') || ($k == $key && (($v === 0) || ($v === '0'))))
 			{
 				continue;
 			}
@@ -1448,7 +1448,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		foreach (get_object_vars($object) as $k => $v)
 		{
 			// Only process scalars that are not internal fields.
-			if (is_array($v) or is_object($v) or $k[0] == '_')
+			if (is_array($v) or is_object($v) or $k[0] === '_')
 			{
 				continue;
 			}

--- a/libraries/joomla/database/driver/sqlite.php
+++ b/libraries/joomla/database/driver/sqlite.php
@@ -253,11 +253,11 @@ class JDatabaseDriverSqlite extends JDatabaseDriverPdo
 				// Do some dirty translation to MySQL output.
 				// TODO: Come up with and implement a standard across databases.
 				$columns[$field->NAME] = (object) array(
-					'Field' => $field->NAME,
-					'Type' => $field->TYPE,
-					'Null' => ($field->NOTNULL == '1' ? 'NO' : 'YES'),
+					'Field'   => $field->NAME,
+					'Type'    => $field->TYPE,
+					'Null'    => $field->NOTNULL == '1' ? 'NO' : 'YES',
 					'Default' => $field->DFLT_VALUE,
-					'Key' => ($field->PK != '0' ? 'PRI' : ''),
+					'Key'     => $field->PK != '0' ? 'PRI' : '',
 				);
 			}
 		}

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -530,7 +530,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 				continue;
 			}
 
-			if ($k[0] == '_')
+			if ($k[0] === '_')
 			{
 				// Internal field
 				continue;

--- a/libraries/joomla/database/importer/mysqli.php
+++ b/libraries/joomla/database/importer/mysqli.php
@@ -145,8 +145,8 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 				$column = $oldFields[$fName];
 
 				// Test whether there is a change.
-				$change = ((string) $field['Type'] != $column->Type) || ((string) $field['Null'] != $column->Null)
-					|| ((string) $field['Default'] != $column->Default) || ((string) $field['Extra'] != $column->Extra);
+				$change = ((string) $field['Type'] !== $column->Type) || ((string) $field['Null'] !== $column->Null)
+					|| ((string) $field['Default'] !== $column->Default) || ((string) $field['Extra'] !== $column->Extra);
 
 				if ($change)
 				{
@@ -185,16 +185,16 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 				$oldCount = count($oldLookup[$name]);
 
 				// There is a key on this field in the old and new tables. Are they the same?
-				if ($newCount == $oldCount)
+				if ($newCount === $oldCount)
 				{
 					// Need to loop through each key and do a fine grained check.
 					for ($i = 0; $i < $newCount; $i++)
 					{
-						$same = (((string) $newLookup[$name][$i]['Non_unique'] == $oldLookup[$name][$i]->Non_unique)
-							&& ((string) $newLookup[$name][$i]['Column_name'] == $oldLookup[$name][$i]->Column_name)
-							&& ((string) $newLookup[$name][$i]['Seq_in_index'] == $oldLookup[$name][$i]->Seq_in_index)
-							&& ((string) $newLookup[$name][$i]['Collation'] == $oldLookup[$name][$i]->Collation)
-							&& ((string) $newLookup[$name][$i]['Index_type'] == $oldLookup[$name][$i]->Index_type));
+						$same = (((string) $newLookup[$name][$i]['Non_unique'] === $oldLookup[$name][$i]->Non_unique)
+							&& ((string) $newLookup[$name][$i]['Column_name'] === $oldLookup[$name][$i]->Column_name)
+							&& ((string) $newLookup[$name][$i]['Seq_in_index'] === $oldLookup[$name][$i]->Seq_in_index)
+							&& ((string) $newLookup[$name][$i]['Collation'] === $oldLookup[$name][$i]->Collation)
+							&& ((string) $newLookup[$name][$i]['Index_type'] === $oldLookup[$name][$i]->Index_type));
 
 						/*
 						Debug.
@@ -250,7 +250,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 		// Any keys left are orphans.
 		foreach ($oldLookup as $name => $keys)
 		{
-			if (strtoupper($name) == 'PRIMARY')
+			if (strtoupper($name) === 'PRIMARY')
 			{
 				$alters[] = $this->getDropPrimaryKeySql($table);
 			}
@@ -301,7 +301,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 
 		$query = $this->db->quoteName($fName) . ' ' . $fType;
 
-		if ($fNull == 'NO')
+		if ($fNull === 'NO')
 		{
 			if (in_array($fType, $blobs) || $fDefault === null)
 			{
@@ -419,7 +419,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 
 		$prefix = '';
 
-		if ($kName == 'PRIMARY')
+		if ($kName === 'PRIMARY')
 		{
 			$prefix = 'PRIMARY ';
 		}
@@ -431,7 +431,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 		$nColumns = count($columns);
 		$kColumns = array();
 
-		if ($nColumns == 1)
+		if ($nColumns === 1)
 		{
 			$kColumns[] = $this->db->quoteName($kColumn);
 		}
@@ -443,7 +443,7 @@ class JDatabaseImporterMysqli extends JDatabaseImporter
 			}
 		}
 
-		$query = $prefix . 'KEY ' . ($kName != 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
+		$query = $prefix . 'KEY ' . ($kName !== 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
 
 		return $query;
 	}

--- a/libraries/joomla/database/importer/pdomysql.php
+++ b/libraries/joomla/database/importer/pdomysql.php
@@ -84,8 +84,8 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 				$column = $oldFields[$fName];
 
 				// Test whether there is a change.
-				$change = ((string) $field['Type'] != $column->Type) || ((string) $field['Null'] != $column->Null)
-					|| ((string) $field['Default'] != $column->Default) || ((string) $field['Extra'] != $column->Extra);
+				$change = ((string) $field['Type'] !== $column->Type) || ((string) $field['Null'] !== $column->Null)
+					|| ((string) $field['Default'] !== $column->Default) || ((string) $field['Extra'] !== $column->Extra);
 
 				if ($change)
 				{
@@ -124,16 +124,16 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 				$oldCount = count($oldLookup[$name]);
 
 				// There is a key on this field in the old and new tables. Are they the same?
-				if ($newCount == $oldCount)
+				if ($newCount === $oldCount)
 				{
 					// Need to loop through each key and do a fine grained check.
 					for ($i = 0; $i < $newCount; $i++)
 					{
-						$same = (((string) $newLookup[$name][$i]['Non_unique'] == $oldLookup[$name][$i]->Non_unique)
-							&& ((string) $newLookup[$name][$i]['Column_name'] == $oldLookup[$name][$i]->Column_name)
-							&& ((string) $newLookup[$name][$i]['Seq_in_index'] == $oldLookup[$name][$i]->Seq_in_index)
-							&& ((string) $newLookup[$name][$i]['Collation'] == $oldLookup[$name][$i]->Collation)
-							&& ((string) $newLookup[$name][$i]['Index_type'] == $oldLookup[$name][$i]->Index_type));
+						$same = (((string) $newLookup[$name][$i]['Non_unique'] === $oldLookup[$name][$i]->Non_unique)
+							&& ((string) $newLookup[$name][$i]['Column_name'] === $oldLookup[$name][$i]->Column_name)
+							&& ((string) $newLookup[$name][$i]['Seq_in_index'] === $oldLookup[$name][$i]->Seq_in_index)
+							&& ((string) $newLookup[$name][$i]['Collation'] === $oldLookup[$name][$i]->Collation)
+							&& ((string) $newLookup[$name][$i]['Index_type'] === $oldLookup[$name][$i]->Index_type));
 
 						/*
 						Debug.
@@ -189,7 +189,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 		// Any keys left are orphans.
 		foreach ($oldLookup as $name => $keys)
 		{
-			if (strtoupper($name) == 'PRIMARY')
+			if (strtoupper($name) === 'PRIMARY')
 			{
 				$alters[] = $this->getDropPrimaryKeySql($table);
 			}
@@ -243,7 +243,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 
 		$sql = $this->db->quoteName($fName) . ' ' . $fType;
 
-		if ($fNull == 'NO')
+		if ($fNull === 'NO')
 		{
 			if (in_array($fType, $blobs) || $fDefault === null)
 			{
@@ -381,7 +381,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 		$kColumn    = (string) $columns[0]['Column_name'];
 		$prefix     = '';
 
-		if ($kName == 'PRIMARY')
+		if ($kName === 'PRIMARY')
 		{
 			$prefix = 'PRIMARY ';
 		}
@@ -393,7 +393,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 		$nColumns = count($columns);
 		$kColumns = array();
 
-		if ($nColumns == 1)
+		if ($nColumns === 1)
 		{
 			$kColumns[] = $this->db->quoteName($kColumn);
 		}
@@ -405,7 +405,7 @@ class JDatabaseImporterPdomysql extends JDatabaseImporter
 			}
 		}
 
-		$sql = $prefix . 'KEY ' . ($kName != 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
+		$sql = $prefix . 'KEY ' . ($kName !== 'PRIMARY' ? $this->db->quoteName($kName) : '') . ' (' . implode(',', $kColumns) . ')';
 
 		return $sql;
 	}

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -350,7 +350,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
-		$fDefault = (isset($field['Default']) && $field['Default'] !== 'NULL') ?
+		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL') ?
 						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 
@@ -404,7 +404,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
-		$fDefault = (isset($field['Default']) && $field['Default'] !== 'NULL') ?
+		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL') ?
 						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -114,11 +114,11 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 				}
 
 				// Test whether there is a change.
-				$change = ((string) $vSeq[0]['Type'] != $column->Type) || ((string) $vSeq[0]['Start_Value'] != $column->Start_Value)
-					|| ((string) $vSeq[0]['Min_Value'] != $column->Min_Value) || ((string) $vSeq[0]['Max_Value'] != $column->Max_Value)
-					|| ((string) $vSeq[0]['Increment'] != $column->Increment) || ((string) $vSeq[0]['Cycle_option'] != $column->Cycle_option)
-					|| ((string) $vSeq[0]['Table'] != $column->Table) || ((string) $vSeq[0]['Column'] != $column->Column)
-					|| ((string) $vSeq[0]['Schema'] != $column->Schema) || ((string) $vSeq[0]['Name'] != $column->Name);
+				$change = ((string) $vSeq[0]['Type'] !== $column->Type) || ((string) $vSeq[0]['Start_Value'] !== $column->Start_Value)
+					|| ((string) $vSeq[0]['Min_Value'] !== $column->Min_Value) || ((string) $vSeq[0]['Max_Value'] !== $column->Max_Value)
+					|| ((string) $vSeq[0]['Increment'] !== $column->Increment) || ((string) $vSeq[0]['Cycle_option'] !== $column->Cycle_option)
+					|| ((string) $vSeq[0]['Table'] !== $column->Table) || ((string) $vSeq[0]['Column'] !== $column->Column)
+					|| ((string) $vSeq[0]['Schema'] !== $column->Schema) || ((string) $vSeq[0]['Name'] !== $column->Name);
 
 				if ($change)
 				{
@@ -154,8 +154,8 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 				$column = $oldFields[$fName];
 
 				// Test whether there is a change.
-				$change = ((string) $field['Type'] != $column->Type) || ((string) $field['Null'] != $column->Null)
-					|| ((string) $field['Default'] != $column->Default);
+				$change = ((string) $field['Type'] !== $column->Type) || ((string) $field['Null'] !== $column->Null)
+					|| ((string) $field['Default'] !== $column->Default);
 
 				if ($change)
 				{
@@ -200,7 +200,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 					for ($i = 0; $i < $newCount; $i++)
 					{
 						// Check only query field -> different query means different index
-						$same = ((string) $newLookup[$name][$i]['Query'] == $oldLookup[$name][$i]->Query);
+						$same = ((string) $newLookup[$name][$i]['Query'] === $oldLookup[$name][$i]->Query);
 
 						if (!$same)
 						{
@@ -234,7 +234,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		// Any keys left are orphans.
 		foreach ($oldLookup as $name => $keys)
 		{
-			if ($oldLookup[$name][0]->is_primary == 'TRUE')
+			if ($oldLookup[$name][0]->is_primary === 'TRUE')
 			{
 				$alters[] = $this->getDropPrimaryKeySql($table, $oldLookup[$name][0]->Index);
 			}
@@ -285,7 +285,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		return 'CREATE SEQUENCE ' . (string) $field['Name'] .
 			' INCREMENT BY ' . (string) $field['Increment'] . ' MINVALUE ' . $field['Min_Value'] .
 			' MAXVALUE ' . (string) $field['Max_Value'] . ' START ' . (string) $field['Start_Value'] .
-			(((string) $field['Cycle_option'] == 'NO') ? ' NO' : '') . ' CYCLE' .
+			(((string) $field['Cycle_option'] === 'NO') ? ' NO' : '') . ' CYCLE' .
 			' OWNED BY ' . $this->db->quoteName((string) $field['Schema'] . '.' . (string) $field['Table'] . '.' . (string) $field['Column']);
 	}
 
@@ -350,13 +350,13 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
-		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL') ?
+		$fDefault = (isset($field['Default']) && $field['Default'] !== 'NULL') ?
 						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 
 		$query = ' TYPE ' . $fType;
 
-		if ($fNull == 'NO')
+		if ($fNull === 'NO')
 		{
 			if (in_array($fType, $blobs) || $fDefault === null)
 			{
@@ -404,7 +404,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		$fName = (string) $field['Field'];
 		$fType = (string) $field['Type'];
 		$fNull = (string) $field['Null'];
-		$fDefault = (isset($field['Default']) && $field['Default'] != 'NULL') ?
+		$fDefault = (isset($field['Default']) && $field['Default'] !== 'NULL') ?
 						preg_match('/^[0-9]$/', $field['Default']) ? $field['Default'] : $this->db->quote((string) $field['Default'])
 					: null;
 
@@ -417,7 +417,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		{
 			$query = $this->db->quoteName($fName) . ' ' . $fType;
 
-			if ($fNull == 'NO')
+			if ($fNull === 'NO')
 			{
 				if (in_array($fType, $blobs) || $fDefault === null)
 				{

--- a/libraries/joomla/database/importer/postgresql.php
+++ b/libraries/joomla/database/importer/postgresql.php
@@ -234,7 +234,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 		// Any keys left are orphans.
 		foreach ($oldLookup as $name => $keys)
 		{
-			if ($oldLookup[$name][0]->is_primary === 'TRUE')
+			if ($oldLookup[$name][0]->is_primary == 'TRUE')
 			{
 				$alters[] = $this->getDropPrimaryKeySql($table, $oldLookup[$name][0]->Index);
 			}
@@ -358,7 +358,7 @@ class JDatabaseImporterPostgresql extends JDatabaseImporter
 
 		if ($fNull === 'NO')
 		{
-			if (in_array($fType, $blobs) || $fDefault === null)
+			if (in_array($fType, $blobs, true) || $fDefault === null)
 			{
 				$query .= ",\nALTER COLUMN " . $this->db->quoteName($fName) . ' SET NOT NULL' .
 						",\nALTER COLUMN " . $this->db->quoteName($fName) . ' DROP DEFAULT';

--- a/libraries/joomla/database/query/element.php
+++ b/libraries/joomla/database/query/element.php
@@ -65,7 +65,7 @@ class JDatabaseQueryElement
 	 */
 	public function __toString()
 	{
-		if (substr($this->name, -2) == '()')
+		if (substr($this->name, -2) === '()')
 		{
 			return PHP_EOL . substr($this->name, 0, -2) . '(' . implode($this->glue, $this->elements) . ')';
 		}

--- a/libraries/joomla/database/query/postgresql.php
+++ b/libraries/joomla/database/query/postgresql.php
@@ -700,7 +700,7 @@ class JDatabaseQueryPostgresql extends JDatabaseQuery implements JDatabaseQueryL
 	 */
 	public function dateAdd($date, $interval, $datePart)
 	{
-		if (substr($interval, 0, 1) != '-')
+		if (substr($interval, 0, 1) !== '-')
 		{
 			return "timestamp '" . $date . "' + interval '" . $interval . " " . $datePart . "'";
 		}

--- a/libraries/joomla/database/query/sqlite.php
+++ b/libraries/joomla/database/query/sqlite.php
@@ -243,13 +243,13 @@ class JDatabaseQuerySqlite extends JDatabaseQueryPdo implements JDatabaseQueryPr
 	public function dateAdd($date, $interval, $datePart)
 	{
 		// SQLite does not support microseconds as a separate unit. Convert the interval to seconds
-		if (strcasecmp($datePart, 'microseconds') == 0)
+		if (strcasecmp($datePart, 'microseconds') === 0)
 		{
 			$interval = .001 * $interval;
 			$datePart = 'seconds';
 		}
 
-		if (substr($interval, 0, 1) != '-')
+		if (substr($interval, 0, 1) !== '-')
 		{
 			return "datetime('" . $date . "', '+" . $interval . " " . $datePart . "')";
 		}

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -451,9 +451,9 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			$lenEndString = strlen($endString);
 			$testEnd      = substr($string, $i, $lenEndString);
 
-			if ($current == '[' || $current == '"' || $current == "'" || $current2 == '--'
-				|| ($current2 == '/*') || ($current == '#' && $current3 != '#__')
-				|| ($lenEndString && $testEnd == $endString))
+			if ($current === '[' || $current === '"' || $current === "'" || $current2 === '--'
+				|| ($current2 === '/*') || ($current === '#' && $current3 !== '#__')
+				|| ($lenEndString && $testEnd === $endString))
 			{
 				if ($open)
 				{
@@ -470,12 +470,12 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 							$start = $i + 1;
 							$comment = false;
 						}
-						elseif ($current == "'" || $current == ']' || $current == '"')
+						elseif ($current === "'" || $current === ']' || $current === '"')
 						{
 							// Check for escaped quote like '', ]] or ""
 							$n = 1;
 
-							while ($i + $n < $length && $string[$i + $n] == $current)
+							while ($i + $n < $length && $string[$i + $n] === $current)
 							{
 								$n++;
 							}
@@ -503,17 +503,17 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				{
 					$open = true;
 
-					if ($current == '#' || $current2 == '--')
+					if ($current === '#' || $current2 === '--')
 					{
 						$endString = "\n";
 						$comment = true;
 					}
-					elseif ($current2 == '/*')
+					elseif ($current2 === '/*')
 					{
 						$endString = '*/';
 						$comment = true;
 					}
-					elseif ($current == '[')
+					elseif ($current === '[')
 					{
 						$endString = ']';
 					}
@@ -533,17 +533,17 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			}
 			elseif (!$open)
 			{
-				if ($current == '(')
+				if ($current === '(')
 				{
 					$openC++;
 					$previous = $current;
 				}
-				elseif ($current == ')')
+				elseif ($current === ')')
 				{
 					$openC--;
 					$previous = $current;
 				}
-				elseif ($current == '.')
+				elseif ($current === '.')
 				{
 					if ($i === $start && $colIdx > 0 && !isset($column[$colIdx]))
 					{
@@ -608,7 +608,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				}
 			}
 
-			if (($current == ',' && !$open && $openC == 0) || $i == $length - 1)
+			if (($current === ',' && !$open && $openC === 0) || $i === $length - 1)
 			{
 				if ($start < $i && !$comment)
 				{
@@ -659,7 +659,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 		{
 			$size = count($column);
 
-			if ($size == 0)
+			if ($size === 0)
 			{
 				continue;
 			}
@@ -682,17 +682,17 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 			$length   = strlen($lastWord);
 			$lastChar = $lastWord[$length - 1];
 
-			if ($lastChar == '*')
+			if ($lastChar === '*')
 			{
 				// Skip on wildcard
 				continue;
 			}
 
-			if ($lastChar == ')'
-				|| ($size == 1 && $lastChar == "'")
-				|| $lastWord[0] == '@'
-				|| $lastWord == 'NULL'
-				|| $lastWord == 'END'
+			if ($lastChar === ')'
+				|| ($size == 1 && $lastChar === "'")
+				|| $lastWord[0] === '@'
+				|| $lastWord === 'NULL'
+				|| $lastWord === 'END'
 				|| is_numeric($lastWord))
 			{
 				/* Ends with:
@@ -708,7 +708,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				continue;
 			}
 
-			if ($size == 1)
+			if ($size === 1)
 			{
 				continue;
 			}
@@ -720,7 +720,7 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 				|| ($size > 2 && $lastChar2 === '.' && isset($operators[substr($column[$size - 3], -1)])))
 			{
 				// Ignore plus signs if column start with them
-				if ($size != 2 || ltrim($column[0], '+') !== '' || $column[1][0] === "'")
+				if ($size !== 2 || ltrim($column[0], '+') !== '' || $column[1][0] === "'")
 				{
 					// If operator exists before last word then alias is required for subquery
 					$columns[$i][] = 'AS';

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -289,6 +289,10 @@ class JDate extends DateTime
 		}
 
 		// If the returned time should not be local use GMT.
+
+		// In PR 16714 I tried to make the two $local == false comparisons type-safe, as it is supposed to be a boolean.
+		// Unfortunately the Travis Tests were failing.
+		// todo: Check if the tests do not provide the correct boolean parameter, but maybe pass null.
 		if ($local == false && !empty(self::$gmt))
 		{
 			parent::setTimezone(self::$gmt);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -290,9 +290,10 @@ class JDate extends DateTime
 
 		// If the returned time should not be local use GMT.
 
-		// In PR 16714 I tried to make the two $local == false comparisons type-safe, as it is supposed to be a boolean.
-		// Unfortunately the Travis Tests were failing.
-		// todo: Check if the tests do not provide the correct boolean parameter, but maybe pass null.
+		/* In PR 16714 I tried to make the two $local == false comparisons type-safe, as it is supposed to be a boolean.
+		 * Unfortunately the Travis Tests were failing.
+		 */
+		// Todo: Check if the tests do not provide the correct boolean parameter, but maybe pass null.
 		if ($local == false && !empty(self::$gmt))
 		{
 			parent::setTimezone(self::$gmt);

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -289,7 +289,7 @@ class JDate extends DateTime
 		}
 
 		// If the returned time should not be local use GMT.
-		if ($local == false && !empty(self::$gmt))
+		if ($local === false && !empty(self::$gmt))
 		{
 			parent::setTimezone(self::$gmt);
 		}
@@ -321,7 +321,7 @@ class JDate extends DateTime
 			}
 		}
 
-		if ($local == false && !empty($this->tz))
+		if ($local === false && !empty($this->tz))
 		{
 			parent::setTimezone($this->tz);
 		}

--- a/libraries/joomla/date/date.php
+++ b/libraries/joomla/date/date.php
@@ -289,7 +289,7 @@ class JDate extends DateTime
 		}
 
 		// If the returned time should not be local use GMT.
-		if ($local === false && !empty(self::$gmt))
+		if ($local == false && !empty(self::$gmt))
 		{
 			parent::setTimezone(self::$gmt);
 		}
@@ -321,7 +321,7 @@ class JDate extends DateTime
 			}
 		}
 
-		if ($local === false && !empty($this->tz))
+		if ($local == false && !empty($this->tz))
 		{
 			parent::setTimezone($this->tz);
 		}

--- a/libraries/joomla/document/document.php
+++ b/libraries/joomla/document/document.php
@@ -394,11 +394,11 @@ class JDocument
 			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
 
-		if ($name == 'generator')
+		if ($name === 'generator')
 		{
 			$result = $this->getGenerator();
 		}
-		elseif ($name == 'description')
+		elseif ($name === 'description')
 		{
 			$result = $this->getDescription();
 		}
@@ -429,11 +429,11 @@ class JDocument
 			$attribute = $attribute == true ? 'http-equiv' : 'name';
 		}
 
-		if ($name == 'generator')
+		if ($name === 'generator')
 		{
 			$this->setGenerator($content);
 		}
-		elseif ($name == 'description')
+		elseif ($name === 'description')
 		{
 			$this->setDescription($content);
 		}

--- a/libraries/joomla/document/html.php
+++ b/libraries/joomla/document/html.php
@@ -284,7 +284,7 @@ class JDocumentHtml extends JDocument
 		{
 			foreach ($data['metaTags'] as $type1 => $data1)
 			{
-				$booldog = $type1 == 'http-equiv' ? true : false;
+				$booldog = $type1 === 'http-equiv' ? true : false;
 
 				foreach ($data1 as $name2 => $data2)
 				{
@@ -454,7 +454,7 @@ class JDocumentHtml extends JDocument
 
 		$renderer = $this->loadRenderer($type);
 
-		if ($this->_caching == true && $type == 'modules')
+		if ($this->_caching == true && $type === 'modules')
 		{
 			$cache = JFactory::getCache('com_modules', '');
 			$hash = md5(serialize(array($name, $attribs, null, $renderer)));
@@ -741,7 +741,7 @@ class JDocumentHtml extends JDocument
 				$name = isset($attribs['name']) ? $attribs['name'] : null;
 
 				// Separate buffers to be executed first and last
-				if ($type == 'module' || $type == 'modules')
+				if ($type === 'module' || $type === 'modules')
 				{
 					$template_tags_first[$matches[0][$i]] = array('type' => $type, 'name' => $name, 'attribs' => $attribs);
 				}

--- a/libraries/joomla/document/json.php
+++ b/libraries/joomla/document/json.php
@@ -69,7 +69,7 @@ class JDocumentJson extends JDocument
 
 		$app->allowCache(false);
 
-		if ($this->_mime == 'application/json')
+		if ($this->_mime === 'application/json')
 		{
 			// Browser other than Internet Explorer < 10
 			$app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);

--- a/libraries/joomla/document/opensearch.php
+++ b/libraries/joomla/document/opensearch.php
@@ -82,13 +82,13 @@ class JDocumentOpensearch extends JDocument
 				$path = str_replace('\\', '/', $path);
 				$favicon = new JOpenSearchImage;
 
-				if ($path == '')
+				if ($path === '')
 				{
 					$favicon->data = JUri::base() . 'favicon.ico';
 				}
 				else
 				{
-					if ($path[0] == '/')
+					if ($path[0] === '/')
 					{
 						$path = substr($path, 1);
 					}
@@ -161,7 +161,7 @@ class JDocumentOpensearch extends JDocument
 			$elUrl->setAttribute('type', $url->type);
 
 			// Results is the default value so we don't need to add it
-			if ($url->rel != 'results')
+			if ($url->rel !== 'results')
 			{
 				$elUrl->setAttribute('rel', $url->rel);
 			}

--- a/libraries/joomla/document/renderer/feed/atom.php
+++ b/libraries/joomla/document/renderer/feed/atom.php
@@ -72,7 +72,7 @@ class JDocumentRendererFeedAtom extends JDocumentRenderer
 
 		$feed = "<feed xmlns=\"http://www.w3.org/2005/Atom\" ";
 
-		if ($data->getLanguage() != '')
+		if ($data->getLanguage() !== '')
 		{
 			$feed .= " xml:lang=\"" . $data->getLanguage() . "\"";
 		}
@@ -100,12 +100,12 @@ class JDocumentRendererFeedAtom extends JDocumentRenderer
 		$feed .= "	<id>" . str_replace(' ', '%20', $data->getBase()) . "</id>\n";
 		$feed .= "	<updated>" . htmlspecialchars($now->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
 
-		if ($data->editor != '')
+		if ($data->editor !== '')
 		{
 			$feed .= "	<author>\n";
 			$feed .= "		<name>" . $data->editor . "</name>\n";
 
-			if ($data->editorEmail != '')
+			if ($data->editorEmail !== '')
 			{
 				$feed .= "		<email>" . htmlspecialchars($data->editorEmail, ENT_COMPAT, 'UTF-8') . "</email>\n";
 			}
@@ -136,7 +136,7 @@ class JDocumentRendererFeedAtom extends JDocumentRenderer
 			$feed .= "		<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
 			$feed .= "		<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . $itemlink . "\"/>\n";
 
-			if ($data->items[$i]->date == '')
+			if ($data->items[$i]->date === '')
 			{
 				$data->items[$i]->date = $now->toUnix();
 			}
@@ -157,7 +157,7 @@ class JDocumentRendererFeedAtom extends JDocumentRenderer
 
 			$feed .= "		<id>" . $itemGuid . "</id>\n";
 
-			if ($data->items[$i]->author != '')
+			if ($data->items[$i]->author !== '')
 			{
 				$feed .= "		<author>\n";
 				$feed .= "			<name>" . htmlspecialchars($data->items[$i]->author, ENT_COMPAT, 'UTF-8') . "</name>\n";

--- a/libraries/joomla/document/renderer/html/head.php
+++ b/libraries/joomla/document/renderer/html/head.php
@@ -88,11 +88,11 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 		{
 			foreach ($tag as $name => $content)
 			{
-				if ($type == 'http-equiv' && !($document->isHtml5() && $name == 'content-type'))
+				if ($type === 'http-equiv' && !($document->isHtml5() && $name === 'content-type'))
 				{
 					$buffer .= $tab . '<meta http-equiv="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
 				}
-				elseif ($type != 'http-equiv' && !empty($content))
+				elseif ($type !== 'http-equiv' && !empty($content))
 				{
 					$buffer .= $tab . '<meta ' . $type . '="' . $name . '" content="' . htmlspecialchars($content, ENT_COMPAT, 'UTF-8') . '" />' . $lnEnd;
 				}
@@ -212,7 +212,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= '>' . $lnEnd;
 
 			// This is for full XHTML support.
-			if ($document->_mime != 'text/html')
+			if ($document->_mime !== 'text/html')
 			{
 				$buffer .= $tab . $tab . '/*<![CDATA[*/' . $lnEnd;
 			}
@@ -220,7 +220,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= $content . $lnEnd;
 
 			// See above note
-			if ($document->_mime != 'text/html')
+			if ($document->_mime !== 'text/html')
 			{
 				$buffer .= $tab . $tab . '/*]]>*/' . $lnEnd;
 			}
@@ -337,7 +337,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= '>' . $lnEnd;
 
 			// This is for full XHTML support.
-			if ($document->_mime != 'text/html')
+			if ($document->_mime !== 'text/html')
 			{
 				$buffer .= $tab . $tab . '//<![CDATA[' . $lnEnd;
 			}
@@ -345,7 +345,7 @@ class JDocumentRendererHtmlHead extends JDocumentRenderer
 			$buffer .= $content . $lnEnd;
 
 			// See above note
-			if ($document->_mime != 'text/html')
+			if ($document->_mime !== 'text/html')
 			{
 				$buffer .= $tab . $tab . '//]]>' . $lnEnd;
 			}

--- a/libraries/joomla/document/renderer/html/module.php
+++ b/libraries/joomla/document/renderer/html/module.php
@@ -78,7 +78,7 @@ class JDocumentRendererHtmlModule extends JDocumentRenderer
 		// Default for compatibility purposes. Set cachemode parameter or use JModuleHelper::moduleCache from within the module instead
 		$cachemode = $params->get('cachemode', 'oldstatic');
 
-		if ($params->get('cache', 0) == 1 && JFactory::getConfig()->get('caching') >= 1 && $cachemode != 'id' && $cachemode != 'safeuri')
+		if ($params->get('cache', 0) == 1 && JFactory::getConfig()->get('caching') >= 1 && $cachemode !== 'id' && $cachemode !== 'safeuri')
 		{
 			// Default to itemid creating method and workarounds on
 			$cacheparams = new stdClass;

--- a/libraries/joomla/document/renderer/html/modules.php
+++ b/libraries/joomla/document/renderer/html/modules.php
@@ -41,7 +41,7 @@ class JDocumentRendererHtmlModules extends JDocumentRenderer
 		{
 			$moduleHtml = $renderer->render($mod, $params, $content);
 
-			if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
+			if ($frontediting && trim($moduleHtml) !== '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id))
 			{
 				$displayData = array('moduleHtml' => &$moduleHtml, 'module' => $mod, 'position' => $position, 'menusediting' => $menusEditing);
 				JLayoutHelper::render('joomla.edit.frontediting_modules', $displayData);

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -264,7 +264,7 @@ class JBrowser
 
 				/* Due to changes in Opera UA, we need to check Version/xx.yy,
 				 * but only if version is > 9.80. See: http://dev.opera.com/articles/view/opera-ua-string-changes/ */
-				if ($this->majorVersion == 9 && $this->minorVersion >= 80)
+				if ($this->majorVersion === 9 && $this->minorVersion >= 80)
 				{
 					$this->identifyBrowserVersion();
 				}
@@ -591,14 +591,14 @@ class JBrowser
 			{
 				$wildcard_match = true;
 
-				if ($type != 'image')
+				if ($type !== 'image')
 				{
 					return true;
 				}
 			}
 
 			// Deal with Mozilla pjpeg/jpeg issue
-			if ($this->isBrowser('mozilla') && ($mimetype == 'image/pjpeg') && (strpos($this->accept, 'image/jpeg') !== false))
+			if ($this->isBrowser('mozilla') && ($mimetype === 'image/pjpeg') && (strpos($this->accept, 'image/jpeg') !== false))
 			{
 				return true;
 			}
@@ -609,7 +609,7 @@ class JBrowser
 			}
 		}
 
-		if ($type != 'image')
+		if ($type !== 'image')
 		{
 			return false;
 		}
@@ -679,6 +679,6 @@ class JBrowser
 			'deprecated'
 		);
 
-		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on')) || getenv('SSL_PROTOCOL_VERSION');
+		return (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] === 'on')) || getenv('SSL_PROTOCOL_VERSION');
 	}
 }

--- a/libraries/joomla/event/dispatcher.php
+++ b/libraries/joomla/event/dispatcher.php
@@ -195,7 +195,7 @@ class JEventDispatcher extends JObject
 			// Make sure we haven't already attached this array as an observer
 			foreach ($this->_observers as $check)
 			{
-				if (is_array($check) && $check['event'] == $observer['event'] && $check['handler'] == $observer['handler'])
+				if (is_array($check) && $check['event'] === $observer['event'] && $check['handler'] === $observer['handler'])
 				{
 					return;
 				}


### PR DESCRIPTION
### Summary of Changes

Implemented type-safe comparisons in the `libraries / joomla` directory.
For easier reviewing, there is a total of five parts, that cover the `libraries / joomla` directory

This is part 2, which covers directories `database` until  `event`


### Testing Instructions

**Code review only**, as those changes should not affect behavior.
Despite the quantity of the changes, it should be fairly easy to review.

Attention to code reviewers:
In order to prevent code-review-fatigue, I only did type safe comparisons, **without applying**:
- formatting
- removal of unnecessary parentheses
- other non-related changes

Please **only** review the correctness of the specific changes, without pointing out any possible formatting issues (unless corrupted by this PR), removal of parentheses and other non-related changes. This will help get this PR reviewed and merged quickly.
If you should find other prospects for type safe comparison in those folders please note them in a review.

Thank you