### PR TITLE
[chromestyle] - manage admin template module style

### DIFF
--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -27,6 +27,103 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 	public $type = 'ChromeStyle';
 
 	/**
+	 * The client ID.
+	 *
+	 * @var    integer
+	 * @since  3.2
+	 */
+	protected $clientId;
+
+	/**
+	 * Method to get certain otherwise inaccessible properties from the form field object.
+	 *
+	 * @param   string  $name  The property name for which to the the value.
+	 *
+	 * @return  mixed  The property value or null.
+	 *
+	 * @since   3.2
+	 */
+	public function __get($name)
+	{
+		switch ($name)
+		{
+			case 'clientId':
+				return $this->clientId;
+		}
+
+		return parent::__get($name);
+	}
+
+	/**
+	 * Method to set certain otherwise inaccessible properties of the form field object.
+	 *
+	 * @param   string  $name   The property name for which to the the value.
+	 * @param   mixed   $value  The value of the property.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.2
+	 */
+	public function __set($name, $value)
+	{
+		switch ($name)
+		{
+			case 'clientId':
+				$this->clientId = (string) $value;
+				break;
+
+			default:
+				parent::__set($name, $value);
+		}
+	}
+
+	/**
+	 * Method to attach a JForm object to the field.
+	 *
+	 * @param   SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed             $value    The form field value to validate.
+	 * @param   string            $group    The field name group control value. This acts as an array container for the field.
+	 *                                      For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                      full field name would end up being "bar[foo]".
+	 *
+	 * @return  boolean  True on success.
+	 *
+	 * @see     JFormField::setup()
+	 * @since   3.2
+	 */
+	public function setup(SimpleXMLElement $element, $value, $group = null)
+	{
+		$result = parent::setup($element, $value, $group);
+
+		if ($result === true)
+		{
+			// Get the client id.
+			$clientId = $this->element['client_id'];
+
+			if (!isset($clientId))
+			{
+				$clientName = $this->element['client'];
+
+				if (isset($clientName))
+				{
+					$client = JApplicationHelper::getClientInfo($clientName, true);
+					$clientId = $client->id;
+				}
+			}
+
+			if (!isset($clientId) && $this->form instanceof JForm)
+			{
+				$clientId = $this->form->getValue('client_id');
+			}
+
+			$this->clientId = (int) $clientId;
+		}
+
+		return $result;
+	}
+
+
+	/**
 	 * Method to get the list of template chrome style options
 	 * grouped by template.
 	 *
@@ -75,10 +172,16 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 
 		$templates = array($this->getSystemTemplate());
 		$templates = array_merge($templates, $this->getTemplates());
+		$path      = JPATH_ADMINISTRATOR;
+
+		if ($this->clientId === 0)
+		{
+			$path = JPATH_SITE;
+		}
 
 		foreach ($templates as $template)
 		{
-			$modulesFilePath = JPATH_SITE . '/templates/' . $template->element . '/html/modules.php';
+			$modulesFilePath = $path . '/templates/' . $template->element . '/html/modules.php';
 
 			// Is there modules.php for that template?
 			if (file_exists($modulesFilePath))
@@ -133,7 +236,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 		// Build the query.
 		$query->select('element, name, enabled')
 			->from('#__extensions')
-			->where('client_id = 0')
+			->where('client_id = ' . $this->clientId)
 			->where('type = ' . $db->quote('template'));
 
 		// Set the query and load the templates.

--- a/libraries/cms/form/field/chromestyle.php
+++ b/libraries/cms/form/field/chromestyle.php
@@ -37,7 +37,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -57,7 +57,7 @@ class JFormFieldChromeStyle extends JFormFieldGroupedList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to get the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for Issue #17054 .

### Summary of Changes
manage admin template module style like "moduleposition"


### Testing Instructions
edit a admin module from backend >advandec tab
and check for Module Style


### Expected result
module style ar from admin templates
![expected](https://user-images.githubusercontent.com/181681/28034136-a461d598-65b0-11e7-9b7b-b182a1f9643e.png)


### Actual result

module style ar from fronted templates

### Documentation Changes Required

