### PR TITLE
codestyle capitalisation in xml

### DIFF
--- a/administrator/components/com_languages/config.xml
+++ b/administrator/components/com_languages/config.xml
@@ -2,14 +2,14 @@
 <config>
 	<fieldset
 		name="permissions"
-		label="JConfig_Permissions_Label"
-		description="JConfig_Permissions_Desc"
+		label="JCONFIG_PERMISSIONS_LABEL"
+		description="JCONFIG_PERMISSIONS_DESC"
 		>
 
 		<field
 			name="rules"
 			type="rules"
-			label="JConfig_Permissions_Label"
+			label="JCONFIG_PERMISSIONS_LABEL"
 			filter="rules"
 			validate="rules"
 			component="com_languages"


### PR DESCRIPTION
Found another one where the options in the xml file were not in uppercase
