### PR TITLE
[4.0] Fixing Travis

### DIFF
--- a/layouts/joomla/toolbar/apply.php
+++ b/layouts/joomla/toolbar/apply.php
@@ -27,7 +27,7 @@ $class    = $displayData['class'];
 $text     = $displayData['text'];
 $btnClass = $displayData['btnClass'];
 ?>
-<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
+<button<?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
 	<span class="<?php echo trim($class); ?>"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -18,7 +18,7 @@ JText::script('ERROR');
 $message = "{'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
 $alert = "Joomla.renderMessages(" . $message . ")";
 ?>
-<button <?php echo $id; ?> data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
+<button<?php echo $id; ?> data-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{jQuery( '#collapseModal' ).modal('show'); return true;}" class="btn btn-outline-primary btn-sm">
 	<span class="icon-checkbox-partial" aria-hidden="true" title="<?php echo $title; ?>"></span>
 	<?php echo $title; ?>
 </button>

--- a/layouts/joomla/toolbar/confirm.php
+++ b/layouts/joomla/toolbar/confirm.php
@@ -16,7 +16,7 @@ $doTask = $displayData['doTask'];
 $class  = $displayData['class'];
 $text   = $displayData['text'];
 ?>
-<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-danger">
+<button<?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-danger">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/help.php
+++ b/layouts/joomla/toolbar/help.php
@@ -15,7 +15,7 @@ $id     = isset($displayData['id']) ? $displayData['id'] : '';
 $doTask = $displayData['doTask'];
 $text   = $displayData['text'];
 ?>
-<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-outline-info btn-sm">
+<button<?php echo $id; ?> onclick="<?php echo $doTask; ?>" rel="help" class="btn btn-outline-info btn-sm">
 	<span class="icon-question-sign" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -15,7 +15,7 @@ $class  = $displayData['class'];
 $text   = $displayData['text'];
 $margin = (strpos($doTask, 'index.php?option=com_config') === false) ? '' : ' ml-auto';
 ?>
-<button <?php echo $id; ?> class="btn btn-outline-danger btn-sm<?php echo $margin; ?>" onclick="location.href='<?php echo $doTask; ?>';">
+<button<?php echo $id; ?> class="btn btn-outline-danger btn-sm<?php echo $margin; ?>" onclick="location.href='<?php echo $doTask; ?>';">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/modal.php
+++ b/layouts/joomla/toolbar/modal.php
@@ -45,6 +45,6 @@ echo JHtml::_('bootstrap.renderModal',
 	)
 );
 ?>
-<button <?php echo $id; ?> onclick="jQuery('#modal_<?php echo $selector; ?>').modal('show')" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">
+<button<?php echo $id; ?> onclick="jQuery('#modal_<?php echo $selector; ?>').modal('show')" class="<?php echo $class; ?>" data-toggle="modal" title="<?php echo $text; ?>">
 	<span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span><?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -17,7 +17,7 @@ $class  = $displayData['class'];
 $text   = $displayData['text'];
 $name   = $displayData['name'];
 ?>
-<button <?php echo $id; ?> value="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-primary" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
+<button<?php echo $id; ?> value="<?php echo $doTask; ?>" class="btn btn-sm btn-outline-primary" data-toggle="modal" data-target="#modal-<?php echo $name; ?>">
 	<span class="<?php echo $class; ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/slider.php
+++ b/layouts/joomla/toolbar/slider.php
@@ -18,7 +18,7 @@ $text    = $displayData['text'];
 $name    = $displayData['name'];
 $onClose = $displayData['onClose'];
 ?>
-<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#collapse-<?php echo $name; ?>"<?php echo $onClose; ?>>
+<button<?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="btn btn-sm btn-secondary" data-toggle="collapse" data-target="#collapse-<?php echo $name; ?>"<?php echo $onClose; ?>>
 	<span class="icon-cog" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -20,12 +20,12 @@ $group    = $displayData['group'];
 ?>
 
 <?php if ($group) : ?>
-<a <?php echo $id; ?> href="#" onclick="<?php echo $doTask; ?>" class="dropdown-item">
+<a<?php echo $id; ?> href="#" onclick="<?php echo $doTask; ?>" class="dropdown-item">
 	<span class="<?php echo trim($class); ?>"></span>
 	<?php echo $text; ?>
 </a>
 <?php else : ?>
