### PR TITLE
Update beez layout overrides to use correct params

### DIFF
--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -14,7 +14,7 @@ $tparams = $this->item->params;
 
 ?>
 
-<div class="contact<?php echo $this->pageclass_sfx?; >">
+<div class="contact<?php echo $this->pageclass_sfx; ?>">
 	<?php if ($tparams->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $this->escape($tparams->get('page_heading')); ?>

--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -100,7 +100,7 @@ $tparams = $this->item->params;
 		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php endif; ?>
-		<?php if ($tparams->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain') : ?>
 			<?php  echo '<h3>'. JText::_('COM_CONTACT_EMAIL_FORM').'</h3>';  ?>
 		<?php endif; ?>
 		<?php  echo $this->loadTemplate('form');  ?>
@@ -135,7 +135,7 @@ $tparams = $this->item->params;
 		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
-		<?php if ($tparams->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain') : ?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_PROFILE').'</h3>'; ?>
 		<?php endif; ?>
 
@@ -155,7 +155,7 @@ $tparams = $this->item->params;
 		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php endif; ?>
-		<?php if ($tparams->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain') : ?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_OTHER_INFORMATION').'</h3>'; ?>
 		<?php endif; ?>
 

--- a/templates/beez3/html/com_contact/contact/default.php
+++ b/templates/beez3/html/com_contact/contact/default.php
@@ -10,27 +10,29 @@
 defined('_JEXEC') or die;
 
 $cparams = JComponentHelper::getParams('com_media');
+$tparams = $this->item->params;
+
 ?>
 
-<div class="contact<?php echo $this->pageclass_sfx?>">
-	<?php if ($this->params->get('show_page_heading')) : ?>
+<div class="contact<?php echo $this->pageclass_sfx?; >">
+	<?php if ($tparams->get('show_page_heading')) : ?>
 		<h1>
-			<?php echo $this->escape($this->params->get('page_heading')); ?>
+			<?php echo $this->escape($tparams->get('page_heading')); ?>
 		</h1>
 	<?php endif; ?>
-	<?php if ($this->contact->name && $this->params->get('show_name')) : ?>
+	<?php if ($this->contact->name && $tparams->get('show_name')) : ?>
 		<div class="page-header">
 			<h2>
 				<span class="contact-name"><?php echo $this->contact->name; ?></span>
 			</h2>
 		</div>
 	<?php endif;  ?>
-	<?php if ($this->params->get('show_contact_category') === 'show_no_link') : ?>
+	<?php if ($tparams->get('show_contact_category') === 'show_no_link') : ?>
 		<h3>
 			<span class="contact-category"><?php echo $this->contact->category_title; ?></span>
 		</h3>
 	<?php endif; ?>
-	<?php if ($this->params->get('show_contact_category') === 'show_with_link') : ?>
+	<?php if ($tparams->get('show_contact_category') === 'show_with_link') : ?>
 		<?php $contactLink = ContactHelperRoute::getCategoryRoute($this->contact->catid);?>
 		<h3>
 			<span class="contact-category"><a href="<?php echo $contactLink; ?>">
@@ -41,40 +43,40 @@ $cparams = JComponentHelper::getParams('com_media');
 
 	<?php echo $this->item->event->afterDisplayTitle; ?>
 
-	<?php if ($this->params->get('show_contact_list') && count($this->contacts) > 1) : ?>
+	<?php if ($tparams->get('show_contact_list') && count($this->contacts) > 1) : ?>
 		<form action="#" method="get" name="selectForm" id="selectForm">
 			<?php echo JText::_('COM_CONTACT_SELECT_CONTACT'); ?>
 			<?php echo JHtml::_('select.genericlist',  $this->contacts, 'id', 'class="inputbox" onchange="document.location.href = this.value"', 'link', 'name', $this->contact->link);?>
 		</form>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
+	<?php if ($tparams->get('show_tags', 1) && !empty($this->item->tags->itemTags)) : ?>
 		<?php $this->item->tagLayout = new JLayoutFile('joomla.content.tags'); ?>
 		<?php echo $this->item->tagLayout->render($this->item->tags->itemTags); ?>
 	<?php endif; ?>
 
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
-	<?php  if ($this->params->get('presentation_style') === 'sliders') : ?>
+	<?php  if ($tparams->get('presentation_style') === 'sliders') : ?>
 		<?php echo JHtml::_('sliders.start', 'panel-sliders', array('useCookie' => '1')); ?>
 		<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 	<?php endif; ?>
-	<?php  if ($this->params->get('presentation_style') === 'tabs') : ?>
+	<?php  if ($tparams->get('presentation_style') === 'tabs') : ?>
 		<?php echo JHtmlTabs::start('tabs', array('useCookie' => '1')); ?>
 		<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_DETAILS'), 'basic-details'); ?>
 
 	<?php endif; ?>
-	<?php if ($this->params->get('presentation_style') === 'plain'):?>
+	<?php if ($tparams->get('presentation_style') === 'plain'):?>
 		<?php  echo '<h3>' . JText::_('COM_CONTACT_DETAILS') . '</h3>';  ?>
 	<?php endif; ?>
 
-	<?php if ($this->contact->image && $this->params->get('show_image')) : ?>
+	<?php if ($this->contact->image && $tparams->get('show_image')) : ?>
 		<div class="thumbnail pull-right">
 			<?php echo JHtml::_('image', $this->contact->image, $this->contact->name, array('align' => 'middle')); ?>
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->contact->con_position && $this->params->get('show_position')) : ?>
+	<?php if ($this->contact->con_position && $tparams->get('show_position')) : ?>
 		<dl class="contact-position dl-horizontal">
 			<dd>
 				<?php echo $this->contact->con_position; ?>
@@ -84,40 +86,40 @@ $cparams = JComponentHelper::getParams('com_media');
 
 	<?php echo $this->loadTemplate('address'); ?>
 
-	<?php if ($this->params->get('allow_vcard')) :	?>
+	<?php if ($tparams->get('allow_vcard')) : ?>
 		<?php echo JText::_('COM_CONTACT_DOWNLOAD_INFORMATION_AS');?>
 			<a href="<?php echo JRoute::_('index.php?option=com_contact&amp;view=contact&amp;id='.$this->contact->id . '&amp;format=vcf'); ?>">
 			<?php echo JText::_('COM_CONTACT_VCARD');?></a>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
+	<?php if ($tparams->get('show_email_form') && ($this->contact->email_to || $this->contact->user_id)) : ?>
 
-		<?php if ($this->params->get('presentation_style') === 'sliders') : ?>
+		<?php if ($tparams->get('presentation_style') === 'sliders') : ?>
 			<?php echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'tabs') : ?>
