### PR TITLE
Namespace updater

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -294,3 +294,9 @@ JLoader::registerAlias('JClientFtp',                        '\\Joomla\\CMS\\Clie
 JLoader::registerAlias('JFTP',                              '\\Joomla\\CMS\\Client\\FtpClient', '4.0');
 JLoader::registerAlias('JClientLdap',                       '\\Joomla\\Ldap\\LdapClient', '5.0');
 JLoader::registerAlias('JLDAP',                             '\\Joomla\\Ldap\\LdapClient', '4.0');
+
+JLoader::registerAlias('JUpdate',                           '\\Joomla\\CMS\\Updater\\Update', '5.0');
+JLoader::registerAlias('JUpdateAdapter',                    '\\Joomla\\CMS\\Updater\\UpdateAdapter', '5.0');
+JLoader::registerAlias('JUpdater',                          '\\Joomla\\CMS\\Updater\\Updater', '5.0');
+JLoader::registerAlias('JUpdaterCollection',                '\\Joomla\\CMS\\Updater\\Adapter\\CollectionAdapter', '5.0');
+JLoader::registerAlias('JUpdaterExtension',                 '\\Joomla\\CMS\\Updater\\Adapter\\ExtensionAdapter', '5.0');

--- a/libraries/joomla/base/adapter.php
+++ b/libraries/joomla/base/adapter.php
@@ -139,6 +139,15 @@ class JAdapter extends JObject
 			return true;
 		}
 
+		$class = rtrim($this->_classprefix, '\\') . '\\' . ucfirst($name) . 'Adapter';
+
+		if (class_exists($class))
+		{
+			$this->_adapters[$name] = new $class($this, $this->_db, $options);
+
+			return true;
+		}
+
 		$fullpath = $this->_basepath . '/' . $this->_adapterfolder . '/' . strtolower($name) . '.php';
 
 		if (!file_exists($fullpath))

--- a/libraries/src/Joomla/CMS/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/Adapter/CollectionAdapter.php
@@ -18,8 +18,6 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\UpdateAdapter;
 use Joomla\CMS\Version;
 
-\JLoader::import('joomla.updater.updateadapter');
-
 /**
  * Collection Update Adapter Class
  *

--- a/libraries/src/Joomla/CMS/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/Adapter/CollectionAdapter.php
@@ -1,22 +1,31 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Updater
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+namespace Joomla\CMS\Updater\Adapter;
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.updater.updateadapter');
+use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Table\Table;
+use Joomla\CMS\Updater\UpdateAdapter;
+use Joomla\CMS\Version;
+
+\JLoader::import('joomla.updater.updateadapter');
 
 /**
  * Collection Update Adapter Class
  *
  * @since  11.1
  */
