### PR TITLE
[J4.0] Moved com_content pagination back to the table footer

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -119,8 +119,7 @@ $assoc = JLanguageAssociations::isEnabled();
 						</thead>
 						<tfoot>
 							<tr>
-								<td colspan="<?php echo $columns; ?>">
-								</td>
+								<td colspan="<?php echo $columns; ?>"><?php echo $this->pagination->getListFooter(); ?></td>
 							</tr>
 						</tfoot>
 						<tbody <?php if ($saveOrder) :?> class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true"<?php endif; ?>>
@@ -249,8 +248,6 @@ $assoc = JLanguageAssociations::isEnabled();
 						); ?>
 					<?php endif; ?>
 				<?php endif; ?>
-
-				<?php echo $this->pagination->getListFooter(); ?>
 
 				<input type="hidden" name="task" value="">
 				<input type="hidden" name="boxchecked" value="0">


### PR DESCRIPTION
### Summary of Changes
In the following PR the pagination was moved outside of the table footer: https://github.com/joomla/joomla-cms/pull/13998/files#diff-ff6e6780813a02e5e864f42f37191c6bR252
This PR readd it to the table again (like in other components)


### Testing Instructions
Look into the source code of the backend article list.


### Expected result
After patch: the pagination is in the table footer


### Actual result
Before patch: the pagination is outside of the table

