### PR TITLE
[4.0] Create a service registry for JHtml

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -174,6 +174,9 @@ final class InstallationApplicationWeb extends CMSApplication
 		// Register the document object with JFactory.
 		JFactory::$document = $document;
 
+		// Register our JHtml service
+		JHtml::getServiceRegistry()->register('installation', new InstallationHtmlHelper($this));
+
 		// Define component path.
 		define('JPATH_COMPONENT', JPATH_BASE);
 		define('JPATH_COMPONENT_SITE', JPATH_SITE);

--- a/installation/html/helper.php
+++ b/installation/html/helper.php
@@ -16,13 +16,33 @@ defined('_JEXEC') or die;
 class InstallationHtmlHelper
 {
 	/**
+	 * The active application
+	 *
+	 * @var    InstallationApplicationWeb
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $application;
+
+	/**
+	 * Service constructor
+	 *
+	 * @param   InstallationApplicationWeb  $application  The active application
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(InstallationApplicationWeb $application)
+	{
+		$this->application = $application;
+	}
+
+	/**
 	 * Method to generate the side bar.
 	 *
 	 * @return  string  Markup for the side bar.
 	 *
 	 * @since   1.6
 	 */
-	public static function stepbar()
+	public function stepbar()
 	{
 		// Determine if the configuration file path is writable.
 		$path   = JPATH_CONFIGURATION . '/configuration.php';
@@ -44,7 +64,7 @@ class InstallationHtmlHelper
 
 		foreach ($tabs as $tab)
 		{
-			$html[] = static::getTab($tab, $tabs);
+			$html[] = $this->getTab($tab, $tabs);
 		}
 
 		$html[] = '</ul>';
@@ -59,7 +79,7 @@ class InstallationHtmlHelper
 	 *
 	 * @since   3.1
 	 */
-	public static function stepbarlanguages()
+	public function stepbarlanguages()
 	{
 		$tabs = array();
 		$tabs[] = 'languages';
@@ -71,7 +91,7 @@ class InstallationHtmlHelper
 
 		foreach ($tabs as $tab)
 		{
-			$html[] = static::getTab($tab, $tabs);
+			$html[] = $this->getTab($tab, $tabs);
 		}
 
 		$html[] = '</ul>';
@@ -89,11 +109,11 @@ class InstallationHtmlHelper
 	 *
 	 * @since   3.1
 	 */
-	private static function getTab($id, $tabs)
+	private function getTab($id, $tabs)
 	{
-		$input  = JFactory::getApplication()->input;
-		$num    = static::getTabNumber($id, $tabs);
-		$view   = static::getTabNumber($input->getWord('view'), $tabs);
+		$input  = $this->application->input;
+		$num    = $this->getTabNumber($id, $tabs);
+		$view   = $this->getTabNumber($input->getWord('view'), $tabs);
 		$tab    = '<span class="badge badge-default">' . $num . '</span> ' . JText::_('INSTL_STEP_' . strtoupper($id) . '_LABEL');
 		$active = $num == $view ? ' active' : '';
 
@@ -123,7 +143,7 @@ class InstallationHtmlHelper
 	 *
 	 * @since   3.1
 	 */
-	private static function getTabNumber($id, $tabs)
+	private function getTabNumber($id, $tabs)
 	{
 		$num = (int) array_search($id, $tabs, true);
 		$num++;

--- a/installation/view/database/tmpl/default.php
+++ b/installation/view/database/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
+<?php echo JHtml::_('installation.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
 	<div class="btn-toolbar justify-content-end">
 		<div class="btn-group">

--- a/installation/view/defaultlanguage/tmpl/default.php
+++ b/installation/view/defaultlanguage/tmpl/default.php
@@ -21,7 +21,7 @@ JFactory::getDocument()->addScriptDeclaration(
 JS
 );
 ?>
-<?php echo JHtml::_('InstallationHtml.helper.stepbarlanguages'); ?>
+<?php echo JHtml::_('installation.stepbarlanguages'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
 	<div class="btn-toolbar justify-content-end">
 		<div class="btn-group">

--- a/installation/view/ftp/tmpl/default.php
+++ b/installation/view/ftp/tmpl/default.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
+<?php echo JHtml::_('installation.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
 	<div class="btn-toolbar justify-content-end">
 		<div class="btn-group">

--- a/installation/view/languages/tmpl/default.php
+++ b/installation/view/languages/tmpl/default.php
@@ -23,7 +23,7 @@ $version = new JVersion;
 	}
 </script>
 
-<?php echo JHtml::_('InstallationHtml.helper.stepbarlanguages'); ?>
+<?php echo JHtml::_('installation.stepbarlanguages'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
 	<div class="btn-toolbar justify-content-end">
 		<div class="btn-group">

--- a/installation/view/site/tmpl/default.php
+++ b/installation/view/site/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 /* @var InstallationViewDefault $this */
 ?>
-<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
+<?php echo JHtml::_('installation.stepbar'); ?>
 <div class="btn-toolbar justify-content-end">
 	<div class="btn-group">
 		<a href="#" class="btn btn-primary" onclick="Install.submitform();" rel="next" title="<?php echo JText::_('JNEXT'); ?>"><span class="fa fa-arrow-right icon-white"></span> <?php echo JText::_('JNEXT'); ?></a>

--- a/installation/view/summary/tmpl/default.php
+++ b/installation/view/summary/tmpl/default.php
@@ -16,7 +16,7 @@ $path = JPATH_CONFIGURATION . '/configuration.php';
 $useftp = file_exists($path) ? !is_writable($path) : !is_writable(JPATH_CONFIGURATION . '/');
 $prev = $useftp ? 'ftp' : 'database';
 ?>
-<?php echo JHtml::_('InstallationHtml.helper.stepbar'); ?>
+<?php echo JHtml::_('installation.stepbar'); ?>
 <form action="index.php" method="post" id="adminForm" class="form-validate">
 	<div class="btn-toolbar justify-content-end">
 		<div class="btn-group">

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -9,6 +9,8 @@
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\HTML\Registry;
+use Joomla\CMS\Log\Log;
 use Joomla\Utilities\ArrayHelper;
 
 jimport('joomla.environment.browser');
@@ -40,6 +42,7 @@ abstract class JHtml
 	 *
 	 * @var    string[]
 	 * @since  1.5
+	 * @deprecated  5.0
 	 */
 	protected static $includePaths = array();
 
@@ -48,8 +51,17 @@ abstract class JHtml
 	 *
 	 * @var    callable[]
 	 * @since  1.6
+	 * @deprecated  5.0
 	 */
 	protected static $registry = array();
+
+	/**
+	 * The service registry for custom and overridden JHtml helpers
+	 *
+	 * @var    Registry
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $serviceRegistry;
 
 	/**
 	 * Method to extract a key
@@ -67,6 +79,22 @@ abstract class JHtml
 
 		// Check to see whether we need to load a helper file
 		$parts = explode('.', $key);
+
+		if (count($parts) === 3)
+		{
+			try
+			{
+				Log::add(
+					'Support for a three segment service key is deprecated and will be removed in Joomla 5.0, use the service registry instead',
+					Log::WARNING,
+					'deprecated'
+				);
+			}
+			catch (RuntimeException $exception)
+			{
+				// Informational message only, continue on
+			}
+		}
 
 		$prefix = count($parts) === 3 ? array_shift($parts) : 'JHtml';
 		$file   = count($parts) === 2 ? array_shift($parts) : '';
@@ -103,6 +131,30 @@ abstract class JHtml
 			array_shift($args);
 
 			return static::call($function, $args);
+		}
+
+		/*
+		 * Support fetching services from the registry if a custom class prefix was not given (a three segment key),
+		 * the service comes from a class other than this one, and a service has been registered for the file.
+		 */
+		if ($prefix === 'JHtml' && $file !== '' && static::getServiceRegistry()->hasService($file))
+		{
+			$service = static::getServiceRegistry()->getService($file);
+
+			$toCall = array($service, $func);
+
+			if (!is_callable($toCall))
+			{
+				throw new InvalidArgumentException(sprintf('%s::%s not found.', $service, $func), 500);
+			}
+
+			static::register($key, $toCall);
+			$args = func_get_args();
+
+			// Remove function name from arguments
+			array_shift($args);
+
+			return static::call($toCall, $args);
 		}
 
 		$className = $prefix . ucfirst($file);
@@ -152,6 +204,19 @@ abstract class JHtml
 	 */
 	public static function register($key, callable $function)
 	{
+		try
+		{
+			Log::add(
+				'Support for registering functions is deprecated and will be removed in Joomla 5.0, use the service registry instead',
+				Log::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational message only, continue on
+		}
+
 		list($key) = static::extract($key);
 
 		static::$registry[$key] = $function;
@@ -170,6 +235,19 @@ abstract class JHtml
 	 */
 	public static function unregister($key)
 	{
+		try
+		{
+			Log::add(
+				'Support for registering functions is deprecated and will be removed in Joomla 5.0, use the service registry instead',
+				Log::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational message only, continue on
+		}
+
 		list($key) = static::extract($key);
 
 		if (isset(static::$registry[$key]))
@@ -198,6 +276,22 @@ abstract class JHtml
 		return isset(static::$registry[$key]);
 	}
 
+	/**
+	 * Retrieves the service registry.
+	 *
+	 * @return  Registry
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getServiceRegistry()
+	{
+		if (!static::$serviceRegistry)
+		{
+			static::$serviceRegistry = new Registry;
+		}
+
+		return static::$serviceRegistry;
+	}
 	/**
 	 * Function caller method
 	 *
@@ -1145,6 +1239,19 @@ abstract class JHtml
 	 */
 	public static function addIncludePath($path = '')
 	{
+		try
+		{
+			Log::add(
+				'Support for registering lookup paths is deprecated and will be removed in Joomla 5.0, use the service registry instead',
+				Log::WARNING,
+				'deprecated'
+			);
+		}
+		catch (RuntimeException $exception)
+		{
+			// Informational message only, continue on
+		}
+
 		// Loop through the path directories
 		foreach ((array) $path as $dir)
 		{

--- a/libraries/src/CMS/HTML/Registry.php
+++ b/libraries/src/CMS/HTML/Registry.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\HTML;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Service registry for JHtml services
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class Registry
+{
+	/**
+	 * Mapping array of the core CMS JHtml helpers
+	 *
+	 * As of 5.0, the $serviceMap will be prepopulated with the contents of this array
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $coreServiceMap = [
+		'access'          => \JHtmlAccess::class,
+		'actionsdropdown' => \JHtmlActionsDropdown::class,
+		'batch'           => \JHtmlBatch::class,
+		'behavior'        => \JHtmlBehavior::class,
+		'bootstrap'       => \JHtmlBootstrap::class,
+		'category'        => \JHtmlCategory::class,
+		'content'         => \JHtmlContent::class,
+		'contentlanguage' => \JHtmlContentlanguage::class,
+		'date'            => \JHtmlDate::class,
+		'debug'           => \JHtmlDebug::class,
+		'draggablelist'   => \JHtmlDraggablelist::class,
+		'dropdown'        => \JHtmlDropdown::class,
+		'email'           => \JHtmlEmail::class,
+		'form'            => \JHtmlForm::class,
+		'formbehavior'    => \JHtmlFormbehavior::class,
+		'grid'            => \JHtmlGrid::class,
+		'icons'           => \JHtmlIcons::class,
+		'jgrid'           => \JHtmlJGrid::class,
+		'jquery'          => \JHtmlJquery::class,
+		'links'           => \JHtmlLinks::class,
+		'list'            => \JHtmlList::class,
+		'menu'            => \JHtmlMenu::class,
+		'number'          => \JHtmlNumber::class,
+		'searchtools'     => \JHtmlSearchtools::class,
+		'select'          => \JHtmlSelect::class,
+		'sidebar'         => \JHtmlSidebar::class,
+		'sortablelist'    => \JHtmlSortablelist::class,
+		'string'          => \JHtmlString::class,
+		'tag'             => \JHtmlTag::class,
+		'tel'             => \JHtmlTel::class,
+		'user'            => \JHtmlUser::class,
+	];
+
+	/**
+	 * Array holding the registered services
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $serviceMap = [];
+
+	/**
+	 * Get the service for a given key
+	 *
+	 * @param   string  $key  The service key to look up
+	 *
+	 * @return  string|object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getService($key)
+	{
+		if (!$this->hasService($key))
+		{
+			throw new \InvalidArgumentException("The '$key' service key is not registered.");
+		}
+
+		return $this->serviceMap[$key];
+	}
+
+	/**
+	 * Check if the registry has a service for the given key
+	 *
+	 * @param   string  $key  The service key to look up
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hasService($key)
+	{
+		return isset($this->serviceMap[$key]);
+	}
+
+	/**
+	 * Register a service
+	 *
+	 * @param   string         $key      The service key to be registered
+	 * @param   string|object  $handler  The handler for the service as either a PHP class name or class object
+	 * @param   boolean        $replace  Flag indicating the service key may replace an existing definition
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function register($key, $handler, $replace = false)
+	{
+		// If the key exists already and we aren't instructed to replace existing services, bail early
+		if (isset($this->serviceMap[$key]) && !$replace)
+		{
+			throw new \RuntimeException("The '$key' service key is already registered.");
+		}
+
+		// If the handler is a string, it must be a class that exists
+		if (is_string($handler) && !class_exists($handler))
+		{
+			throw new \RuntimeException("The '$handler' class for service key '$key' does not exist.");
+		}
+
+		// Otherwise the handler must be a class object
+		if (!is_string($handler) && !is_object($handler))
+		{
+			throw new \RuntimeException(
+				sprintf(
+					'The handler for service key %1$s must be a PHP class name or class object, a %2$s was given.',
+					$key,
+					gettype($handler)
+				)
+			);
+		}
+
+		$this->serviceMap[$key] = $handler;
+	}
+}


### PR DESCRIPTION
### Summary of Changes

The manner in which services are integrated into JHtml are very sporadic and not the friendliest thing.  The `register` and `unregister` API maps specific keys to single callbacks and integrating services from components requires registering filesystem paths to scan for specific files.  We can do better than this.

This PR does two things.

First, it introduces a new service registry.  The registry allows developers to register a service key to either a PHP class name (static method calls, essentially what the system does now) or a class object (removing the requirement to either manually register callbacks through `JHtml::register()` or to use purely static methods).

Second, this PR deprecates the existing logic for registering things.  Manual lookup paths, registering (and unregistering) callbacks, and support for a three-piece key will be removed with Joomla 5.0 if this is accepted in favor of registering everything to the service registry.  The three-piece key is what allows developers to replace the `JHtml` class prefix with a prefix of their choosing, with this registry it really won't matter what they name their classes as the key will no longer have to directly map to a class name.  Path lookups are being removed as by the time we get to 5.0 extension architecture should really be at a point where it won't be needed.

The installation application's `JHtml` helper is updated to demonstrate this new methodology.

### Testing Instructions

Register a custom service to the registry by calling `JHtml::getServiceRegistry()->register($key, $handler);` where `$key` is the service key and `$handler` is either a PHP class name or a class object.  Once registered, calls to `JHtml::_($key . '.method');` should use your service.

### Documentation Changes Required

The deprecation and new manner of working should be documented.