### PR TITLE
Spelling fix

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -193,7 +193,7 @@ class AdminModelSysInfo extends JModelLegacy
 	}
 
 	/**
-	 * Offuscate section values
+	 * Obfuscate section values
 	 *
 	 * @param   mixed  $sectionValues  Section data
 	 *


### PR DESCRIPTION
Or perhaps merely a usage fix. "Offuscate" is a real English word, but it's archaic, hasn't been used much since the 17th century. "Obfuscate" is the prevailing term for what this method wants to do.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

