### PR TITLE
[4.0] Move toolbar button ID'd to buttons themselves

### DIFF
--- a/layouts/joomla/toolbar/apply.php
+++ b/layouts/joomla/toolbar/apply.php
@@ -21,12 +21,13 @@ if (preg_match('/Joomla.submitbutton/', $displayData['doTask']))
 	JFactory::getDocument()->addScriptOptions('keySave', $options);
 }
 
+$id       = $displayData['id'];
 $doTask   = $displayData['doTask'];
 $class    = $displayData['class'];
 $text     = $displayData['text'];
 $btnClass = $displayData['btnClass'];
 ?>
-<button onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
+<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
 	<span class="<?php echo trim($class); ?>"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/apply.php
+++ b/layouts/joomla/toolbar/apply.php
@@ -21,7 +21,7 @@ if (preg_match('/Joomla.submitbutton/', $displayData['doTask']))
 	JFactory::getDocument()->addScriptOptions('keySave', $options);
 }
 
-$id       = $displayData['id'];
+$id       = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask   = $displayData['doTask'];
 $class    = $displayData['class'];
 $text     = $displayData['text'];

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -9,9 +9,5 @@
 
 defined('JPATH_BASE') or die;
 
-$id     = $displayData['id'];
-$margin = (strpos($id, 'toolbar-options') === false) ? '' : ' ml-auto';
 ?>
-<div class="btn-wrapper<?php echo $margin; ?>" <?php echo $id; ?>>
-	<?php echo $displayData['action']; ?>
-</div>
+<?php echo $displayData['action']; ?>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -11,13 +11,14 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id    = isset($displayData['id']) ? $displayData['id'] : '';
 $title = $displayData['title'];
 JText::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 JText::script('ERROR');
 $message = "{'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
 $alert = "Joomla.renderMessages(" . $message . ")";
 ?>
-<button data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
+<button <?php echo $id; ?> data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
 	<span class="icon-checkbox-partial" aria-hidden="true" title="<?php echo $title; ?>"></span>
 	<?php echo $title; ?>
 </button>

--- a/layouts/joomla/toolbar/confirm.php
+++ b/layouts/joomla/toolbar/confirm.php
@@ -11,11 +11,12 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id     = $displayData['id'];
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];
 ?>
-<button onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-danger">
+<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-danger">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/confirm.php
+++ b/layouts/joomla/toolbar/confirm.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
-$id     = $displayData['id'];
+$id     = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -11,10 +11,11 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id     = $displayData['id'];
 $doTask = $displayData['doTask'];
 $text   = $displayData['text'];
 ?>
-<button onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-outline-info btn-sm">
+<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-outline-info btn-sm">
 	<span class="icon-question-sign" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
-$id     = $displayData['id'];
+$id     = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask = $displayData['doTask'];
 $text   = $displayData['text'];
 ?>

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -9,7 +9,7 @@
 
 defined('JPATH_BASE') or die;
 
-$id     = $displayData['id'];
+$id     = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -9,11 +9,13 @@
 
 defined('JPATH_BASE') or die;
 
+$id     = $displayData['id'];
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];
+$margin = (strpos($doTask, 'index.php?option=com_config') === false) ? '' : ' ml-auto';
 ?>
-<button onclick="location.href='<?php echo $doTask; ?>';" class="btn btn-outline-danger btn-sm">
+<button <?php echo $id; ?> class="btn btn-outline-danger btn-sm<?php echo $margin; ?>" onclick="location.href='<?php echo $doTask; ?>';">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -19,6 +19,7 @@ defined('JPATH_BASE') or die;
  *                                  - text      string  Button text
  */
 
+$id       = $displayData['id'];
 $selector = $displayData['selector'];
 $class    = isset($displayData['class']) ? $displayData['class'] : 'btn btn-secondary btn-sm';
 $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download';
@@ -44,6 +45,6 @@ echo JHtml::_('bootstrap.renderModal',
 	)
 );
 ?>
-<button onclick="jQuery('#modal_<?php echo $selector; ?>').modal('show')" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">
+<button <?php echo $id; ?> onclick="jQuery('#modal_<?php echo $selector; ?>').modal('show')" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">
 	<span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span><?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -19,8 +19,8 @@ defined('JPATH_BASE') or die;
  *                                  - text      string  Button text
  */
 
