### PR TITLE
Fixed SQL update queries

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-07-03.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-07-03.sql
@@ -1,3 +1,3 @@
 INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(458, ''plg_behaviour_taggable'', ''plugin'', ''taggable'', ''behaviour'', 0, 1, 1, 0, '''', ''{}'', '''', '''', 0, ''0000-00-00 00:00:00'', 0, 0),
-(459, ''plg_behaviour_versionable'', ''plugin'', ''versionable'', ''behaviour'', 0, 1, 1, 0, '''', ''{}'', '''', '''', 0, ''0000-00-00 00:00:00'', 0, 0);
+(458, 'plg_behaviour_taggable', 'plugin', 'taggable', 'behaviour', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
+(459, 'plg_behaviour_versionable', 'plugin', 'versionable', 'behaviour', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-04-25.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-04-25.sql
@@ -1,5 +1,5 @@
-INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `system_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
-(481, 'plg_filesystem_local', 'plugin', 'local', 'filesystem', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(482, 'plg_media-action_crop', 'plugin', 'crop', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(483, 'plg_media-action_resize', 'plugin', 'resize', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0),
-(484, 'plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
+INSERT INTO `#__extensions` (`extension_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+(481, 'plg_filesystem_local', 'plugin', 'local', 'filesystem', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0),
+(482, 'plg_media-action_crop', 'plugin', 'crop', 'media-action', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0),
+(483, 'plg_media-action_resize', 'plugin', 'resize', 'media-action', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0),
+(484, 'plg_media-action_rotate', 'plugin', 'rotate', 'media-action', 0, 1, 1, 0, '', '{}', 0, '0000-00-00 00:00:00', 0, 0);


### PR DESCRIPTION
### Summary of Changes
The update SQL files have 2 issues:
1. The file administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-07-03.sql has duplicate single quotes making the SQL invalid
2. The file administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-04-25.sql is executed after the administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-03-18.sql file. The 2017-03-18 file drops the columns custom_data and system_data so they cannot be altered in the 2017-04-25 file.

### Testing Instructions
1. Install a Joomla 3 website
2. Execute the SQL queries in the mentioned files and the correct order. You will get database errors.
3. Apply patch
4. Install a Joomla 3 website
4. Execute the SQL queries in the mentioned files and the correct order. There should be no errors

### Expected result
Queries are executed as needed.


### Actual result
Database errors occur


### Documentation Changes Required
None
