### PR TITLE
[4.0] Unset the modified value in the group form

### DIFF
--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -79,18 +79,15 @@
 
 		<field
 			name="modified"
-			type="calendar"
+			type="text"
 			label="JGLOBAL_FIELD_MODIFIED_LABEL"
-			translateformat="true"
-			showtime="true"
-			size="22"
 			class="readonly"
+			filter="unset"
 			readonly="true"
-			filter="user_utc"
 		/>
 
-		<field 
-			name="modified_by" 
+		<field
+			name="modified_by"
 			type="user"
 			label="JGLOBAL_FIELD_MODIFIED_BY_LABEL"
 			class="readonly"


### PR DESCRIPTION
### Summary of Changes
Creating a custom field group fails because of 
_datetime value: '' for column 'modified' at row 1_

This pr fixes it.
