### PR TITLE
Adding some warnings/infos to sampledata module

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_sampledata.ini
+++ b/administrator/language/en-GB/en-GB.mod_sampledata.ini
@@ -5,6 +5,10 @@
 
 MOD_SAMPLEDATA="Sample Data"
 MOD_SAMPLEDATA_CONFIRM_START="Proceeding will install a sample data set into your Joomla. This process can't be reverted once done."
+MOD_SAMPLEDATA_INFO_LANGUAGE="If available in that language, the Sample Data will be installed in the language used in administration."
+MOD_SAMPLEDATA_INFO_MULTILINGUAL="Joomla! is set as a multilingual site. It is not advised to install any Sample Data which is not multilingual aware."
+MOD_SAMPLEDATA_INFO_OTHER_CORE="If you have already installed some Core Sample Data when installing Joomla!, it is not advised to install the same or another core one."
+MOD_SAMPLEDATA_INFO_PRODUCTION="Do not install Core Sample Data sets on a production site!"
 MOD_SAMPLEDATA_INVALID_RESPONSE="There is an error in the sample data plugins. Response is invalid."
 MOD_SAMPLEDATA_ITEM_ALREADY_PROCESSED="This sample data set is already installed."
 MOD_SAMPLEDATA_XML_DESCRIPTION="This Module allows to install sample data."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.ini
@@ -3,9 +3,9 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SAMPLEDATA_BLOG="Sample Data - Blog"
+PLG_SAMPLEDATA_BLOG="Sample Data - Blog (Core)"
 PLG_SAMPLEDATA_BLOG_OVERVIEW_DESC="Sample data which will set up a blog site."
-PLG_SAMPLEDATA_BLOG_OVERVIEW_TITLE="Blog Sample data"
+PLG_SAMPLEDATA_BLOG_OVERVIEW_TITLE="Blog Sample Data (Core)"
 PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_0_FULLTEXT=""
 PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_0_INTROTEXT="<p>This tells you a bit about this blog and the person who writes it. </p><p>When you are logged in you will be able to edit this page by clicking on the edit icon.</p>"
 PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_0_TITLE="About"
@@ -61,4 +61,4 @@ PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not instal
 PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Articles done!"
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
-PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module"
+PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_blog.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_blog.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SAMPLEDATA_BLOG="Sample Data - Blog"
-PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module"
+PLG_SAMPLEDATA_BLOG="Sample Data - Blog (Core)"
+PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_testing.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_testing.ini
@@ -3,9 +3,9 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SAMPLEDATA_TESTING="Sample Data - Testing"
+PLG_SAMPLEDATA_TESTING="Sample Data - Testing (Core)"
 PLG_SAMPLEDATA_TESTING_OVERVIEW_DESC="Sample data which will help with testing the CMS."
-PLG_SAMPLEDATA_TESTING_OVERVIEW_TITLE="Testing Sample Data"
+PLG_SAMPLEDATA_TESTING_OVERVIEW_TITLE="Testing Sample Data (Core)"
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_1_DESC="Get books about Joomla! at the Joomla! Book Shop."
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_1_NAME="Shop 1"
 PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_BANNER_2_DESC="T-shirts, caps and more from the Joomla! Shop."
@@ -533,4 +533,4 @@ PLG_SAMPLEDATA_TESTING_STEP4_SUCCESS="Step 4: Contacts done!"
 PLG_SAMPLEDATA_TESTING_STEP5_SUCCESS="Step 5: Newsfeeds done!"
 PLG_SAMPLEDATA_TESTING_STEP6_SUCCESS="Step 6: Menus done!"
 PLG_SAMPLEDATA_TESTING_STEP7_SUCCESS="Step 7: Modules done!"
-PLG_SAMPLEDATA_TESTING_XML_DESCRIPTION="Provides the testing sample data. Can be installed using the sample data module"
+PLG_SAMPLEDATA_TESTING_XML_DESCRIPTION="Provides the testing sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/en-GB.plg_sampledata_testing.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_sampledata_testing.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SAMPLEDATA_TESTING="Sample Data - Testing"
-PLG_SAMPLEDATA_TESTING_XML_DESCRIPTION="Provides the testing sample data. Can be installed using the sample data module"
+PLG_SAMPLEDATA_TESTING="Sample Data - Testing (Core)"
+PLG_SAMPLEDATA_TESTING_XML_DESCRIPTION="Provides the testing sample data. Can be installed using the sample data module."

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -22,6 +22,14 @@ JFactory::getDocument()->addScriptDeclaration('
 		modSampledataIconProgress = "' . JUri::root(true) . '/media/jui/img/ajax-loader.gif";
 ');
 ?>
+<div class="alert alert-heading">
+<p><strong><?php echo JText::_('MOD_SAMPLEDATA_INFO_PRODUCTION'); ?></strong></p>
+<p><?php echo JText::_('MOD_SAMPLEDATA_INFO_LANGUAGE'); ?></p>
+<p><?php echo JText::_('MOD_SAMPLEDATA_INFO_OTHER_CORE'); ?></p>
+<?php if (JLanguageMultilang::isEnabled()) : ?>
+	<p><?php echo JText::_('MOD_SAMPLEDATA_INFO_MULTILINGUAL'); ?></p>
+<?php endif; ?>
+</div>
 <div class="sampledata-container">
 	<?php if ($items) : ?>
 		<div class="row-striped">


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17415 (partly)

### Summary of Changes
Adds warnings and informations 


### Testing Instructions
Install staging.
Make sure both sampledata plugins are enabled.
Make sure the sampledata admin module is published in cpanel position.
Display the Control Panel page.
Patch and display again.

After patch, you should get:

![screen shot 2017-08-09 at 12 19 33](https://user-images.githubusercontent.com/869724/29117501-ad76e9d8-7cfe-11e7-9029-c7338f20825b.png)

Feedback welcome. 
@brianteeman I may have capitalised a bit too much. Please check.

@Bakual 
