### PR TITLE
mod_login showon option

### DIFF
--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -85,18 +85,6 @@
 				</field>
 
 				<field
-					name="profilelink"
-					type="radio"
-					label="MOD_LOGIN_FIELD_PROFILE_LABEL"
-					description="MOD_LOGIN_FIELD_PROFILE_DESC"
-					class="btn-group btn-group-yesno"
-					default="0"
-					>
-					<option value="1">JYES</option>
-					<option value="0">JNO</option>
-				</field>
-
-				<field
 					name="name"
 					type="list"
 					label="MOD_LOGIN_FIELD_NAME_LABEL"
@@ -106,6 +94,18 @@
 					>
 					<option value="0">MOD_LOGIN_VALUE_NAME</option>
 					<option value="1">MOD_LOGIN_VALUE_USERNAME</option>
+				</field>
+				
+				<field
+					name="profilelink"
+					type="radio"
+					label="MOD_LOGIN_FIELD_PROFILE_LABEL"
+					description="MOD_LOGIN_FIELD_PROFILE_DESC"
+					class="btn-group btn-group-yesno"
+					default="0"
+					>
+					<option value="1">JYES</option>
+					<option value="0">JNO</option>
 				</field>
 
 				<field


### PR DESCRIPTION
As seen below the option for Show Name is in the wrong place

### before
![beforelogin](https://user-images.githubusercontent.com/1296369/28273540-91578ff0-6b06-11e7-9c02-cfe2b7189a05.gif)

### after
![afterlogin](https://user-images.githubusercontent.com/1296369/28273546-95bc5238-6b06-11e7-96e1-7f467a9ea3e5.gif)
