### PR TITLE
[ libraries / joomla] Type-safe comparisons #4

### DIFF
--- a/libraries/joomla/github/account.php
+++ b/libraries/joomla/github/account.php
@@ -44,7 +44,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -75,7 +75,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -150,7 +150,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -182,7 +182,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -212,7 +212,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -241,7 +241,7 @@ class JGithubAccount extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/commits.php
+++ b/libraries/joomla/github/commits.php
@@ -48,7 +48,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -94,7 +94,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -126,7 +126,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -165,7 +165,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -199,7 +199,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -231,7 +231,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -265,7 +265,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -298,7 +298,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -331,7 +331,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -364,7 +364,7 @@ class JGithubCommits extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/forks.php
+++ b/libraries/joomla/github/forks.php
@@ -51,7 +51,7 @@ class JGithubForks extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 202)
+		if ($response->code !== 202)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -85,7 +85,7 @@ class JGithubForks extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/github.php
+++ b/libraries/joomla/github/github.php
@@ -106,12 +106,12 @@ class JGithub
 	 */
 	public function __get($name)
 	{
-		if (false == in_array($name, $this->packages))
+		if (in_array($name, $this->packages, true) === false)
 		{
 			// Check for a legacy class
-			if (in_array($name, $this->legacyPackages))
+			if (in_array($name, $this->legacyPackages, true))
 			{
-				if (false == isset($this->$name))
+				if (isset($this->$name) === false)
 				{
 					$className = 'JGithub' . ucfirst($name);
 
@@ -124,7 +124,7 @@ class JGithub
 			throw new RuntimeException(sprintf('%1$s - Unknown package %2$s', __METHOD__, $name));
 		}
 
-		if (false == isset($this->$name))
+		if (isset($this->$name) === false)
 		{
 			$className = 'JGithubPackage' . ucfirst($name);
 

--- a/libraries/joomla/github/milestones.php
+++ b/libraries/joomla/github/milestones.php
@@ -47,7 +47,7 @@ class JGithubMilestones extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -79,7 +79,7 @@ class JGithubMilestones extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -136,7 +136,7 @@ class JGithubMilestones extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -229,7 +229,7 @@ class JGithubMilestones extends JGithubObject
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/object.php
+++ b/libraries/joomla/github/object.php
@@ -116,7 +116,7 @@ abstract class JGithubObject
 	protected function processResponse(JHttpResponse $response, $expectedCode = 200, $decode = true)
 	{
 		// Validate the response code.
-		if ($response->code == $expectedCode)
+		if ($response->code === $expectedCode)
 		{
 			return ($decode) ? json_decode($response->body) : $response->body;
 		}

--- a/libraries/joomla/github/package.php
+++ b/libraries/joomla/github/package.php
@@ -41,12 +41,12 @@ abstract class JGithubPackage extends JGithubObject
 	 */
 	public function __get($name)
 	{
-		if (false == in_array($name, $this->packages))
+		if (in_array($name, $this->packages, true) === false)
 		{
 			throw new RuntimeException(sprintf('%1$s - Unknown package %2$s', __METHOD__, $name));
 		}
 
-		if (false == isset($this->$name))
+		if (isset($this->$name) === false)
 		{
 			$className = 'JGithubPackage' . ucfirst($this->name) . ucfirst($name);
 

--- a/libraries/joomla/github/package/authorization.php
+++ b/libraries/joomla/github/package/authorization.php
@@ -176,7 +176,7 @@ class JGithubPackageAuthorization extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -204,7 +204,7 @@ class JGithubPackageAuthorization extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -231,7 +231,7 @@ class JGithubPackageAuthorization extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/data/refs.php
+++ b/libraries/joomla/github/package/data/refs.php
@@ -39,7 +39,7 @@ class JGithubPackageDataRefs extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -71,7 +71,7 @@ class JGithubPackageDataRefs extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -111,7 +111,7 @@ class JGithubPackageDataRefs extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -158,7 +158,7 @@ class JGithubPackageDataRefs extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/gists.php
+++ b/libraries/joomla/github/package/gists.php
@@ -57,7 +57,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -86,7 +86,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -140,7 +140,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -170,7 +170,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), '');
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -199,7 +199,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -230,7 +230,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -261,7 +261,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -291,7 +291,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -321,7 +321,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -350,11 +350,11 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code == 204)
+		if ($response->code === 204)
 		{
 			return true;
 		}
-		elseif ($response->code == 404)
+		elseif ($response->code === 404)
 		{
 			return false;
 		}
@@ -385,7 +385,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->put($this->fetchUrl($path), '');
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -412,7 +412,7 @@ class JGithubPackageGists extends JGithubPackage
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/gists/comments.php
+++ b/libraries/joomla/github/package/gists/comments.php
@@ -46,7 +46,7 @@ class JGithubPackageGistsComments extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -75,7 +75,7 @@ class JGithubPackageGistsComments extends JGithubPackage
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -110,7 +110,7 @@ class JGithubPackageGistsComments extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -139,7 +139,7 @@ class JGithubPackageGistsComments extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -170,7 +170,7 @@ class JGithubPackageGistsComments extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/gitignore.php
+++ b/libraries/joomla/github/package/gitignore.php
@@ -67,7 +67,7 @@ class JGithubPackageGitignore extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path), $headers);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error   = json_decode($response->body);

--- a/libraries/joomla/github/package/issues.php
+++ b/libraries/joomla/github/package/issues.php
@@ -71,7 +71,7 @@ class JGithubPackageIssues extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -156,7 +156,7 @@ class JGithubPackageIssues extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -187,7 +187,7 @@ class JGithubPackageIssues extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -226,7 +226,7 @@ class JGithubPackageIssues extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -309,7 +309,7 @@ class JGithubPackageIssues extends JGithubPackage
 		$response = $this->client->get((string) $uri);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/issues/assignees.php
+++ b/libraries/joomla/github/package/issues/assignees.php
@@ -63,7 +63,7 @@ class JGithubPackageIssuesAssignees extends JGithubPackage
 		{
 			$response = $this->client->get($this->fetchUrl($path));
 
-			if (204 == $response->code)
+			if ($response->code === 204)
 			{
 				return true;
 			}
@@ -72,7 +72,7 @@ class JGithubPackageIssuesAssignees extends JGithubPackage
 		}
 		catch (DomainException $e)
 		{
-			if (isset($response->code) && 404 == $response->code)
+			if (isset($response->code) && $response->code === 404)
 			{
 				return false;
 			}

--- a/libraries/joomla/github/package/issues/comments.php
+++ b/libraries/joomla/github/package/issues/comments.php
@@ -67,7 +67,7 @@ class JGithubPackageIssuesComments extends JGithubPackage
 		// Build the request path.
 		$path = '/repos/' . $owner . '/' . $repo . '/issues/comments';
 
-		if (false == in_array($sort, array('created', 'updated')))
+		if (in_array($sort, array('created', 'updated')) === false)
 		{
 			throw new UnexpectedValueException(
 				sprintf(
@@ -76,7 +76,7 @@ class JGithubPackageIssuesComments extends JGithubPackage
 			);
 		}
 
-		if (false == in_array($direction, array('asc', 'desc')))
+		if (in_array($direction, array('asc', 'desc')) === false)
 		{
 			throw new UnexpectedValueException(
 				sprintf(

--- a/libraries/joomla/github/package/issues/labels.php
+++ b/libraries/joomla/github/package/issues/labels.php
@@ -94,7 +94,7 @@ class JGithubPackageIssuesLabels extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/issues/milestones.php
+++ b/libraries/joomla/github/package/issues/milestones.php
@@ -48,7 +48,7 @@ class JGithubPackageIssuesMilestones extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -79,7 +79,7 @@ class JGithubPackageIssuesMilestones extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -135,7 +135,7 @@ class JGithubPackageIssuesMilestones extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -195,7 +195,7 @@ class JGithubPackageIssuesMilestones extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -226,7 +226,7 @@ class JGithubPackageIssuesMilestones extends JGithubPackage
 		$response = $this->client->delete($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 204)
+		if ($response->code !== 204)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/markdown.php
+++ b/libraries/joomla/github/package/markdown.php
@@ -60,7 +60,7 @@ class JGithubPackageMarkdown extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/orgs/teams.php
+++ b/libraries/joomla/github/package/orgs/teams.php
@@ -95,7 +95,7 @@ class JGithubPackageOrgsTeams extends JGithubPackage
 
 		if ($permission)
 		{
-			if (false == in_array($permission, array('pull', 'push', 'admin')))
+			if (in_array($permission, array('pull', 'push', 'admin'), true) === false)
 			{
 				throw new UnexpectedValueException('Permissions must be either "pull", "push", or "admin".');
 			}
@@ -137,7 +137,7 @@ class JGithubPackageOrgsTeams extends JGithubPackage
 
 		if ($permission)
 		{
-			if (false == in_array($permission, array('pull', 'push', 'admin')))
+			if (in_array($permission, array('pull', 'push', 'admin')) === false)
 			{
 				throw new UnexpectedValueException('Permissions must be either "pull", "push", or "admin".');
 			}

--- a/libraries/joomla/github/package/pulls.php
+++ b/libraries/joomla/github/package/pulls.php
@@ -64,7 +64,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -109,7 +109,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -167,7 +167,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -198,7 +198,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -231,7 +231,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -264,7 +264,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -294,7 +294,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$path = '/repos/' . $user . '/' . $repo . '/pulls';
 
 		// If a state exists append it as an option.
-		if ($state != 'open')
+		if ($state !== 'open')
 		{
 			$path .= '?state=' . $state;
 		}
@@ -303,7 +303,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -334,11 +334,11 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code == 204)
+		if ($response->code === 204)
 		{
 			return true;
 		}
-		elseif ($response->code == 404)
+		elseif ($response->code === 404)
 		{
 			return false;
 		}
@@ -379,7 +379,7 @@ class JGithubPackagePulls extends JGithubPackage
 		$response = $this->client->put($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/repositories.php
+++ b/libraries/joomla/github/package/repositories.php
@@ -106,7 +106,7 @@ class JGithubPackageRepositories extends JGithubPackage
 		}
 
 		// Sort direction default: when using full_name: asc, otherwise desc.
-		$direction = ($direction) ? : (('full_name' == $sort) ? 'asc' : 'desc');
+		$direction = ($direction) ? : (($sort === 'full_name') ? 'asc' : 'desc');
 
 		if (false == in_array($direction, array('asc', 'desc')))
 		{

--- a/libraries/joomla/github/package/repositories/commits.php
+++ b/libraries/joomla/github/package/repositories/commits.php
@@ -55,7 +55,7 @@ class JGithubPackageRepositoriesCommits extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($rPath));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -86,7 +86,7 @@ class JGithubPackageRepositoriesCommits extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/repositories/contents.php
+++ b/libraries/joomla/github/package/repositories/contents.php
@@ -179,7 +179,7 @@ class JGithubPackageRepositoriesContents extends JGithubPackage
 	 */
 	public function getArchiveLink($owner, $repo, $archive_format = 'zipball', $ref = '')
 	{
-		if (false == in_array($archive_format, array('tarball', 'zipball')))
+		if (in_array($archive_format, array('tarball', 'zipball'), true) === false)
 		{
 			throw new UnexpectedValueException('Archive format must be either "tarball" or "zipball".');
 		}

--- a/libraries/joomla/github/package/repositories/forks.php
+++ b/libraries/joomla/github/package/repositories/forks.php
@@ -51,7 +51,7 @@ class JGithubPackageRepositoriesForks extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 202)
+		if ($response->code !== 202)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -83,7 +83,7 @@ class JGithubPackageRepositoriesForks extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/repositories/statistics.php
+++ b/libraries/joomla/github/package/repositories/statistics.php
@@ -162,7 +162,7 @@ class JGithubPackageRepositoriesStatistics  extends JGithubPackage
 	 */
 	protected function processResponse(JHttpResponse $response, $expectedCode = 200, $decode = true)
 	{
-		if (202 == $response->code)
+		if ($response->code === 202)
 		{
 			throw new \DomainException(
 				'GitHub is building the statistics data. Please try again in a few moments.',

--- a/libraries/joomla/github/package/repositories/statuses.php
+++ b/libraries/joomla/github/package/repositories/statuses.php
@@ -65,7 +65,7 @@ class JGithubPackageRepositoriesStatuses extends JGithubPackage
 		$response = $this->client->post($this->fetchUrl($path), json_encode($data));
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -95,7 +95,7 @@ class JGithubPackageRepositoriesStatuses extends JGithubPackage
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/package/search.php
+++ b/libraries/joomla/github/package/search.php
@@ -35,7 +35,7 @@ class JGithubPackageSearch extends JGithubPackage
 	 */
 	public function issues($owner, $repo, $state, $keyword)
 	{
-		if (false == in_array($state, array('open', 'close')))
+		if (in_array($state, array('open', 'close'), true) === false)
 		{
 			throw new UnexpectedValueException('State must be either "open" or "closed"');
 		}

--- a/libraries/joomla/github/refs.php
+++ b/libraries/joomla/github/refs.php
@@ -48,7 +48,7 @@ class JGithubRefs extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -96,7 +96,7 @@ class JGithubRefs extends JGithubObject
 		$response = $this->client->patch($this->fetchUrl($path), $data);
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -128,7 +128,7 @@ class JGithubRefs extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -162,7 +162,7 @@ class JGithubRefs extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path, $page, $limit));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/github/statuses.php
+++ b/libraries/joomla/github/statuses.php
@@ -38,7 +38,7 @@ class JGithubStatuses extends JGithubObject
 		// Build the request path.
 		$path = '/repos/' . $user . '/' . $repo . '/statuses/' . $sha;
 
-		if (!in_array($state, array('pending', 'success', 'error', 'failure')))
+		if (!in_array($state, array('pending', 'success', 'error', 'failure'), true))
 		{
 			throw new InvalidArgumentException('State must be one of pending, success, error or failure.');
 		}
@@ -62,7 +62,7 @@ class JGithubStatuses extends JGithubObject
 		$response = $this->client->post($this->fetchUrl($path), json_encode($data));
 
 		// Validate the response code.
-		if ($response->code != 201)
+		if ($response->code !== 201)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);
@@ -94,7 +94,7 @@ class JGithubStatuses extends JGithubObject
 		$response = $this->client->get($this->fetchUrl($path));
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			// Decode the error response and throw an exception.
 			$error = json_decode($response->body);

--- a/libraries/joomla/google/auth/oauth2.php
+++ b/libraries/joomla/google/auth/oauth2.php
@@ -115,7 +115,7 @@ class JGoogleAuthOauth2 extends JGoogleAuth
 			$params['access_type'] = 'offline';
 		}
 
-		if ($params['access_type'] == 'offline' && $this->client->getOption('userefresh') === null)
+		if ($params['access_type'] === 'offline' && $this->client->getOption('userefresh') === null)
 		{
 			$this->client->setOption('userefresh', true);
 		}

--- a/libraries/joomla/google/data.php
+++ b/libraries/joomla/google/data.php
@@ -121,7 +121,7 @@ abstract class JGoogleData
 
 		if ($data && array_key_exists('items', $data))
 		{
-			if ($maxpages != 1 && array_key_exists('nextPageToken', $data))
+			if ($maxpages !== 1 && array_key_exists('nextPageToken', $data))
 			{
 				$data['items'] = array_merge($data['items'], $this->listGetData($url, $maxpages - 1, $data['nextPageToken']));
 			}

--- a/libraries/joomla/google/data/picasa.php
+++ b/libraries/joomla/google/data/picasa.php
@@ -97,7 +97,7 @@ class JGoogleDataPicasa extends JGoogleData
 		if ($this->isAuthenticated())
 		{
 			$time = $time ? $time : time();
-			$title = $title != '' ? $title : date('F j, Y');
+			$title = $title !== '' ? $title : date('F j, Y');
 			$xml = new SimpleXMLElement('<entry></entry>');
 			$xml->addAttribute('xmlns', 'http://www.w3.org/2005/Atom');
 			$xml->addChild('title', $title);

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -84,7 +84,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 				throw $e;
 			}
 
-			if ($jdata->body != '')
+			if ($jdata->body !== '')
 			{
 				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
@@ -114,7 +114,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 
 		foreach ($links as $link)
 		{
-			if ($link->attributes()->rel == $type)
+			if ($link->attributes()->rel === $type)
 			{
 				return (string) $link->attributes()->href;
 			}
@@ -389,7 +389,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 		if ($this->isAuthenticated())
 		{
 			jimport('joomla.filesystem.file');
-			$title = $title != '' ? $title : JFile::getName($file);
+			$title = $title !== '' ? $title : JFile::getName($file);
 
 			if (!($type = $this->getMime($file)))
 			{

--- a/libraries/joomla/google/data/picasa/album.php
+++ b/libraries/joomla/google/data/picasa/album.php
@@ -114,7 +114,7 @@ class JGoogleDataPicasaAlbum extends JGoogleData
 
 		foreach ($links as $link)
 		{
-			if ($link->attributes()->rel === $type)
+			if ($link->attributes()->rel == $type)
 			{
 				return (string) $link->attributes()->href;
 			}

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -114,7 +114,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 
 		foreach ($links as $link)
 		{
-			if ($link->attributes()->rel === $type)
+			if ($link->attributes()->rel == $type)
 			{
 				return (string) $link->attributes()->href;
 			}

--- a/libraries/joomla/google/data/picasa/photo.php
+++ b/libraries/joomla/google/data/picasa/photo.php
@@ -84,7 +84,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 				throw $e;
 			}
 
-			if ($jdata->body != '')
+			if ($jdata->body !== '')
 			{
 				throw new UnexpectedValueException("Unexpected data received from Google: `{$jdata->body}`.");
 			}
@@ -114,7 +114,7 @@ class JGoogleDataPicasaPhoto extends JGoogleData
 
 		foreach ($links as $link)
 		{
-			if ($link->attributes()->rel == $type)
+			if ($link->attributes()->rel === $type)
 			{
 				return (string) $link->attributes()->href;
 			}

--- a/libraries/joomla/google/data/plus/activities.php
+++ b/libraries/joomla/google/data/plus/activities.php
@@ -65,7 +65,7 @@ class JGoogleDataPlusActivities extends JGoogleData
 			}
 
 			// Check if max is specified.
-			if ($max != 10)
+			if ($max !== 10)
 			{
 				$url .= (strpos($url, '?') === false) ? '?maxResults=' : '&maxResults=';
 				$url .= $max;
@@ -169,7 +169,7 @@ class JGoogleDataPlusActivities extends JGoogleData
 			}
 
 			// Check if max is specified.
-			if ($max != 10)
+			if ($max !== 10)
 			{
 				$url .= '&maxResults=' . $max;
 			}

--- a/libraries/joomla/google/data/plus/comments.php
+++ b/libraries/joomla/google/data/plus/comments.php
@@ -65,7 +65,7 @@ class JGoogleDataPlusComments extends JGoogleData
 			}
 
 			// Check if max is specified.
-			if ($max != 20)
+			if ($max !== 20)
 			{
 				$url .= (strpos($url, '?') === false) ? '?maxResults=' : '&maxResults=';
 				$url .= $max;

--- a/libraries/joomla/google/data/plus/people.php
+++ b/libraries/joomla/google/data/plus/people.php
@@ -102,7 +102,7 @@ class JGoogleDataPlusPeople extends JGoogleData
 			}
 
 			// Check if max is specified.
-			if ($max != 10)
+			if ($max !== 10)
 			{
 				$url .= '&maxResults=' . $max;
 			}
@@ -150,7 +150,7 @@ class JGoogleDataPlusPeople extends JGoogleData
 			}
 
 			// Check if max is specified.
-			if ($max != 10)
+			if ($max !== 10)
 			{
 				$url .= (strpos($url, '?') === false) ? '?maxResults=' : '&maxResults=';
 				$url .= $max;

--- a/libraries/joomla/google/embed.php
+++ b/libraries/joomla/google/embed.php
@@ -54,7 +54,7 @@ abstract class JGoogleEmbed
 	 */
 	public function isSecure()
 	{
-		return $this->uri->getScheme() == 'https';
+		return $this->uri->getScheme() === 'https';
 	}
 
 	/**

--- a/libraries/joomla/google/embed/maps.php
+++ b/libraries/joomla/google/embed/maps.php
@@ -806,7 +806,7 @@ class JGoogleEmbedMaps extends JGoogleEmbed
 			throw new RuntimeException('Invalid json received geocoding address: ' . $response->body . '.');
 		}
 
-		if ($data['status'] != 'OK')
+		if ($data['status'] !== 'OK')
 		{
 			if (!empty($data['error_message']))
 			{

--- a/libraries/joomla/grid/grid.php
+++ b/libraries/joomla/grid/grid.php
@@ -371,7 +371,7 @@ class JGrid
 			unset($this->specialRows['footer'][array_search($id, $this->specialRows['footer'])]);
 		}
 
-		if ($this->activeRow == $id)
+		if ($this->activeRow === $id)
 		{
 			end($this->rows);
 			$this->activeRow = key($this->rows);
@@ -462,7 +462,7 @@ class JGrid
 	 */
 	protected function renderAttributes($attributes)
 	{
-		if (count((array) $attributes) == 0)
+		if (count((array) $attributes) === 0)
 		{
 			return '';
 		}

--- a/libraries/joomla/http/factory.php
+++ b/libraries/joomla/http/factory.php
@@ -104,7 +104,7 @@ class JHttpFactory
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			if ($file->isFile() && $file->getExtension() == 'php')
+			if ($file->isFile() && $file->getExtension() === 'php')
 			{
 				$names[] = substr($fileName, 0, strrpos($fileName, '.'));
 			}

--- a/libraries/joomla/http/transport/socket.php
+++ b/libraries/joomla/http/transport/socket.php
@@ -241,7 +241,7 @@ class JHttpTransportSocket implements JHttpTransport
 		// If the port is not explicitly set in the URI detect it.
 		if (!$uri->getPort())
 		{
-			$port = ($uri->getScheme() == 'https') ? 443 : 80;
+			$port = ($uri->getScheme() === 'https') ? 443 : 80;
 		}
 
 		// Use the set port.

--- a/libraries/joomla/image/filter.php
+++ b/libraries/joomla/image/filter.php
@@ -44,7 +44,7 @@ abstract class JImageFilter
 		}
 
 		// Make sure the file handle is valid.
-		if (!is_resource($handle) || (get_resource_type($handle) != 'gd'))
+		if (!is_resource($handle) || (get_resource_type($handle) !== 'gd'))
 		{
 			JLog::add('The image handle is invalid for the image filter.', JLog::ERROR);
 			throw new InvalidArgumentException('The image handle is invalid for the image filter.');

--- a/libraries/joomla/image/image.php
+++ b/libraries/joomla/image/image.php
@@ -125,7 +125,7 @@ class JImage
 		}
 
 		// If the source input is a resource, set it as the image handle.
-		if (is_resource($source) && (get_resource_type($source) == 'gd'))
+		if (is_resource($source) && (get_resource_type($source) === 'gd'))
 		{
 			$this->handle = &$source;
 		}
@@ -264,7 +264,7 @@ class JImage
 				// Desired thumbnail size
 				$size = explode('x', strtolower($thumbSize));
 
-				if (count($size) != 2)
+				if (count($size) !== 2)
 				{
 					throw new InvalidArgumentException('Invalid thumb size received: ' . $thumbSize);
 				}
@@ -549,7 +549,7 @@ class JImage
 	public function isLoaded()
 	{
 		// Make sure the resource handle is valid.
-		if (!is_resource($this->handle) || (get_resource_type($this->handle) != 'gd'))
+		if (!is_resource($this->handle) || (get_resource_type($this->handle) !== 'gd'))
 		{
 			return false;
 		}
@@ -726,7 +726,7 @@ class JImage
 		$offset->x = $offset->y = 0;
 
 		// Center image if needed and create the new truecolor image handle.
-		if ($scaleMethod == self::SCALE_FIT)
+		if ($scaleMethod === self::SCALE_FIT)
 		{
 			// Get the offsets
 			$offset->x = round(($width - $dimensions->width) / 2);
@@ -874,7 +874,7 @@ class JImage
 		$handle = imagecreatetruecolor($this->getWidth(), $this->getHeight());
 
 		// Make background transparent if no external background color is provided.
-		if ($background == -1)
+		if ($background === -1)
 		{
 			// Allow transparency for the new image handle.
 			imagealphablending($handle, false);
@@ -1069,7 +1069,7 @@ class JImage
 				$rx = ($width > 0) ? ($this->getWidth() / $width) : 0;
 				$ry = ($height > 0) ? ($this->getHeight() / $height) : 0;
 
-				if ($scaleMethod != self::SCALE_OUTSIDE)
+				if ($scaleMethod !== self::SCALE_OUTSIDE)
 				{
 					$ratio = max($rx, $ry);
 				}

--- a/libraries/joomla/input/files.php
+++ b/libraries/joomla/input/files.php
@@ -78,7 +78,7 @@ class JInputFiles extends JInput
 			);
 
 			// Prevent returning an unsafe file unless speciffically requested
-			if ($filter != 'raw')
+			if ($filter !== 'raw')
 			{
 				$isSafe = JFilterInput::isSafeFile($results);
 

--- a/libraries/joomla/input/input.php
+++ b/libraries/joomla/input/input.php
@@ -309,7 +309,7 @@ class JInput implements Serializable, Countable
 	 */
 	public function __call($name, $arguments)
 	{
-		if (substr($name, 0, 3) == 'get')
+		if (substr($name, 0, 3) === 'get')
 		{
 			$filter = substr($name, 3);
 


### PR DESCRIPTION
### Summary of Changes

Implemented type-safe comparisons in the `libraries / joomla` directory.
For easier reviewing, there is a total of five parts, that cover the `libraries / joomla` directory

This is part 4, which covers directories `github` until  `input`


### Testing Instructions

**Code review only**, as those changes should not affect behavior.
Despite the quantity of the changes, it should be fairly easy to review.

Attention to code reviewers:
In order to prevent code-review-fatigue, I only did type safe comparisons, **without applying**:
- formatting
- removal of unnecessary parentheses
- other non-related changes

Please **only** review the correctness of the specific changes, without pointing out any possible formatting issues (unless corrupted by this PR), removal of parentheses and other non-related changes. This will help get this PR reviewed and merged quickly.
If you should find other prospects for type safe comparison in those folders please note them in a review.

Thank you