### PR TITLE
Read More link a11y improvements

### DIFF
--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -14,7 +14,7 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo $item->title; ?>">
+	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>"
 		<span class="icon-chevron-right" aria-hidden="true"></span>
 		<?php if (!$params->get('access-view')) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -14,7 +14,7 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url">
+	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo $item->title;?>">
 		<span class="icon-chevron-right" aria-hidden="true"></span>
 		<?php if (!$params->get('access-view')) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -14,7 +14,7 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>"
+	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
 		<span class="icon-chevron-right" aria-hidden="true"></span>
 		<?php if (!$params->get('access-view')) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -14,7 +14,7 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo $item->title;?>">
+	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo $item->title; ?>">
 		<span class="icon-chevron-right" aria-hidden="true"></span>
 		<?php if (!$params->get('access-view')) :
 			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');


### PR DESCRIPTION
There are four possible ways to display a readmore link depending on the options chosen
1. Read more
2. Read more title
3. Read more title limited to a set number of characters
4. Register to Read more (Show unathorised links)

Option 1 fails a11y as you end up with multiple links on the page all with the same title
Option 3 may fail a11y as the title may be truncated (even inside a word) and this can lose meaning and sometimes result on multiple links with the same title
Option 4 fails a11y as you end up with multiple links on the page all with the same title

To resolve this we can use the aria-label attribute on the link to ensure that assistive technology will always see a unique and meaningful link.

### Testing instructions
View source as below
<img width="501" alt="screenshotr12-27-10" src="https://user-images.githubusercontent.com/1296369/29168574-576771a6-7dc7-11e7-983c-3cee0f01acb0.png">

