### PR TITLE
Don't take "Create Article" menuitem for an article edit

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -55,7 +55,19 @@ class ContentControllerArticle extends JControllerForm
 		{
 			// Redirect to the return page.
 			$this->setRedirect($this->getReturnPage());
+
+			return;
 		}
+
+		// Redirect to the edit screen.
+		$this->setRedirect(
+			JRoute::_(
+				'index.php?option=' . $this->option . '&view=' . $this->view_item . '&a_id=0'
+				. $this->getRedirectToItemAppend(), false
+			)
+		);
+
+		return true;
 	}
 
 	/**

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -39,7 +39,9 @@ class ContentRouter extends JComponentRouterView
 		$this->registerView($article);
 		$this->registerView(new JComponentRouterViewconfiguration('archive'));
 		$this->registerView(new JComponentRouterViewconfiguration('featured'));
-		$this->registerView(new JComponentRouterViewconfiguration('form'));
+		$form = new JComponentRouterViewconfiguration('form');
+		$form->setKey('a_id');
+		$this->registerView($form);
 
 		parent::__construct($app, $menu);
 
@@ -131,6 +133,19 @@ class ContentRouter extends JComponentRouterView
 		}
 
 		return array((int) $id => $id);
+	}
+
+	/**
+	 * Method to get the segment(s) for an form
+	 *
+	 * @param   string  $id     ID of the article form to retrieve the segments for
+	 * @param   array   $query  The request that is built right now
+	 *
+	 * @return  array|string  The segments of this item
+	 */
+	public function getFormSegment($id, $query)
+	{
+		return $this->getArticleSegment($id, $query);
 	}
 
 	/**

--- a/libraries/cms/component/router/rules/menu.php
+++ b/libraries/cms/component/router/rules/menu.php
@@ -188,13 +188,18 @@ class JComponentRouterRulesMenu implements JComponentRouterRulesInterface
 							$this->lookup[$language][$view] = array();
 						}
 
+						// If menuitem has no key set, we assume 0.
+						if (!isset($item->query[$views[$view]->key]))
+						{
+							$item->query[$views[$view]->key] = 0;
+						}
+
 						/**
 						 * Here it will become a bit tricky
 						 * language != * can override existing entries
 						 * language == * cannot override existing entries
 						 */
-						if (isset($item->query[$views[$view]->key])
-							&& (!isset($this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]]) || $item->language !== '*'))
+						if (!isset($this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]]) || $item->language !== '*')
 						{
 							$this->lookup[$language][$view . $layout][$item->query[$views[$view]->key]] = $item->id;
 							$this->lookup[$language][$view][$item->query[$views[$view]->key]] = $item->id;


### PR DESCRIPTION
Pull Request for Issue #12687 and #16612 .

### Summary of Changes
This adjusts the ContentRouter so it only takes the "Create Article" menuitem for new articles, not when editing an existing article. I adjusted the Viewconfiguration for that and added `&a_id=0` to the URL for the view in the controller.
Please note that most of the change are only within com_content, but there is one change in the menu rule which may affect other extensions. But only if they use those new JComponentRouterView stuff and I think the change should be fine. If you come into that part of the code and don't have a key set in the menuitem, it will not be stored into the needles array and never be used for the URL. So that looked wrong anyway.

### Testing Instructions
* Create at least two articles. Have a menuitem pointing to one of them and a menuitem pointing to the category.
* Create a menuitem "Create Article". For better testing you can adjust the settings within that menuitem (eg the title or the standardcategory) so the view is distinguishable easy from a regular edit.
* Now try the article edit links (in the category list and/or the single article view) and that "Create Article" link


### Expected result
* The "Create Article" menuitem should be used for any "New Article" links. Test for example the "New" button in the category list
* The edit links should **not** use the "Create Article" menuitem. Instead it should be based on the article menuitem or the category one. Whatever fits best.

### Actual result
Any edit links use the "Create Article" menuitem


### Documentation Changes Required
Don't think there is any doc at all for this router stuff.