### PR TITLE
Fix for B/C in filter input

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -844,13 +844,13 @@ class JFilterInput extends InputFilter
 
 		while ($offset < $length)
 		{
-			// Remove every '>' character which exists before related '<'
+			// Preserve '>' character which exists before related '<'
 			if ($tagOpenEndOffset !== false && ($tagOpenStartOffset === false || $tagOpenEndOffset < $tagOpenStartOffset))
 			{
-				$result .= substr($source, $offset, $tagOpenEndOffset - $offset);
+				$result .= substr($source, $offset, $tagOpenEndOffset - $offset) . '>';
 				$offset  = $tagOpenEndOffset + 1;
 
-				// Search for new close tag
+				// Search for a new closing indicator
 				$tagOpenEndOffset = strpos($source, '>', $offset);
 
 				continue;
@@ -863,17 +863,6 @@ class JFilterInput extends InputFilter
 				$offset  = $tagOpenStartOffset;
 			}
 
-			// Remove every '<' character if '>' does not exists or we have '<>'
-			if ($tagOpenStartOffset !== false && $tagOpenEndOffset === false || $tagOpenStartOffset + 1 == $tagOpenEndOffset)
-			{
-				$offset++;
-
-				// Search for new open tag
-				$tagOpenStartOffset = strpos($source, '<', $offset);
-
-				continue;
-			}
-
 			// There is no more tags
 			if ($tagOpenStartOffset === false && $tagOpenEndOffset === false)
 			{
@@ -881,6 +870,17 @@ class JFilterInput extends InputFilter
 				$offset  = $length;
 
 				break;
+			}
+
+			// Remove every '<' character if '>' does not exists or we have '<>'
+			if ($tagOpenStartOffset !== false && $tagOpenEndOffset === false || $tagOpenStartOffset + 1 == $tagOpenEndOffset)
+			{
+				$offset++;
+
+				// Search for a new opening indicator
+				$tagOpenStartOffset = strpos($source, '<', $offset);
+
+				continue;
 			}
 
 			// Check for mal-formed tag where we have a second '<' before the '>'
@@ -891,7 +891,7 @@ class JFilterInput extends InputFilter
 				// At this point we have a mal-formed tag, skip previous '<'
 				$offset++;
 
-				// Set a new open tag position
+				// Set a new opening indicator position
 				$tagOpenStartOffset = $nextOpenStartOffset;
 
 				continue;
@@ -1199,7 +1199,7 @@ class JFilterInput extends InputFilter
 		// Convert hex
 		$source = preg_replace_callback('/&#x([a-f0-9]+);/mi', function($m)
 		{
-			return utf8_encode(chr('0x' . $m[1]));
+			return utf8_encode(chr(hexdec($m[1])));
 		}, $source
 		);
 

--- a/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
+++ b/tests/unit/suites/libraries/joomla/filter/JFilterInputTest.php
@@ -476,6 +476,12 @@ class JFilterInputTest extends \PHPUnit\Framework\TestCase
 				'123.567',
 				'From generic cases'
 			),
+			'string_02' => array(
+				'string',
+				'em>',
+				'em>',
+				'From generic cases'
+			),
 			'string_single_quote' => array(
 				'string',
 				"this is a 'test' of ?",
@@ -552,6 +558,12 @@ class JFilterInputTest extends \PHPUnit\Framework\TestCase
 				'',
 				'<em',
 				'em',
+				'From generic cases'
+			),
+			'tag_02' => array(
+				'',
+				'em>',
+				'em>',
 				'From generic cases'
 			),
 			'Kill script' => array(
@@ -1365,6 +1377,12 @@ class JFilterInputTest extends \PHPUnit\Framework\TestCase
 				"<img src='<img src='///'/> ",
 				"<img src=\"'&lt;img\" src=\"'///'/\" /> ",
 				'From specific cases'
+			),
+			'decode_01' => array(
+				'',
+				'<div&#x003e;Hello &quot;Joomla&quot;&#60;/div>',
+				'<div>Hello "Joomla"</div>',
+				'Generic test case for decode string with HTML cleaning'
 			),
 			'html_01' => array(
 				'html',


### PR DESCRIPTION
Pull Request for Issue #16812

### Summary of Changes
This is minimalist version of my previous PR #16875  

1. Fix B/C - preserve `>` character
2. Fix notice:
```
Notice: A non well formed numeric value encountered in .../libraries/joomla/filter/input.php on line 1202 divHello "Joomla"
```
tested as:
```
$_REQUEST['test'] = '<div&#x003e;Hello &quot;Joomla&quot;&#60;/div>';
echo JFactory::getApplication()->input->getString('test', '');
```

### Testing Instructions
Add in your template index.php a php code like:

```
$_REQUEST['test'] = '<div&#x003e;Hello &quot;Joomla&quot;&#60;/div>';
echo JFactory::getApplication()->input->getString('test', '');
```

and 

```
$_REQUEST['test'] = 'Menu > Modules';
echo JFactory::getApplication()->input->getString('test', '');
```

### Expected result
Input methods `getString()` or `getHtml()` does not remove alone `>`.
There is no `PHP Notice` mentioned above.


### Actual result
Input methods `getString()` or `getHtml()` removes `>` and this is B/C break.
`PHP Notice` mentioned above exists.


### Documentation Changes Required
No
