### PR TITLE
[4.0] Fix com_redirect Fatal error

### DIFF
--- a/administrator/components/com_redirect/View/Links/Html.php
+++ b/administrator/components/com_redirect/View/Links/Html.php
@@ -103,12 +103,12 @@ class Html extends HtmlView
 		// Show messages about the enabled plugin and if the plugin should collect URLs
 		if ($this->enabled && $this->collect_urls_enabled)
 		{
-			$app->enqueueMessage(\JText::_('COM_REDIRECT_PLUGIN_ENABLED') . ' ' . JText::_('COM_REDIRECT_COLLECT_URLS_ENABLED'), 'notice');
+			$app->enqueueMessage(\JText::_('COM_REDIRECT_PLUGIN_ENABLED') . ' ' . \JText::_('COM_REDIRECT_COLLECT_URLS_ENABLED'), 'notice');
 		}
 		elseif ($this->enabled && !$this->collect_urls_enabled)
 		{
 			$link = \JRoute::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . RedirectHelper::getRedirectPluginId());
-			$app->enqueueMessage(\JText::_('COM_REDIRECT_PLUGIN_ENABLED') . JText::sprintf('COM_REDIRECT_COLLECT_URLS_DISABLED', $link), 'notice');
+			$app->enqueueMessage(\JText::_('COM_REDIRECT_PLUGIN_ENABLED') . \JText::sprintf('COM_REDIRECT_COLLECT_URLS_DISABLED', $link), 'notice');
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue #17576

### Summary of Changes

Fixes the PHP error being throw on `com_redirect`

### Testing Instructions

Enable the redirect plugin and then try to open `com_redirect`