### PR TITLE
[4.0] Change vote option to switcher

### DIFF
--- a/administrator/components/com_content/Field/VotelistField.php
+++ b/administrator/components/com_content/Field/VotelistField.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Plugin\PluginHelper;
  *
  * @since  3.7.1
  */
-class VotelistField extends \JFormFieldList
+class VotelistField extends \JFormFieldRadio
 {
 	/**
 	 * The form field type.

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -932,8 +932,8 @@
 			type="votelist"
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC"
-			default="0"
 			class="switcher"
+			default="0"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -944,8 +944,8 @@
 			type="votelist"
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC"
-			default="0"
 			class="switcher"
+			default="0"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -935,8 +935,8 @@
 			class="switcher"
 			default="0"
 			>
-			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
 		</field>
 
 		<field 
@@ -947,8 +947,8 @@
 			class="switcher"
 			default="0"
 			>
-			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
 		</field>
 
 	</fieldset>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -933,6 +933,7 @@
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC"
 			default="0"
+			class="switcher"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>
@@ -944,6 +945,7 @@
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC"
 			default="0"
+			class="switcher"
 			>
 			<option value="1">JSHOW</option>
 			<option value="0">JHIDE</option>


### PR DESCRIPTION
This PR changes the vote setting in the article options to the new switcher class for options

An added benefit it that before when the plugin was not enabled the select list was empty. Now if the plugin is not enabled there is nothing displayed in the values. NOTE if someone knows how to improve this perhaps by hiding the label as well that would be great

### Before with plugin enabled
<img width="437" alt="screenshotr16-55-53" src="https://user-images.githubusercontent.com/1296369/28427368-e01584e4-6d6d-11e7-8c00-bc5636218b04.png">

### Before with plugin disabled
<img width="411" alt="screenshotr17-05-42" src="https://user-images.githubusercontent.com/1296369/28427373-e6eee74c-6d6d-11e7-9cdd-d1f14d82a210.png">

### After with plugin enabled
<img width="369" alt="screenshotr17-02-52" src="https://user-images.githubusercontent.com/1296369/28427378-ec69a2f2-6d6d-11e7-969f-4fdaf86f70c3.png">

### After with plugin disabled
<img width="348" alt="screenshotr17-02-18" src="https://user-images.githubusercontent.com/1296369/28427388-f385584c-6d6d-11e7-9371-d7f12b556b83.png">
