### PR TITLE
Correct Admin modules warning when nativeName is not defined in language pack.

### DIFF
--- a/administrator/components/com_menus/controller.php
+++ b/administrator/components/com_menus/controller.php
@@ -38,7 +38,16 @@ class MenusController extends JControllerLegacy
 
 			foreach ($languages as $language)
 			{
-				$langCodes[$language->metadata['tag']] = $language->metadata['nativeName'];
+				if (isset($language->metadata['nativeName']))
+				{
+					$languageName = $language->metadata['nativeName'];
+				}
+				else
+				{
+					$languageName = $language->metadata['name'];
+				}
+
+				$langCodes[$language->metadata['tag']] = $languageName;
 			}
 
 			$db    = JFactory::getDbo();

--- a/administrator/components/com_modules/controller.php
+++ b/administrator/components/com_modules/controller.php
@@ -84,7 +84,16 @@ class ModulesController extends JControllerLegacy
 
 			foreach ($languages as $language)
 			{
-				$langCodes[$language->metadata['tag']] = $language->metadata['nativeName'];
+				if (isset($language->metadata['nativeName']))
+				{
+					$languageName = $language->metadata['nativeName'];
+				}
+				else
+				{
+					$languageName = $language->metadata['name'];
+				}
+
+				$langCodes[$language->metadata['tag']] = $languageName;
 			}
 
 			$db    = JFactory::getDbo();


### PR DESCRIPTION
Correcting `Notice: Undefined index: nativeName in ROOT/administrator/components/com_modules/controller.php on line 87`

This isssue was discovered with the de-AT language pack where `nativeName` is missing in the language metadata

### Summary of Changes
If `nativeName` does not exist, use `name`.


### Testing Instructions
Install the de-AT language pack on staging.
Set `Language Filtering` to Yes in the Modules Manager Options.
Display the module Manager.

Before patch we get the notice.
After patch, issue is solved.

@izharaazmi @franz-wohlkoenig
