### PR TITLE
Regression: Reverting PR 15724 as it breaks some User Profile parameters

### DIFF
--- a/components/com_users/models/registration.php
+++ b/components/com_users/models/registration.php
@@ -243,26 +243,12 @@ class UsersModelRegistration extends JModelForm
 			// Override the base user data with any data in the session.
 			$temp = (array) $app->getUserState('com_users.registration.data', array());
 
-			// Don't load the data in this getForm call, or we'll call ourself
-			$form = $this->getForm(array(), false);
+			$form = $this->getForm(array());
 
 			foreach ($temp as $k => $v)
 			{
-				// Here we could have a grouped field, let's check it
-				if (is_array($v))
-				{
-					$this->data->$k = new stdClass;
-
-					foreach ($v as $key => $val)
-					{
-						if ($form->getField($key, $k) !== false)
-						{
-							$this->data->$k->$key = $val;
-						}
-					}
-				}
 				// Only merge the field if it exists in the form.
-				elseif ($form->getField($k) !== false)
+				if ($form->getField($k) !== false)
 				{
 					$this->data->$k = $v;
 				}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17001

### Summary of Changes
Revert #15724

### Testing Instructions
Set some User Profile plugin fields for registration and administrator user forms to Optional and Required.
Details in https://github.com/joomla/joomla-cms/issues/17001#issuecomment-313902739

### Expected result
The frontend Registration and backend Create User obey to the plugin parameters

### Actual result
All fields are presented as Optional and the TOS link is missing.

### NOTE:
By reverting https://github.com/joomla/joomla-cms/pull/15724, which purpose was to `Refill fields when there is an error in the registration`, we lose this nice feature BUT it breaks badly the user profile settings.
These settings have priority imho over #15724

Any other solution which would keep the feature is welcome.
@bembelimen 
