### PR TITLE
[4.0] com_redirect remove archive state

### DIFF
--- a/administrator/components/com_redirect/Helper/RedirectHelper.php
+++ b/administrator/components/com_redirect/Helper/RedirectHelper.php
@@ -50,7 +50,6 @@ class RedirectHelper
 		$options[] = \JHtml::_('select.option', '*', 'JALL');
 		$options[] = \JHtml::_('select.option', '1', 'JENABLED');
 		$options[] = \JHtml::_('select.option', '0', 'JDISABLED');
-		$options[] = \JHtml::_('select.option', '2', 'JARCHIVED');
 		$options[] = \JHtml::_('select.option', '-2', 'JTRASHED');
 
 		return $options;

--- a/administrator/components/com_redirect/View/Links/Html.php
+++ b/administrator/components/com_redirect/View/Links/Html.php
@@ -142,26 +142,9 @@ class Html extends HtmlView
 
 		if ($canDo->get('core.edit.state'))
 		{
-			if ($state->get('filter.state') != 2)
-			{
-				\JToolbarHelper::divider();
-				\JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
-				\JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
-			}
-
-			if ($state->get('filter.state') != -1 )
-			{
-				\JToolbarHelper::divider();
-
-				if ($state->get('filter.state') != 2)
-				{
-					\JToolbarHelper::archiveList('links.archive');
-				}
-				elseif ($state->get('filter.state') == 2)
-				{
-					\JToolbarHelper::unarchiveList('links.publish', 'JTOOLBAR_UNARCHIVE');
-				}
-			}
+			\JToolbarHelper::divider();
+			\JToolbarHelper::publish('links.publish', 'JTOOLBAR_ENABLE', true);
+			\JToolbarHelper::unpublish('links.unpublish', 'JTOOLBAR_DISABLE', true);
 		}
 
 		if ($canDo->get('core.create'))

--- a/administrator/components/com_redirect/forms/filter_links.xml
+++ b/administrator/components/com_redirect/forms/filter_links.xml
@@ -11,6 +11,7 @@
 		<field
 			name="state"
 			type="status"
+			filter="*,-2,0,1"
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>

--- a/administrator/components/com_redirect/forms/link.xml
+++ b/administrator/components/com_redirect/forms/link.xml
@@ -49,7 +49,6 @@
 			>
 			<option value="1">JENABLED</option>
 			<option value="0">JDISABLED</option>
-			<option value="2">JARCHIVED</option>
 			<option value="-2">JTRASHED</option>
 		</field>
 


### PR DESCRIPTION
In com_redirect we have all the states (published, unpublished, deleted and archived) but just like other components such as com_modules we have no need for the archived state.

Note it was suggested by @mbabker in #17417 that this was a small b/c break so could not go into J3.x

Not sure if I should be doing another PR to the J3 branch to add deprecate notices and if so where?
