### PR TITLE
Remove the not existing constant SOME_ERROR_CODE from the code base

### DIFF
--- a/administrator/components/com_admin/postinstall/eaccelerator.php
+++ b/administrator/components/com_admin/postinstall/eaccelerator.php
@@ -60,7 +60,7 @@ function admin_postinstall_eaccelerator_action()
 	// Attempt to make the file writeable if using FTP.
 	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0644'))
 	{
-		JError::raiseNotice('SOME_ERROR_CODE', JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'));
+		JError::raiseNotice(500, JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'));
 	}
 
 	// Attempt to write the configuration file as a PHP class named JConfig.
@@ -76,6 +76,6 @@ function admin_postinstall_eaccelerator_action()
 	// Attempt to make the file unwriteable if using FTP.
 	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))
 	{
-		JError::raiseNotice('SOME_ERROR_CODE', JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'));
+		JError::raiseNotice(500, JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'));
 	}
 }

--- a/administrator/components/com_config/model/application.php
+++ b/administrator/components/com_config/model/application.php
@@ -184,7 +184,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$asset->check() || !$asset->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					$app->enqueueMessage($asset->getError(), 'error');
 
 					return;
 				}
@@ -215,7 +215,7 @@ class ConfigModelApplication extends ConfigModelForm
 
 				if (!$extension->check() || !$extension->store())
 				{
-					$app->enqueueMessage(JText::_('SOME_ERROR_CODE'), 'error');
+					$app->enqueueMessage($extension->getError(), 'error');
 
 					return;
 				}

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -421,7 +421,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 				// Add credentials to the session
 				if (!JClientHelper::setCredentials('ftp', $user, $pass))
 				{
-					JError::raiseWarning('SOME_ERROR_CODE', JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
+					JError::raiseWarning(500, JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
 				}
 			}
 		}

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -353,7 +353,7 @@ class ContentModelArticle extends JModelItem
 			return true;
 		}
 
-		JError::raiseWarning('SOME_ERROR_CODE', JText::sprintf('COM_CONTENT_INVALID_RATING', $rate), "JModelArticle::storeVote($rate)");
+		JError::raiseWarning(500, JText::sprintf('COM_CONTENT_INVALID_RATING', $rate), "JModelArticle::storeVote($rate)");
 
 		return false;
 	}

--- a/libraries/cms/toolbar/toolbar.php
+++ b/libraries/cms/toolbar/toolbar.php
@@ -261,7 +261,6 @@ class JToolbar
 
 		if (!class_exists($buttonClass) && !class_exists($buttonClassOld))
 		{
-			// @todo remove code: return	JError::raiseError('SOME_ERROR_CODE', "Module file $buttonFile does not contain class $buttonClass.");
 			return false;
 		}
 

--- a/libraries/joomla/client/helper.php
+++ b/libraries/joomla/client/helper.php
@@ -221,7 +221,7 @@ class JClientHelper
 			{
 				if (class_exists('JError'))
 				{
-					$return = JError::raiseWarning('SOME_ERROR_CODE', JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
+					$return = JError::raiseWarning(500, JText::_('JLIB_CLIENT_ERROR_HELPER_SETCREDENTIALSFROMREQUEST_FAILED'));
 				}
 				else
 				{

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -95,7 +95,7 @@ class JUserHelperTest extends TestCaseDatabase
 				1000,
 				array(),
 				array(
-					'code' => 'SOME_ERROR_CODE',
+					'code' => 500,
 					'msg' => 'JLIB_USER_ERROR_UNABLE_TO_LOAD_USER',
 					'info' => ''),
 			),


### PR DESCRIPTION
### Summary of Changes

Remove the not existing constant SOME_ERROR_CODE from the code base

### Testing Instructions

Code review.

### Expected result

Do not use the not defined `SOME_ERROR_CODE` constant

### Actual result

We use a not defined `SOME_ERROR_CODE` constant

### Documentation Changes Required

none