### PR TITLE
Make the core user plugin optional

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -131,7 +131,7 @@ class UsersModelUser extends JModelAdmin
 		// Passwords fields are required when mail to user is set to No in joomla user plugin
 		$userId = $form->getValue('id');
 
-		if ($userId === 0 && $pluginParams->get('mail_to_user', '0') === '0')
+		if ($userId === 0 && $pluginParams->get('mail_to_user', '1') === '0')
 		{
 			$form->setFieldAttribute('password', 'required', 'true');
 			$form->setFieldAttribute('password2', 'required', 'true');

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -112,8 +112,13 @@ class UsersModelUser extends JModelAdmin
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
-		$plugin = JPluginHelper::getPlugin('user', 'joomla');
-		$pluginParams = new Registry($plugin->params);
+		$pluginParams = new Registry;
+		
+		if (JPluginHelper::isEnabled('user', 'joomla'))
+		{
+			$plugin = JPluginHelper::getPlugin('user', 'joomla');
+			$pluginParams = new Registry($plugin->params);
+		}
 
 		// Get the form.
 		$form = $this->loadForm('com_users.user', 'user', array('control' => 'jform', 'load_data' => $loadData));
@@ -126,7 +131,7 @@ class UsersModelUser extends JModelAdmin
 		// Passwords fields are required when mail to user is set to No in joomla user plugin
 		$userId = $form->getValue('id');
 
-		if ($userId === 0 && $pluginParams->get('mail_to_user') === '0')
+		if ($userId === 0 && $pluginParams->get('mail_to_user', '0') === '0')
 		{
 			$form->setFieldAttribute('password', 'required', 'true');
 			$form->setFieldAttribute('password2', 'required', 'true');

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -117,7 +117,7 @@ class UsersModelUser extends JModelAdmin
 		if (JPluginHelper::isEnabled('user', 'joomla'))
 		{
 			$plugin = JPluginHelper::getPlugin('user', 'joomla');
-			$pluginParams = new Registry($plugin->params);
+			$pluginParams->loadString($plugin->params);
 		}
 
 		// Get the form.
@@ -131,7 +131,7 @@ class UsersModelUser extends JModelAdmin
 		// Passwords fields are required when mail to user is set to No in joomla user plugin
 		$userId = $form->getValue('id');
 
-		if ($userId === 0 && $pluginParams->get('mail_to_user', 0) === 0)
+		if ($userId === 0 && $pluginParams->get('mail_to_user', '0') === '0')
 		{
 			$form->setFieldAttribute('password', 'required', 'true');
 			$form->setFieldAttribute('password2', 'required', 'true');

--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -131,7 +131,7 @@ class UsersModelUser extends JModelAdmin
 		// Passwords fields are required when mail to user is set to No in joomla user plugin
 		$userId = $form->getValue('id');
 
-		if ($userId === 0 && $pluginParams->get('mail_to_user', '1') === '0')
+		if ($userId === 0 && $pluginParams->get('mail_to_user', 0) === 0)
 		{
 			$form->setFieldAttribute('password', 'required', 'true');
 			$form->setFieldAttribute('password2', 'required', 'true');


### PR DESCRIPTION
Pull Request for Issue #16921

### Summary of Changes

In case that the plugin is not enabled there is a notice on the screen. 

### Testing Instructions

set error reporting to maximum
disable the joomla user plugin (User - Joomla)

### Expected result

No error and the password field is required

### Actual result

a php notice

### Documentation Changes Required

none