### PR TITLE
Allow use of redis over sock

### DIFF
--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -39,7 +39,7 @@ class JSessionStorageRedis extends JSessionStorage
 		);
 
 		// If connecting with a sock file and not a TCP Port then ignore port provided
-		if (strstr($this->_server['host'],'sock'))
+		if (strstr($this->_server['host'], 'sock'))
 		{
 			$this->_server['port'] = 0;
 		}

--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -38,6 +38,12 @@ class JSessionStorageRedis extends JSessionStorage
 			'port' => $config->get('session_redis_server_port', 6379),
 		);
 
+		// If connecting with a sock file and not a TCP Port then ignore port provided
+		if (strstr($this->_server['host'],'sock'))
+		{
+			$this->_server['port'] = 0;
+		}
+
 		parent::__construct($options);
 	}
 

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -79,6 +79,12 @@ class RedisStorage extends CacheStorage
 			'db'   => (int) $app->get('redis_server_db', null),
 		);
 
+		// If connecting with a sock file and not a TCP Port then ignore port provided
+		if (strstr($server['host'],'sock'))
+		{
+			$server['port'] = 0;
+		}
+
 		static::$_redis = new \Redis;
 
 		if ($this->_persistent)

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -80,7 +80,7 @@ class RedisStorage extends CacheStorage
 		);
 
 		// If connecting with a sock file and not a TCP Port then ignore port provided
-		if (strstr($server['host'],'sock'))
+		if (strstr($server['host'], 'sock'))
 		{
 			$server['port'] = 0;
 		}


### PR DESCRIPTION
Pull Request for Issue #15836 #15822

### CODED IN BED WITHOUT TESTING AND WITHOUT QUALITY - TEST TEST TEST

### Summary of Changes


Allow Joomla to connect correctly to Redis that is using sock and not TCP


### Testing Instructions

Set up redis.conf with port 0 and listening on a sock
`port 0`
`unixsocket /tmp/redis.sock`
restart redis

Joomla global Config as such:
<img width="445" alt="screen shot 2017-05-05 at 13 56 08" src="https://cloud.githubusercontent.com/assets/400092/25746267/9da67dc0-319a-11e7-93ee-4d7df323c4f2.png">


### Expected result

no matter what port you enter, joomla will ignore it, as long as the sock file is correct, Joomla can connect and cache



