### PR TITLE
[4.0] Try and fix appveyor tests by mocking server globals

### DIFF
--- a/tests/unit/suites/libraries/cms/view/JViewLegacyTest.php
+++ b/tests/unit/suites/libraries/cms/view/JViewLegacyTest.php
@@ -437,6 +437,7 @@ class JViewLegacyTest extends TestCase
 		defined('JPATH_COMPONENT') or define('JPATH_COMPONENT', JPATH_BASE . '/components/com_foobar');
 		$_SERVER['REQUEST_METHOD'] = 'get';
 		$_SERVER['HTTP_HOST'] = 'mydomain.com';
+		$_SERVER['REQUEST_URI'] = '/';
 
 		$this->class = new JViewLegacy;
 	}

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldColorTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldColorTest.php
@@ -19,6 +19,13 @@ JFormHelper::loadFieldClass('color');
 class JFormFieldColorTest extends TestCaseDatabase
 {
 	/**
+	 * $_SERVER variable
+	 *
+	 * @var   array
+	 */
+	protected $server;
+
+	/**
 	 * This method is called before the first test of this test class is run.
 	 *
 	 * @return  void
@@ -30,6 +37,10 @@ class JFormFieldColorTest extends TestCaseDatabase
 		parent::setUp();
 
 		$this->saveFactoryState();
+		$this->server = $_SERVER;
+		$_SERVER['REQUEST_METHOD'] = 'get';
+		$_SERVER['HTTP_HOST'] = 'mydomain.com';
+		$_SERVER['SCRIPT_NAME'] = '/';
 
 		JFactory::$application = $this->getMockCmsApp();
 	}
@@ -45,6 +56,8 @@ class JFormFieldColorTest extends TestCaseDatabase
 	protected function tearDown()
 	{
 		$this->restoreFactoryState();
+		$_SERVER = $this->server;
+		JUri::reset();
 
 		parent::tearDown();
 	}

--- a/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRulesTest.php
+++ b/tests/unit/suites/libraries/joomla/form/fields/JFormFieldRulesTest.php
@@ -19,6 +19,13 @@ JFormHelper::loadFieldClass('rules');
 class JFormFieldRulesTest extends TestCaseDatabase
 {
 	/**
+	 * $_SERVER variable
+	 *
+	 * @var   array
+	 */
+	protected $server;
+
+	/**
 	 * Sets up dependencies for the test.
 	 *
 	 * @return void
@@ -28,6 +35,10 @@ class JFormFieldRulesTest extends TestCaseDatabase
 		parent::setUp();
 
 		$this->saveFactoryState();
+		$this->server = $_SERVER;
+		$_SERVER['REQUEST_METHOD'] = 'get';
+		$_SERVER['HTTP_HOST'] = 'mydomain.com';
+		$_SERVER['SCRIPT_NAME'] = '/';
 
 		JFactory::$application = $this->getMockCmsApp();
 		JFactory::$session = $this->getMockSession();
@@ -42,6 +53,8 @@ class JFormFieldRulesTest extends TestCaseDatabase
 	protected function tearDown()
 	{
 		$this->restoreFactoryState();
+		$_SERVER = $this->server;
+		JUri::reset();
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
PR for issue https://github.com/joomla/joomla-cms/issues/16698

This PR hopefully fixes the unit tests which are failing because they try to get a URI instance (either directly in `Joomla\Cms\View\HtmlView::__construct()` or in the case of the form fields, where they are getting URLs when including javascript files.

In 4.0 we now have stricter validation on URLs which is why we haven't seen this issue until now. Although there is no real reason to not port this back to staging as it is presumably an issue there - just one we ignore.