### PR TITLE
[4.0] Atum: Calling JDocument in template files is not needed

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -9,8 +9,9 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $lang = JFactory::getLanguage();
-$doc  = JFactory::getDocument();
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -9,13 +9,12 @@
 
 defined('_JEXEC') or die;
 
-$app             = JFactory::getApplication();
-$doc             = JFactory::getDocument();
-$lang            = JFactory::getLanguage();
-$user            = JFactory::getUser();
-$this->language  = $doc->language;
-$this->direction = $doc->direction;
-$input           = $app->input;
+/** @var JDocumentHtml $this */
+
+$app   = JFactory::getApplication();
+$lang  = JFactory::getLanguage();
+$user  = JFactory::getUser();
+$input = $app->input;
 
 // Add JavaScript
 JHtml::_('bootstrap.framework');
@@ -55,9 +54,9 @@ $logoLg      = $this->baseurl . '/templates/' . $this->template . '/images/logo.
 $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-icon.svg';
 
 // Set some meta data
-$doc->setMetaData('viewport', 'width=device-width, initial-scale=1');
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 // @TODO sync with _variables.scss
-$doc->setMetaData('theme-color', '#1c3d5c');
+$this->setMetaData('theme-color', '#1c3d5c');
 
 ?>
 <!DOCTYPE html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -9,8 +9,9 @@
 
 defined('_JEXEC') or die;
 
+/** @var JDocumentHtml $this */
+
 $app  = JFactory::getApplication();
-$doc  = JFactory::getDocument();
 $lang = JFactory::getLanguage();
 
 // Add JavaScript Frameworks
@@ -46,9 +47,9 @@ $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
 // Set some meta data
-$doc->setMetaData('viewport', 'width=device-width, initial-scale=1');
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 // @TODO sync with _variables.scss
-$doc->setMetaData('theme-color', '#1c3d5c');
+$this->setMetaData('theme-color', '#1c3d5c');
 
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
Pull Request for Improvement.

### Summary of Changes

In 4.0 Atum template it's getting JDocument as `$doc` when we already have `$this` that is a JDocumentHtml.
So remove those and replace with `$this`.

### Testing Instructions

Mainly code review.
But to test:
- Use 4.0 latest
- Apply patch
- Atum administrator template works as usual.

### Documentation Changes Required

None.