### PR TITLE
remove extra slash

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -584,7 +584,7 @@ class PlgEditorTinymce extends JPlugin
 
 		if ($dragdrop && $user->authorise('core.create', 'com_media'))
 		{
-			$externalPlugins['jdragdrop'] = JUri::root() . '/media/editors/tinymce/js/plugins/dragdrop/plugin.min.js';
+			$externalPlugins['jdragdrop'] = JUri::root() . 'media/editors/tinymce/js/plugins/dragdrop/plugin.min.js';
 			$allowImgPaste = true;
 			$isSubDir      = '';
 			$session       = JFactory::getSession();
@@ -1905,7 +1905,7 @@ class PlgEditorTinymce extends JPlugin
 			$scriptOptions['uploadUri']       = $uploadUrl;
 
 			$externalPlugins = array(
-				array('jdragdrop' => JUri::root() . '/media/editors/tinymce/js/plugins/dragdrop/plugin.min.js'),
+				array('jdragdrop' => JUri::root() . 'media/editors/tinymce/js/plugins/dragdrop/plugin.min.js'),
 			);
 		}
 


### PR DESCRIPTION
 JUri::root() returns the domain with a slash at the end so there is no need for the slash in the second part

### To test
View the source of any page with th tinymce editor and your will see
`{"jdragdrop":"http:\/\/127.0.0.1\/cms\/\/media\/editors\/tinymce\/js\/plugins\/dragdrop\/plugin.min.js"}`

Note the double escaped slash `\/\/`

After the pr view the source
`{"jdragdrop":"http:\/\/127.0.0.1\/cms\/media\/editors\/tinymce\/js\/plugins\/dragdrop\/plugin.min.js"}
`
Note the single escaped slash `\/`
