### PR TITLE
com_redirect remove archive state

### DIFF
--- a/administrator/components/com_redirect/helpers/redirect.php
+++ b/administrator/components/com_redirect/helpers/redirect.php
@@ -75,7 +75,6 @@ class RedirectHelper
 		$options[] = JHtml::_('select.option', '*', 'JALL');
 		$options[] = JHtml::_('select.option', '1', 'JENABLED');
 		$options[] = JHtml::_('select.option', '0', 'JDISABLED');
-		$options[] = JHtml::_('select.option', '2', 'JARCHIVED');
 		$options[] = JHtml::_('select.option', '-2', 'JTRASHED');
 
 		return $options;

--- a/administrator/components/com_redirect/models/forms/filter_links.xml
+++ b/administrator/components/com_redirect/models/forms/filter_links.xml
@@ -13,6 +13,7 @@
 			type="status"
 			label="COM_REDIRECT_FILTER_PUBLISHED"
 			description="COM_REDIRECT_FILTER_PUBLISHED_DESC"
+			filter="*,-2,0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_redirect/models/forms/link.xml
+++ b/administrator/components/com_redirect/models/forms/link.xml
@@ -52,7 +52,6 @@
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>
-			<option value="2">JARCHIVED</option>
 			<option value="-2">JTRASHED</option>
 		</field>
 

--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -100,7 +100,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<?php // Create dropdown items and render the dropdown list.
 								if ($canChange)
 								{
-									JHtml::_('actionsdropdown.' . ((int) $item->published === 2 ? 'un' : '') . 'archive', 'cb' . $i, 'links');
 									JHtml::_('actionsdropdown.' . ((int) $item->published === -2 ? 'un' : '') . 'trash', 'cb' . $i, 'links');
 									echo JHtml::_('actionsdropdown.render', $this->escape($item->old_url));
 								}

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -134,20 +134,6 @@ class RedirectViewLinks extends JViewLegacy
 				JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
 				JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
 			}
-
-			if ($state->get('filter.state') != -1 )
-			{
-				JToolbarHelper::divider();
-
-				if ($state->get('filter.state') != 2)
-				{
-					JToolbarHelper::archiveList('links.archive');
-				}
-				elseif ($state->get('filter.state') == 2)
-				{
-					JToolbarHelper::unarchiveList('links.publish', 'JTOOLBAR_UNARCHIVE');
-				}
-			}
 		}
 
 		if ($canDo->get('core.create'))

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -128,9 +128,9 @@ class RedirectViewLinks extends JViewLegacy
 
 		if ($canDo->get('core.edit.state'))
 		{
-				JToolbarHelper::divider();
-				JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
-				JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
+			JToolbarHelper::divider();
+			JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
+			JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
 		}
 
 		if ($canDo->get('core.create'))

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -128,12 +128,9 @@ class RedirectViewLinks extends JViewLegacy
 
 		if ($canDo->get('core.edit.state'))
 		{
-			if ($state->get('filter.state') != 2)
-			{
 				JToolbarHelper::divider();
 				JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
 				JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
-			}
 		}
 
 		if ($canDo->get('core.create'))


### PR DESCRIPTION
In com_redirect we have all the states (published, unpublished, deleted and archived) but just like other components such as com_modules we have no need for the archived state.

This PR removes the archived state from the helper and the selects and the toolbar and the select in the hathor template