### PR TITLE
JFactory::getInstance couldn't deal with namespaced classes with container only entry

### DIFF
--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -481,11 +481,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			// Create a CmsApplication object.
 			$classname = $prefix . ucfirst($name);
 
-			if (!class_exists($classname))
-			{
-				throw new \RuntimeException(\JText::sprintf('JLIB_APPLICATION_ERROR_APPLICATION_LOAD', $name), 500);
-			}
-
 			if (!$container)
 			{
 				$container = \JFactory::getContainer();
@@ -495,10 +490,14 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			{
 				static::$instances[$name] = $container->get($classname);
 			}
-			else
+			else if (class_exists($classname))
 			{
 				// TODO - This creates an implicit hard requirement on the JApplicationCms constructor
 				static::$instances[$name] = new $classname(null, null, null, $container);
+			}
+			else
+			{
+				throw new \RuntimeException(\JText::sprintf('JLIB_APPLICATION_ERROR_APPLICATION_LOAD', $name), 500);
 			}
 
 			static::$instances[$name]->loadIdentity(\JFactory::getUser());

--- a/libraries/src/CMS/Application/CMSApplication.php
+++ b/libraries/src/CMS/Application/CMSApplication.php
@@ -490,7 +490,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			{
 				static::$instances[$name] = $container->get($classname);
 			}
-			else if (class_exists($classname))
+			elseif (class_exists($classname))
 			{
 				// TODO - This creates an implicit hard requirement on the JApplicationCms constructor
 				static::$instances[$name] = new $classname(null, null, null, $container);


### PR DESCRIPTION
If a class doesn't have a non-namespaced class (e.g. the WIP API Application) but does have an entry in the container, at the moment we bail because `JApplicationApi` doesn't exist (which it doesn't). This moves the class exists check until later in the process so we check the container before throwing an exception.