### PR TITLE
[4.0-dev] Only try to load the module if we are in multilang mode

### DIFF
--- a/administrator/modules/mod_status/tmpl/default.php
+++ b/administrator/modules/mod_status/tmpl/default.php
@@ -14,11 +14,10 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 ?>
 <div class="ml-auto">
 	<ul class="nav text-center">
-
-		<?php
-			$module = JModuleHelper::getModule('multilangstatus');
-			echo JModuleHelper::renderModule($module);
-		?>
+		<?php if (JLanguageMultilang::isEnabled()) : ?>
+			<?php $module = JModuleHelper::getModule('mod_multilangstatus'); ?>
+			<?php echo JModuleHelper::renderModule($module); ?>
+		<?php endif; ?>	
 
 		<li class="nav-item">
 			<a class="nav-link" href="<?php echo JUri::root(); ?>" title="<?php echo JText::sprintf('MOD_STATUS_PREVIEW', $sitename); ?>" target="_blank">


### PR DESCRIPTION
Pull Request for Issue #17181 

### Summary of Changes

The get Module returns null in case that the module does not exists..

### Testing Instructions

### Steps to reproduce the issue

- Do a fresh install from repo
- Go to Global Settings
- **Enable Debugging**
- Save

### Expected result

- No warnings at all

### Actual result

An error regarding this

![image](https://user-images.githubusercontent.com/13379595/28372591-c05c60d8-6cbd-11e7-8993-6f6bc14ca4b4.png)

### Documentation Changes Required

none

### Additional comments

@infograf768 is it possible that we have setup a multi language site but do not have a `mod_multilangstatus` module? This needs to be tested too than.