### PR TITLE
Add JBrowser tests

### DIFF
--- a/tests/unit/suites/libraries/joomla/environment/JBrowserTest.php
+++ b/tests/unit/suites/libraries/joomla/environment/JBrowserTest.php
@@ -9,15 +9,20 @@
 
 /**
  * Test class for JBrowser.
- *
- * @package     Joomla.UnitTest
- * @subpackage  Environment
- * @since       11.1
  */
 class JBrowserTest extends \PHPUnit\Framework\TestCase
 {
 	/**
-	 * @var JBrowser
+	 * Backup of the SERVER superglobal
+	 *
+	 * @var  array
+	 */
+	protected $backupServer;
+
+	/**
+	 * Object being tested
+	 *
+	 * @var  JBrowser
 	 */
 	protected $object;
 
@@ -25,11 +30,13 @@ class JBrowserTest extends \PHPUnit\Framework\TestCase
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	protected function setUp()
 	{
 		parent::setUp();
+
+		$this->backupServer = $_SERVER;
 
 		$this->object = new JBrowser;
 	}
@@ -40,35 +47,151 @@ class JBrowserTest extends \PHPUnit\Framework\TestCase
 	 * @return  void
 	 *
 	 * @see     \PHPUnit\Framework\TestCase::tearDown()
-	 * @since   3.6
 	 */
 	protected function tearDown()
 	{
+		$_SERVER = $this->backupServer;
+
 		unset($this->object);
 		parent::tearDown();
 	}
 
 	/**
-	 * Test...
+	 * Data provider for the testBrowserMatching method
 	 *
-	 * @covers JBrowser::isSSLConnection
+	 * @return  array
+	 */
+	public function dataMatch()
+	{
+		return array(
+			'Edge 14' => array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393',
+				'edge',
+				'win',
+				'14',
+				false,
+			),
+			'Opera 9.80 Mobile Linux' => array(
+				'Opera/9.80 (Android 3.2.1; Linux; Opera Tablet/ADR-1111101157; U; en) Presto/2.9.201 Version/11.50',
+				'opera',
+				'unix',
+				'11',
+				true,
+			),
+			'Chrome 13 OS X' => array(
+				'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_3) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/13.0.782.32 Safari/535.1',
+				'chrome',
+				'mac',
+				'13',
+				false,
+			),
+			'Chrome 12 Windows' => array(
+				'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.113 Safari/534.30',
+				'chrome',
+				'win',
+				'12',
+				false,
+			),
+			'Chrome 54 Windows' => array(
+				'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36',
+				'chrome',
+				'win',
+				'54',
+				false,
+			),
+			'Chrome 12 Ubuntu' => array(
+				'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.30 (KHTML, like Gecko) Ubuntu/10.04 Chromium/12.0.742.112 Chrome/12.0.742.112 Safari/534.30',
+				'chrome',
+				'unix',
+				'12',
+				false,
+			),
+			'Internet Explorer 10' => array(
+				'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
+				'msie',
+				'win',
+				'10',
+				false,
+			),
+			'Internet Explorer 9' => array(
+				'Mozilla/5.0 (Windows; U; MSIE 9.0; WIndows NT 9.0; en-US))',
+				'msie',
+				'win',
+				'9',
+				false,
+			),
+			'Firefox 12 Android Tablet' => array(
+				'Mozilla/5.0 (Android; Tablet; rv:12.0) Gecko/12.0 Firefox/12.0',
+				'mozilla',
+				'unix',
+				'12',
+				true,
+			),
+			'Firefox 6 Windows' => array(
+				'Mozilla/5.0 (Windows NT 5.0; WOW64; rv:6.0) Gecko/20100101 Firefox/6.0',
+				'mozilla',
+				'win',
+				'6',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * @testdox  A browser with a given user agent is correctly detected
 	 *
-	 * @return void
+	 * @covers        JBrowser::match
+	 * @dataProvider  dataMatch
+	 *
+	 * @param   string   $userAgent             The user agent to test
+	 * @param   string   $expectedBrowser       The expected browser value
+	 * @param   string   $expectedPlatform      The expected platform value
+	 * @param   string   $expectedMajorVersion  The expected major version value
+	 * @param   boolean  $expectedMobile        The expected mobile state
+	 */
+	public function testBrowserMatching($userAgent, $expectedBrowser, $expectedPlatform, $expectedMajorVersion, $expectedMobile)
+	{
+		if ($expectedBrowser === 'mozilla')
+		{
+			$this->markTestSkipped('Requires PR #17051 to be tested correctly');
+		}
+
+		$this->object->match($userAgent);
+
+		$this->assertSame(
+			$expectedBrowser,
+			$this->object->getBrowser()
+		);
+
+		$this->assertSame(
+			$expectedPlatform,
+			$this->object->getPlatform()
+		);
+
+		$this->assertSame(
+			$expectedMajorVersion,
+			$this->object->getMajor()
+		);
+
+		$this->assertSame(
+			$expectedMobile,
+			$this->object->isMobile()
+		);
+	}
+
+	/**
+	 * @testdox  The isSSLConnection method correctly detects if a secure connection was made
+	 *
+	 * @covers   JBrowser::isSSLConnection
 	 */
 	public function testIsSSLConnection()
 	{
 		unset($_SERVER['HTTPS']);
 
-		$this->assertThat(
-			$this->object->isSSLConnection(),
-			$this->equalTo(false)
-		);
+		$this->assertFalse($this->object->isSSLConnection());
 
 		$_SERVER['HTTPS'] = 'on';
 
-		$this->assertThat(
-			$this->object->isSSLConnection(),
-			$this->equalTo(true)
-		);
+		$this->assertTrue($this->object->isSSLConnection());
 	}
 }


### PR DESCRIPTION
### Summary of Changes

1) ~~`JBrowser` does not correctly detect version data for Firefox browsers, this is now added~~
2) `JBrowser` itself has no test coverage, this adds several test cases based on user agents used to test `Joomla\Application\Web\WebClient` to cover `JBrowser::match()`

### Testing Instructions

~~For Firefox browsers, their data (especially the version) should now be detected correctly.~~  All added test cases should pass.