### PR TITLE
[4.0] Fix component tmpl

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -24,7 +24,7 @@ JHtml::_('stylesheet', 'template' . ($this->direction === 'rtl' ? '-rtl' : '') .
 JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true));
 
 // Load specific language related CSS
-JHtml::_('stylesheet', 'administrator/language/' . $this->language->getTag() . '/' . $this->language->getTag() . '.css', array('version' => 'auto'));
+JHtml::_('stylesheet', 'administrator/language/' . $lang->getTag() . '/' . $lang->getTag() . '.css', array('version' => 'auto'));
 ?>
 
 <!DOCTYPE html>


### PR DESCRIPTION
Currently, probably most admin modals are broken in 4.0 because of a broken `component.php' template file and give `Call to a member function getTag() on string`

### Summary of Changes
Changes the call so it uses `$lang` instead of `$this->language`. Same as done in `index.php`.

What I don't understand is why we don't just use the string `$this->language`. The only difference I see is that `$lang->getTag()` returns `en-GB` while `$this->language` is the lowercased variant `en-gb`. But maybe I miss something.

### Testing Instructions
Test a modal or just apply `&tmpl=component` to an URL in backend.


### Expected result
Works


### Actual result
Exception `Call to a member function getTag() on string`


### Documentation Changes Required
None
