### PR TITLE
[com_fields] Unify rendering

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -36,11 +36,11 @@ if (($renderClassSuffix = $field->params->get('render_class', '')))
 }
 
 ?>
-<?php if ($showLabel) : ?>
 <dt class="<?php echo $this->escape($renderClass); ?>">
+<?php if ($showLabel) : ?>
 	<span class="field-label"><?php echo $this->escape($field->label); ?>:</span>
-</dt>
 <?php endif; ?>
+</dt>
 <dd class="<?php echo $this->escape($renderClass); ?>">
 	<span class="field-value"><?php echo $this->escape($field->value); ?></span>
 </dd>

--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -6,39 +6,41 @@
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
 
-if (!key_exists('field', $displayData))
+if (empty($field = $displayData['field']) || !($field instanceof stdClass))
 {
 	return;
 }
-
-$field     = $displayData['field'];
-$label     = $field->label;
-$value     = $field->value;
-$class     = $field->params->get('render_class');
-$showLabel = $field->params->get('showlabel');
 
 if ($field->context == 'com_contact.mail')
 {
-	// Prepare the value for the contact form mail
-	$value = html_entity_decode($value);
+	echo ($showLabel ? $field->label . ': ' : '') . html_entity_decode($field->value) . "\r\n";
 
-	echo ($showLabel ? $label . ': ' : '') . $value . "\r\n";
 	return;
 }
 
-if (!$value)
+if (empty($field->value))
 {
 	return;
 }
 
+$showLabel = (bool) $field->params->get('showlabel', true);
+
+$renderClass = 'contact-field-entry';
+
+if (($renderClassSuffix = $field->params->get('render_class', '')))
+{
+	$renderClass .= ' ' . $renderClassSuffix;
+}
+
 ?>
-<dt class="contact-field-entry <?php echo $class; ?>">
-	<?php if ($showLabel == 1) : ?>
-		<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
-	<?php endif; ?>
+<?php if ($showLabel) : ?>
+<dt class="<?php echo $this->escape($renderClass); ?>">
+	<span class="field-label"><?php echo $this->escape($field->label); ?>:</span>
 </dt>
-<dd class="contact-field-entry <?php echo $class; ?>">
-	<span class="field-value"><?php echo $value; ?></span>
+<?php endif; ?>
+<dd class="<?php echo $this->escape($renderClass); ?>">
+	<span class="field-value"><?php echo $this->escape($field->value); ?></span>
 </dd>

--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -9,7 +9,9 @@
 
 defined('_JEXEC') or die;
 
-if (empty($field = $displayData['field']) || !($field instanceof stdClass))
+$field = isset($displayData['field']) ? $displayData['field'] : null;
+
+if (empty($field) || !($field instanceof stdClass))
 {
 	return;
 }

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -6,73 +6,41 @@
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
 
-// Check if we have all the data
-if (!key_exists('item', $displayData) || !key_exists('context', $displayData))
-{
-	return;
-}
-
-// Setting up for display
-$item = $displayData['item'];
-
-if (!$item)
-{
-	return;
-}
-
-$context = $displayData['context'];
-
-if (!$context)
+if (empty($item = $displayData['item']) || !($item instanceof stdClass) || empty($context = $displayData['context']))
 {
 	return;
 }
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 
-$parts     = explode('.', $context);
-$component = $parts[0];
-$fields    = null;
+$fields = null;
 
-if (key_exists('fields', $displayData))
-{
-	$fields = $displayData['fields'];
-}
-else
+if (empty($fields = $displayData['fields']))
 {
 	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
 }
 
-if (!$fields)
+if (empty($fields))
 {
 	return;
 }
 
 // Check if we have mail context in first element
-$isMail = (reset($fields)->context == 'com_contact.mail');
+$isMail = (reset($fields)->context === 'com_contact.mail');
 