-class JUpdaterCollection extends JUpdateAdapter
+class CollectionAdapter extends UpdateAdapter
 {
 	/**
 	 * Root of the tree
@@ -114,7 +123,7 @@ class JUpdaterCollection extends JUpdateAdapter
 				}
 				break;
 			case 'EXTENSION':
-				$update = JTable::getInstance('update');
+				$update = Table::getInstance('update');
 				$update->set('update_site_id', $this->updateSiteId);
 
 				foreach ($this->updatecols as $col)
@@ -131,7 +140,7 @@ class JUpdaterCollection extends JUpdateAdapter
 					}
 				}
 
-				$client = JApplicationHelper::getClientInfo($attrs['CLIENT'], 1);
+				$client = ApplicationHelper::getClientInfo($attrs['CLIENT'], 1);
 
 				if (isset($client->id))
 				{
@@ -145,10 +154,10 @@ class JUpdaterCollection extends JUpdateAdapter
 				}
 
 				// Only add the update if it is on the same platform and release as we are
-				$ver = new JVersion;
+				$ver = new Version;
 
 				// Lower case and remove the exclamation mark
-				$product = strtolower(JFilterInput::getInstance()->clean($ver::PRODUCT, 'cmd'));
+				$product = strtolower(InputFilter::getInstance()->clean($ver::PRODUCT, 'cmd'));
 
 				/*
 				 * Set defaults, the extension file should clarify in case but it may be only available in one version
@@ -241,10 +250,10 @@ class JUpdaterCollection extends JUpdateAdapter
 				return $this->findUpdate($options);
 			}
 
-			JLog::add('Error parsing url: ' . $this->_url, JLog::WARNING, 'updater');
+			Log::add('Error parsing url: ' . $this->_url, Log::WARNING, 'updater');
 
-			$app = JFactory::getApplication();
-			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $this->_url), 'warning');
+			$app = Factory::getApplication();
+			$app->enqueueMessage(\JText::sprintf('JLIB_UPDATER_ERROR_COLLECTION_PARSE_URL', $this->_url), 'warning');
 
 			return false;
 		}

--- a/libraries/src/Joomla/CMS/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/Adapter/ExtensionAdapter.php
@@ -19,8 +19,6 @@ use Joomla\CMS\Updater\UpdateAdapter;
 use Joomla\CMS\Updater\Updater;
 use Joomla\CMS\Version;
 
-\JLoader::import('joomla.updater.updateadapter');
-
 /**
  * Extension class for updater
  *

--- a/libraries/src/Joomla/CMS/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/Adapter/ExtensionAdapter.php
@@ -1,22 +1,32 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Updater
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+namespace Joomla\CMS\Updater\Adapter;
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.updater.updateadapter');
+use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Table\Table;
+use Joomla\CMS\Updater\UpdateAdapter;
+use Joomla\CMS\Updater\Updater;
+use Joomla\CMS\Version;
+
+\JLoader::import('joomla.updater.updateadapter');
 
 /**
  * Extension class for updater
  *
  * @since  11.1
  */
-class JUpdaterExtension extends JUpdateAdapter
+class ExtensionAdapter extends UpdateAdapter
 {
 	/**
 	 * Start element parser callback.
@@ -43,7 +53,7 @@ class JUpdaterExtension extends JUpdateAdapter
 		switch ($name)
 		{
 			case 'UPDATE':
-				$this->currentUpdate = JTable::getInstance('update');
+				$this->currentUpdate = Table::getInstance('update');
 				$this->currentUpdate->update_site_id = $this->updateSiteId;
 				$this->currentUpdate->detailsurl = $this->_url;
 				$this->currentUpdate->folder = '';
@@ -98,15 +108,15 @@ class JUpdaterExtension extends JUpdateAdapter
 		{
 			case 'UPDATE':
 				// Lower case and remove the exclamation mark
-				$product = strtolower(JFilterInput::getInstance()->clean(JVersion::PRODUCT, 'cmd'));
+				$product = strtolower(InputFilter::getInstance()->clean(Version::PRODUCT, 'cmd'));
 
 				// Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be used instead
 				if (isset($this->currentUpdate->targetplatform->min_dev_level) || isset($this->currentUpdate->targetplatform->max_dev_level))
 				{
-					JLog::add(
+					Log::add(
 						'Support for the min_dev_level and max_dev_level attributes of an update\'s <targetplatform> tag is deprecated and'
 						. ' will be removed in 4.0. The full version should be specified in the version attribute and may optionally be a regexp.',
-						JLog::WARNING,
+						Log::WARNING,
 						'deprecated'
 					);
 				}
@@ -118,8 +128,8 @@ class JUpdaterExtension extends JUpdateAdapter
 				 */
 				if ($product == $this->currentUpdate->targetplatform['NAME']
 					&& preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
-					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || JVersion::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
-					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || JVersion::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
+					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) || Version::DEV_LEVEL >= $this->currentUpdate->targetplatform->min_dev_level)
+					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) || Version::DEV_LEVEL <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					// Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
 					if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum, '>='))
