### PR TITLE
Fix all access levels granted to guest users when root_user (emergency recovery variable) is specified in configuration.php

### DIFF
--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1073,7 +1073,7 @@ class Access
 		$user      = \JUser::getInstance($userId);
 		$root_user = \JFactory::getConfig()->get('root_user');
 
-		if ($root_user && ($root_user == $user->username || $root_user == $user->id))
+		if (($user->username && $user->username == $root_user) || (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
 		{
 			// Find the super user levels.
 			foreach (self::$viewLevels as $level => $rule)

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1073,8 +1073,7 @@ class Access
 		$user      = \JUser::getInstance($userId);
 		$root_user = \JFactory::getConfig()->get('root_user');
 
-		if (($user->username && $user->username == $root_user)
-		    || (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
+		if (($user->username && $user->username == $root_user) || (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
 		{
 			// Find the super user levels.
 			foreach (self::$viewLevels as $level => $rule)

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1073,7 +1073,10 @@ class Access
 		$user      = \JUser::getInstance($userId);
 		$root_user = \JFactory::getConfig()->get('root_user');
 
-		if (($user->username && $user->username == $root_user) || (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
+		if (
+			($user->username && $user->username == $root_user) ||
+			(is_numeric($root_user) && $user->id > 0 && $user->id == $root_user)
+		)
 		{
 			// Find the super user levels.
 			foreach (self::$viewLevels as $level => $rule)

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1073,10 +1073,8 @@ class Access
 		$user      = \JUser::getInstance($userId);
 		$root_user = \JFactory::getConfig()->get('root_user');
 
-		if (
-			($user->username && $user->username == $root_user) ||
-			(is_numeric($root_user) && $user->id > 0 && $user->id == $root_user)
-		)
+		if (($user->username && $user->username == $root_user)
+		    || (is_numeric($root_user) && $user->id > 0 && $user->id == $root_user))
 		{
 			// Find the super user levels.
 			foreach (self::$viewLevels as $level => $rule)


### PR DESCRIPTION
Pull Request for Issue #16997

### Summary of Changes
Currently there is a string with int comparison in the code (please see the code that i am chaning)
`$root_user == $user_id`

Example:
`"somename" == 0` will return **true**,
because "somename" typecasted to integer is 0 , thus you get
`0 == 0` which is true

There are several ways to fix the comparison, for consistenct, i choose to use same code as used in
`JUser::authorize()` method

### Testing Instructions
1. Make a module of "Registered" access level (better a module shown to all menu items)
2. Add `$root_user = "somename";`  to configuration.php
3. Visiting website without being logged

### Expected result
The module is not showed

### Actual result
The module is showed because all access levels have been granted to the guest user

### Documentation Changes Required
None
