### PR TITLE
[4.0] [Frontend] Move all module class suffix to outside container

### DIFF
--- a/modules/mod_articles_archive/mod_articles_archive.php
+++ b/modules/mod_articles_archive/mod_articles_archive.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesArchive\Site\Helper\ArticlesArchiveHelper;
 
 $params->def('count', 10);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $list            = ArticlesArchiveHelper::getList($params);
 
 require ModuleHelper::getLayoutPath('mod_articles_archive', $params->get('layout', 'default'));

--- a/modules/mod_articles_archive/mod_articles_archive.php
+++ b/modules/mod_articles_archive/mod_articles_archive.php
@@ -13,6 +13,6 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesArchive\Site\Helper\ArticlesArchiveHelper;
 
 $params->def('count', 10);
-$list            = ArticlesArchiveHelper::getList($params);
+$list = ArticlesArchiveHelper::getList($params);
 
 require ModuleHelper::getLayoutPath('mod_articles_archive', $params->get('layout', 'default'));

--- a/modules/mod_articles_archive/tmpl/default.php
+++ b/modules/mod_articles_archive/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($list)) : ?>
-	<ul class="archive-module<?php echo $moduleclass_sfx; ?>">
+	<ul class="archive-module">
 	<?php foreach ($list as $item) : ?>
 	<li>
 		<a href="<?php echo $item->link; ?>">

