### PR TITLE
Use the right section for the front contact category view contacts

### DIFF
--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -195,6 +195,12 @@ class ContactHelper extends JHelperContent
 			$section = 'mail';
 		}
 
+		if (JFactory::getApplication()->isClient('site') && $section == 'category')
+		{
+			// The contact form needs to be the mail section
+			$section = 'contact';
+		}
+
 		if ($section != 'mail' && $section != 'contact')
 		{
 			// We don't know other sections


### PR DESCRIPTION
Pull Request for Issue #16961.

### Summary of Changes
The sections are not correctly translated for the contact category view.

A side effect is that custom fields are rendered automatically in the list itself (which is the correct behavior):
![image](https://user-images.githubusercontent.com/251072/27920261-5198da58-6274-11e7-87f7-4a4b17ade8d8.png)

### Testing Instructions
- Create a contact custom field
- Create a contact and define a value for the custom field
- Use the category "Uncategorised" for the contact
- Create a new menu item "Contacts » List Contacts in a Category" with the category "Uncategorised"
- Open the menu item on the front

### Expected result
The custom fields are shown on the list.

### Actual result
The custom fields are not shown.