### PR TITLE
Refer to "installation" folder instead of installation folder

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -120,19 +120,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The installation folder has already been deleted."
+INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The folder \"installation\" has already been deleted."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_DELETE="Installation folder could not be deleted. Please manually delete the folder."
+INSTL_COMPLETE_ERROR_FOLDER_DELETE="Folder \"installation\" could not be deleted. Please manually delete the folder."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_FOLDER_REMOVED="Installation folder removed."
+INSTL_COMPLETE_FOLDER_REMOVED="Folder \"installation\" removed."
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_LANGUAGE_DESC="Before removing the installation folder you can install extra languages. If you want to add extra languages to your Joomla! application select the following button."
-INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla! to download and install the new languages. <br />Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! Administrator."
+INSTL_COMPLETE_LANGUAGE_DESC="Before removing the folder \"installation\" you can install extra languages. If you want to add extra languages to your Joomla! application select the following button."
+INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla! to download and install the new languages. <br>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! Administrator."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_FOLDER="Remove installation folder"
+INSTL_COMPLETE_REMOVE_FOLDER="Remove folder \"installation\""
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE INSTALLATION FOLDER.<br />You will not be able to proceed beyond this point until the installation folder has been removed. This is a security feature of Joomla!"
+INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE FOLDER \"INSTALLATION\".<br>You will not be able to proceed beyond this point until the folder \"installation\" has been removed. This is a security feature of Joomla!"
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -120,19 +120,19 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The folder \"installation\" has already been deleted."
+INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The 'installation' folder  has already been deleted."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_DELETE="Folder \"installation\" could not be deleted. Please manually delete the folder."
+INSTL_COMPLETE_ERROR_FOLDER_DELETE="'Installation' folder could not be deleted. Please manually delete the folder."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_FOLDER_REMOVED="Folder \"installation\" removed."
+INSTL_COMPLETE_FOLDER_REMOVED="'Installation' folder removed."
 INSTL_COMPLETE_LANGUAGE_1="Joomla! in your own language and/or automatic basic native multilingual site creation"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_LANGUAGE_DESC="Before removing the folder \"installation\" you can install extra languages. If you want to add extra languages to your Joomla! application select the following button."
+INSTL_COMPLETE_LANGUAGE_DESC="Before removing the 'installation' folder you can install extra languages. If you want to add extra languages to your Joomla! application select the following button."
 INSTL_COMPLETE_LANGUAGE_DESC2="Note: you will need internet access for Joomla! to download and install the new languages. <br>Some server configurations won't allow Joomla! to install the languages. If this is your case, don't worry, you will be able to install them later using the Joomla! Administrator."
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_FOLDER="Remove folder \"installation\""
+INSTL_COMPLETE_REMOVE_FOLDER="Remove 'installation' folder"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE FOLDER \"INSTALLATION\".<br>You will not be able to proceed beyond this point until the folder \"installation\" has been removed. This is a security feature of Joomla!"
+INSTL_COMPLETE_REMOVE_INSTALLATION="PLEASE REMEMBER TO COMPLETELY REMOVE THE 'INSTALLATION' FOLDER.<br>You will not be able to proceed beyond this point until the 'installation' folder has been removed. This is a security feature of Joomla!"
 INSTL_COMPLETE_TITLE="Congratulations! Joomla! is now installed."
 INSTL_COMPLETE_INSTALL_LANGUAGES="Extra steps: Install languages"
 

--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -120,7 +120,7 @@ INSTL_EMAIL_NOT_SENT="Email could not be sent."
 ;Complete view
 INSTL_COMPLETE_ADMINISTRATION_LOGIN_DETAILS="Administration Login Details"
 ; The word 'installation' should not be translated as it is a physical folder.
-INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The 'installation' folder  has already been deleted."
+INSTL_COMPLETE_ERROR_FOLDER_ALREADY_REMOVED="The 'installation' folder has already been deleted."
 ; The word 'installation' should not be translated as it is a physical folder.
 INSTL_COMPLETE_ERROR_FOLDER_DELETE="'Installation' folder could not be deleted. Please manually delete the folder."
 ; The word 'installation' should not be translated as it is a physical folder.


### PR DESCRIPTION
There seem to be some inconsistency in how we refer to the installation folder during installation.

### Summary of Changes
This PR proposes to use `folder "installation"` instead `installation folder`.
Please note that this is based on my native language german where we would rather say `Das Verzeichnis "Installation"` instead of `Das Installationsverzeichnis` when we want to give weigth to the name of the folder. `Installationsverzeichnis` has a more generic meaning of "the directory where the installation is".
I really don't know if the same applies to english or if that just sounds awkward this way. So @brianteeman and other native speakers have to give their insight here.


### Testing Instructions
Test that installation works and especially the language strings related to deleting the installation folder.
