### PR TITLE
[4.0] Trying to fix AppVeyor failure

### DIFF
--- a/tests/unit/suites/libraries/joomla/form/JFormTest.php
+++ b/tests/unit/suites/libraries/joomla/form/JFormTest.php
@@ -96,7 +96,7 @@ class JFormTest extends TestCaseDatabase
 
 		// The default path is the class file folder/forms
 		// use of realpath to ensure test works for on all platforms
-		$valid = realpath(JPATH_PLATFORM . '/joomla/form') . '/fields';
+		$valid = JPATH_PLATFORM . '/joomla/form/fields';
 
 		$this->assertThat(
 			in_array($valid, $paths),


### PR DESCRIPTION
Pull Request for Issue #16698 (at least part of it).
AppVeyor currently shows 17 errors and 1 failure. This PR only addresses the single failure..

### Summary of Changes
Removes the `realpath` call from the test. Reason is that the paths are stored in JForm with mixed dividers, eg the stored default path we check looks like this on Windows: "D:\xampp\htdocs\joomla4\libraries/joomla/form/fields". Realpath however will change the expected path to "D:\xampp\htdocs\joomla4\libraries\joomla\form/fields" and thus the `in_array()` check fails.

### Testing Instructions
I guess if AppVeyor (17 errors remain, but the fail is gone) and Travis passes, then this is fine.

Lets see what the tests say.

### Expected result
No failurs in AppVeyor


### Actual result
One failur in AppVeyor


### Documentation Changes Required
None
