### PR TITLE
Required fields cleanup

### DIFF
--- a/administrator/components/com_banners/models/forms/client.xml
+++ b/administrator/components/com_banners/models/forms/client.xml
@@ -37,7 +37,6 @@
 			description="COM_BANNERS_FIELD_EMAIL_DESC"
 			size="40"
 			validate="email"
-			required="true"
 		/>
 
 		<field

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -197,7 +197,6 @@
 			description="COM_CONFIG_FIELD_CACHE_TIME_DESC"
 			min="1"
 			default="15"
-			required="true"
 			filter="integer"
 			validate="number"
 			size="6"
@@ -598,7 +597,6 @@
 			hint="25"
 			validate="number"
 			filter="integer"
-			required="true"
 			size="5"
 		/>
 
@@ -929,7 +927,6 @@
 			description="COM_CONFIG_FIELD_SESSION_TIME_DESC"
 			min="1"
 			default="15"
-			required="true"
 			filter="integer"
 			validate="number"
 			size="6"

--- a/administrator/components/com_menus/models/forms/menu.xml
+++ b/administrator/components/com_menus/models/forms/menu.xml
@@ -51,7 +51,6 @@
 			id="client_id"
 			default="0"
 			class="btn-group btn-group-yesno btn-group-reversed"
-			required="true"
 			>
 			<option value="0">JSITE</option>
 			<option value="1">JADMINISTRATOR</option>

--- a/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/models/forms/newsfeed.xml
@@ -114,7 +114,6 @@
 			description="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_DESC"
 			default="5"
 			size="2"
-			required="true"
 		/>
 
 		<field
@@ -124,7 +123,6 @@
 			description="JGLOBAL_FIELD_FIELD_CACHETIME_DESC"
 			default="3600"
 			size="4"
-			required="true"
 		/>
 
 		<field
@@ -363,7 +361,6 @@
 			description="COM_NEWSFEEDS_FIELD_NUM_ARTICLES_DESC"
 			default="5"
 			size="2"
-			required="true"
 		/>
 
 		<field
@@ -373,7 +370,6 @@
 			description="JGLOBAL_FIELD_FIELD_CACHETIME_DESC"
 			default="3600"
 			size="4"
-			required="true"
 		/>
 
 		<field

--- a/administrator/components/com_redirect/models/forms/link.xml
+++ b/administrator/components/com_redirect/models/forms/link.xml
@@ -47,7 +47,6 @@
 			description="JFIELD_PUBLISHED_DESC"
 			class="chzn-color-state"
 			size="1"
-			required="true"
 			default="1"
 			>
 			<option value="1">JENABLED</option>

--- a/administrator/components/com_users/models/forms/group.xml
+++ b/administrator/components/com_users/models/forms/group.xml
@@ -23,7 +23,6 @@
 			type="groupparent"
 			label="COM_USERS_GROUP_FIELD_PARENT_LABEL"
 			description="COM_USERS_GROUP_FIELD_PARENT_DESC"
-			required="true"
 		/>
 
 		<field 

--- a/components/com_config/model/form/config.xml
+++ b/components/com_config/model/form/config.xml
@@ -99,7 +99,6 @@
 			label="COM_CONFIG_FIELD_DEFAULT_ACCESS_LEVEL_LABEL"
 			description="COM_CONFIG_FIELD_DEFAULT_ACCESS_LEVEL_DESC"
 			default="1"
-			required="true"
 			filter="integer" 
 		/>
 

--- a/components/com_users/models/forms/sitelang.xml
+++ b/components/com_users/models/forms/sitelang.xml
@@ -8,7 +8,6 @@
 				label="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_LABEL"
 				description="COM_USERS_USER_FIELD_FRONTEND_LANGUAGE_DESC"
 				client="site"
-				required="true"
 				filter="cmd"
 				default="active"
 			/>

--- a/plugins/fields/imagelist/imagelist.xml
+++ b/plugins/fields/imagelist/imagelist.xml
@@ -27,7 +27,6 @@
 					label="PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_LABEL"
 					description="PLG_FIELDS_IMAGELIST_PARAMS_DIRECTORY_DESC"
 					directory="images"
-					required="true"
 					hide_none="true"
 					hide_default="true"
 					recursive="true"

--- a/plugins/fields/integer/integer.xml
+++ b/plugins/fields/integer/integer.xml
@@ -40,7 +40,6 @@
 					description="PLG_FIELDS_INTEGER_PARAMS_FIRST_DESC"
 					default="1"
 					size="5"
-					required="true"
 				/>
 	
 				<field
@@ -50,7 +49,6 @@
 					description="PLG_FIELDS_INTEGER_PARAMS_LAST_DESC"
 					default="100"
 					size="5"
-					required="true"
 				/>
 	
 				<field
@@ -60,7 +58,6 @@
 					description="PLG_FIELDS_INTEGER_PARAMS_STEP_DESC"
 					default="1"
 					size="5"
-					required="true"
 				/>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
A form should have as few required fields as possible. In many cases we have marked a field as required even though it can never be empty because it has a default value (either defined in the xml or as a result of the fieldtype) so we dont need to mark it as required.

In addition we have the field banner clients email marked as required but there is no functional reason for this to be required
