### PR TITLE
[4.0] media manager licence

### DIFF
--- a/administrator/components/com_media/package.json
+++ b/administrator/components/com_media/package.json
@@ -2,7 +2,7 @@
   "name": "com_media",
   "version": "3.0.0",
   "description": "Component for managing site media",
-  "license": "GPL-3.0",
+  "license": "GPL-2.0",
   "author": "",
   "scripts": {
     "build": "npm run build-css & npm run build-js",


### PR DESCRIPTION
Correct the licence for the new media manager to gpl 2 not 3
