### PR TITLE
Add descriptions to CLI scripts

### DIFF
--- a/cli/deletefiles.php
+++ b/cli/deletefiles.php
@@ -6,6 +6,10 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+/**
+ * A command line cron job to attempt to remove files that should have been deleted at update.
+ */
+
 // We are a valid entry point.
 const _JEXEC = 1;
 

--- a/cli/garbagecron.php
+++ b/cli/garbagecron.php
@@ -6,6 +6,10 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+/**
+ * A command line cron job to trash expired cache data.
+ */
+
 // Initialize Joomla framework
 const _JEXEC = 1;
 


### PR DESCRIPTION
I was looking at the CLI scripts and wasn't sure what these two did as they had no description. Eventually I saw the description lower down the file. To make it easier for others I copied the description to the top (as with the other CLI scripts)