### PR TITLE
Load the system language in modal

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -18,7 +18,7 @@ if ($app->isClient('site'))
 
 JLoader::register('ContentHelperRoute', JPATH_ROOT . '/components/com_content/helpers/route.php');
 
-// Load the system language, is needed when modal is shown on the front end
+// Load the system language. This is needed when a modal is shown on the front end
 JFactory::getLanguage()->load('', JPATH_ADMINISTRATOR);
 
 // Include the component HTML helpers.

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -18,6 +18,9 @@ if ($app->isClient('site'))
 
 JLoader::register('ContentHelperRoute', JPATH_ROOT . '/components/com_content/helpers/route.php');
 
+// Load the system language, is needed when modal is shown on the front end
+JFactory::getLanguage()->load('', JPATH_ADMINISTRATOR);
+
 // Include the component HTML helpers.
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 


### PR DESCRIPTION
### Summary of Changes
When the article modal form field is shown on the front end then the filter strings are not translated.
![image](https://user-images.githubusercontent.com/251072/29016432-b52c8b2c-7b52-11e7-9496-bccbf14fe671.png)

### Testing Instructions
- Install DPFields from https://joomla.digital-peak.com/download/dpfields
- Create a new article custom field for articles
- Edit the article on the front end
- Select an article in the custom field

### Expected result
All strings are translated.

### Actual result
The filters are not translated.