-if (!$isMail)
-{
-	// Print the container tag
-	echo '<dl class="fields-container contact-fields dl-horizontal">';
-}
-
-// Loop through the fields and print them
-foreach ($fields as $field)
-{
-	// If the value is empty do nothing
-	if (empty($field->value) && !$isMail)
-	{
+?>
+<?php if (!$isMail) : ?>
+<dl class="fields-container contact-fields dl-horizontal">
+<?php endif; ?>
+<?php foreach ($fields as $field) : ?>
+	<?php if (empty($field->value) && !$isMail) :
 		continue;
-	}
-
-	echo FieldsHelper::render($context, 'field.render', array('field' => $field));
-}
-
-if (!$isMail)
-{
-	// Close the container
-	echo '</dl>';
-}
-
+	endif; ?>
+	<?php echo FieldsHelper::render($context, 'field.render', array('field' => $field)); ?>
+<?php endforeach; ?>
+<?php if (!$isMail) : ?>
+</dl>
+<?php endif; ?>

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -19,9 +19,9 @@ if (empty($item) || !($item instanceof stdClass) || empty($context))
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 
-$fields = null;
+$fields = !empty($displayData['fields']) ? $displayData['fields'] : array();
 
-if (empty($fields = $displayData['fields']))
+if (empty($fields))
 {
 	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
 }

--- a/components/com_contact/layouts/fields/render.php
+++ b/components/com_contact/layouts/fields/render.php
@@ -9,7 +9,10 @@
 
 defined('_JEXEC') or die;
 
-if (empty($item = $displayData['item']) || !($item instanceof stdClass) || empty($context = $displayData['context']))
+$item = isset($displayData['item']) ? $displayData['item'] : null;
+$context = isset($displayData['context']) ? $displayData['context'] : null;
+
+if (empty($item) || !($item instanceof stdClass) || empty($context))
 {
 	return;
 }

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -6,24 +6,34 @@
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
 
-if (!key_exists('field', $displayData))
+if (empty($field = $displayData['field']) || !($field instanceof stdClass))
 {
 	return;
 }
 
-$field = $displayData['field'];
-$label = JText::_($field->label);
-$value = $field->value;
-$showLabel = $field->params->get('showlabel');
-
-if ($value == '')
+if (empty($field->value))
 {
 	return;
 }
+
+$showLabel = (bool) $field->params->get('showlabel', true);
+
+$renderClass = 'field-entry';
+
+if (($renderClassSuffix = $field->params->get('render_class', '')))
+{
+	$renderClass .= ' ' . $renderClassSuffix;
+}
+
 ?>
-<?php if ($showLabel == 1) : ?>
-	<span class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
+<?php if ($showLabel) : ?>
+<dt class="<?php echo $this->escape($renderClass); ?>">
+	<span class="field-label"><?php echo $this->escape($field->label); ?>:</span>
+</dt>
 <?php endif; ?>
-<span class="field-value"><?php echo $value; ?></span>
+<dd class="<?php echo $this->escape($renderClass); ?>">
+	<span class="field-value"><?php echo $this->escape($field->value); ?></span>
+</dd>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -29,11 +29,11 @@ if (($renderClassSuffix = $field->params->get('render_class', '')))
 }
 
 ?>
-<?php if ($showLabel) : ?>
 <dt class="<?php echo $this->escape($renderClass); ?>">
+<?php if ($showLabel) : ?>
 	<span class="field-label"><?php echo $this->escape($field->label); ?>:</span>
-</dt>
 <?php endif; ?>
+</dt>
 <dd class="<?php echo $this->escape($renderClass); ?>">
 	<span class="field-value"><?php echo $this->escape($field->value); ?></span>
 </dd>

--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -9,7 +9,9 @@
 
 defined('_JEXEC') or die;
 
-if (empty($field = $displayData['field']) || !($field instanceof stdClass))
+$field = isset($displayData['field']) ? $displayData['field'] : null;
+
+if (empty($field) || !($field instanceof stdClass))
 {
 	return;
 }

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -6,58 +6,34 @@
  * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 defined('_JEXEC') or die;
 
-// Check if we have all the data
-if (!key_exists('item', $displayData) || !key_exists('context', $displayData))
-{
-	return;
-}
-
-// Setting up for display
-$item = $displayData['item'];
-
-if (!$item)
-{
-	return;
-}
-
-$context = $displayData['context'];
-
-if (!$context)
+if (empty($item = $displayData['item']) || !($item instanceof stdClass) || empty($context = $displayData['context']))
 {
 	return;
 }
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 
-$parts     = explode('.', $context);
-$component = $parts[0];
-$fields    = null;
+$fields = null;
 
