### PR TITLE
Logout Module emitting invalid html. Update default_logout.php (enclose params JRoute parameter in htmlentities)

### DIFF
--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 JHtml::_('behavior.keepalive');
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-vertical">
+<form action="<?php echo JRoute::_('index.php', true, htmlentities($params->get('usesecure')) ); ?>" method="post" id="login-form" class="form-vertical">
 <?php if ($params->get('greeting')) : ?>
 	<div class="login-greeting">
 	<?php if ($params->get('name') == 0) : ?>


### PR DESCRIPTION
Enclose JRoute param in htmlentities to emit valid html.
The getInstance part is right, but params remains unprotected, can emit invalid html!

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions

Create some contacts with associated tags
Create a menu item of type tagged-elements of contacts type
Publish a login/logout module on that page.

### Expected result
valid html

### Actual result
Invalid html. The logout form url contains invalid '[' and ']' chars; th eurl will be similar to (when sef url disabled): /index.php?option=com_tags&view=tag&id[0]=2&types[0]=2&Itemid=nnn

This problem is related to issue "Bug in AbstractUri::buildQuery - invalid HTML emitted ('[' and ']' not encoded in tagged elements list) #21" (joomla-framework/uri#21).

I think the preferred way to solve both problems is solving the above mentioned problem in AbstractUri:buildQuery

Similar problem in PR  [#17368](https://github.com/joomla/joomla-cms/pull/17368)

### Documentation Changes Required

