### PR TITLE
Add a missing space in Standard.php before btn-success

### DIFF
--- a/libraries/cms/toolbar/button/standard.php
+++ b/libraries/cms/toolbar/button/standard.php
@@ -47,7 +47,7 @@ class JToolbarButtonStandard extends JToolbarButton
 
 		if ($name === 'apply' || $name === 'new')
 		{
-			$options['btnClass'] .= 'btn-success';
+			$options['btnClass'] .= ' btn-success';
 			$options['class'] .= ' icon-white';
 		}
 


### PR DESCRIPTION
### Summary of Changes

There is a space missing before btn-success

### Testing Instructions

Code review

### Expected result

Space between

### Actual result

No space

### Documentation Changes Required