+		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_EMAIL_FORM'), 'display-form'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain'):?>
 			<?php  echo '<h3>'. JText::_('COM_CONTACT_EMAIL_FORM').'</h3>';  ?>
 		<?php endif; ?>
 		<?php  echo $this->loadTemplate('form');  ?>
 
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_links')) : ?>
+	<?php if ($tparams->get('show_links')) : ?>
 		<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
+	<?php if ($tparams->get('show_articles') && $this->contact->user_id && $this->contact->articles) : ?>
 
-		<?php if ($this->params->get('presentation_style') === 'sliders') :
+		<?php if ($tparams->get('presentation_style') === 'sliders') :
 			echo JHtml::_('sliders.panel', JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'tabs') : ?>
+		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('JGLOBAL_ARTICLES'), 'display-articles'); ?>
 		<?php endif; ?>
-		<?php if  ($this->params->get('presentation_style') === 'plain'):?>
+		<?php if  ($tparams->get('presentation_style') === 'plain'):?>
 			<?php echo '<h3>'. JText::_('JGLOBAL_ARTICLES').'</h3>'; ?>
 		<?php endif; ?>
 
@@ -125,15 +127,15 @@ $cparams = JComponentHelper::getParams('com_media');
 
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
+	<?php if ($tparams->get('show_profile') && $this->contact->user_id && JPluginHelper::isEnabled('user', 'profile')) : ?>
 
-		<?php if ($this->params->get('presentation_style') === 'sliders') :
+		<?php if ($tparams->get('presentation_style') === 'sliders') :
 			echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'tabs') : ?>
