### PR TITLE
[com_fields] Fields are not copied when batch duplicating an article

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -67,6 +67,12 @@ class ContentModelArticle extends JModelAdmin
 			return false;
 		}
 
+		JPluginHelper::importPlugin('system');
+		$dispatcher = JEventDispatcher::getInstance();
+
+		// Register FieldsHelper
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
 		// Parent exists so we let's proceed
 		while (!empty($pks))
 		{
@@ -90,6 +96,19 @@ class ContentModelArticle extends JModelAdmin
 					// Not fatal error
 					$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk));
 					continue;
+				}
+			}
+
+			$fields = FieldsHelper::getFields('com_content.article', $this->table, true);
+			$fieldsData = array();
+
+			if (!empty($fields))
+			{
+				$fieldsData['com_fields'] = array();
+
+				foreach ($fields as $field)
+				{
+					$fieldsData['com_fields'][$field->name] = $field->value;
 				}
 			}
 
@@ -150,12 +169,126 @@ class ContentModelArticle extends JModelAdmin
 				$db->setQuery($query);
 				$db->execute();
 			}
+
+			// Run event for copied article
+			$dispatcher->trigger('onContentAfterSave', array('com_content.article', &$this->table, true, $fieldsData));
 		}
 
 		// Clean the cache
 		$this->cleanCache();
 
 		return $newIds;
+	}
+
+	/**
+	 * Batch move categories to a new category.
+	 *
+	 * @param   integer  $value     The new category ID.
+	 * @param   array    $pks       An array of row IDs.
+	 * @param   array    $contexts  An array of item contexts.
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @since   1.6
+	 */
+	protected function batchMove($value, $pks, $contexts)
+	{
+		if (empty($this->batchSet))
+		{
+			// Set some needed variables.
+			$this->user = JFactory::getUser();
+			$this->table = $this->getTable();
+			$this->tableClassName = get_class($this->table);
+			$this->contentType = new JUcmType;
+			$this->type = $this->contentType->getTypeByTable($this->tableClassName);
+		}
+
+		$categoryId = (int) $value;
+
+		if (!$this->checkCategoryId($categoryId))
+		{
+			return false;
+		}
+
+		JPluginHelper::importPlugin('system');
+		$dispatcher = JEventDispatcher::getInstance();
+
+		// Register FieldsHelper
+		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
+		// Parent exists so we proceed
+		foreach ($pks as $pk)
+		{
+			if (!$this->user->authorise('core.edit', $contexts[$pk]))
+			{
+				$this->setError(JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
+
+				return false;
+			}
+
+			// Check that the row actually exists
+			if (!$this->table->load($pk))
+			{
+				if ($error = $this->table->getError())
+				{
+					// Fatal error
+					$this->setError($error);
+
+					return false;
+				}
+				else
+				{
+					// Not fatal error
+					$this->setError(JText::sprintf('JLIB_APPLICATION_ERROR_BATCH_MOVE_ROW_NOT_FOUND', $pk));
+					continue;
+				}
+			}
+
+			$fields = FieldsHelper::getFields('com_content.article', $this->table, true);
+			$fieldsData = array();
+
+			if (!empty($fields))
+			{
+				$fieldsData['com_fields'] = array();
+
+				foreach ($fields as $field)
+				{
+					$fieldsData['com_fields'][$field->name] = $field->value;
+				}
+			}
+
+			// Set the new category ID
+			$this->table->catid = $categoryId;
+
+			// Check the row.
+			if (!$this->table->check())
+			{
+				$this->setError($this->table->getError());
+
+				return false;
+			}
+
+			if (!empty($this->type))
+			{
+				$this->createTagsHelper($this->tagsObserver, $this->type, $pk, $this->typeAlias, $this->table);
+			}
+
+			// Store the row.
+			if (!$this->table->store())
+			{
+				$this->setError($this->table->getError());
+
+				return false;
+			}
+
+			// Run event for moved article
+			$dispatcher->trigger('onContentAfterSave', array('com_content.article', &$this->table, false, $fieldsData));
+		}
+
+		// Clean the cache
+		$this->cleanCache();
+
+		return true;
 	}
 
 	/**

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -189,7 +189,7 @@ class ContentModelArticle extends JModelAdmin
 	 *
 	 * @return  boolean  True on success.
 	 *
-	 * @since   1.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function batchMove($value, $pks, $contexts)
 	{

--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -108,7 +108,7 @@ class ContentModelArticle extends JModelAdmin
 
 				foreach ($fields as $field)
 				{
-					$fieldsData['com_fields'][$field->name] = $field->value;
+					$fieldsData['com_fields'][$field->name] = $field->rawvalue;
 				}
 			}
 
@@ -253,7 +253,7 @@ class ContentModelArticle extends JModelAdmin
 
 				foreach ($fields as $field)
 				{
-					$fieldsData['com_fields'][$field->name] = $field->value;
+					$fieldsData['com_fields'][$field->name] = $field->rawvalue;
 				}
 			}
 


### PR DESCRIPTION
Pull Request for Issue #16740

### Summary of Changes
Add import plugin and run event for articles when do an batch copy or batch move to make sure these new article (Batch - copy) or changed articles (Batch - move) still have event stuff same as create / edit single article.


### Testing Instructions
- Create 2 categories: "Category 1" and "Category 2"
- Create 2 fields: "Field 1" and "Field 2"
- Assign "Field 1" and "Field 2" for "Category 1"
- Assign "Field 1" for "Category 2"
- Create an "Article 1", assign for "Category 1", enter data for custom fields "Field 1" and "Field 2"
- Go to Articles Management page, check for select "Article 1" in list, press button "Batch", choose "Category 2", choose "Copy" and press "Process"
- Go to Articles Management page, check for select "Article 1" in list, press button "Batch", choose "Category 2", choose "Move" and press "Process"

### Expected result
- For "Batch - Copy" process, new "Article 1" has been created in "Category 2". Custom field data for "Field 1" was copied too.
- For "Batch - Move" process, "Article 1" has been assigned to "Category 2". Custom field data for "Field 1" still stay with this article.

### Actual result
- For "Batch - Copy" process, Custom fields data has been gone.
- For "Batch - Move" process, Custom fields data has been gone.


### Documentation Changes Required

