### PR TITLE
correct test schema - change `TEXT` or `TIMESTAMP` to `DATETIME`

### DIFF
--- a/tests/unit/schema/ddl.sql
+++ b/tests/unit/schema/ddl.sql
@@ -44,16 +44,16 @@ CREATE TABLE `jos_categories` (
   `description` TEXT NOT NULL DEFAULT '',
   `published` INTEGER NOT NULL DEFAULT '0',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `access` INTEGER NOT NULL DEFAULT '0',
   `params` TEXT NOT NULL DEFAULT '',
   `metadesc` TEXT NOT NULL DEFAULT '',
   `metakey` TEXT NOT NULL DEFAULT '',
   `metadata` TEXT NOT NULL DEFAULT '',
   `created_user_id` INTEGER NOT NULL DEFAULT '0',
-  `created_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `created_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modified_user_id` INTEGER NOT NULL DEFAULT '0',
-  `modified_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `hits` INTEGER NOT NULL DEFAULT '0',
   `language` TEXT NOT NULL DEFAULT '',
 	`version` INTEGER NOT NULL DEFAULT '1'
@@ -82,15 +82,15 @@ CREATE TABLE `jos_content` (
   `fulltext` TEXT NOT NULL DEFAULT '',
   `state` INTEGER NOT NULL DEFAULT '0',
   `catid` INTEGER NOT NULL DEFAULT '0',
-  `created` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `created` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `created_by` INTEGER NOT NULL DEFAULT '0',
   `created_by_alias` TEXT NOT NULL DEFAULT '',
-  `modified` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modified` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modified_by` INTEGER NOT NULL DEFAULT '0',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `publish_up` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `publish_down` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `images` TEXT NOT NULL DEFAULT '',
   `urls` TEXT NOT NULL DEFAULT '',
   `attribs` TEXT NOT NULL DEFAULT '',
@@ -145,7 +145,7 @@ CREATE TABLE IF NOT EXISTS `jos_contentitem_tag_map` (
   `core_content_id` INTEGER NOT NULL,
   `content_item_id` INTEGER NOT NULL,
   `tag_id` INTEGER NOT NULL,
-  `tag_date` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `tag_date` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `type_id` INTEGER NOT NULL,
 	CONSTRAINT `idx_contentitemtagmap_uc_ItemnameTagid` UNIQUE (`type_id`,`content_item_id`,`tag_id`)
 );
@@ -188,7 +188,7 @@ CREATE TABLE `jos_extensions` (
   `custom_data` TEXT NOT NULL DEFAULT '',
   `system_data` TEXT NOT NULL DEFAULT '',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `ordering` INTEGER DEFAULT '0',
   `state` INTEGER DEFAULT '0'
 );
@@ -284,7 +284,7 @@ CREATE TABLE `jos_menu` (
   `level` INTEGER NOT NULL DEFAULT '0',
   `component_id` INTEGER NOT NULL DEFAULT '0',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `browserNav` INTEGER NOT NULL DEFAULT '0',
   `access` INTEGER NOT NULL DEFAULT '0',
   `img` TEXT NOT NULL DEFAULT '',
@@ -334,9 +334,9 @@ CREATE TABLE `jos_modules` (
   `ordering` INTEGER NOT NULL DEFAULT '0',
   `position` TEXT DEFAULT NULL,
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `publish_up` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `publish_down` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `published` INTEGER NOT NULL DEFAULT '0',
   `module` TEXT DEFAULT NULL,
   `access` INTEGER NOT NULL DEFAULT '0',
@@ -414,24 +414,24 @@ CREATE TABLE `jos_tags` (
   `description` TEXT NOT NULL DEFAULT '',
   `published` INTEGER NOT NULL DEFAULT '0',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `access` INTEGER NOT NULL DEFAULT '0',
   `params` TEXT NOT NULL DEFAULT '',
   `metadesc` TEXT NOT NULL DEFAULT '',
   `metakey` TEXT NOT NULL DEFAULT '',
   `metadata` TEXT NOT NULL DEFAULT '',
   `created_user_id` INTEGER NOT NULL DEFAULT '0',
-  `created_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-	`created_by_alias` TEXT NOT NULL DEFAULT '',
+  `created_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `created_by_alias` TEXT NOT NULL DEFAULT '',
   `modified_user_id` INTEGER NOT NULL DEFAULT '0',
-  `modified_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-	`images` TEXT NOT NULL DEFAULT '',
-	`urls` TEXT NOT NULL DEFAULT '',
+  `modified_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `images` TEXT NOT NULL DEFAULT '',
+  `urls` TEXT NOT NULL DEFAULT '',
   `hits` INTEGER NOT NULL DEFAULT '0',
   `language` TEXT NOT NULL DEFAULT '',
-	`version` INTEGER NOT NULL DEFAULT '1',
-	`publish_up` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-	`publish_down` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00'
+  `version` INTEGER NOT NULL DEFAULT '1',
+  `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00'
 );
 
 CREATE INDEX `idx_tags_lookup` ON `jos_tags` (`published`,`access`);
@@ -453,8 +453,8 @@ CREATE TABLE `jos_template_styles` (
   `template` TEXT NOT NULL DEFAULT '',
   `client_id` INTEGER NOT NULL DEFAULT '0',
   `home` TEXT NOT NULL DEFAULT '0',
-	`title` TEXT NOT NULL DEFAULT '',
-	`params` TEXT NOT NULL DEFAULT ''
+  `title` TEXT NOT NULL DEFAULT '',
+  `params` TEXT NOT NULL DEFAULT ''
 );
 
 CREATE INDEX `idx_template_styles_template` ON `jos_template_styles` (`template`);
@@ -490,7 +490,7 @@ CREATE TABLE `jos_ucm_content` (
   `core_alias` TEXT NOT NULL DEFAULT '',
   `core_body` TEXT NOT NULL DEFAULT '',
   `core_state` INTEGER NOT NULL DEFAULT '0',
-  `core_checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `core_checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `core_checked_out_user_id` INTEGER NOT NULL DEFAULT '0',
   `core_access` INTEGER NOT NULL DEFAULT '0',
   `core_params` TEXT NOT NULL DEFAULT '',
@@ -498,12 +498,12 @@ CREATE TABLE `jos_ucm_content` (
   `core_metadata` TEXT NOT NULL DEFAULT '',
   `core_created_user_id` INTEGER NOT NULL DEFAULT '0',
   `core_created_by_alias` TEXT NOT NULL DEFAULT '',
-  `core_created_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `core_created_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `core_modified_user_id` INTEGER NOT NULL DEFAULT '0',
-  `core_modified_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `core_modified_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `core_language` TEXT NOT NULL DEFAULT '',
-  `core_publish_up` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `core_publish_down` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `core_publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `core_publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `core_content_item_id` INTEGER NOT NULL DEFAULT '0',
   `asset_id` INTEGER NOT NULL DEFAULT '0',
   `core_images` TEXT NOT NULL DEFAULT '',
@@ -551,7 +551,7 @@ CREATE TABLE `jos_updates` (
   `version` TEXT DEFAULT '',
   `data` TEXT NOT NULL DEFAULT '',
   `detailsurl` TEXT NOT NULL DEFAULT '',
-	`infourl` TEXT NOT NULL DEFAULT ''
+  `infourl` TEXT NOT NULL DEFAULT ''
 );
 
 -- --------------------------------------------------------
@@ -566,7 +566,7 @@ CREATE TABLE `jos_update_sites` (
   `type` TEXT DEFAULT '',
   `location` TEXT NOT NULL DEFAULT '',
   `enabled` INTEGER DEFAULT '0',
-	`last_check_timestamp` INTEGER DEFAULT '0'
+  `last_check_timestamp` INTEGER DEFAULT '0'
 );
 
 -- --------------------------------------------------------
@@ -614,12 +614,12 @@ CREATE TABLE `jos_users` (
   `password` TEXT NOT NULL DEFAULT '',
   `block` INTEGER NOT NULL DEFAULT '0',
   `sendEmail` INTEGER DEFAULT '0',
-  `registerDate` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `lastvisitDate` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `registerDate` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `lastvisitDate` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `activation` TEXT NOT NULL DEFAULT '',
   `params` TEXT NOT NULL DEFAULT '',
-	`lastResetTime` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-	`resetCount` INTEGER DEFAULT '0'
+  `lastResetTime` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `resetCount` INTEGER DEFAULT '0'
 );
 
 CREATE INDEX `idx_users_name` ON `jos_users` (`name`);
@@ -693,10 +693,10 @@ CREATE TABLE `jos_dbtest_composite` (
   `asset_id` INTEGER NOT NULL DEFAULT '0',
   `hits` INTEGER NOT NULL DEFAULT '0',
   `checked_out` INTEGER NOT NULL DEFAULT '0',
-  `checked_out_time` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `checked_out_time` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `published` INTEGER NOT NULL DEFAULT '0',
-  `publish_up` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `publish_down` TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_up` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `publish_down` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
   `ordering` INTEGER NOT NULL DEFAULT '0',
   `params` TEXT NOT NULL DEFAULT '',
   CONSTRAINT `idx_dbtest_composite` PRIMARY KEY (`id1`,`id2`)

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -108,7 +108,7 @@ class JTableTest extends TestCaseDatabase
 				),
 				'checked_out_time' => (object) array(
 					'Field' => 'checked_out_time',
-					'Type' => 'TEXT',
+					'Type' => 'DATETIME',
 					'Null' => 'NO',
 					'Default' => '\'0000-00-00 00:00:00\'',
 					'Key' => ''
@@ -122,14 +122,14 @@ class JTableTest extends TestCaseDatabase
 				),
 				'publish_up' => (object) array(
 					'Field' => 'publish_up',
-					'Type' => 'TEXT',
+					'Type' => 'DATETIME',
 					'Null' => 'NO',
 					'Default' => '\'0000-00-00 00:00:00\'',
 					'Key' => ''
 				),
 				'publish_down' => (object) array(
 					'Field' => 'publish_down',
-					'Type' => 'TEXT',
+					'Type' => 'DATETIME',
 					'Null' => 'NO',
 					'Default' => '\'0000-00-00 00:00:00\'',
 					'Key' => ''


### PR DESCRIPTION
Pull Request for Issue test schema use wrong types.

### Summary of Changes
change some fields from `TEXT` or `TIMESTAMP` to `DATETIME`


### Testing Instructions
code review / tests pass


### Expected result
tests pass and have correct types


### Actual result
some fields used `TEXT` or `TIMESTAMP` when they should have been using `DATETIME`


### Documentation Changes Required
None, this is a testing setup fix
