### PR TITLE
User list : modal view : un-activated icon not shown in certain cases

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -104,7 +104,7 @@ if ($isMoo)
 							<span class="<?php echo $enabledStates[(int) $this->escape($item->block)]; ?>"></span>
 						</td>
 						<td class="center">
-							<span class="<?php echo $activatedStates[(int) $this->escape($item->activation)]; ?>"></span>
+							<span class="<?php echo $activatedStates[(empty( $item->activation) ? 0 : 1)]; ?>"></span>
 						</td>
 						<td>
 							<?php echo nl2br($item->group_names); ?>

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -104,7 +104,7 @@ if ($isMoo)
 							<span class="<?php echo $enabledStates[(int) $this->escape($item->block)]; ?>"></span>
 						</td>
 						<td class="center">
-							<span class="<?php echo $activatedStates[(empty( $item->activation) ? 0 : 1)]; ?>"></span>
+							<span class="<?php echo $activatedStates[(empty($item->activation) ? 0 : 1)]; ?>"></span>
 						</td>
 						<td>
 							<?php echo nl2br($item->group_names); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Administrator : User list : modal view : un-activated icon not shown in certain cases
field was cast to int instead if empty or not.
it is done after this patch as on default users list view : https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_users/views/users/tmpl/default.php#L137


### Testing Instructions
- create a certain number of users, activated and unactivated ones
- find a modal user list view on administrator ( you have them for example on com_content > articles > author, but you can also create a new wondefull 3.7's custom field of type user)
- then you can see the modal view

### Expected result
![exepcted](https://user-images.githubusercontent.com/3170104/29160399-5ef52fc2-7db2-11e7-883f-9fb1eb71523b.jpg)

### Actual result
![actual](https://user-images.githubusercontent.com/3170104/29160387-52ef76c4-7db2-11e7-8245-00782f13e1e5.jpg)


### Documentation Changes Required
none