### PR TITLE
Fixed packages "block uninstall" feature breaking updates for included libraries (#16720)

### DIFF
--- a/libraries/cms/installer/adapter/library.php
+++ b/libraries/cms/installer/adapter/library.php
@@ -35,6 +35,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 			{
 				// We can upgrade, so uninstall the old one
 				$installer = new JInstaller; // we don't want to compromise this instance!
+				$installer->setPackageUninstall(true);
 				$installer->uninstall('library', $this->currentExtensionId);
 
 				// Clear the cached data
@@ -334,6 +335,7 @@ class JInstallerAdapterLibrary extends JInstallerAdapter
 		if ($result)
 		{
 			// Already installed, which would make sense
+			$installer->setPackageUninstall(true);
 			$installer->uninstall('library', $result);
 
 			// Clear the cached data


### PR DESCRIPTION
Pull Request for Issue #16720.

### Summary of Changes

Fixed broken package update for child library when the manifest file of the package has: `<blockChildUninstall>1</blockChildUninstall>`

### Testing Instructions

The issue can be reproduced on any package which uses the new Joomla 3.7 feature and contains a library in it. Here's one that I know of:

* Download Gantry 5 package from https://github.com/gantry/gantry5/releases/download/5.4.13/joomla-pkg_gantry5_v5.4.13.zip
* Install the package. All should be OK.
* Install the package again (updates library). This breaks unpatched Joomla.

Installation should succeed without warnings and if you go to `Extensions > Manage > Manage` and filter by Gantry 5, you should see `Gantry 5 Framework` library entry only a single time.

### Actual result

During second installation you will see a warning:

```
Warning
The Gantry 5 Framework extension is part of a package which does not allow individual extensions to be uninstalled.
```

When you visit `Extensions > Manage > Manage`, you will see the library installed 2 times. Every new install after this will add a new extension entry.

### Documentation Changes Required

Maybe there's a need for instructions on how to fix broken database (release notes? known issues?). The easiest way to do that is to uninstall the package. After uninstalling the package, you can also uninstall all the extra extensions. Uninstalling will raise a warning, but it can be safely ignored.
