### PR TITLE
Fix for menu item type change

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -689,7 +689,7 @@ class MenusModelItem extends JModelAdmin
 		{
 
 			// Check if we are changing away from the actual link type.
-			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id !== (int) $this->getState('item.id')) 
+			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id === (int) $this->getState('item.id')) 
 			{
 				$table->link = $link;
 			}

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -689,8 +689,7 @@ class MenusModelItem extends JModelAdmin
 		{
 
 			// Check if we are changing away from the actual link type.
-			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id !== (int) $this->getState('item.id')
-				|| MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && is_null($table->id))
+			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id !== (int) $this->getState('item.id')) 
 			{
 				$table->link = $link;
 			}


### PR DESCRIPTION
Pull for #16719 and closing of #16735. When changing menu items from say a blog to a single article, it would not show all available options i.e. select article. This was caused by my PR #16486  so I have relaxed the conditioning which allows this to work again, and whilst having two menu items open refreshing the page loads on the menu item details they are on. The only downside here, is if you have two tabs open and one tab is a new menu item it will load in the other tabs details if a change was made when you refresh the page. A very rare scenario which I believe can be overlooked at this point.

Please test.