### PR TITLE
[J4.0] Autum Center pagination

### DIFF
--- a/administrator/templates/atum/html/pagination.php
+++ b/administrator/templates/atum/html/pagination.php
@@ -110,7 +110,7 @@ function pagination_list_render($list)
 		}
 	}
 
-	$html = '<ul class="pagination pagination-sm">';
+	$html = '<ul class="pagination pagination-sm justify-content-center">';
 	$html .= $list['start']['data'];
 	$html .= $list['previous']['data'];
 


### PR DESCRIPTION
### Summary of Changes
This PR centers the pagination the Bootstrap V4 way.


### Testing Instructions
Apply patch and open the articles backend view. The pagination should be centered now.