### PR TITLE
JFormFieldVotelist extends wrong field

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -931,6 +931,7 @@
 			type="votelist"
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC"
+			class="btn-group btn-group-yesno"
 			default="0"
 			>
 			<option value="1">JSHOW</option>
@@ -942,6 +943,7 @@
 			type="votelist"
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC"
+			class="btn-group btn-group-yesno"
 			default="0"
 			>
 			<option value="1">JSHOW</option>

--- a/administrator/components/com_content/models/fields/votelist.php
+++ b/administrator/components/com_content/models/fields/votelist.php
@@ -16,7 +16,7 @@ JFormHelper::loadFieldClass('list');
  *
  * @since  3.7.1
  */
-class JFormFieldVotelist extends JFormFieldList
+class JFormFieldVotelist extends JFormFieldRadio
 {
 	/**
 	 * The form field type.


### PR DESCRIPTION
It is extending JFormFieldList but it should be extending JFormFieldRadio so that the field is displayed as a show/hide switch and not a dropdown select

### Before
<img width="455" alt="screenshotr17-20-02" src="https://user-images.githubusercontent.com/1296369/28787570-93d1fb4e-7614-11e7-8840-cb6f07375fab.png">


### After

<img width="388" alt="screenshotr17-15-41" src="https://user-images.githubusercontent.com/1296369/28787564-8f83bfc8-7614-11e7-928d-77c4c957056b.png">
