### PR TITLE
[4.0] Hide toggle on edit view

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -83,18 +83,19 @@ $this->setMetaData('theme-color', '#1c3d5c');
 		<header id="header" class="header">
 			<div class="container-fluid">
 				<div class="d-flex row justify-content-end">
+					<?php if (!$hidden) : ?>
 					<div class="menu-collapse">
 						<a id="menu-collapse" class="menu-toggle" href="#">
 							<span class="menu-toggle-icon fa fa-chevron-left fa-fw" aria-hidden="true"></span>
 							<span class="sr-only"><?php echo JText::_('TPL_ATUM_CONTROL_PANEL_MENU'); ?></span>
 						</a>
 					</div>
+					<?php endif; ?>
 					<div class="d-flex col">
 						<div class="container-title">
 							<jdoc:include type="modules" name="title" />
 						</div>
 					</div>
-
 					<div class="ml-auto">
 						<ul class="nav text-center">
 							<li class="nav-item">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Hides the sidebar toggle button on edit views


### Testing Instructions
Navigate to any edit view. Ensure toggle is removed.


### Before
![edit-toggle1](https://user-images.githubusercontent.com/2803503/28013137-ef701154-655f-11e7-86d0-2cbb4986f5ac.png)



### After
![edit-toggle2](https://user-images.githubusercontent.com/2803503/28013144-f324d6a4-655f-11e7-9dd1-468256c9664e.png)



### Documentation Changes Required

