### PR TITLE
Skip crypto cipher tests if operation cannot be performed

### DIFF
--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherCryptoTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherCryptoTest.php
@@ -28,6 +28,10 @@ class JCryptCipherCryptoTest extends TestCase
 		{
 			self::markTestSkipped('The environment cannot safely perform encryption with this cipher.');
 		}
+		catch (CannotPerformOperationException $e)
+		{
+			self::markTestSkipped('The environment cannot safely perform encryption with this cipher.');
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

The version of the crypto library that we ship has an internal dependency to `mcrypt`.  When running on PHP 7.2, this library can't be used safely and the test build (see https://travis-ci.org/joomla/joomla-cms/jobs/236743260 for example output) fails.

This PR adds a catch for the Exception that gets thrown when the library can't run due to missing dependencies in the test class so the class will skip the tests if the dependencies aren't met.