### PR TITLE
Removed timezone setter - We want to use Global as default, not set f…

### DIFF
--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -122,15 +122,6 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	{
 		$groups = array();
 
-		$keyField = !empty($this->keyField) ? $this->keyField : 'id';
-		$keyValue = $this->form->getValue($keyField);
-
-		// If the timezone is not set use the server setting.
-		if (strlen($this->value) == 0 && empty($keyValue))
-		{
-			$this->value = JFactory::getConfig()->get('offset');
-		}
-
 		// Get the list of time zones from the server.
 		$zones = DateTimeZone::listIdentifiers();
 


### PR DESCRIPTION
Removed timezone setter - We want to use Global as default, not set for every user.

Pull Request for Issue #17333.

### Summary of Changes
Removed the default setting timezone if specified in Joomla! Global Config.

### Testing Instructions
Change Joomla! Global timezone to say Isle of man ;-) then create a new user, they are now Isle of Man by default. It should still be set to 'Use Global', only users should override their timezone.

### Expected result
When creating a user the timezone to be 'Use Default'

### Actual result
Timezone is taken from the Joomla! Global Config
