### PR TITLE
[4.0] Disallow access to internal JHtml methods

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -124,6 +124,15 @@ abstract class JHtml
 			}
 		}
 
+		// If calling a method from this class, do not allow access to internal methods
+		if ($className === __CLASS__)
+		{
+			if (!((new ReflectionMethod($className, $func))->isPublic()))
+			{
+				throw new InvalidArgumentException('Access to internal class methods is not allowed.');
+			}
+		}
+
 		$toCall = array($className, $func);
 
 		if (!is_callable($toCall))


### PR DESCRIPTION
### Summary of Changes

Through `JHtml::_()`, it is possible to access internal methods of the `JHtml` class that are not public API.  This PR changes the logic to detect if a non-public method of `JHtml` is being called and will disallow these methods to be called going forward.

### Testing Instructions

Make a call to `JHtml::_('extract', 'date.relative')` and you'll find that the protected `JHtml::extract()` method is executed and the results returned to the caller without the patch applied.  With the patch, an exception is now thrown.

### Expected result

No access to internal class methods.

### Actual result

Internal class methods can be accessed.

### Documentation Changes Required

Technically this is a B/C break and should be noted as devs could conceivably call and use one of the protected methods of `JHtml` right now, hence the reason I'm doing this against 4.0 instead of 3.x.