### PR TITLE
Language detection in snowball stem

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/stemmer/snowball.php
+++ b/administrator/components/com_finder/helpers/indexer/stemmer/snowball.php
@@ -33,11 +33,16 @@ class FinderIndexerStemmerSnowball extends FinderIndexerStemmer
 		// Language to use if All is specified.
 		static $defaultLang = '';
 
-		// If language is All then try to get site default language.
-		if ($lang == '*' && $defaultLang == '')
+		// If language is All then try to use site default language.
+		if ($lang == '*')
 		{
-			$languages = JLanguageHelper::getLanguages();
-			$defaultLang = isset($languages[0]->sef) ? $languages[0]->sef : '*';
+			if ($defaultLang == '')
+			{
+				// Try to get site default language.
+				$languages = JLanguageHelper::getLanguages();
+				$defaultLang = isset($languages[0]->sef) ? $languages[0]->sef : '*';
+			}
+
 			$lang = $defaultLang;
 		}
 


### PR DESCRIPTION
As @chrisdavenport  requested

Pull Request for Issue #16981 .


Test-Instructions (a little bit complicated)
1. You need a second frontend language (german in this example)
2. Make german the default language
3. Configure finder to use stem and snowball
4. Install snowball stem (standard php does not include snowball). For php 5.6 this can be done via pecl from https://github.com/marc-mabe/php-stem (for php 7 it must be done by hand)
5. Have 2 different articles, place the words "Heiterkeit" in the first and "Heiterung" in the second one. Both have the stem "Heiter" in german
6. Without this patch at least one of them does not have the stem "Heiter". You could check this by direct sql query "select * from ...finder_terms where term like 'heiter%'"

Please excuse the delay but I digged a bit deeper into joomla's finder component and the use of stems. See  #17085 if interrested.