@@ -129,7 +139,7 @@ class JUpdaterExtension extends JUpdateAdapter
 					else
 					{
 						// Notify the user of the potential update
-						$msg = JText::sprintf(
+						$msg = \JText::sprintf(
 							'JLIB_INSTALLER_AVAILABLE_UPDATE_PHP_VERSION',
 							$this->currentUpdate->name,
 							$this->currentUpdate->version,
@@ -137,7 +147,7 @@ class JUpdaterExtension extends JUpdateAdapter
 							PHP_VERSION
 						);
 
-						JFactory::getApplication()->enqueueMessage($msg, 'warning');
+						Factory::getApplication()->enqueueMessage($msg, 'warning');
 
 						$phpMatch = false;
 					}
@@ -147,7 +157,7 @@ class JUpdaterExtension extends JUpdateAdapter
 					// Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
 					if (isset($this->currentUpdate->supported_databases))
 					{
-						$db           = JFactory::getDbo();
+						$db           = Factory::getDbo();
 						$dbType       = strtoupper($db->getServerType());
 						$dbVersion    = $db->getVersion();
 						$supportedDbs = $this->currentUpdate->supported_databases;
@@ -161,29 +171,29 @@ class JUpdaterExtension extends JUpdateAdapter
 							if (!$dbMatch)
 							{
 								// Notify the user of the potential update
-								$dbMsg = JText::sprintf(
+								$dbMsg = \JText::sprintf(
 									'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_MINIMUM',
 									$this->currentUpdate->name,
 									$this->currentUpdate->version,
-									JText::_($db->name),
+									\JText::_($db->name),
 									$dbVersion,
 									$minumumVersion
 								);
 
-								JFactory::getApplication()->enqueueMessage($dbMsg, 'warning');
+								Factory::getApplication()->enqueueMessage($dbMsg, 'warning');
 							}
 						}
 						else
 						{
 							// Notify the user of the potential update
-							$dbMsg = JText::sprintf(
+							$dbMsg = \JText::sprintf(
 								'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_TYPE',
 								$this->currentUpdate->name,
 								$this->currentUpdate->version,
-								JText::_($db->name)
+								\JText::_($db->name)
 							);
 
-							JFactory::getApplication()->enqueueMessage($dbMsg, 'warning');
+							Factory::getApplication()->enqueueMessage($dbMsg, 'warning');
 						}
 					}
 					else
@@ -314,10 +324,10 @@ class JUpdaterExtension extends JUpdateAdapter
 				return $this->findUpdate($options);
 			}
 
-			JLog::add('Error parsing url: ' . $this->_url, JLog::WARNING, 'updater');
+			Log::add('Error parsing url: ' . $this->_url, Log::WARNING, 'updater');
 
-			$app = JFactory::getApplication();
-			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $this->_url), 'warning');
+			$app = Factory::getApplication();
+			$app->enqueueMessage(\JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_PARSE_URL', $this->_url), 'warning');
 
 			return false;
 		}
@@ -333,9 +343,9 @@ class JUpdaterExtension extends JUpdateAdapter
 					$byName = false;
 
 					// <client> has to be 'administrator' or 'site', numeric values are deprecated. See https://docs.joomla.org/Special:MyLanguage/Design_of_JUpdate
-					JLog::add(
+					Log::add(
 						'Using numeric values for <client> in the updater xml is deprecated. Use \'administrator\' or \'site\' instead.',
-						JLog::WARNING, 'deprecated'
+						Log::WARNING, 'deprecated'
 					);
 				}
 				else
@@ -343,7 +353,7 @@ class JUpdaterExtension extends JUpdateAdapter
 					$byName = true;
 				}
 
-				$this->latest->client_id = JApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
+				$this->latest->client_id = ApplicationHelper::getClientInfo($this->latest->client, $byName)->id;
 				unset($this->latest->client);
 			}
 
@@ -369,13 +379,13 @@ class JUpdaterExtension extends JUpdateAdapter
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = 'JUpdater::STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{
 			return constant($constant);
 		}
 
-		return JUpdater::STABILITY_STABLE;
+		return Updater::STABILITY_STABLE;
 	}
 }

--- a/libraries/src/Joomla/CMS/Updater/Update.php
+++ b/libraries/src/Joomla/CMS/Updater/Update.php
@@ -8,12 +8,12 @@
 
 namespace Joomla\CMS\Updater;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Version;
-
-defined('JPATH_PLATFORM') or die;
 
 /**
  * Update class. It is used by Updater::update() to install an update. Use Updater::findUpdates() to find updates for

--- a/libraries/src/Joomla/CMS/Updater/Update.php
+++ b/libraries/src/Joomla/CMS/Updater/Update.php
@@ -1,21 +1,27 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Updater
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+namespace Joomla\CMS\Updater;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Version;
 
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Update class. It is used by JUpdater::update() to install an update. Use JUpdater::findUpdates() to find updates for
+ * Update class. It is used by Updater::update() to install an update. Use Updater::findUpdates() to find updates for
  * an extension.
  *
  * @since  11.1
  */
