### PR TITLE
URL is not a scheme

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -337,7 +337,7 @@ class MenusControllerItem extends JControllerForm
 				$segments = explode(':', $data['link']);
 				$protocol = strtolower($segments[0]);
 				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais','mid', 'cid', 'nntp',
-				 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
+						 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
 
 				if (!in_array($protocol, $scheme))
 				{

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -336,8 +336,8 @@ class MenusControllerItem extends JControllerForm
 			{
 				$segments = explode(':', $data['link']);
 				$protocol = strtolower($segments[0]);
-				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais', 'url',
-					'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
+				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais','mid', 'cid', 'nntp',
+				 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
 
 				if (!in_array($protocol, $scheme))
 				{

--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -337,7 +337,7 @@ class MenusControllerItem extends JControllerForm
 				$segments = explode(':', $data['link']);
 				$protocol = strtolower($segments[0]);
 				$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'tn3270', 'wais','mid', 'cid', 'nntp',
-						 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
+					 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git', 'sms');
 
 				if (!in_array($protocol, $scheme))
 				{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -101,7 +101,7 @@ class UrlRule extends FormRule
 		}
 
 		// For some schemes here must be two slashes.
-		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 	'sftp', 'telnet', 'git');
+		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 'sftp', 'telnet', 'git');
 
 		if (in_array($urlScheme, $scheme) && substr($value, strlen($urlScheme), 3) !== '://')
 		{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -56,8 +56,8 @@ class UrlRule extends FormRule
 		// Use the full list or optionally specify a list of permitted schemes.
 		if ($element['schemes'] == '')
 		{
-			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'mid', 'cid', 'nntp', 
-				'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
+			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 
+					'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
 		}
 		else
 		{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -57,7 +57,7 @@ class UrlRule extends FormRule
 		if ($element['schemes'] == '')
 		{
 			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'mid', 'cid', 'nntp', 
-			'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
+				'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
 		}
 		else
 		{
@@ -101,7 +101,7 @@ class UrlRule extends FormRule
 		}
 
 		// For some schemes here must be two slashes.
-		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 				'sftp', 'telnet', 'git');
+		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 	'sftp', 'telnet', 'git');
 
 		if (in_array($urlScheme, $scheme) && substr($value, strlen($urlScheme), 3) !== '://')
 		{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -56,8 +56,8 @@ class UrlRule extends FormRule
 		// Use the full list or optionally specify a list of permitted schemes.
 		if ($element['schemes'] == '')
 		{
-			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'url',
-				'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
+			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 'mid', 'cid', 'nntp', 
+			'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
 		}
 		else
 		{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -57,7 +57,7 @@ class UrlRule extends FormRule
 		if ($element['schemes'] == '')
 		{
 			$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'mailto', 'news', 'prospero', 'telnet', 'rlogin', 'sftp', 'tn3270', 'wais', 
-					'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
+				'mid', 'cid', 'nntp', 'tel', 'urn', 'ldap', 'file', 'fax', 'modem', 'git');
 		}
 		else
 		{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -101,7 +101,7 @@ class UrlRule extends FormRule
 		}
 
 		// For some schemes here must be two slashes.
-		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 'sftp', 'telnet', 'git');
+		$scheme = array('http', 'https', 'ftp', 'ftps', 'gopher', 'wais', 'prospero', 				'sftp', 'telnet', 'git');
 
 		if (in_array($urlScheme, $scheme) && substr($value, strlen($urlScheme), 3) !== '://')
 		{

--- a/plugins/fields/url/params/url.xml
+++ b/plugins/fields/url/params/url.xml
@@ -13,7 +13,6 @@
 				<option value="https">HTTPS</option>
 				<option value="ftp">FTP</option>
 				<option value="ftps">FTPS</option>
-				<option value="url">URL</option>
 				<option value="file">FILE</option>
 				<option value="mailto">MAILTO</option>
 			</field>

--- a/plugins/fields/url/url.xml
+++ b/plugins/fields/url/url.xml
@@ -32,7 +32,6 @@
 					<option value="https">HTTPS</option>
 					<option value="ftp">FTP</option>
 					<option value="ftps">FTPS</option>
-					<option value="url">URL</option>
 					<option value="file">FILE</option>
 					<option value="mailto">MAILTO</option>
 				</field>


### PR DESCRIPTION
In the list of valid URL scheme used in Joomla and in the url field plugin is a type of "url"

This is not a valid url scheme - see https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml

This PR removes it and also solves #14360 which was caused by this confusion