### PR TITLE
Prepare also the intro text in the article details view

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -189,6 +189,25 @@ class ContentViewArticle extends JViewLegacy
 		JPluginHelper::importPlugin('content');
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
+		// Check if the intro text needs to be processed as well
+		if ($item->introtext && strpos($item->text, $item->introtext) !== 0)
+		{
+			// Save the old text of the article
+			$text = $item->text;
+
+			// Set the intro text as new text
+			$item->text = $item->introtext;
+
+			// Trigger the event with the introtext
+			$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
+
+			// Set the prepared intro text back
+			$item->introtext = $item->text;
+
+			// Restore the original text variable
+			$item->text = $text;
+		}
+
 		$item->event = new stdClass;
 		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->afterDisplayTitle = trim(implode("\n", $results));


### PR DESCRIPTION
Pull Request for Issue #15751.

### Summary of Changes
Triggers the prepare event also on the intro text in the article details view. So are plugins triggered on the intro text as well.

### Testing Instructions
- Insert Field in Article
- Article Options - Set Linked Titles to Yes, Show Unauthorised Links to Yes, Show Intro Text to Hide,
- Set Article Access to Registered
- Create any custom field with access right to public and insert in the article before read more (intro text)
- Create category blog menu item
- Check front end as non logged in user.

### Expected result
Clicking on article title should show inserted field value.

### Actual result
Clicking on article title show field name as (field --}