### PR TITLE
Login Module emitting invalid html. Update default_logout.php (enclose params JRoute parameter in htmlentities)

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -15,7 +15,7 @@ JHtml::_('behavior.keepalive');
 JHtml::_('bootstrap.tooltip');
 
 ?>
-<form action="<?php echo JRoute::_('index.php', true, $params->get('usesecure')); ?>" method="post" id="login-form" class="form-inline">
+<form action="<?php echo JRoute::_('index.php', true, htmlentities($params->get('usesecure')) ); ?>" method="post" id="login-form" class="form-inline">
 	<?php if ($params->get('pretext')) : ?>
 		<div class="pretext">
 			<p><?php echo $params->get('pretext'); ?></p>


### PR DESCRIPTION
Enclose JRoute param in htmlentities to avoid emitting invalid html

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions
Create some contacts with associated tags
Create a menu item of type tagged-elements of contacts type
Publish a login module on that page.

### Expected result
Valid html


### Actual result
Invalid html. The login form url contains invalid '[' and ']' chars; th eurl will be similar to (when sef url disabled): /index.php?option=com_tags&view=tag&id[0]=2&types[0]=2&Itemid=nnn

This problem is related to issue "Bug in AbstractUri::buildQuery - invalid HTML emitted ('[' and ']' not encoded in tagged elements list) #21" (joomla-framework/uri#21).

I think the preferred way to solve both problems is solving the above mentioned problem in AbstractUri:buildQuery

### Documentation Changes Required