+		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_PROFILE'), 'display-profile'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_PROFILE').'</h3>'; ?>
 		<?php endif; ?>
 
@@ -141,27 +143,27 @@ $cparams = JComponentHelper::getParams('com_media');
 
 	<?php endif; ?>
 
-	<?php if ($this->params->get('show_user_custom_fields') && $this->contactUser) : ?>
+	<?php if ($tparams->get('show_user_custom_fields') && $this->contactUser) : ?>
 		<?php echo $this->loadTemplate('user_custom_fields'); ?>
 	<?php endif; ?>
 
-	<?php if ($this->contact->misc && $this->params->get('show_misc')) : ?>
+	<?php if ($this->contact->misc && $tparams->get('show_misc')) : ?>
 
-		<?php if ($this->params->get('presentation_style') === 'sliders') :
+		<?php if ($tparams->get('presentation_style') === 'sliders') :
 			echo JHtml::_('sliders.panel', JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'tabs') : ?>
+		<?php if ($tparams->get('presentation_style') === 'tabs') : ?>
 			<?php echo JHtmlTabs::panel(JText::_('COM_CONTACT_OTHER_INFORMATION'), 'display-misc'); ?>
 		<?php endif; ?>
-		<?php if ($this->params->get('presentation_style') === 'plain'):?>
+		<?php if ($tparams->get('presentation_style') === 'plain'):?>
 			<?php echo '<h3>'. JText::_('COM_CONTACT_OTHER_INFORMATION').'</h3>'; ?>
 		<?php endif; ?>
 
 		<div class="contact-miscinfo">
 			<dl class="dl-horizontal">
 				<dt>
-					<span class="<?php echo $this->params->get('marker_class'); ?>">
-						<?php echo $this->params->get('marker_misc'); ?>
+					<span class="<?php echo $tparams->get('marker_class'); ?>">
+						<?php echo $tparams->get('marker_misc'); ?>
 					</span>
 				</dt>
 				<dd>
@@ -173,7 +175,7 @@ $cparams = JComponentHelper::getParams('com_media');
 		</div>
 	<?php endif; ?>
 
-	<?php if ($this->params->get('presentation_style') === 'sliders') :
+	<?php if ($tparams->get('presentation_style') === 'sliders') :
 		echo JHtml::_('sliders.end');
 	endif; ?>
 

--- a/templates/beez3/html/com_contact/contact/default_address.php
+++ b/templates/beez3/html/com_contact/contact/default_address.php
@@ -12,53 +12,56 @@ defined('_JEXEC') or die;
 /* marker_class: Class based on the selection of text, none, or icons
  * jicon-text, jicon-none, jicon-icon
  */
+
+$tparams = $this->item->params;
+
 ?>
 <dl class="contact-address dl-horizontal">
-<?php if (($this->params->get('address_check') > 0) &&  ($this->contact->address || $this->contact->suburb  || $this->contact->state || $this->contact->country || $this->contact->postcode)) : ?>
-	<?php if ($this->params->get('address_check') > 0) : ?>
+<?php if (($tparams->get('address_check') > 0) &&  ($this->contact->address || $this->contact->suburb  || $this->contact->state || $this->contact->country || $this->contact->postcode)) : ?>
+	<?php if ($tparams->get('address_check') > 0) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
-			<?php echo $this->params->get('marker_address'); ?>
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
+			<?php echo $tparams->get('marker_address'); ?>
 		</span>
 	</dt>
 	<dd>
 	<address>
 	<?php endif; ?>
-	<?php if ($this->contact->address && $this->params->get('show_street_address')) : ?>
+	<?php if ($this->contact->address && $tparams->get('show_street_address')) : ?>
 		<span class="contact-street">
 			<?php echo nl2br($this->contact->address); ?>
 		</span>
 	<?php endif; ?>
-	<?php if ($this->contact->suburb && $this->params->get('show_suburb')) : ?>
+	<?php if ($this->contact->suburb && $tparams->get('show_suburb')) : ?>
 		<span class="contact-suburb">
 			<?php echo $this->contact->suburb; ?>
 		</span>
 	<?php endif; ?>
