### PR TITLE
Use native php transliterate method when available (stringURLSafe)

### DIFF
--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -252,12 +252,7 @@ class JLanguage
 			 * -a getSearchDisplayCharactersNumber method
 			 */
 
-			// Override custom transliterate method with native php function if enabled
-			if (function_exists('transliterator_transliterate') && function_exists('iconv'))
-			{
-				$this->transliterator = null;
-			}
-			elseif (method_exists($class, 'transliterate'))
+			if (method_exists($class, 'transliterate'))
 			{
 				$this->transliterator = array($class, 'transliterate');
 			}
@@ -400,23 +395,20 @@ class JLanguage
 	 */
 	public function transliterate($string)
 	{
+		// Override custom and core transliterate method with native php function if enabled
+		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+		{
+			return iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $string));
+		}
+
 		if ($this->transliterator !== null)
 		{
 			return call_user_func($this->transliterator, $string);
 		}
 
-		// Try transiterating with native php function if enabled
-		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
-		{
-			$string = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $string));
-		}
-		else
-		{
-			$string = JLanguageTransliterate::utf8_latin_to_ascii($string);
-			$string = StringHelper::strtolower($string);
-		}
+		$string = JLanguageTransliterate::utf8_latin_to_ascii($string);
 
-		return $string;
+		return StringHelper::strtolower($string);
 	}
 
 	/**

--- a/libraries/joomla/language/language.php
+++ b/libraries/joomla/language/language.php
@@ -251,7 +251,13 @@ class JLanguage
 			 * -a getUpperLimitSearchWord method
 			 * -a getSearchDisplayCharactersNumber method
 			 */
-			if (method_exists($class, 'transliterate'))
+
+			// Override custom transliterate method with native php function if enabled
+			if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+			{
+				$this->transliterator = null;
+			}
+			elseif (method_exists($class, 'transliterate'))
 			{
 				$this->transliterator = array($class, 'transliterate');
 			}
@@ -399,8 +405,16 @@ class JLanguage
 			return call_user_func($this->transliterator, $string);
 		}
 
-		$string = JLanguageTransliterate::utf8_latin_to_ascii($string);
-		$string = StringHelper::strtolower($string);
+		// Try transiterating with native php function if enabled
+		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
+		{
+			$string = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $string));
+		}
+		else
+		{
+			$string = JLanguageTransliterate::utf8_latin_to_ascii($string);
+			$string = StringHelper::strtolower($string);
+		}
 
 		return $string;
 	}


### PR DESCRIPTION
See similar PR  https://github.com/joomla/joomla-cms/pull/16878

### Summary of Changes
This PR lets override any custom transliterate method form the languages xx-XX.localise.php and create same alias **whatever the language used in the title of the item** when the alias field is empty/emptied.

It takes advantage of the PHP extension `intl` **when it is enabled** to use the `transliterator_transliterate()` method, itself using `ICU` library.

The php extension is available since **php 5.4.0**, but may not be enabled on some hosts.
If disabled, former behavior is used, i.e. depending of the language in use or the item language or the site language (Depending on situation).

Using `iconv` and `IGNORE` let's get rid of some prime-characters that can't be transliterated, like the Cyrillic letter `ь`.

It is totally B/C as existing aliases are not modified.

### Testing Instructions
Check in System Information => PHP Information that the extension is enabled:
You should get something like this:

![screen shot 2017-06-27 at 10 14 47](https://user-images.githubusercontent.com/869724/27577578-89238806-5b21-11e7-9eed-11488fe8fac6.png)
(It is more likely to be enabled by default when using php 5.5.x or higher).
If it is not enabled on your local environment, try to modify your PHP.ini.

After patch, create or modify an item (menu item, article, category).
Leave the alias field empty or empty it and save.
For the same item, change its content language, empty alias field and save again.

Example with title `完 成`

![screen shot 2017-06-27 at 12 00 12](https://user-images.githubusercontent.com/869724/27582145-3b33c142-5b30-11e7-9f46-7f9a9defd6e8.png)

