### PR TITLE
[com_fields] Show the loading icon only when needed

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -342,9 +342,9 @@ class FieldsHelper
 			// Preload spindle-wheel when we need to submit form due to category selector changed
 			JFactory::getDocument()->addScriptDeclaration("
 			function categoryHasChanged(element) {
-				Joomla.loadingLayer('show');
 				var cat = jQuery(element);
 				if (cat.val() == '" . $assignedCatids . "')return;
+				Joomla.loadingLayer('show');
 				jQuery('input[name=task]').val('field.storeform');
 				element.form.action='" . $uri . "';
 				element.form.submit();


### PR DESCRIPTION
When a category is changed on article edit, then a JS event is triggered to show the loading icon till the page reload is done. When the event is triggered by an external script and the catid field hasn't changed it returns without shutting down the loading icon properly.

This pr changes the behavior to show the loading icon, only when needed.

Actually I can't offer test instructions as this is happening with one of my commercial extensions. But it should be good to merge as all it does is moving a line after a return statement. Pinging here @rdeutz as release lead as it should fine to merge by review.