### PR TITLE
Fix : Correcting Template style delete Notice

### DIFF
--- a/administrator/components/com_templates/models/style.php
+++ b/administrator/components/com_templates/models/style.php
@@ -120,7 +120,7 @@ class TemplatesModelStyle extends JModelAdmin
 				// You should not delete a default style
 				if ($table->home != '0')
 				{
-					JError::raiseWarning(SOME_ERROR_NUMBER, JText::_('COM_TEMPLATES_STYLE_CANNOT_DELETE_DEFAULT_STYLE'));
+					JError::raiseWarning(500, JText::_('COM_TEMPLATES_STYLE_CANNOT_DELETE_DEFAULT_STYLE'));
 
 					return false;
 				}


### PR DESCRIPTION
Delete a default template style  (set to ALL or to a specific language)

One gets correctly the Error message in the manager but we get in the PHP logs

`PHP Notice: Use of undefined constant SOME_ERROR_NUMBER - assumed 'SOME_ERROR_NUMBER etc.`

Changed `SOME_ERROR_NUMBER` to 500.

Test again after patch

Simple one that can go in 3.7.3
@rdeutz 