### PR TITLE
Checkboxes form field disables all options after first disabled optio…

### DIFF
--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -69,9 +69,9 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 			$checked = in_array((string) $option->value, $checkedOptions, true) ? 'checked' : '';
 
 			// In case there is no stored value, use the option's default state.
-			$checked     = (!$hasValue && $option->checked) ? 'checked' : $checked;
-			$optionClass = !empty($option->class) ? 'class="' . $option->class . '"' : '';
-			$disabled    = !empty($option->disable) || $disabled ? 'disabled' : '';
+			$checked        = (!$hasValue && $option->checked) ? 'checked' : $checked;
+			$optionClass    = !empty($option->class) ? 'class="' . $option->class . '"' : '';
+			$optionDisabled = !empty($option->disable) || $disabled ? 'disabled' : '';
 
 			// Initialize some JavaScript option attributes.
 			$onclick  = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
@@ -79,7 +79,7 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 
 			$oid        = $id . $i;
 			$value      = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-			$attributes = array_filter(array($checked, $optionClass, $disabled, $onchange, $onclick));
+			$attributes = array_filter(array($checked, $optionClass, $optionDisabled, $onchange, $onclick));
 		?>
 
 		<label for="<?php echo $oid; ?>" class="checkbox">


### PR DESCRIPTION
### Steps to reproduce the issue

Create custom field extended from `JFormFieldCheckboxes` and add multiple options with disabled option in the middle of options.

Or test with XML:

```
<field name="test" type="checkboxes">
	<option value="1">1</option>
	<option value="2" disabled="true">2</option>
	<option value="3">3</option>
</field>
```
### Expected result
Only 2nd checkbox is disabled.

### Actual result
2nd and 3rd checkboxes are disabled.

### System information (as much as possible)

As usual.

### Additional comments

`/layout/joomla/form/field/checkboxes.php`:

The idea is to not use previous/field-specific 'disabled'  attribute if there are more than 1 option.