### PR TITLE
Fix issue with "'a.asset_id' isn't in GROUP BY" when ONLY_FULL_GROUP_BY enabled

### DIFF
--- a/administrator/modules/mod_menu/helper.php
+++ b/administrator/modules/mod_menu/helper.php
@@ -41,7 +41,7 @@ abstract class ModMenuHelper
 			->where('(b.client_id = 0 OR b.client_id IS NULL)');
 
 		// Sqlsrv change
-		$query->group('a.id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native');
+		$query->group('a.id, a.asset_id, a.client_id, a.menutype, a.description, a.title, b.menutype,b.language,l.image,l.sef,l.title_native');
 
 		$db->setQuery($query);
 
@@ -52,7 +52,9 @@ abstract class ModMenuHelper
 		catch (RuntimeException $e)
 		{
 			$result = array();
-			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+
+			$msg = JDEBUG ? $e->getMessage() : JText::_('JERROR_AN_ERROR_HAS_OCCURRED');
+			JFactory::getApplication()->enqueueMessage($msg, 'error');
 		}
 
 		return $result;


### PR DESCRIPTION
Just a simple fix for admin mod_menu gorup in `ONLY_FULL_GROUP_BY` mode.

### Testing Instructions

Force enable `ONLY_FULL_GROUP_BY` mode. You can use this code in pdomysql:

```php
$this->connection->query("SET @@SESSION.sql_mode = 'STRICT_TRANS_TABLES,ONLY_FULL_GROUP_BY';");
```

Now admin panel will show this error, and the menu options all disappeared.

![p-2017-07-01-001](https://user-images.githubusercontent.com/1639206/27759270-05bd8eb2-5e5f-11e7-8339-c1315b14d13c.jpg)

After this PR, all menutypes will back:

![p-2017-07-01-002](https://user-images.githubusercontent.com/1639206/27759272-122a4910-5e5f-11e7-9ec0-4018146da8d0.jpg)
