### PR TITLE
Replace the ns path correctly with the file path

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -537,7 +537,7 @@ abstract class JLoader
 				// Loop through paths registered to this namespace until we find a match.
 				foreach ($paths as $path)
 				{
-					$classFilePath = $path . DIRECTORY_SEPARATOR . str_replace($nsPath, '', $classPath);
+					$classFilePath = $path . DIRECTORY_SEPARATOR . substr_replace($classPath, '', 0, strlen($nsPath) + 1);
 
 					// We check for class_exists to handle case-sensitive file systems
 					if (file_exists($classFilePath) && !class_exists($class, false))


### PR DESCRIPTION
Pull Request for Issue #17413.

### Summary of Changes
If the class contains a PSR 4 namespace the file location is not correctly compiled. This pr fixes that.

### Testing Instructions
- Create a file Application.php with the following content in the _App_ folder under the Joomla root directory:
```
<?php
namespace App;

class Application
{
	public static function loaded()
	{
		return 'LOADED!';
	}
}
```
- Add the following code to the file components/com_content/content.php after line 36
```
JLoader::registerNamespace('App',JPATH_SITE.DIRECTORY_SEPARATOR.'App',false,false,'psr4');
echo \App\Application::loaded();die;
``` 
- Open an article on the front end

### Expected result
String **LOADED!** is printed.

### Actual result
"Class 'App\Application' not found" error is displayed.