### PR TITLE
Deleting obsolete php warning

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.7.4-2017-07-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.7.4-2017-07-05.sql
@@ -1,0 +1,1 @@
+DELETE FROM `#__postinstall_messages` WHERE `title_key` = 'COM_CPANEL_MSG_PHPVERSION_TITLE';

--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.4-2017-07-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.4-2017-07-05.sql
@@ -1,0 +1,1 @@
+DELETE FROM "#__postinstall_messages" WHERE "title_key" = 'COM_CPANEL_MSG_PHPVERSION_TITLE';

--- a/administrator/components/com_admin/sql/updates/sqlazure/3.7.4-2017-07-05.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.7.4-2017-07-05.sql
@@ -1,0 +1,1 @@
+DELETE FROM [#__postinstall_messages] WHERE [title_key] = 'COM_CPANEL_MSG_PHPVERSION_TITLE';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16964

### Summary of Changes
Adding update sqls to delete the obsolete php warning when php < 5.3.10

To merge on review.