### PR TITLE
[a11y] Icons: Print, Email, Edit - change to button

### DIFF
--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -103,6 +103,7 @@ JTRASH="Trash"
 JTRASHED="Trashed"
 JTRUE="True"
 JUNPUBLISHED="Unpublished"
+JUSER_TOOLS="User tools"
 JYEAR="Year"
 JYES="Yes"
 

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -12,6 +12,7 @@ defined('JPATH_BASE') or die;
 JHtml::_('bootstrap.framework');
 
 $canEdit = $displayData['params']->get('access-edit');
+$articleId = $displayData['item']->id;
 
 ?>
 
@@ -20,12 +21,12 @@ $canEdit = $displayData['params']->get('access-edit');
 
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 			<div class="btn-group pull-right">
-				  <button class="btn dropdown-toggle" type="button" id="dropdownMenuButton" aria-label="<?php echo JText::_('JUSER_TOOLS')?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				  <button class="btn dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS')?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 					<span class="icon-cog" aria-hidden="true"></span>
 					<span class="caret" aria-hidden="true"></span>
 				  </button>
 				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
-				<ul class="dropdown-menu">
+				<ul class="dropdown-menu" aria-labelledby="dropdownMenuButton-<?php echo $articleId; ?>">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>
 						<li class="print-icon"> <?php echo JHtml::_('icon.print_popup', $displayData['item'], $displayData['params']); ?> </li>
 					<?php endif; ?>

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -20,7 +20,10 @@ $canEdit = $displayData['params']->get('access-edit');
 
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 			<div class="btn-group pull-right">
-				<a class="btn dropdown-toggle" data-toggle="dropdown" href="#"> <span class="icon-cog"></span><span class="caret"></span> </a>
+				  <button class="btn dropdown-toggle" type="button" id="dropdownMenuButton" aria-label="<?php echo JText::_('JUSER_TOOLS')?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					<span class="icon-cog" aria-hidden="true"></span>
+					<span class="caret" aria-hidden="true"></span>
+				  </button>
 				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
 				<ul class="dropdown-menu">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -21,10 +21,11 @@ $articleId = $displayData['item']->id;
 
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 			<div class="btn-group pull-right">
-				  <button class="btn dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS')?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				<button class="btn dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS'); ?>"
+				data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 					<span class="icon-cog" aria-hidden="true"></span>
 					<span class="caret" aria-hidden="true"></span>
-				  </button>
+				</button>
 				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
 				<ul class="dropdown-menu" aria-labelledby="dropdownMenuButton-<?php echo $articleId; ?>">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>


### PR DESCRIPTION
## Summary of Changes
1. Change the tag a to button
2. Add ARIA
3. Add new language string: JUSER_TOOLS="User tools
## Testing Instructions
1. Open the page with the article and the Print, Email, Edit icon
2. Check the appearance of the button
3. Check keyboard support
4. Make sure the screen reader (e.g. NVDA and add-on ChromeVox to Chrome) announces the menu button as a user tool
## Expected result
* TAB - moves focus
* ENTER - expands menu
* Down arrow / TAB - moves to Print, Email, Edit icon
Screen reader announces the menu button as a user tool
## Actual result
The assistive technology user is informed that he is dealing with a link.
He does not know where the link leads. But this is not a link. 
On the blog page, the link repeat several times with the goal: "eight" (incomprehensible word...)
## Documentation Changes Required
No changes to the documentation required - no new functionality introduced.