### PR TITLE
[a11y] Readmore links

### DIFF
--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -14,20 +14,29 @@ $item = $displayData['item'];
 ?>
 
 <p class="readmore">
-	<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url">
-		<span class="icon-chevron-right" aria-hidden="true"></span>
-		<?php if (!$params->get('access-view')) :
-			echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE');
-		elseif ($readmore = $item->alternative_readmore) :
-			echo $readmore;
-			if ($params->get('show_readmore_title', 0) != 0) :
-				echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit'));
-			endif;
-		elseif ($params->get('show_readmore_title', 0) == 0) :
-			echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE');
-		else :
-			echo JText::_('COM_CONTENT_READ_MORE');
-			echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit'));
-		endif; ?>
-	</a>
+	<?php if (!$params->get('access-view')) : ?>
+		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
+		</a>
+	<?php elseif ($readmore = $item->alternative_readmore) : ?>
+		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo $readmore; ?>
+			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+					<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
+			<?php endif; ?>
+		</a>
+	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
+		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+		</a>
+	<?php else : ?>
+		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo JText::_('COM_CONTENT_READ_MORE'); ?>
+			<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
+		</a>
+	<?php endif; ?>
 </p>

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -24,7 +24,7 @@ $item = $displayData['item'];
 			<span class="icon-chevron-right" aria-hidden="true"></span>
 			<?php echo $readmore; ?>
 			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
-					<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
+				<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
 			<?php endif; ?>
 		</a>
 	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>


### PR DESCRIPTION
Alternative to #17469

There are many possible ways to display a readmore link depending on the options chosen
1. Read more
2. Read more with title
3. Read more with title limited to a set number of characters
4. Register to Read more
5. Register to Read more with title (Show unauthorised links)
6. Register to Read more with title limited to a set number of characters (Show unauthorised links)
7. As above with alternative Read More Text

Option 1 and 4 fails a11y as you end up with multiple links on the page all with the same title
Option 3 and 6 may fail a11y as the title may be truncated (even inside a word) and this can lose meaning and sometimes result on multiple links with the same title

To resolve this we can use the aria-label attribute on the link to ensure that assistive technology will always see a unique and meaningful link.

This alternative PR addresses the issues raised by @zwiastunsw

> A) does not say that it is a continuation (Read more).
> B) when access is for registered users - incorrectly states that this link and specifies where instead of message: Login to see

### Testing Instructions
Create a series of articles with all the possible readmore options in a blog category and make sure that  the visible links are the same with and without this PR. 
If you view the source after the PR you will see appropriate text for the aria-label attribute of the href