### PR TITLE
Contact image option reorder

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -272,6 +272,15 @@
 		</field>
 
 		<field
+			name="image"
+			type="media"
+			label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
+			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
+			default=""
+			showon="show_image:1"
+		/>
+
+		<field
 			name="show_misc"
 			type="radio"
 			label="COM_CONTACT_FIELD_PARAMS_MISC_INFO_LABEL"
@@ -282,15 +291,6 @@
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
 		</field>
-
-		<field
-			name="image"
-			type="media"
-			label="COM_CONTACT_FIELD_PARAMS_IMAGE_LABEL"
-			description="COM_CONTACT_FIELD_PARAMS_IMAGE_DESC"
-			default=""
-			showon="show_image:1"
-		/>
 
 		<field
 			name="allow_vcard"


### PR DESCRIPTION
The image select field in the contact options is only shown if the option to show the image is selected. It was in the wrong place. As you can see below. This simple PR fixes that.

### Before
![image-contact](https://user-images.githubusercontent.com/1296369/28165201-bbbeed40-67ca-11e7-8a0a-0725744cc4f9.gif)
### After

![image-contact-fter](https://user-images.githubusercontent.com/1296369/28165202-bbc3b488-67ca-11e7-8dc0-0ed2d534cd64.gif)
