### PR TITLE
Fixes #16912

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -220,7 +220,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		{
 			foreach ($this->disconnectHandlers as $h)
 			{
-				$h($this);
+				call_user_func_array($h, array( &$this));
 			}
 
 			mysqli_close($this->connection);

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -321,7 +321,7 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 	{
 		foreach ($this->disconnectHandlers as $h)
 		{
-			$h($this);
+			call_user_func_array($h, array( &$this));
 		}
 
 		$this->freeResult();

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -156,7 +156,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		{
 			foreach ($this->disconnectHandlers as $h)
 			{
-				$h($this);
+				call_user_func_array($h, array( &$this));
 			}
 
 			pg_close($this->connection);

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -167,7 +167,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		{
 			foreach ($this->disconnectHandlers as $h)
 			{
-				$h($this);
+				call_user_func_array($h, array( &$this));
 			}
 
 			sqlsrv_close($this->connection);

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -109,7 +109,7 @@ class PlgSystemRedirect extends JPlugin
 			// Proxy to the previous exception handler if available, otherwise just render the error page
 			if (self::$previousExceptionHandler)
 			{
-				self::$previousExceptionHandler($error);
+				call_user_func_array(self::$previousExceptionHandler, array($error));
 			}
 			else
 			{


### PR DESCRIPTION
Pull Request for Issue #16912.

This PR reverts all but one replacement of call_user_func_array() in PR #13257 as the other ones "may" also cause similar problems.

I mistakenly assumed that the callable in those cases would be a string, but it might be an array that potentially can have many forms. Therefore I reverted other ones that might also cause issues, too.

### Summary of Changes
Reversal of some changes of PR #13257 


### Testing Instructions
Check, that problem reported in issue #16912 has been resolved


### Expected result
See issue #16912


### Actual result
See issue #16912


### Documentation Changes Required
None