### PR TITLE
Get rid of the not needed buttons at update time and hide the menu thanks @hamby

### DIFF
--- a/administrator/components/com_joomlaupdate/views/update/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/update/view.html.php
@@ -21,22 +21,14 @@ class JoomlaupdateViewUpdate extends JViewLegacy
 	 *
 	 * @param   string  $tpl  Template name.
 	 *
-	 * @return void
+	 * @return  void
 	 */
-	public function display($tpl=null)
+	public function display($tpl = null)
 	{
+		JFactory::getApplication()->input->set('hidemainmenu', true);
+
 		// Set the toolbar information.
 		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'loop install');
-		JToolBarHelper::divider();
-		JToolBarHelper::help('JHELP_COMPONENTS_JOOMLA_UPDATE');
-
-		// Add toolbar buttons.
-		$user = JFactory::getUser();
-
-		if ($user->authorise('core.admin', 'com_joomlaupdate') || $user->authorise('core.options', 'com_joomlaupdate'))
-		{
-			JToolbarHelper::preferences('com_joomlaupdate');
-		}
 
 		// Import com_login's model
 		JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_login/models', 'LoginModel');


### PR DESCRIPTION
### Summary of Changes

This PR hides the menu and the extra set of buttons at the actual update screens in com_joomlaupdate. Idea by @hamby

### Testing Instructions

Run "reinstall the joomla core files"
confirm the old behavior
apply this patch
run "reinstall the joomla core files" again
confirm the new behavior

### Expected result

![after_pr](https://user-images.githubusercontent.com/2596554/27881447-f0240c76-61c8-11e7-8d96-4aeaa7f72fe2.PNG)


### Actual result

![image](https://user-images.githubusercontent.com/2596554/27881528-43fb5f16-61c9-11e7-94b2-555079851c06.png)


### Documentation Changes Required

None