### PR TITLE
Regression: Multilingual com_tags getting wrong language cookie

### DIFF
--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -145,7 +145,22 @@ class JHelperContent
 	public static function getCurrentLanguage($detectBrowser = true)
 	{
 		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+		// Get the languagefilter parameters
+		if (JLanguageMultilang::isEnabled())
+		{
+			$plugin       = JPluginHelper::getPlugin('system', 'languagefilter');
+			$pluginParams = new JRegistry($plugin->params);
+
+			if ((int) $pluginParams->get('lang_cookie', 1) === 1)
+			{
+				$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+			}
+			else
+			{
+				$langCode = JFactory::getSession()->get('plg_system_languagefilter.language');
+			}
+		}
 
 		// No cookie - let's try to detect browser language or use site default
 		if (!$langCode)

--- a/libraries/cms/helper/content.php
+++ b/libraries/cms/helper/content.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Helper for standard content style extensions.
  * This class mainly simplifies static helper methods often repeated in individual components
@@ -150,7 +152,7 @@ class JHelperContent
 		if (JLanguageMultilang::isEnabled())
 		{
 			$plugin       = JPluginHelper::getPlugin('system', 'languagefilter');
-			$pluginParams = new JRegistry($plugin->params);
+			$pluginParams = new Registry($plugin->params);
 
 			if ((int) $pluginParams->get('lang_cookie', 1) === 1)
 			{

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\Registry\Registry;
+
 /**
  * Base Helper class.
  *
@@ -33,7 +35,7 @@ class JHelper
 		if (JLanguageMultilang::isEnabled())
 		{
 			$plugin       = JPluginHelper::getPlugin('system', 'languagefilter');
-			$pluginParams = new JRegistry($plugin->params);
+			$pluginParams = new Registry($plugin->params);
 
 			if ((int) $pluginParams->get('lang_cookie', 1) === 1)
 			{

--- a/libraries/cms/helper/helper.php
+++ b/libraries/cms/helper/helper.php
@@ -28,7 +28,22 @@ class JHelper
 	public function getCurrentLanguage($detectBrowser = true)
 	{
 		$app = JFactory::getApplication();
-		$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+
+		// Get the languagefilter parameters
+		if (JLanguageMultilang::isEnabled())
+		{
+			$plugin       = JPluginHelper::getPlugin('system', 'languagefilter');
+			$pluginParams = new JRegistry($plugin->params);
+
+			if ((int) $pluginParams->get('lang_cookie', 1) === 1)
+			{
+				$langCode = $app->input->cookie->getString(JApplicationHelper::getHash('language'));
+			}
+			else
+			{
+				$langCode = JFactory::getSession()->get('plg_system_languagefilter.language');
+			}
+		}
 
 		// No cookie - let's try to detect browser language or use site default
 		if (!$langCode)


### PR DESCRIPTION
Pull Request for Issue #17053

### Summary of Changes
JHelper and JHelperContent do not take into account both ways of setting a lang cookie by the languagefilter plugin.
If the setting is to a year, the cookie is stored separately.
If the setting is set to Session, it is set in the session cookie (this was introduced in https://github.com/joomla/joomla-cms/pull/12306 )

com_tags (and possibly some 3rd party extensions) use these classes to display the tags when the parameter is set to use `current_language`

### Testing Instructions
See details in #17053 

Set the languagefilter `Cookie lifetime` to `Session`:

![screen shot 2017-07-12 at 09 45 49](https://user-images.githubusercontent.com/869724/28107205-0e8c126c-66e7-11e7-8cd0-c6092c8270db.png)

for the following demo, I have created a single tag `Mystag`.
I have assigned it to the article `Another article french` tagged to French (fr-FR)
Also to to the article `newarticle english` tagged to English (en-GB)
And to the article `myarticle` tagged to ALL content languages.
Create a `Tagged Items` menu item  to display that single tag and make sure Language Filter is set to `Current`

![screen shot 2017-07-12 at 09 53 15](https://user-images.githubusercontent.com/869724/28107442-19cbfd8a-66e8-11e7-9197-588c240bcc60.png)

When switching languages, that menu item will now correctly display 2 articles, one set to the Content Language in use, the other set to ALL content languages.
![cookies_tags](https://user-images.githubusercontent.com/869724/28107600-ba713e76-66e8-11e7-8644-9b71aef6edea.gif)

@mino182
@tonypartridge
