### PR TITLE
[Router] RulesStandard Supports `default` layout

### DIFF
--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -211,7 +211,7 @@ class StandardRules implements RulesInterface
 
 				unset($query['view']);
 
-				if (isset($item->query['layout']) && isset($query['layout']) && $item->query['layout'] === $query['layout'])
+				if (!isset($item->query['layout'], $query['layout']) || (isset($item->query['layout'], $query['layout']) && $item->query['layout'] === $query['layout']))
 				{
 					unset($query['layout']);
 				}


### PR DESCRIPTION
### Summary of Changes

The Standard rule will remove `view` and `layout` if found menu item's layout name same as query.

For example: `view=foo&layout=blog` will generate route as `/blog.html`

But if we use `default` layout, mostly we will not add layout to URL, the StandardRule will generate a route like: `/blog.html&view=foo`

This PR try to remove view and layout if menu item and query both has no layout params.

### Testing Instructions

Install Joomla will **test** sample data, in admin open `Australian Parks` article and add a link with URL: `index.php?option=com_content&view=featured`, then save it.

Go to frontend and you will see the SEF link is: `.../index.php/using-joomla/extensions/templates/beez-2/home-page-beez-2?view=featured`

Apply this PR should remove the `?view=featured`

