### PR TITLE
JFormField Calendar: Set todaybutton to "false" if today is not in th…

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -171,6 +171,11 @@ class JFormFieldCalendar extends JFormField
 			$this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';
 			$this->minyear      = (string) $this->element['minyear'] ? (string) $this->element['minyear'] : null;
 			$this->maxyear      = (string) $this->element['maxyear'] ? (string) $this->element['maxyear'] : null;
+			
+			if ($this->maxyear < 0 || $this->minyear > 0)
+			{
+				$this->todaybutton = 'false';
+			}
 		}
 
 		return $return;

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -171,7 +171,7 @@ class JFormFieldCalendar extends JFormField
 			$this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';
 			$this->minyear      = (string) $this->element['minyear'] ? (string) $this->element['minyear'] : null;
 			$this->maxyear      = (string) $this->element['maxyear'] ? (string) $this->element['maxyear'] : null;
-			
+
 			if ($this->maxyear < 0 || $this->minyear > 0)
 			{
 				$this->todaybutton = 'false';


### PR DESCRIPTION
**Summary of Changes**
If there is a minyear in the future or a maxyear in the past, this pr sets the todaybutton attribute to "false"


**Testing Instructions**
Take any calendar field, for examle com_content/models/forms/article.xml
Modify the field "publish_up" like this, i.e. add the attribute maxyear="-2" or minyear="+4".

		<field
			id="publish_up"
			name="publish_up"
			type="calendar"
			label="JGLOBAL_FIELD_PUBLISH_UP_LABEL"
			description="JGLOBAL_FIELD_PUBLISH_UP_DESC"
			class="inputbox"
			translateformat="true"
			showtime="true"
			size="22"
			filter="user_utc"
			minyear="+1"
		/>
	
Open an article for editing and go the publishing tab.	


**Expected result** 
The calendar takes only Dates for the next year or later. 

**Actual result**
If the the attribute todayButton is not explictely set  to "false", there is a today button. The user can enter todays date

Apply the patch and refresh, the today button has gone

**Documentation Changes Required**
No