### PR TITLE
Fix: Adding thumbs file names in Media Manager

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7774,8 +7774,6 @@ ul.manager .height-50 .icon-folder-2 {
 .thumbnails-media .thumbnail *:before {
 	-webkit-transition: all 0.2s ease;
 	transition: all 0.2s ease;
-	-webkit-background-clip: padding-box;
-	background-clip: padding-box;
 	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
@@ -7867,6 +7865,9 @@ ul.manager .height-50 .icon-folder-2 {
 	height: 26px;
 	width: 26px;
 }
+.thumbnails-media .imgPreview a {
+	width: 100%;
+}
 .thumbnails-media .imgDelete a.close {
 	background-color: #bd362f;
 	border-color: #bd362f rgba(0,0,0,0.2) rgba(0,0,0,0.2) #bd362f;
@@ -7894,12 +7895,13 @@ ul.manager .height-50 .icon-folder-2 {
 .thumbnails-media .imgDetails {
 	position: absolute;
 	left: 0;
+	text-align: left;
 	background-color: #fff;
 	border-color: rgba(0,0,0,0.2);
 	bottom: 0;
 	line-height: 26px;
 	border: 1px solid rgba(0,0,0,0.1);
-	border-width: 1px 1px 0 0;
+	border-width: 1px;
 	border-radius: 0 3px 0 0;
 	z-index: 1;
 }
@@ -7955,7 +7957,8 @@ ul.manager .height-50 .icon-folder-2 {
 	line-height: 120px;
 }
 #mediamanager-form .icon-search::before {
-	padding-right: 10px;
+	padding-right: 5px;
+	padding-left: 1px;
 }
 #mediamanager-form .height-50 {
 	background-color: #fafafa;
@@ -10012,10 +10015,14 @@ a.grid_true {
 .thumbnails-media .imgPreview a,
 .thumbnails-media .imgDetails {
 	border-radius: 3px 0;
-	border-width: 1px 0 0 1px;
+	border-width: 1px;
 	left: 0;
 	right: 5px;
+	text-align: left;
 	direction: ltr;
+}
+.thumbnails-media .imgPreview a {
+	width: 100%;
 }
 .subform-table-layout td {
 	padding-left: 10px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -7954,6 +7954,9 @@ ul.manager .height-50 .icon-folder-2 {
 #mediamanager-form .thumbnails .imgTotal {
 	line-height: 120px;
 }
+#mediamanager-form .icon-search::before {
+	padding-right: 10px;
+}
 #mediamanager-form .height-50 {
 	background-color: #fafafa;
 	height: 77px;
@@ -9989,6 +9992,8 @@ a.grid_true {
 #mediamanager-form .thumbnails-media .thumbnail {
 	margin-left: 18px !important;
 	margin-right: 0;
+	direction: ltr;
+	text-align: center;
 }
 .thumbnails-media .imgThumb label::before,
 .thumbnails-media .imgThumb .imgThumbInside::before {
@@ -10008,8 +10013,9 @@ a.grid_true {
 .thumbnails-media .imgDetails {
 	border-radius: 3px 0;
 	border-width: 1px 0 0 1px;
-	left: auto;
-	right: 0;
+	left: 0;
+	right: 5px;
+	direction: ltr;
 }
 .subform-table-layout td {
 	padding-left: 10px;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -10017,7 +10017,7 @@ a.grid_true {
 	border-radius: 3px 0;
 	border-width: 1px;
 	left: 0;
-	right: 5px;
+	right: 0;
 	text-align: left;
 	direction: ltr;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7774,8 +7774,6 @@ ul.manager .height-50 .icon-folder-2 {
 .thumbnails-media .thumbnail *:before {
 	-webkit-transition: all 0.2s ease;
 	transition: all 0.2s ease;
-	-webkit-background-clip: padding-box;
-	background-clip: padding-box;
 	-webkit-box-sizing: border-box;
 	box-sizing: border-box;
 }
@@ -7867,6 +7865,9 @@ ul.manager .height-50 .icon-folder-2 {
 	height: 26px;
 	width: 26px;
 }
+.thumbnails-media .imgPreview a {
+	width: 100%;
+}
 .thumbnails-media .imgDelete a.close {
 	background-color: #bd362f;
 	border-color: #bd362f rgba(0,0,0,0.2) rgba(0,0,0,0.2) #bd362f;
@@ -7894,12 +7895,13 @@ ul.manager .height-50 .icon-folder-2 {
 .thumbnails-media .imgDetails {
 	position: absolute;
 	left: 0;
+	text-align: left;
 	background-color: #fff;
 	border-color: rgba(0,0,0,0.2);
 	bottom: 0;
 	line-height: 26px;
 	border: 1px solid rgba(0,0,0,0.1);
-	border-width: 1px 1px 0 0;
+	border-width: 1px;
 	border-radius: 0 3px 0 0;
 	z-index: 1;
 }
@@ -7955,7 +7957,8 @@ ul.manager .height-50 .icon-folder-2 {
 	line-height: 120px;
 }
 #mediamanager-form .icon-search::before {
-	padding-right: 10px;
+	padding-right: 5px;
+	padding-left: 1px;
 }
 #mediamanager-form .height-50 {
 	background-color: #fafafa;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -7954,6 +7954,9 @@ ul.manager .height-50 .icon-folder-2 {
 #mediamanager-form .thumbnails .imgTotal {
 	line-height: 120px;
 }
+#mediamanager-form .icon-search::before {
+	padding-right: 10px;
+}
 #mediamanager-form .height-50 {
 	background-color: #fafafa;
 	height: 77px;

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -36,9 +36,9 @@ $dispatcher = JEventDispatcher::getInstance();
 			</label>
 		</div>
 
- 		<div class="imgPreview nowrap">
+ 		<div class="imgPreview nowrap small">
 			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview">
-				<span class="icon-search" aria-hidden="true"><?php echo JHtml::_('string.truncate', $img->name, 10, false); ?></span>
+				<span class="icon-search" aria-hidden="true"><?php echo JHtml::_('string.truncate', $img->name, 16, false); ?></span>
 			</a>
 		</div>
 	</li>

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -37,8 +37,8 @@ $dispatcher = JEventDispatcher::getInstance();
 		</div>
 
  		<div class="imgPreview nowrap small">
-			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview">
-				<span class="icon-search" aria-hidden="true"><?php echo JHtml::_('string.truncate', $img->name, 16, false); ?></span>
+			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview truncate">
+				<span class="icon-search" aria-hidden="true"></span><?php echo $img->name; ?>
 			</a>
 		</div>
 	</li>

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -36,7 +36,7 @@ $dispatcher = JEventDispatcher::getInstance();
 			</label>
 		</div>
 
- 		<div class="imgPreview">
+ 		<div class="imgPreview nowrap">
 			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview">
 				<span class="icon-search" aria-hidden="true"><?php echo JHtml::_('string.truncate', $img->name, 10, false); ?></span>
 			</a>

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -38,7 +38,7 @@ $dispatcher = JEventDispatcher::getInstance();
 
  		<div class="imgPreview">
 			<a href="<?php echo COM_MEDIA_BASEURL, '/', $img->path_relative; ?>" title="<?php echo $img->name; ?>" class="preview">
-				<span class="icon-search"> </span>
+				<span class="icon-search" aria-hidden="true"><?php echo JHtml::_('string.truncate', $img->name, 10, false); ?></span>
 			</a>
 		</div>
 	</li>

--- a/administrator/templates/isis/less/blocks/_media.less
+++ b/administrator/templates/isis/less/blocks/_media.less
@@ -45,10 +45,8 @@ ul.manager .height-50 .icon-folder-2 {
 		    }
 		}
 		*, *:before {
-	    	-webkit-transition: all 0.2s ease;
+			-webkit-transition: all 0.2s ease;
 			transition: all 0.2s ease;
-			-webkit-background-clip: padding-box;
-			background-clip: padding-box;
 			-webkit-box-sizing: border-box;
 			box-sizing: border-box;
 	    }
@@ -129,6 +127,9 @@ ul.manager .height-50 .icon-folder-2 {
 	    height: 26px;
 	    width: 26px;
 	}
+	.imgPreview a {
+		width: 100%;
+	}
 	.imgDelete a.close {
 	    background-color: @btnDangerBackground;
 	    border-color: @btnDangerBackground rgba(0, 0, 0, 0.2) rgba(0, 0, 0, 0.2) @btnDangerBackground;
@@ -155,12 +156,13 @@ ul.manager .height-50 .icon-folder-2 {
 	.imgPreview a, .imgDetails {
 		position: absolute;
 		left:0;
+		text-align: left;
 	    background-color: #fff;
 	    border-color: rgba(0, 0, 0, 0.2);
 	    bottom: 0;
 	    line-height: 26px;
 		border: 1px solid rgba(0, 0, 0, 0.1);
-		border-width: 1px 1px 0 0; 
+		border-width: 1px; 
 		border-radius: 0 @inputBorderRadius 0 0;
 		z-index: 1;
 		&:hover {
@@ -222,9 +224,9 @@ ul.manager .height-50 .icon-folder-2 {
 		}
 	}
 	.icon-search::before {
-		padding-right: 10px;
+		padding-right: 5px;
+		padding-left: 1px;
 	}
-
 	.height-50 {
 	    background-color: #fafafa;
 	    height: 77px;

--- a/administrator/templates/isis/less/blocks/_media.less
+++ b/administrator/templates/isis/less/blocks/_media.less
@@ -221,6 +221,9 @@ ul.manager .height-50 .icon-folder-2 {
 			line-height: 120px;
 		}
 	}
+	.icon-search::before {
+		padding-right: 10px;
+	}
 
 	.height-50 {
 	    background-color: #fafafa;

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -368,6 +368,8 @@ a.grid_true {
 #mediamanager-form .thumbnails-media .thumbnail {
     margin-left: 18px !important;
     margin-right: 0;
+    direction: ltr;
+    text-align: center;
 }
 .thumbnails-media .imgThumb label::before, .thumbnails-media .imgThumb .imgThumbInside::before {
 	left: 0;
@@ -384,8 +386,9 @@ a.grid_true {
 .thumbnails-media .imgPreview a, .thumbnails-media .imgDetails {
     border-radius: 3px 0;
     border-width: 1px 0 0 1px;
-    left: auto;
-    right: 0;
+    left: 0;
+    right: 5px;
+    direction: ltr;
 }
 
 /* SubForms (Table) */

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -387,7 +387,7 @@ a.grid_true {
     border-radius: 3px 0;
     border-width: 1px;
     left: 0;
-    right: 5px;
+    right: 0;
     text-align: left;
     direction: ltr;
 }

--- a/administrator/templates/isis/less/template-rtl.less
+++ b/administrator/templates/isis/less/template-rtl.less
@@ -385,10 +385,14 @@ a.grid_true {
 }
 .thumbnails-media .imgPreview a, .thumbnails-media .imgDetails {
     border-radius: 3px 0;
-    border-width: 1px 0 0 1px;
+    border-width: 1px;
     left: 0;
     right: 5px;
+    text-align: left;
     direction: ltr;
+}
+.thumbnails-media .imgPreview a {
+	width: 100%;
 }
 
 /* SubForms (Table) */


### PR DESCRIPTION
Pull Request for Issue #16710

The name of the image files do not display in Isis Media Manager.

After patch, one should get in LTR

![screen shot 2017-06-19 at 11 29 19](https://user-images.githubusercontent.com/869724/27279614-79a57f0c-54e5-11e7-9df5-8313deefdcbb.png)

and in RTL
![screen shot 2017-06-19 at 11 30 12](https://user-images.githubusercontent.com/869724/27279627-8485dda4-54e5-11e7-8c9e-883a4a21e3c2.png)

For RTL, as it was impossible to keep the magnifiying glass to the right and that anyway a file name should be LTR, I have put it to the left as in LTR. It is not an issue imho in that specific case to move it.

@bertmert @franz-wohlkoenig
Getting the image title in the Preview modal title is not easy. It requires some JS to append it.