### PR TITLE
Reference issue #17065 - REGRESSION[4.0]: Database driver limit/offset not working anymore for SQL strings

### DIFF
--- a/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php
+++ b/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php
@@ -829,6 +829,11 @@ class MysqliDriver extends DatabaseDriver implements UTF8MB4SupportInterface
 		{
 			// Allows taking advantage of bound variables in a direct query:
 			$query = $this->getQuery(true)->setQuery($query);
+			
+			// Allows to set a LIMIT clause for direct query
+			if($offset || $limit) {
+				$query->setQuery($query->processLimit($query->sql, $limit, $offset));
+			}
 		}
 
 		if ($query instanceof LimitableInterface && !is_null($offset) && !is_null($limit))


### PR DESCRIPTION
Pull Request for Issue #17065 .

### Summary of Changes
Allow to set a LIMIT clause for direct queries.


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

