### PR TITLE
[4.0] com modules - remove options

### DIFF
--- a/administrator/components/com_modules/config.xml
+++ b/administrator/components/com_modules/config.xml
@@ -1,23 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<fieldset
-		name="modules"
-		label="COM_MODULES_GENERAL"
-		description="COM_MODULES_GENERAL_FIELDSET_DESC"
-		>
-		<field
-			name="redirect_edit"
-			type="list"
-			class="advancedSelect"
-			default="site"
-			label="COM_MODULES_REDIRECT_EDIT_LABEL"
-			description="COM_MODULES_REDIRECT_EDIT_DESC"
-			>
-			<option value="admin">JADMINISTRATOR</option>
-			<option value="site">JSITE</option>
-		</field>
-	</fieldset>
-	<fieldset
 		name="permissions"
 		label="JCONFIG_PERMISSIONS_LABEL"
 		description="JCONFIG_PERMISSIONS_DESC"

--- a/administrator/language/en-GB/en-GB.com_modules.sys.ini
+++ b/administrator/language/en-GB/en-GB.com_modules.sys.ini
@@ -9,6 +9,4 @@ COM_MODULES_ACTION_EDITFRONTEND_COMPONENT_DESC="Allows users in the group to edi
 COM_MODULES_GENERAL="General"
 COM_MODULES_MODULES_VIEW_DEFAULT_DESC="Shows a list of modules to manage"
 COM_MODULES_MODULES_VIEW_DEFAULT_TITLE="Module Manager"
-COM_MODULES_REDIRECT_EDIT_DESC="Select if module editing should be opened in the site or administration interface."
-COM_MODULES_REDIRECT_EDIT_LABEL="Edit Module"
 COM_MODULES_XML_DESCRIPTION="Component for module management on the Backend."

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -28,11 +28,8 @@ if (preg_match('/<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]* jmoddiv"/', $modu
 // Add css class jmoddiv and data attributes for module-editing URL and for the tooltip:
 $editUrl = JUri::base() . 'administrator/index.php?option=com_modules&task=module.edit&id=' . (int) $mod->id;
 
-if ($parameters->get('redirect_edit', 'site') === 'site')
-{
-	$editUrl = JUri::base() . 'index.php?option=com_config&view=modules&id=' . (int) $mod->id . $redirectUri;
-	$target  = '_self';
-}
+$editUrl = JUri::base() . 'index.php?option=com_config&view=modules&id=' . (int) $mod->id . $redirectUri;
+$target  = '_self';
 
 // Add class, editing URL and tooltip, and if module of type menu, also the tooltip for editing the menu item:
 $count = 0;


### PR DESCRIPTION
com_modules just has one option to set the default state for the list of modules to site or admin and its realy not needed. This PR removes the option
