### PR TITLE
Remove unused join from categoredit, greatly hindering performance when having large number of categories

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -192,8 +192,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$subQuery->where('access IN (' . $groups . ')');
 		}
 
-		$query->from('(' . (string) $subQuery . ') AS a')
-			->join('LEFT', $db->quoteName('#__categories') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+		$query->from('(' . (string) $subQuery . ') AS a');
 		$query->order('a.lft ASC');
 
 		// If parent isn't explicitly stated but we are in com_categories assume we want parents

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -145,19 +145,17 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		$user = JFactory::getUser();
 
 		$query = $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.title AS text, a.level, a.published, a.lft');
-		$subQuery = $db->getQuery(true)
-			->select('id,title,level,published,parent_id,extension,lft,rgt')
-			->from('#__categories');
+			->select('a.id AS value, a.title AS text, a.level, a.published, a.lft')
+			->from('#__categories AS a');
 
 		// Filter by the extension type
 		if ($this->element['parent'] == true || $jinput->get('option') == 'com_categories')
 		{
-			$subQuery->where('(extension = ' . $db->quote($extension) . ' OR parent_id = 0)');
+			$query->where('(a.extension = ' . $db->quote($extension) . ' OR a.parent_id = 0)');
 		}
 		else
 		{
-			$subQuery->where('(extension = ' . $db->quote($extension) . ')');
+			$query->where('(a.extension = ' . $db->quote($extension) . ')');
 		}
 
 		// Filter language
@@ -171,17 +169,17 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			{
 				$language = $db->quote($this->element['language']);
 			}
-			$subQuery->where($db->quoteName('language') . ' IN (' . $language . ')');
+			$query->where($db->quoteName('a.language') . ' IN (' . $language . ')');
 		}
 
 		// Filter on the published state
 		if (is_numeric($published))
 		{
-			$subQuery->where('published = ' . (int) $published);
+			$query->where('a.published = ' . (int) $published);
 		}
 		elseif (is_array($published))
 		{
-			$subQuery->where('published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
+			$query->where('a.published IN (' . implode(',', ArrayHelper::toInteger($published)) . ')');
 		}
 
 		// Filter categories on User Access Level
@@ -189,10 +187,9 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		if (!$user->authorise('core.admin'))
 		{
 			$groups = implode(',', $user->getAuthorisedViewLevels());
-			$subQuery->where('access IN (' . $groups . ')');
+			$query->where('a.access IN (' . $groups . ')');
 		}
 
-		$query->from('(' . (string) $subQuery . ') AS a');
 		$query->order('a.lft ASC');
 
 		// If parent isn't explicitly stated but we are in com_categories assume we want parents


### PR DESCRIPTION
Pull Request for Issue #8884

### Summary of Changes
Performance changes to allow categoryedit to scale well when number of category increases 

1. Remove a useless join from the **categoryedit form field**, used forms:
**banner form, category form, contact form, newsfeed form, article form (Backend / Frontend)**
2. Remove DISTINCT (duplicates were created because of the above removed JOIN)
3. Merge sub-query with SELF to main query

Probably this join (1) originates from some code that was copied, or it was used by some code that is no longer present in categoryedit form field

Why its existense is useless , please read my explanation here:
https://github.com/joomla/joomla-cms/issues/8884#issuecomment-170822487

**Also for worries of this join being used to remove child categories in category-edit form**
so that you can not set a parent category to be under one of its childs !
The answer is that it is another join, please see my other comment here:
https://github.com/joomla/joomla-cms/issues/8884#issuecomment-171013012

### Testing Instructions
- the queries of the categoryedit should not produce query error on 
all forms that the field is used:
banner form, category form, contact form, newsfeed form, article form (Backend / Frontend)
- and categories displayed inside the category select should not be different

```
administrator/components/com_banners/models/forms/banner.xml(36):   type="categoryedit"
administrator/components/com_categories/models/forms/category.xml(34):  type="categoryedit"
administrator/components/com_contact/models/forms/contact.xml(73):  type="categoryedit"
administrator/components/com_content/models/forms/article.xml(77):   type="categoryedit"
administrator/components/com_newsfeeds/models/forms/newsfeed.xml(52):  type="categoryedit"
components/com_content/models/forms/article.xml(93):  type="categoryedit"
```

### Expected result
Performance of categoryedit field scales with the number of categories e.g. 5000

### Actual result
Performance of categoryedit field does not scales with number of categories

### Documentation Changes Required
none