### PR TITLE
[CS] Cleanup module helper docblocks

### DIFF
--- a/modules/mod_articles_archive/helper.php
+++ b/modules/mod_articles_archive/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_articles_archive
  *
- * @package     Joomla.Site
- * @subpackage  mod_articles_archive
- * @since       1.5
+ * @since  1.5
  */
 class ModArchiveHelper
 {

--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -19,10 +19,7 @@ JModelLegacy::addIncludePath($com_path . 'models', 'ContentModel');
 /**
  * Helper for mod_articles_category
  *
- * @package     Joomla.Site
- * @subpackage  mod_articles_category
- *
- * @since       1.6
+ * @since  1.6
  */
 abstract class ModArticlesCategoryHelper
 {

--- a/modules/mod_articles_popular/helper.php
+++ b/modules/mod_articles_popular/helper.php
@@ -16,10 +16,7 @@ JModelLegacy::addIncludePath(JPATH_SITE . '/components/com_content/models', 'Con
 /**
  * Helper for mod_articles_popular
  *
- * @package     Joomla.Site
- * @subpackage  mod_articles_popular
- *
- * @since       1.6.0
+ * @since  1.6
  */
 abstract class ModArticlesPopularHelper
 {

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_breadcrumbs
  *
- * @package     Joomla.Site
- * @subpackage  mod_breadcrumbs
- * @since       1.5
+ * @since  1.5
  */
 class ModBreadCrumbsHelper
 {

--- a/modules/mod_feed/helper.php
+++ b/modules/mod_feed/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_feed
  *
- * @package     Joomla.Site
- * @subpackage  mod_feed
- * @since       1.5
+ * @since  1.5
  */
 class ModFeedHelper
 {

--- a/modules/mod_finder/helper.php
+++ b/modules/mod_finder/helper.php
@@ -14,9 +14,7 @@ use Joomla\Utilities\ArrayHelper;
 /**
  * Finder module helper.
  *
- * @package     Joomla.Site
- * @subpackage  mod_finder
- * @since       2.5
+ * @since  2.5
  */
 class ModFinderHelper
 {

--- a/modules/mod_languages/helper.php
+++ b/modules/mod_languages/helper.php
@@ -14,10 +14,7 @@ JLoader::register('MenusHelper', JPATH_ADMINISTRATOR . '/components/com_menus/he
 /**
  * Helper for mod_languages
  *
- * @package     Joomla.Site
- * @subpackage  mod_languages
- *
- * @since       1.6.0
+ * @since  1.6
  */
 abstract class ModLanguagesHelper
 {

--- a/modules/mod_login/helper.php
+++ b/modules/mod_login/helper.php
@@ -12,10 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_login
  *
- * @package     Joomla.Site
- * @subpackage  mod_login
- *
- * @since       1.5
+ * @since  1.5
  */
 class ModLoginHelper
 {

--- a/modules/mod_menu/helper.php
+++ b/modules/mod_menu/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_menu
  *
- * @package     Joomla.Site
- * @subpackage  mod_menu
- * @since       1.5
+ * @since  1.5
  */
 class ModMenuHelper
 {

--- a/modules/mod_random_image/helper.php
+++ b/modules/mod_random_image/helper.php
@@ -14,9 +14,7 @@ use Joomla\String\StringHelper;
 /**
  * Helper for mod_random_image
  *
- * @package     Joomla.Site
- * @subpackage  mod_random_image
- * @since       1.5
+ * @since  1.5
  */
 class ModRandomImageHelper
 {

--- a/modules/mod_related_items/helper.php
+++ b/modules/mod_related_items/helper.php
@@ -14,9 +14,7 @@ JLoader::register('ContentHelperRoute', JPATH_SITE . '/components/com_content/he
 /**
  * Helper for mod_related_items
  *
- * @package     Joomla.Site
- * @subpackage  mod_related_items
- * @since       1.5
+ * @since  1.5
  */
 abstract class ModRelatedItemsHelper
 {

--- a/modules/mod_search/helper.php
+++ b/modules/mod_search/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_search
  *
- * @package     Joomla.Site
- * @subpackage  mod_search
- * @since       1.5
+ * @since  1.5
  */
 class ModSearchHelper
 {

--- a/modules/mod_syndicate/helper.php
+++ b/modules/mod_syndicate/helper.php
@@ -14,9 +14,7 @@ use Joomla\Utilities\ArrayHelper;
 /**
  * Helper for mod_syndicate
  *
- * @package     Joomla.Site
- * @subpackage  mod_syndicate
- * @since       1.5
+ * @since  1.5
  */
 class ModSyndicateHelper
 {

--- a/modules/mod_tags_popular/helper.php
+++ b/modules/mod_tags_popular/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_tags_popular
  *
- * @package     Joomla.Site
- * @subpackage  mod_tags_popular
- * @since       3.1
+ * @since  3.1
  */
 abstract class ModTagsPopularHelper
 {

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -14,9 +14,7 @@ use Joomla\Registry\Registry;
 /**
  * Helper for mod_tags_similar
  *
- * @package     Joomla.Site
- * @subpackage  mod_tags_similar
- * @since       3.1
+ * @since  3.1
  */
 abstract class ModTagssimilarHelper
 {

--- a/modules/mod_users_latest/helper.php
+++ b/modules/mod_users_latest/helper.php
@@ -12,10 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_users_latest
  *
- * @package     Joomla.Site
- * @subpackage  mod_users_latest
- *
- * @since       1.6
+ * @since  1.6
  */
 class ModUsersLatestHelper
 {

--- a/modules/mod_wrapper/helper.php
+++ b/modules/mod_wrapper/helper.php
@@ -12,9 +12,7 @@ defined('_JEXEC') or die;
 /**
  * Helper for mod_wrapper
  *
- * @package     Joomla.Site
- * @subpackage  mod_wrapper
- * @since       1.5
+ * @since  1.5
  */
 class ModWrapperHelper
 {


### PR DESCRIPTION
### Summary of Changes

Cleanup module helper docblocks by removing the `@package` and `@subpackage` blocks that are not required since ages

### Testing Instructions

review as no production code is changed

### Expected result

no `@package` and `@subpackage` tags in the helpers

### Actual result

`@package` and `@subpackage` tags in the helpers

### Documentation Changes Required

None