-$id       = $displayData['id'];
 $selector = $displayData['selector'];
+$id       = isset($displayData['id']) ? $displayData['id'] : '';
 $class    = isset($displayData['class']) ? $displayData['class'] : 'btn btn-secondary btn-sm';
 $icon     = isset($displayData['icon']) ? $displayData['icon'] : 'fa fa-download';
 $text     = isset($displayData['text']) ? $displayData['text'] : '';

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -11,12 +11,13 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id     = $displayData['id'];
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];
 $name   = $displayData['name'];
 ?>
-<button value="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-primary" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
+<button <?php echo $id; ?> value="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-primary" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
-$id     = $displayData['id'];
+$id     = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
-$id      = $displayData['id'];
+$id      = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask  = $displayData['doTask'];
 $class   = $displayData['class'];
 $text    = $displayData['text'];

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -11,13 +11,14 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id      = $displayData['id'];
 $doTask  = $displayData['doTask'];
 $class   = $displayData['class'];
 $text    = $displayData['text'];
 $name    = $displayData['name'];
 $onClose = $displayData['onClose'];
 ?>
-<button onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#collapse-<?php echo $name; ?>"<?php echo $onClose; ?>>
+<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#collapse-<?php echo $name; ?>"<?php echo $onClose; ?>>
 	<span class="icon-cog" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
-$id       = $displayData['id'];
+$id       = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask   = $displayData['doTask'];
 $class    = $displayData['class'];
 $text     = $displayData['text'];

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -11,6 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('behavior.core');
 
+$id       = $displayData['id'];
 $doTask   = $displayData['doTask'];
 $class    = $displayData['class'];
 $text     = $displayData['text'];
@@ -19,12 +20,12 @@ $group    = $displayData['group'];
 ?>
 
 <?php if ($group) : ?>
-<a href="#" onclick="<?php echo $doTask; ?>" class="dropdown-item">
+<a <?php echo $id; ?> href="#" onclick="<?php echo $doTask; ?>" class="dropdown-item">
 	<span class="<?php echo trim($class); ?>"></span>
 	<?php echo $text; ?>
 </a>
 <?php else : ?>
-<button onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
+<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
 	<span class="<?php echo trim($class); ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -28,7 +28,7 @@ echo JHtml::_(
 	)
 );
 
-$id = $displayData['id'];
+$id = isset($displayData['id']) ? $displayData['id'] : '';
 
 ?>
 <button <?php echo $id; ?> onclick="jQuery('#versionsModal').modal('show')" class="btn btn-sm btn-outline-primary" data-toggle="modal" title="<?php echo $displayData['title']; ?>">

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -28,7 +28,9 @@ echo JHtml::_(
 	)
 );
 
+$id = $displayData['id'];
+
 ?>
-<button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-sm btn-outline-primary" data-toggle="modal" title="<?php echo $displayData['title']; ?>">
+<button <?php echo $id; ?> onclick="jQuery('#versionsModal').modal('show')" class="btn btn-sm btn-outline-primary" data-toggle="modal" title="<?php echo $displayData['title']; ?>">
 	<span class="icon-archive" aria-hidden="true"></span><?php echo $displayData['title']; ?>
 </button>

