### PR TITLE
Don't add the field when it is set to hidden

### DIFF
--- a/components/com_users/views/remind/tmpl/default.php
+++ b/components/com_users/views/remind/tmpl/default.php
@@ -26,14 +26,16 @@ JHtml::_('behavior.formvalidator');
 		<fieldset>
 			<p><?php echo JText::_($fieldset->label); ?></p>
 			<?php foreach ($this->form->getFieldset($fieldset->name) as $name => $field) : ?>
-				<div class="control-group">
-					<div class="control-label">
-						<?php echo $field->label; ?>
+				<?php if ($field->hidden === false) : ?>
+					<div class="control-group">
+						<div class="control-label">
+							<?php echo $field->label; ?>
+						</div>
+						<div class="controls">
+							<?php echo $field->input; ?>
+						</div>
 					</div>
-					<div class="controls">
-						<?php echo $field->input; ?>
-					</div>
-				</div>
+				<?php endif; ?>
 			<?php endforeach; ?>
 		</fieldset>
 		<?php endforeach; ?>

--- a/components/com_users/views/reset/tmpl/default.php
+++ b/components/com_users/views/reset/tmpl/default.php
@@ -26,14 +26,16 @@ JHtml::_('behavior.formvalidator');
 			<fieldset>
 				<p><?php echo JText::_($fieldset->label); ?></p>
 				<?php foreach ($this->form->getFieldset($fieldset->name) as $name => $field) : ?>
-					<div class="control-group">
-						<div class="control-label">
-							<?php echo $field->label; ?>
+					<?php if ($field->hidden === false) : ?>
+						<div class="control-group">
+							<div class="control-label">
+								<?php echo $field->label; ?>
+							</div>
+							<div class="controls">
+								<?php echo $field->input; ?>
+							</div>
 						</div>
-						<div class="controls">
-							<?php echo $field->input; ?>
-						</div>
-					</div>
+					<?php endif; ?>
 				<?php endforeach; ?>
 			</fieldset>
 		<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Issue #16887

### Summary of Changes

When the field is set to hidden we don't push it as available field

### Testing Instructions

Go to the `Forgot your username?` or `Forgot your password?` view with and without the recatcha plugin enabled

### Expected result

Works with and without the plugin enabled.
Without the plugin enabled see:

![image](https://user-images.githubusercontent.com/2596554/27762697-37a8b93e-5e77-11e7-8686-ed239084f526.png)


### Actual result

![image](https://user-images.githubusercontent.com/2596554/27762692-12534dde-5e77-11e7-8ce3-aa5a5cedfa74.png)


### Documentation Changes Required

none

### Additional Infos

@mbabker i have requested a review as I'm not sure if this is the correct way to do that. Should the view be resposible to hide the hidden fields or is the underlaying code responsible to do that?