### PR TITLE
[4.0] Fix keepalive

### DIFF
--- a/libraries/src/CMS/Service/Provider/Session.php
+++ b/libraries/src/CMS/Service/Provider/Session.php
@@ -206,7 +206,7 @@ class Session implements ServiceProviderInterface
 					}
 					else
 					{
-						$storage = new JoomlaStorage($input, $handler, array('cookie_lifetime' => $lifetime));
+						$storage = new JoomlaStorage($input, $handler);
 					}
 
 					$dispatcher = $container->get('Joomla\Event\DispatcherInterface');


### PR DESCRIPTION
Pull Request for Issue #16304 .

### Summary of Changes
Fixes session keep alive behaviour in J4 - cookie's containing the session name should last for the full session duration!

### Testing Instructions
Go to create new article page in the backend. Before patch keepalive doesn't work after the patch it does

### Documentation Changes Required
None
