### PR TITLE
Use the correct parameter value for truncating description of tags

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -113,7 +113,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<div class="caption">
 				<?php if ($this->params->get('all_tags_show_tag_description', 1)) : ?>
 					<span class="tag-body">
-					<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('tag_list_item_maximum_characters')); ?>
+					<?php echo JHtml::_('string.truncate', $item->description, $this->params->get('all_tags_tag_maximum_characters')); ?>
 				</span>
 				<?php endif; ?>
 				<?php if ($this->params->get('all_tags_show_tag_hits')) : ?>


### PR DESCRIPTION
Pull Request for Issue #14667

### Summary of Changes
The view used the wrong parameter value so the tag description wasn't truncated

### Testing Instructions
See #14667 and #16844 

* Create a menu item of type "List of all tags."
* From the Options tab while defining this menu item set the "Maximum characters" (under description) to 200 (presumably any number).

### Before Patch
The full description is always displayed regardless of what value is used to truncate it.

### After Patch
The tag description is truncated at 200 characters according to the menu options above when selecting the menu item above for display.

### Documentation Changes Required
none
