### PR TITLE
Adjusting copyright and versions and two remaining "sampledata"

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_sampledata.ini
+++ b/administrator/language/en-GB/en-GB.mod_sampledata.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/administrator/language/en-GB/en-GB.mod_sampledata.sys.ini
+++ b/administrator/language/en-GB/en-GB.mod_sampledata.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/administrator/language/en-GB/en-GB.plg_sampledata_testing.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_testing.ini
@@ -1,11 +1,11 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SAMPLEDATA_TESTING="Sample Data - Testing"
-PLG_SAMPLEDATA_TESTING_OVERVIEW_DESC="Sampledata which will help with testing the CMS."
-PLG_SAMPLEDATA_TESTING_OVERVIEW_TITLE="Testing Sampledata"
+PLG_SAMPLEDATA_TESTING_OVERVIEW_DESC="Sample data which will help with testing the CMS."
+PLG_SAMPLEDATA_TESTING_OVERVIEW_TITLE="Testing Sample Data"
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_1_DESC="Get books about Joomla! at the Joomla! Book Shop."
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_1_NAME="Shop 1"
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_2_DESC="T-shirts, caps and more from the Joomla! Shop."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_testing.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_testing.sys.ini
@@ -1,5 +1,5 @@
 ; Joomla! Project
-; Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.
+; Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 

--- a/administrator/modules/mod_sampledata/helper.php
+++ b/administrator/modules/mod_sampledata/helper.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  mod_sampledata
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/administrator/modules/mod_sampledata/mod_sampledata.php
+++ b/administrator/modules/mod_sampledata/mod_sampledata.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  mod_sampledata
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/administrator/modules/mod_sampledata/mod_sampledata.xml
+++ b/administrator/modules/mod_sampledata/mod_sampledata.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension type="module" version="3.5" client="administrator" method="upgrade">
+<extension type="module" version="3.8" client="administrator" method="upgrade">
 	<name>mod_sampledata</name>
 	<author>Joomla! Project</author>
-	<creationDate>July 2015</creationDate>
-	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
+	<creationDate>July 2017</creationDate>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.5.0</version>
+	<version>3.8.0</version>
 	<description>MOD_SAMPLEDATA_XML_DESCRIPTION</description>
 	<files>
 		<filename module="mod_sampledata">mod_sampledata.php</filename>

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  mod_sampledata
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Plugin
  * @subpackage  Sampledata.Blog
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/plugins/sampledata/blog/blog.xml
+++ b/plugins/sampledata/blog/blog.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.5" type="plugin" group="sampledata" method="upgrade">
+<extension version="3.8" type="plugin" group="sampledata" method="upgrade">
 	<name>plg_sampledata_blog</name>
 	<author>Joomla! Project</author>
-	<creationDate>July 2015</creationDate>
-	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
+	<creationDate>July 2017</creationDate>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.5.0</version>
+	<version>3.8.0</version>
 	<description>PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="blog">blog.php</filename>

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Plugin
  * @subpackage  Sampledata.Testing
  *
- * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/plugins/sampledata/testing/testing.xml
+++ b/plugins/sampledata/testing/testing.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.5" type="plugin" group="sampledata" method="upgrade">
+<extension version="3.8" type="plugin" group="sampledata" method="upgrade">
 	<name>plg_sampledata_testing</name>
 	<author>Joomla! Project</author>
-	<creationDate>July 2015</creationDate>
-	<copyright>Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved.</copyright>
+	<creationDate>July 2017</creationDate>
+	<copyright>Copyright (C) 2005 - 2017 Open Source Matters. All rights reserved.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>3.5.0</version>
+	<version>3.8.0</version>
 	<description>PLG_SAMPLEDATA_TESTING_XML_DESCRIPTION</description>
 	<files>
 		<filename plugin="testing">testing.php</filename>


### PR DESCRIPTION
As mentioned in https://github.com/joomla/joomla-cms/pull/7680#issuecomment-320459799, adjusting the version tags and dates in the extension manifests.
I also updated the copyrights even if not strictly needed.

There was also two remaining "sampledata" which I corrected to "sample data".

Should be able to merge by review. Otherwise just test if sample data installation still works.