### PR TITLE
Fix hover on selected file in template manager

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -8751,6 +8751,9 @@ ul.treeselect ul.dropdown-menu li {
 	background-color: #f5f5f5;
 	color: #3071a9;
 }
+.tree-holder .active.file:hover {
+	background-color: #3071a9;
+}
 .tree-holder ul ul {
 	box-shadow: -3px 0 0 rgba(0,0,0,0.08);
 	padding-right: 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -8751,6 +8751,9 @@ ul.treeselect ul.dropdown-menu li {
 	background-color: #f5f5f5;
 	color: #3071a9;
 }
+.tree-holder .active.file:hover {
+	background-color: #3071a9;
+}
 .tree-holder ul ul {
 	box-shadow: -3px 0 0 rgba(0,0,0,0.08);
 	padding-right: 0;

--- a/administrator/templates/isis/less/blocks/_treeselect.less
+++ b/administrator/templates/isis/less/blocks/_treeselect.less
@@ -69,7 +69,7 @@ ul.treeselect ul.dropdown-menu li {
 			color: @linkColor;
 		}
 		&.file:hover {
-			background-color:#3071a9;
+			background-color: #3071a9;
 		}
 	}
 	ul {

--- a/administrator/templates/isis/less/blocks/_treeselect.less
+++ b/administrator/templates/isis/less/blocks/_treeselect.less
@@ -68,6 +68,9 @@ ul.treeselect ul.dropdown-menu li {
 			background-color: #f5f5f5;
 			color: @linkColor;
 		}
+		&.file:hover {
+			background-color:#3071a9;
+		}
 	}
 	ul {
 		ul {


### PR DESCRIPTION
Pull Request for Issue #16614 .

### Summary of Changes
Hover over a selected file in the template manager editor and it is hard to see the text due to the background. This PR makes the hover background the same as the active background for the selected file

### Steps to reproduce the issue
#### Templates > Protostar > css > click on "template.css":
![1](https://user-images.githubusercontent.com/8235763/27004195-77441386-4e05-11e7-8bd3-14c07dac7c19.jpg)
#### hover "template.css":
![2](https://user-images.githubusercontent.com/8235763/27004201-8c8d334e-4e05-11e7-832b-84bcd1082b00.jpeg)