-if (key_exists('fields', $displayData))
-{
-	$fields = $displayData['fields'];
-}
-else
+if (empty($fields = $displayData['fields']))
 {
 	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
 }
 
-if (!$fields)
+if (empty($fields))
 {
 	return;
 }
+
 ?>
 <dl class="fields-container">
 <?php foreach ($fields as $field) : ?>
-	<?php // If the value is empty do nothing
-	if (!isset($field->value) or $field->value == '') :
+	<?php if (empty($field->value)) :
 		continue;
 	endif; ?>
-	<?php $class = $field->params->get('render_class'); ?>
-	<dd class="field-entry <?php echo $class; ?>">
-		<?php echo FieldsHelper::render($context, 'field.render', array('field' => $field)); ?>
-	</dd>
+	<?php echo FieldsHelper::render($context, 'field.render', array('field' => $field)); ?>
 <?php endforeach; ?>
 </dl>

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -19,9 +19,9 @@ if (empty($item) || !($item instanceof stdClass) || empty($context))
 
 JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 
-$fields = null;
+$fields = !empty($displayData['fields']) ? $displayData['fields'] : array();
 
-if (empty($fields = $displayData['fields']))
+if (empty($fields))
 {
 	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
 }

--- a/components/com_fields/layouts/fields/render.php
+++ b/components/com_fields/layouts/fields/render.php
@@ -9,7 +9,10 @@
 
 defined('_JEXEC') or die;
 
-if (empty($item = $displayData['item']) || !($item instanceof stdClass) || empty($context = $displayData['context']))
+$item = isset($displayData['item']) ? $displayData['item'] : null;
+$context = isset($displayData['context']) ? $displayData['context'] : null;
+
+if (empty($item) || !($item instanceof stdClass) || empty($context))
 {
 	return;
 }


### PR DESCRIPTION
Pull Request for Issue #16594. Further references: PR #17636, PR #15968

### Summary of Changes
- Unify custom fields rendering for com_contact and com_fields (keeping it as close to what it has been as possible).
- Fix obsolete whitespaces in field class attribute
- Refactoring / Cleanup variables, conditions and remove unused code blocks.
- Add and unify escaping to all output (labels / values).

### Testing Instructions
- Create one or more custom fields in the context of both com_contact (single contact) and com_content (single article).
- Create a menu item to each of those entities.
- Inspect the rendered HTML markup.

### Expected result
The HTML markup for custom fields in both views (contact / article) should look something like this:
Articles after patch:
```
<dl class="fields-container">
	<dt class="field-entry">
		<span class="field-label">Custom Article Field:</span>
	</dt>
	<dd class="field-entry">
		<span class="field-value">Custom Article Field</span>
	</dd>
</dl>
```
Contacts after patch:
```
<dl class="fields-container contact-fields dl-horizontal">
	<dt class="contact-field-entry">
		<span class="field-label">Custom Contact Field:</span>
	</dt>
	<dd class="contact-field-entry">
		<span class="field-value">Custom Contact Field</span>
	</dd>
</dl>
```
### Actual result
- The rendered HTML markup shows obsolete whitespace in a fields class attributes when no render class was entered.
- The markup for custom fields in the context of articles is missing* the dt tag and instead renders both "label" and "value" inside a dd tag.

Articles before patch:
```
<dl class="fields-container">
	<dd class="field-entry ">
		<span class="field-label">Custom Article Field: </span>
		<span class="field-value">Custom Article Field</span>
	</dd>
</dl>
```
Contacts before patch:
```
<dl class="fields-container contact-fields dl-horizontal">
	<dt class="contact-field-entry ">
		<span class="field-label">Custom Contact Field: </span>
	</dt>
	<dd class="contact-field-entry ">
		<span class="field-value">Custom Contact Field</span>
	</dd>
</dl>
```
#### Notes
It seems to be a good choice to make use of a definition list instead of an unordered list here, but we're runing into a dilemma when a fields label was set to "hide". Before the patch, com_content wouldn't have rendered a dt tag at all, though it is required, while com_contact on the other hand, just renders an empty dt tag.

Edit: The validator seems to be fine with an empty dt tag, so I guess we go with that for now.
