### PR TITLE
string cases to test JFilterInput

### DIFF
--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -290,6 +290,30 @@ class JFilterInputTest extends \PHPUnit\Framework\TestCase
 				array(true, false, true, false, true, false, false),
 				'From generic cases'
 			),
+			'string1' => array(
+				'string',
+				'string>passed>ok',
+				'string>passed>ok',
+				'From generic cases'
+			),
+			'string2' => array(
+				'string',
+				'string<passed<ok',
+				'string<passed<ok',
+				'From generic cases'
+			),
+			'string3' => array(
+				'string',
+				'string<>number',
+				'string<>number',
+				'From generic cases'
+			),
+			'string4' => array(
+				'string',
+				'string><number',
+				'string><number',
+				'From generic cases'
+			),
 			'word_01' => array(
 				'word',
 				$input,


### PR DESCRIPTION
For Issue #16812

### Summary of Changes
Adding unit test cases for strings to let the unit test fail on the current codebase
