### PR TITLE
Fix category and fields menu item permission checks in admin menu

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -258,7 +258,20 @@ class JAdminCssMenu
 			}
 
 			// Exclude item if the component is not authorised
-			if ($item->element && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $item->element))
+			$assetName = $item->element;
+
+			if ($item->element == 'com_categories')
+			{
+				parse_str($item->link, $query);
+				$assetName = isset($query['extension']) ? $query['extension'] : 'com_content';
+			}
+			elseif ($item->element == 'com_fields')
+			{
+				parse_str($item->link, $query);
+				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
+			}
+
+			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))
 			{
 				continue;
 			}


### PR DESCRIPTION
Pull Request for Issue #17603.

### Summary of Changes
Use appropriate parameter value to identify the effective asset name for com_categories and com_fields menu items.

### Testing Instructions
* Create a new user and add them to the Manager user group

* Create a new admin menu
Item 1: menu item type - menu heading
Item 2: menu item type - list all articles, and set it have parent Item 1
Item 3: menu item type - list all categories, component is articles, set it have parent Item 1
Item 4: menu item type - list all categories, component is users, set it to have parent Item 1

* Create a module for the menu and set the position to Menu and access to Special
You should be able to now see this menu logged in as Super User with three items in it.

* Log in as your new user (Manager).
The admin menu you created will be shown but will only have one item in it - Item 1 (Item 1 is to ensure that the menu is shown.)

* Do similar test for com_fields as well.

### Expected result
User should be able to see category list menu items if they have the correct permissions, so a user who is a Manager should be able to see menu Item 1 and Item 2

### Actual result
Can't see these menu items

### Documentation Changes Required
None