### PR TITLE
Fix a fatal error for PHP 5.3 and a multilanguage side

### DIFF
--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -636,7 +636,7 @@ class JRouter
 
 		foreach ($this->_rules['build' . $stage] as $rule)
 		{
-			-			call_user_func_array($rule, array(&$this, &$uri));
+			call_user_func_array($rule, array(&$this, &$uri));
 		}
 	}
 

--- a/libraries/cms/router/router.php
+++ b/libraries/cms/router/router.php
@@ -636,7 +636,7 @@ class JRouter
 
 		foreach ($this->_rules['build' . $stage] as $rule)
 		{
-			$rule($this, $uri);
+			-			call_user_func_array($rule, array(&$this, &$uri));
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue #16965.

### Summary of Changes
This reverts the last change form #13257

### Testing Instructions
Test a multilanguage side under PHP 5.3.29. After applying the patch the fatal error should be gone.

