### PR TITLE
Readmore chevron RTL aware

### DIFF
--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -11,17 +11,19 @@ defined('JPATH_BASE') or die;
 
 $params = $displayData['params'];
 $item = $displayData['item'];
+$direction = JFactory::getLanguage()->isRtl() ? 'left' : 'right';
 ?>
 
 <p class="readmore">
 	<?php if (!$params->get('access-view')) : ?>
-		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
-			<span class="icon-chevron-right" aria-hidden="true"></span>
+		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?> 
+			<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo JText::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
 		</a>
 	<?php elseif ($readmore = $item->alternative_readmore) : ?>
 		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
-			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?> 
 			<?php echo $readmore; ?>
 			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
 				<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
@@ -29,12 +31,12 @@ $item = $displayData['item'];
 		</a>
 	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
 		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
-			<span class="icon-chevron-right" aria-hidden="true"></span>
-			<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+				<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?> 
+				<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
 		</a>
 	<?php else : ?>
 		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
-			<span class="icon-chevron-right" aria-hidden="true"></span>
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?> 
 			<?php echo JText::_('COM_CONTENT_READ_MORE'); ?>
 			<?php echo JHtml::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
 		</a>

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -31,8 +31,8 @@ $direction = JFactory::getLanguage()->isRtl() ? 'left' : 'right';
 		</a>
 	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
 		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">
-				<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?> 
-				<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
+			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?> 
+			<?php echo JText::sprintf('COM_CONTENT_READ_MORE_TITLE'); ?>
 		</a>
 	<?php else : ?>
 		<a class="btn" href="<?php echo $displayData['link']; ?>" itemprop="url" aria-label="<?php echo JText::_('COM_CONTENT_READ_MORE'); ?> <?php echo htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8'); ?>">


### PR DESCRIPTION
As identified by @infograf768 https://github.com/joomla/joomla-cms/pull/17530#issuecomment-322688887 the chevron in the readmore links is not rtl aware.

### Before
![screen shot 2017-08-16 at 09 08 17](https://user-images.githubusercontent.com/869724/29351426-e81fbe2a-8262-11e7-9b5f-2accc4c4af4a.png)

### After
![screen shot 2017-08-16 at 09 09 05](https://user-images.githubusercontent.com/869724/29351437-f7637fb6-8262-11e7-85a2-de791ed8ed50.png)
