### PR TITLE
fix the drone error Line exceeds 150 characters error

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -643,8 +643,11 @@ class PlgSystemDebug extends CMSPlugin
 			$totalTime += $mark->time;
 			$totalMem  += (float) $mark->memory;
 			$htmlMark  = sprintf(
-				JText::_('PLG_DEBUG_TIME') . ': <span class="label label-time">%.2f&nbsp;ms</span> / <span class="badge badge-default">%.2f&nbsp;ms</span>'
-				. ' ' . JText::_('PLG_DEBUG_MEMORY') . ': <span class="label label-memory">%0.3f MB</span> / <span class="badge badge-default">%0.2f MB</span>'
+				JText::_('PLG_DEBUG_TIME')
+				. ': <span class="label label-time">%.2f&nbsp;ms</span> / <span class="badge badge-default">%.2f&nbsp;ms</span>'
+				. ' '
+				. JText::_('PLG_DEBUG_MEMORY')
+				. ': <span class="label label-memory">%0.3f MB</span> / <span class="badge badge-default">%0.2f MB</span>'
 				. ' %s: %s',
 				$mark->time,
 				$mark->totalTime,


### PR DESCRIPTION
Pull Request for Issue #17637

### Summary of Changes

fix the drone error Line exceeds 150 characters error cc @wilsonge @C-Lodder

### Testing Instructions

review

### Expected result

no errors

### Actual result

```
FILE: /drone/src/github.com/joomla/joomla-cms/plugins/system/debug/debug.php
--------------------------------------------------------------------------------
FOUND 0 ERROR(S) AND 1 WARNING(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 647 | WARNING | Line exceeds 150 characters; contains 165 characters
--------------------------------------------------------------------------------
```

### Documentation Changes Required