-class JUpdate extends JObject
+class Update extends \JObject
 {
 	/**
 	 * Update manifest `<name>` element
@@ -180,7 +186,7 @@ class JUpdate extends JObject
 	/**
 	 * Object containing the latest update data
 	 *
-	 * @var    stdClass
+	 * @var    \stdClass
 	 * @since  12.1
 	 */
 	protected $latest;
@@ -196,9 +202,9 @@ class JUpdate extends JObject
 	 * @var    int
 	 * @since  14.1
 	 *
-	 * @see    JUpdater
+	 * @see    Updater
 	 */
-	protected $minimum_stability = JUpdater::STABILITY_STABLE;
+	protected $minimum_stability = Updater::STABILITY_STABLE;
 
 	/**
 	 * Gets the reference to the current direct parent
@@ -251,7 +257,7 @@ class JUpdate extends JObject
 		{
 			// This is a new update; create a current update
 			case 'UPDATE':
-				$this->currentUpdate = new stdClass;
+				$this->currentUpdate = new \stdClass;
 				break;
 
 			// Don't do anything
@@ -264,7 +270,7 @@ class JUpdate extends JObject
 
 				if (!isset($this->currentUpdate->$name))
 				{
-					$this->currentUpdate->$name = new stdClass;
+					$this->currentUpdate->$name = new \stdClass;
 				}
 
 				$this->currentUpdate->$name->_data = '';
@@ -297,15 +303,15 @@ class JUpdate extends JObject
 		{
 			// Closing update, find the latest version and check
 			case 'UPDATE':
-				$product = strtolower(JFilterInput::getInstance()->clean(JVersion::PRODUCT, 'cmd'));
+				$product = strtolower(InputFilter::getInstance()->clean(Version::PRODUCT, 'cmd'));
 
 				// Support for the min_dev_level and max_dev_level attributes is deprecated, a regexp should be used instead
 				if (isset($this->currentUpdate->targetplatform->min_dev_level) || isset($this->currentUpdate->targetplatform->max_dev_level))
 				{
-					JLog::add(
+					Log::add(
 						'Support for the min_dev_level and max_dev_level attributes of an update\'s <targetplatform> tag is deprecated and'
 						. ' will be removed in 4.0. The full version should be specified in the version attribute and may optionally be a regexp.',
-						JLog::WARNING,
+						Log::WARNING,
 						'deprecated'
 					);
 				}
@@ -319,9 +325,9 @@ class JUpdate extends JObject
 					&& $product == $this->currentUpdate->targetplatform->name
 					&& preg_match('/^' . $this->currentUpdate->targetplatform->version . '/', $this->get('jversion.full', JVERSION))
 					&& ((!isset($this->currentUpdate->targetplatform->min_dev_level)) 
-					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
+					|| $this->get('jversion.dev_level', Version::DEV_LEVEL) >= $this->currentUpdate->targetplatform->min_dev_level)
 					&& ((!isset($this->currentUpdate->targetplatform->max_dev_level)) 
-					|| $this->get('jversion.dev_level', JVersion::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
+					|| $this->get('jversion.dev_level', Version::DEV_LEVEL) <= $this->currentUpdate->targetplatform->max_dev_level))
 				{
 					$phpMatch = false;
 
@@ -336,7 +342,7 @@ class JUpdate extends JObject
 					// Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
 					if (isset($this->currentUpdate->supported_databases))
 					{
-						$db           = JFactory::getDbo();
+						$db           = Factory::getDbo();
 						$dbType       = strtolower($db->getServerType());
 						$dbVersion    = $db->getVersion();
 						$supportedDbs = $this->currentUpdate->supported_databases;
@@ -434,21 +440,21 @@ class JUpdate extends JObject
 	 * Loads an XML file from a URL.
 	 *
 	 * @param   string  $url                The URL.
-	 * @param   int     $minimum_stability  The minimum stability required for updating the extension {@see JUpdater}
+	 * @param   int     $minimum_stability  The minimum stability required for updating the extension {@see Updater}
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @since   11.1
 	 */
-	public function loadFromXml($url, $minimum_stability = JUpdater::STABILITY_STABLE)
+	public function loadFromXml($url, $minimum_stability = Updater::STABILITY_STABLE)
 	{
-		$http = JHttpFactory::getHttp();
+		$http = \JHttpFactory::getHttp();
 
 		try
 		{
 			$response = $http->get($url);
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			$response = null;
 		}
@@ -456,7 +462,7 @@ class JUpdate extends JObject
 		if ($response === null || $response->code !== 200)
 		{
 			// TODO: Add a 'mark bad' setting here somehow
-			JLog::add(JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), JLog::WARNING, 'jerror');
+			Log::add(\JText::sprintf('JLIB_UPDATER_ERROR_EXTENSION_OPEN_URL', $url), Log::WARNING, 'jerror');
 
 			return false;
 		}
@@ -470,12 +476,12 @@ class JUpdate extends JObject
 
 		if (!xml_parse($this->xmlParser, $response->body))
 		{
-			JLog::add(
+			Log::add(
 				sprintf(
 					'XML error: %s at line %d', xml_error_string(xml_get_error_code($this->xmlParser)),
 					xml_get_current_line_number($this->xmlParser)
 				),
-				JLog::WARNING, 'updater'
+				Log::WARNING, 'updater'
 			);
 
 			return false;
@@ -498,13 +504,13 @@ class JUpdate extends JObject
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = 'JUpdater::STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{
 			return constant($constant);
 		}
 
-		return JUpdater::STABILITY_STABLE;
+		return Updater::STABILITY_STABLE;
 	}
 }

