### PR TITLE
[postgresql] - sql error upgrading from 3.6.5  to 3.74

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-04-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.7.0-2017-04-19.sql
@@ -1,2 +1,2 @@
 -- Set integer field default values.
-UPDATE `#__extensions` SET `params` = '{"multiple":"0","first":"1","last":"100","step":"1"}' WHERE `name` = 'plg_fields_integer';
+UPDATE "#__extensions" SET "params" = '{"multiple":"0","first":"1","last":"100","step":"1"}' WHERE "name" = 'plg_fields_integer';


### PR DESCRIPTION
### Summary of Changes
fixed mysql  ** ` **   with postgres "


### Testing Instructions
upgrading from 3.6.5  to 3.7
apply pr #17499


### Expected result
no sql error


### Actual result
sql error upgrading from 3.6.5  to 3.74


![screenshot from 2017-08-12 11-10-33](https://user-images.githubusercontent.com/181681/29239469-becf30ac-7f4f-11e7-9371-0e376180e0dd.png)


### Documentation Changes Required

