### PR TITLE
Mark unused file as deprecated

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -15,6 +15,7 @@ JFormHelper::loadFieldClass('list');
  * Category Parent field.
  *
  * @since  1.6
+ * @deprecated  4.0  Use categoryedit instead.
  */
 class JFormFieldCategoryParent extends JFormFieldList
 {
@@ -117,7 +118,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 			$db->setQuery($query);
 			$language = $db->loadResult();
 
-			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+			$options[$i]->text = str_repeat('b- ', $options[$i]->level) . $options[$i]->text;
 
 			if ($language !== '*')
 			{

--- a/administrator/components/com_categories/models/fields/categoryparent.php
+++ b/administrator/components/com_categories/models/fields/categoryparent.php
@@ -118,7 +118,7 @@ class JFormFieldCategoryParent extends JFormFieldList
 			$db->setQuery($query);
 			$language = $db->loadResult();
 
-			$options[$i]->text = str_repeat('b- ', $options[$i]->level) . $options[$i]->text;
+			$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
 
 			if ($language !== '*')
 			{


### PR DESCRIPTION
PR for #17382

This file is not used in the core and hasnt been for a very long time as it was replaced by categoryedit. This simple PR add a deprecated notice that this will be removed in J4
