### PR TITLE
[4.0] Drop version comparisons for unsupported environments

### DIFF
--- a/build/travis/unit-tests.sh
+++ b/build/travis/unit-tests.sh
@@ -26,6 +26,5 @@ psql -d joomla_ut -a -f "$BASE/tests/unit/schema/postgresql.sql"
 if [[ $INSTALL_MEMCACHE == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcache.ini"; fi
 if [[ $INSTALL_MEMCACHED == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/memcached.ini"; fi
 if [[ $INSTALL_APC == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/apc-$TRAVIS_PHP_VERSION.ini"; fi
-if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 5.* ]]; then printf "\n" | pecl install apcu-4.0.10 && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_APCU == "yes" && $TRAVIS_PHP_VERSION = 7.* ]]; then printf "\n" | pecl install apcu && phpenv config-add "$BASE/build/travis/phpenv/apcu-$TRAVIS_PHP_VERSION.ini"; fi
 if [[ $INSTALL_REDIS == "yes" ]]; then phpenv config-add "$BASE/build/travis/phpenv/redis.ini"; fi

--- a/components/com_search/View/Search/Html.php
+++ b/components/com_search/View/Search/Html.php
@@ -268,8 +268,7 @@ class Html extends HtmlView
 				$row = &$results[$i]->text;
 
 				// Doing HTML entity decoding here, just in case we get any HTML entities here.
-				$quoteStyle   = version_compare(PHP_VERSION, '5.4', '>=') ? ENT_NOQUOTES | ENT_HTML401 : ENT_NOQUOTES;
-				$row          = html_entity_decode($row, $quoteStyle, 'UTF-8');
+				$row          = html_entity_decode($row, ENT_NOQUOTES | ENT_HTML401, 'UTF-8');
 				$row          = SearchHelper::prepareSearchContent($row, $needle);
 				$searchWords  = array_values(array_unique($searchWords));
 				$lowerCaseRow = $mbString ? mb_strtolower($row) : StringHelper::strtolower($row);

--- a/installation/model/database.php
+++ b/installation/model/database.php
@@ -181,7 +181,7 @@ class InstallationModelDatabase extends JModelBase
 		if ($shouldCheckLocalhost && !in_array($options->db_host, $localhost))
 		{
 			$remoteDbFileTestsPassed = JFactory::getSession()->get('remoteDbFileTestsPassed', false);
-			
+
 			// When all checks have been passed we don't need to do this here again.
 			if ($remoteDbFileTestsPassed === false)
 			{
@@ -228,7 +228,7 @@ class InstallationModelDatabase extends JModelBase
 				{
 					// Add the general message
 					JFactory::getApplication()->enqueueMessage($generalRemoteDatabaseMessage, 'warning');
-					
+
 					JFactory::getApplication()->enqueueMessage(JText::sprintf('INSTL_DATABASE_HOST_IS_NOT_LOCALHOST_DELETE_FILE', $remoteDbFile), 'error');
 
 					return false;
@@ -375,15 +375,6 @@ class InstallationModelDatabase extends JModelBase
 			throw new RuntimeException(JText::sprintf('INSTL_DATABASE_INVALID_' . strtoupper($type) . '_VERSION', $db_version));
 		}
 
-		if ($db->getServerType() === 'mysql')
-		{
-			// @internal MySQL versions pre 5.1.6 forbid . / or \ or NULL.
-			if (preg_match('#[\\\/\.\0]#', $options->db_name) && (!version_compare($db_version, '5.1.6', '>=')))
-			{
-				throw new RuntimeException(JText::sprintf('INSTL_DATABASE_INVALID_NAME', $db_version));
-			}
-		}
-
 		// @internal Check for spaces in beginning or end of name.
 		if (strlen(trim($options->db_name)) <> strlen($options->db_name))
 		{
@@ -394,37 +385,6 @@ class InstallationModelDatabase extends JModelBase
 		if (strpos($options->db_name, chr(00)) !== false)
 		{
 			throw new RuntimeException(JText::_('INSTL_DATABASE_NAME_INVALID_CHAR'));
-		}
-
-		// PostgreSQL database older than version 9.0.0 needs to run 'CREATE LANGUAGE' to create function.
-		if ($db->getServerType() === 'postgresql' && !version_compare($db_version, '9.0.0', '>='))
-		{
-			$db->setQuery("select lanpltrusted from pg_language where lanname='plpgsql'");
-
-			try
-			{
-				$db->execute();
-			}
-			catch (ExecutionFailureException $e)
-			{
-				throw new RuntimeException(JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-			}
-
-			$column = $db->loadResult();
-
-			if ($column != 't')
-			{
-				$db->setQuery('CREATE LANGUAGE plpgsql');
-
-				try
-				{
-					$db->execute();
-				}
-				catch (ExecutionFailureException $e)
-				{
-					throw new RuntimeException(JText::_('INSTL_DATABASE_ERROR_POSTGRESQL_QUERY'), 500, $e);
-				}
-			}
 		}
 
 		// Get database's UTF support.

--- a/libraries/src/CMS/Http/Transport/CurlTransport.php
+++ b/libraries/src/CMS/Http/Transport/CurlTransport.php
@@ -306,23 +306,10 @@ class CurlTransport extends AbstractTransport implements TransportInterface
 	{
 		$curlVersion = curl_version();
 
-		// In PHP 5.6.0 or later there are no issues with curl redirects
-		if (version_compare(PHP_VERSION, '5.6', '>='))
+		// If open_basedir is enabled we also need to check if libcurl version is 7.19.4 or higher
+		if (!ini_get('open_basedir') || version_compare($curlVersion['version'], '7.19.4', '>='))
 		{
-			// But if open_basedir is enabled we also need to check if libcurl version is 7.19.4 or higher
-			if (!ini_get('open_basedir') || version_compare($curlVersion['version'], '7.19.4', '>='))
-			{
-				return true;
-			}
-		}
-
-		// In the PHP 5.5 branch, curl redirects are only allowed if open_basedir is disabled
-		if (version_compare(PHP_VERSION, '5.5.9', '>='))
-		{
-			if (!ini_get('open_basedir'))
-			{
-				return true;
-			}
+			return true;
 		}
 
 		return false;

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -107,14 +107,6 @@ class PlgQuickiconPhpVersionCheck extends JPlugin
 	private function getPhpSupport()
 	{
 		$phpSupportData = array(
-			'5.5' => array(
-				'security' => '2015-07-10',
-				'eos'      => '2016-07-21'
-			),
-			'5.6' => array(
-				'security' => '2016-12-31',
-				'eos'      => '2018-12-31'
-			),
 			'7.0' => array(
 				'security' => '2017-12-03',
 				'eos'      => '2018-12-03'

--- a/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
+++ b/tests/unit/suites/libraries/cms/application/JApplicationCmsTest.php
@@ -182,11 +182,6 @@ class JApplicationCmsTest extends TestCaseDatabase
 	 */
 	public function test__constructDependancyInjection()
 	{
-		if (PHP_VERSION == '5.5.13' || PHP_MINOR_VERSION == '6')
-		{
-			$this->markTestSkipped('Test is skipped due to a PHP bug in version 5.5.13 and a change in behavior in the 5.6 branch');
-		}
-
 		$mockInput = $this->getMockInput();
 
 		$config = new Registry;

--- a/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationCliTest.php
@@ -85,11 +85,6 @@ class JApplicationCliTest extends TestCase
 	 */
 	public function test__constructDependancyInjection()
 	{
-		if (PHP_VERSION == '5.5.13' || PHP_MINOR_VERSION == '6')
-		{
-			$this->markTestSkipped('Test is skipped due to a PHP bug in version 5.5.13 and a change in behavior in the 5.6 branch');
-		}
-
 		// Build the mock object.
 		$mockInput = $this->getMockBuilder('JInputCli')
 					->setMethods(array('test'))

--- a/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
+++ b/tests/unit/suites/libraries/joomla/application/JApplicationWebTest.php
@@ -156,11 +156,6 @@ class JApplicationWebTest extends TestCase
 	 */
 	public function test__constructDependancyInjection()
 	{
-		if (PHP_VERSION == '5.5.13' || PHP_MINOR_VERSION == '6')
-		{
-			$this->markTestSkipped('Test is skipped due to a PHP bug in version 5.5.13 and a change in behavior in the 5.6 branch');
-		}
-
 		// Build the mock object.
 		$mockInput = $this->getMockBuilder('JInput')
 					->setMethods(array('test'))
@@ -610,7 +605,7 @@ class JApplicationWebTest extends TestCase
 	 * @since   11.3
 	 */
 	public function testRedirectWithExistingStatusCode2()
-	{	
+	{
 		// Case Sensitive: Status
 		$this->class->setHeader('Status', 201);
 

--- a/tests/unit/suites/libraries/joomla/feed/JFeedTest.php
+++ b/tests/unit/suites/libraries/joomla/feed/JFeedTest.php
@@ -229,11 +229,6 @@ class JFeedTest extends TestCase
 	 */
 	public function testOffsetExists()
 	{
-		if (PHP_VERSION == '5.5.13' || PHP_MINOR_VERSION == '6')
-		{
-			$this->markTestSkipped('Test is skipped due to a PHP bug in version 5.5.13 and a change in behavior in the 5.6 branch');
-		}
-
 		$offset = new stdClass;
 
 		$mock = $this->getMockBuilder('SplObjectStorage')
@@ -258,11 +253,6 @@ class JFeedTest extends TestCase
 	 */
 	public function testOffsetGet()
 	{
-		if (PHP_VERSION == '5.5.13' || PHP_MINOR_VERSION == '6')
-		{
-			$this->markTestSkipped('Test is skipped due to a PHP bug in version 5.5.13 and a change in behavior in the 5.6 branch');
-		}
-
 		$offset = new stdClass;
 
 		$mock = $this->getMockBuilder('SplObjectStorage')


### PR DESCRIPTION
### Summary of Changes

Drop version comparisons for unsupported PHP, MySQL, and PostgreSQL versions.

### Testing Instructions

- Travis runs
- com_search results render appropriately
- Joomla installs
- HTTP requests with curl work
- Tests pass