### PR TITLE
[com_fields] Clear the field cache after save operations

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -728,4 +728,17 @@ class FieldsHelper
 
 		return $data;
 	}
+
+	/**
+	 * Clears the internal cache for the custom fields.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function clearFieldsCache()
+	{
+		self::$fieldCache  = null;
+		self::$fieldsCache = null;
+	}
 }

--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -196,6 +196,8 @@ class FieldsModelField extends JModelAdmin
 			}
 		}
 
+		FieldsHelper::clearFieldsCache();
+
 		return true;
 	}
 
@@ -642,6 +644,7 @@ class FieldsModelField extends JModelAdmin
 		}
 
 		$this->valueCache = array();
+		FieldsHelper::clearFieldsCache();
 
 		return true;
 	}


### PR DESCRIPTION
### Summary of Changes
For performance reasons, com_fields saves the fields in memory during a request. This cache should be cleared after saving custom fields or custom fields values.

### Testing Instructions
Add the following code to the file administrator/components/com_content/models/article.php after line 623 (`if (parent::save($data))
		{`)
```
$params = \Joomla\CMS\Component\ComponentHelper::getParams('com_content');
$article = $this->getItem();
$article->text = '';
JEventDispatcher::getInstance()->trigger(
	'onContentPrepare',
	[
		'com_content.article',
		&$article,
		&$params,
		0
	]
);
print_r($article->jcfields);die;
```

- Create an article custom field
- Create an article
- Fill in a value for the custom field
- Save the article

### Expected result
In the output should the _value_ and _rawvalue_ fields be filled.

### Actual result
In the output are the _value_ and _rawvalue_ fields are empty.