--- a/modules/mod_articles_categories/mod_articles_categories.php
+++ b/modules/mod_articles_categories/mod_articles_categories.php
@@ -28,7 +28,6 @@ $list = ModuleHelper::moduleCache($module, $params, $cacheparams);
 
 if (!empty($list))
 {
-	$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 	$startLevel      = reset($list)->getParent()->level;
 
 	require ModuleHelper::getLayoutPath('mod_articles_categories', $params->get('layout', 'default'));

--- a/modules/mod_articles_categories/tmpl/default.php
+++ b/modules/mod_articles_categories/tmpl/default.php
@@ -9,6 +9,6 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="categories-module<?php echo $moduleclass_sfx; ?>">
+<ul class="categories-module">
 <?php require JModuleHelper::getLayoutPath('mod_articles_categories', $params->get('layout', 'default') . '_items'); ?>
 </ul>

--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -66,7 +66,6 @@ if (!empty($list))
 	$grouped                    = false;
 	$article_grouping           = $params->get('article_grouping', 'none');
 	$article_grouping_direction = $params->get('article_grouping_direction', 'ksort');
-	$moduleclass_sfx            = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 	$item_heading               = $params->get('item_heading');
 
 	if ($article_grouping !== 'none')

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<ul class="category-module<?php echo $moduleclass_sfx; ?>">
+<ul class="category-module">
 	<?php if ($grouped) : ?>
 		<?php foreach ($list as $group_name => $group) : ?>
 		<li>

--- a/modules/mod_articles_latest/mod_articles_latest.php
+++ b/modules/mod_articles_latest/mod_articles_latest.php
@@ -13,6 +13,5 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesLatest\Site\Helper\ArticlesLatestHelper;
 
 $list            = ArticlesLatestHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_articles_latest', $params->get('layout', 'default'));

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="latestnews<?php echo $moduleclass_sfx; ?>">
+<ul class="latestnews">
 <?php foreach ($list as $item) : ?>
 	<li itemscope itemtype="https://schema.org/Article">
 		<a href="<?php echo $item->link; ?>" itemprop="url">

--- a/modules/mod_articles_news/mod_articles_news.php
+++ b/modules/mod_articles_news/mod_articles_news.php
@@ -13,6 +13,5 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesNews\Site\Helper\ArticlesNewsHelper;
 
 $list            = ArticlesNewsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_articles_news', $params->get('layout', 'horizontal'));

--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -13,7 +13,7 @@ $item_heading = $params->get('item_heading', 'h4');
 ?>
 <?php if ($params->get('item_title')) : ?>
 
-	<<?php echo $item_heading; ?> class="newsflash-title<?php echo $params->get('moduleclass_sfx'); ?>">
+	<<?php echo $item_heading; ?> class="newsflash-title">
 	<?php if ($item->link !== '' && $params->get('link_titles')) : ?>
 		<a href="<?php echo $item->link; ?>">
 			<?php echo $item->title; ?>

--- a/modules/mod_articles_news/tmpl/default.php
+++ b/modules/mod_articles_news/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<div class="newsflash<?php echo $moduleclass_sfx; ?>">
+<div class="newsflash">
 	<?php foreach ($list as $item) : ?>
 		<?php require JModuleHelper::getLayoutPath('mod_articles_news', '_item'); ?>
 	<?php endforeach; ?>

--- a/modules/mod_articles_news/tmpl/horizontal.php
+++ b/modules/mod_articles_news/tmpl/horizontal.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="newsflash-horiz<?php echo $params->get('moduleclass_sfx'); ?>">
+<ul class="newsflash-horiz">
 	<?php for ($i = 0, $n = count($list); $i < $n; $i ++) : ?>
 		<?php $item = $list[$i]; ?>
 		<li>

--- a/modules/mod_articles_news/tmpl/vertical.php
+++ b/modules/mod_articles_news/tmpl/vertical.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="newsflash-vert<?php echo $params->get('moduleclass_sfx'); ?>">
+<ul class="newsflash-vert">
 	<?php for ($i = 0, $n = count($list); $i < $n; $i ++) : ?>
 		<?php $item = $list[$i]; ?>
 		<li class="newsflash-item">

--- a/modules/mod_articles_popular/mod_articles_popular.php
+++ b/modules/mod_articles_popular/mod_articles_popular.php
@@ -13,6 +13,5 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesPopular\Site\Helper\ArticlesPopularHelper;
 
 $list            = ArticlesPopularHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_articles_popular', $params->get('layout', 'default'));

--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="mostread<?php echo $moduleclass_sfx; ?>">
+<ul class="mostread">
 <?php foreach ($list as $item) : ?>
 	<li itemscope itemtype="https://schema.org/Article">
 		<a href="<?php echo $item->link; ?>" itemprop="url">

--- a/modules/mod_banners/mod_banners.php
+++ b/modules/mod_banners/mod_banners.php
@@ -18,6 +18,5 @@ $footerText = trim($params->get('footer_text'));
 
 BannersHelper::updateReset();
 $list = &ModBannersHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_banners', $params->get('layout', 'default'));

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Banners\Site\Helper\BannerHelper;
 ?>
-<div class="bannergroup<?php echo $moduleclass_sfx; ?>">
+<div class="bannergroup">
 <?php if ($headerText) : ?>
 	<?php echo $headerText; ?>
 <?php endif; ?>

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.php
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.php
@@ -16,6 +16,4 @@ use Joomla\Module\Breadcrumbs\Site\Helper\BreadcrumbsHelper;
 $list  = BreadcrumbsHelper::getList($params);
 $count = count($list);
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-
 require ModuleHelper::getLayoutPath('mod_breadcrumbs', $params->get('layout', 'default'));

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 ?>
 
-<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb<?php echo $moduleclass_sfx; ?>">
+<ul itemscope itemtype="https://schema.org/BreadcrumbList" class="breadcrumb">
 	<?php if ($params->get('showHere', 1)) : ?>
 		<li class="float-left">
 			<?php echo JText::_('MOD_BREADCRUMBS_HERE'); ?>&#160;

--- a/modules/mod_custom/mod_custom.php
+++ b/modules/mod_custom/mod_custom.php
@@ -15,6 +15,4 @@ if ($params->def('prepare_content', 1))
 	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_custom.content');
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-
 require JModuleHelper::getLayoutPath('mod_custom', $params->get('layout', 'default'));

--- a/modules/mod_custom/tmpl/default.php
+++ b/modules/mod_custom/tmpl/default.php
@@ -11,6 +11,6 @@ defined('_JEXEC') or die;
 ?>
 
 
-<div class="custom<?php echo $moduleclass_sfx; ?>" <?php if ($params->get('backgroundimage')) : ?> style="background-image:url(<?php echo $params->get('backgroundimage'); ?>)"<?php endif; ?> >
+<div class="custom" <?php if ($params->get('backgroundimage')) : ?> style="background-image:url(<?php echo $params->get('backgroundimage'); ?>)"<?php endif; ?> >
 	<?php echo $module->content; ?>
 </div>

--- a/modules/mod_feed/mod_feed.php
+++ b/modules/mod_feed/mod_feed.php
@@ -16,6 +16,5 @@ $rssurl = $params->get('rssurl', '');
 $rssrtl = $params->get('rssrtl', 0);
 
 $feed            = FeedHelper::getFeed($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -64,7 +64,7 @@ else
 		$iUrl   = isset($feed->image) ? $feed->image : null;
 		$iTitle = isset($feed->imagetitle) ? $feed->imagetitle : null;
 		?>
-		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> ! important"  class="feed<?php echo $moduleclass_sfx; ?>">
+		<div style="direction: <?php echo $rssrtl ? 'rtl' :'ltr'; ?>; text-align: <?php echo $rssrtl ? 'right' :'left'; ?> ! important"  class="feed">
 		<?php
 		// Feed description
 		if ($feed->title !== null && $params->get('rsstitle', 1))
@@ -93,7 +93,7 @@ else
 	<!-- Show items -->
 	<?php if (!empty($feed))
 	{ ?>
-		<ul class="newsfeed<?php echo $params->get('moduleclass_sfx'); ?>">
+		<ul class="newsfeed">
 		<?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 5)); $i < $max; $i++) { ?>
 			<?php
 				$uri   = (!empty($feed[$i]->uri) || $feed[$i]->uri !== null) ? trim($feed[$i]->uri) : trim($feed[$i]->guid);

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -17,12 +17,11 @@ JHtml::addIncludePath(JPATH_SITE . '/components/com_finder/helpers/html');
 $lang = JFactory::getLanguage();
 $lang->load('com_finder', JPATH_SITE);
 
-$suffix = $params->get('moduleclass_sfx');
 $input = '<input type="text" name="q" class="js-finder-search-query form-control" value="' . htmlspecialchars(JFactory::getApplication()->input->get('q', '', 'string'), ENT_COMPAT, 'UTF-8') . '"'
 	. ' placeholder="' . JText::_('MOD_FINDER_SEARCH_VALUE') . '">';
 
 $showLabel  = $params->get('show_label', 1);
-$labelClass = (!$showLabel ? 'sr-only ' : '') . 'finder' . $suffix;
+$labelClass = (!$showLabel ? 'sr-only ' : '') . 'finder';
 $label      = '<label for="mod-finder-searchword' . $module->id . '" class="' . $labelClass . '">' . $params->get('alt_label', JText::_('JSEARCH_FILTER_SUBMIT')) . '</label>';
 
 $output = '';
@@ -33,7 +32,7 @@ if ($params->get('show_button'))
 	$output .= '<div class="input-group">';
 	$output .= $input;
 	$output .= '<span class="input-group-btn">';
-	$output .= '<button class="btn btn-primary hasTooltip ' . $suffix . ' finder' . $suffix . '" type="submit" title="' . JText::_('MOD_FINDER_SEARCH_BUTTON') . '"><span class="icon-search icon-white"></span> ' . JText::_('JSEARCH_FILTER_SUBMIT') . '</button>';
+	$output .= '<button class="btn btn-primary hasTooltip finder" type="submit" title="' . JText::_('MOD_FINDER_SEARCH_BUTTON') . '"><span class="icon-search icon-white"></span> ' . JText::_('JSEARCH_FILTER_SUBMIT') . '</button>';
 	$output .= '</span>';
 	$output .= '</div>';
 }
