### PR TITLE
Multilingual: Item should not show as associated to itself in the association column

### DIFF
--- a/administrator/components/com_categories/helpers/html/categoriesadministrator.php
+++ b/administrator/components/com_categories/helpers/html/categoriesadministrator.php
@@ -49,6 +49,7 @@ abstract class JHtmlCategoriesAdministrator
 				->select('l.lang_code')
 				->from('#__categories as c')
 				->where('c.id IN (' . implode(',', array_values($associations)) . ')')
+				->where('c.id != ' . $catid)
 				->join('LEFT', '#__languages as l ON c.language=l.lang_code')
 				->select('l.image')
 				->select('l.title as language_title');

--- a/administrator/components/com_contact/helpers/html/contact.php
+++ b/administrator/components/com_contact/helpers/html/contact.php
@@ -51,6 +51,7 @@ abstract class JHtmlContact
 				->select('cat.title as category_title')
 				->join('LEFT', '#__categories as cat ON cat.id=c.catid')
 				->where('c.id IN (' . implode(',', array_values($associations)) . ')')
+				->where('c.id != ' . $contactid)
 				->join('LEFT', '#__languages as l ON c.language=l.lang_code')
 				->select('l.image')
 				->select('l.title as language_title');

--- a/administrator/components/com_content/helpers/html/contentadministrator.php
+++ b/administrator/components/com_content/helpers/html/contentadministrator.php
@@ -52,6 +52,7 @@ abstract class JHtmlContentAdministrator
 				->select('cat.title as category_title')
 				->join('LEFT', '#__categories as cat ON cat.id=c.catid')
 				->where('c.id IN (' . implode(',', array_values($associations)) . ')')
+				->where('c.id != ' . $articleid)
 				->join('LEFT', '#__languages as l ON c.language=l.lang_code')
 				->select('l.image')
 				->select('l.title as language_title');

--- a/administrator/components/com_menus/helpers/html/menus.php
+++ b/administrator/components/com_menus/helpers/html/menus.php
@@ -50,6 +50,7 @@ abstract class MenusHtmlMenus
 				->from('#__menu as m')
 				->join('LEFT', '#__menu_types as mt ON mt.menutype=m.menutype')
 				->where('m.id IN (' . implode(',', array_values($associations)) . ')')
+				->where('m.id != ' . $itemid)
 				->join('LEFT', '#__languages as l ON m.language=l.lang_code')
 				->select('l.image')
 				->select('l.title as language_title');

--- a/administrator/components/com_newsfeeds/helpers/html/newsfeed.php
+++ b/administrator/components/com_newsfeeds/helpers/html/newsfeed.php
@@ -49,6 +49,7 @@ class JHtmlNewsfeed
 				->select('cat.title as category_title')
 				->join('LEFT', '#__categories as cat ON cat.id=c.catid')
 				->where('c.id IN (' . implode(',', array_values($associations)) . ')')
+				->where('c.id != ' . $newsfeedid)
 				->join('LEFT', '#__languages as l ON c.language=l.lang_code')
 				->select('l.image')
 				->select('l.title as language_title');


### PR DESCRIPTION
### Testing Instructions
Install a multilingual site from last staging.
Make sure the language filter is set to allow associations.
Associate some menus, articles, categories, contacts, newsfeeds.
Display the various managers

### What we have before patch
The item lang icon concerned is also displayed in the Association column. Confusing.

![screen shot 2017-08-12 at 10 38 50](https://user-images.githubusercontent.com/869724/29239305-faae60f6-7f4b-11e7-8f5a-89eacfda3fc3.png)

Patch
### What we get after patch
![screen shot 2017-08-12 at 10 38 10](https://user-images.githubusercontent.com/869724/29239308-1574ac24-7f4c-11e7-9856-af2c6f575bfd.png)

The column now displays only the associated icons for the specific languages.