### PR TITLE
Remove unnecessary inline style parameter

### DIFF
--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -141,7 +141,7 @@ if ($saveOrder)
 								<span class="icon-menu" aria-hidden="true"></span>
 							</span>
 								<?php if ($canChange && $saveOrder) : ?>
-									<input type="text" style="display:none" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
+									<input type="text" name="order[]" size="5" value="<?php echo $item->ordering; ?>" class="width-20 text-area-order" />
 								<?php endif; ?>
 							</td>
 							<td class="center">


### PR DESCRIPTION
Someone added an unnecessary inline style with "display. none" parameter to the line 144.
This line makes an input field for article ordering numbers when the selected listing is the ordering.
This function not work with the inline style parameter.

Pull Request for Issue # .

### Summary of Changes

Line 144, removed this: style="display: none;"

### Testing Instructions

Choose the futured articles in backend and change the column ordering to the first column (sequence?)

### Expected result

Between the drag&drop icon and the checkbox appear the input field with the article ordering number.

### Actual result

If you choose the ordering sequence, nothing else between the drag&drop and checkbox

### Documentation Changes Required
Please help for here. 
