### PR TITLE
Moved JLanguageMultilang::isAdminEnabled() to JModuleHelper::isAdminMultilang()

### DIFF
--- a/administrator/components/com_menus/controller.php
+++ b/administrator/components/com_menus/controller.php
@@ -31,7 +31,7 @@ class MenusController extends JControllerLegacy
 		JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/helpers/menus.php');
 
 		// Check custom administrator menu modules
-		if (JLanguageMultilang::isAdminEnabled())
+		if (JModuleHelper::isAdminMultilang())
 		{
 			$languages = JLanguageHelper::getInstalledLanguages(1, true);
 			$langCodes = array();

--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -77,7 +77,7 @@ class ModulesController extends JControllerLegacy
 		ModulesHelper::addSubmenu($this->input->get('view', 'modules'));
 
 		// Check custom administrator menu modules
-		if (JLanguageMultilang::isAdminEnabled())
+		if (JModuleHelper::isAdminMultilang())
 		{
 			$languages = JLanguageHelper::getInstalledLanguages(1, true);
 			$langCodes = array();

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -543,7 +543,7 @@ class ModulesModelModule extends JModelAdmin
 			$form = $this->loadForm('com_modules.module.admin', 'moduleadmin', array('control' => 'jform', 'load_data' => $loadData), true);
 
 			// Display language field to filter admin custom menus per language
-			if (!JLanguageMultilang::isAdminEnabled())
+			if (!JModuleHelper::isAdminMultilang())
 			{
 				$form->setFieldAttribute('language', 'type', 'hidden');
 			}

--- a/administrator/components/com_modules/views/modules/tmpl/default.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default.php
@@ -69,7 +69,7 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
 						</th>
-						<?php elseif ($clientId === 1 && JLanguageMultilang::isAdminEnabled()) : ?>
+						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 						<th width="10%" class="nowrap hidden-phone">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 						</th>
@@ -191,7 +191,7 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<td class="small hidden-phone">
 							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 						</td>
-						<?php elseif ($clientId === 1 && JLanguageMultilang::isAdminEnabled()) : ?>
+						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 							<td class="small hidden-phone">
 								<?php if ($item->language == ''):?>
 									<?php echo JText::_('JUNDEFINED'); ?>

--- a/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
+++ b/administrator/components/com_modules/views/modules/tmpl/default_batch_body.php
@@ -39,7 +39,7 @@ $attr = array(
 					<?php echo JLayoutHelper::render('joomla.html.batch.language', array()); ?>
 				</div>
 			</div>
-		<?php elseif ($clientId == 1 && JLanguageMultilang::isAdminEnabled()) : ?>
+		<?php elseif ($clientId == 1 && JModuleHelper::isAdminMultilang()) : ?>
 			<div class="control-group span6">
 				<div class="controls">
 					<?php echo JLayoutHelper::render('joomla.html.batch.adminlanguage', array()); ?>

--- a/administrator/components/com_modules/views/modules/view.html.php
+++ b/administrator/components/com_modules/views/modules/view.html.php
@@ -48,7 +48,7 @@ class ModulesViewModules extends JViewLegacy
 		}
 
 		// We do not need the Language filter when modules are not filtered
-		if ($this->clientId == 1 && !JLanguageMultilang::isAdminEnabled())
+		if ($this->clientId == 1 && !JModuleHelper::isAdminMultilang())
 		{
 			unset($this->activeFilters['language']);
 			$this->filterForm->removeField('language', 'filter');

--- a/libraries/src/Joomla/CMS/Helper/ModuleHelper.php
+++ b/libraries/src/Joomla/CMS/Helper/ModuleHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Helper;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\Registry\Registry;
 
 /**
@@ -636,9 +637,9 @@ abstract class ModuleHelper
 	{
 		static $enabled = false;
 
-		if (count(\JLanguageHelper::getInstalledLanguages(1)) > 1)
+		if (count(LanguageHelper::getInstalledLanguages(1)) > 1)
 		{
-			$enabled = (bool) \JComponentHelper::getParams('com_modules')->get('adminlangfilter', 0);
+			$enabled = (bool) ComponentHelper::getParams('com_modules')->get('adminlangfilter', 0);
 		}
 
 		return $enabled;

--- a/libraries/src/Joomla/CMS/Helper/ModuleHelper.php
+++ b/libraries/src/Joomla/CMS/Helper/ModuleHelper.php
@@ -413,7 +413,7 @@ abstract class ModuleHelper
 			$cacheId .= $lang . '*';
 		}
 
-		if ($app->isClient('administrator') && \JLanguageMultilang::isAdminEnabled())
+		if ($app->isClient('administrator') && static::isAdminMultilang())
 		{
 			$query->where('m.language IN (' . $db->quote($lang) . ',' . $db->quote('*') . ')');
 			$cacheId .= $lang . '*';
@@ -623,5 +623,24 @@ abstract class ModuleHelper
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Method to determine if filtering by language is enabled in back-end for modules.
+	 *
+	 * @return  boolean  True if enabled; false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isAdminMultilang()
+	{
+		static $enabled = false;
+
+		if (count(\JLanguageHelper::getInstalledLanguages(1)) > 1)
+		{
+			$enabled = (bool) \JComponentHelper::getParams('com_modules')->get('adminlangfilter', 0);
+		}
+
+		return $enabled;
 	}
 }

--- a/libraries/src/Joomla/CMS/Language/Multilanguage.php
+++ b/libraries/src/Joomla/CMS/Language/Multilanguage.php
@@ -109,23 +109,4 @@ class Multilanguage
 
 		return $multilangSiteHomePages;
 	}
-
-	/**
-	 * Method to determine if filtering by language is enabled in back-end for custom menus.
-	 *
-	 * @return  boolean  True if admin is supporting multiple languages; false otherwise.
-	 *
-	 * @since   3.8.0
-	 */
-	public static function isAdminEnabled()
-	{
-		static $enabled = false;
-
-		if (count(\JLanguageHelper::getInstalledLanguages(1)) > 1)
-		{
-			$enabled = \JComponentHelper::getParams('com_modules')->get('adminlangfilter', 0);
-		}
-
-		return (bool) $enabled;
-	}
 }


### PR DESCRIPTION
Continuing #17215 (https://github.com/joomla/joomla-cms/pull/17215#issuecomment-318373574)

### Summary of Changes
Moved `JLanguageMultilang::isAdminEnabled()` to `JModuleHelper::isAdminMultilang()` as the check is more closer context to the module manager than the global multilingual system.

### Testing Instructions
See the #17215 test instruction and make sure everything mentioned there still works.

