### PR TITLE
Enforce array for subform values

### DIFF
--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -221,7 +221,7 @@ class JFormFieldSubform extends JFormField
 	 */
 	protected function getInput()
 	{
-		$value = $this->value ? $this->value : array();
+		$value = $this->value ? (array) $this->value : array();
 
 		// Prepare data for renderer
 		$data    = parent::getLayoutData();


### PR DESCRIPTION
### Summary of Changes
This PR enforce, that the value is an array, because I had the case, that I get an object and the field stopped working.


### Testing Instructions
Apply the patch, it should work like before.
