### PR TITLE
Update placeholder with module name from manifest.

### DIFF
--- a/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
@@ -89,10 +89,9 @@ class ModuleAdapter extends InstallerAdapter
 		// Copy all necessary files
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
-			throw new \RuntimeException(sprintf(
-				\JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'),
-				$this->getManifest()->name
-			));
+			throw new \RuntimeException(
+				\JText::sprintf('JLIB_INSTALLER_ABORT_MOD_COPY_FILES', $this->getManifest()->name)
+			);
 		}
 
 		// If there is a manifest script, let's copy it.

--- a/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
@@ -89,7 +89,10 @@ class ModuleAdapter extends InstallerAdapter
 		// Copy all necessary files
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
-			throw new \RuntimeException(\JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'));
+			throw new \RuntimeException(sprintf(
+			    \JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'),
+                $this->getManifest()->name
+            ));
 		}
 
 		// If there is a manifest script, let's copy it.

--- a/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Joomla/CMS/Installer/Adapter/ModuleAdapter.php
@@ -90,9 +90,9 @@ class ModuleAdapter extends InstallerAdapter
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
 			throw new \RuntimeException(sprintf(
-			    \JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'),
-                $this->getManifest()->name
-            ));
+				\JText::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'),
+				$this->getManifest()->name
+			));
 		}
 
 		// If there is a manifest script, let's copy it.


### PR DESCRIPTION

Pull Request for Issue # .

### Summary of Changes

During a module install, when copying base files fails and exception is
thrown with a language definition. This language definition contains a
placeholder but is no replaced.

This commit will now make it replace the placeholder with the name from the
manifest.

The language definition is "JLIB_INSTALLER_ABORT_MOD_COPY_FILES"
The text at this time is "Module %s: Could not copy files from the
source."

Before:
![screenshot from 2017-07-28 10-53-49](https://user-images.githubusercontent.com/1764057/28712785-583881a8-7384-11e7-96cd-673c3b023428.png)

After:
![screenshot from 2017-07-28 10-58-14](https://user-images.githubusercontent.com/1764057/28712791-5cd2bbd4-7384-11e7-9764-11705fa9af32.png)

Given that the manifest has a name tag containing "mod_example"
```
<?xml version="1.0" encoding="utf-8"?>
<extension type="module" version="3.7.0" client="site" method="upgrade">
    <name>mod_example</name>
</extension
```

### Testing Instructions

Install a module with a files/folders that do not exist.

### Expected result

The error to contain the extension name or remove the placeholder altogether.

### Actual result

A placeholder in the error message on the Joomla! installation interface..

### Documentation Changes Required

Not required.
