### PR TITLE
Don't use array merge here.

### DIFF
--- a/libraries/joomla/database/query/element.php
+++ b/libraries/joomla/database/query/element.php
@@ -92,7 +92,7 @@ class JDatabaseQueryElement
 		}
 		else
 		{
-			$this->elements = array_merge($this->elements, array($elements));
+			$this->elements[] = $elements;
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Instead of:
  create array
  merge new array into old array to create another array
  replace old array with newly merged array

Just:
  push item onto old array


### Testing Instructions
1) Check that your php `max_execution_time` is something sensible like 30 seconds. 
1) Turn on finder indexing for content.
2) Create a super long article. Maybe like 10,000 words. Maybe this can help: http://slipsum.com/
3) Save the article.


### Expected result
Well, I expect the article to save properly and the page to reload without crashing.


### Actual result
Most likely, the article will save but in the post-save indexing process there will be a timeout. This happens because we are looping over a huge array of tokens and adding each one to the `values` array of the query object. The query object handles this rather inefficiently by creating an array, merging it with an existing array to create a third array and then replacing the existing array with the new one when all it needed to do was a push. This gets very bad when the existing `values` array is already very large.

There is another half of this function which is when an array is passed to it instead of a string. This would probably be a lot better like:

```php
foreach ($elements as $element)
{
    $this->elements[] = $element;		
}
```

Anybody agree?

### Documentation Changes Required
nope
