### PR TITLE
Add mandatory fourth argument for content events in com_media

### DIFF
--- a/administrator/components/com_media/views/imageslist/tmpl/default_image.php
+++ b/administrator/components/com_media/views/imageslist/tmpl/default_image.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));
 ?>
 
 <li class="imgOutline thumbnail height-80 width-80 center">
@@ -27,4 +27,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	</a>
 </li>
 <?php
-$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));

--- a/administrator/components/com_media/views/medialist/tmpl/details_doc.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_doc.php
@@ -15,7 +15,7 @@ JHtml::_('bootstrap.tooltip');
 $user       = JFactory::getUser();
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_doc, &$params, 0));
 ?>
 
 <tr>
@@ -39,4 +39,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	</td>
 <?php endif;?>
 </tr>
-<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_doc, &$params, 0));

--- a/administrator/components/com_media/views/medialist/tmpl/details_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_docs.php
@@ -17,7 +17,7 @@ $dispatcher = JEventDispatcher::getInstance();
 ?>
 
 <?php foreach ($this->documents as $i => $doc) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params, 0)); ?>
 	<tr>
 		<?php if ($this->canDelete) : ?>
 			<td>
@@ -50,5 +50,5 @@ $dispatcher = JEventDispatcher::getInstance();
 		<?php endif; ?>
 
 	</tr>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$doc, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$doc, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_img.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_img.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 $user       = JFactory::getUser();
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));
 ?>
 
 <tr>
@@ -39,4 +39,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 		</td>
 	<?php endif;?>
 </tr>
-<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));

--- a/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_imgs.php
@@ -19,7 +19,7 @@ $dispatcher = JEventDispatcher::getInstance();
 ?>
 
 <?php foreach ($this->images as $i => $image) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$image, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$image, &$params, 0)); ?>
 	<tr>
 		<?php if ($this->canDelete) : ?>
 			<td>
@@ -55,5 +55,5 @@ $dispatcher = JEventDispatcher::getInstance();
 			</td>
 		<?php endif; ?>
 	</tr>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$image, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$image, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/details_video.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_video.php
@@ -16,7 +16,7 @@ JHtml::_('bootstrap.tooltip');
 $user       = JFactory::getUser();
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_video, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_video, &$params, 0));
 
 JFactory::getDocument()->addScriptDeclaration("
 jQuery(document).ready(function($){
@@ -51,4 +51,4 @@ jQuery(document).ready(function($){
 </tr>
 
 <?php
-$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_video, &$params));
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_video, &$params, 0));

--- a/administrator/components/com_media/views/medialist/tmpl/details_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/details_videos.php
@@ -26,7 +26,7 @@ jQuery(document).ready(function($){
 ?>
 
 <?php foreach ($this->videos as $i => $video) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params, 0)); ?>
 	<tr>
 		<?php if ($this->canDelete) : ?>
 			<td>
@@ -63,5 +63,5 @@ jQuery(document).ready(function($){
 		<?php endif; ?>
 	</tr>
 
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$video, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$video, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_docs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_docs.php
@@ -16,7 +16,7 @@ $dispatcher = JEventDispatcher::getInstance();
 ?>
 
 <?php foreach ($this->documents as $i => $doc) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$doc, &$params, 0)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
 		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $doc->name; ?>" rel="<?php echo $doc->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
@@ -36,5 +36,5 @@ $dispatcher = JEventDispatcher::getInstance();
 			<?php echo JHtml::_('string.truncate', $doc->name, 10, false); ?>
 		</div>
 	</li>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$doc, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$doc, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_imgs.php
@@ -16,7 +16,7 @@ $dispatcher = JEventDispatcher::getInstance();
 ?>
 
 <?php foreach ($this->images as $i => $img) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params, 0)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
 		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top"
@@ -40,5 +40,5 @@ $dispatcher = JEventDispatcher::getInstance();
 			</a>
 		</div>
 	</li>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$img, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$img, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
+++ b/administrator/components/com_media/views/medialist/tmpl/thumbs_videos.php
@@ -23,7 +23,7 @@ jQuery(document).ready(function($){
 ");
 ?>
 <?php foreach ($this->videos as $i => $video) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$video, &$params, 0)); ?>
 	<li class="imgOutline thumbnail height-80 width-80 center">
 		<?php if ($this->canDelete) : ?>
 			<a class="close delete-item" target="_top" href="index.php?option=com_media&amp;task=file.delete&amp;tmpl=index&amp;<?php echo JSession::getFormToken(); ?>=1&amp;folder=<?php echo $this->state->folder; ?>&amp;rm[]=<?php echo $video->name; ?>" rel="<?php echo $video->name; ?>" title="<?php echo JText::_('JACTION_DELETE'); ?>">&#215;</a>
@@ -43,5 +43,5 @@ jQuery(document).ready(function($){
 			</a>
 		</div>
 	</li>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$video, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$video, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/administrator/templates/isis/html/com_media/imageslist/default_image.php
+++ b/administrator/templates/isis/html/com_media/imageslist/default_image.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));
 ?>
 
 <li class="imgOutline thumbnail height-80 width-80 center">
@@ -29,4 +29,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	</a>
 </li>
 <?php
-$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));

