### PR TITLE
Add button name to the toolbar class list

### DIFF
--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -54,6 +54,9 @@ class JToolbarButtonStandard extends JToolbarButton
 			$options['btnClass'] = 'btn btn-small';
 		}
 
+		// Add the button name class
+		$options['btnClass'] .= ' button-' . $name; 
+
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('joomla.toolbar.standard');
 

--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -40,22 +40,16 @@ class JToolbarButtonStandard extends JToolbarButton
 	{
 		// Store all data to the options array for use with JLayout
 		$options = array();
-		$options['text'] = JText::_($text);
-		$options['class'] = $this->fetchIconClass($name);
-		$options['doTask'] = $this->_getCommand($options['text'], $task, $list);
+		$options['text']     = JText::_($text);
+		$options['class']    = $this->fetchIconClass($name);
+		$options['doTask']   = $this->_getCommand($options['text'], $task, $list);
+		$options['btnClass'] = 'btn btn-small button-' . $name;
 
 		if ($name === 'apply' || $name === 'new')
 		{
-			$options['btnClass'] = 'btn btn-small btn-success';
+			$options['btnClass'] .= 'btn-success';
 			$options['class'] .= ' icon-white';
 		}
-		else
-		{
-			$options['btnClass'] = 'btn btn-small';
-		}
-
-		// Add the button name class
-		$options['btnClass'] .= ' button-' . $name; 
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new JLayoutFile('joomla.toolbar.standard');

--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -122,7 +122,7 @@ class JToolbarButtonTest extends TestCaseDatabase
 		$type = array('Standard', 'test');
 
 		$expected = "<div class=\"btn-wrapper\"  id=\"toolbar-test\">\n"
-			. "\t<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { Joomla.submitbutton(''); }\" class=\"btn btn-small\">\n"
+			. "\t<button onclick=\"if (document.adminForm.boxchecked.value == 0) { alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')); } else { Joomla.submitbutton(''); }\" class=\"btn btn-small button-test\">\n"
 			. "\t<span class=\"icon-test\" aria-hidden=\"true\"></span>\n"
 			. "\t</button>\n"
 			. "</div>\n";


### PR DESCRIPTION
### Summary of Changes

This just add another class to the toolbar buttons. 

### Testing Instructions

apply the patch
got to the backend list views
inspect a toolbar button (like checkin)
confirm you now find `button-checkin` (or similiar)
![image](https://user-images.githubusercontent.com/2596554/27252606-1e96f9fc-5363-11e7-9e0f-ff12f0dfca6f.png)



### Expected result

`button-$name`

### Actual result

none

### Documentation Changes Required

None