### PR TITLE
Regression: Fix undefined offset: 1

### DIFF
--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -276,7 +276,9 @@ class JBrowser
 				$this->setBrowser('opera');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
 			}
-			elseif (preg_match('/Chrome|CrMo|CriOS[\/ ]([0-9.]+)/i', $agent, $version))
+			elseif (preg_match('/Chrome[\/ ]([0-9.]+)/', $this->agent, $version)
+				|| preg_match('/CrMo[\/ ]([0-9.]+)/', $this->agent, $version)
+				|| preg_match('/CriOS[\/ ]([0-9.]+)/', $this->agent, $version))
 			{
 				$this->setBrowser('chrome');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
@@ -287,9 +289,7 @@ class JBrowser
 			{
 				$this->setBrowser('palm');
 			}
-			elseif (preg_match('|MSIE ([0-9.]+)|', $this->agent, $version)
-				|| preg_match('|Internet Explorer/([0-9.]+)|', $this->agent, $version)
-				|| preg_match('|Trident/([0-9.]+)|', $this->agent, $version))
+			elseif (preg_match('/MSIE ([0-9.]+)|Internet Explorer\/([0-9.]+)|Trident\/([0-9.]+)/i', $this->agent, $version))
 			{
 				$this->setBrowser('msie');
 

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -271,14 +271,12 @@ class JBrowser
 			}
 
 			// Opera 15+
-			elseif (preg_match('|OPR[/ ]([0-9.]+)|', $this->agent, $version))
+			elseif (preg_match('/OPR[\/ ]([0-9.]+)/', $this->agent, $version))
 			{
 				$this->setBrowser('opera');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
 			}
-			elseif (preg_match('|Chrome[/ ]([0-9.]+)|', $this->agent, $version)
-				|| preg_match('|CrMo[/ ]([0-9.]+)|', $this->agent, $version)
-				|| preg_match('|CriOS[/ ]([0-9.]+)|', $this->agent, $version))
+			elseif (preg_match('/Chrome|CrMo|CriOS[\/ ]([0-9.]+)/i', $agent, $version))
 			{
 				$this->setBrowser('chrome');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);

--- a/libraries/joomla/environment/browser.php
+++ b/libraries/joomla/environment/browser.php
@@ -271,12 +271,14 @@ class JBrowser
 			}
 
 			// Opera 15+
-			elseif (preg_match('/OPR[\/ ]([0-9.]+)/', $this->agent, $version))
+			elseif (preg_match('|OPR[/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('opera');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
 			}
-			elseif (preg_match('/Chrome[\/ ]([0-9.]+)|CrMo[\/ ]([0-9.]+)|CriOS[\/ ]([0-9.]+)/i', $this->agent, $version))
+			elseif (preg_match('|Chrome[/ ]([0-9.]+)|', $this->agent, $version)
+				|| preg_match('|CrMo[/ ]([0-9.]+)|', $this->agent, $version)
+				|| preg_match('|CriOS[/ ]([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('chrome');
 				list ($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
@@ -287,7 +289,9 @@ class JBrowser
 			{
 				$this->setBrowser('palm');
 			}
-			elseif ((preg_match('/MSIE ([0-9.]+)|Internet Explorer\/([0-9.]+)|Trident\/([0-9.]+)/i', $this->agent, $version)))
+			elseif (preg_match('|MSIE ([0-9.]+)|', $this->agent, $version)
+				|| preg_match('|Internet Explorer/([0-9.]+)|', $this->agent, $version)
+				|| preg_match('|Trident/([0-9.]+)|', $this->agent, $version))
 			{
 				$this->setBrowser('msie');
 


### PR DESCRIPTION
Pull Request for Issue #16970 .
Fix regression for Issue #15228 .

### Summary of Changes
Revert to previous individual preg_match rather than combine them into 1.


### Testing Instructions
Check your PHP error log.

or

Create the following PHP script and run it.  1st preg_match( (previous) outputs no error. 2nd preg_match( (current) outputs error.
```
<?php

$agent = "Mozilla/5.0 (iPad; CPU OS 10_3_2 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) CriOS/59.0.3071.102 Mobile/14F89 Safari/602.1";

echo 'v3.6.5 ';
preg_match('|CriOS[/ ]([0-9.]+)|', $agent, $version);
var_dump($version);
list ($majorVersion, $minorVersion) = explode('.', $version[1]);

echo 'v3.7.3 ';
preg_match('/Chrome[\/ ]([0-9.]+)|CrMo[\/ ]([0-9.]+)|CriOS[\/ ]([0-9.]+)/i', $agent, $version);
var_dump($version);
list ($majorVersion, $minorVersion) = explode('.', $version[1]);

?>
```
results (1st array is v3.6.5 and 2nd array is v3.7.3):
```
v3.6.5 array(2) {
  [0]=>
  string(19) "CriOS/59.0.3071.102"
  [1]=>
  string(13) "59.0.3071.102"
}
v3.7.3 array(4) {
  [0]=>
  string(19) "CriOS/59.0.3071.102"
  [1]=>
  string(0) ""
  [2]=>
  string(0) ""
  [3]=>
  string(13) "59.0.3071.102"
}
<br />
<b>Notice</b>:  Undefined offset: 1 in <b>C:\xampp\htdocs\agent.php</b> on line <b>14</b><br />
```

### Expected result
No PHP Notice


### Actual result
> PHP message: PHP Notice: Undefined offset: 1 in /libraries/joomla/environment/browser.php on line 282\n


### Documentation Changes Required
None
