### PR TITLE
Fix delete cache items from redis and others

### DIFF
--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -56,7 +56,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				foreach ($this->data as $folder => $item) : ?>
 					<tr class="row<?php echo $i % 2; ?>">
 						<td>
-							<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $item->group; ?>" onclick="Joomla.isChecked(this.checked);" />
+							<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $this->escape($item->group); ?>" onclick="Joomla.isChecked(this.checked);" />
 						</td>
 						<td>
 							<label for="cb<?php echo $i; ?>">

--- a/administrator/components/com_cache/views/cache/tmpl/default.php
+++ b/administrator/components/com_cache/views/cache/tmpl/default.php
@@ -60,7 +60,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</td>
 						<td>
 							<label for="cb<?php echo $i; ?>">
-								<strong><?php echo $item->group; ?></strong>
+								<strong><?php echo $this->escape($item->group); ?></strong>
 							</label>
 						</td>
 						<td>

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -401,7 +401,7 @@ class Cache
 
 		if ($this->_options['locking'] == true)
 		{
-			$returning->locked = $handler->store(1, $id2, $group);
+			$returning->locked = $handler->store($id2, $group, 1);
 		}
 
 		// Revert lifetime to previous one


### PR DESCRIPTION
### Summary of Changes

1. Correct the order of parameters for `$handler->store()`.
2. Backend -> System -> Clear cache: Add html escape for input value.

### Testing Instructions
1. Install J3.8
2. Enable redis cache as example below (to test you can also use cache lite):
![obraz](https://user-images.githubusercontent.com/9054379/28847648-5179b690-7710-11e7-8606-b67ff121b303.png)

3. In order to see more errors change default front-end template to Beez3
4. Open a new tab to see home page
5. Go to Backend -> System -> Clear cache
You should see something like below:

![obraz](https://user-images.githubusercontent.com/9054379/28847613-26742f52-7710-11e7-816a-0af668916857.png)

6. You can not delete single cache group if it contains `"` (double quote)
7. Apply this patch
8. Now you can delete such single cache group.
9. After you clear all cache, Joomla does not show more cache groups with suffix `_lock` or similar to `menu_items{"menutype":"mainmenu","startLevel":...`

Above points are detailed for redis but for cache lite should be similar.

### Expected result
Cache item groups does not contains examples as below.

### Actual result
There are weird cache item groups:
- `Joomla\CMS\Helper\LibraryHelper::loadLibraryjoomla_lock`
- `menu_items{"menutype":"mainmenu","startLevel":"0","endLevel":"0","showAllChildren":"1","tag_id":"","class_sfx":"","window_open":"","layout":"","moduleclass_sfx":"_`

### Documentation Changes Required
No