### PR TITLE
[a11y] Blog cat - Restore More Articles heading...

### DIFF
--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -8,16 +8,17 @@
  */
 
 defined('_JEXEC') or die;
+
 ?>
-<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
+<h3>
+	<?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?>
+</h3>
 <ul class="nav nav-tabs nav-stacked">
 	<?php foreach ($this->link_items as &$item) : ?>
 		<li>
 			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
-				<?php echo $item->title; ?></a>
+				<?php echo $item->title; ?>
+			</a>
 		</li>
 	<?php endforeach; ?>
 </ul>
-
-
-

--- a/components/com_content/views/category/tmpl/blog_links.php
+++ b/components/com_content/views/category/tmpl/blog_links.php
@@ -9,12 +9,15 @@
 
 defined('_JEXEC') or die;
 ?>
-
-<ol class="nav nav-tabs nav-stacked">
+<h3><?php echo JText::_('COM_CONTENT_MORE_ARTICLES'); ?></h3>
+<ul class="nav nav-tabs nav-stacked">
 	<?php foreach ($this->link_items as &$item) : ?>
 		<li>
 			<a href="<?php echo JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
 				<?php echo $item->title; ?></a>
 		</li>
 	<?php endforeach; ?>
-</ol>
+</ul>
+
+
+


### PR DESCRIPTION
**a11y improvement: Blog category - Restore More Articles heading and change the article list tag**
## Summary of Changes
1. Restore the "More Articles..." headings
2. Change the tags from the list ordered to the unordered list
## Testing Instructions
1. Create a category blog page with many articles
2. Set the #Links option to 4 for example
3. Check the category blog page:
- Does the link to other articles precede the h3 header "More Articles..."?
- Is the list of links an unordered list? 
## Expected result
1. The link to other articles does precede the h3 header "More Articles..."
2. The list of links is an unordered list
**WCAG 2.0 Success criteria**: 1.3.1, 2.4.6, 2.4.10
## Actual result
The section links to other articles in the category is not tagged.
An ordered list marker is used for the tag. The order of items in this list is irrelevant. This should be an unordered list.
## Documentation Changes Required
No changes to the documentation required - no new functionality introduced.