### PR TITLE
required = false is not required

### DIFF
--- a/administrator/components/com_content/models/forms/article.xml
+++ b/administrator/components/com_content/models/forms/article.xml
@@ -1029,7 +1029,6 @@
 				type="textarea" 
 				label="JFIELD_META_RIGHTS_LABEL"
 				description="JFIELD_META_RIGHTS_DESC" 
-				required="false" 
 				filter="string"
 				cols="30" 
 				rows="2" 

--- a/administrator/components/com_languages/models/forms/language.xml
+++ b/administrator/components/com_languages/models/forms/language.xml
@@ -60,7 +60,6 @@
 			directory="media/mod_languages/images/"
 			hide_none="1"
 			hide_default="1"
-			required="false"
 			filter="\.gif$"
 			size="10"
 			>

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -477,7 +477,6 @@
 				type="text"
 				label="JFIELD_META_RIGHTS_LABEL"
 				description="JFIELD_META_RIGHTS_DESC"
-				required="false"
 				rows="2"
 				cols="30"
 				filter="string"

--- a/components/com_content/models/forms/article.xml
+++ b/components/com_content/models/forms/article.xml
@@ -409,7 +409,6 @@
 					label="JFIELD_META_RIGHTS_LABEL"
 					description="JFIELD_META_RIGHTS_DESC"
 					filter="unset"
-					required="false"
 					labelclass="control-label"
 				/>
 

--- a/components/com_users/models/forms/login.xml
+++ b/components/com_users/models/forms/login.xml
@@ -29,7 +29,6 @@
 			type="text"
 			label="JGLOBAL_SECRETKEY"
 			class=""
-			required="false"
 			filter="int"
 			size="25"
 		/>

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -63,7 +63,6 @@
 					label="PLG_RECAPTCHA_THEME_LABEL"
 					description="PLG_RECAPTCHA_THEME_DESC"
 					default="clean"
-					required="false"
 					showon="version:1.0"
 					filter=""
 					>
@@ -79,7 +78,6 @@
 					label="PLG_RECAPTCHA_THEME_LABEL"
 					description="PLG_RECAPTCHA_THEME_DESC"
 					default="light"
-					required="false"
 					showon="version:2.0"
 					filter=""
 					>
@@ -93,7 +91,6 @@
 					label="PLG_RECAPTCHA_SIZE_LABEL"
 					description="PLG_RECAPTCHA_SIZE_DESC"
 					default="normal"
-					required="false"
 					showon="version:2.0"
 					filter=""
 					>


### PR DESCRIPTION
Looks like some commits included this in the xml definition fr a field when it is not needed (and doesnt do anything).

You can confirm this by checking the markup of the content rights field in the article edit form before and after the PR - there will be no change

