### PR TITLE
html code module mod_logged (admin)

### DIFF
--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -17,7 +17,7 @@ JHtml::_('bootstrap.tooltip');
 			<div class="span8">
 				<?php if ($user->client_id == 0) : ?>
 					<a title="<?php echo JHtml::_('tooltipText', 'MOD_LOGGED_LOGOUT'); ?>" href="<?php echo $user->logoutLink; ?>" class="btn btn-danger btn-mini hasTooltip">
-						<span class="icon-remove icon-white" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JLOGOUT'); ?>"></span></span>
+						<span class="icon-remove icon-white" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JLOGOUT'); ?></span></span>
 					</a>
 				<?php endif; ?>
 


### PR DESCRIPTION
### Steps to reproduce the issue

* Log in at the backend.
* Go to the Control Panel -> Logged-in Users
* Log in at the frontend.
* Look at the source code in the backend.

### Expected result

See source code:
```
....<span class="element-invisible">Log out</span></span>
```

### Actual result

See source code:
```
....<span class="element-invisible">Log out"></span></span>
```
Look specially at

```
>Log out"></span>
```
(see **">**)

### System information (as much as possible)
File:
```
..\Joomla\administrator\modules\mod_logged\tmpl\default.php
```
Line 20:
```
<span class="icon-remove icon-white" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JLOGOUT'); ?>"></span></span>
```
Should (possible) be:
```
<span class="icon-remove icon-white" aria-hidden="true"><span class="element-invisible"><?php echo JText::_('JLOGOUT'); ?></span></span>

```
Delete: **">**

### Additional comments
Joomla 3.7.4 - mod_logged (admin)

Pull Request for Issue # 17599