### PR TITLE
Janitorial Duty

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -21,7 +21,7 @@ class ModArchiveHelper
 	/**
 	 * Retrieve list of archived articles
 	 *
-	 * @param   \Joomla\Registry\Registry  $params  module parameters
+	 * @param   \Joomla\Registry\Registry  &$params  module parameters
 	 *
 	 * @return  array
 	 *

--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -21,7 +21,7 @@ class ModArchiveHelper
 	/**
 	 * Retrieve list of archived articles
 	 *
-	 * @param   \Joomla\Registry\Registry  &$params  module parameters
+	 * @param   \Joomla\Registry\Registry  $params  module parameters
 	 *
 	 * @return  array
 	 *
@@ -56,7 +56,7 @@ class ModArchiveHelper
 		{
 			JFactory::getApplication()->enqueueMessage(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
-			return;
+			return array();
 		}
 
 		$app    = JFactory::getApplication();
@@ -71,16 +71,16 @@ class ModArchiveHelper
 		{
 			$date = JFactory::getDate($row->created);
 
-			$created_month = $date->format('n');
-			$created_year  = $date->format('Y');
+			$createdMonth = $date->format('n');
+			$createdYear  = $date->format('Y');
 
-			$created_year_cal = JHtml::_('date', $row->created, 'Y');
-			$month_name_cal   = JHtml::_('date', $row->created, 'F');
+			$createdYearCal = JHtml::_('date', $row->created, 'Y');
+			$monthNameCal   = JHtml::_('date', $row->created, 'F');
 
 			$lists[$i] = new stdClass;
 
-			$lists[$i]->link = JRoute::_('index.php?option=com_content&view=archive&year=' . $created_year . '&month=' . $created_month . $itemid);
-			$lists[$i]->text = JText::sprintf('MOD_ARTICLES_ARCHIVE_DATE', $month_name_cal, $created_year_cal);
+			$lists[$i]->link = JRoute::_('index.php?option=com_content&view=archive&year=' . $createdYear . '&month=' . $createdMonth . $itemid);
+			$lists[$i]->text = JText::sprintf('MOD_ARTICLES_ARCHIVE_DATE', $monthNameCal, $createdYearCal);
 
 			$i++;
 		}


### PR DESCRIPTION
(And I mean that literally.)

Cleans up ModArchiveHelper so it conforms to Joomla coding conventions and is ready for PHP7.

### Summary of Changes

Let's cover the "biggest" change in here first:

Line 59 returned a void while line 88 (still in the same method) returned an Array. Returns from methods should be consistent (PHP7 supports specifying method return types -- it's an essential part of Design By Contract) and given the fact the docblock claims the method returns an array, we should ensure the method always returns an array, like it promises. That way any future developer writing code that uses it knows what to expect.

B/C exposure on this exists, but is minimal, and as far as I can see entirely hypothetical. First it's in an exception handling routine, so there's already a problem happening; normal processing may already be off the table when it gets executed. Also, the way this is handled in the output routines is by testing the return for empty (empty($lists)) and emtpy(NULL) and empty(array()) both return true. I've looked, and not run into a single instance of B/C breakage from of this change, and I think the change is worth doing because it makes the method perform as the documentation says it does, which I think is important. It's hard to see how making software behave as advertised is breaking B/C; if we grant that, then isn't pretty much *any* bug fix a B/C break? And in this case I have seen literally no instances in the wild this would break. (It's hard to even conceive of one, as the list is typically processed as a foreach, which works without error for empty arrays.)

The rest of the changes are routine. The docblock change in line 24 reflects the fact the '&' is not part of the parameter; it's meta-data about how the parameter is passed (Side note: Look deep enough, it may even have been me that put it in there, back in the day. I recall doing that several times before I caught myself.) Zero impact.

The rest of the changes involve changing local variables from serpentine case to camel case. Zero potential impact outside of the method itself.


### Testing Instructions

Running the normal tests for the module, including simply loading a website with archived articles that publishes this module, will prove the correctness/failure of the variable name changes. As for the return value, I have been unable to find anything that breaks B/C, but if there's a template out there that might, either load it up (or pass me a copy of the template and I will) and test it. The result from a B/C break will be something appearing on the site where that module should be that shouldn't be there.

### Expected result

Should pass every test it passed before. If testing by displaying on website, should display the exact same after the change as it did before the change (I can't specify the exact code it will display, because it's output through a template, so the output code is malleable).

### Actual result

For me, I saw no results changes in testing between before and after. That was expected, as this does not fix a user issue; it cleans up the code so other developers can work with it easier.

There was one difference, however: It now passes phpcs with the Joomla coding standards selected, whereas before it cited 11 problems with the code.

### Documentation Changes Required

None.