--- a/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
@@ -275,7 +275,8 @@ abstract class UpdateAdapter extends \JAdapterInstance
 				return $this->getUpdateSiteResponse($options);
 			}
 
-			// Log the exact update site name and URL which could not be loadedJLog::add('Error opening url: ' . $url . ' for update site: ' . $this->updateSiteName, JLog::WARNING, 'updater');
+			// Log the exact update site name and URL which could not be loaded
+			Log::add('Error opening url: ' . $url . ' for update site: ' . $this->updateSiteName, Log::WARNING, 'updater');
 			$app = Factory::getApplication();
 			$app->enqueueMessage(\JText::sprintf('JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE', $this->updateSiteId, $this->updateSiteName, $url), 'warning');
 

--- a/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Updater;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\Log\Log;
-
-defined('JPATH_PLATFORM') or die;
 
 \JLoader::import('joomla.base.adapterinstance');
 

--- a/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
+++ b/libraries/src/Joomla/CMS/Updater/UpdateAdapter.php
@@ -1,22 +1,26 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Updater
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+namespace Joomla\CMS\Updater;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.base.adapterinstance');
+\JLoader::import('joomla.base.adapterinstance');
 
 /**
  * UpdateAdapter class.
  *
  * @since  11.1
  */
-abstract class JUpdateAdapter extends JAdapterInstance
+abstract class UpdateAdapter extends \JAdapterInstance
 {
 	/**
 	 * Resource handle for the XML Parser
@@ -82,9 +86,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 	 * @var    int
 	 * @since  14.1
 	 *
-	 * @see    JUpdater
+	 * @see    Updater
 	 */
-	protected $minimum_stability = JUpdater::STABILITY_STABLE;
+	protected $minimum_stability = Updater::STABILITY_STABLE;
 
 	/**
 	 * Gets the reference to the current direct parent
@@ -152,7 +156,7 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		{
 			$db->execute();
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			// Do nothing
 		}
@@ -187,7 +191,7 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		{
 			$name = $db->loadResult();
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			// Do nothing
 		}
@@ -200,9 +204,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 	 *
 	 * @param   array  $options  The update options, see findUpdate() in children classes
 	 *
-	 * @return  bool|JHttpResponse  False if we can't connect to the site, JHttpResponse otherwise
+	 * @return  bool|\JHttpResponse  False if we can't connect to the site, JHttpResponse otherwise
 	 *
-	 * @throws  Exception
+	 * @throws  \Exception
 	 */
 	protected function getUpdateSiteResponse($options = array())
 	{
@@ -242,10 +246,10 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		// JHttp transport throws an exception when there's no response.
 		try
 		{
-			$http = JHttpFactory::getHttp();
+			$http = \JHttpFactory::getHttp();
 			$response = $http->get($url, array(), 20);
 		}
-		catch (RuntimeException $e)
+		catch (\RuntimeException $e)
 		{
 			$response = null;
 		}
@@ -256,9 +260,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 		// Log the time it took to load this update site's information
 		$endTime = microtime(true);
 		$timeToLoad = sprintf('%0.2f', $endTime - $startTime);
-		JLog::add(
+		Log::add(
 			"Loading information from update site #{$this->updateSiteId} with name " .
-			"\"$this->updateSiteName\" and URL $url took $timeToLoad seconds", JLog::INFO, 'updater'
+			"\"$this->updateSiteName\" and URL $url took $timeToLoad seconds", Log::INFO, 'updater'
 		);
 
 		if ($response === null || $response->code !== 200)
@@ -271,10 +275,9 @@ abstract class JUpdateAdapter extends JAdapterInstance
 				return $this->getUpdateSiteResponse($options);
 			}
 
-			// Log the exact update site name and URL which could not be loaded
-			JLog::add('Error opening url: ' . $url . ' for update site: ' . $this->updateSiteName, JLog::WARNING, 'updater');
-			$app = JFactory::getApplication();
-			$app->enqueueMessage(JText::sprintf('JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE', $this->updateSiteId, $this->updateSiteName, $url), 'warning');
+			// Log the exact update site name and URL which could not be loadedJLog::add('Error opening url: ' . $url . ' for update site: ' . $this->updateSiteName, JLog::WARNING, 'updater');
+			$app = Factory::getApplication();
+			$app->enqueueMessage(\JText::sprintf('JLIB_UPDATER_ERROR_OPEN_UPDATE_SITE', $this->updateSiteId, $this->updateSiteName, $url), 'warning');
 
 			return false;
 		}

--- a/libraries/src/Joomla/CMS/Updater/Updater.php
+++ b/libraries/src/Joomla/CMS/Updater/Updater.php
@@ -1,26 +1,30 @@
 <?php
 /**
- * @package     Joomla.Platform
- * @subpackage  Updater
+ * Joomla! Content Management System
  *
- * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
- * @license     GNU General Public License version 2 or later; see LICENSE
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+namespace Joomla\CMS\Updater;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-jimport('joomla.filesystem.file');
-jimport('joomla.filesystem.folder');
-jimport('joomla.filesystem.path');
-jimport('joomla.base.adapter');
-jimport('joomla.utilities.arrayhelper');
+\JLoader::import('joomla.filesystem.file');
+\JLoader::import('joomla.filesystem.folder');
+\JLoader::import('joomla.filesystem.path');
+\JLoader::import('joomla.base.adapter');
+\JLoader::import('joomla.utilities.arrayhelper');
 
 /**
  * Updater Class
  *
  * @since  11.1
  */
-class JUpdater extends JAdapter
+class Updater extends \JAdapter
 {
 	/**
 	 * Development snapshots, nightly builds, pre-release versions and so on
@@ -63,7 +67,7 @@ class JUpdater extends JAdapter
 	const STABILITY_STABLE = 4;
 
 	/**
-	 * @var    JUpdater  JUpdater instance container.
+	 * @var    Updater  Updater instance container.
 	 * @since  11.3
 	 */
 	protected static $instance;
@@ -71,19 +75,22 @@ class JUpdater extends JAdapter
 	/**
 	 * Constructor
 	 *
-	 * @since   11.1
+	 * @param   string  $basepath       Base Path of the adapters
+	 * @param   string  $classprefix    Class prefix of adapters
+	 * @param   string  $adapterfolder  Name of folder to append to base path
+	 *
+	 * @since   3.1
 	 */
-	public function __construct()
+	public function __construct($basepath = __DIR__, $classprefix = '\\Joomla\\CMS\\Updater\\Adapter', $adapterfolder = 'Adapter')
 	{
-		// Adapter base path, class prefix
-		parent::__construct(__DIR__, 'JUpdater');
+		parent::__construct($basepath, $classprefix, $adapterfolder);
 	}
 
 	/**
 	 * Returns a reference to the global Installer object, only creating it
 	 * if it doesn't already exist.
 	 *
-	 * @return  JUpdater  An installer object
+	 * @return  Updater  An installer object
 	 *
 	 * @since   11.1
 	 */
@@ -91,7 +98,7 @@ class JUpdater extends JAdapter
 	{
 		if (!isset(self::$instance))
 		{
-			self::$instance = new JUpdater;
+			self::$instance = new Updater;
 		}
 
 		return self::$instance;
@@ -154,7 +161,7 @@ class JUpdater extends JAdapter
 			{
 				$retval = true;
 
-				/** @var JTableUpdate $update */
+				/** @var \JTableUpdate $update */
 				foreach ($updateObjects as $update)
 				{
 					$update->check();
@@ -182,9 +189,9 @@ class JUpdater extends JAdapter
 	 */
 	public function update($id)
 	{
-		$updaterow = JTable::getInstance('update');
+		$updaterow = Table::getInstance('update');
 		$updaterow->load($id);
-		$update = new JUpdate;
+		$update = new Update;
 
 		if ($update->loadFromXml($updaterow->detailsurl))
 		{
@@ -265,7 +272,7 @@ class JUpdater extends JAdapter
 		$updateSite['minimum_stability'] = $minimum_stability;
 
 		// Get the update information from the remote update XML document
-		/** @var JUpdateAdapter $adapter */
+		/** @var UpdateAdapter $adapter */
 		$adapter       = $this->_adapters[ $updateSite['type']];
 		$update_result = $adapter->findUpdate($updateSite);
 
@@ -302,16 +309,16 @@ class JUpdater extends JAdapter
 
 			if (array_key_exists('updates', $update_result) && count($update_result['updates']))
 			{
-				/** @var JTableUpdate $current_update */
+				/** @var \JTableUpdate $current_update */
 				foreach ($update_result['updates'] as $current_update)
 				{
 					$current_update->extra_query = $updateSite['extra_query'];
 
-					/** @var JTableUpdate $update */
-					$update = JTable::getInstance('update');
+					/** @var \JTableUpdate $update */
+					$update = Table::getInstance('update');
 
-					/** @var JTableExtension $extension */
-					$extension = JTable::getInstance('extension');
+					/** @var \JTableExtension $extension */
+					$extension = Table::getInstance('extension');
 
 					$uid = $update
 						->find(
@@ -383,7 +390,7 @@ class JUpdater extends JAdapter
 	 */
 	private function getSitesWithUpdates($timestamp = 0)
 	{
-		$db = JFactory::getDbo();
+		$db = Factory::getDbo();
 
 		$query = $db->getQuery(true)
 			->select('DISTINCT update_site_id')
@@ -422,7 +429,7 @@ class JUpdater extends JAdapter
 	private function updateLastCheckTimestamp($updateSiteId)
 	{
 		$timestamp = time();
-		$db        = JFactory::getDbo();
+		$db        = Factory::getDbo();
 
 		$query = $db->getQuery(true)
 			->update($db->quoteName('#__update_sites'))

--- a/libraries/src/Joomla/CMS/Updater/Updater.php
+++ b/libraries/src/Joomla/CMS/Updater/Updater.php
@@ -8,10 +8,10 @@
 
 namespace Joomla\CMS\Updater;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Factory;
 use Joomla\CMS\Table\Table;
-
-defined('JPATH_PLATFORM') or die;
 
 \JLoader::import('joomla.filesystem.file');
 \JLoader::import('joomla.filesystem.folder');

--- a/libraries/src/Joomla/CMS/Updater/Updater.php
+++ b/libraries/src/Joomla/CMS/Updater/Updater.php
@@ -17,7 +17,6 @@ defined('JPATH_PLATFORM') or die;
 \JLoader::import('joomla.filesystem.folder');
 \JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
-\JLoader::import('joomla.utilities.arrayhelper');
 
 /**
  * Updater Class


### PR DESCRIPTION
### Summary of Changes
Namespaces the updater library. Additionally it adds support in the adapter library to fetch classes which do end with Adapter.

### Testing Instructions
- Install patch tester 2.0.0 from [here](https://github.com/joomla-extensions/patchtester/releases/download/2.0.0/com_patchtester.zip).
- Go to Extensions -> Manage -> Update
- Hit the "Clear the cache" button
- Hit the "Find updates" button
- Install the patchtester 3.0.x trough the updater

If possible, test it out with other extensions.

### Expected result
All should work fine.

### Actual result
All is working fine.