### PR TITLE
Simple change from str_ireplace to pref_replace for matching case sen…

### DIFF
--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -227,10 +227,12 @@ class SearchViewSearch extends JViewLegacy
 					{
 						$pos += $cnt * $highlighterLen;
 
-						/* Avoid overlapping/corrupted highlighter-spans
+						/*
+						 * Avoid overlapping/corrupted highlighter-spans
 						 * TODO $chkOverlap could be used to highlight remaining part
 						 * of search-word outside last highlighter-span.
-						 * At the moment no additional highlighter is set.*/
+						 * At the moment no additional highlighter is set.
+						 */
 						$chkOverlap = $pos - $lastHighlighterEnd;
 
 						if ($chkOverlap >= 0)
@@ -257,17 +259,14 @@ class SearchViewSearch extends JViewLegacy
 				}
 
 				$result = &$results[$i];
+				$created = '';
 
 				if ($result->created)
 				{
 					$created = JHtml::_('date', $result->created, JText::_('DATE_FORMAT_LC3'));
 				}
-				else
-				{
-					$created = '';
-				}
 
-				$result->title   = StringHelper::str_ireplace($needle, $hl1 . $needle . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
+				$result->title   = preg_replace("/\b($needle)\b/i", $hl1 . "$1" . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
 				$result->text    = JHtml::_('content.prepare', $result->text, '', 'com_search.search');
 				$result->created = $created;
 				$result->count   = $i + 1;

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -266,7 +266,7 @@ class SearchViewSearch extends JViewLegacy
 					$created = JHtml::_('date', $result->created, JText::_('DATE_FORMAT_LC3'));
 				}
 
-				$result->title   = preg_replace("/\b($needle)\b/i", $hl1 . "$1" . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
+				$result->title   = preg_replace("/\b($needle)\b/ui", $hl1 . "$1" . $hl2, htmlspecialchars($result->title, ENT_COMPAT, 'UTF-8'));
 				$result->text    = JHtml::_('content.prepare', $result->text, '', 'com_search.search');
 				$result->created = $created;
 				$result->count   = $i + 1;


### PR DESCRIPTION
Pull Request for Issue #17241

This stops the title replacements being replaced with the searched word and instead the actual word which is being replaced to be wrapped.

### Summary of Changes
moved from str_ireplace
to preg_replace


### Testing Instructions

Use joomla! com_search, search for a result which is is an uppercase with a lowercase letter i.e. Article is the title of the article search for article

### Expected result
article and Article to be found but the hightlighted word to be case sensitive. 


### Actual result

The found match is replaced which the searched word.

