### PR TITLE
[com_fields] Value for the custom mail field in contacts should not be htmlentities() encoded when it is sent in the mail body

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -22,6 +22,8 @@ $showLabel = $field->params->get('showlabel');
 if ($field->context == 'com_contact.mail')
 {
 	// Prepare the value for the contact form mail
+	$value = html_entity_decode($value);
+
 	echo ($showLabel ? $label . ': ' : '') . $value . "\r\n";
 	return;
 }
@@ -34,7 +36,7 @@ if (!$value)
 ?>
 <dt class="contact-field-entry <?php echo $class; ?>">
 	<?php if ($showLabel == 1) : ?>
-        <span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
+		<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 	<?php endif; ?>
 </dt>
 <dd class="contact-field-entry <?php echo $class; ?>">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/16996

### Summary of Changes
Decoding the $value of the mail field when it used in the body of the mail as otherwise it is displayed in the mail as htmlentities.


### Testing Instructions
Create one contact
Create a mail custom field for example one list custom field and put values with non latin characters (for example Greek characters like `Ολοκλήρωση`)
Same if you use a text custom field and enter Greek Characters when the contact is displayed on frontend.
Try to sent email from contact form on frontend.


### Expected result
`Η εγκατάσταση της PHP απαιτεί το JSON για Joomla να είναι εγκατεστημένο.`
`Διαμονή: Ολοκλήρωση`

### Actual result
`Η εγκατάσταση της PHP απαιτεί το JSON για Joomla να είναι εγκατεστημένο.`
`Διαμονή: &Omicron;&lambda;&omicron;&kappa;&lambda;ή&rho;&omega;&sigma;&eta;`