-	<?php if ($this->contact->state && $this->params->get('show_state')) : ?>
+	<?php if ($this->contact->state && $tparams->get('show_state')) : ?>
 		<span class="contact-state">
 			<?php echo $this->contact->state; ?>
 		</span>
 	<?php endif; ?>
-	<?php if ($this->contact->postcode && $this->params->get('show_postcode')) : ?>
+	<?php if ($this->contact->postcode && $tparams->get('show_postcode')) : ?>
 		<span class="contact-postcode">
 			<?php echo $this->contact->postcode; ?>
 		</span>
 	<?php endif; ?>
-	<?php if ($this->contact->country && $this->params->get('show_country')) : ?>
+	<?php if ($this->contact->country && $tparams->get('show_country')) : ?>
 		<span class="contact-country">
 			<?php echo $this->contact->country; ?>
 		</span>
 	<?php endif; ?>
 <?php endif; ?>
-<?php if ($this->params->get('address_check') > 0) : ?>
+<?php if ($tparams->get('address_check') > 0) : ?>
 	</address>
 	</dd>
 <?php endif; ?>
 
-<?php if ($this->contact->email_to && $this->params->get('show_email')) : ?>
+<?php if ($this->contact->email_to && $tparams->get('show_email')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
-			<?php echo $this->params->get('marker_email'); ?>
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
+			<?php echo $tparams->get('marker_email'); ?>
 		</span>
 	</dt>
 	<dd>
@@ -68,10 +71,10 @@ defined('_JEXEC') or die;
 	</dd>
 <?php endif; ?>
 
-<?php if ($this->contact->telephone && $this->params->get('show_telephone')) : ?>
+<?php if ($this->contact->telephone && $tparams->get('show_telephone')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
-			<?php echo $this->params->get('marker_telephone'); ?>
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
+			<?php echo $tparams->get('marker_telephone'); ?>
 		</span>
 	</dt>
 	<dd>
@@ -80,10 +83,10 @@ defined('_JEXEC') or die;
 		</span>
 	</dd>
 <?php endif; ?>
-<?php if ($this->contact->fax && $this->params->get('show_fax')) : ?>
+<?php if ($this->contact->fax && $tparams->get('show_fax')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
-			<?php echo $this->params->get('marker_fax'); ?>
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
+			<?php echo $tparams->get('marker_fax'); ?>
 		</span>
 	</dt>
 	<dd>
@@ -92,10 +95,10 @@ defined('_JEXEC') or die;
 		</span>
 	</dd>
 <?php endif; ?>
-<?php if ($this->contact->mobile && $this->params->get('show_mobile')) :?>
+<?php if ($this->contact->mobile && $tparams->get('show_mobile')) :?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
-			<?php echo $this->params->get('marker_mobile'); ?>
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
+			<?php echo $tparams->get('marker_mobile'); ?>
 		</span>
 	</dt>
 	<dd>
@@ -104,9 +107,9 @@ defined('_JEXEC') or die;
 		</span>
 	</dd>
 <?php endif; ?>
-<?php if ($this->contact->webpage && $this->params->get('show_webpage')) : ?>
+<?php if ($this->contact->webpage && $tparams->get('show_webpage')) : ?>
 	<dt>
-		<span class="<?php echo $this->params->get('marker_class'); ?>" >
+		<span class="<?php echo $tparams->get('marker_class'); ?>" >
 		</span>
 	</dt>
 	<dd>


### PR DESCRIPTION
References:  #16971, #16968

### Summary of Changes
Update beez layout overrides to use correct params as mentioned by @AlexRed here: https://github.com/joomla/joomla-cms/pull/16971#issuecomment-313077067

### Testing Instructions
Create a menu entry to a contact item and assign an existing user to that contact. Make sure that the output reflects the settings (global, entity, menu item) in both the protostar and beez template alike.

_Note: I did not evaluate the overrides. Since Protostar and Beez are different templates, the output may vary between them. The important thing here is not the style but the behavior in regards to the settings._

### Expected result
The contact item overrides of the Beez template should reflect the global, entity, menu settings.

### Actual result
The contact item override of the Beez template does not reflect the global, entity, menu settings.