### PR TITLE
Changed Update Notification Version compare

### DIFF
--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -146,7 +146,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		$update = array_pop($updates);
 
 		// Check the available version. If it's the same as the installed version we have no updates to notify about.
-		if (version_compare($update->version, JVERSION, 'eq'))
+		if (version_compare($update->version, JVERSION, 'le'))
 		{
 			return;
 		}

--- a/plugins/system/updatenotification/updatenotification.php
+++ b/plugins/system/updatenotification/updatenotification.php
@@ -145,7 +145,7 @@ class PlgSystemUpdatenotification extends JPlugin
 		// Get the available update
 		$update = array_pop($updates);
 
-		// Check the available version. If it's the same as the installed version we have no updates to notify about.
+		// Check the available version. If it's the same or less than the installed version we have no updates to notify about.
 		if (version_compare($update->version, JVERSION, 'le'))
 		{
 			return;


### PR DESCRIPTION
Changed Update Notification Version compare to use le = Less than or Equal to. In some cases the users have updated the site before they have been notified within Joomla! i.e. a 3rd part component. Then the localised Joomla! install is stuck in the past and given it no longer equals to it informs the users constantly.

Pull Request for Issue #17299 .

### Summary of Changes
version compare from GT to LE

### Testing Instructions
Install Joomla! 3.7.3 and then setup update notifications, ensure you still get notified about V3.7.4 update.

