### PR TITLE
[Router] RuleStandard Fallback to nomenu URL if segments not found

### DIFF
--- a/libraries/cms/component/router/rules/standard.php
+++ b/libraries/cms/component/router/rules/standard.php
@@ -242,16 +242,27 @@ class JComponentRouterRulesStandard implements JComponentRouterRulesInterface
 
 				if ($views[$view]->nestable)
 				{
+					$ids = array_map(function ($segment)
+					{
+						return str_replace(':', '-', $segment);
+					}, $ids);
+
 					foreach (array_reverse($ids, true) as $id => $segment)
 					{
 						if ($found2)
 						{
-							$segments[] = str_replace(':', '-', $segment);
+							$segments[] = $segment;
 						}
 						elseif ((int) $item->query[$views[$view]->key] == (int) $id)
 						{
 							$found2 = true;
 						}
+					}
+
+					if (!$found2)
+					{
+						array_pop($ids);
+						$segments = array_reverse($ids);
 					}
 				}
 				elseif (is_bool($ids))


### PR DESCRIPTION
### Summary of Changes

If a nestable view has a menu linked to some child items, then other items which not in children and havn't assigned to any menus will unable to create route.

### Testing Instructions

Create a component (com_test) with new router rules and nesteable view, and add some items:

```
- Foo
    - Bar
        - Yoo
- Flower
    - Japan
        -Sakura
```

Assign a menu to `Bar`, go to Bar page, all routes linked to `Japan` and `Sakura` will not work, only link to `Bar`.

The route will be:

- Bar: `/bar`
- Yoo: `/bar/3-yoo`
- Japan: `/bar` (Wrong URL)
- Sakura: `/bar`  (Wrong URL)

This PR fixed that if a view can not found parent menu, it will use an exists menu and add view alias after it.

Japan: `/bar/5-japan`
Sakura: `/bar/5-japan/6-sakura`

Actually, I think the real solution is fallback to `/component/test/5-japan/6-sakura` not after `/bar`, but I don't know how to do this. Router rules is too complex...


