### PR TITLE
[4.0] Correcting fatal error in TemplatestyleField.php

### DIFF
--- a/libraries/src/CMS/Form/Field/TemplatestyleField.php
+++ b/libraries/src/CMS/Form/Field/TemplatestyleField.php
@@ -16,8 +16,6 @@ use Joomla\CMS\Form\FormHelper;
 
 FormHelper::loadFieldClass('groupedlist');
 
-use Joomla\CMS\Application\ApplicationHelper;
-
 /**
  * Supports a select grouped list of template styles
  *


### PR DESCRIPTION
Edit a menu item.

One gets 
`Fatal error: Cannot use Joomla\CMS\Application\ApplicationHelper as ApplicationHelper because the name is already in use in /libraries/src/CMS/Form/Field/TemplatestyleField.php on line 19`

patch.