### PR TITLE
[4.0] Add support for categories with sections to com_associations

### DIFF
--- a/administrator/components/com_associations/Controller/Association.php
+++ b/administrator/components/com_associations/Controller/Association.php
@@ -33,7 +33,7 @@ class Association extends Form
 	 */
 	public function edit($key = null, $urlVar = null)
 	{
-		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'));
+		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'),2);
 
 		$id = $this->input->get('id', 0, 'int');
 
@@ -62,7 +62,7 @@ class Association extends Form
 	{
 		\JSession::checkToken() or jexit(\JText::_('JINVALID_TOKEN'));
 
-		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'));
+		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'), 2);
 
 		// Only check in, if component item type allows to check out.
 		if (AssociationsHelper::typeSupportsCheckout($extensionName, $typeName))

--- a/administrator/components/com_associations/Controller/Association.php
+++ b/administrator/components/com_associations/Controller/Association.php
@@ -33,7 +33,7 @@ class Association extends Form
 	 */
 	public function edit($key = null, $urlVar = null)
 	{
-		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'),2);
+		list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'), 2);
 
 		$id = $this->input->get('id', 0, 'int');
 

--- a/administrator/components/com_associations/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/Helper/AssociationsHelper.php
@@ -388,7 +388,8 @@ class AssociationsHelper extends ContentHelper
 			$title       = $helper->getTypeTitle($typeName);
 			$languageKey = $typeName;
 
-			if ($typeName === 'category')
+			$typeNameExploded = explode('.', $typeName);
+			if (array_pop($typeNameExploded) === 'category')
 			{
 				$languageKey = strtoupper($extensionName) . '_CATEGORIES';
 				$context     = 'category';

--- a/administrator/components/com_associations/Model/Associations.php
+++ b/administrator/components/com_associations/Model/Associations.php
@@ -158,7 +158,7 @@ class Associations extends ListModel
 	{
 		$type         = null;
 
-		list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'));
+		list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'), 2);
 
 		$extension = AssociationsHelper::getSupportedExtension($extensionName);
 		$types     = $extension->get('types');
@@ -353,6 +353,14 @@ class Associations extends ListModel
 		if ($typeName === 'category')
 		{
 			$query->where($db->qn('a.extension') . ' = ' . $db->quote($extensionName));
+		}
+		elseif ($typeNameExploded = explode('.', $typeName))
+		{
+			if (count ($typeNameExploded) > 1 && array_pop($typeNameExploded) === 'category')
+			{
+				$section = implode('.', $typeNameExploded);
+				$query->where($db->qn('a.extension') . ' = ' . $db->quote($extensionName . '.' . $section));
+			}
 		}
 
 		// Filter on the language.

--- a/administrator/components/com_associations/View/Association/Html.php
+++ b/administrator/components/com_associations/View/Association/Html.php
@@ -82,7 +82,7 @@ class Html extends HtmlView
 		$input      = $this->app->input;
 		$this->referenceId = $input->get('id', 0, 'int');
 
-		list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'));
+		list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'), 2);
 
 		$extension = AssociationsHelper::getSupportedExtension($extensionName);
 		$types     = $extension->get('types');
@@ -116,12 +116,33 @@ class Html extends HtmlView
 
 		$this->referenceLanguage = $reference[$languageField];
 
-		$options = array(
-			'option'    => $typeName === 'category' ? 'com_categories' : $extensionName,
-			'view'      => $typeName,
-			'extension' => $extensionName,
-			'tmpl'      => 'component',
-		);
+		// Check for special case category
+		$typeNameExploded = explode('.', $typeName);
+		if (array_pop($typeNameExploded) === 'category')
+		{
+			$this->typeName = 'category';
+
+			if ($typeNameExploded)
+			{
+				$extensionName .= '.' . implode('.', $typeNameExploded);
+			}
+
+			$options = array(
+				'option'    => 'com_categories',
+				'view'      => 'category',
+				'extension' => $extensionName,
+				'tmpl'      => 'component',
+			);
+		}
+		else
+		{
+			$options = array(
+				'option'    => $extensionName,
+				'view'      => $typeName,
+				'extension' => $extensionName,
+				'tmpl'      => 'component',
+			);
+		}
 
 		// Reference and target edit links.
 		$this->editUri = 'index.php?' . http_build_query($options);
@@ -138,7 +159,7 @@ class Html extends HtmlView
 			$this->targetAction     = $matches[2];
 			$this->targetId         = $matches[1];
 			$this->targetLanguage   = $matches[0];
-			$task                   = $typeName . '.' . $this->targetAction;
+			$task                   = $this->typeName . '.' . $this->targetAction;
 			$this->defaultTargetSrc = \JRoute::_($this->editUri . '&task=' . $task . '&id=' . (int) $this->targetId);
 			$this->form->setValue('itemlanguage', '', $this->targetLanguage . ':' . $this->targetId . ':' . $this->targetAction);
 		}

--- a/administrator/components/com_associations/View/Associations/Html.php
+++ b/administrator/components/com_associations/View/Associations/Html.php
@@ -86,7 +86,7 @@ class Html extends HtmlView
 		{
 			$type = null;
 
-			list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'));
+			list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'), 2);
 
 			$extension = AssociationsHelper::getSupportedExtension($extensionName);
 

--- a/administrator/components/com_associations/models/fields/itemlanguage.php
+++ b/administrator/components/com_associations/models/fields/itemlanguage.php
@@ -40,7 +40,7 @@ class JFormFieldItemLanguage extends JFormFieldList
 	{
 		$input = JFactory::getApplication()->input;
 
-		list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'));
+		list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'), 2);
 
 		// Get the extension specific helper method
 		$helper = AssociationsHelper::getExtensionHelper($extensionName);


### PR DESCRIPTION
Currently, com_associations can't handle categories with sections (eg `extension=com_sermonspeaker.sermons`). This was actually to a degree expected limitation of the component when it was merged. The thing was that we had no extension to try it.
That is also the reason this PR is targeted for J4, because I doubt it will ever get tested in J3 due to the lack of an extension which would use it (my SermonSpeaker 6 only installs in J4).

### Summary of Changes
This PR adds support for such categories to com_associations in J4.


### Testing Instructions
In the "Multilingual Associations" component
* test that you can still associate regular categories (eg from com_content) and items as before. Nothing should change.
* test with an extension that uses categories with sections that you can associate them. You can use my SermonSpeaker version here (or another one, if you know one): 
[com_sermonspeaker.zip](https://github.com/joomla/joomla-cms/files/1091745/com_sermonspeaker.zip)



### Expected result
Can select and edit categories with sections


### Actual result
Categories with sections can't be selected.


### Documentation Changes Required
None
