### PR TITLE
Media Manager: Transliteration of UTF8 file names when uploading (makeSafe)

### DIFF
--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -99,24 +99,7 @@ class MediaControllerFile extends JControllerLegacy
 		// Perform basic checks on file info before attempting anything
 		foreach ($files as &$file)
 		{
-			// Try transiterating the file name, else use the basic JFile::makeSafe() method
-			if (function_exists('transliterator_transliterate') && function_exists('iconv'))
-			{
-				// Remove any trailing dots, as those aren't ever valid file names.
-				$file['name'] = rtrim($file['name'], '.');
-
-				// Using iconv to ignore characters that can't be transliterated
-				$file['name'] = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $file['name']));
-
-				$regex        = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
-
-				$file['name'] = trim(preg_replace($regex, '', $file['name']));
-			}
-			else
-			{
-				$file['name'] = JFile::makeSafe($file['name']);
-			}
-
+			$file['name']     = JFile::makeSafe($file['name']);
 			$file['name']     = str_replace(' ', '-', $file['name']);
 			$file['filepath'] = JPath::clean(implode(DIRECTORY_SEPARATOR, array(COM_MEDIA_BASE, $this->folder, $file['name'])));
 

--- a/libraries/joomla/filesystem/file.php
+++ b/libraries/joomla/filesystem/file.php
@@ -65,6 +65,13 @@ class JFile
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
+		// Try transiterating the file name using the native php function
+		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+		{
+			// Using iconv to ignore characters that can't be transliterated
+			$file = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $file));
+		}
+
 		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');
 
 		return trim(preg_replace($regex, '', $file));


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/12049

### Summary of Changes
This PR takes advantage of the PHP extension `intl` **when it is enabled** to use the `transliterator_transliterate()` method, itself using `ICU` library.

The php extension is available since **php 5.4.0**, but may not be enabled on some hosts.

If disabled, former behavior is used which does not accept to upload files with UTF8 names and displays an error. This PR is therefore totally BC.

Using `iconv` and `IGNORE` let's get rid of some prime-characters that can't be transliterated, like the Cyrillic letter `ь`.

### Testing Instructions
Check in System Information => PHP Information that the extension is enabled:
You should get something like this:

![screen shot 2017-06-27 at 10 14 47](https://user-images.githubusercontent.com/869724/27577578-89238806-5b21-11e7-9eed-11488fe8fac6.png)
(It is more likely to be enabled by default when using php 5.5.x or higher).
If it is not enabled on your local environment, try to modify your PHP.ini.

Change an image file name to utf8.
I used here `'完 成'".png` to be sure we also get rid of unwanted characters.

![screen shot 2017-06-27 at 10 02 22](https://user-images.githubusercontent.com/869724/27577693-eaf6cf70-5b21-11e7-83d4-210a9d66851c.png)

Go to Media Manager =>Upload, select the file and click upload.
In the case above I get a pure ascii name `wan-cheng.png`:

![screen shot 2017-06-27 at 10 03 28](https://user-images.githubusercontent.com/869724/27578018-13cf0ef2-5b23-11e7-8dec-c14bd402f00e.png)

Test with other utf8 fine names.

NOTE: J4 may use a similar code.

@ggppdk @schnuti 