### PR TITLE
[4.0] Fix buttons and icons in Multilingual Associations Edit

### DIFF
--- a/administrator/components/com_associations/View/Association/Html.php
+++ b/administrator/components/com_associations/View/Association/Html.php
@@ -202,13 +202,13 @@ class Html extends HtmlView
 
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'reference\')" '
-			. 'class="btn btn-sm btn-success"><span class="icon-32-apply icon-white" aria-hidden="true"></span>'
+			. 'class="btn btn-sm btn-success"><span class="icon-apply" aria-hidden="true"></span>'
 			. \JText::_('COM_ASSOCIATIONS_SAVE_REFERENCE') . '</button>', 'reference'
 		);
 
 		$bar->appendButton(
 			'Custom', '<button onclick="Joomla.submitbutton(\'target\')" '
-			. 'class="btn btn-sm btn-success"><span class="icon-32-apply icon-white" aria-hidden="true"></span>'
+			. 'class="btn btn-sm btn-success"><span class="icon-apply" aria-hidden="true"></span>'
 			. \JText::_('COM_ASSOCIATIONS_SAVE_TARGET') . '</button>', 'target'
 		);
 

--- a/administrator/components/com_associations/models/fields/modalassociation.php
+++ b/administrator/components/com_associations/models/fields/modalassociation.php
@@ -53,22 +53,22 @@ class JFormFieldModalAssociation extends JFormField
 		// Select custom association button
 		$html[] = '<a'
 			. ' id="select-change"'
-			. ' class="btn' . ($value ? '' : ' hidden') . '"'
+			. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
 			. ' data-toggle="modal"'
 			. ' data-select="' . JText::_('COM_ASSOCIATIONS_SELECT_TARGET') . '"'
 			. ' data-change="' . JText::_('COM_ASSOCIATIONS_CHANGE_TARGET') . '"'
 			. ' role="button"'
 			. ' href="#associationSelect' . $this->id . 'Modal">'
-			. '<span class="icon-file" aria-hidden="true"></span>'
+			. '<span class="icon-file" aria-hidden="true"></span> '
 			. '<span id="select-change-text"></span>'
 			. '</a>';
 
 		// Clear association button
 		$html[] = '<button'
- 				. ' class="btn' . ($value ? '' : ' hidden') . '"'
+ 				. ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
  				. ' onclick="return Joomla.submitbutton(\'undo-association\');"'
  				. ' id="remove-assoc">'
- 				. '<span class="icon-remove" aria-hidden="true"></span>' . JText::_('JCLEAR')
+ 				. '<span class="icon-remove" aria-hidden="true"></span> ' . JText::_('JCLEAR')
  				. '</button>';
 
 		$html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $value . '">';

--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -22,7 +22,7 @@ $options = array(
 			'id'       => $this->referenceId,
 		);
 ?>
-<button id="toogle-left-panel" class="btn btn-sm"
+<button id="toogle-left-panel" class="btn btn-sm btn-secondary"
 		data-show-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_SHOW_REFERENCE'); ?>"
 		data-hide-reference="<?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>"><?php echo JText::_('COM_ASSOCIATIONS_EDIT_HIDE_REFERENCE'); ?>
 </button>


### PR DESCRIPTION
The Multilingual Association component looks quite broken in J4 once you open the edit view

### Summary of Changes
Corrects icons for the buttons and applies BS4 button classes to the links and buttons.


### Testing Instructions
Try to edit something in the multilingual asssociation component



### Expected result
![image](https://user-images.githubusercontent.com/1018684/27275930-bb8fec92-54d9-11e7-90a4-97f8bbf5853e.png)
![image](https://user-images.githubusercontent.com/1018684/27275963-d20b6ff0-54d9-11e7-99a7-34ea9511af84.png)


### Actual result
![image](https://user-images.githubusercontent.com/1018684/27275983-e1c7344c-54d9-11e7-89f5-2f4d0830510e.png)
![image](https://user-images.githubusercontent.com/1018684/27275993-e9222e22-54d9-11e7-9adc-f30807c6801a.png)


### Documentation Changes Required
None

### Note
There is a lot more to do here, eg the selects have a min-width defined which makes them go outside the form. That's not in the topic of this PR.
