### PR TITLE
[4.0] [installation]  set proper default for lastResetTime

### DIFF
--- a/installation/model/configuration.php
+++ b/installation/model/configuration.php
@@ -301,7 +301,8 @@ class InstallationModelConfiguration extends JModelBase
 				$db->quoteName('registerDate'),
 				$db->quoteName('lastvisitDate'),
 				$db->quoteName('activation'),
-				$db->quoteName('params')
+				$db->quoteName('params'),
+				$db->quoteName('lastResetTime')				
 			);
 			$query->clear()
 				->insert('#__users', true)
@@ -310,7 +311,7 @@ class InstallationModelConfiguration extends JModelBase
 					$db->quote($userId) . ', ' . $db->quote('Super User') . ', ' . $db->quote(trim($options->admin_user)) . ', ' .
 					$db->quote($options->admin_email) . ', ' . $db->quote($cryptpass) . ', ' .
 					$db->quote('0') . ', ' . $db->quote('1') . ', ' . $db->quote($installdate) . ', ' . $db->quote($nullDate) . ', ' .
-					$db->quote('0') . ', ' . $db->quote('')
+					$db->quote('0') . ', ' . $db->quote('') . ', ' . $db->quote($nullDate)
 				);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #16788 .

### Summary of Changes
set proper default for lastResetTime


### Testing Instructions
apply:

-  https://github.com/joomla-framework/database/pull/92
- https://github.com/joomla-framework/database/pull/94

an set something like this in MysqlDriver.php

`$sqlModes = [
			'ONLY_FULL_GROUP_BY',
			'STRICT_TRANS_TABLES',
			'ERROR_FOR_DIVISION_BY_ZERO',
			'NO_AUTO_CREATE_USER',
			'NO_ENGINE_SUBSTITUTION',
			'NO_ZERO_DATE',
			'NO_ZERO_IN_DATE',
		];`
and install

### Expected Result
install ok

### Actual  Result
Incorrect datetime value: '0000-00-00 00:00:00' for column 'lastResetTime' 