### PR TITLE
[4.0] Displaying Client and Menus filters in Menu Items manager

### DIFF
--- a/administrator/components/com_menus/View/Menus/Html.php
+++ b/administrator/components/com_menus/View/Menus/Html.php
@@ -10,9 +10,10 @@ namespace Joomla\Component\Menus\Administrator\View\Menus;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Helper\ContentHelper;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\View\HtmlView;
+use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 
 /**
@@ -137,7 +138,7 @@ class Html extends HtmlView
 
 		if ($canDo->get('core.admin') && $this->state->get('client_id') == 1)
 		{
-			JToolbarHelper::custom('menu.exportXml', 'download', 'download', 'COM_MENUS_MENU_EXPORT_BUTTON', true);
+			ToolbarHelper::custom('menu.exportXml', 'download', 'download', 'COM_MENUS_MENU_EXPORT_BUTTON', true);
 		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -15,7 +15,8 @@ $data = $displayData;
 // Receive overridable options
 $data['options'] = !empty($data['options']) ? $data['options'] : array();
 
-if ($data['view'] instanceof MenusViewItems || $data['view'] instanceof MenusViewMenus)
+if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\Html
+	|| $data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\Html)
 {
 	// Client selector doesn't have to activate the filter bar.
 	unset($data['view']->activeFilters['client_id']);

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
@@ -12,7 +12,7 @@ defined('JPATH_BASE') or die;
 /** @var  array  $displayData */
 $data = $displayData;
 
-if ($data['view'] instanceof MenusViewItems)
+if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\Html)
 {
 	// We will get the menutype filter & remove it from the form filters
 	$menuTypeField = $data['view']->filterForm->getField('menutype');
@@ -31,7 +31,7 @@ if ($data['view'] instanceof MenusViewItems)
 	</div>
 	<?php
 }
-elseif ($data['view'] instanceof MenusViewMenus)
+elseif ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menus\Html)
 {
 	// Add the client selector before the form filters.
 	$clientIdField = $data['view']->filterForm->getField('client_id');

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
@@ -39,8 +39,10 @@ elseif ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Menu
 	// Add the client selector before the form filters.
 	$clientIdField = $data['view']->filterForm->getField('client_id');
 	?>
-	<div class="js-stools-field-filter js-stools-client_id">
-		<?php echo $clientIdField->input; ?>
+	<div class="js-stools-container-selector">
+		<div class="js-stools-field-selector js-stools-client_id">
+			<?php echo $clientIdField->input; ?>
+		</div>
 	</div>
 	<?php
 }

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default/bar.php
@@ -21,13 +21,16 @@ if ($data['view'] instanceof \Joomla\Component\Menus\Administrator\View\Items\Ht
 	$clientIdField = $data['view']->filterForm->getField('client_id');
 
 	if ($clientIdField): ?>
-	<div class="js-stools-field-filter js-stools-client_id">
-		<?php echo $clientIdField->input; ?>
+	<div class="js-stools-container-selector">
+		<div class="js-stools-field-selector js-stools-client_id">
+			<?php echo $clientIdField->input; ?>
+		</div>
 	</div>
 	<?php endif; ?>
-
-	<div class="js-stools-field-filter js-stools-menutype">
-		<?php echo $menuTypeField->input; ?>
+	<div class="js-stools-container-selector">
+		<div class="js-stools-field-selector js-stools-menutype">
+			<?php echo $menuTypeField->input; ?>
+		</div>
 	</div>
 	<?php
 }


### PR DESCRIPTION
The filters are missing in the menu manager

### Before patch
![screen shot 2017-08-20 at 10 42 47](https://user-images.githubusercontent.com/869724/29493354-5abd0706-8594-11e7-9e91-5882abe8c998.png)


### After patch

![screen shot 2017-08-20 at 10 38 28](https://user-images.githubusercontent.com/869724/29493334-13b8cc78-8594-11e7-999b-acd134928d12.png)

