### PR TITLE
[4.0] Converting fix done in #17424 to Sample Data module

### DIFF
--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -3679,7 +3679,7 @@ class PlgSampledataTesting extends JPlugin
 					'url'         => 'http://www.youtube.com/embed/vb2eObvmvdI',
 					'add'         => 1,
 					'scrolling'   => 'auto',
-					'width'       => 640,
+					'width'       => '100%',
 					'height'      => 390,
 					'height_auto' => 1,
 					'cache'       => 1,


### PR DESCRIPTION
Same fix that was done in https://github.com/joomla/joomla-cms/pull/17424, but for the Sample Data module. So it doesn't get lost if we eventually drop the SQL files.