### PR TITLE
Don't use the 'file' cache handler (or any cache handler)

### DIFF
--- a/cli/finder_indexer.php
+++ b/cli/finder_indexer.php
@@ -157,7 +157,7 @@ class FinderCli extends JApplicationCli
 		// Disable caching.
 		$config = JFactory::getConfig();
 		$config->set('caching', 0);
-		$config->set('cache_handler', 'file');
+		$config->set('cache_handler', '');
 
 		// Reset the indexer state.
 		FinderIndexer::resetState();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Instead of forcing Joomla to load a cache storage handler which we have no intentions of using and which might not be available (and would throw an exception), load only the base storage class which is always available and does nothing (which is what we want). 

### Testing Instructions
Set your cache directory to something unwritable so that file storage is not available.
Run the `finder_indexer` script from the command line.

### Expected result
You'd expect it to run and index your content, right?

### Actual result
Throws an exception and fails when it tries to load the file storage handler even though caching is switched off because we don't intend to use it anyway.

### Documentation Changes Required
no