### PR TITLE
[4.0] Remove "noopener" from "rel" attribute

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -115,7 +115,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php echo $item->detailsurl; ?>
 											<?php if (isset($item->infourl)) : ?>
 												<br>
-												<a href="<?php echo $item->infourl; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->infourl); ?></a>
+												<a href="<?php echo $item->infourl; ?>" target="_blank" rel="noreferrer"><?php echo $this->escape($item->infourl); ?></a>
 											<?php endif; ?>
 										</span>
 									</td>

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -82,7 +82,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php echo JText::_($item->update_site_name); ?>
 										<br>
 										<span class="small break-word">
-											<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->location); ?></a>
+											<a href="<?php echo $item->location; ?>" target="_blank" rel="noreferrer"><?php echo $this->escape($item->location); ?></a>
 										</span>
 									</label>
 								</td>

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -122,7 +122,7 @@ defined('_JEXEC') or die;
 	</dt>
 	<dd>
 		<span class="contact-webpage">
-			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noopener noreferrer" itemprop="url">
+			<a href="<?php echo $this->contact->webpage; ?>" target="_blank" rel="noreferrer" itemprop="url">
 			<?php echo JStringPunycode::urlToUTF8($this->contact->webpage); ?></a>
 		</span>
 	</dd>

--- a/components/com_content/tmpl/article/default_links.php
+++ b/components/com_content/tmpl/article/default_links.php
@@ -48,20 +48,20 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// Open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank" rel="nofollow noopener noreferrer">' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank" rel="nofollow noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 
 						case 2:
 							// Open in a popup window
 							$attribs = 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=600,height=600';
-							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\" rel=\"noopener noreferrer\">" .
+							echo "<a href=\"" . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . "\" onclick=\"window.open(this.href, 'targetWindow', '" . $attribs . "'); return false;\" rel=\"noreferrer\">" .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . '</a>';
 							break;
 						case 3:
 							// Open in a modal window
 							JHtml::_('behavior.modal', 'a.modal');
-							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} noopener noreferrer">' .
+							echo '<a class="modal" href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '"  rel="{handler: \'iframe\', size: {x:600, y:600}} noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') . ' </a>';
 							break;
 

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -71,7 +71,7 @@ $this->addScriptOptions('system.installation', array('url' => JRoute::_('index.p
 			<h5>
 				<?php // Fix wrong display of Joomla!® in RTL language ?>
 				<?php $joomla  = '<a href="https://www.joomla.org" target="_blank">Joomla!</a><sup>' . (JFactory::getLanguage()->isRtl() ? '&#x200E;' : '') . '</sup>'; ?>
-				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank" rel="noopener noreferrer">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
+				<?php $license = '<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html" target="_blank" rel="noreferrer">' . JText::_('INSTL_GNU_GPL_LICENSE') . '</a>'; ?>
 				<?php echo JText::sprintf('JGLOBAL_ISFREESOFTWARE', $joomla, $license); ?>
 			</h5>
 		</div>

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -38,7 +38,7 @@ use Joomla\Component\Banners\Site\Helper\BannerHelper;
 					<?php if ($target == 1) : ?>
 						<?php // Open in a new window ?>
 						<a
-							href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
+							href="<?php echo $link; ?>" target="_blank" rel="noreferrer"
 							title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
 							<img
 								src="<?php echo $baseurl . $imageurl; ?>"

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -41,7 +41,7 @@ if ($item->menu_image)
 if ($item->browserNav == 1)
 {
 	$attributes['target'] = '_blank';
-	$attributes['rel'] = 'noopener noreferrer';
+	$attributes['rel'] = 'noreferrer';
 }
 elseif ($item->browserNav == 2)
 {

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -19,7 +19,7 @@ $attributes = '';
 
 if (!JUri::isInternal($value))
 {
-	$attributes = ' rel="nofollow noopener noreferrer" target="_blank"';
+	$attributes = ' rel="nofollow noreferrer" target="_blank"';
 }
 
 echo sprintf('<a href="%s"%s>%s</a>',

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -1976,7 +1976,7 @@ class PlgSystemDebug extends CMSPlugin
 
 			if (!$this->linkFormat)
 			{
-				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank" rel="noopener noreferrer">';
+				$htmlCallStack .= '<div>[<a href="https://xdebug.org/docs/all_settings#file_link_format" target="_blank" rel="noreferrer">';
 				$htmlCallStack .= JText::_('PLG_DEBUG_LINK_FORMAT') . '</a>]</div>';
 			}
 		}

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -26,12 +26,12 @@ defined('_JEXEC') or die;
 	</p>
 	<ul>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener noreferrer">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noreferrer">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1') ?>
 			</a>
 		</li>
 		<li>
-			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener noreferrer">
+			<a href="<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noreferrer">
 				<?php echo JText::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2') ?>
 			</a>
 		</li>


### PR DESCRIPTION
### Summary of Changes

This PR removes `noopener` from the `rel=""` attribute which was used as a fallback for earlier IE and FF versions.

In Joomla 4, seeing as we're supporting the latest IE11 and the last 2 of other modern browsers, we nolonger need this.