--- a/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
+++ b/administrator/templates/isis/html/com_media/medialist/thumbs_imgs.php
@@ -16,7 +16,7 @@ $dispatcher = JEventDispatcher::getInstance();
 ?>
 
 <?php foreach ($this->images as $i => $img) : ?>
-	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params)); ?>
+	<?php $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$img, &$params, 0)); ?>
 	<li class="imgOutline thumbnail center">
 
 		<?php if ($this->canDelete):?>
@@ -42,5 +42,5 @@ $dispatcher = JEventDispatcher::getInstance();
 			</a>
 		</div>
 	</li>
-	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$img, &$params)); ?>
+	<?php $dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$img, &$params, 0)); ?>
 <?php endforeach; ?>

--- a/templates/protostar/html/com_media/imageslist/default_image.php
+++ b/templates/protostar/html/com_media/imageslist/default_image.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 
 $params     = new Registry;
 $dispatcher = JEventDispatcher::getInstance();
-$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));
 ?>
 
 <li class="imgOutline thumbnail height-80 width-80 center">
@@ -29,4 +29,4 @@ $dispatcher->trigger('onContentBeforeDisplay', array('com_media.file', &$this->_
 	</a>
 </li>
 <?php
-$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params));
+$dispatcher->trigger('onContentAfterDisplay', array('com_media.file', &$this->_tmp_img, &$params, 0));


### PR DESCRIPTION
Pull Request for Issue #17129 

### Summary of Changes
This PR adds a fourth argument to the dispatcher for the `onContentBeforeDisplay` and `onContentAfterDisplay` events. Without this argument the following error might occur if there is no fallback for this argument:
```
Too few arguments to function PlgContentVote::onContentBeforeDisplay(), 3 passed in /usr/local/apache2/htdocs/libraries/joomla/event/event.php on line 70 and exactly 4 expected
````

### Testing Instructions
1. Create `onContentBeforeDisplay` plugin event without a fallback variable for the `$page` parameter. Like this:
```php
public function onContentBeforeDisplay($context, &$row, &$params, $page) {
}
```
You can also temporary remove the `= 0` after the `$page` for a existing plugin. For example the vote plugin on this line: https://github.com/joomla/joomla-cms/blob/staging/plugins/content/vote/vote.php#L62
2. Set the error reporting to `maximum`
3. Go to the media manager and notice the following error:
```
Too few arguments to function PlgContentVote::onContentBeforeDisplay(), 3 passed in /usr/local/apache2/htdocs/libraries/joomla/event/event.php on line 70 and exactly 4 expected
```
4. Apply the patch and confirm the error is solved

