### PR TITLE
[com_fields] Add custom fields support to modules

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -396,7 +396,29 @@
 			element="com_modules"
 			link="index.php?option=com_modules"
 			class="class:module"
-		/>
+		>
+			<menuitem
+				title="MOD_MENU_EXTENSIONS_MODULE_MANAGER"
+				type="component"
+				element="com_modules"
+				link="index.php?option=com_modules"
+				class="class:module"
+			/>
+			<menuitem
+				title="MOD_MENU_FIELDS"
+				type="component"
+				element="com_fields"
+				link="index.php?option=com_fields&amp;context=com_modules.module"
+				class="class:fields"
+			/>
+			<menuitem
+				title="MOD_MENU_FIELDS_GROUP"
+				type="component"
+				element="com_fields"
+				link="index.php?option=com_fields&amp;view=groups&amp;context=com_modules.module"
+				class="class:category"
+			/>
+		</menuitem>
 		<menuitem
 			title="MOD_MENU_EXTENSIONS_PLUGIN_MANAGER"
 			type="component"

--- a/administrator/components/com_modules/config.xml
+++ b/administrator/components/com_modules/config.xml
@@ -47,7 +47,7 @@
 			description="JGLOBAL_CUSTOM_FIELDS_ENABLE_DESC"
 			class="btn-group btn-group-yesno"
 			default="1"
-		>
+			>
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>

--- a/administrator/components/com_modules/config.xml
+++ b/administrator/components/com_modules/config.xml
@@ -37,6 +37,23 @@
 	</fieldset>
 
 	<fieldset
