### PR TITLE
Improve menu main fix

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -51,7 +51,7 @@ UPDATE `#__menu`
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
 -- mistake and it should be deleted. This is also the case with menu type "menu"
--- for the admin which we renamed before in step 3.
+-- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM `#__menu_types`
  WHERE `client_id` = 1
    AND `menutype` = IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -55,4 +55,4 @@ UPDATE `#__menu`
 -- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM `#__menu_types`
  WHERE `client_id` = 1
-   AND `menutype` = IN ('main', 'menu');
+   AND `menutype` IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -50,15 +50,8 @@ UPDATE `#__menu`
 
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
--- mistake and it should be deleted, but here we rename it so the admin can see
--- it and delete it then. This is also to be done with menu type "menu" for the
--- admin which we renamed before in step 3.
-UPDATE `#__menu_types`
-   SET `menutype` = 'main_to_be_deleted'
+-- mistake and it should be deleted. This is also the case with menu type "menu"
+-- for the admin which we renamed before in step 3.
+DELETE FROM `#__menu_types`
  WHERE `client_id` = 1
-   AND `menutype` = 'main';
-
-UPDATE `#__menu_types`
-   SET `menutype` = 'menu_to_be_deleted'
- WHERE `client_id` = 1
-   AND `menutype` = 'menu';
+   AND `menutype` = IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.0-2017-01-17.sql
@@ -6,20 +6,21 @@
 
 -- Step 1: If there is any user-defined menu and menu type "main" for the site
 -- (client_id = 0), then change the menu type for the menu, any module and the
--- menu type to something hopefully not being used yet.
+-- menu type to something very likely not being used yet and just within the
+-- max. length of 24 characters.
 UPDATE `#__menu`
-   SET `menutype` = 'main_is_reserved'
+   SET `menutype` = 'main_is_reserved_133C585'
  WHERE `client_id` = 0
    AND `menutype` = 'main'
    AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `client_id` = 0 AND `menutype` = 'main') > 0;
 
 UPDATE `#__modules`
-   SET `params` = REPLACE(`params`,'"menutype":"main"','"menutype":"main_is_reserved"')
+   SET `params` = REPLACE(`params`,'"menutype":"main"','"menutype":"main_is_reserved_133C585"')
  WHERE `client_id` = 0
    AND (SELECT COUNT(`id`) FROM `#__menu_types` WHERE `client_id` = 0 AND `menutype` = 'main') > 0;
 
 UPDATE `#__menu_types`
-   SET `menutype` = 'main_is_reserved'
+   SET `menutype` = 'main_is_reserved_133C585'
  WHERE `client_id` = 0 
    AND `menutype` = 'main';
 

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -6,20 +6,21 @@
 
 -- Step 1: If there is any user-defined menu and menu type "main" for the site
 -- (client_id = 0), then change the menu type for the menu, any module and the
--- menu type to something hopefully not being used yet.
+-- menu type to something very likely not being used yet and just within the
+-- max. length of 24 characters.
 UPDATE "#__menu"
-   SET "menutype" = 'main_is_reserved'
+   SET "menutype" = 'main_is_reserved_133C585'
  WHERE "client_id" = 0
    AND "menutype" = 'main'
    AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "client_id" = 0 AND "menutype" = 'main') > 0;
 
 UPDATE "#__modules"
-   SET "params" = REPLACE("params",'"menutype":"main"','"menutype":"main_is_reserved"')
+   SET "params" = REPLACE("params",'"menutype":"main"','"menutype":"main_is_reserved_133C585"')
  WHERE "client_id" = 0
    AND (SELECT COUNT("id") FROM "#__menu_types" WHERE "client_id" = 0 AND "menutype" = 'main') > 0;
 
 UPDATE "#__menu_types"
-   SET "menutype" = 'main_is_reserved'
+   SET "menutype" = 'main_is_reserved_133C585'
  WHERE "client_id" = 0 
    AND "menutype" = 'main';
 

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -50,15 +50,8 @@ UPDATE "#__menu"
 
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
--- mistake and it should be deleted, but here we rename it so the admin can see
--- it and delete it then. This is also to be done with menu type "menu" for the
--- admin which we renamed before in step 3.
-UPDATE "#__menu_types"
-   SET "menutype" = 'main_to_be_deleted'
+-- mistake and it should be deleted. This is also the case with menu type "menu"
+-- for the admin which we renamed before in step 3.
+DELETE FROM "#__menu_types"
  WHERE "client_id" = 1
