### PR TITLE
[J!4.0] Fix form location for com_categories custom XML

### DIFF
--- a/administrator/components/com_categories/Model/Category.php
+++ b/administrator/components/com_categories/Model/Category.php
@@ -385,8 +385,14 @@ class Category extends Admin
 		// Get the component form if it exists
 		$name = 'category' . ($section ? ('.' . $section) : '');
 
-		// Looking first in the component models/forms folder
-		$path = \JPath::clean(JPATH_ADMINISTRATOR . "/components/$component/models/forms/$name.xml");
+		// Looking first in the component forms folder
+		$path = \JPath::clean(JPATH_ADMINISTRATOR . "/components/$component/forms/$name.xml");
+
+		// Looking in the component models/forms folder (J! 3)
+		if (!file_exists($path))
+		{
+			$path = \JPath::clean(JPATH_ADMINISTRATOR . "/components/$component/models/forms/$name.xml");
+		}
 
 		// Old way: looking in the component folder
 		if (!file_exists($path))


### PR DESCRIPTION
### Summary of Changes
With PR https://github.com/joomla/joomla-cms/pull/16219 the location of the form XML were updates. This PR adds the new path for the category loading.


### Testing Instructions
Put your custom XML to administrator/components/com_content/forms/category.xml

### Expected result
Fields will be loaded.


### Actual result
XML not found