### PR TITLE
Debug Language string path

### DIFF
--- a/libraries/cms/html/debug.php
+++ b/libraries/cms/html/debug.php
@@ -48,7 +48,7 @@ abstract class JHtmlDebug
 			static::$xdebugLinkFormat = ini_get('xdebug.file_link_format');
 		}
 
-		$link = str_replace(JPATH_ROOT, 'JROOT', $file);
+		$link = str_replace(array(JPATH_ROOT, '\\'), array('JROOT', '/'), $file);
 		$link .= $line ? ':' . $line : '';
 
 		if (static::$xdebugLinkFormat)

--- a/libraries/cms/html/debug.php
+++ b/libraries/cms/html/debug.php
@@ -48,7 +48,7 @@ abstract class JHtmlDebug
 			static::$xdebugLinkFormat = ini_get('xdebug.file_link_format');
 		}
 
-		$link = str_replace(array(JPATH_ROOT, '\\'), array('JROOT', '/'), $file);
+		$link = str_replace(JPATH_ROOT, 'JROOT', JPath::clean($file));
 		$link .= $line ? ':' . $line : '';
 
 		if (static::$xdebugLinkFormat)


### PR DESCRIPTION
when looking at the output with debug language the following output
```

**Loaded** : JROOT/language/en-GB/en-GB.mod_search.ini
**Loaded** : JROOT/language/en-GB/en-GB.mod_finder.ini
**Loaded** : JROOT/language/en-GB/en-GB.com_finder.ini
**Loaded** : JROOT\administrator/language/en-GB/en-GB.plg_content_finder.ini
**Loaded** : JROOT\administrator/language/en-GB/en-GB.plg_finder_categories.ini
**Loaded** : JROOT\administrator/language/en-GB/en-GB.plg_finder_contacts.ini
```

Note that the site files are in JROOT forward slash but the admin files are in JROOT backslash

This is on a windows system - it is fine on a linux system

Thanks @tonypartridge for the suggestion your code normalises the slash

@mbabker I couldnt get your JPath:clean method to work correctly

Pull Request for Issue #17510