### PR TITLE
[fix] nested mode for tags field

### DIFF
--- a/libraries/src/Joomla/CMS/Form/Field/TagField.php
+++ b/libraries/src/Joomla/CMS/Form/Field/TagField.php
@@ -243,7 +243,7 @@ class TagField extends \JFormFieldList
 		if ($this->isNested === null)
 		{
 			// If mode="nested" || ( mode not set & config = nested )
-			if (isset($this->element['mode']) && $this->element['mode'] === 'nested'
+			if (isset($this->element['mode']) && (string) $this->element['mode'] === 'nested'
 				|| !isset($this->element['mode']) && $this->comParams->get('tag_field_ajax_mode', 1) == 0)
 			{
 				$this->isNested = true;


### PR DESCRIPTION
Pull Request for Issue #17386

### Summary of Changes

Nested mode for tags field is never detected as active because it's using:

```php
 $this->element['mode'] === 'nested'
```

which returns false because `$this->element['mode']` is a `SimpleXMLElement` object. It should be casted to string:

```php
(string) $this->element['mode'] === 'nested'
```

### Testing Instructions

Apply the patch and check that tags filter on articles view filters is shown as a category field (with dashes).


### Expected result

![nested-tags](https://user-images.githubusercontent.com/1119272/28918423-75ed7aa4-7849-11e7-81f6-64f28bebf6ff.png)


### Actual result

![nested-tags-broken](https://user-images.githubusercontent.com/1119272/28918503-c0e872ac-7849-11e7-9200-e89cd7f69834.png)