-<button <?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
+<button<?php echo $id; ?> onclick="<?php echo $doTask; ?>" class="<?php echo $btnClass; ?>">
 	<span class="<?php echo trim($class); ?>" aria-hidden="true"></span>
 	<?php echo $text; ?>
 </button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -31,6 +31,6 @@ echo JHtml::_(
 $id = isset($displayData['id']) ? $displayData['id'] : '';
 
 ?>
-<button <?php echo $id; ?> onclick="jQuery('#versionsModal').modal('show')" class="btn btn-sm btn-outline-primary" data-toggle="modal" title="<?php echo $displayData['title']; ?>">
+<button<?php echo $id; ?> onclick="jQuery('#versionsModal').modal('show')" class="btn btn-sm btn-outline-primary" data-toggle="modal" title="<?php echo $displayData['title']; ?>">
 	<span class="icon-archive" aria-hidden="true"></span><?php echo $displayData['title']; ?>
 </button>

--- a/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/JToolbarButtonTest.php
@@ -123,7 +123,7 @@ class JToolbarButtonTest extends TestCaseDatabase
 	{
 		$type = array('Standard', 'test');
 
-		$expected = "\n<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { Joomla.submitbutton(''); }\" class=\"btn btn-sm btn-outline-primary\">\n\t<span class=\"icon-test\" aria-hidden=\"true\"></span>\n\t</button>\n";
+		$expected = "\n<button id=\"toolbar-test\" onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { Joomla.submitbutton(''); }\" class=\"btn btn-sm btn-outline-primary\">\n\t<span class=\"icon-test\" aria-hidden=\"true\"></span>\n\t</button>\n";
 
 		$this->assertEquals(
 			$expected,

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonConfirmTest.php
@@ -92,14 +92,14 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
+		$html = "<button id=\"toolbar-\" onclick=\"if (document.adminForm.boxchecked.value == 0) { Joomla.renderMessages({'error': [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}) } else { if (confirm('Confirm action?')) { Joomla.submitbutton('article.save'); } }\" class=\"btn btn-sm btn-outline-danger\">\n"
 			. "\t<span class=\"icon-confirm-test\" aria-hidden=\"true\"></span>\n"
 			. "\tConfirm?</button>\n";
 
 
 		$this->assertEquals(
-			$this->object->fetchButton('Confirm', 'Confirm action?', 'confirm-test', 'Confirm?', 'article.save'),
-			$html
+			$html,
+			$this->object->fetchButton('Confirm', 'Confirm action?', 'confirm-test', 'Confirm?', 'article.save')
 		);
 	}
 
@@ -113,8 +113,8 @@ class JToolbarButtonConfirmTest extends TestCaseDatabase
 	public function testFetchId()
 	{
 		$this->assertEquals(
-			$this->object->fetchId('confirm', 'Message to render', 'test'),
-			'toolbar-test'
+			'toolbar-test',
+			$this->object->fetchId('confirm', 'Message to render', 'test')
 		);
 	}
 }

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
@@ -94,7 +94,7 @@ class JToolbarButtonHelpTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button  id=\"toolbar-help\" onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-outline-info btn-sm\">\n"
+		$html = "<button id=\"toolbar-help\" onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-outline-info btn-sm\">\n"
 			. "\t<span class=\"icon-question-sign\" aria-hidden=\"true\"></span>\n"
 			. "\tJTOOLBAR_HELP</button>\n";
 

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonHelpTest.php
@@ -94,13 +94,13 @@ class JToolbarButtonHelpTest extends TestCaseDatabase
 	 */
 	public function testFetchButton()
 	{
-		$html = "<button onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-outline-info btn-sm\">\n"
+		$html = "<button  id=\"toolbar-help\" onclick=\"Joomla.popupWindow('help/en-GB/JHELP_CONTENT_ARTICLE_MANAGER.html', 'JHELP', 700, 500, 1)\" rel=\"help\" class=\"btn btn-outline-info btn-sm\">\n"
 			. "\t<span class=\"icon-question-sign\" aria-hidden=\"true\"></span>\n"
 			. "\tJTOOLBAR_HELP</button>\n";
 
 		$this->assertEquals(
-			$this->object->fetchButton('Help', 'JHELP_CONTENT_ARTICLE_MANAGER'),
-			$html
+			$html,
+			$this->object->fetchButton('Help', 'JHELP_CONTENT_ARTICLE_MANAGER')
 		);
 	}
 

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonLinkTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonLinkTest.php
@@ -83,7 +83,7 @@ class JToolbarButtonLinkTest extends TestCase
 		$url = 'https://www.joomla.org';
 
 		$this->assertRegExp(
-			'#<button onclick="location.href=\'' . preg_quote($url, '#') . '\';" class="btn btn-outline-danger btn-sm">\s*'
+			'#<button id="toolbar-jdotorg" onclick="location.href=\'' . preg_quote($url, '#') . '\';" class="btn btn-outline-danger btn-sm">\s*'
 			. '<span class="icon-' . preg_quote($name, '#') . '" aria-hidden=\"true\"></span>\s+' . preg_quote($text, '#') . '\s*'
 			. '</button>\s*#',
 			$this->object->fetchButton('Link', $name, $text, $url)

--- a/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonLinkTest.php
+++ b/tests/unit/suites/libraries/cms/toolbar/button/JToolbarButtonLinkTest.php
@@ -83,7 +83,7 @@ class JToolbarButtonLinkTest extends TestCase
 		$url = 'https://www.joomla.org';
 
 		$this->assertRegExp(
-			'#<button id="toolbar-jdotorg" onclick="location.href=\'' . preg_quote($url, '#') . '\';" class="btn btn-outline-danger btn-sm">\s*'
+			'#<button id="toolbar-jdotorg" class="btn btn-outline-danger btn-sm" onclick="location.href=\'' . preg_quote($url, '#') . '\';">\s*'
 			. '<span class="icon-' . preg_quote($name, '#') . '" aria-hidden=\"true\"></span>\s+' . preg_quote($text, '#') . '\s*'
 			. '</button>\s*#',
 			$this->object->fetchButton('Link', $name, $text, $url)


### PR DESCRIPTION
Fixing Travis error introduced by #16779 

Some tests did also have "expected" and "actual" inverted. I've switched those.

I don't understand why `JToolbarButtonConfirmTest::testFetchButton` has the id `id="toolbar-"`, looks like it is missing a part there. But Travis should (hopefully) pass again.