### PR TITLE
Do not delete categories on uninstalling extension

### DIFF
--- a/libraries/cms/installer/adapter/component.php
+++ b/libraries/cms/installer/adapter/component.php
@@ -807,18 +807,6 @@ class JInstallerAdapterComponent extends JInstallerAdapter
 			$asset->delete();
 		}
 
-		// Remove categories for this component
-		$query->clear()
-			->delete('#__categories')
-			->where('extension=' . $db->quote($this->element), 'OR')
-			->where('extension LIKE ' . $db->quote($this->element . '.%'));
-		$db->setQuery($query);
-		$db->execute();
-
-		// Rebuild the categories for correct lft/rgt
-		$category = JTable::getInstance('category');
-		$category->rebuild();
-
 		// Clobber any possible pending updates
 		$update = JTable::getInstance('update');
 		$uid = $update->find(


### PR DESCRIPTION
Pull Request for Issue #11490.
Awaiting Joomla 4.0 I suggest this solution

### Summary of Changes
Joomla doesn't delete categories when uninstall a component. The user must manually delete them before uninstalling the component.

### Testing Instructions

1) Install a 3rd party extension that uses Joomla category manager.
2) Create a category using that extesnsion.
3) Uninstall the extension.
4) Install the same extension again.
5) We can see that the category gets deleted with that extension.
6) Install the patch.
7) Create a category using that extesnsion.
8) Uninstall the extension.
9) Install the same extension again.
10) We can see that categories is still there.