### PR TITLE
Make UserHelper aware of Argon2i password hashing

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -312,7 +312,7 @@ abstract class UserHelper
 		// \JCrypt::hasStrongPasswordSupport() includes a fallback for us in the worst case
 		\JCrypt::hasStrongPasswordSupport();
 
-		return password_hash($password, PASSWORD_DEFAULT);
+		return password_hash($password, PASSWORD_BCRYPT);
 	}
 
 	/**
@@ -340,14 +340,22 @@ abstract class UserHelper
 
 			$rehash = true;
 		}
-		elseif ($hash[0] == '$')
+		// Check for Argon2i hashes
+		elseif (strpos($hash, '$argon2i') === 0)
+		{
+			// This implementation is not supported through any existing polyfills
+			$match = password_verify($password, $hash);
+
+			$rehash = password_needs_rehash($hash, PASSWORD_ARGON2I);
+		}
+		// Check for bcrypt hashes
+		elseif (strpos($hash, '$2') === 0)
 		{
 			// \JCrypt::hasStrongPasswordSupport() includes a fallback for us in the worst case
 			\JCrypt::hasStrongPasswordSupport();
 			$match = password_verify($password, $hash);
 
-			// Uncomment this line if we actually move to bcrypt.
-			$rehash = password_needs_rehash($hash, PASSWORD_DEFAULT);
+			$rehash = password_needs_rehash($hash, PASSWORD_BCRYPT);
 		}
 		elseif (substr($hash, 0, 8) == '{SHA256}')
 		{


### PR DESCRIPTION
### Summary of Changes

PHP 7.2 introduces support for a new native password hashing algorithm based on Argon2 (see https://wiki.php.net/rfc/argon2_password_hash for the relevant RFC).  Since the native password API now supports multiple algorithms, the use of `PASSWORD_DEFAULT` is a little more flaky since conceivably one day PHP core could change this to point to a different hash.  Therefore, this PR does a few things.

1) Changes `PASSWORD_DEFAULT` uses to the explicit `PASSWORD_BCRYPT` constant instead
2) Makes the check for the hash prefix for bcrypt hashed passwords in `Joomla\CMS\User\UserHelper::verifyPassword()` a little more strict
3) Adds logic into `Joomla\CMS\User\UserHelper::verifyPassword()` to detect Argon2 passwords and attempt to validate them (officially, we aren't going to advertise this as a supported password hash and no part of the core API will support generating Argon2 hashes, BUT, if someone running PHP 7.2 chooses to compile it with support for the hash and implement some handling to put Argon2 hashes in their database, we can validate it since the native PHP API will handle it)

### Testing Instructions

Generating password hashes still results in a valid bcrypt hash, users can still authenticate correctly.