### PR TITLE
[4.0] Removal of tooltips - PART 1

### DIFF
--- a/administrator/components/com_admin/tmpl/help/default.php
+++ b/administrator/components/com_admin/tmpl/help/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_admin&amp;view=help'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
 JHtml::_('jquery.framework');
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $listOrder        = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -19,7 +19,6 @@ if ($app->isClient('site'))
 }
 
 JHtml::_('jquery.framework');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', 'select');
 

--- a/administrator/components/com_banners/helpers/html/banner.php
+++ b/administrator/components/com_banners/helpers/html/banner.php
@@ -25,8 +25,6 @@ abstract class JHtmlBanner
 	 */
 	public static function clients()
 	{
-		JHtml::_('bootstrap.tooltip');
-
 		// Create the batch selector to change the client on a selection list.
 		return implode(
 			"\n",

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.tabstate');
 

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 

--- a/administrator/components/com_banners/tmpl/download/default.php
+++ b/administrator/components/com_banners/tmpl/download/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
 <div class="container-popup">
 	<form

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-
-JHtml::_('bootstrap.tooltip');
-
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));
 ?>

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-
-JHtml::_('bootstrap.tooltip');
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -14,7 +14,6 @@ use Joomla\String\Inflector;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -22,12 +22,6 @@ JLoader::register('ContentHelperRoute', JPATH_ROOT . '/components/com_content/he
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $extension = $this->escape($this->state->get('filter.extension'));
 $function  = $app->input->getCmd('function', 'jSelectCategory');

--- a/administrator/components/com_categories/tmpl/category/modal.php
+++ b/administrator/components/com_categories/tmpl/category/modal.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 // @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since 3.7.0.
 $function  = JFactory::getApplication()->input->getCmd('function', 'jEditCategory_' . (int) $this->item->id);
 

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -9,9 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -14,7 +14,6 @@ use Joomla\Registry\Registry;
 // Load tooltips behavior
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.tabstate');
 
 // Load JS message titles

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -13,7 +13,6 @@ $app = JFactory::getApplication();
 $template = $app->getTemplate();
 
 // Load the tooltip behavior.
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.tabstate');

--- a/administrator/components/com_contact/tmpl/contact/modal.php
+++ b/administrator/components/com_contact/tmpl/contact/modal.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 // @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since 3.7.0.
 $function  = JFactory::getApplication()->input->getCmd('function', 'jEditContact_' . (int) $this->item->id);
 

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.tabstate');
 

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -21,13 +21,7 @@ JLoader::register('ContactHelperRoute', JPATH_ROOT . '/components/com_contact/he
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 JHtml::_('script', 'com_contact/admin-contacts-modal.min.js', array('version' => 'auto', 'relative' => true));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $function  = $app->input->getCmd('function', 'jSelectContact');
 $editor    = $app->input->getCmd('editor', '');

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -100,8 +100,6 @@ abstract class JHtmlContentAdministrator
 	 */
 	public static function featured($value = 0, $i, $canChange = true)
 	{
-		JHtml::_('bootstrap.tooltip');
-
 		// Array of image, task, title, action
 		$states = array(
 			0 => array('unfeatured', 'articles.featured', 'COM_CONTENT_UNFEATURED', 'JGLOBAL_TOGGLE_FEATURED'),

--- a/administrator/components/com_content/tmpl/article/modal.php
+++ b/administrator/components/com_content/tmpl/article/modal.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 // @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since 3.7.0.
 $function  = JFactory::getApplication()->input->getCmd('function', 'jEditArticle_' . (int) $this->item->id);
 

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $app       = JFactory::getApplication();

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -23,11 +23,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('script', 'com_content/admin-articles-modal.min.js', array('version' => 'auto', 'relative' => true));
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $function  = $app->input->getCmd('function', 'jSelectArticle');
 $editor    = $app->input->getCmd('editor', '');

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $user      = JFactory::getUser();

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 JSession::checkToken('get') or die(JText::_('JINVALID_TOKEN'));
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('behavior.multiselect');
 JHtml::_('jquery.framework');
 

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $app       = JFactory::getApplication();

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -14,13 +14,8 @@ if (JFactory::getApplication()->isClient('site'))
 }
 
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', '.advancedSelect');
 JHtml::_('script', 'com_fields/admin-fields-modal.js', array('version' => 'auto', 'relative' => true));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', '.advancedSelect');
 

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -9,9 +9,6 @@
 
 defined('_JEXEC') or die;
 
-
-JHtml::_('bootstrap.tooltip');
-
 $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Finder\Administrator\Helper\FinderHelperLanguage;
 
-JHtml::_('bootstrap.tooltip');
-
 JHtml::_('bootstrap.popover');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Finder\Administrator\Helper\FinderHelperLanguage;
 
-JHtml::_('bootstrap.tooltip');
-
 $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = JFactory::getLanguage();

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -10,8 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
-JHtml::_('bootstrap.tooltip');
-
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -15,7 +15,6 @@ JText::script('PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH');
 JText::script('PLG_INSTALLER_URLINSTALLER_NO_URL');
 JText::script('COM_INSTALLER_MSG_INSTALL_ENTER_A_URL');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.tabstate');
 JHtml::_('stylesheet', 'com_installer/installer.css', false, true);
 JHtml::_('script', 'com_installer/installer.js', false, true);

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
-JHtml::_('bootstrap.tooltip');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
-JHtml::_('bootstrap.tooltip');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
 
-JHtml::_('bootstrap.tooltip');
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.multiselect');
 
-JHtml::_('bootstrap.tooltip');
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default.php
@@ -12,8 +12,6 @@ defined('_JEXEC') or die;
 /** @var JoomlaupdateViewDefault $this */
 
 JHtml::_('jquery.framework');
-JHtml::_('bootstrap.tooltip');
-
 JHtml::_('behavior.core');
 JText::script('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE', true);
 

--- a/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 
 $twofactormethods = \Joomla\CMS\Helper\AuthenticationHelper::getTwoFactorMethods();
 

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 
 $twofactormethods = \Joomla\CMS\Helper\AuthenticationHelper::getTwoFactorMethods();
 

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -12,9 +12,6 @@ defined('_JEXEC') or die;
 // Add specific helper files for html generation
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-
-JHtml::_('bootstrap.tooltip');
-
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -13,8 +13,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.multiselect');
 
-JHtml::_('bootstrap.tooltip');
-
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -11,9 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Languages\Administrator\Helper\LanguagesHelper;
 
-
-JHtml::_('bootstrap.tooltip');
-
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 $client    = $this->state->get('filter.client') == '0' ? JText::_('JSITE') : JText::_('JADMINISTRATOR');
 $language  = $this->state->get('filter.language');

--- a/administrator/components/com_menus/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/Field/Modal/MenuField.php
@@ -129,8 +129,6 @@ class MenuField extends FormField
 
 		if ($return)
 		{
-			\JHtml::_('bootstrap.tooltip', '.hasTooltip');
-
 			$this->allowSelect = ((string) $this->element['select']) !== 'false';
 			$this->allowClear = ((string) $this->element['clear']) !== 'false';
 			$this->allowNew = ((string) $this->element['new']) === 'true';

--- a/administrator/components/com_menus/tmpl/item/modal.php
+++ b/administrator/components/com_menus/tmpl/item/modal.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
 <button id="applyBtn" type="button" class="sr-only" onclick="Joomla.submitbutton('item.apply'); jEditMenuModal();"></button>
 <button id="saveBtn" type="button" class="sr-only" onclick="Joomla.submitbutton('item.save'); jEditMenuModal();"></button>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $user      = JFactory::getUser();

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -20,11 +20,6 @@ JHtml::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('script', 'com_menus/admin-items-modal.min.js', array('version' => 'auto', 'relative' => true));
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $function     = $app->input->get('function', 'jSelectMenuItem', 'cmd');
 $editor    = $app->input->getCmd('editor', '');

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $uri       = JUri::getInstance();

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -14,7 +14,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
 <div class="container-popup">
 	<form action="<?php echo JRoute::_('index.php?option=com_messages&view=config'); ?>" method="post" name="adminForm" id="message-form">

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 ?>
 <button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.apply');"></button>
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -9,9 +9,7 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $clientId  = (int) $this->state->get('client_id', 0);
 $user      = JFactory::getUser();

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -16,14 +16,9 @@ if (JFactory::getApplication()->isClient('site'))
 
 // Load needed scripts
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
 
 // Scripts for the modules xtd-button
 JHtml::_('script', 'com_modules/admin-modules-modal.min.js', array('version' => 'auto', 'relative' => true));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 // @deprecated 4.0 the function parameter, the inline js and the buttons are not needed since 3.7.0.
 $function  = JFactory::getApplication()->input->getCmd('function', 'jEditNewsfeed_' . (int) $this->item->id);
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.tabstate');
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -14,11 +14,6 @@ JLoader::register('NewsfeedsHelperRoute', JPATH_ROOT . '/components/com_newsfeed
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $app = JFactory::getApplication();
 

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -13,7 +13,6 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 
 $this->fieldsets = $this->form->getFieldsets('params');
 ?>

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.tabstate');
 

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $user      = JFactory::getUser();

--- a/administrator/components/com_search/tmpl/searches/default.php
+++ b/administrator/components/com_search/tmpl/searches/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -14,7 +14,6 @@ use Joomla\String\Inflector;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $app       = JFactory::getApplication();

--- a/administrator/components/com_templates/helpers/html/templates.php
+++ b/administrator/components/com_templates/helpers/html/templates.php
@@ -38,8 +38,6 @@ class JHtmlTemplates
 
 		if (file_exists($thumb))
 		{
-			JHtml::_('bootstrap.tooltip');
-
 			$clientPath = ($clientId == 0) ? '' : 'administrator/';
 			$thumb = $clientPath . 'templates/' . $template . '/template_thumbnail.png';
 			$html = JHtml::_('image', $thumb, JText::_('COM_TEMPLATES_PREVIEW'));

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $user      = JFactory::getUser();
 $clientId = (int) $this->state->get('client_id', 0);

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.tabstate');

--- a/administrator/components/com_templates/tmpl/template/readonly.php
+++ b/administrator/components/com_templates/tmpl/template/readonly.php
@@ -12,8 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
-
 $input = JFactory::getApplication()->input;
 ?>
 <form action="<?php echo JRoute::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $user      = JFactory::getUser();
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_users/views/debuggroup/tmpl/default.php
+++ b/administrator/components/com_users/views/debuggroup/tmpl/default.php
@@ -12,9 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
-
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $colSpan   = 4 + count($this->actions);

--- a/administrator/components/com_users/views/debuguser/tmpl/default.php
+++ b/administrator/components/com_users/views/debuguser/tmpl/default.php
@@ -12,9 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
-
-
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $colSpan   = 4 + count($this->actions);

--- a/administrator/components/com_users/views/groups/tmpl/default.php
+++ b/administrator/components/com_users/views/groups/tmpl/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $user        = JFactory::getUser();

--- a/administrator/components/com_users/views/levels/tmpl/default.php
+++ b/administrator/components/com_users/views/levels/tmpl/default.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
-
 
 $user       = JFactory::getUser();
 $listOrder  = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_users/views/notes/tmpl/default.php
+++ b/administrator/components/com_users/views/notes/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 
 $user       = JFactory::getUser();

--- a/administrator/components/com_users/views/users/tmpl/default.php
+++ b/administrator/components/com_users/views/users/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.multiselect');
 JHtml::_('behavior.tabstate');
 

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -11,13 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
-JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
-
 JHtml::_('behavior.multiselect');
-
-// Special case for the search field tooltip.
-$searchFilterDesc = $this->filterForm->getFieldAttribute('search', 'description', null, 'filter');
-JHtml::_('bootstrap.tooltip', '#filter_search', array('title' => JText::_($searchFilterDesc), 'placement' => 'bottom'));
 
 $input           = JFactory::getApplication()->input;
 $field           = $input->getCmd('field');

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 ?>
 <ul class="list-group list-group-flush">
 	<?php if (count($list)) : ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 ?>
 <ul class="list-group list-group-flush">
 	<?php foreach ($users as $user) : ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -10,7 +10,6 @@
 defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 
 $spacing = 0;
 

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 ?>
 <ul class="list-group list-group-flush">
 	<?php if (count($list)) : ?>

--- a/administrator/templates/atum/html/pagination.php
+++ b/administrator/templates/atum/html/pagination.php
@@ -191,7 +191,6 @@ function pagination_item_active(&$item)
 	$title = '';
 	if (!is_numeric($item->text))
 	{
-		JHtml::_('bootstrap.tooltip');
 		$title = ' class="hasTooltip" title="' . $item->text . '"';
 	}
 

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -16,7 +16,6 @@ $lang = JFactory::getLanguage();
 
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
-JHtml::_('bootstrap.tooltip');
 JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);
 
 // Load template CSS file

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 // Load tooltips behavior
 JHtml::_('behavior.formvalidator');
-JHtml::_('bootstrap.tooltip');
-
 
 JFactory::getDocument()->addScriptDeclaration("
 	Joomla.submitbutton = function(task)

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 JHtml::_('behavior.formvalidator');
 JHtml::_('behavior.keepalive');
 JHtml::_('behavior.combobox');

--- a/components/com_contact/tmpl/categories/default_items.php
+++ b/components/com_contact/tmpl/categories/default_items.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Contact\Site\Helper\Route as ContactHelperRoute;
 
-JHtml::_('bootstrap.tooltip');
-
 $class = ' class="first"';
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>

--- a/components/com_content/tmpl/categories/default_items.php
+++ b/components/com_content/tmpl/categories/default_items.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $class = ' class="first"';
 $lang  = JFactory::getLanguage();
 

--- a/components/com_content/tmpl/category/blog_children.php
+++ b/components/com_content/tmpl/category/blog_children.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $class = ' class="first"';
 $lang  = JFactory::getLanguage();
 

--- a/components/com_content/tmpl/category/default_children.php
+++ b/components/com_content/tmpl/category/default_children.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $class = ' class="first"';
 $lang  = JFactory::getLanguage();
 ?>

--- a/components/com_newsfeeds/tmpl/categories/default_items.php
+++ b/components/com_newsfeeds/tmpl/categories/default_items.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Newsfeeds\Site\Helper\Route as NewsfeedsHelperRoute;
 
-JHtml::_('bootstrap.tooltip');
-
 $class = ' class="first"';
 if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 ?>

--- a/components/com_search/tmpl/search/default_form.php
+++ b/components/com_search/tmpl/search/default_form.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $lang = JFactory::getLanguage();
 $upper_limit = $lang->getUpperLimitSearchWord();
 ?>

--- a/layouts/joomla/content/categories_default_items.php
+++ b/layouts/joomla/content/categories_default_items.php
@@ -10,7 +10,6 @@
 defined('JPATH_BASE') or die;
 
 $class = ' class="first"';
-JHtml::_('bootstrap.tooltip');
 
 $item = $displayData->item;
 $items = $displayData->get('items');

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $params = $displayData['params'];
 $legacy = $displayData['legacy'];
 

--- a/layouts/joomla/content/icons/edit.php
+++ b/layouts/joomla/content/icons/edit.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $article = $displayData['article'];
 $overlib = $displayData['overlib'];
 $legacy  = $displayData['legacy'];

--- a/layouts/joomla/content/icons/edit_lock.php
+++ b/layouts/joomla/content/icons/edit_lock.php
@@ -9,8 +9,6 @@
 
 defined('JPATH_BASE') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $tooltip = $displayData['tooltip'];
 $legacy  = $displayData['legacy'];
 

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -60,8 +60,7 @@ $moduleHtml = preg_replace(
 
 if ($count)
 {
-	// Load once booststrap tooltip and add stylesheet and javascript to head:
-	JHtml::_('bootstrap.tooltip');
+	// Load stylesheet and javascript to head:
 	JHtml::_('bootstrap.popover');
 
 	JHtml::_('stylesheet', 'system/frontediting.css', array('version' => 'auto', 'relative' => true));

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -35,12 +35,6 @@ use Joomla\CMS\Component\ComponentHelper;
  */
 extract($displayData);
 
-// The button.
-if ($disabled != true)
-{
-	JHtml::_('bootstrap.tooltip');
-}
-
 $attr = '';
 
 // Initialize some field attributes.

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -57,6 +57,7 @@ $autocomplete = $autocomplete === ' autocomplete="on"' ? '' : $autocomplete;
 $attributes = array(
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
 	!empty($size) ? 'size="' . $size . '"' : '',
+	!empty($description) ? 'title="' . $description . '"' : '',
 	$disabled ? 'disabled' : '',
 	$readonly ? 'readonly' : '',
 	$list,

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -43,7 +43,6 @@ if (!empty($description))
 	}
 	else
 	{
-		JHtml::_('bootstrap.tooltip');
 		$classes[] = 'hasTooltip';
 		$title     = ' title="' . JHtml::_('tooltipText', trim($text, ':'), $description, 0) . '"';
 	}

--- a/layouts/joomla/modal/main.php
+++ b/layouts/joomla/modal/main.php
@@ -11,9 +11,6 @@ defined('JPATH_BASE') or die;
 
 use Joomla\Utilities\ArrayHelper;
 
-// Load bootstrap-tooltip-extended plugin for additional tooltip positions in modal
-JHtml::_('bootstrap.tooltip');
-
 extract($displayData);
 
 /**

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -64,7 +64,6 @@ if ($displayData['active'])
 
 	if (!is_numeric($item->text))
 	{
-		JHtml::_('bootstrap.tooltip');
 		$cssClasses[] = 'hasTooltip';
 		$title = ' title="' . $item->text . '" ';
 	}

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -41,9 +41,6 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<div class="btn-group mr-2">
 				<div class="input-group">
 					<?php echo $filters['filter_search']->input; ?>
-					<?php if ($filters['filter_search']->description) : ?>
-						<?php JHtmlBootstrap::tooltip('#filter_search', array('title' => JText::_($filters['filter_search']->description))); ?>
-					<?php endif; ?>
 					<span class="input-group-btn">
 						<button type="submit" class="btn btn-secondary hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>">
 							<span class="icon-search"></span>

--- a/libraries/cms/html/grid.php
+++ b/libraries/cms/html/grid.php
@@ -32,7 +32,6 @@ abstract class JHtmlGrid
 	{
 		// Load the behavior.
 		static::behavior();
-		JHtml::_('bootstrap.tooltip');
 
 		// Build the title.
 		$title = $value ? JText::_('JYES') : JText::_('JNO');
@@ -130,7 +129,6 @@ abstract class JHtmlGrid
 	public static function checkall($name = 'checkall-toggle', $tip = 'JGLOBAL_CHECK_ALL', $action = 'Joomla.checkAll(this)')
 	{
 		JHtml::_('behavior.core');
-		JHtml::_('bootstrap.tooltip');
 
 		return '<input type="checkbox" name="' . $name . '" value="" class="hasTooltip" title="' . JHtml::_('tooltipText', $tip)
 			. '" onclick="' . $action . '">';
@@ -300,8 +298,6 @@ abstract class JHtmlGrid
 
 		if ($overlib)
 		{
-			JHtml::_('bootstrap.tooltip');
-
 			$date = JHtml::_('date', $row->checked_out_time, JText::_('DATE_FORMAT_LC1'));
 			$time = JHtml::_('date', $row->checked_out_time, 'H:i');
 

--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -57,8 +57,6 @@ abstract class JHtmlJGrid
 
 		if ($tip)
 		{
-			JHtml::_('bootstrap.tooltip');
-
 			$title = $enabled ? $active_title : $inactive_title;
 			$title = $translate ? JText::_($title) : $title;
 			$title = JHtml::_('tooltipText', $title, '', 0);
@@ -328,8 +326,6 @@ abstract class JHtmlJGrid
 	 */
 	public static function checkedout($i, $editorName, $time, $prefix = '', $enabled = false, $checkbox = 'cb')
 	{
-		JHtml::_('bootstrap.tooltip');
-
 		if (is_array($prefix))
 		{
 			$options = $prefix;

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -136,8 +136,6 @@ class JFormFieldRules extends JFormField
 	 */
 	protected function getInput()
 	{
-		JHtml::_('bootstrap.tooltip');
-
 		// Add Javascript for permission change
 		JHtml::_('script', 'system/fields/permissions.min.js', array('version' => 'auto', 'relative' => true));
 

--- a/libraries/joomla/form/fields/spacer.php
+++ b/libraries/joomla/form/fields/spacer.php
@@ -77,7 +77,6 @@ class JFormFieldSpacer extends JFormField
 			// If a description is specified, use it to build a tooltip.
 			if (!empty($this->description))
 			{
-				JHtml::_('bootstrap.tooltip');
 				$label .= ' title="' . JHtml::_('tooltipText', trim($text, ':'), JText::_($this->description), 0) . '"';
 			}
 

--- a/libraries/src/CMS/Pagination/Pagination.php
+++ b/libraries/src/CMS/Pagination/Pagination.php
@@ -713,7 +713,6 @@ class Pagination
 
 		if (!is_numeric($item->text))
 		{
-			\JHtml::_('bootstrap.tooltip');
 			$title = ' title="' . $item->text . '"';
 			$class = 'hasTooltip ';
 		}

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 ?>
 
 <ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -11,8 +11,6 @@ defined('_JEXEC') or die;
 
 JHtml::addIncludePath(JPATH_SITE . '/components/com_finder/helpers/html');
 
-JHtml::_('bootstrap.tooltip');
-
 // Load the smart search component language file.
 $lang = JFactory::getLanguage();
 $lang->load('com_finder', JPATH_SITE);

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 JLoader::register('UsersHelperRoute', JPATH_SITE . '/components/com_users/helpers/route.php');
 
 JHtml::_('behavior.keepalive');
-JHtml::_('bootstrap.tooltip');
 
 ?>
 <form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form">

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $app = JFactory::getApplication('administrator');
 ?>
 

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
-
 $token   = JSession::getFormToken();
 $return  = JFactory::getApplication()->input->getBase64('return');
 $maxSize = JFilesystemHelper::fileUploadMaxSize();

--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -9,7 +9,6 @@
 
 defined('_JEXEC') or die;
 
-JHtml::_('bootstrap.tooltip');
 ?>
 
 <legend><?php echo JText::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></legend>

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -229,7 +229,6 @@ class PlgSystemDebug extends CMSPlugin
 		// Only if debugging is enabled for SQL query popovers.
 		if (JDEBUG && $this->isAuthorisedDisplayDebug())
 		{
-			JHtml::_('bootstrap.tooltip');
 			JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'top'));
 		}
 	}


### PR DESCRIPTION
### Summary of Changes

This PR is the start of the removal of tooltips. It remove all `JHtml::_('bootstrap.tooltip');` calls from core

@brianteeman @dgt41 