+		name="integration"
+		label="JGLOBAL_INTEGRATION_LABEL"
+		>
+		<field
+			name="custom_fields_enable"
+			type="radio"
+			label="JGLOBAL_CUSTOM_FIELDS_ENABLE_LABEL"
+			description="JGLOBAL_CUSTOM_FIELDS_ENABLE_DESC"
+			class="btn-group btn-group-yesno"
+			default="1"
+		>
+			<option value="1">JYES</option>
+			<option value="0">JNO</option>
+		</field>
+	</fieldset>
+
+	<fieldset
 		name="permissions"
 		label="JCONFIG_PERMISSIONS_LABEL"
 		description="JCONFIG_PERMISSIONS_DESC"

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -27,7 +29,25 @@ abstract class ModulesHelper
 	 */
 	public static function addSubmenu($vName)
 	{
-		// Not used in this component.
+		JHtmlSidebar::addEntry(
+			JText::_('COM_MODULES_MODULES'),
+			'index.php?option=com_modules',
+			$vName == 'modules'
+		);
+
+		if (ComponentHelper::isEnabled('com_fields') && ComponentHelper::getParams('com_modules')->get('custom_fields_enable', '1'))
+		{
+			JHtmlSidebar::addEntry(
+				JText::_('JGLOBAL_FIELDS'),
+				'index.php?option=com_fields&context=com_modules.module',
+				$vName == 'fields.fields'
+			);
+			JHtmlSidebar::addEntry(
+				JText::_('JGLOBAL_FIELD_GROUPS'),
+				'index.php?option=com_fields&view=groups&context=com_modules.module',
+				$vName == 'fields.groups'
+			);
+		}
 	}
 
 	/**

--- a/administrator/components/com_modules/models/forms/fields/module.xml
+++ b/administrator/components/com_modules/models/forms/fields/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fields name="params" label="COM_FIELDS_FIELD_BASIC_LABEL">
+		<fieldset name="basic">
+			<field
+				name="display"
+				type="hidden"
+				default="2"
+			/>
+		</fieldset>
+	</fields>
+</form>

--- a/administrator/components/com_modules/models/module.php
+++ b/administrator/components/com_modules/models/module.php
@@ -951,7 +951,7 @@ class ModulesModelModule extends JModelAdmin
 		}
 
 		// Trigger the before save event.
-		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew));
+		$result = $dispatcher->trigger($this->event_before_save, array($context, &$table, $isNew, $data));
 
 		if (in_array(false, $result, true))
 		{
@@ -1053,7 +1053,7 @@ class ModulesModelModule extends JModelAdmin
 		}
 
 		// Trigger the after save event.
-		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew));
+		$dispatcher->trigger($this->event_after_save, array($context, &$table, $isNew, $data));
 
 		// Compute the extension id of this module in case the controller wants it.
 		$query->clear()

--- a/components/com_config/view/modules/tmpl/default_options.php
+++ b/components/com_config/view/modules/tmpl/default_options.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 $fieldSets = $this->form->getFieldsets('params');
+$fieldSets = array_merge($fieldSets, $this->form->getFieldsets('com_fields'));
 
 echo JHtml::_('bootstrap.startAccordion', 'collapseTypes');
 $i = 0;

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -644,4 +644,26 @@ abstract class ModuleHelper
 
 		return $enabled;
 	}
+
+	/**
+	 * Returns a list of fields for the module with the given id.
+	 *
+	 * @return  \stdClass[]  An array of fields
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getFields($moduleId)
+	{
+		foreach (self::getModuleList() as $module)
+		{
+			if ($module->id != $moduleId)
+			{
+				continue;
+			}
+
+			return \FieldsHelper::getFields('com_modules.module', $module, true);
+		}
+
+		return array();
+	}
 }

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -133,6 +133,23 @@ class PlgSystemFields extends JPlugin
 	}
 
 	/**
+	 * The save event.
+	 *
+	 * @param   string   $context  The context
+	 * @param   JTable   $item     The extension
+	 * @param   boolean  $isNew    Is new item
+	 * @param   array    $data     The validated data
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onExtensionAfterSave ($context, $item, $isNew, $data = array())
+	{
+		return $this->onContentAfterSave($context, $item, $isNew, $data);
+	}
+
+	/**
 	 * The delete event.
 	 *
 	 * @param   string    $context  The context
@@ -194,6 +211,12 @@ class PlgSystemFields extends JPlugin
 	public function onContentPrepareForm(JForm $form, $data)
 	{
 		$context = $form->getName();
+
+		// Front end editing of modules is done trough com_config
+		if ($context == 'com_config.modules' && JFactory::getApplication()->isClient('site'))
+		{
+			$context = 'com_modules.module';
+		}
 
 		// When a category is edited, the context is com_categories.categorycom_content
 		if (strpos($context, 'com_categories.category') === 0)
@@ -346,9 +369,9 @@ class PlgSystemFields extends JPlugin
 				$context,
 				'fields.render',
 				array(
-					'item'            => $item,
-					'context'         => $context,
-					'fields'          => $fields
+					'item'    => $item,
+					'context' => $context,
+					'fields'  => $fields
 				)
 			);
 		}

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -146,6 +146,12 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onExtensionAfterSave ($context, $item, $isNew, $data = array())
 	{
+		// Only support modules
+		if ($context != 'com_modules.module')
+		{
+			return true;
+		}
+
 		return $this->onContentAfterSave($context, $item, $isNew, $data);
 	}
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -212,7 +212,7 @@ class PlgSystemFields extends JPlugin
 	{
 		$context = $form->getName();
 
-		// Front end editing of modules is done trough com_config
+		// Front end editing of modules is done through com_config
 		if ($context == 'com_config.modules' && JFactory::getApplication()->isClient('site'))
 		{
 			$context = 'com_modules.module';


### PR DESCRIPTION
Pull Request for Issue #17378.

### Summary of Changes
This pr adds custom fields support for modules. It should work on the front end and on the back end.

#### Performance
For performance reasons, the site admin needs to fetch the fields in a template override with the following code:
`\Joomla\CMS\Helper\ModuleHelper::getFields($module->id)`

### Testing Instructions
- In the back end go to Extensions -> Modules
- Click on Fields in the sidebar
- Create a new Text custom field
- Edit the "Main Menu Module"
- In the "Fields" tab add the value "Hello Fields"
- In the file modules/mod_menu/tmpl/default.php add the following code after line 17
```
$fields = \Joomla\CMS\Helper\ModuleHelper::getFields($module->id);
echo '<div class="alert">' . $fields[0]->value . '</div>';
```
### Expected result
An alert box is shown in the menu module with the value of the custom field.

### Actual result
This code actually doesn't work as it is a new feature.

### Documentation Changes Required
It should be documented that modules do support custom fields, but have to be fetched manually in a template override.
