### PR TITLE
apply sef autocorrection

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_system_sef.ini
+++ b/administrator/language/en-GB/en-GB.plg_system_sef.ini
@@ -7,3 +7,5 @@ PLG_SEF_XML_DESCRIPTION="Adds SEF support to links in the document. It operates 
 PLG_SYSTEM_SEF="System - SEF"
 PLG_SEF_DOMAIN_LABEL="Site Domain"
 PLG_SEF_DOMAIN_DESCRIPTION="If your site can be accessed through more than one domain enter the preferred (sometimes referred to as canonical) domain here. <br /><strong>Note:</strong> https://example.com and https://www.example.com are different domains."
+PLG_SEF_AUTOREDIRECT_LABEL="Auto redirect"
+PLG_SEF_AUTOREDIRECT_DESCRIPTION="Enable this option if you want to use urls autocorrection (if possible)."

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -83,6 +83,7 @@ class PlgSystemSef extends JPlugin
 	 * AutoCorrect SEF url so there is no content-duplicates
 	 *
 	 * @return  void
+	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function onAfterRoute()

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -80,6 +80,33 @@ class PlgSystemSef extends JPlugin
 	}
 
 	/**
+	 * AutoCorrect SEF url so there is no content-duplicates
+	 *
+	 * @return  void
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function onAfterRoute()
+	{
+		if ($this->params->get('autoredirect', true))
+		{
+			if (!JFactory::getApplication()->isClient('administrator') && !JFactory::getApplication()->input->post->getArray())
+			{
+				$uri   = JUri::getInstance();
+				$vars  = JFactory::getApplication()->input->getArray();
+				$query = array();
+				foreach ($vars as $k => $v)
+				{
+					$query[] = $k . '=' . $v;
+				}
+				if ($uri->getPath() . ($uri->getQuery() ? '?' . $uri->getQuery() : '') != JRoute::_('index.php?' . implode('&', $query)))
+				{
+					JFactory::getApplication()->redirect(JRoute::_('index.php?' . implode('&', $query)), 301);
+				}
+			}
+		}
+	}
+
+	/**
 	 * Convert the site URL to fit to the HTTP request.
 	 *
 	 * @return  void

--- a/plugins/system/sef/sef.xml
+++ b/plugins/system/sef/sef.xml
@@ -28,6 +28,17 @@
 					filter="url"
 					validate="url"
 				/>
+				<field
+						name="autoredirect"
+						type="radio"
+						label="PLG_SEF_AUTOREDIRECT_LABEL"
+						description="PLG_SEF_AUTOREDIRECT_DESCRIPTION"
+						class="btn-group btn-group-yesno"
+						default="1"
+				>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
+				</field>
 			</fieldset>
 		</fields>
 	</config>

--- a/plugins/system/sef/sef.xml
+++ b/plugins/system/sef/sef.xml
@@ -29,12 +29,12 @@
 					validate="url"
 				/>
 				<field
-						name="autoredirect"
-						type="radio"
-						label="PLG_SEF_AUTOREDIRECT_LABEL"
-						description="PLG_SEF_AUTOREDIRECT_DESCRIPTION"
-						class="btn-group btn-group-yesno"
-						default="1"
+					name="autoredirect"
+					type="radio"
+					label="PLG_SEF_AUTOREDIRECT_LABEL"
+					description="PLG_SEF_AUTOREDIRECT_DESCRIPTION"
+					class="btn-group btn-group-yesno"
+					default="1"
 				>
 					<option value="1">JYES</option>
 					<option value="0">JNO</option>


### PR DESCRIPTION
### Summary of Changes
Add (and enable by default) SEF url auto correction by redirecting to appropriate url.

### Testing Instructions
Create an article in category and use aliases like:
cagetory: `subcategory` 
article: `qtestucat`
Correct link for the article is `/index.php/8-subcategory/2-qtestucat`
You should have access only for correct urls.
And 404 or 301 at incorrect urls.

### Expected result
You can't access article by `/index.php/8-subcategory/2-qtest`(`?somevar=exists`)
it redirects you to `/index.php/8-subcategory/2-qtestcat`(`?somevar=exists`)


### Actual result
You can access article by `/index.php/8-subcategory/2-qtest`(`?somevar=exists`)
