### PR TITLE
[4.0] Make JHtml::_() final and variadic

### DIFF
--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -109,28 +109,25 @@ abstract class JHtml
 	 * Additional arguments may be supplied and are passed to the sub-class.
 	 * Additional include paths are also able to be specified for third-party use
 	 *
-	 * @param   string  $key  The name of helper method to load, (prefix).(class).function
-	 *                        prefix and class are optional and can be used to load custom
-	 *                        html helpers.
+	 * @param   string  $key         The name of helper method to load, (prefix).(class).function
+	 *                               prefix and class are optional and can be used to load custom
+	 *                               html helpers.
+	 * @param   array   $methodArgs  The arguments to pass forward to the method being called
 	 *
 	 * @return  mixed  Result of JHtml::call($function, $args)
 	 *
 	 * @since   1.5
 	 * @throws  InvalidArgumentException
 	 */
-	final public static function _($key)
+	final public static function _($key, ...$methodArgs)
 	{
 		list($key, $prefix, $file, $func) = static::extract($key);
 
 		if (array_key_exists($key, static::$registry))
 		{
 			$function = static::$registry[$key];
-			$args     = func_get_args();
 
-			// Remove function name from arguments
-			array_shift($args);
-
-			return static::call($function, $args);
+			return static::call($function, $methodArgs);
 		}
 
 		/*
@@ -149,12 +146,8 @@ abstract class JHtml
 			}
 
 			static::register($key, $toCall);
-			$args = func_get_args();
 
-			// Remove function name from arguments
-			array_shift($args);
-
-			return static::call($toCall, $args);
+			return static::call($toCall, $methodArgs);
 		}
 
 		$className = $prefix . ucfirst($file);
@@ -193,12 +186,8 @@ abstract class JHtml
 		}
 
 		static::register($key, $toCall);
-		$args = func_get_args();
 
-		// Remove function name from arguments
-		array_shift($args);
-
-		return static::call($toCall, $args);
+		return static::call($toCall, $methodArgs);
 	}
 
 	/**

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -118,7 +118,7 @@ abstract class JHtml
 	 * @since   1.5
 	 * @throws  InvalidArgumentException
 	 */
-	public static function _($key)
+	final public static function _($key)
 	{
 		list($key, $prefix, $file, $func) = static::extract($key);
 

--- a/libraries/cms/html/html.php
+++ b/libraries/cms/html/html.php
@@ -119,7 +119,7 @@ abstract class JHtml
 	 * @since   1.5
 	 * @throws  InvalidArgumentException
 	 */
-	final public static function _($key, ...$methodArgs)
+	final public static function _(string $key, ...$methodArgs)
 	{
 		list($key, $prefix, $file, $func) = static::extract($key);
 


### PR DESCRIPTION
### Summary of Changes

1) We really shouldn't allow `JHtml::_()` to be extended/overridden if someone subclasses `JHtml`, so this makes the method final.
2) Since the method is now final, we can typehint the `$key` argument with its scalar value.
3) Now that we can allow PHP 5.6 features, lets make the `JHtml::_()` method signature variadic so it is now documented more efficiently that the method has more than one argument.

### Testing Instructions

The CMS still works.

### Documentation Changes Required

Note the B/C break in `JHtml::_()` being made final.