### PR TITLE
Fixing category creation in sample data

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -110,7 +110,7 @@ class PlgSampledataBlog extends JPlugin
 		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_0_TITLE');
 		$category      = array(
 			'title'           => $categoryTitle,
-			'parent_id'       => 0,
+			'parent_id'       => 1,
 			'id'              => 0,
 			'published'       => 1,
 			'access'          => $access,
@@ -126,7 +126,10 @@ class PlgSampledataBlog extends JPlugin
 
 		try
 		{
-			$categoryModel->save($category);
+			if (!$categoryModel->save($category))
+			{
+				throw new Exception($categoryModel->getError());
+			}
 		}
 		catch (Exception $e)
 		{
@@ -144,7 +147,7 @@ class PlgSampledataBlog extends JPlugin
 		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_1_TITLE');
 		$category      = array(
 			'title'           => $categoryTitle,
-			'parent_id'       => 0,
+			'parent_id'       => 1,
 			'id'              => 0,
 			'published'       => 1,
 			'access'          => $access,
@@ -160,7 +163,10 @@ class PlgSampledataBlog extends JPlugin
 
 		try
 		{
-			$categoryModel->save($category);
+			if (!$categoryModel->save($category))
+			{
+				throw new Exception($categoryModel->getError());
+			}
 		}
 		catch (Exception $e)
 		{

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -223,7 +223,7 @@ class PlgSampledataTesting extends JPlugin
 		$categories   = array();
 		$categories[] = array(
 			'title'     => JText::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_BANNERS_CATEGORY_0_TITLE'),
-			'parent_id' => 0,
+			'parent_id' => 1,
 		);
 
 		try
@@ -405,7 +405,7 @@ class PlgSampledataTesting extends JPlugin
 		$categories   = array();
 		$categories[] = array(
 			'title'     => JText::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_CONTENT_CATEGORY_0_TITLE'),
-			'parent_id' => 0,
+			'parent_id' => 1,
 		);
 
 		try
@@ -1023,7 +1023,7 @@ class PlgSampledataTesting extends JPlugin
 		$categories   = array();
 		$categories[] = array(
 			'title'     => JText::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_CONTACT_CATEGORY_0_TITLE'),
-			'parent_id' => 0,
+			'parent_id' => 1,
 		);
 
 		try
@@ -1379,7 +1379,7 @@ class PlgSampledataTesting extends JPlugin
 		$categories   = array();
 		$categories[] = array(
 			'title'     => JText::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_NEWSFEEDS_CATEGORY_0_TITLE'),
-			'parent_id' => 0,
+			'parent_id' => 1,
 		);
 
 		try


### PR DESCRIPTION
When installing the "blog" sample data set multiple times, the categories and articles and created multiple times, but in fact it should fail because the category alias already exists.

### Summary of Changes
* The `parent_id` was set wrong for the categories. The parent should be `1` and not `0`.
* The blog sample data didn't check the return value of the save method, it just checked for an exception. Now it will do both.

### Testing Instructions
Try installing the blog sample data set twice.

### Expected result
Get an error on second install about duplicate alias


### Actual result
No error and content is created (there is an error in a later step).


### Documentation Changes Required
None