### PR TITLE
[CS] Code Style fixes for administrator/components/com_installer/

### DIFF
--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -51,7 +51,7 @@ class InstallerHelper
 			$vName == 'database'
 		);
 		JHtmlSidebar::addEntry(
-		JText::_('COM_INSTALLER_SUBMENU_WARNINGS'),
+			JText::_('COM_INSTALLER_SUBMENU_WARNINGS'),
 			'index.php?option=com_installer&view=warnings',
 			$vName == 'warnings'
 		);

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -310,9 +310,8 @@ class InstallerModelDatabase extends InstallerModel
 		if ($count > 1)
 		{
 			// Table messed up somehow, clear it
-			$db->setQuery('DELETE FROM ' . $db->quoteName('#__utf8_conversion')
-				. ';'
-			)->execute();
+			$db->setQuery('DELETE FROM ' . $db->quoteName('#__utf8_conversion') . ';')
+				->execute();
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
 				. ' (' . $db->quoteName('converted') . ') VALUES (0);'
 			)->execute();

--- a/administrator/components/com_installer/models/database.php
+++ b/administrator/components/com_installer/models/database.php
@@ -99,6 +99,7 @@ class InstallerModelDatabase extends InstallerModel
 
 			return false;
 		}
+
 		return $changeSet;
 	}
 
@@ -310,15 +311,18 @@ class InstallerModelDatabase extends InstallerModel
 		{
 			// Table messed up somehow, clear it
 			$db->setQuery('DELETE FROM ' . $db->quoteName('#__utf8_conversion')
-				. ';')->execute();
+				. ';'
+			)->execute();
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
-				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
+				. ' (' . $db->quoteName('converted') . ') VALUES (0);'
+			)->execute();
 		}
 		elseif ($count == 0)
 		{
 			// Record missing somehow, fix this
 			$db->setQuery('INSERT INTO ' . $db->quoteName('#__utf8_conversion')
-				. ' (' . $db->quoteName('converted') . ') VALUES (0);')->execute();
+				. ' (' . $db->quoteName('converted') . ') VALUES (0);'
+			)->execute();
 		}
 	}
 }

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -92,6 +92,7 @@ class InstallerModel extends JModelList
 				{
 					// Check if search string exists in any of the fields to be searched.
 					$found = 0;
+
 					foreach ($searchFields as $key => $field)
 					{
 						if (!$found && preg_match('/' . $escapedSearchString . '/i', $item->{$field}))

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -495,6 +495,7 @@ class InstallerModelUpdate extends JModelList
 
 			return false;
 		}
+
 		// Check the session for previously entered form data.
 		$data = $this->loadFormData();
 

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -388,8 +388,9 @@ class InstallerModelUpdatesites extends InstallerModel
 				. '(' . $db->qn('e.type') . ' = ' . $db->quote('file') . ' AND ' . $db->qn('e.element') . ' = ' . $db->quote('joomla') . ')'
 				. ' OR (' . $db->qn('e.type') . ' = ' . $db->quote('package') . ' AND ' . $db->qn('e.element') . ' = ' . $db->quote('pkg_en-GB') . ')'
 				. ' OR (' . $db->qn('e.type') . ' = ' . $db->quote('component') . ' AND ' . $db->qn('e.element') . ' = ' . $db->quote('com_joomlaupdate') . ')'
-				. ')');
-		
+				. ')'
+			);
+
 		$db->setQuery($query);
 
 		return $db->loadColumn($column);


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Multi-line function call not indented correctly;
- No blank line found after control structure
- Closing parenthesis of a multi-line function call must be on a line by itself
- Please consider an empty line before the foreach statement;
- Expected 1 space after "="; 2 found
- Expected 1 space after FUNCTION keyword; 0 found
- Expected 3 tabs before opening brace; 4 found
- Whitespace found at end of line

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review


### Expected result
code style has been applied as listed above, old code style on drone does not error.


### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style



### Documentation Changes Required
none
