### PR TITLE
[4.0] List views always have a javascript error

### DIFF
--- a/libraries/cms/html/tag.php
+++ b/libraries/cms/html/tag.php
@@ -173,6 +173,7 @@ abstract class JHtmlTag
 		// Include scripts
 		JHtml::_('behavior.core');
 		JHtml::_('jquery.framework');
+		JHtml::_('formbehavior.chosen');
 		JHtml::_('script', 'system/legacy/ajax-chosen.min.js', false, true, false, false, JDEBUG);
 
 		JFactory::getDocument()->addScriptOptions(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Tags need chosen but not actually loading it. This PR solves that.


### Testing Instructions
Check the browser's console in admin articles before and after applying this patch


### Expected result
No errors

### Actual result
Error logged


### Documentation Changes Required
NONE

Chosen, will be replaced by choices.js, once we push some code upstream to get the functionality for the old tags script...