### PR TITLE
Prevent the api url from being indexed

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -156,7 +156,7 @@ switch ($format)
 	case 'json' :
 
 		$app->setHeader('X-Robots-Tag', 'noindex');
-        $app->setHeader('Content-Type', 'application/json');
+		$app->setHeader('Content-Type', 'application/json');
 
 		echo new JResponseJson($results, null, false, $input->get('ignoreMessages', true, 'bool'));
 

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -21,6 +21,9 @@ defined('_JEXEC') or die;
 // Reference global application object
 $app = JFactory::getApplication();
 
+// Prevent the api url from being indexed
+$app->setHeader('X-Robots-Tag', 'noindex');
+
 // JInput object
 $input = $app->input;
 
@@ -155,7 +158,6 @@ switch ($format)
 	// JSONinzed
 	case 'json' :
 
-		$app->setHeader('X-Robots-Tag', 'noindex');
 		$app->setHeader('Content-Type', 'application/json');
 
 		echo new JResponseJson($results, null, false, $input->get('ignoreMessages', true, 'bool'));

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -154,6 +154,10 @@ switch ($format)
 {
 	// JSONinzed
 	case 'json' :
+
+		$app->setHeader('X-Robots-Tag', 'noindex');
+        $app->setHeader('Content-Type', 'application/json');
+
 		echo new JResponseJson($results, null, false, $input->get('ignoreMessages', true, 'bool'));
 
 		break;

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -22,7 +22,7 @@ defined('_JEXEC') or die;
 $app = JFactory::getApplication();
 
 // Prevent the api url from being indexed
-$app->setHeader('X-Robots-Tag', 'noindex');
+$app->setHeader('X-Robots-Tag', 'noindex, nofollow');
 
 // JInput object
 $input = $app->input;

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -158,8 +158,6 @@ switch ($format)
 	// JSONinzed
 	case 'json' :
 
-		$app->setHeader('Content-Type', 'application/json');
-
 		echo new JResponseJson($results, null, false, $input->get('ignoreMessages', true, 'bool'));
 
 		break;


### PR DESCRIPTION
Pull Request for Issue #16998.

### Summary of Changes
Prevent the api url from being indexed by search engines via the X-Robots-Tag which is acknowledged by at least [Google](https://developers.google.com/search/reference/robots_meta_tag?hl=en) and [Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240).

### Testing Instructions
1. Code review
2. Call http(s)://domain.tld/index.php?option=com_ajax&format=json in your browser (or programmatically)
3. Check the return header for the X-Robots-Tag with the value "noindex"

### Expected result
The X-Robots-Tag should be present in the response header.

### Actual result
The X-Robots-Tag ist not yet present in the response header.