### PR TITLE
[4.0][mysqlidriver] - missed getConnectionCollation

### DIFF
--- a/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php
+++ b/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php
@@ -413,6 +413,23 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 	}
 
 	/**
+	 * Method to get the database connection collation in use by sampling a text field of a table in the database.
+	 *
+	 * @return  mixed  The collation in use by the database connection (string) or boolean false if not supported.
+	 *
+	 * @since   1.0
+	 * @throws  \RuntimeException
+	 */
+	public function getConnectionCollation()
+	{
+
+		$this->connect();
+
+		return $this->setQuery('SELECT @@collation_connection;')->loadResult();
+
+	}
+	
+	/**
 	 * Return the query string to create new Database.
 	 *
 	 * @param   stdClass  $options  Object used to pass user and database name to database driver. This object must have "db_name" and "db_user" set.


### PR DESCRIPTION
Pull Request for Issue #16789 .

### Summary of Changes
added the missed `getConnectionCollation()` method


### Testing Instructions
Access to System -> System Information


### Expected result
NO error


### Actual result
Call to undefined method Joomla\Database\Mysqli\MysqliDriver::getConnectionCollation()




