### PR TITLE
Adjusted the Search Query to be Case Sensitive.

### DIFF
--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -227,10 +227,12 @@ class SearchViewSearch extends JViewLegacy
 					{
 						$pos += $cnt * $highlighterLen;
 
-						/* Avoid overlapping/corrupted highlighter-spans
+						/*
+						 * Avoid overlapping/corrupted highlighter-spans
 						 * TODO $chkOverlap could be used to highlight remaining part
 						 * of search-word outside last highlighter-span.
-						 * At the moment no additional highlighter is set.*/
+						 * At the moment no additional highlighter is set.
+						 */
 						$chkOverlap = $pos - $lastHighlighterEnd;
 
 						if ($chkOverlap >= 0)
@@ -258,16 +260,22 @@ class SearchViewSearch extends JViewLegacy
 
 				$result = &$results[$i];
 
+				$created = '';
+
 				if ($result->created)
 				{
 					$created = JHtml::_('date', $result->created, JText::_('DATE_FORMAT_LC3'));
 				}
-				else
-				{
-					$created = '';
-				}
 
-				$result->title   = StringHelper::str_ireplace($needle, $hl1 . $needle . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
+				$result->title   = StringHelper::substr_replace(
+					$needle,
+					$hl1 . $needle . $hl2,
+					htmlspecialchars(
+						$result->title, ENT_COMPAT, 'UTF-8'
+					)
+				);
+
+				var_dump($result->text);die;
 				$result->text    = JHtml::_('content.prepare', $result->text, '', 'com_search.search');
 				$result->created = $created;
 				$result->count   = $i + 1;

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -267,7 +267,7 @@ class SearchViewSearch extends JViewLegacy
 					$created = JHtml::_('date', $result->created, JText::_('DATE_FORMAT_LC3'));
 				}
 
-				$result->title   = StringHelper::substr_replace(
+				$result->title   = StringHelper::str_ireplace(
 					$needle,
 					$hl1 . $needle . $hl2,
 					htmlspecialchars(
@@ -275,7 +275,6 @@ class SearchViewSearch extends JViewLegacy
 					)
 				);
 
-				var_dump($result->text);die;
 				$result->text    = JHtml::_('content.prepare', $result->text, '', 'com_search.search');
 				$result->created = $created;
 				$result->count   = $i + 1;

--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -84,12 +84,12 @@ class PlgSearchContent extends JPlugin
 			case 'exact':
 				$text      = $db->quote('%' . $db->escape($text, true) . '%', false);
 				$wheres2   = array();
-				$wheres2[] = 'a.title LIKE ' . $text;
-				$wheres2[] = 'a.introtext LIKE ' . $text;
-				$wheres2[] = 'a.fulltext LIKE ' . $text;
-				$wheres2[] = 'a.metakey LIKE ' . $text;
-				$wheres2[] = 'a.metadesc LIKE ' . $text;
-				$wheres2[] = 'fv.value LIKE ' . $text;
+				$wheres2[] = 'a.title LIKE BINARY ' . $text;
+				$wheres2[] = 'a.introtext LIKE BINARY ' . $text;
+				$wheres2[] = 'a.fulltext LIKE BINARY ' . $text;
+				$wheres2[] = 'a.metakey LIKE BINARY ' . $text;
+				$wheres2[] = 'a.metadesc LIKE BINARY ' . $text;
+				$wheres2[] = 'fv.value LIKE BINARY ' . $text;
 				$where     = '(' . implode(') OR (', $wheres2) . ')';
 				break;
 
@@ -103,12 +103,12 @@ class PlgSearchContent extends JPlugin
 				{
 					$word      = $db->quote('%' . $db->escape($word, true) . '%', false);
 					$wheres2   = array();
-					$wheres2[] = 'LOWER(a.title) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.introtext) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.fulltext) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.metakey) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.metadesc) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(fv.value) LIKE LOWER(' . $word . ')';
+					$wheres2[] = 'a.title LIKE BINARY ' . $word;
+					$wheres2[] = 'a.introtext LIKE BINARY ' . $word;
+					$wheres2[] = 'a.fulltext LIKE BINARY ' . $word;
+					$wheres2[] = 'a.metakey LIKE BINARY ' . $word;
+					$wheres2[] = 'a.metadesc LIKE BINARY ' . $word;
+					$wheres2[] = 'fv.value LIKE BINARY ' . $word;
 					$wheres[]  = implode(' OR ', $wheres2);
 				}
 


### PR DESCRIPTION
More work is needed, StringHelper::substr_replace doesn't find a result?? and the description highlighting is always forcing lower on the search and match replacing with the keyword.

Pull Request for Issue #17241 

### Testing Instructions
Create an article with title: Article and Description: Article

Search: article, both article and Article are found. 


### Expected result

The exact string is found not both upper and lower case.

### Actual result

All cases are found.

### Documentation Changes Required