@@ -59,7 +58,7 @@ if ($params->get('show_autosuggest', 1))
 ?>
 
 <form class="js-finder-searchform form-search" action="<?php echo JRoute::_($route); ?>" method="get">
-	<div class="finder<?php echo $suffix; ?>">
+	<div class="finder">
 
 		<?php echo $output; ?>
 

--- a/modules/mod_footer/mod_footer.php
+++ b/modules/mod_footer/mod_footer.php
@@ -34,6 +34,4 @@ else
 	$lineone = $line1;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-
 require JModuleHelper::getLayoutPath('mod_footer', $params->get('layout', 'default'));

--- a/modules/mod_footer/tmpl/default.php
+++ b/modules/mod_footer/tmpl/default.php
@@ -9,5 +9,5 @@
 
 defined('_JEXEC') or die;
 ?>
-<div class="footer1<?php echo $moduleclass_sfx; ?>"><?php echo $lineone; ?></div>
-<div class="footer2<?php echo $moduleclass_sfx; ?>"><?php echo JText::_('MOD_FOOTER_LINE2'); ?></div>
+<div class="footer1"><?php echo $lineone; ?></div>
+<div class="footer2"><?php echo JText::_('MOD_FOOTER_LINE2'); ?></div>

--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -15,6 +15,5 @@ use Joomla\Module\Languages\Site\Helper\LanguagesHelper;
 $headerText      = $params->get('header_text');
 $footerText      = $params->get('footer_text');
 $list            = LanguagesHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_languages', $params->get('layout', 'default'));

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -16,7 +16,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 	JHtml::_('formbehavior.chosen');
 }
 ?>
