### PR TITLE
Fix com_content legacy router trying to use menu items of other components

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -74,7 +74,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		}
 
 		// Make sure that the menu item selected above actually points to com_content component
-		if (!empty($menuItem) && $menuItem->component != 'com_content')
+		if ($menuItem !== null && $menuItem->component != 'com_content')
 		{
 			$menuItemGiven = false;
 			unset($query['Itemid']);

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -73,8 +73,8 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 			$menuItemGiven = true;
 		}
 
-		// Check again
-		if ($menuItemGiven && isset($menuItem) && $menuItem->component != 'com_content')
+		// Make sure that the menu item selected above actually points to com_content component
+		if (!empty($menuItem) && $menuItem->component != 'com_content')
 		{
 			$menuItemGiven = false;
 			unset($query['Itemid']);


### PR DESCRIPTION
Pull Request for Issues #15823

com_content router will only check if menu item is of 'com_content' type only if "menuItemGiven" flag is set, but this is not enough

The result is that current menu item can be tried without caring if it is com_content menu item

### Summary of Changes
Always check if selected menu item is 

### Testing Instructions
Code review

Also an example for testing is shown here:

1. Enable error reporting to maximum
2 .Unpublish ALL com_content menu items
3. Create a menu item M1  of some other component but 
- but select a menu item that DOES NOT have ID variable, 
- but it has a view name either 'article' or 'category' so that you get the undefined variable notice,
4. Display a Joomla latest articles module in your home page (make sure you have some items in it)
5. Enable SEF urls and view the menu item M1 in frontend

Result is shown here
https://cloud.githubusercontent.com/assets/5092940/17293281/0f36a64a-57f8-11e6-8ae2-3012187cb7ea.png

### Expected result
The current menu item since it belongs to other component should not be examined by the com_content router

### Actual result
The com_content router tries to use the menu item



### Documentation Changes Required

