### PR TITLE
[3.7] Allow setting reset PW together with a new PW.

### DIFF
--- a/libraries/joomla/user/user.php
+++ b/libraries/joomla/user/user.php
@@ -667,9 +667,6 @@ class JUser extends JObject
 				}
 
 				$array['password'] = $this->userHelper->hashPassword($array['password']);
-
-				// Reset the change password flag
-				$array['requireReset'] = 0;
 			}
 			else
 			{


### PR DESCRIPTION
### Summary of Changes

Allow setting reset PW together with a new PW.

### Testing Instructions

(- install 3.7.3-rc)
- add a new user
- set a PW
- edit the user
- set a new PW + require PW reset (like what should happen when the support is called)
- save the user
- notice that the require PW reset option is disabled.

### Expected result

PW reset is set if selected

### Actual result

PW reset is not set if we set a new PW in the backend.

### Documentation Changes Required

none

### Additional Infos

@mbabker The line comes from the initial PR do you know the reason why you did it that way?