-<div class="mod-languages<?php echo $moduleclass_sfx; ?>">
+<div class="mod-languages">
 <?php if ($headerText) : ?>
 	<div class="pretext"><p><?php echo $headerText; ?></p></div>
 <?php endif; ?>

--- a/modules/mod_random_image/mod_random_image.php
+++ b/modules/mod_random_image/mod_random_image.php
@@ -16,6 +16,5 @@ $link            = $params->get('link');
 $folder          = RandomImageHelper::getFolder($params);
 $images          = RandomImageHelper::getImages($params, $folder);
 $image           = RandomImageHelper::getRandomImage($params, $images);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_random_image', $params->get('layout', 'default'));

--- a/modules/mod_random_image/tmpl/default.php
+++ b/modules/mod_random_image/tmpl/default.php
@@ -17,7 +17,7 @@ if (!count($images))
 }
 ?>
 
-<div class="random-image<?php echo $moduleclass_sfx; ?>">
+<div class="random-image">
 <?php if ($link) : ?>
 <a href="<?php echo $link; ?>">
 <?php endif; ?>

--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -36,7 +36,6 @@ $maxlength       = $upper_limit;
 $text            = htmlspecialchars($params->get('text', \JText::_('MOD_SEARCH_SEARCHBOX_TEXT')), ENT_COMPAT, 'UTF-8');
 $label           = htmlspecialchars($params->get('label', \JText::_('MOD_SEARCH_LABEL_TEXT')), ENT_COMPAT, 'UTF-8');
 $set_Itemid      = (int) $params->get('set_itemid', 0);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 if ($imagebutton)
 {

--- a/modules/mod_search/tmpl/default.php
+++ b/modules/mod_search/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<div class="search<?php echo $moduleclass_sfx; ?>">
+<div class="search">
 	<form action="<?php echo JRoute::_('index.php'); ?>" method="post">
 		<?php
 			$input  = '<input name="searchword" id="mod-search-searchword' . $module->id . '" class="form-control" type="search" placeholder="' . $text . '">';

--- a/modules/mod_stats/mod_stats.php
+++ b/modules/mod_stats/mod_stats.php
@@ -15,6 +15,5 @@ use Joomla\Module\Stats\Site\Helper\StatsHelper;
 $serverinfo      = $params->get('serverinfo');
 $siteinfo        = $params->get('siteinfo');
 $list            = StatsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_stats', $params->get('layout', 'default'));

--- a/modules/mod_stats/tmpl/default.php
+++ b/modules/mod_stats/tmpl/default.php
@@ -9,7 +9,7 @@
 
 defined('_JEXEC') or die;
 ?>
-<ul class="list-group<?php echo $moduleclass_sfx; ?>">
+<ul class="list-group">
 <?php foreach ($list as $item) : ?>
 	<li class="list-group-item justify-content-between">
 		<?php echo $item->title; ?>

--- a/modules/mod_syndicate/mod_syndicate.php
+++ b/modules/mod_syndicate/mod_syndicate.php
@@ -21,7 +21,6 @@ if ($link === null)
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $text            = htmlspecialchars($params->get('text'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_syndicate', $params->get('layout', 'default'));

--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 
 ?>
-<a href="<?php echo $link; ?>" class="syndicate-module<?php echo $moduleclass_sfx; ?>">
+<a href="<?php echo $link; ?>" class="syndicate-module">
 	<?php echo JHtml::_('image', 'system/livemarks.png', 'feed-image', null, true); ?>
 	<?php if ($params->get('display_text', 1)) : ?>
 		<span>

--- a/modules/mod_tags_popular/mod_tags_popular.php
+++ b/modules/mod_tags_popular/mod_tags_popular.php
@@ -26,7 +26,6 @@ if (!count($list) && !$params->get('no_results_text'))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $display_count   = $params->get('display_count', 0);
 
 require ModuleHelper::getLayoutPath('mod_tags_popular', $params->get('layout', 'default'));

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -14,7 +14,7 @@ $maxsize = $params->get('maxsize', 2);
 
 JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php');
 ?>
-<div class="tagspopular<?php echo $moduleclass_sfx; ?> tagscloud<?php echo $moduleclass_sfx; ?>">
+<div class="tagspopular tagscloud">
 <?php
 if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 ?>
 <?php JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php'); ?>
-<div class="tagspopular<?php echo $moduleclass_sfx; ?>">
+<div class="tagspopular">
 <?php if (!count($list)) : ?>
 	<div class="alert alert-no-items"><?php echo JText::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?></div>
 <?php else : ?>

--- a/modules/mod_tags_similar/mod_tags_similar.php
+++ b/modules/mod_tags_similar/mod_tags_similar.php
@@ -26,6 +26,4 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-
 require ModuleHelper::getLayoutPath('mod_tags_similar', $params->get('layout', 'default'));

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 ?>
 <?php JLoader::register('TagsHelperRoute', JPATH_BASE . '/components/com_tags/helpers/route.php'); ?>
-<div class="tagssimilar<?php echo $moduleclass_sfx; ?>">
+<div class="tagssimilar">
 <?php if ($list) : ?>
 	<ul>
 	<?php foreach ($list as $i => $item) : ?>

--- a/modules/mod_users_latest/mod_users_latest.php
+++ b/modules/mod_users_latest/mod_users_latest.php
@@ -14,6 +14,5 @@ use Joomla\Module\UsersLatest\Site\Helper\UsersLatestHelper;
 
 $shownumber      = $params->get('shownumber', 5);
 $names           = UsersLatestHelper::getUsers($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_users_latest', $params->get('layout', 'default'));

--- a/modules/mod_users_latest/tmpl/default.php
+++ b/modules/mod_users_latest/tmpl/default.php
@@ -10,7 +10,7 @@
 defined('_JEXEC') or die;
 ?>
 <?php if (!empty($names)) : ?>
-	<ul class="latestusers<?php echo $moduleclass_sfx; ?>" >
+	<ul class="latestusers" >
 	<?php foreach ($names as $name) : ?>
 		<li>
 			<?php echo $name->username; ?>

--- a/modules/mod_whosonline/mod_whosonline.php
+++ b/modules/mod_whosonline/mod_whosonline.php
@@ -24,6 +24,4 @@ if ($showmode > 0)
 	$names = WhosonlineHelper::getOnlineUserNames($params);
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-
 require ModuleHelper::getLayoutPath('mod_whosonline', $params->get('layout', 'default'));

--- a/modules/mod_whosonline/tmpl/default.php
+++ b/modules/mod_whosonline/tmpl/default.php
@@ -20,7 +20,7 @@ defined('_JEXEC') or die;
 	<?php if ($params->get('filter_groups')) : ?>
 		<p><?php echo JText::_('MOD_WHOSONLINE_SAME_GROUP_MESSAGE'); ?></p>
 	<?php endif; ?>
-	<ul class="nav flex-column<?php echo $moduleclass_sfx; ?>">
+	<ul class="nav flex-column">
 	<?php foreach ($names as $name) : ?>
 		<li>
 			<?php echo $name->username; ?>

--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -20,7 +20,6 @@ $target          = htmlspecialchars($params->get('target'), ENT_COMPAT, 'UTF-8')
 $width           = htmlspecialchars($params->get('width'), ENT_COMPAT, 'UTF-8');
 $height          = htmlspecialchars($params->get('height'), ENT_COMPAT, 'UTF-8');
 $scroll          = htmlspecialchars($params->get('scrolling'), ENT_COMPAT, 'UTF-8');
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
 $frameborder     = htmlspecialchars($params->get('frameborder'), ENT_COMPAT, 'UTF-8');
 
 require ModuleHelper::getLayoutPath('mod_wrapper', $params->get('layout', 'default'));

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -19,6 +19,6 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	height="<?php echo $height; ?>"
 	scrolling="<?php echo $scroll; ?>"
 	frameborder="<?php echo $frameborder; ?>"
-	class="wrapper<?php echo $moduleclass_sfx; ?>" >
+	class="wrapper" >
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>
 </iframe>

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -19,6 +19,6 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	height="<?php echo $height; ?>"
 	scrolling="<?php echo $scroll; ?>"
 	frameborder="<?php echo $frameborder; ?>"
-	class="wrapper" >
+	class="wrapper">
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>
 </iframe>

--- a/templates/aurora/html/modules.php
+++ b/templates/aurora/html/modules.php
@@ -43,8 +43,7 @@ function modChrome_default($module, &$params, &$attribs)
 
 	if ($module->content)
 	{
-		echo '<' . $moduleTag . ' class="' . $modulePos . '">';
-		echo '<div class="card' . htmlspecialchars($params->get('moduleclass_sfx')) . '">';
+		echo '<' . $moduleTag . ' class="' . $modulePos . ' card' . htmlspecialchars($params->get('moduleclass_sfx')) . '">';
 		if ($module->showtitle && $headerClass !== 'card-title')
 		{
 			echo '<' . $headerTag . ' class="card-header' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
@@ -55,7 +54,6 @@ function modChrome_default($module, &$params, &$attribs)
 			echo '<' . $headerTag . ' class="' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
 		}
 		echo $module->content;
-		echo '</div>';
 		echo '</div>';
 		echo '</' . $moduleTag . '>';
 	}
@@ -70,8 +68,7 @@ function modChrome_cardGrey($module, &$params, &$attribs)
 
 	if ($module->content)
 	{
-		echo '<' . $moduleTag . ' class="' . $modulePos . '">';
-		echo '<div class="card card-grey' . htmlspecialchars($params->get('moduleclass_sfx')) . '">';
+		echo '<' . $moduleTag . ' class="' . $modulePos . ' card card-grey' . htmlspecialchars($params->get('moduleclass_sfx')) . '">';
 		if ($module->showtitle && $headerClass !== 'card-title')
 		{
 			echo '<' . $headerTag . ' class="card-header' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
@@ -82,7 +79,6 @@ function modChrome_cardGrey($module, &$params, &$attribs)
 			echo '<' . $headerTag . ' class="' . $headerClass . '">' . $module->title . '</' . $headerTag . '>';
 		}
 		echo $module->content;
-		echo '</div>';
 		echo '</div>';
 		echo '</' . $moduleTag . '>';
 	}


### PR DESCRIPTION
Pull Request for Issue #16894.

### Summary of Changes
This PR stops the module class suffix from been echo'd twice and moves it to the outer most module container. Moving to the outside container allows the use of grid classes (Bootstrap) in the **Module Class Suffix.** field. This PR only effects frontend modules. Applying the same to the backend is probably best done in a separate PR. Once done we can then remove the **Bootstrap Width** field which currently only ~~works for~~ used by the backend.

### Before
Module Class Suffix = `card-outline-danger`

![suffix](https://user-images.githubusercontent.com/2803503/29085294-ccd2cdda-7c66-11e7-8cfe-44f54591475b.png)


### After
Module Class Suffix = `card-outline-danger`

![suffix2](https://user-images.githubusercontent.com/2803503/29085299-cefc2516-7c66-11e7-8a70-6850ff2b1923.png)
