### PR TITLE
Show exception message instead of generic message

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -52,7 +52,7 @@ abstract class ModMenuHelper
 		catch (RuntimeException $e)
 		{
 			$result = array();
-			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		return $result;
@@ -112,7 +112,7 @@ abstract class ModMenuHelper
 		catch (RuntimeException $e)
 		{
 			$components = array();
-			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		// Parse the list of extensions.
@@ -209,7 +209,7 @@ abstract class ModMenuHelper
 		catch (RuntimeException $e)
 		{
 			$menuItems = array();
-			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+			JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		return $menuItems;


### PR DESCRIPTION
At the moment if an error occurs we get just "An error has occurred" message and not anything helpful.

Today the error was "Out of sort memory, consider increasing server sort buffer size" which would have been a hell of a lot better output than just "An Error has occurred"

As this is the /administrator/ menu helper I dont see any reason why we should not display the exception message instead of a generic error message? 

@mbabker 
https://twitter.com/blueflameit/status/877887820286746624

