### PR TITLE
[4.0] Templates are already html5 (default), so remove unused setHtml5 code

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -12,9 +12,6 @@ defined('_JEXEC') or die;
 $lang = JFactory::getLanguage();
 $doc  = JFactory::getDocument();
 
-// Output as HTML5
-$this->setHtml5(true);
-
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);

--- a/administrator/templates/system/component.php
+++ b/administrator/templates/system/component.php
@@ -11,9 +11,6 @@ defined('_JEXEC') or die;
 
 /** @var JDocumentHtml $this */
 
-// Output as HTML5
-$this->setHtml5(true);
-
 // Add html5 shiv
 JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 ?>

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -15,9 +15,6 @@ JHtml::_('bootstrap.loadCss', true, $this->direction);
 JHtml::_('stylesheet', 'installation/template/css/template.css');
 JHtml::_('stylesheet', 'media/vendor/font-awesome/css/font-awesome.min.css');
 
-// Output as HTML5
-$this->setHtml5(true);
-
 // Load the JavaScript behaviors
 JHtml::_('bootstrap.framework');
 

--- a/templates/aurora/offline.php
+++ b/templates/aurora/offline.php
@@ -14,9 +14,6 @@ defined('_JEXEC') or die;
 $twofactormethods = JAuthenticationHelper::getTwoFactorMethods();
 $app              = JFactory::getApplication();
 
-// Output as HTML5
-$this->setHtml5(true);
-
 $fullWidth = 1;
 
 // Add JavaScript Frameworks

--- a/templates/system/component.php
+++ b/templates/system/component.php
@@ -11,9 +11,6 @@ defined('_JEXEC') or die;
 
 /** @var JDocumentHtml $this */
 
-// Output as HTML5
-$this->setHtml5(true);
-
 // Add html5 shiv
 JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -13,9 +13,6 @@ defined('_JEXEC') or die;
 
 $app = JFactory::getApplication();
 
-// Output as HTML5
-$this->setHtml5(true);
-
 // Add html5 shiv
 JHtml::_('script', 'jui/html5.js', ['version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9']);
 


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

Small change.
In 4.0 html5 is the default rendering engine (see https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/joomla/document/html.php#L101) so default templates don't need to set them as html5.

Remove that code from the the remaning template files (component and offline template files) and installation index.php.

### Testing Instructions

Mainly code review, but you can test as this:
1. Apply patch
2. Component (ex: article e-mail button) and offline (site offline) site/admin templates render as before.
3. Installation template render as before.

### Documentation Changes Required

None.