### PR TITLE
com contact options missing description

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -368,7 +368,7 @@
 			name="show_links"
 			type="radio"
 			label="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
-			description="COM_CONTACT_FIELD_SHOW_LINKS_LABEL"
+			description="COM_CONTACT_FIELD_SHOW_LINKS_DESC"
 			default="1"
 			class="btn-group btn-group-yesno"
 			>


### PR DESCRIPTION
The final option in com_contacts for Content Links was incorrectly using the _LABEL string where it should have been using the _DESC

### Before
<img width="357" alt="screenshotr18-26-35" src="https://user-images.githubusercontent.com/1296369/28031152-4de7ff56-659e-11e7-8a7f-f548f8271f1c.png">


### After
<img width="424" alt="screenshotr18-34-26" src="https://user-images.githubusercontent.com/1296369/28031192-670b5a28-659e-11e7-9ceb-f698b9987b39.png">