-   AND "menutype" = 'main';
-
-UPDATE "#__menu_types"
-   SET "menutype" = 'menu_to_be_deleted'
- WHERE "client_id" = 1
-   AND "menutype" = 'menu';
+   AND "menutype" = IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -51,7 +51,7 @@ UPDATE "#__menu"
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
 -- mistake and it should be deleted. This is also the case with menu type "menu"
--- for the admin which we renamed before in step 3.
+-- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM "#__menu_types"
  WHERE "client_id" = 1
    AND "menutype" = IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-01-17.sql
@@ -55,4 +55,4 @@ UPDATE "#__menu"
 -- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM "#__menu_types"
  WHERE "client_id" = 1
-   AND "menutype" = IN ('main', 'menu');
+   AND "menutype" IN ('main', 'menu');

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -54,7 +54,7 @@ UPDATE [#__menu]
 -- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM [#__menu_types]
  WHERE [client_id] = 1
-   AND [menutype] = IN ('main', 'menu');
+   AND [menutype] IN ('main', 'menu');
 
 -- End sync menutype for admin menu and set client_id correct
 

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -5,20 +5,21 @@
 
 -- Step 1: If there is any user-defined menu and menu type "main" for the site
 -- (client_id = 0), then change the menu type for the menu, any module and the
--- menu type to something hopefully not being used yet.
+-- menu type to something very likely not being used yet and just within the
+-- max. length of 24 characters.
 UPDATE [#__menu]
-   SET [menutype] = 'main_is_reserved'
+   SET [menutype] = 'main_is_reserved_133C585'
  WHERE [client_id] = 0
    AND [menutype] = 'main'
    AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [client_id] = 0 AND [menutype] = 'main') > 0;
 
 UPDATE [#__modules]
-   SET [params] = REPLACE([params],'"menutype":"main"','"menutype":"main_is_reserved"')
+   SET [params] = REPLACE([params],'"menutype":"main"','"menutype":"main_is_reserved_133C585"')
  WHERE [client_id] = 0
    AND (SELECT COUNT([id]) FROM [#__menu_types] WHERE [client_id] = 0 AND [menutype] = 'main') > 0;
 
 UPDATE [#__menu_types]
-   SET [menutype] = 'main_is_reserved'
+   SET [menutype] = 'main_is_reserved_133C585'
  WHERE [client_id] = 0 
    AND [menutype] = 'main';
 

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -49,18 +49,11 @@ UPDATE [#__menu]
 
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
--- mistake and it should be deleted, but here we rename it so the admin can see
--- it and delete it then. This is also to be done with menu type "menu" for the
--- admin which we renamed before in step 3.
-UPDATE [#__menu_types]
-   SET [menutype] = 'main_to_be_deleted'
+-- mistake and it should be deleted. This is also the case with menu type "menu"
+-- for the admin which we renamed before in step 3.
+DELETE FROM [#__menu_types]
  WHERE [client_id] = 1
-   AND [menutype] = 'main';
-
-UPDATE [#__menu_types]
-   SET [menutype] = 'menu_to_be_deleted'
- WHERE [client_id] = 1
-   AND [menutype] = 'menu';
+   AND [menutype] = IN ('main', 'menu');
 
 -- End sync menutype for admin menu and set client_id correct
 

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.0-2017-01-17.sql
@@ -50,7 +50,7 @@ UPDATE [#__menu]
 -- Step 5: For the standard admin menu items of menutype "main" there is no record
 -- in the menutype table on a clean Joomla installation. If there is one, it is a
 -- mistake and it should be deleted. This is also the case with menu type "menu"
--- for the admin which we renamed before in step 3.
+-- for the admin, for which we changed the menutype of the menu items in step 3.
 DELETE FROM [#__menu_types]
  WHERE [client_id] = 1
    AND [menutype] = IN ('main', 'menu');


### PR DESCRIPTION
Pull Request for no issue.

### Summary of Changes

This Pull Request (PR) improves the already merged PR #16577 as discussed there with @rdeutz .

1. Delete the obsolete menu types and not rename them to ".._to_be_deleted".
2. On renaming the "menu" menu type, use a new name which is more likely not already being used by a user-defined menu type. The new name is "main_is_reserved_133C585", with "133C585" being the hex value of "20170117", which is the date part of the schema update scripts' names. This should be crazy enough for not being used yet.

### Testing Instructions

Code review.

### Expected result

New name of menu type "main" is "main_is_reserved_133C585".

Obsolete menu type records "main" or "menu" for admin menu are deleted.

### Actual result

New name of menu type "main" is "main_is_reserved".

Obsolete menu type records "main" or "menu" for admin menu are renamed to "..._to_be_deleted".

### Documentation Changes Required

None.