### PR TITLE
Category select list indent

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -251,7 +251,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
 			}
-
 			else
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -242,10 +242,16 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$db->setQuery($query);
 			$language = $db->loadResult();
 
+			if ($options[$i]->level != 0)
+			{
+				$options[$i]->level = $options[$i]->level -1;
+			}
+
 			if ($options[$i]->published == 1)
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
 			}
+
 			else
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -119,7 +119,8 @@ abstract class JHtmlCategory
 
 			foreach ($items as &$item)
 			{
-				$item->title = str_repeat('- ', $item->level) . $item->title;
+				$repeat = ($item->level - 1 >= 0) ? $item->level - 1 : 0;
+				$item->title = str_repeat('- ', $repeat) . $item->title;
 
 				if ($item->language !== '*')
 				{

--- a/libraries/cms/html/category.php
+++ b/libraries/cms/html/category.php
@@ -119,8 +119,7 @@ abstract class JHtmlCategory
 
 			foreach ($items as &$item)
 			{
-				$repeat = ($item->level - 1 >= 0) ? $item->level - 1 : 0;
-				$item->title = str_repeat('- ', $repeat) . $item->title;
+				$item->title = str_repeat('- ', $item->level) . $item->title;
 
 				if ($item->language !== '*')
 				{


### PR DESCRIPTION
Pull Request for Issue #17380 .

### Summary of Changes

If you select a category in Searchtools the categories are displayed like that:
![image](https://user-images.githubusercontent.com/828371/28846953-b3499ea6-770d-11e7-9dea-c47a67187dc8.png)

If you select it in the Article, the Parent item has already a dash in front:
![image](https://user-images.githubusercontent.com/828371/28846979-cdf04e08-770d-11e7-930f-62aa902098cb.png)

So in one case its:
Category Parent
- category child

and in the other case 
- Category Parent
-- category child

### UPDATED
I have adjusted the select box in the Category select

### Test instructions
1. Create a main category and sub category
2. Observe that in the category select for a new item they are all displayed with at least one - dash
3. Apply the PR and observe that parents no longer have a - dash
4. Unpublish categories and observe that they are still wrapped in [] eg [unpublished category]