### PR TITLE
[4.0] Fix component layout path

### DIFF
--- a/libraries/cms/form/field/componentlayout.php
+++ b/libraries/cms/form/field/componentlayout.php
@@ -108,7 +108,14 @@ class JFormFieldComponentlayout extends JFormField
 			$templates = $db->loadObjectList('element');
 
 			// Build the search paths for component layouts.
-			$component_path = JPath::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
+			$oldTmpl        = JPath::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
+			$component_path = $oldTmpl;
+
+			// Check if the old layouts folder exists, else use the new one
+			if (!file_exists($oldTmpl))
+			{
+				$component_path = JPath::clean($client->path . '/components/' . $extension . '/tmpl/' . $view);
+			}
 
 			// Prepare array of component layouts
 			$component_layouts = array();

--- a/libraries/cms/form/field/componentlayout.php
+++ b/libraries/cms/form/field/componentlayout.php
@@ -108,11 +108,10 @@ class JFormFieldComponentlayout extends JFormField
 			$templates = $db->loadObjectList('element');
 
 			// Build the search paths for component layouts.
-			$oldTmpl        = JPath::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
-			$component_path = $oldTmpl;
+			$component_path = JPath::clean($client->path . '/components/' . $extension . '/views/' . $view . '/tmpl');
 
 			// Check if the old layouts folder exists, else use the new one
-			if (!file_exists($oldTmpl))
+			if (!file_exists($component_path))
 			{
 				$component_path = JPath::clean($client->path . '/components/' . $extension . '/tmpl/' . $view);
 			}


### PR DESCRIPTION
Pull Request for Issue #17214

### Summary of Changes

Because we've moved component layouts from `view/VIEW_NAME/tmpl` to `tmpl/VIEW_NAME`, the dropdown allowing you to select a layout is empty.

This PR addresses that whilst keeping B/C

### Testing Instructions

- Go to Components >> Contacts >> New >> Display (tab)
- At the bottom, there's an option called "**Layout**"

Before the PR, there was only an option to select a layout from the global options.
After the PR, there's an option to select from component