### PR TITLE
Prevent duplicate ID's with mod_wrapper

### DIFF
--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 <iframe <?php echo $load; ?>
-	id="blockrandom"
+	id="iframe_<?php echo $module->id; ?>"
 	name="<?php echo $target; ?>"
 	src="<?php echo $url; ?>"
 	width="<?php echo $width; ?>"


### PR DESCRIPTION
### Summary of Changes

If you have 2 instances of `mod_wrapper` on 1 page, then there will be 2 iframes with the same ID ('blockrandom'). This PR addresses that

### Testing Instructions

- Create 2 wrapper modules
- Assign them both to the same page
- Inspect the element and they should have different ID's
