### PR TITLE
Fix 3.7 calendar in zh-TW language

### DIFF
--- a/media/system/js/fields/calendar-locales/zh-TW.js
+++ b/media/system/js/fields/calendar-locales/zh-TW.js
@@ -11,7 +11,7 @@ window.JoomlaCalLocale = {
 	PM :  "PM",
 	am : "am",
 	pm : "pm",
-	dateType : "西元",
+	dateType : "gregorian",
 	minYear : 1900,
 	maxYear : 2100,
 	exit: "關閉",


### PR DESCRIPTION
### Summary of Changes

Fix calendar date display issue in zh-TW language.

### Testing Instructions

Install zh-TW (Traditional Chinese) package and go to Article Edit page, click calendar field.

Before this patch:

![](https://user-images.githubusercontent.com/1639206/27510189-2db8466c-593e-11e7-8738-013323349e74.png)

After this patch:

![datepicker_in_zhtw](https://user-images.githubusercontent.com/1639206/27510191-3c7b5f36-593e-11e7-90f5-8db24909bae5.png)

Reference:
- [修正Joomla! 3.7 日期選擇顯示不正常的問題](https://goo.gl/RkkEsJ)
