### PR TITLE
Text Filters layout

### DIFF
--- a/administrator/components/com_config/view/application/tmpl/default_filters.php
+++ b/administrator/components/com_config/view/application/tmpl/default_filters.php
@@ -12,4 +12,4 @@ defined('_JEXEC') or die;
 $this->name = JText::_('COM_CONFIG_TEXT_FILTER_SETTINGS');
 $this->fieldsname = 'filters';
 $this->description = JText::_('COM_CONFIG_TEXT_FILTERS_DESC');
-echo JLayoutHelper::render('joomla.content.options_default', $this);
+echo JLayoutHelper::render('joomla.content.text_filters', $this);

--- a/layouts/joomla/content/text_filters.php
+++ b/layouts/joomla/content/text_filters.php
@@ -12,22 +12,13 @@ defined('JPATH_BASE') or die;
 
 <fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : 'form-horizontal'; ?>">
 	<legend><?php echo $displayData->name; ?></legend>
-
 	<?php if (!empty($displayData->description)) : ?>
 		<p><?php echo $displayData->description; ?></p>
 	<?php endif; ?>
-
-	<?php
-	$fieldsnames = explode(',', $displayData->fieldsname);
-
-	foreach ($fieldsnames as $fieldname)
-	{
-		foreach ($displayData->form->getFieldset($fieldname) as $field)
-		{
-			?>
-				<div><?php echo $field->input; ?></div>
-			<?php
-		}
-	}
-	?>
+	<?php $fieldsnames = explode(',', $displayData->fieldsname); ?>
+	<?php foreach ($fieldsnames as $fieldname) : ?>
+		<?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
+			<div><?php echo $field->input; ?></div>
+		<?php endforeach; ?>
+	<?php endforeach; ?>
 </fieldset>

--- a/layouts/joomla/content/text_filters.php
+++ b/layouts/joomla/content/text_filters.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('JPATH_BASE') or die;
+?>
+
+<fieldset class="<?php echo !empty($displayData->formclass) ? $displayData->formclass : 'form-horizontal'; ?>">
+	<legend><?php echo $displayData->name; ?></legend>
+
+	<?php if (!empty($displayData->description)) : ?>
+		<p><?php echo $displayData->description; ?></p>
+	<?php endif; ?>
+
+	<?php
+	$fieldsnames = explode(',', $displayData->fieldsname);
+
+	foreach ($fieldsnames as $fieldname)
+	{
+		foreach ($displayData->form->getFieldset($fieldname) as $field)
+		{
+			?>
+				<div><?php echo $field->input; ?></div>
+			<?php
+		}
+	}
+	?>
+</fieldset>


### PR DESCRIPTION
At some point in the past (3.6.5?) when layouts were added the design of the global configuration text filters  was changed and it looks odd

This PR adds a new layout just for text filters without the big empty space

Pull Request for Issue #15423

### Before
<img width="832" alt="screenshotr16-37-17" src="https://user-images.githubusercontent.com/1296369/28174641-f39f57d0-67e9-11e7-9ced-6a4dfb6e5dcc.png">

### After
<img width="820" alt="screenshotr16-36-43" src="https://user-images.githubusercontent.com/1296369/28174664-03165db2-67ea-11e7-8336-ddfee044223b.png">