--- a/libraries/src/CMS/Toolbar/Button/ApplyButton.php
+++ b/libraries/src/CMS/Toolbar/Button/ApplyButton.php
@@ -45,9 +45,15 @@ class ApplyButton extends ToolbarButton
 	{
 		// Store all data to the options array for use with JLayout
 		$options = array();
-		$options['text'] = \JText::_($text);
-		$options['class'] = $this->fetchIconClass($name);
+		$options['text']   = \JText::_($text);
+		$options['class']  = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($options['text'], $task, $list);
+		$options['id']     = $this->fetchId('Apply', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		if ($name == 'apply' || $name == 'save')
 		{

--- a/libraries/src/CMS/Toolbar/Button/ConfirmButton.php
+++ b/libraries/src/CMS/Toolbar/Button/ConfirmButton.php
@@ -50,6 +50,12 @@ class ConfirmButton extends ToolbarButton
 		$options['msg']    = \JText::_($msg, true);
 		$options['class']  = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($options['msg'], $name, $task, $list);
+		$options['id']     = $this->fetchId('Confirm', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new FileLayout('joomla.toolbar.confirm');

--- a/libraries/src/CMS/Toolbar/Button/HelpButton.php
+++ b/libraries/src/CMS/Toolbar/Button/HelpButton.php
@@ -45,6 +45,12 @@ class HelpButton extends ToolbarButton
 		$options = array();
 		$options['text']   = \JText::_('JTOOLBAR_HELP');
 		$options['doTask'] = $this->_getCommand($ref, $com, $override, $component);
+		$options['id']     = $this->fetchId();
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new FileLayout('joomla.toolbar.help');

--- a/libraries/src/CMS/Toolbar/Button/LinkButton.php
+++ b/libraries/src/CMS/Toolbar/Button/LinkButton.php
@@ -45,6 +45,12 @@ class LinkButton extends ToolbarButton
 		$options['text']   = \JText::_($text);
 		$options['class']  = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($url);
+		$options['id']     = $this->fetchId('Link', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new FileLayout('joomla.toolbar.link');

--- a/libraries/src/CMS/Toolbar/Button/PopupButton.php
+++ b/libraries/src/CMS/Toolbar/Button/PopupButton.php
@@ -62,6 +62,12 @@ class PopupButton extends ToolbarButton
 		$options['title']  = \JText::_($title);
 		$options['class']  = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($url);
+		$options['id']     = $this->fetchId('Popup', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		// Instantiate a new JLayoutFile instance and render the layout
 		$layout = new FileLayout('joomla.toolbar.popup');

--- a/libraries/src/CMS/Toolbar/Button/SliderButton.php
+++ b/libraries/src/CMS/Toolbar/Button/SliderButton.php
@@ -52,6 +52,12 @@ class SliderButton extends ToolbarButton
 		$options['name']    = $name;
 		$options['class']   = $this->fetchIconClass($name);
 		$options['onClose'] = '';
+		$options['id']      = $this->fetchId('Slider', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		$doTask = $this->_getCommand($url);
 		$options['doTask'] = 'Joomla.setcollapse(\'' . $doTask . '\', \'' . $name . '\', \'' . $height . '\');';

--- a/libraries/src/CMS/Toolbar/Button/StandardButton.php
+++ b/libraries/src/CMS/Toolbar/Button/StandardButton.php
@@ -49,6 +49,12 @@ class StandardButton extends ToolbarButton
 		$options['class']  = $this->fetchIconClass($name);
 		$options['doTask'] = $this->_getCommand($options['text'], $task, $list);
 		$options['group']  = $group;
+		$options['id']     = $this->fetchId('Standard', $name);
+
+		if ($options['id'])
+		{
+			$options['id'] = ' id="' . $options['id'] . '"';
+		}
 
 		switch ($name)
 		{

--- a/libraries/src/CMS/Toolbar/ToolbarButton.php
+++ b/libraries/src/CMS/Toolbar/ToolbarButton.php
@@ -73,18 +73,10 @@ abstract class ToolbarButton
 		/*
 		 * Initialise some variables
 		 */
-		$id = call_user_func_array(array(&$this, 'fetchId'), $definition);
 		$action = call_user_func_array(array(&$this, 'fetchButton'), $definition);
-
-		// Build id attribute
-		if ($id)
-		{
-			$id = ' id="' . $id . '"';
-		}
 
 		// Build the HTML Button
 		$options = array();
-		$options['id'] = $id;
 		$options['action'] = $action;
 
 		$layout = new FileLayout('joomla.toolbar.base');


### PR DESCRIPTION
This PR fixes the issue mentioned here https://github.com/joomla/joomla-cms/issues/16763

I've reverted the previous PR (https://github.com/joomla/joomla-cms/pull/16749) I did that adds a `div` wrapper for each button and the ID is now added on the button itself.

Both list and edit views seem to work.

@infograf768 - You mentioned something about `com_associations` using JS to target these ID's. Would you mind testing please and let me know.

