### PR TITLE
Allow disabling the Joomla! localhost database security check.

### DIFF
--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -164,6 +164,8 @@ class InstallationModelDatabase extends JModelBase
 			return false;
 		}
 
+		$shouldCheckLocalhost = getenv('JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK') !== '1';
+		
 		// Per Default allowed DB Hosts
 		$localhost = array(
 			'localhost',
@@ -172,7 +174,7 @@ class InstallationModelDatabase extends JModelBase
 		);
 
 		// Check the security file if the db_host is not localhost / 127.0.0.1 / ::1
-		if (!in_array($options->db_host, $localhost))
+		if ($shouldCheckLocalhost && !in_array($options->db_host, $localhost))
 		{
 			// Add the general message
 			JFactory::getApplication()->enqueueMessage(


### PR DESCRIPTION
As Joomla! provides a Docker image, the chance of using "localhost" is never. Therefore if the container is scheduled in an environment where you cannot access the container (not that you should ever need to) then you need to be able to bypass this check. This environment variable can be placed in the containers build file and will disable checks meaning you can install hassle free.

This check still keeps the installation secure as you'd need the same access to the server to delete the file.

Pull Request for Issue # joomla/docker-joomla#25.

### Summary of Changes

Allow the check for localhost to be bypassed by an environment variable.

### Testing Instructions

Set the environment variable `JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK` to one, attempt to install on a non localhost database server and no requirements to delete files should be shown.


### Documentation Changes Required

This will need to go into the Joomla! docker build files, but may help to be documented somewhere.

There is a PR depending on this: https://github.com/joomla/docker-joomla/pull/26