### PR TITLE
JFormFieldVotelist extends wrong field #17370

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2132,6 +2132,7 @@ class JoomlaInstallerScript
 			'/libraries/legacy/view',
 			'/libraries/legacy/web',
 			'/administrator/modules/mod_menu/preset',
+			'/administrator/components/com_content/models/fields/votelist.php',
 		);
 
 		jimport('joomla.filesystem.file');

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -928,9 +928,10 @@
 
 		<field 
 			name="list_show_votes"
-			type="votelist"
+			type="voteradio"
 			label="JGLOBAL_LIST_VOTES_LABEL"
 			description="JGLOBAL_LIST_VOTES_DESC"
+			class="btn-group btn-group-yesno"
 			default="0"
 			>
 			<option value="1">JSHOW</option>
@@ -939,9 +940,10 @@
 
 		<field 
 			name="list_show_ratings"
-			type="votelist"
+			type="voteradio"
 			label="JGLOBAL_LIST_RATINGS_LABEL"
 			description="JGLOBAL_LIST_RATINGS_DESC"
+			class="btn-group btn-group-yesno"
 			default="0"
 			>
 			<option value="1">JSHOW</option>

--- a/administrator/components/com_content/models/fields/voteradio.php
+++ b/administrator/components/com_content/models/fields/voteradio.php
@@ -9,14 +9,14 @@
 
 defined('_JEXEC') or die;
 
-JFormHelper::loadFieldClass('list');
+JFormHelper::loadFieldClass('radio');
 
 /**
- * Votelist Field class.
+ * Voteradio Field class.
  *
- * @since  3.7.1
+ * @since  __DEPLOY_VERSION__
  */
-class JFormFieldVotelist extends JFormFieldList
+class JFormFieldVoteradio extends JFormFieldRadio
 {
 	/**
 	 * The form field type.
@@ -24,7 +24,7 @@ class JFormFieldVotelist extends JFormFieldList
 	 * @var    string
 	 * @since  3.7.1
 	 */
-	protected $type = 'Votelist';
+	protected $type = 'Voteradio';
 
 	/**
 	 * Method to get the field options.


### PR DESCRIPTION
The custom field for votelist is extending JFormFieldList but it should be extending JFormFieldRadio so that the field is displayed as a show/hide switch and not a dropdown select

This PR replaces the votelist field with a voteradio field (as it is a custom field for the component I replaced votelist - i can always put it back and mark it as deprecated and unused but I dont "think" thats required


### Before
<img width="455" alt="screenshotr17-20-02" src="https://user-images.githubusercontent.com/1296369/28787570-93d1fb4e-7614-11e7-8840-cb6f07375fab.png">


### After

<img width="388" alt="screenshotr17-15-41" src="https://user-images.githubusercontent.com/1296369/28787564-8f83bfc8-7614-11e7-928d-77c4c957056b.png">
