### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,14 @@ matrix:
       env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     - php: 7.1
       env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
+    # Requires older Precise image
     - php: 5.3
       env: INSTALL_APC="yes"
+      sudo: true
+      dist: precise
+    # The new Trusty image has issues with running APC, do not enable it here
     - php: 5.4
-      env: INSTALL_APC="yes"
+      env: INSTALL_APC="no"
     - php: 5.5
       env: INSTALL_APCU="yes"
     - php: 5.6


### PR DESCRIPTION
### Summary of Changes

Travis is rolling out their new Trusty images, which breaks our PHP 5.3 and 5.4 builds.  The Trusty images do not support PHP 5.3 at all, so this one is required to remain on the older Precise image.  As for PHP 5.4's APC issues, it's not a problem with the PECL extension not being installed (I tried that on a build and it failed groaning the extension was already there).  So for now, it's just turned off.

### Testing Instructions

CI passes