### PR TITLE
Admin modules: no need to sort by language when filtering is disabled

### DIFF
--- a/administrator/components/com_modules/models/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/models/forms/filter_modulesadmin.xml
@@ -91,8 +91,8 @@
 			<option value="name DESC">COM_MODULES_HEADING_MODULE_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -117,6 +117,12 @@ class JFormFieldList extends JFormField
 				{
 					continue;
 				}
+
+				// Requires adminlanguage
+				if (in_array('adminlanguage', $requires) && !JModuleHelper::isAdminMultilang())
+				{
+					continue;
+				}
 			}
 
 			$value = (string) $option['value'];


### PR DESCRIPTION
Completing multilang administrator modules new feature

### Summary of Changes
Added a specific requires in list.php and use it in the `filter_modulesadmin.xml` filter file.


### Testing Instructions
Patch an instance of staging. 

In Modules Parameters, enable or not `Language Filtering`
When `Language Filtering` is off, the Sorting options will no more display Sorting by language.

![screen shot 2017-07-31 at 09 04 40](https://user-images.githubusercontent.com/869724/28766317-697a7dfc-75cf-11e7-8e6f-f3d861ea94ba.png)
 
@izharaazmi @AlexRed 