### PR TITLE
Add parent_id filter for JHtml::_('category.options')

### DIFF
--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -50,16 +50,33 @@ abstract class JHtmlCategory
 
 			$query = $db->getQuery(true)
 				->select('a.id, a.title, a.level, a.language')
-				->from('#__categories AS a')
-				->where('a.parent_id > 0');
+				->from('#__categories AS a');
+			
+			// Filter on parent id.
+			if (isset($config['filter.parent_id']))
+			{
+				if (is_numeric($config['filter.parent_id']))
+				{
+					$query->where('a.parent_id = ' . (int) $config['filter.parent_id']);
+				}
+				elseif (is_array($config['filter.parent_id']))
+				{
+					$config['filter.parent_id'] = ArrayHelper::toInteger($config['filter.parent_id']);
+					$query->where('a.parent_id IN (' . implode(',', $config['filter.parent_id']) . ')');
+				}
+			}
+			else
+			{
+				$query->where('a.parent_id > 0');
+			}
 
 			// Filter on extension.
 			$query->where('extension = ' . $db->quote($extension));
 			
-			// Filter on user access level
+			// Filter on user access level.
 			$query->where('a.access IN (' . $groups . ')');
 
-			// Filter on the published state
+			// Filter on the published state.
 			if (isset($config['filter.published']))
 			{
 				if (is_numeric($config['filter.published']))
@@ -73,7 +90,7 @@ abstract class JHtmlCategory
 				}
 			}
 
-			// Filter on the language
+			// Filter on the language.
 			if (isset($config['filter.language']))
 			{
 				if (is_string($config['filter.language']))
@@ -91,7 +108,7 @@ abstract class JHtmlCategory
 				}
 			}
 
-			// Filter on the access
+			// Filter on the access.
 			if (isset($config['filter.access']))
 			{
 				if (is_string($config['filter.access']))
@@ -165,7 +182,7 @@ abstract class JHtmlCategory
 			$groups = implode(',', $user->getAuthorisedViewLevels());
 			$query->where('a.access IN (' . $groups . ')');
 
-			// Filter on the published state
+			// Filter on the published state.
 			if (isset($config['filter.published']))
 			{
 				if (is_numeric($config['filter.published']))


### PR DESCRIPTION
Hello all. When developing my own components and using the core Categories system, I have come across a need to have the ability to filter the default Categories dropdown list by a Parent Category. So I figured I'd share this PR in hopes it can be incorporated into the project.

### Summary of Changes
Only one file was changed (`libraries/cms/html/category.php`). Updated the query statement to allow for `filter.parent` which would filter the categories based off of a specific Parent Category ID number (or an array of parent ID numbers).

With this change a developer can now use some code like the following to filter the default Categories dropdown list...

**Filter by a single Parent ID number:**
`JHtml::_('category.options', 'com_customcomponentname', $config = array('filter.published' => array(1), 'filter.parent_id' => 15))`

**Filter by multiple Parent ID numbers:**
`JHtml::_('category.options', 'com_customcomponentname', $config = array('filter.published' => array(1), 'filter.parent_id' => array(15,37)))`


### Testing Instructions
This can be easily tested using a custom component, specifically when doing a front-end view. Here is an example Categories setup for the custom component:

Books
– Books Subcategory 1
– Books Subcategory 2
Movies
– Movies Subcategory 1
– Movies Subcategory 2
Toys
– Toys Subcategory 1
– Toys Subcategory 2

Now previously if you used `JHtml::_('category.options')` to do the dropdown list of Categories, **all** of the Categories for the Custom Component would be listed. So the big list above would be shown. But what if you had a front-end view for Movies? The Books and Toys categories would be shown too. A bit odd and confusing for end users.

With this PR in place, you can now add `filter.parent_id` to the `$config` array, like the following code, to show **only** the Movies categories when on the Movies front-end view...

```
<select id="filter_category" name="filter_category" class="input-block-level" onchange="this.form.submit()">
  <option value=""><?php echo JText::_('- Show All Movies -'); ?></option>
  <?php echo JHtml::_('select.options', JHtml::_('category.options', 'com_customcomponentname', $config = array('filter.published' => array(1), 'filter.parent_id' => 15)), 'value', 'text', $this->state->get('filter.category')); ?>
</select>
```

Just change parent_id `15` to whatever ID number it is in your setup and your Categories dropdown will now only show...

– Movies Subcategory 1
– Movies Subcategory 2

No more un-relevant categories listed on specific views and no more confusion for the users :)


### Documentation Changes Required
I would imagine that some documentation somewhere would need updating. I'd be happy to contribute as needed if folks would like.
