### PR TITLE
Remove PHP memory_limit from max upload size calculation

### DIFF
--- a/libraries/joomla/utilities/utility.php
+++ b/libraries/joomla/utilities/utility.php
@@ -71,7 +71,6 @@ class JUtility
 		 * Read INI settings which affects upload size limits
 		 * and Convert each into number of bytes so that we can compare
 		 */
-		$sizes[] = JHtml::_('number.bytes', ini_get('memory_limit'), '');
 		$sizes[] = JHtml::_('number.bytes', ini_get('post_max_size'), '');
 		$sizes[] = JHtml::_('number.bytes', ini_get('upload_max_filesize'), '');
 


### PR DESCRIPTION
### Summary of Changes
With this PR I removed the current value for memory_limit from the max_upload_size calculation in JUtility::getMaxUploadSize. The memory_limit does NOT affect the maximum upload size of files as files are handled as streams which have a very low memory impact, therefore the value should not be taken into account.


### Testing Instructions
We stumbled upon this issue while running the Joomla unit test suite in cli environment with memory_limit = -1 which means "unlimited memory".
Because of the way how the memory calculation in JUtility works, -1 is returned as the "smallest" and therefore limiting value, causing the unit test to fail.

So, in order to test this PR, you should run the JFormFieldFileTest (which uses JUtility in it's rendering) in a CLI environment with memory_limit = -1 - you'll get an error like this:

> There was 1 error:
> 
> 1) JFormFieldFileTest::testGetInput
> Undefined offset: -9223372036854775808

Afterwards, apply the patch and re-run the test, it will work now.

### Expected result
The test suite should work.


### Actual result
Error message, see above


### Documentation Changes Required
none
