### PR TITLE
Make it possible to use the redirect field

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -305,12 +305,10 @@ class ContentControllerArticle extends JControllerForm
 				$lang =  !is_null($item) && $item->language != '*' ? '&lang=' . $item->language : '';
 			}
 
-			$return = base64_encode('index.php?Itemid=' . $menuitem . $lang);
-
 			// If ok, redirect to the return page.
 			if ($result)
 			{
-				$this->setRedirect(JRoute::_(base64_decode($return)));
+				$this->setRedirect(JRoute::_('index.php?Itemid=' . $menuitem . $lang));
 			}
 		}
 		else

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -829,7 +829,7 @@ class JControllerForm extends JControllerLegacy
 				// Check if there is a return value
 				$return = $this->input->get('return', null, 'base64');
 
-				if (!is_null($return))
+				if (!is_null($return) && JUri::isInternal(base64_decode($return)))
 				{
 					$url = base64_decode($return);
 				}

--- a/libraries/legacy/controller/form.php
+++ b/libraries/legacy/controller/form.php
@@ -481,6 +481,13 @@ class JControllerForm extends JControllerLegacy
 			$append .= '&' . $urlVar . '=' . $recordId;
 		}
 
+		$return = $this->input->get('return', null, 'base64');
+
+		if ($return)
+		{
+			$append .= '&return=' . $return;
+		}
+
 		return $append;
 	}
 
@@ -816,13 +823,19 @@ class JControllerForm extends JControllerLegacy
 				$this->releaseEditId($context, $recordId);
 				$app->setUserState($context . '.data', null);
 
+				$url = 'index.php?option=' . $this->option . '&view=' . $this->view_list
+					. $this->getRedirectToListAppend();
+
+				// Check if there is a return value
+				$return = $this->input->get('return', null, 'base64');
+
+				if (!is_null($return))
+				{
+					$url = base64_decode($return);
+				}
+
 				// Redirect to the list screen.
-				$this->setRedirect(
-					JRoute::_(
-						'index.php?option=' . $this->option . '&view=' . $this->view_list
-						. $this->getRedirectToListAppend(), false
-					)
-				);
+				$this->setRedirect(JRoute::_($url, false));
 				break;
 		}
 


### PR DESCRIPTION
### Summary of Changes
This pull requests makes it possible to use the redirect form field when editing an item to allow the user to be redirected to the given URL after closing the item. For example when you have a link to a Joomla article within your own extension, you can set the return URL and after saving the article the user is redirected back to where he/she came from.

This change doesn't only affect Joomla articles but anybody implementing the return feature can use it.

### Testing Instructions
1. Open an article by pasting this URL into the URL field of the browser ```http://joomla.dev/administrator/index.php?option=com_content&task=article.edit&id=89&return=aW5kZXgucGhwP29wdGlvbj1jb21fYmFubmVycw==```
2. Replace joomla.dev with your own domain name and the 89 with an existing article ID
3. Open the article and notice that the return field remains empty. You can find the field by right clicking on the page and choose Inspect element.
![image](https://user-images.githubusercontent.com/359377/27219843-64d9ddfc-5283-11e7-8c5c-741bba6a3649.png)
4. This happens because Joomla redirects to another URL to edit the article and the return argument gets dropped.
5. Apply the patch
6. Open the article again with the corrected URL as done in step 1 and 2
7. Check the return field and see that it is filled now
![image](https://user-images.githubusercontent.com/359377/27219937-a7aff5ee-5283-11e7-88ec-232fc551e908.png)
8. Save and close the article
9. You are now redirected to com_banners (had to choose something :P)
10. The redirect works

### Expected result
The expected result is that when the return value is set in the URL, it is applied to the form.

### Actual result
The supplied return URL is not set in the form.

### Documentation Changes Required
None
