### PR TITLE
Add a default empty array for the session queue

### DIFF
--- a/libraries/src/Joomla/CMS/Application/CMSApplication.php
+++ b/libraries/src/Joomla/CMS/Application/CMSApplication.php
@@ -468,12 +468,12 @@ class CMSApplication extends WebApplication
 		if (!$this->_messageQueue)
 		{
 			$session = \JFactory::getSession();
-			$sessionQueue = $session->get('application.queue');
+			$sessionQueue = $session->get('application.queue', array());
 
 			if ($sessionQueue)
 			{
 				$this->_messageQueue = $sessionQueue;
-				$session->set('application.queue', null);
+				$session->set('application.queue', array());
 			}
 		}
 

--- a/tests/unit/core/mock/session.php
+++ b/tests/unit/core/mock/session.php
@@ -109,13 +109,14 @@ class TestMockSession
 	/**
 	 * Mocking the get method.
 	 *
-	 * @param   string  $key  The key to get.
+	 * @param   string  $key      The key to get.
+	 * @param   mixed   $default  The default value for the value.
 	 *
 	 * @return  mixed
 	 *
 	 * @since   11.3
 	 */
-	public static function mockGet($key)
+	public static function mockGet($key, $default = null)
 	{
 		switch ($key)
 		{
@@ -130,6 +131,6 @@ class TestMockSession
 				return $user;
 		}
 
-		return null;
+		return $default;
 	}
 }


### PR DESCRIPTION
### Summary of Changes
Fix mock session default values not being used and also ensure the session stored messages are always an array. Fixes issues in Joomla in PHP 7.2

### Testing Instructions
See less tests failing in PHP Nightly