### PR TITLE
[ libraries / joomla] Type-safe comparisons #3

### DIFF
--- a/libraries/joomla/facebook/album.php
+++ b/libraries/joomla/facebook/album.php
@@ -187,7 +187,7 @@ class JFacebookAlbum extends JFacebookObject
 	{
 		$extra_fields = '';
 
-		if ($redirect == false)
+		if ($redirect === false)
 		{
 			$extra_fields = '?redirect=false';
 		}

--- a/libraries/joomla/facebook/event.php
+++ b/libraries/joomla/facebook/event.php
@@ -413,7 +413,7 @@ class JFacebookEvent extends JFacebookObject
 	{
 		$extra_fields = '';
 
-		if ($redirect == false)
+		if ($redirect === false)
 		{
 			$extra_fields = '?redirect=false';
 		}

--- a/libraries/joomla/facebook/facebook.php
+++ b/libraries/joomla/facebook/facebook.php
@@ -144,7 +144,7 @@ class JFacebook
 
 		if (class_exists($class))
 		{
-			if (false == isset($this->$name))
+			if (isset($this->$name) === false)
 			{
 				$this->$name = new $class($this->options, $this->client, $this->oauth);
 			}

--- a/libraries/joomla/facebook/group.php
+++ b/libraries/joomla/facebook/group.php
@@ -109,7 +109,7 @@ class JFacebookGroup extends JFacebookObject
 	 *
 	 * @param   string  $group    The group id.
 	 * @param   string  $link     Link URL.
-	 * @param   string   $message  Link message.
+	 * @param   string  $message  Link message.
 	 *
 	 * @return  mixed   The decoded JSON response or false if the client is not authenticated.
 	 *

--- a/libraries/joomla/facebook/group.php
+++ b/libraries/joomla/facebook/group.php
@@ -109,7 +109,7 @@ class JFacebookGroup extends JFacebookObject
 	 *
 	 * @param   string  $group    The group id.
 	 * @param   string  $link     Link URL.
-	 * @param   strin   $message  Link message.
+	 * @param   string   $message  Link message.
 	 *
 	 * @return  mixed   The decoded JSON response or false if the client is not authenticated.
 	 *

--- a/libraries/joomla/facebook/photo.php
+++ b/libraries/joomla/facebook/photo.php
@@ -235,7 +235,7 @@ class JFacebookPhoto extends JFacebookObject
 	{
 		$extra_fields = '';
 
-		if ($redirect == false)
+		if ($redirect === false)
 		{
 			$extra_fields = '?redirect=false';
 		}

--- a/libraries/joomla/facebook/user.php
+++ b/libraries/joomla/facebook/user.php
@@ -126,7 +126,7 @@ class JFacebookUser extends JFacebookObject
 			$extra_fields = '?filter=' . $filter;
 		}
 
-		if ($location == true)
+		if ($location === true)
 		{
 			$extra_fields .= (strpos($extra_fields, '?') === false) ? '?with=location' : '&with=location';
 		}
@@ -181,7 +181,7 @@ class JFacebookUser extends JFacebookObject
 	{
 		$extra_fields = '';
 
-		if ($redirect == false)
+		if ($redirect === false)
 		{
 			$extra_fields = '?redirect=false';
 		}
@@ -226,7 +226,7 @@ class JFacebookUser extends JFacebookObject
 	 */
 	public function getNotifications($user, $read = null, $limit = 0, $offset = 0, $until = null, $since = null)
 	{
-		if ($read == true)
+		if ($read === true)
 		{
 			$read = '?include_read=1';
 		}
@@ -538,7 +538,7 @@ class JFacebookUser extends JFacebookObject
 	 *
 	 * @param   mixed   $user     Either an integer containing the user ID or a string containing the username.
 	 * @param   string  $link     Link URL.
-	 * @param   strin   $message  Link message.
+	 * @param   string   $message  Link message.
 	 *
 	 * @return  mixed   The decoded JSON response or false if the client is not authenticated.
 	 *

--- a/libraries/joomla/facebook/user.php
+++ b/libraries/joomla/facebook/user.php
@@ -538,7 +538,7 @@ class JFacebookUser extends JFacebookObject
 	 *
 	 * @param   mixed   $user     Either an integer containing the user ID or a string containing the username.
 	 * @param   string  $link     Link URL.
-	 * @param   string   $message  Link message.
+	 * @param   string  $message  Link message.
 	 *
 	 * @return  mixed   The decoded JSON response or false if the client is not authenticated.
 	 *

--- a/libraries/joomla/feed/entry.php
+++ b/libraries/joomla/feed/entry.php
@@ -69,25 +69,25 @@ class JFeedEntry
 	public function __set($name, $value)
 	{
 		// Ensure that setting a date always sets a JDate instance.
-		if ((($name == 'updatedDate') || ($name == 'publishedDate')) && !($value instanceof JDate))
+		if ((($name === 'updatedDate') || ($name === 'publishedDate')) && !($value instanceof JDate))
 		{
 			$value = new JDate($value);
 		}
 
 		// Validate that any authors that are set are instances of JFeedPerson or null.
-		if (($name == 'author') && (!($value instanceof JFeedPerson) || ($value === null)))
+		if (($name === 'author') && (!($value instanceof JFeedPerson) || ($value === null)))
 		{
 			throw new InvalidArgumentException('JFeedEntry "author" must be of type JFeedPerson. ' . gettype($value) . 'given.');
 		}
 
 		// Validate that any sources that are set are instances of JFeed or null.
-		if (($name == 'source') && (!($value instanceof JFeed) || ($value === null)))
+		if (($name === 'source') && (!($value instanceof JFeed) || ($value === null)))
 		{
 			throw new InvalidArgumentException('JFeedEntry "source" must be of type JFeed. ' . gettype($value) . 'given.');
 		}
 
 		// Disallow setting categories, contributors, or links directly.
-		if (($name == 'categories') || ($name == 'contributors') || ($name == 'links'))
+		if (($name === 'categories') || ($name === 'contributors') || ($name === 'links'))
 		{
 			throw new InvalidArgumentException('Cannot directly set JFeedEntry property "' . $name . '".');
 		}

--- a/libraries/joomla/feed/factory.php
+++ b/libraries/joomla/feed/factory.php
@@ -50,7 +50,7 @@ class JFeedFactory
 			$connector 	= JHttpFactory::getHttp($options);
 			$feed 		= $connector->get($uri);
 
-			if ($feed->code != 200)
+			if ($feed->code !== 200)
 			{
 				throw new RuntimeException('Unable to open the feed.');
 			}

--- a/libraries/joomla/feed/feed.php
+++ b/libraries/joomla/feed/feed.php
@@ -74,19 +74,19 @@ class JFeed implements ArrayAccess, Countable
 	public function __set($name, $value)
 	{
 		// Ensure that setting a date always sets a JDate instance.
-		if ((($name == 'updatedDate') || ($name == 'publishedDate')) && !($value instanceof JDate))
+		if ((($name === 'updatedDate') || ($name === 'publishedDate')) && !($value instanceof JDate))
 		{
 			$value = new JDate($value);
 		}
 
 		// Validate that any authors that are set are instances of JFeedPerson or null.
-		if (($name == 'author') && (!($value instanceof JFeedPerson) || ($value === null)))
+		if (($name === 'author') && (!($value instanceof JFeedPerson) || ($value === null)))
 		{
 			throw new InvalidArgumentException('JFeed "author" must be of type JFeedPerson. ' . gettype($value) . 'given.');
 		}
 
 		// Disallow setting categories or contributors directly.
-		if (($name == 'categories') || ($name == 'contributors'))
+		if (($name === 'categories') || ($name === 'contributors'))
 		{
 			throw new InvalidArgumentException('Cannot directly set JFeed property "' . $name . '".');
 		}

--- a/libraries/joomla/feed/parser.php
+++ b/libraries/joomla/feed/parser.php
@@ -151,7 +151,7 @@ abstract class JFeedParser
 		$method = 'handle' . ucfirst($el->getName());
 
 		// If we are dealing with an item then it is feed entry time.
-		if ($el->getName() == $this->entryElementName)
+		if ($el->getName() === $this->entryElementName)
 		{
 			// Create a new feed entry for the item.
 			$entry = new JFeedEntry;

--- a/libraries/joomla/feed/parser/atom.php
+++ b/libraries/joomla/feed/parser/atom.php
@@ -178,7 +178,7 @@ class JFeedParserAtom extends JFeedParser
 	protected function initialise()
 	{
 		// Read the version attribute.
-		$this->version = ($this->stream->getAttribute('version') == '0.3') ? '0.3' : '1.0';
+		$this->version = ($this->stream->getAttribute('version') === '0.3') ? '0.3' : '1.0';
 
 		// We want to move forward to the first element after the root element.
 		$this->moveToNextElement();

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -82,7 +82,7 @@ abstract class JFolder
 				switch (filetype($sfid))
 				{
 					case 'dir':
-						if ($file != '.' && $file != '..')
+						if ($file !== '.' && $file !== '..')
 						{
 							$ret = self::copy($sfid, $dfid, null, $force);
 
@@ -120,7 +120,7 @@ abstract class JFolder
 				switch (filetype($sfid))
 				{
 					case 'dir':
-						if ($file != '.' && $file != '..')
+						if ($file !== '.' && $file !== '..')
 						{
 							$ret = self::copy($sfid, $dfid, null, $force, $use_streams);
 
@@ -612,7 +612,7 @@ abstract class JFolder
 
 		while (($file = readdir($handle)) !== false)
 		{
-			if ($file != '.' && $file != '..' && !in_array($file, $exclude)
+			if ($file !== '.' && $file !== '..' && !in_array($file, $exclude)
 				&& (empty($excludefilter_string) || !preg_match($excludefilter_string, $file)))
 			{
 				// Compute the fullpath

--- a/libraries/joomla/filesystem/helper.php
+++ b/libraries/joomla/filesystem/helper.php
@@ -32,12 +32,12 @@ class JFilesystemHelper
 	{
 		$sch = parse_url($url, PHP_URL_SCHEME);
 
-		if (($sch != 'http') && ($sch != 'https') && ($sch != 'ftp') && ($sch != 'ftps'))
+		if (($sch !== 'http') && ($sch !== 'https') && ($sch !== 'ftp') && ($sch !== 'ftps'))
 		{
 			return false;
 		}
 
-		if (($sch == 'http') || ($sch == 'https'))
+		if (($sch === 'http') || ($sch === 'https'))
 		{
 			$headers = get_headers($url, 1);
 
@@ -49,7 +49,7 @@ class JFilesystemHelper
 			return $headers['Content-Length'];
 		}
 
-		if (($sch == 'ftp') || ($sch == 'ftps'))
+		if (($sch === 'ftp') || ($sch === 'ftps'))
 		{
 			$server = parse_url($url, PHP_URL_HOST);
 			$port = parse_url($url, PHP_URL_PORT);
@@ -103,7 +103,7 @@ class JFilesystemHelper
 			$ftpsize = ftp_size($ftpid, $path);
 			ftp_close($ftpid);
 
-			if ($ftpsize == -1)
+			if ($ftpsize === -1)
 			{
 				return false;
 			}
@@ -127,7 +127,7 @@ class JFilesystemHelper
 	{
 		$sch = parse_url($url, PHP_URL_SCHEME);
 
-		if (($sch != 'ftp') && ($sch != 'ftps'))
+		if (($sch !== 'ftp') && ($sch !== 'ftps'))
 		{
 			return false;
 		}
@@ -310,7 +310,7 @@ class JFilesystemHelper
 		static $max_size = false;
 		static $output_type = true;
 
-		if ($max_size === false || $output_type != $unit_output)
+		if ($max_size === false || $output_type !== $unit_output)
 		{
 			$max_size   = self::parseSize(ini_get('post_max_size'));
 			$upload_max = self::parseSize(ini_get('upload_max_filesize'));

--- a/libraries/joomla/filesystem/patcher.php
+++ b/libraries/joomla/filesystem/patcher.php
@@ -406,7 +406,7 @@ class JFilesystemPatcher
 				$src_left--;
 				$dst_left--;
 			}
-			elseif ($line[0] == '-')
+			elseif ($line[0] === '-')
 			{
 				if ($src_left == 0)
 				{
@@ -416,7 +416,7 @@ class JFilesystemPatcher
 				$source[] = substr($line, 1);
 				$src_left--;
 			}
-			elseif ($line[0] == '+')
+			elseif ($line[0] === '+')
 			{
 				if ($dst_left == 0)
 				{
@@ -426,7 +426,7 @@ class JFilesystemPatcher
 				$destin[] = substr($line, 1);
 				$dst_left--;
 			}
-			elseif ($line != '\\ No newline at end of file')
+			elseif ($line !== '\\ No newline at end of file')
 			{
 				$line = substr($line, 1);
 				$source[] = $line;

--- a/libraries/joomla/filesystem/path.php
+++ b/libraries/joomla/filesystem/path.php
@@ -71,7 +71,7 @@ class JPath
 
 			while ($file = readdir($dh))
 			{
-				if ($file != '.' && $file != '..')
+				if ($file !== '.' && $file !== '..')
 				{
 					$fullpath = $path . '/' . $file;
 
@@ -172,7 +172,7 @@ class JPath
 
 		$path = self::clean($path);
 
-		if ((JPATH_ROOT != '') && strpos($path, self::clean(JPATH_ROOT)) !== 0)
+		if ((JPATH_ROOT !== '') && strpos($path, self::clean(JPATH_ROOT)) !== 0)
 		{
 			throw new Exception('JPath::check Snooping out of bounds @ ' . $path, 20);
 		}
@@ -206,7 +206,7 @@ class JPath
 		}
 		// Remove double slashes and backslashes and convert all slashes and backslashes to DIRECTORY_SEPARATOR
 		// If dealing with a UNC path don't forget to prepend the path with a backslash.
-		elseif (($ds == '\\') && substr($path, 0, 2) == '\\\\')
+		elseif (($ds === '\\') && substr($path, 0, 2) === '\\\\')
 		{
 			$path = "\\" . preg_replace('#[/\\\\]+#', $ds, $path);
 		}
@@ -258,7 +258,7 @@ class JPath
 			$fileObject->write($test, $blank, false);
 
 			// Test ownership
-			$return = (fileowner($test) == fileowner($path));
+			$return = (fileowner($test) === fileowner($path));
 
 			// Delete the test file
 			$fileObject->delete($test);
@@ -310,7 +310,7 @@ class JPath
 			 * non-registered directories are not accessible via directory
 			 * traversal attempts.
 			 */
-			if (file_exists($fullname) && substr($fullname, 0, strlen($path)) == $path)
+			if (file_exists($fullname) && substr($fullname, 0, strlen($path)) === $path)
 			{
 				return $fullname;
 			}

--- a/libraries/joomla/filesystem/stream.php
+++ b/libraries/joomla/filesystem/stream.php
@@ -343,7 +343,7 @@ class JStream extends JObject
 		}
 
 		// If we wrote, chmod the file after it's closed
-		if ($this->openmode[0] == 'w')
+		if ($this->openmode[0] === 'w')
 		{
 			$this->chmod();
 		}

--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -864,7 +864,7 @@ class JFilterInput extends InputFilter
 			}
 
 			// Remove every '<' character if '>' does not exists or we have '<>'
-			if ($tagOpenStartOffset !== false && $tagOpenEndOffset === false || $tagOpenStartOffset + 1 == $tagOpenEndOffset)
+			if ($tagOpenStartOffset !== false && $tagOpenEndOffset === false || $tagOpenStartOffset + 1 === $tagOpenEndOffset)
 			{
 				$offset++;
 
@@ -1120,7 +1120,7 @@ class JFilterInput extends InputFilter
 			 * Closing quote should be "/>, ">, "<space>, or " at the end of the string
 			 */
 			$quote = substr($matches[0][0], -1);
-			$pregMatch = ($quote == '"') ? '#(\"\s*/\s*>|\"\s*>|\"\s+|\"$)#' : "#(\'\s*/\s*>|\'\s*>|\'\s+|\'$)#";
+			$pregMatch = ($quote === '"') ? '#(\"\s*/\s*>|\"\s*>|\"\s+|\"$)#' : "#(\'\s*/\s*>|\'\s*>|\'\s+|\'$)#";
 
 			// Get the portion after attribute value
 			if (preg_match($pregMatch, substr($remainder, $nextBefore), $matches, PREG_OFFSET_CAPTURE))

--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -69,7 +69,7 @@ class JFilterOutput extends OutputFilter
 		$str = str_replace('-', ' ', $string);
 
 		// Transliterate on the language requested (fallback to current language if not specified)
-		$lang = $language == '' || $language == '*' ? JFactory::getLanguage() : JLanguage::getInstance($language);
+		$lang = $language === '' || $language === '*' ? JFactory::getLanguage() : JLanguage::getInstance($language);
 		$str = $lang->transliterate($str);
 
 		// Trim white spaces at beginning and end of alias and make lowercase

--- a/libraries/joomla/form/field.php
+++ b/libraries/joomla/form/field.php
@@ -356,7 +356,7 @@ abstract class JFormField
 		{
 			$parts = Normalise::fromCamelCase(get_called_class(), true);
 
-			if ($parts[0] == 'J')
+			if ($parts[0] === 'J')
 			{
 				$this->type = StringHelper::ucfirst($parts[count($parts) - 1], '_');
 			}
@@ -494,7 +494,7 @@ abstract class JFormField
 
 			case 'autocomplete':
 				$value = (string) $value;
-				$value = ($value == 'on' || $value == '') ? 'on' : $value;
+				$value = ($value === 'on' || $value === '') ? 'on' : $value;
 				$this->$name = ($value === 'false' || $value === 'off' || $value === '0') ? false : $value;
 				break;
 
@@ -565,7 +565,7 @@ abstract class JFormField
 	public function setup(SimpleXMLElement $element, $value, $group = null)
 	{
 		// Make sure there is a valid JFormField XML element.
-		if ((string) $element->getName() != 'field')
+		if ((string) $element->getName() !== 'field')
 		{
 			return false;
 		}
@@ -597,10 +597,10 @@ abstract class JFormField
 
 		// Allow for repeatable elements
 		$repeat = (string) $element['repeat'];
-		$this->repeat = ($repeat == 'true' || $repeat == 'multiple' || (!empty($this->form->repeat) && $this->form->repeat == 1));
+		$this->repeat = ($repeat === 'true' || $repeat === 'multiple' || (!empty($this->form->repeat) && $this->form->repeat == 1));
 
 		// Set the visibility.
-		$this->hidden = ($this->hidden || (string) $element['type'] == 'hidden');
+		$this->hidden = ($this->hidden || (string) $element['type'] === 'hidden');
 
 		$this->layout = !empty($this->element['layout']) ? (string) $this->element['layout'] : $this->layout;
 
@@ -680,7 +680,7 @@ abstract class JFormField
 			$repeatCounter = empty($this->form->repeatCounter) ? 0 : $this->form->repeatCounter;
 			$id .= '-' . $repeatCounter;
 
-			if (strtolower($this->type) == 'radio')
+			if (strtolower($this->type) === 'radio')
 			{
 				$id .= '-';
 			}
@@ -746,7 +746,7 @@ abstract class JFormField
 		$data = $this->getLayoutData();
 
 		// Forcing the Alias field to display the tip below
-		$position = $this->element['name'] == 'alias' ? ' data-placement="bottom" ' : '';
+		$position = $this->element['name'] === 'alias' ? ' data-placement="bottom" ' : '';
 
 		// Here mainly for B/C with old layouts. This can be done in the layouts directly
 		$extraData = array(

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -191,11 +191,11 @@ class JFormFieldCalendar extends JFormField
 		// Translate the format if requested
 		$translateFormat = (string) $this->element['translateformat'];
 
-		if ($translateFormat && $translateFormat != 'false')
+		if ($translateFormat && $translateFormat !== 'false')
 		{
 			$showTime = (string) $this->element['showtime'];
 
-			if ($showTime && $showTime != 'false')
+			if ($showTime && $showTime !== 'false')
 			{
 				$this->format = JText::_('DATE_FORMAT_CALENDAR_DATETIME');
 			}

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -59,7 +59,7 @@ class JFormFieldCheckbox extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void
@@ -72,7 +72,7 @@ class JFormFieldCheckbox extends JFormField
 		{
 			case 'checked':
 				$value = (string) $value;
-				$this->checked = ($value == 'true' || $value == $name || $value == '1');
+				$this->checked = ($value === 'true' || $value == $name || $value == '1');
 				break;
 
 			default:
@@ -111,7 +111,7 @@ class JFormFieldCheckbox extends JFormField
 		if ($return)
 		{
 			$checked = (string) $this->element['checked'];
-			$this->checked = ($checked == 'true' || $checked == 'checked' || $checked == '1');
+			$this->checked = ($checked === 'true' || $checked === 'checked' || $checked === '1');
 
 			empty($this->value) || $this->checked ? null : $this->checked = true;
 		}

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -202,13 +202,13 @@ class JFormFieldColor extends JFormField
 		$color = ! $color ? '' : $color;
 
 		// Position of the panel can be: right (default), left, top or bottom (default RTL is left)
-		$position = ' data-position="' . (($lang->isRTL() && $this->position == 'default') ? 'left' : $this->position) . '"';
+		$position = ' data-position="' . (($lang->isRTL() && $this->position === 'default') ? 'left' : $this->position) . '"';
 
 		if (!$color || in_array($color, array('none', 'transparent')))
 		{
 			$color = 'none';
 		}
-		elseif ($color['0'] != '#' && $this->format == 'hex')
+		elseif ($color['0'] !== '#' && $this->format === 'hex')
 		{
 			$color = '#' . $color;
 		}
@@ -263,13 +263,13 @@ class JFormFieldColor extends JFormField
 		if (!$this->split)
 		{
 			$count = count($colors);
-			if ($count % 5 == 0)
+			if ($count % 5 === 0)
 			{
 				$split = 5;
 			}
 			else
 			{
-				if ($count % 4 == 0)
+				if ($count % 4 === 0)
 				{
 					$split = 4;
 				}

--- a/libraries/joomla/form/fields/databaseconnection.php
+++ b/libraries/joomla/form/fields/databaseconnection.php
@@ -59,7 +59,7 @@ class JFormFieldDatabaseConnection extends JFormFieldList
 
 			foreach ($supported as $support)
 			{
-				if (in_array($support, $available))
+				if (in_array($support, $available, true))
 				{
 					$options[$support] = JText::_(ucfirst($support));
 				}

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -159,13 +159,13 @@ class JFormFieldFileList extends JFormFieldList
 			$this->exclude = (string) $this->element['exclude'];
 
 			$hideNone       = (string) $this->element['hide_none'];
-			$this->hideNone = ($hideNone == 'true' || $hideNone == 'hideNone' || $hideNone == '1');
+			$this->hideNone = ($hideNone === 'true' || $hideNone === 'hideNone' || $hideNone === '1');
 
 			$hideDefault       = (string) $this->element['hide_default'];
-			$this->hideDefault = ($hideDefault == 'true' || $hideDefault == 'hideDefault' || $hideDefault == '1');
+			$this->hideDefault = ($hideDefault === 'true' || $hideDefault === 'hideDefault' || $hideDefault === '1');
 
 			$stripExt       = (string) $this->element['stripext'];
-			$this->stripExt = ($stripExt == 'true' || $stripExt == 'stripExt' || $stripExt == '1');
+			$this->stripExt = ($stripExt === 'true' || $stripExt === 'stripExt' || $stripExt === '1');
 
 			// Get the path in which to search for file options.
 			$this->directory = (string) $this->element['directory'];

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -158,13 +158,13 @@ class JFormFieldFolderList extends JFormFieldList
 			$this->exclude = (string) $this->element['exclude'];
 
 			$recursive       = (string) $this->element['recursive'];
-			$this->recursive = ($recursive == 'true' || $recursive == 'recursive' || $recursive == '1');
+			$this->recursive = ($recursive === 'true' || $recursive === 'recursive' || $recursive == '1');
 
 			$hideNone       = (string) $this->element['hide_none'];
-			$this->hideNone = ($hideNone == 'true' || $hideNone == 'hideNone' || $hideNone == '1');
+			$this->hideNone = ($hideNone === 'true' || $hideNone === 'hideNone' || $hideNone == '1');
 
 			$hideDefault       = (string) $this->element['hide_default'];
-			$this->hideDefault = ($hideDefault == 'true' || $hideDefault == 'hideDefault' || $hideDefault == '1');
+			$this->hideDefault = ($hideDefault === 'true' || $hideDefault === 'hideDefault' || $hideDefault == '1');
 
 			// Get the path in which to search for file options.
 			$this->directory = (string) $this->element['directory'];

--- a/libraries/joomla/form/fields/groupedlist.php
+++ b/libraries/joomla/form/fields/groupedlist.php
@@ -88,13 +88,13 @@ class JFormFieldGroupedList extends JFormField
 					foreach ($element->children() as $option)
 					{
 						// Only add <option /> elements.
-						if ($option->getName() != 'option')
+						if ($option->getName() !== 'option')
 						{
 							continue;
 						}
 
 						$disabled = (string) $option['disabled'];
-						$disabled = ($disabled == 'true' || $disabled == 'disabled' || $disabled == '1');
+						$disabled = ($disabled === 'true' || $disabled === 'disabled' || $disabled === '1');
 
 						// Create a new option object based on the <option /> element.
 						$tmp = JHtml::_(

--- a/libraries/joomla/form/fields/integer.php
+++ b/libraries/joomla/form/fields/integer.php
@@ -44,7 +44,7 @@ class JFormFieldInteger extends JFormFieldList
 		$step = (int) $this->element['step'];
 
 		// Sanity checks.
-		if ($step == 0)
+		if ($step === 0)
 		{
 			// Step of 0 will create an endless loop.
 			return $options;

--- a/libraries/joomla/form/fields/language.php
+++ b/libraries/joomla/form/fields/language.php
@@ -40,7 +40,7 @@ class JFormFieldLanguage extends JFormFieldList
 		// Initialize some field attributes.
 		$client = (string) $this->element['client'];
 
-		if ($client != 'site' && $client != 'administrator')
+		if ($client !== 'site' && $client !== 'administrator')
 		{
 			$client = 'site';
 		}

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -46,8 +46,8 @@ class JFormFieldList extends JFormField
 		$attr .= $this->autofocus ? ' autofocus' : '';
 
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true' ||
-			(string) $this->disabled === '1' || (string) $this->disabled === 'true')
+		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true'
+			|| (string) $this->disabled === '1' || (string) $this->disabled === 'true')
 		{
 			$attr .= ' disabled="disabled"';
 		}

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -46,7 +46,8 @@ class JFormFieldList extends JFormField
 		$attr .= $this->autofocus ? ' autofocus' : '';
 
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true' || (string) $this->disabled === '1'|| (string) $this->disabled === 'true')
+		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true' ||
+			(string) $this->disabled === '1' || (string) $this->disabled === 'true')
 		{
 			$attr .= ' disabled="disabled"';
 		}

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -46,7 +46,7 @@ class JFormFieldList extends JFormField
 		$attr .= $this->autofocus ? ' autofocus' : '';
 
 		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true' || (string) $this->disabled == '1'|| (string) $this->disabled == 'true')
+		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true' || (string) $this->disabled === '1'|| (string) $this->disabled === 'true')
 		{
 			$attr .= ' disabled="disabled"';
 		}
@@ -58,7 +58,7 @@ class JFormFieldList extends JFormField
 		$options = (array) $this->getOptions();
 
 		// Create a read-only list (no name) with hidden input(s) to store the value(s).
-		if ((string) $this->readonly == '1' || (string) $this->readonly == 'true')
+		if ((string) $this->readonly === '1' || (string) $this->readonly === 'true')
 		{
 			$html[] = JHtml::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $this->value, $this->id);
 
@@ -120,17 +120,17 @@ class JFormFieldList extends JFormField
 			}
 
 			$value = (string) $option['value'];
-			$text  = trim((string) $option) != '' ? trim((string) $option) : $value;
+			$text  = trim((string) $option) !== '' ? trim((string) $option) : $value;
 
 			$disabled = (string) $option['disabled'];
-			$disabled = ($disabled == 'true' || $disabled == 'disabled' || $disabled == '1');
-			$disabled = $disabled || ($this->readonly && $value != $this->value);
+			$disabled = ($disabled === 'true' || $disabled === 'disabled' || $disabled === '1');
+			$disabled = $disabled || ($this->readonly && $value !== $this->value);
 
 			$checked = (string) $option['checked'];
-			$checked = ($checked == 'true' || $checked == 'checked' || $checked == '1');
+			$checked = ($checked === 'true' || $checked === 'checked' || $checked === '1');
 
 			$selected = (string) $option['selected'];
-			$selected = ($selected == 'true' || $selected == 'selected' || $selected == '1');
+			$selected = ($selected === 'true' || $selected === 'selected' || $selected === '1');
 
 			$tmp = array(
 					'value'    => $value,
@@ -157,7 +157,7 @@ class JFormFieldList extends JFormField
 			$component  = JFactory::getApplication()->input->getCmd('option');
 
 			// Get correct component for menu items
-			if ($component == 'com_menus')
+			if ($component === 'com_menus')
 			{
 				$link      = $this->form->getData()->get('link');
 				$uri       = new JUri($link);
@@ -174,7 +174,7 @@ class JFormFieldList extends JFormField
 			}
 
 			// Try with menu configuration
-			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') == 'com_menus')
+			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') === 'com_menus')
 			{
 				$value = JComponentHelper::getParams('com_menus')->get($this->fieldname);
 			}
@@ -240,7 +240,7 @@ class JFormFieldList extends JFormField
 	 */
 	public function __get($name)
 	{
-		if ($name == 'options')
+		if ($name === 'options')
 		{
 			return $this->getOptions();
 		}

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -149,10 +149,10 @@ class JFormFieldMeter extends JFormFieldNumber
 			$this->color = isset($this->element['color']) ? (string) $this->element['color'] : '';
 
 			$active       = (string) $this->element['active'];
-			$this->active = ($active == 'true' || $active == 'on' || $active == '1');
+			$this->active = ($active === 'true' || $active === 'on' || $active === '1');
 
 			$animated       = (string) $this->element['animated'];
-			$this->animated = !($animated == 'false' || $animated == 'off' || $animated == '0');
+			$this->animated = !($animated === 'false' || $animated === 'off' || $animated === '0');
 		}
 
 		return $return;

--- a/libraries/joomla/form/fields/note.php
+++ b/libraries/joomla/form/fields/note.php
@@ -50,7 +50,7 @@ class JFormFieldNote extends JFormField
 
 		if ($close)
 		{
-			$close = $close == 'true' ? 'alert' : $close;
+			$close = $close === 'true' ? 'alert' : $close;
 			$html[] = '<button type="button" class="close" data-dismiss="' . $close . '">&times;</button>';
 		}
 

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -135,7 +135,7 @@ class JFormFieldPassword extends JFormField
 			$this->threshold = $this->element['threshold'] ? (int) $this->element['threshold'] : 66;
 
 			$meter       = (string) $this->element['strengthmeter'];
-			$this->meter = ($meter == 'true' || $meter == 'on' || $meter == '1');
+			$this->meter = ($meter === 'true' || $meter === 'on' || $meter === '1');
 		}
 
 		return $return;

--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -55,7 +55,7 @@ class JFormFieldSpacer extends JFormField
 		$html[] = '<span class="before"></span>';
 		$html[] = '<span' . $class . '>';
 
-		if ((string) $this->element['hr'] == 'true')
+		if ((string) $this->element['hr'] === 'true')
 		{
 			$html[] = '<hr' . $class . ' />';
 		}

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -299,7 +299,7 @@ class JFormFieldSQL extends JFormFieldList
 		{
 			foreach ($items as $item)
 			{
-				if ($this->translate == true)
+				if ($this->translate === true)
 				{
 					$options[] = JHtml::_('select.option', $item->$key, JText::_($item->$value));
 				}

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -100,7 +100,7 @@ class JFormFieldText extends JFormField
 
 			case 'dirname':
 				$value = (string) $value;
-				$this->dirname = ($value == $name || $value == 'true' || $value == '1');
+				$this->dirname = ($value == $name || $value === 'true' || $value === '1');
 				break;
 
 			case 'inputmode':
@@ -152,7 +152,7 @@ class JFormFieldText extends JFormField
 			}
 
 			// Set the dirname.
-			$dirname = ((string) $dirname == 'dirname' || $dirname == 'true' || $dirname == '1');
+			$dirname = ($dirname === 'dirname' || $dirname === 'true' || $dirname === '1');
 			$this->dirname = $dirname ? $this->getName($this->fieldname . '_dir') : false;
 
 			$this->maxLength = (int) $this->element['maxlength'];
@@ -175,7 +175,7 @@ class JFormFieldText extends JFormField
 			$component = JFactory::getApplication()->input->getCmd('option');
 
 			// Get correct component for menu items
-			if ($component == 'com_menus')
+			if ($component === 'com_menus')
 			{
 				$link      = $this->form->getData()->get('link');
 				$uri       = new JUri($link);
@@ -192,7 +192,7 @@ class JFormFieldText extends JFormField
 			}
 
 			// Try with menu configuration
-			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') == 'com_menus')
+			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') === 'com_menus')
 			{
 				$value = JComponentHelper::getParams('com_menus')->get($this->fieldname);
 			}
@@ -222,7 +222,7 @@ class JFormFieldText extends JFormField
 		foreach ($this->element->children() as $option)
 		{
 			// Only add <option /> elements.
-			if ($option->getName() != 'option')
+			if ($option->getName() !== 'option')
 			{
 				continue;
 			}

--- a/libraries/joomla/form/fields/usergroup.php
+++ b/libraries/joomla/form/fields/usergroup.php
@@ -57,13 +57,13 @@ class JFormFieldUsergroup extends JFormField
 		foreach ($this->element->children() as $option)
 		{
 			// Only add <option /> elements.
-			if ($option->getName() != 'option')
+			if ($option->getName() !== 'option')
 			{
 				continue;
 			}
 
 			$disabled = (string) $option['disabled'];
-			$disabled = ($disabled == 'true' || $disabled == 'disabled' || $disabled == '1');
+			$disabled = ($disabled === 'true' || $disabled === 'disabled' || $disabled === '1');
 
 			// Create a new option object based on the <option /> element.
 			$tmp = JHtml::_(

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1273,7 +1273,7 @@ class JForm
 					{
 						if ($p !== '')
 						{
-							$return[$action][$id] = ($p == '1' || $p === 'true') ? true : false;
+							$return[$action][$id] = ($p == '1' || $p == 'true') ? true : false;
 						}
 					}
 				}

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -1415,8 +1415,8 @@ class JForm
 
 				// If there is no protocol and the relative option is not specified,
 				// we assume that it is an external URL and prepend http://.
-				if (($element['type'] === 'url' && !$protocol &&  !$element['relative'])
-					|| (!$element['type'] === 'url' && !$protocol))
+				if (($element['type'] == 'url' && !$protocol &&  !$element['relative'])
+					|| (!$element['type'] == 'url' && !$protocol))
 				{
 					$protocol = 'http';
 

--- a/libraries/joomla/form/form.php
+++ b/libraries/joomla/form/form.php
@@ -413,7 +413,7 @@ class JForm
 		// Process each found fieldset.
 		foreach ($sets as $set)
 		{
-			if ((string) $set['hidden'] == 'true')
+			if ((string) $set['hidden'] === 'true')
 			{
 				continue;
 			}
@@ -743,7 +743,7 @@ class JForm
 		if (empty($this->xml))
 		{
 			// If no XPath query is set to search for fields, and we have a <form />, set it and return.
-			if (!$xpath && ($data->getName() == 'form'))
+			if (!$xpath && ($data->getName() === 'form'))
 			{
 				$this->xml = $data;
 
@@ -767,7 +767,7 @@ class JForm
 		{
 			$elements = $data->xpath($xpath);
 		}
-		elseif ($data->getName() == 'form')
+		elseif ($data->getName() === 'form')
 		{
 			$elements = $data->children();
 		}
@@ -1273,7 +1273,7 @@ class JForm
 					{
 						if ($p !== '')
 						{
-							$return[$action][$id] = ($p == '1' || $p == 'true') ? true : false;
+							$return[$action][$id] = ($p == '1' || $p === 'true') ? true : false;
 						}
 					}
 				}
@@ -1314,10 +1314,10 @@ class JForm
 					// Check if we have a localised date format
 					$translateFormat = (string) $element['translateformat'];
 
-					if ($translateFormat && $translateFormat != 'false')
+					if ($translateFormat && $translateFormat !== 'false')
 					{
 						$showTime = (string) $element['showtime'];
-						$showTime = ($showTime && $showTime != 'false');
+						$showTime = ($showTime && $showTime !== 'false');
 						$format   = ($showTime) ? JText::_('DATE_FORMAT_FILTER_DATETIME') : JText::_('DATE_FORMAT_FILTER_DATE');
 						$date     = date_parse_from_format($format, $value);
 						$value    = (int) $date['year'] . '-' . (int) $date['month'] . '-' . (int) $date['day'];
@@ -1356,10 +1356,10 @@ class JForm
 					// Check if we have a localised date format
 					$translateFormat = (string) $element['translateformat'];
 
-					if ($translateFormat && $translateFormat != 'false')
+					if ($translateFormat && $translateFormat !== 'false')
 					{
 						$showTime = (string) $element['showtime'];
-						$showTime = ($showTime && $showTime != 'false');
+						$showTime = ($showTime && $showTime !== 'false');
 						$format   = ($showTime) ? JText::_('DATE_FORMAT_FILTER_DATETIME') : JText::_('DATE_FORMAT_FILTER_DATE');
 						$date     = date_parse_from_format($format, $value);
 						$value    = (int) $date['year'] . '-' . (int) $date['month'] . '-' . (int) $date['day'];
@@ -1415,13 +1415,13 @@ class JForm
 
 				// If there is no protocol and the relative option is not specified,
 				// we assume that it is an external URL and prepend http://.
-				if (($element['type'] == 'url' && !$protocol &&  !$element['relative'])
-					|| (!$element['type'] == 'url' && !$protocol))
+				if (($element['type'] === 'url' && !$protocol &&  !$element['relative'])
+					|| (!$element['type'] === 'url' && !$protocol))
 				{
 					$protocol = 'http';
 
 					// If it looks like an internal link, then add the root.
-					if (substr($value, 0, 9) == 'index.php')
+					if (substr($value, 0, 9) === 'index.php')
 					{
 						$value = JUri::root() . $value;
 					}
@@ -1446,7 +1446,7 @@ class JForm
 					}
 
 					// Otherwise if it doesn't start with "/" prepend the prefix of the current site.
-					elseif (substr($value, 0, 1) != '/')
+					elseif (substr($value, 0, 1) !== '/')
 					{
 						$value = JUri::root(true) . '/' . $value;
 					}
@@ -1554,7 +1554,7 @@ class JForm
 				// otherwise filter using JFilterInput. All HTML code is filtered by default.
 				else
 				{
-					$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+					$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 					if (($value === '' || $value === null) && ! $required)
 					{
@@ -1892,7 +1892,7 @@ class JForm
 		{
 			$default = (string) ($element['default'] ? $element['default'] : $element->default);
 
-			if (($translate = $element['translate_default']) && ((string) $translate == 'true' || (string) $translate == '1'))
+			if (($translate = $element['translate_default']) && ((string) $translate === 'true' || (string) $translate == '1'))
 			{
 				$lang = JFactory::getLanguage();
 
@@ -2027,7 +2027,7 @@ class JForm
 		$valid = true;
 
 		// Check if the field is required.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if ($required)
 		{
@@ -2174,7 +2174,7 @@ class JForm
 			$forms[$name] = new JForm($name, $options);
 
 			// Load the data.
-			if (substr($data, 0, 1) == '<')
+			if (substr($data, 0, 1) === '<')
 			{
 				if ($forms[$name]->load($data, $replace, $xpath) == false)
 				{

--- a/libraries/joomla/form/rule/calendar.php
+++ b/libraries/joomla/form/rule/calendar.php
@@ -36,14 +36,14 @@ class JFormRuleCalendar extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
 			return true;
 		}
 
-		if (strtolower($value) == 'now')
+		if (strtolower($value) === 'now')
 		{
 			return true;
 		}

--- a/libraries/joomla/form/rule/color.php
+++ b/libraries/joomla/form/rule/color.php
@@ -38,14 +38,14 @@ class JFormRuleColor extends JFormRule
 		$value = trim($value);
 
 		// If the field is empty and not required, the field is valid.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
 			return true;
 		}
 
-		if ($value[0] != '#')
+		if ($value[0] !== '#')
 		{
 			return false;
 		}
@@ -54,7 +54,7 @@ class JFormRuleColor extends JFormRule
 		$value = ltrim($value, '#');
 
 		// The value must be 6 or 3 characters long
-		if (!((strlen($value) == 6 || strlen($value) == 3) && ctype_xdigit($value)))
+		if (!((strlen($value) === 6 || strlen($value) === 3) && ctype_xdigit($value)))
 		{
 			return false;
 		}

--- a/libraries/joomla/form/rule/email.php
+++ b/libraries/joomla/form/rule/email.php
@@ -45,7 +45,7 @@ class JFormRuleEmail extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
@@ -53,7 +53,7 @@ class JFormRuleEmail extends JFormRule
 		}
 
 		// If the tld attribute is present, change the regular expression to require at least 2 characters for it.
-		$tld = ((string) $element['tld'] == 'tld' || (string) $element['tld'] == 'required');
+		$tld = ((string) $element['tld'] === 'tld' || (string) $element['tld'] === 'required');
 
 		if ($tld)
 		{
@@ -62,7 +62,7 @@ class JFormRuleEmail extends JFormRule
 		}
 
 		// Determine if the multiple attribute is present
-		$multiple = ((string) $element['multiple'] == 'true' || (string) $element['multiple'] == 'multiple');
+		$multiple = ((string) $element['multiple'] === 'true' || (string) $element['multiple'] === 'multiple');
 
 		if (!$multiple)
 		{
@@ -93,7 +93,7 @@ class JFormRuleEmail extends JFormRule
 		}
 
 		// Check if we should test for uniqueness. This only can be used if multiple is not true
-		$unique = ((string) $element['unique'] == 'true' || (string) $element['unique'] == 'unique');
+		$unique = ((string) $element['unique'] === 'true' || (string) $element['unique'] === 'unique');
 
 		if ($unique && !$multiple)
 		{

--- a/libraries/joomla/form/rule/number.php
+++ b/libraries/joomla/form/rule/number.php
@@ -36,7 +36,7 @@ class JFormRuleNumber extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Check if the field is required.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		// If the value is empty and the field is not required return True.
 		if (($value === '' || $value === null) && ! $required)

--- a/libraries/joomla/form/rule/options.php
+++ b/libraries/joomla/form/rule/options.php
@@ -36,7 +36,7 @@ class JFormRuleOptions extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// Check if the field is required.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
@@ -82,7 +82,7 @@ class JFormRuleOptions extends JFormRule
 		else
 		{
 			// In this case value must be a string
-			return in_array((string) $value, $options);
+			return in_array((string) $value, $options, true);
 		}
 	}
 }

--- a/libraries/joomla/form/rule/options.php
+++ b/libraries/joomla/form/rule/options.php
@@ -82,7 +82,7 @@ class JFormRuleOptions extends JFormRule
 		else
 		{
 			// In this case value must be a string
-			return in_array((string) $value, $options, true);
+			return in_array((string) $value, $options, false);
 		}
 	}
 }

--- a/libraries/joomla/form/rule/rules.php
+++ b/libraries/joomla/form/rule/rules.php
@@ -102,7 +102,7 @@ class JFormRuleRules extends JFormRule
 		// Iterate over the children and add to the actions.
 		foreach ($element->children() as $el)
 		{
-			if ($el->getName() == 'action')
+			if ($el->getName() === 'action')
 			{
 				$actions[] = (string) $el['name'];
 			}

--- a/libraries/joomla/form/rule/tel.php
+++ b/libraries/joomla/form/rule/tel.php
@@ -36,7 +36,7 @@ class JFormRuleTel extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
@@ -62,15 +62,15 @@ class JFormRuleTel extends JFormRule
 		{
 			$plan = (string) $element['plan'];
 
-			if ($plan == 'northamerica' || $plan == 'us')
+			if ($plan === 'northamerica' || $plan === 'us')
 			{
 				$plan = 'NANP';
 			}
-			elseif ($plan == 'International' || $plan == 'int' || $plan == 'missdn' || !$plan)
+			elseif ($plan === 'International' || $plan === 'int' || $plan === 'missdn' || !$plan)
 			{
 				$plan = 'ITU-T';
 			}
-			elseif ($plan == 'IETF')
+			elseif ($plan === 'IETF')
 			{
 				$plan = 'EPP';
 			}

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -40,7 +40,7 @@ class JFormRuleUrl extends JFormRule
 	public function test(SimpleXMLElement $element, $value, $group = null, Registry $input = null, JForm $form = null)
 	{
 		// If the field is empty and not required, the field is valid.
-		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
 		if (!$required && empty($value))
 		{
@@ -51,7 +51,7 @@ class JFormRuleUrl extends JFormRule
 
 		// See http://www.w3.org/Addressing/URL/url-spec.txt
 		// Use the full list or optionally specify a list of permitted schemes.
-		if ($element['schemes'] == '')
+		if ($element['schemes'] === '')
 		{
 			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'url',
 				'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');

--- a/libraries/joomla/form/rule/url.php
+++ b/libraries/joomla/form/rule/url.php
@@ -51,7 +51,7 @@ class JFormRuleUrl extends JFormRule
 
 		// See http://www.w3.org/Addressing/URL/url-spec.txt
 		// Use the full list or optionally specify a list of permitted schemes.
-		if ($element['schemes'] === '')
+		if ($element['schemes'] == '')
 		{
 			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'url',
 				'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');


### PR DESCRIPTION
### Summary of Changes

Implemented type-safe comparisons in the `libraries / joomla` directory.
For easier reviewing, there is a total of five parts, that cover the `libraries / joomla` directory

This is part 3, which covers directories `facebook` until  `form`


### Testing Instructions

**Code review only**, as those changes should not affect behavior.
Despite the quantity of the changes, it should be fairly easy to review.

Attention to code reviewers:
In order to prevent code-review-fatigue, I only did type safe comparisons, **without applying**:
- formatting
- removal of unnecessary parentheses
- other non-related changes

Please **only** review the correctness of the specific changes, without pointing out any possible formatting issues (unless corrupted by this PR), removal of parentheses and other non-related changes. This will help get this PR reviewed and merged quickly.
If you should find other prospects for type safe comparison in those folders please note them in a review.

Thank you