### PR TITLE
[ libraries / joomla] Type-safe comparisons #5

### DIFF
--- a/libraries/joomla/factory.php
+++ b/libraries/joomla/factory.php
@@ -274,7 +274,7 @@ abstract class JFactory
 			return self::$cache[$hash];
 		}
 
-		$handler = ($handler == 'function') ? 'callback' : $handler;
+		$handler = ($handler === 'function') ? 'callback' : $handler;
 
 		$options = array('defaultgroup' => $group);
 
@@ -501,7 +501,7 @@ abstract class JFactory
 		$language = self::getLanguage();
 		$locale = $language->getTag();
 
-		if (!isset($classname) || $locale != $mainLocale)
+		if (!isset($classname) || $locale !== $mainLocale)
 		{
 			// Store the locale for future reference
 			$mainLocale = $locale;
@@ -564,7 +564,7 @@ abstract class JFactory
 		$name = 'JConfig' . $namespace;
 
 		// Handle the PHP configuration type.
-		if ($type == 'PHP' && class_exists($name))
+		if ($type === 'PHP' && class_exists($name))
 		{
 			// Create the JConfig object
 			$config = new $name;
@@ -602,7 +602,7 @@ abstract class JFactory
 
 		$session = JSession::getInstance($handler, $options, $sessionHandler);
 
-		if ($session->getState() == 'expired')
+		if ($session->getState() === 'expired')
 		{
 			$session->restart();
 		}
@@ -663,15 +663,15 @@ abstract class JFactory
 	{
 		$conf = self::getConfig();
 
-		$smtpauth = ($conf->get('smtpauth') == 0) ? null : 1;
-		$smtpuser = $conf->get('smtpuser');
-		$smtppass = $conf->get('smtppass');
-		$smtphost = $conf->get('smtphost');
+		$smtpauth   = $conf->get('smtpauth') == 0 ? null : 1;
+		$smtpuser   = $conf->get('smtpuser');
+		$smtppass   = $conf->get('smtppass');
+		$smtphost   = $conf->get('smtphost');
 		$smtpsecure = $conf->get('smtpsecure');
-		$smtpport = $conf->get('smtpport');
-		$mailfrom = $conf->get('mailfrom');
-		$fromname = $conf->get('fromname');
-		$mailer = $conf->get('mailer');
+		$smtpport   = $conf->get('smtpport');
+		$mailfrom   = $conf->get('mailfrom');
+		$fromname   = $conf->get('fromname');
+		$mailer     = $conf->get('mailer');
 
 		// Create a JMail object
 		$mail = JMail::getInstance();

--- a/libraries/joomla/keychain/keychain.php
+++ b/libraries/joomla/keychain/keychain.php
@@ -85,7 +85,7 @@ class JKeychain extends \Joomla\Registry\Registry
 			// Traverse the registry to find the correct node for the result.
 			for ($i = 0, $n = count($nodes) - 1; $i < $n; $i++)
 			{
-				if (!isset($node->{$nodes[$i]}) && ($i != $n))
+				if (!isset($node->{$nodes[$i]}) && ($i !== $n))
 				{
 					$node->{$nodes[$i]} = new stdClass;
 				}

--- a/libraries/joomla/language/helper.php
+++ b/libraries/joomla/language/helper.php
@@ -77,11 +77,11 @@ class JLanguageHelper
 
 					if (strlen($Jinstall_lang) < 6)
 					{
-						if (strtolower($browserLang) == strtolower(substr($systemLang->lang_code, 0, strlen($browserLang))))
+						if (strtolower($browserLang) === strtolower(substr($systemLang->lang_code, 0, strlen($browserLang))))
 						{
 							return $systemLang->lang_code;
 						}
-						elseif ($primary_browserLang == substr($systemLang->lang_code, 0, 2))
+						elseif ($primary_browserLang === substr($systemLang->lang_code, 0, 2))
 						{
 							$primaryDetectedLang = $systemLang->lang_code;
 						}

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -321,7 +321,7 @@ class JLanguage
 	public function _($string, $jsSafe = false, $interpretBackSlashes = true)
 	{
 		// Detect empty string
-		if ($string == '')
+		if ($string === '')
 		{
 			return '';
 		}
@@ -717,14 +717,14 @@ class JLanguage
 
 		// Load the default language first if we're not debugging and a non-default language is requested to be loaded
 		// with $default set to true
-		if (!$this->debug && ($lang != $this->default) && $default)
+		if (!$this->debug && ($lang !== $this->default) && $default)
 		{
 			$this->load($extension, $basePath, $this->default, false, true);
 		}
 
 		$path = JLanguageHelper::getLanguagePath($basePath, $lang);
 
-		$internal = $extension == 'joomla' || $extension == '';
+		$internal = $extension === 'joomla' || $extension === '';
 		$filename = $internal ? $lang : $lang . '.' . $extension;
 		$filename = "$path/$filename.ini";
 
@@ -753,7 +753,7 @@ class JLanguage
 					$filename = "$path/$filename.ini";
 
 					// If the one we tried is different than the new name, try again
-					if ($oldFilename != $filename)
+					if ($oldFilename !== $filename)
 					{
 						$result = $this->loadLanguage($filename, $extension, false);
 					}
@@ -890,7 +890,7 @@ class JLanguage
 		foreach ($file as $lineNumber => $line)
 		{
 			// Avoid BOM error as BOM is OK when using parse_ini.
-			if ($lineNumber == 0)
+			if ($lineNumber === 0)
 			{
 				$line = str_replace("\xEF\xBB\xBF", '', $line);
 			}
@@ -898,7 +898,7 @@ class JLanguage
 			$line = trim($line);
 
 			// Ignore comment lines.
-			if (!strlen($line) || $line['0'] == ';')
+			if (!strlen($line) || $line['0'] === ';')
 			{
 				continue;
 			}
@@ -921,7 +921,7 @@ class JLanguage
 			}
 
 			// Check for odd number of double quotes.
-			if (substr_count($line, '"') % 2 != 0)
+			if (substr_count($line, '"') % 2 !== 0)
 			{
 				$errors[] = $realNumber;
 				continue;
@@ -937,7 +937,7 @@ class JLanguage
 			// Check that the key is not in the blacklist.
 			$key = strtoupper(trim(substr($line, 0, strpos($line, '='))));
 
-			if (in_array($key, $blacklist))
+			if (in_array($key, $blacklist, true))
 			{
 				$errors[] = $realNumber;
 			}
@@ -1006,7 +1006,7 @@ class JLanguage
 			$class = @ $step['class'];
 
 			// We're looking for something outside of language.php
-			if ($class != 'JLanguage' && $class != 'JText')
+			if ($class !== 'JLanguage' && $class !== 'JText')
 			{
 				$info['function'] = @ $step['function'];
 				$info['class'] = $class;

--- a/libraries/joomla/language/stemmer/porteren.php
+++ b/libraries/joomla/language/stemmer/porteren.php
@@ -90,7 +90,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 	private static function _step1ab($word)
 	{
 		// Part a
-		if (substr($word, -1) == 's')
+		if (substr($word, -1) === 's')
 		{
 				self::_replace($word, 'sses', 'ss')
 			or self::_replace($word, 'ies', 'i')
@@ -99,7 +99,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 		}
 
 		// Part b
-		if (substr($word, -2, 1) != 'e' or !self::_replace($word, 'eed', 'ee', 0))
+		if (substr($word, -2, 1) !== 'e' or !self::_replace($word, 'eed', 'ee', 0))
 		{
 			// First rule
 			$v = self::$_regex_vowel;
@@ -113,11 +113,11 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 				if (!self::_replace($word, 'at', 'ate') and !self::_replace($word, 'bl', 'ble') and !self::_replace($word, 'iz', 'ize'))
 				{
 					// Double consonant ending
-					if (self::_doubleConsonant($word) and substr($word, -2) != 'll' and substr($word, -2) != 'ss' and substr($word, -2) != 'zz')
+					if (self::_doubleConsonant($word) and substr($word, -2) !== 'll' and substr($word, -2) !== 'ss' and substr($word, -2) !== 'zz')
 					{
 						$word = substr($word, 0, -1);
 					}
-					elseif (self::_m($word) == 1 and self::_cvc($word))
+					elseif (self::_m($word) === 1 and self::_cvc($word))
 					{
 						$word .= 'e';
 					}
@@ -141,7 +141,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 	{
 		$v = self::$_regex_vowel;
 
-		if (substr($word, -1) == 'y' && preg_match("#$v+#", substr($word, 0, -1)))
+		if (substr($word, -1) === 'y' && preg_match("#$v+#", substr($word, 0, -1)))
 		{
 			self::_replace($word, 'y', 'i');
 		}
@@ -278,7 +278,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 				or self::_replace($word, 'ent', '', 1);
 				break;
 			case 'o':
-				if (substr($word, -4) == 'tion' or substr($word, -4) == 'sion')
+				if (substr($word, -4) === 'tion' or substr($word, -4) === 'sion')
 				{
 					self::_replace($word, 'ion', '', 1);
 				}
@@ -320,7 +320,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 	private static function _step5($word)
 	{
 		// Part a
-		if (substr($word, -1) == 'e')
+		if (substr($word, -1) === 'e')
 		{
 			if (self::_m(substr($word, 0, -1)) > 1)
 			{
@@ -336,7 +336,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 		}
 
 		// Part b
-		if (self::_m($word) > 1 and self::_doubleConsonant($word) and substr($word, -1) == 'l')
+		if (self::_m($word) > 1 and self::_doubleConsonant($word) and substr($word, -1) === 'l')
 		{
 			$word = substr($word, 0, -1);
 		}
@@ -363,7 +363,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 	{
 		$len = 0 - strlen($check);
 
-		if (substr($str, $len) == $check)
+		if (substr($str, $len) === $check)
 		{
 			$substr = substr($str, 0, $len);
 
@@ -421,7 +421,7 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 	{
 		$c = self::$_regex_consonant;
 
-		return preg_match("#$c{2}$#", $str, $matches) and $matches[0]{0} == $matches[0]{1};
+		return preg_match("#$c{2}$#", $str, $matches) and $matches[0]{0} === $matches[0]{1};
 	}
 
 	/**
@@ -439,10 +439,10 @@ class JLanguageStemmerPorteren extends JLanguageStemmer
 		$v = self::$_regex_vowel;
 
 		$result = preg_match("#($c$v$c)$#", $str, $matches)
-			and strlen($matches[1]) == 3
-			and $matches[1]{2} != 'w'
-			and $matches[1]{2} != 'x'
-			and $matches[1]{2} != 'y';
+			and strlen($matches[1]) === 3
+			and $matches[1]{2} !== 'w'
+			and $matches[1]{2} !== 'x'
+			and $matches[1]{2} !== 'y';
 
 		return $result;
 	}

--- a/libraries/joomla/language/text.php
+++ b/libraries/joomla/language/text.php
@@ -201,7 +201,7 @@ class JText
 			return '';
 		}
 
-		if ($count == 1)
+		if ($count === 1)
 		{
 			// Default to the normal sprintf handling.
 			$args[0] = $lang->_($string);

--- a/libraries/joomla/linkedin/companies.php
+++ b/libraries/joomla/linkedin/companies.php
@@ -204,32 +204,32 @@ class JLinkedinCompanies extends JLinkedinObject
 			{
 				if ($facet[$i])
 				{
-					if ($i == 0)
+					if ($i === 0)
 					{
 						$data['facet'][] = 'location,' . $facet[$i];
 					}
 
-					if ($i == 1)
+					if ($i === 1)
 					{
 						$data['facet'][] = 'industry,' . $facet[$i];
 					}
 
-					if ($i == 2)
+					if ($i === 2)
 					{
 						$data['facet'][] = 'network,' . $facet[$i];
 					}
 
-					if ($i == 3)
+					if ($i === 3)
 					{
 						$data['facet'][] = 'company-size,' . $facet[$i];
 					}
 
-					if ($i == 4)
+					if ($i === 4)
 					{
 						$data['facet'][] = 'num-followers-range,' . $facet[$i];
 					}
 
-					if ($i == 5)
+					if ($i === 5)
 					{
 						$data['facet'][] = 'fortune,' . $facet[$i];
 					}

--- a/libraries/joomla/linkedin/groups.php
+++ b/libraries/joomla/linkedin/groups.php
@@ -55,7 +55,7 @@ class JLinkedinGroups extends JLinkedinObject
 		}
 
 		// Check if count is specified.
-		if ($count != 5)
+		if ($count !== 5)
 		{
 			$data['count'] = $count;
 		}
@@ -120,7 +120,7 @@ class JLinkedinGroups extends JLinkedinObject
 		}
 
 		// Check if count is specified.
-		if ($count != 5)
+		if ($count !== 5)
 		{
 			$data['count'] = $count;
 		}
@@ -196,7 +196,7 @@ class JLinkedinGroups extends JLinkedinObject
 		}
 
 		// Check if count is specified.
-		if ($count != 5)
+		if ($count !== 5)
 		{
 			$data['count'] = $count;
 		}

--- a/libraries/joomla/linkedin/jobs.php
+++ b/libraries/joomla/linkedin/jobs.php
@@ -314,32 +314,32 @@ class JLinkedinJobs extends JLinkedinObject
 			{
 				if ($facet[$i])
 				{
-					if ($i == 0)
+					if ($i === 0)
 					{
 						$data['facet'][] = 'company,' . $this->oauth->safeEncode($facet[$i]);
 					}
 
-					if ($i == 1)
+					if ($i === 1)
 					{
 						$data['facet'][] = 'date-posted,' . $facet[$i];
 					}
 
-					if ($i == 2)
+					if ($i === 2)
 					{
 						$data['facet'][] = 'location,' . $facet[$i];
 					}
 
-					if ($i == 3)
+					if ($i === 3)
 					{
 						$data['facet'][] = 'job-function,' . $this->oauth->safeEncode($facet[$i]);
 					}
 
-					if ($i == 4)
+					if ($i === 4)
 					{
 						$data['facet'][] = 'industry,' . $facet[$i];
 					}
 
-					if ($i == 5)
+					if ($i === 5)
 					{
 						$data['facet'][] = 'salary,' . $facet[$i];
 					}

--- a/libraries/joomla/linkedin/linkedin.php
+++ b/libraries/joomla/linkedin/linkedin.php
@@ -107,7 +107,7 @@ class JLinkedin
 
 		if (class_exists($class))
 		{
-			if (false == isset($this->$name))
+			if (isset($this->$name) === false)
 			{
 				$this->$name = new $class($this->options, $this->client, $this->oauth);
 			}

--- a/libraries/joomla/linkedin/oauth.php
+++ b/libraries/joomla/linkedin/oauth.php
@@ -71,7 +71,7 @@ class JLinkedinOauth extends JOAuth1Client
 		$response = $this->oauthRequest($path, 'GET', $parameters, $data);
 
 		// Verify response
-		if ($response->code == 200)
+		if ($response->code === 200)
 		{
 			return true;
 		}
@@ -99,7 +99,7 @@ class JLinkedinOauth extends JOAuth1Client
 			$code = 200;
 		}
 
-		if (strpos($url, '::(~)') === false && $response->code != $code)
+		if (strpos($url, '::(~)') === false && $response->code !== $code)
 		{
 			if ($error = json_decode($response->body))
 			{

--- a/libraries/joomla/linkedin/people.php
+++ b/libraries/joomla/linkedin/people.php
@@ -127,7 +127,7 @@ class JLinkedinPeople extends JLinkedinObject
 			$data['start'] = $start;
 		}
 		// Check if count is specified.
-		if ($count != 500)
+		if ($count !== 500)
 		{
 			$data['count'] = $count;
 		}
@@ -294,37 +294,37 @@ class JLinkedinPeople extends JLinkedinObject
 			{
 				if ($facet[$i])
 				{
-					if ($i == 0)
+					if ($i === 0)
 					{
 						$data['facet'][] = 'location,' . $facet[$i];
 					}
 
-					if ($i == 1)
+					if ($i === 1)
 					{
 						$data['facet'][] = 'industry,' . $facet[$i];
 					}
 
-					if ($i == 2)
+					if ($i === 2)
 					{
 						$data['facet'][] = 'network,' . $facet[$i];
 					}
 
-					if ($i == 3)
+					if ($i === 3)
 					{
 						$data['facet'][] = 'language,' . $facet[$i];
 					}
 
-					if ($i == 4)
+					if ($i === 4)
 					{
 						$data['facet'][] = 'current-company,' . $facet[$i];
 					}
 
-					if ($i == 5)
+					if ($i === 5)
 					{
 						$data['facet'][] = 'past-company,' . $facet[$i];
 					}
 
-					if ($i == 6)
+					if ($i === 6)
 					{
 						$data['facet'][] = 'school,' . $facet[$i];
 					}
@@ -339,7 +339,7 @@ class JLinkedinPeople extends JLinkedinObject
 		}
 
 		// Check if count is specified.
-		if ($count != 10)
+		if ($count !== 10)
 		{
 			$data['count'] = $count;
 		}

--- a/libraries/joomla/log/log.php
+++ b/libraries/joomla/log/log.php
@@ -219,7 +219,7 @@ class JLog
 				$callback = $options['callback'];
 				$options['callback'] = spl_object_hash($options['callback']);
 			}
-			elseif (is_array($options['callback']) && count($options['callback']) == 2 && is_object($options['callback'][0]))
+			elseif (is_array($options['callback']) && count($options['callback']) === 2 && is_object($options['callback'][0]))
 			{
 				$callback = $options['callback'];
 				$options['callback'] = spl_object_hash($options['callback'][0]) . '::' . $options['callback'][1];

--- a/libraries/joomla/log/logger/formattedtext.php
+++ b/libraries/joomla/log/logger/formattedtext.php
@@ -125,7 +125,7 @@ class JLogLoggerFormattedtext extends JLogLogger
 		}
 
 		// If the time field is missing or the date field isn't only the date we need to rework it.
-		if ((strlen($entry->date) != 10) || !isset($entry->time))
+		if ((strlen($entry->date) !== 10) || !isset($entry->time))
 		{
 			// Get the date and time strings in GMT.
 			$entry->datetime = $entry->date->toISO8601();

--- a/libraries/joomla/mail/helper.php
+++ b/libraries/joomla/mail/helper.php
@@ -130,7 +130,7 @@ abstract class JMailHelper
 		$allowed = "a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-";
 		$regex = "/^[$allowed][\.$allowed]{0,63}$/";
 
-		if (!preg_match($regex, $local) || substr($local, -1) == '.' || $local[0] == '.' || preg_match('/\.\./', $local))
+		if (!preg_match($regex, $local) || substr($local, -1) === '.' || $local[0] === '.' || preg_match('/\.\./', $local))
 		{
 			return false;
 		}

--- a/libraries/joomla/mail/mail.php
+++ b/libraries/joomla/mail/mail.php
@@ -98,7 +98,7 @@ class JMail extends PHPMailer
 	{
 		if (JFactory::getConfig()->get('mailonline', 1))
 		{
-			if (($this->Mailer == 'mail') && !function_exists('mail'))
+			if (($this->Mailer === 'mail') && !function_exists('mail'))
 			{
 				return JError::raiseNotice(500, JText::_('JLIB_MAIL_FUNCTION_DISABLED'));
 			}
@@ -635,7 +635,7 @@ class JMail extends PHPMailer
 		$this->Password = $pass;
 		$this->Port = $port;
 
-		if ($secure == 'ssl' || $secure == 'tls')
+		if ($secure === 'ssl' || $secure === 'tls')
 		{
 			$this->SMTPSecure = $secure;
 		}

--- a/libraries/joomla/oauth2/client.php
+++ b/libraries/joomla/oauth2/client.php
@@ -219,11 +219,11 @@ class JOAuth2Client
 			$token = $this->refreshToken($token['refresh_token']);
 		}
 
-		if (!$this->getOption('authmethod') || $this->getOption('authmethod') == 'bearer')
+		if (!$this->getOption('authmethod') || $this->getOption('authmethod') === 'bearer')
 		{
 			$headers['Authorization'] = 'Bearer ' . $token['access_token'];
 		}
-		elseif ($this->getOption('authmethod') == 'get')
+		elseif ($this->getOption('authmethod') === 'get')
 		{
 			if (strpos($url, '?'))
 			{

--- a/libraries/joomla/object/object.php
+++ b/libraries/joomla/object/object.php
@@ -117,7 +117,7 @@ class JObject
 		{
 			foreach ($vars as $key => $value)
 			{
-				if ('_' == substr($key, 0, 1))
+				if (substr($key, 0, 1) === '_')
 				{
 					unset($vars[$key]);
 				}

--- a/libraries/joomla/openstreetmap/elements.php
+++ b/libraries/joomla/openstreetmap/elements.php
@@ -178,11 +178,11 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 		{
 			foreach ($members as $member)
 			{
-				if ($member['type'] == 'node')
+				if ($member['type'] === 'node')
 				{
 					$member_list .= '<member type="' . $member['type'] . '" role="' . $member['role'] . '" ref="' . $member['ref'] . '"/>';
 				}
-				elseif ($member['type'] == 'way')
+				elseif ($member['type'] === 'way')
 				{
 					$member_list .= '<member type="' . $member['type'] . '" ref="' . $member['ref'] . '"/>';
 				}
@@ -218,7 +218,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function readElement($element, $id)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -249,7 +249,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function updateElement($element, $xml, $id)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -292,7 +292,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function deleteElement($element, $id, $version, $changeset, $latitude = null, $longitude = null)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -343,7 +343,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function historyOfElement($element, $id)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -374,7 +374,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function versionOfElement($element, $id, $version)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -404,7 +404,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function multiFetchElements($element, $params)
 	{
-		if ($element != 'nodes' && $element != 'ways' && $element != 'relations')
+		if ($element !== 'nodes' && $element !== 'ways' && $element !== 'relations')
 		{
 			throw new DomainException('Element should be nodes, ways or relations');
 		}
@@ -437,7 +437,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function relationsForElement($element, $id)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}
@@ -490,7 +490,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function fullElement($element, $id)
 	{
-		if ($element != 'way' && $element != 'relation')
+		if ($element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a way or a relation');
 		}
@@ -522,7 +522,7 @@ class JOpenstreetmapElements extends JOpenstreetmapObject
 	 */
 	public function redaction($element, $id, $version, $redaction_id)
 	{
-		if ($element != 'node' && $element != 'way' && $element != 'relation')
+		if ($element !== 'node' && $element !== 'way' && $element !== 'relation')
 		{
 			throw new DomainException('Element should be a node, a way or a relation');
 		}

--- a/libraries/joomla/openstreetmap/oauth.php
+++ b/libraries/joomla/openstreetmap/oauth.php
@@ -79,7 +79,7 @@ class JOpenstreetmapOauth extends JOAuth1Client
 	 */
 	public function validateResponse($url, $response)
 	{
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			$error = htmlspecialchars($response->body, ENT_COMPAT, 'UTF-8');
 

--- a/libraries/joomla/openstreetmap/object.php
+++ b/libraries/joomla/openstreetmap/object.php
@@ -118,7 +118,7 @@ abstract class JOpenstreetmapObject
 		}
 
 		// Validate the response code.
-		if ($response->code != 200)
+		if ($response->code !== 200)
 		{
 			$error = htmlspecialchars($response->body, ENT_COMPAT, 'UTF-8');
 

--- a/libraries/joomla/openstreetmap/openstreetmap.php
+++ b/libraries/joomla/openstreetmap/openstreetmap.php
@@ -120,7 +120,7 @@ class JOpenstreetmap
 
 		if (class_exists($class))
 		{
-			if (false == isset($this->$name))
+			if (isset($this->$name) === false)
 			{
 				$this->$name = new $class($this->options, $this->client, $this->oauth);
 			}

--- a/libraries/joomla/platform.php
+++ b/libraries/joomla/platform.php
@@ -62,7 +62,7 @@ final class JPlatform
 	 */
 	public static function isCompatible($minimum)
 	{
-		return version_compare(self::getShortVersion(), $minimum, 'eq') == 1;
+		return version_compare(self::getShortVersion(), $minimum, 'eq') === true;
 	}
 
 	/**

--- a/libraries/joomla/session/handler/joomla.php
+++ b/libraries/joomla/session/handler/joomla.php
@@ -125,12 +125,12 @@ class JSessionHandlerJoomla extends JSessionHandlerNative
 
 		$config = JFactory::getConfig();
 
-		if ($config->get('cookie_domain', '') != '')
+		if ($config->get('cookie_domain', '') !== '')
 		{
 			$cookie['domain'] = $config->get('cookie_domain');
 		}
 
-		if ($config->get('cookie_path', '') != '')
+		if ($config->get('cookie_path', '') !== '')
 		{
 			$cookie['path'] = $config->get('cookie_path');
 		}

--- a/libraries/joomla/session/session.php
+++ b/libraries/joomla/session/session.php
@@ -394,7 +394,7 @@ class JSession implements IteratorAggregate
 			$fileName = $file->getFilename();
 
 			// Only load for php files.
-			if (!$file->isFile() || $file->getExtension() != 'php')
+			if (!$file->isFile() || $file->getExtension() !== 'php')
 			{
 				continue;
 			}
@@ -428,7 +428,7 @@ class JSession implements IteratorAggregate
 	 */
 	public function isActive()
 	{
-		return (bool) ($this->getState() == 'active');
+		return (bool) ($this->getState() === 'active');
 	}
 
 	/**

--- a/libraries/joomla/string/punycode.php
+++ b/libraries/joomla/string/punycode.php
@@ -69,7 +69,7 @@ abstract class JStringPunycode
 	{
 		$parsed = UriHelper::parse_url($uri);
 
-		if (!isset($parsed['host']) || $parsed['host'] == '')
+		if (!isset($parsed['host']) || $parsed['host'] === '')
 		{
 			// If there is no host we do not need to convert it.
 			return $uri;
@@ -140,7 +140,7 @@ abstract class JStringPunycode
 
 		$parsed = UriHelper::parse_url($uri);
 
-		if (!isset($parsed['host']) || $parsed['host'] == '')
+		if (!isset($parsed['host']) || $parsed['host'] === '')
 		{
 			// If there is no host we do not need to convert it.
 			return $uri;

--- a/libraries/joomla/table/extension.php
+++ b/libraries/joomla/table/extension.php
@@ -42,7 +42,7 @@ class JTableExtension extends JTable
 	public function check()
 	{
 		// Check for valid name
-		if (trim($this->name) == '' || trim($this->element) == '')
+		if (trim($this->name) === '' || trim($this->element) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_EXTENSION'));
 

--- a/libraries/joomla/table/language.php
+++ b/libraries/joomla/table/language.php
@@ -37,7 +37,7 @@ class JTableLanguage extends JTable
 	 */
 	public function check()
 	{
-		if (trim($this->title) == '')
+		if (trim($this->title) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_LANGUAGE_NO_TITLE'));
 

--- a/libraries/joomla/table/nested.php
+++ b/libraries/joomla/table/nested.php
@@ -1406,7 +1406,7 @@ class JTableNested extends JTable
 		$segments = $this->_db->loadColumn();
 
 		// Make sure to remove the root path if it exists in the list.
-		if ($segments[0] == 'root')
+		if ($segments[0] === 'root')
 		{
 			array_shift($segments);
 		}

--- a/libraries/joomla/table/update.php
+++ b/libraries/joomla/table/update.php
@@ -42,7 +42,7 @@ class JTableUpdate extends JTable
 	public function check()
 	{
 		// Check for valid name
-		if (trim($this->name) == '' || trim($this->element) == '')
+		if (trim($this->name) === '' || trim($this->element) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_EXTENSION'));
 

--- a/libraries/joomla/table/updatesite.php
+++ b/libraries/joomla/table/updatesite.php
@@ -42,7 +42,7 @@ class JTableUpdatesite extends JTable
 	public function check()
 	{
 		// Check for valid name
-		if (trim($this->name) == '' || trim($this->location) == '')
+		if (trim($this->name) === '' || trim($this->location) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_EXTENSION'));
 

--- a/libraries/joomla/table/user.php
+++ b/libraries/joomla/table/user.php
@@ -173,14 +173,14 @@ class JTableUser extends JTable
 		$filterInput = JFilterInput::getInstance();
 
 		// Validate user information
-		if ($filterInput->clean($this->name, 'TRIM') == '')
+		if ($filterInput->clean($this->name, 'TRIM') === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_PLEASE_ENTER_YOUR_NAME'));
 
 			return false;
 		}
 
-		if ($filterInput->clean($this->username, 'TRIM') == '')
+		if ($filterInput->clean($this->username, 'TRIM') === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_PLEASE_ENTER_A_USER_NAME'));
 
@@ -195,7 +195,7 @@ class JTableUser extends JTable
 			return false;
 		}
 
-		if (($filterInput->clean($this->email, 'TRIM') == '') || !JMailHelper::isEmailAddress($this->email))
+		if (($filterInput->clean($this->email, 'TRIM') === '') || !JMailHelper::isEmailAddress($this->email))
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_VALID_MAIL'));
 

--- a/libraries/joomla/table/usergroup.php
+++ b/libraries/joomla/table/usergroup.php
@@ -38,7 +38,7 @@ class JTableUsergroup extends JTable
 	public function check()
 	{
 		// Validate the title.
-		if ((trim($this->title)) == '')
+		if ((trim($this->title)) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_USERGROUP_TITLE'));
 

--- a/libraries/joomla/table/viewlevel.php
+++ b/libraries/joomla/table/viewlevel.php
@@ -62,7 +62,7 @@ class JTableViewlevel extends JTable
 	public function check()
 	{
 		// Validate the title.
-		if ((trim($this->title)) == '')
+		if ((trim($this->title)) === '')
 		{
 			$this->setError(JText::_('JLIB_DATABASE_ERROR_VIEWLEVEL'));
 

--- a/libraries/joomla/twitter/oauth.php
+++ b/libraries/joomla/twitter/oauth.php
@@ -69,7 +69,7 @@ class JTwitterOAuth extends JOAuth1Client
 		$response = $this->oauthRequest($path, 'GET', $parameters);
 
 		// Verify response
-		if ($response->code == 200)
+		if ($response->code === 200)
 		{
 			return true;
 		}
@@ -115,7 +115,7 @@ class JTwitterOAuth extends JOAuth1Client
 	 */
 	public function validateResponse($url, $response)
 	{
-		if (strpos($url, 'verify_credentials') === false && $response->code != 200)
+		if (strpos($url, 'verify_credentials') === false && $response->code !== 200)
 		{
 			$error = json_decode($response->body);
 

--- a/libraries/joomla/updater/adapters/collection.php
+++ b/libraries/joomla/updater/adapters/collection.php
@@ -124,7 +124,7 @@ class JUpdaterCollection extends JUpdateAdapter
 					{
 						$attrs[$col] = '';
 
-						if ($col == 'CLIENT')
+						if ($col === 'CLIENT')
 						{
 							$attrs[$col] = 'site';
 						}
@@ -171,7 +171,7 @@ class JUpdaterCollection extends JUpdateAdapter
 
 				// Set this to ourselves as a default
 				// validate that we can install the extension
-				if ($product == $values['targetplatform'] && preg_match('/^' . $values['targetplatformversion'] . '/', JVERSION))
+				if ($product === $values['targetplatform'] && preg_match('/^' . $values['targetplatformversion'] . '/', JVERSION))
 				{
 					$update->bind($values);
 					$this->updates[] = $update;
@@ -234,7 +234,7 @@ class JUpdaterCollection extends JUpdateAdapter
 		if (!xml_parse($this->xmlParser, $response->body))
 		{
 			// If the URL is missing the .xml extension, try appending it and retry loading the update
-			if (!$this->appendExtension && (substr($this->_url, -4) != '.xml'))
+			if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml'))
 			{
 				$options['append_extension'] = true;
 

--- a/libraries/joomla/updater/adapters/extension.php
+++ b/libraries/joomla/updater/adapters/extension.php
@@ -61,17 +61,17 @@ class JUpdaterExtension extends JUpdateAdapter
 					$this->currentUpdate->$name = '';
 				}
 
-				if ($name == 'TARGETPLATFORM')
+				if ($name === 'TARGETPLATFORM')
 				{
 					$this->currentUpdate->targetplatform = $attrs;
 				}
 
-				if ($name == 'PHP_MINIMUM')
+				if ($name === 'PHP_MINIMUM')
 				{
 					$this->currentUpdate->php_minimum = '';
 				}
 
-				if ($name == 'SUPPORTED_DATABASES')
+				if ($name === 'SUPPORTED_DATABASES')
 				{
 					$this->currentUpdate->supported_databases = $attrs;
 				}
@@ -116,7 +116,7 @@ class JUpdaterExtension extends JUpdateAdapter
 				 *
 				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
 				 */
-				if ($product == $this->currentUpdate->targetplatform['NAME']
+				if ($product === $this->currentUpdate->targetplatform['NAME']
 					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || JVersion::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || JVersion::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
@@ -224,7 +224,7 @@ class JUpdaterExtension extends JUpdateAdapter
 						if (isset($this->latest))
 						{
 							// We already have a possible update. Check the version.
-							if (version_compare($this->currentUpdate->version, $this->latest->version, '>') == 1)
+							if (version_compare($this->currentUpdate->version, $this->latest->version, '>') === true)
 							{
 								$this->latest = $this->currentUpdate;
 							}
@@ -265,12 +265,12 @@ class JUpdaterExtension extends JUpdateAdapter
 			$this->currentUpdate->$tag .= $data;
 		}
 
-		if ($tag == 'PHP_MINIMUM')
+		if ($tag === 'PHP_MINIMUM')
 		{
 			$this->currentUpdate->php_minimum = $data;
 		}
 
-		if ($tag == 'TAG')
+		if ($tag === 'TAG')
 		{
 			$this->currentUpdate->stability = $this->stabilityTagToInteger((string) $data);
 		}
@@ -307,7 +307,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		if (!xml_parse($this->xmlParser, $response->body))
 		{
 			// If the URL is missing the .xml extension, try appending it and retry loading the update
-			if (!$this->appendExtension && (substr($this->_url, -4) != '.xml'))
+			if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml'))
 			{
 				$options['append_extension'] = true;
 

--- a/libraries/joomla/updater/update.php
+++ b/libraries/joomla/updater/update.php
@@ -316,7 +316,7 @@ class JUpdate extends JObject
 				 * Check for optional min_dev_level and max_dev_level attributes to further specify targetplatform (e.g., 3.0.1)
 				 */
 				if (isset($this->currentUpdate->targetplatform->name)
-					&& $product == $this->currentUpdate->targetplatform->name
+					&& $product === $this->currentUpdate->targetplatform->name
 					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) 
 					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
@@ -366,7 +366,7 @@ class JUpdate extends JObject
 					{
 						if (isset($this->latest))
 						{
-							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>') == 1)
+							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>') === true)
 							{
 								$this->latest = $this->currentUpdate;
 							}
@@ -417,7 +417,7 @@ class JUpdate extends JObject
 		// Throw the data for this item together
 		$tag = strtolower($tag);
 
-		if ($tag == 'tag')
+		if ($tag === 'tag')
 		{
 			$this->currentUpdate->stability = $this->stabilityTagToInteger((string) $data);
 

--- a/libraries/joomla/updater/updateadapter.php
+++ b/libraries/joomla/updater/updateadapter.php
@@ -223,9 +223,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 			$this->appendExtension = $options['append_extension'];
 		}
 
-		if ($this->appendExtension && (substr($url, -4) != '.xml'))
+		if ($this->appendExtension && (substr($url, -4) !== '.xml'))
 		{
-			if (substr($url, -1) != '/')
+			if (substr($url, -1) !== '/')
 			{
 				$url .= '/';
 			}
@@ -264,7 +264,7 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		if ($response === null || $response->code !== 200)
 		{
 			// If the URL is missing the .xml extension, try appending it and retry loading the update
-			if (!$this->appendExtension && (substr($url, -4) != '.xml'))
+			if (!$this->appendExtension && (substr($url, -4) !== '.xml'))
 			{
 				$options['append_extension'] = true;
 

--- a/libraries/joomla/updater/updater.php
+++ b/libraries/joomla/updater/updater.php
@@ -286,7 +286,7 @@ class JUpdater extends JAdapter
 					$extraId  = (int) $extraUpdateSite['update_site_id'];
 
 					// Do not try to fetch the same update site twice
-					if (($thisId == $extraId) || ($thisUrl == $extraUrl))
+					if (($thisId === $extraId) || ($thisUrl === $extraUrl))
 					{
 						continue;
 					}
@@ -342,7 +342,7 @@ class JUpdater extends JAdapter
 							$extension->load($eid);
 							$data = json_decode($extension->manifest_cache, true);
 
-							if (version_compare($current_update->version, $data['version'], $operator) == 1)
+							if (version_compare($current_update->version, $data['version'], $operator) === true)
 							{
 								$current_update->extension_id = $eid;
 								$retVal[] = $current_update;
@@ -359,7 +359,7 @@ class JUpdater extends JAdapter
 						$update->load($uid);
 
 						// If there is an update, check that the version is newer then replaces
-						if (version_compare($current_update->version, $update->version, $operator) == 1)
+						if (version_compare($current_update->version, $update->version, $operator) === true)
 						{
 							$retVal[] = $current_update;
 						}

--- a/libraries/joomla/uri/uri.php
+++ b/libraries/joomla/uri/uri.php
@@ -60,10 +60,10 @@ class JUri extends Uri
 		if (empty(static::$instances[$uri]))
 		{
 			// Are we obtaining the URI from the server?
-			if ($uri == 'SERVER')
+			if ($uri === 'SERVER')
 			{
 				// Determine if the request was over SSL (HTTPS).
-				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) != 'off'))
+				if (isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) !== 'off'))
 				{
 					$https = 's://';
 				}
@@ -141,7 +141,7 @@ class JUri extends Uri
 			$uri = static::getInstance();
 			$live_site = ($uri->isSsl()) ? str_replace('http://', 'https://', $config->get('live_site')) : $config->get('live_site');
 
-			if (trim($live_site) != '')
+			if (trim($live_site) !== '')
 			{
 				$uri = static::getInstance($live_site);
 				static::$base['prefix'] = $uri->toString(array('scheme', 'host', 'port'));
@@ -149,7 +149,7 @@ class JUri extends Uri
 
 				if (defined('JPATH_BASE') && defined('JPATH_ADMINISTRATOR'))
 				{
-					if (JPATH_BASE == JPATH_ADMINISTRATOR)
+					if (JPATH_BASE === JPATH_ADMINISTRATOR)
 					{
 						static::$base['path'] .= '/administrator';
 					}

--- a/libraries/joomla/user/helper.php
+++ b/libraries/joomla/user/helper.php
@@ -71,7 +71,7 @@ abstract class JUserHelper
 			// Set the group data for the user object in the session.
 			$temp = JFactory::getUser();
 
-			if ($temp->id == $userId)
+			if ($temp->id === (int) $userId)
 			{
 				$temp->groups = $user->groups;
 			}
@@ -131,7 +131,7 @@ abstract class JUserHelper
 		// Set the group data for the user object in the session.
 		$temp = JFactory::getUser();
 
-		if ($temp->id == $userId)
+		if ($temp->id ===  (int) $userId)
 		{
 			$temp->groups = $user->groups;
 		}
@@ -185,7 +185,7 @@ abstract class JUserHelper
 			// Set the group data for the user object in the session.
 			$temp = JFactory::getUser();
 
-			if ($temp->id == $userId)
+			if ($temp->id === (int) $userId)
 			{
 				$temp->groups = $user->groups;
 			}
@@ -337,7 +337,7 @@ abstract class JUserHelper
 
 			$rehash = true;
 		}
-		elseif ($hash[0] == '$')
+		elseif ($hash[0] === '$')
 		{
 			// JCrypt::hasStrongPasswordSupport() includes a fallback for us in the worst case
 			JCrypt::hasStrongPasswordSupport();
@@ -346,7 +346,7 @@ abstract class JUserHelper
 			// Uncomment this line if we actually move to bcrypt.
 			$rehash = password_needs_rehash($hash, PASSWORD_DEFAULT);
 		}
-		elseif (substr($hash, 0, 8) == '{SHA256}')
+		elseif (substr($hash, 0, 8) === '{SHA256}')
 		{
 			// Check the password
 			$parts     = explode(':', $hash);

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -367,7 +367,7 @@ class JUser extends JObject
 			$rootUser = JFactory::getConfig()->get('root_user');
 
 			// The root_user variable can be a numeric user ID or a username.
-			if (is_numeric($rootUser) && $this->id > 0 && $this->id === (int) $rootUser)
+			if (is_numeric($rootUser) && $this->id > 0 && $this->id == $rootUser)
 			{
 				$this->isRoot = true;
 			}

--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -367,11 +367,11 @@ class JUser extends JObject
 			$rootUser = JFactory::getConfig()->get('root_user');
 
 			// The root_user variable can be a numeric user ID or a username.
-			if (is_numeric($rootUser) && $this->id > 0 && $this->id == $rootUser)
+			if (is_numeric($rootUser) && $this->id > 0 && $this->id === (int) $rootUser)
 			{
 				$this->isRoot = true;
 			}
-			elseif ($this->username && $this->username == $rootUser)
+			elseif ($this->username && $this->username === $rootUser)
 			{
 				$this->isRoot = true;
 			}
@@ -621,7 +621,7 @@ class JUser extends JObject
 
 			// Not all controllers check the password, although they should.
 			// Hence this code is required:
-			if (isset($array['password2']) && $array['password'] != $array['password2'])
+			if (isset($array['password2']) && $array['password'] !== $array['password2'])
 			{
 				JFactory::getApplication()->enqueueMessage(JText::_('JLIB_USER_ERROR_PASSWORD_NOT_MATCH'), 'error');
 
@@ -649,7 +649,7 @@ class JUser extends JObject
 			// Updating an existing user
 			if (!empty($array['password']))
 			{
-				if ($array['password'] != $array['password2'])
+				if ($array['password'] !== $array['password2'])
 				{
 					$this->setError(JText::_('JLIB_USER_ERROR_PASSWORD_NOT_MATCH'));
 
@@ -764,13 +764,13 @@ class JUser extends JObject
 
 			$iAmRehashingSuperadmin = false;
 
-			if (($my->id == 0 && !$isNew) && $this->id == $oldUser->id && $oldUser->authorise('core.admin') && $oldUser->password != $this->password)
+			if (($my->id === 0 && !$isNew) && $this->id === $oldUser->id && $oldUser->authorise('core.admin') && $this->password !== $oldUser->password)
 			{
 				$iAmRehashingSuperadmin = true;
 			}
 
 			// We are only worried about edits to this account if I am not a Super Admin.
-			if ($iAmSuperAdmin != true && $iAmRehashingSuperadmin != true)
+			if ($iAmSuperAdmin !== true && $iAmRehashingSuperadmin !== true)
 			{
 				// I am not a Super Admin, and this one is, so fail.
 				if (!$isNew && JAccess::check($this->id, 'core.admin'))
@@ -778,7 +778,7 @@ class JUser extends JObject
 					throw new RuntimeException('User not Super Administrator');
 				}
 
-				if ($this->groups != null)
+				if (!$this->groups != null)
 				{
 					// I am not a Super Admin and I'm trying to make one.
 					foreach ($this->groups as $groupId)
@@ -812,7 +812,7 @@ class JUser extends JObject
 				$this->id = $table->get('id');
 			}
 
-			if ($my->id == $table->id)
+			if ($my->id === (int) $table->id)
 			{
 				$registry = new Registry($table->params);
 				$my->setParameters($registry);
@@ -897,7 +897,7 @@ class JUser extends JObject
 		$this->setProperties($table->getProperties());
 
 		// The user is no longer a guest
-		if ($this->id != 0)
+		if ($this->id !== 0)
 		{
 			$this->guest = 0;
 		}


### PR DESCRIPTION
### Summary of Changes

Implemented type-safe comparisons in the `libraries / joomla` directory.
For easier reviewing, there is a total of five parts, that cover the `libraries / joomla` directory

This is part 5, which covers directories `keychain` until  `user` + 2 files directly under the directory


### Testing Instructions

**Code review only**, as those changes should not affect behavior.
Despite the quantity of the changes, it should be fairly easy to review.

Attention to code reviewers:
In order to prevent code-review-fatigue, I only did type safe comparisons, **without applying**:
- formatting
- removal of unnecessary parentheses
- other non-related changes

Please **only** review the correctness of the specific changes, without pointing out any possible formatting issues (unless corrupted by this PR), removal of parentheses and other non-related changes. This will help get this PR reviewed and merged quickly.
If you should find other prospects for type safe comparison in those folders please note them in a review.

Thank you