### PR TITLE
[4.0] Update Travis PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-      env: INSTALL_APCU="yes"
-    - php: 5.6
-      env: INSTALL_APCU="yes"
     - php: 7.0
       env: INSTALL_APCU="yes" INSTALL_MEMCACHE="no"
     - php: 7.1


### PR DESCRIPTION
As [Joomla 4 will require PHP 7](https://developer.joomla.org/news/704-looking-forward-with-joomla-4.html), I assume we don't need to continue testing on PHP 5.5 and 5.6

@mbabker ?