### PR TITLE
Skip the JCryptCipherSodiumTest on PHP_INT_SIZE === 4

### DIFF
--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -25,8 +25,8 @@ class JCryptCipherSodiumTest extends TestCase
 	{
 		parent::setUp();
 
-		// Don't run this tests on windows
-		if (PHP_OS === 'WINNT')
+		// Don't run this tests on windows with PHP lover that 7.0
+		if (PHP_OS === 'WINNT' && version_compare(PHP_VERSION, '7.0.0', '<'))
 		{
 			$this->markTestSkipped('The tests does not work on windows.');
 		}

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -25,7 +25,7 @@ class JCryptCipherSodiumTest extends TestCase
 	{
 		parent::setUp();
 
-		// Don't run this tests on windows with PHP lover that 7.0
+		// Don't run this tests on windows with PHP lower that 7.0
 		if (PHP_OS === 'WINNT' && version_compare(PHP_VERSION, '7.0.0', '<'))
 		{
 			$this->markTestSkipped('The tests does not work on windows.');

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -25,7 +25,7 @@ class JCryptCipherSodiumTest extends TestCase
 	{
 		parent::setUp();
 
-		// Don't run this tests on windows with PHP lower that 7.0
+		// Don't run this tests on windows with PHP lower than 7.0
 		if (PHP_OS === 'WINNT' && version_compare(PHP_VERSION, '7.0.0', '<'))
 		{
 			$this->markTestSkipped('The tests does not work on windows.');

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -17,6 +17,22 @@ use ParagonIE\Sodium\Compat;
 class JCryptCipherSodiumTest extends TestCase
 {
 	/**
+	 * Prepares the environment before running a test.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		// Don't run this tests on windows
+		if (PHP_OS === 'WINNT')
+		{
+			$this->markTestSkipped('The tests does not work on windows.');
+		}
+	}
+
+	/**
 	 * Test data for processing
 	 *
 	 * @return  array

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -25,11 +25,11 @@ class JCryptCipherSodiumTest extends TestCase
 	{
 		parent::setUp();
 
-		// The lib sodium_compat does not support PHP_INT_SIZE === 4 see https://github.com/paragonie/sodium_compat/issues/38
-		if (PHP_INT_SIZE === 4)
+		// Skip if neither the `libsodium` (PECL 1.x) or `sodium` (PHP 7.2+ or PECL 2.x) extensions are available and this PHP build does not support 64-bit integers
+		if (!extension_loaded('libsodium') && !extension_loaded('sodium') && PHP_INT_SIZE === 4)
 		{
 			$this->markTestSkipped(
-				'The lib sodium_compat does not support PHP_INT_SIZE === 4 please see https://github.com/paragonie/sodium_compat/issues/38.'
+				'Cannot run tests on this environment due to not having the sodium PHP extension and not running a x64 PHP build'
 			);
 		}
 	}

--- a/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
+++ b/tests/unit/suites/libraries/joomla/crypt/cipher/JCryptCipherSodiumTest.php
@@ -25,10 +25,12 @@ class JCryptCipherSodiumTest extends TestCase
 	{
 		parent::setUp();
 
-		// Don't run this tests on windows with PHP lower than 7.0
-		if (PHP_OS === 'WINNT' && version_compare(PHP_VERSION, '7.0.0', '<'))
+		// The lib sodium_compat does not support PHP_INT_SIZE === 4 see https://github.com/paragonie/sodium_compat/issues/38
+		if (PHP_INT_SIZE === 4)
 		{
-			$this->markTestSkipped('The tests does not work on windows.');
+			$this->markTestSkipped(
+				'The lib sodium_compat does not support PHP_INT_SIZE === 4 please see https://github.com/paragonie/sodium_compat/issues/38.'
+			);
 		}
 	}
 


### PR DESCRIPTION
### Summary of Changes

Give this exection: `RuntimeException: Sodium_compat produces incorrect results on systems that do not support 64-bit integers. Please upgrade to PHP 7 or newer for Windows x64 support.`

https://ci.appveyor.com/project/joomla/joomla-cms/build/1.0.8484/job/vlv1htg6ro5b6aue

I have marked the test as skipped.

### Testing Instructions

Lets see that appveyor runs

### Expected result

tests passes

### Actual result

tests fail with the RuntimeException above.

### Documentation Changes Required

Maybe some note that Sodium_compat does not work on that systems? cc: @mbabker 