### PR TITLE
com_redirect improvements

### DIFF
--- a/administrator/components/com_redirect/config.xml
+++ b/administrator/components/com_redirect/config.xml
@@ -15,6 +15,13 @@
 			<option value="1">JYES</option>
 			<option value="0">JNO</option>
 		</field>
+		<field
+			name="separator"
+			type="text"
+			label="COM_REDIRECT_BULK_SEPARATOR_LABEL"
+			description="COM_REDIRECT_BULK_SEPARATOR_DESC"
+			default="|"
+			/>
 	</fieldset>
 
 	<fieldset

--- a/administrator/components/com_redirect/config.xml
+++ b/administrator/components/com_redirect/config.xml
@@ -21,7 +21,7 @@
 			label="COM_REDIRECT_BULK_SEPARATOR_LABEL"
 			description="COM_REDIRECT_BULK_SEPARATOR_DESC"
 			default="|"
-			/>
+		/>
 	</fieldset>
 
 	<fieldset

--- a/administrator/components/com_redirect/controllers/links.php
+++ b/administrator/components/com_redirect/controllers/links.php
@@ -132,7 +132,8 @@ class RedirectControllerLinks extends JControllerAdmin
 		{
 			if (!empty($batch_urls_line))
 			{
-				$batch_urls[] = array_map('trim', explode('|', $batch_urls_line));
+				$params = JComponentHelper::getParams('com_redirect');
+				$batch_urls[] = array_map('trim', explode($params->get('separator', '|'), $batch_urls_line));
 			}
 		}
 

--- a/administrator/components/com_redirect/models/links.php
+++ b/administrator/components/com_redirect/models/links.php
@@ -212,8 +212,6 @@ class RedirectModelLinks extends JModelList
 
 		$query->columns($columns);
 
-		$runQuery = false;
-
 		foreach ($batch_urls as $batch_url)
 		{
 			$old_url = $batch_url[0];
@@ -228,7 +226,6 @@ class RedirectModelLinks extends JModelList
 				$new_url = '';
 			}
 
-			$runQuery = true;
 			$query->insert($db->quoteName('#__redirect_links'), false)
 				->values(
 					$db->quote($old_url) . ', ' . $db->quote($new_url) . ' ,' . $db->quote('') . ', ' . $db->quote('') . ', 0, 0, ' .
@@ -236,11 +233,10 @@ class RedirectModelLinks extends JModelList
 				);
 		}
 
-		if ($runQuery)
-		{
-			$db->setQuery($query);
-			$db->execute();
-		}
+
+		$db->setQuery($query);
+		$db->execute();
+
 		return true;
 	}
 }

--- a/administrator/components/com_redirect/models/links.php
+++ b/administrator/components/com_redirect/models/links.php
@@ -233,7 +233,6 @@ class RedirectModelLinks extends JModelList
 				);
 		}
 
-
 		$db->setQuery($query);
 		$db->execute();
 

--- a/administrator/components/com_redirect/models/links.php
+++ b/administrator/components/com_redirect/models/links.php
@@ -212,17 +212,11 @@ class RedirectModelLinks extends JModelList
 
 		$query->columns($columns);
 
+		$runQuery = false;
+
 		foreach ($batch_urls as $batch_url)
 		{
-			// Source URLs need to have the correct URL format to work properly
-			if (strpos($batch_url[0], JUri::root()) === false)
-			{
-				$old_url = JUri::root() . $batch_url[0];
-			}
-			else
-			{
-				$old_url = $batch_url[0];
-			}
+			$old_url = $batch_url[0];
 
 			// Destination URL can also be an external URL
 			if (!empty($batch_url[1]))
@@ -234,6 +228,7 @@ class RedirectModelLinks extends JModelList
 				$new_url = '';
 			}
 
+			$runQuery = true;
 			$query->insert($db->quoteName('#__redirect_links'), false)
 				->values(
 					$db->quote($old_url) . ', ' . $db->quote($new_url) . ' ,' . $db->quote('') . ', ' . $db->quote('') . ', 0, 0, ' .
@@ -241,9 +236,11 @@ class RedirectModelLinks extends JModelList
 				);
 		}
 
-		$db->setQuery($query);
-		$db->execute();
-
+		if ($runQuery)
+		{
+			$db->setQuery($query);
+			$db->execute();
+		}
 		return true;
 	}
 }

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -15,7 +15,7 @@ $separator = $params->get('separator', '|');
 <div class="container-fluid">
 	<div class="row-fluid">
 		<div class="control-group span12">
-			<p><?php echo JText::sprintf('COM_REDIRECT_BATCH_TIP', $separator, $separator); ?></p>
+			<p><?php echo JText::sprintf('COM_REDIRECT_BATCH_TIP', $separator); ?></p>
 			<div class="controls">
 				<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>

--- a/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default_batch_body.php
@@ -8,12 +8,14 @@
  */
 defined('_JEXEC') or die;
 $published = $this->state->get('filter.published');
+$params    = $this->params;
+$separator = $params->get('separator', '|');
 ?>
 
 <div class="container-fluid">
 	<div class="row-fluid">
 		<div class="control-group span12">
-			<p><?php echo JText::_('COM_REDIRECT_BATCH_TIP'); ?></p>
+			<p><?php echo JText::sprintf('COM_REDIRECT_BATCH_TIP', $separator, $separator); ?></p>
 			<div class="controls">
 				<textarea class="span12" rows="10" aria-required="true" value="" id="batch_urls" name="batch_urls"></textarea>
 			</div>

--- a/administrator/components/com_redirect/views/links/view.html.php
+++ b/administrator/components/com_redirect/views/links/view.html.php
@@ -54,6 +54,7 @@ class RedirectViewLinks extends JViewLegacy
 		$this->state                = $this->get('State');
 		$this->filterForm           = $this->get('FilterForm');
 		$this->activeFilters        = $this->get('ActiveFilters');
+		$this->params               = JComponentHelper::getParams('com_redirect');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -6,7 +6,7 @@
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
-COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with | (eg old-url|new-url). Each line one entry!"
+COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with %1$s (eg old-url%2$snew-url). Each line one entry!"
 COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is '|' but it can be ',' for a copy / paste from a CSV file for instance."
 COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BUTTON_UPDATE_LINKS="Update Links"

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -5,7 +5,7 @@
 
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
-COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is | but it can be , for a copy / paste from a CSV file for instance."
+COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is '|' but it can be ',' for a copy / paste from a CSV file for instance."
 COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
 COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with | (eg old-url|new-url). Each line one entry!"

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -5,7 +5,7 @@
 
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
-COM_REDIRECT_BULK_SEPARATOR_DESC="The sperator used for bulk import, by default it is | but it can be , for a copy / paste from a CSV file for instance."
+COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is | but it can be , for a copy / paste from a CSV file for instance."
 COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
 COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with | (eg old-url|new-url). Each line one entry!"

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -5,10 +5,10 @@
 
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
-COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is '|' but it can be ',' for a copy / paste from a CSV file for instance."
-COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
 COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with | (eg old-url|new-url). Each line one entry!"
+COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is '|' but it can be ',' for a copy / paste from a CSV file for instance."
+COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BUTTON_UPDATE_LINKS="Update Links"
 COM_REDIRECT_CLEAR_FAIL="Failed to delete disabled links."
 COM_REDIRECT_CLEAR_SUCCESS="All disabled links have been deleted."

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -6,7 +6,7 @@
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
-COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with %1$s (eg old-url%2$snew-url). Each line one entry!"
+COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with %1$s (eg old-url%1$snew-url). Each line one entry!"
 COM_REDIRECT_BULK_SEPARATOR_DESC="The separator used for bulk import, by default it is '|' but it can be ',' for a copy / paste from a CSV file for instance."
 COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BUTTON_UPDATE_LINKS="Update Links"

--- a/administrator/language/en-GB/en-GB.com_redirect.ini
+++ b/administrator/language/en-GB/en-GB.com_redirect.ini
@@ -5,6 +5,8 @@
 
 COM_REDIRECT="Redirects"
 COM_REDIRECT_ADVANCED_OPTIONS="Advanced"
+COM_REDIRECT_BULK_SEPARATOR_DESC="The sperator used for bulk import, by default it is | but it can be , for a copy / paste from a CSV file for instance."
+COM_REDIRECT_BULK_SEPARATOR_LABEL="Bulk Import Separator"
 COM_REDIRECT_BATCH_OPTIONS="Bulk process to add new URLs"
 COM_REDIRECT_BATCH_TIP="Enter expired URL (mandatory) with a new URL (optional) separated with | (eg old-url|new-url). Each line one entry!"
 COM_REDIRECT_BUTTON_UPDATE_LINKS="Update Links"

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -122,16 +122,24 @@ class PlgSystemRedirect extends JPlugin
 		// These are the original URLs
 		$orgurl                = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment')));
 		$orgurlRel             = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
-		$orgurlRootRel         = str_replace(JUri::root(), '', $orgurl); // The above doesn't work for sub directories, so do this
-		$orgurlRootRelSlash    = str_replace(JUri::root(), '/', $orgurl); // Cater for when users have added / to the url
+
+		// The above doesn't work for sub directories, so do this
+		$orgurlRootRel         = str_replace(JUri::root(), '', $orgurl);
+
+		// Cater for when users have added / to the url
+		$orgurlRootRelSlash    = str_replace(JUri::root(), '/', $orgurl);
 		$orgurlWithoutQuery    = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment')));
 		$orgurlRelWithoutQuery = rawurldecode($uri->toString(array('path', 'fragment')));
 
 		// These are the URLs we save and use
 		$url                = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
 		$urlRel             = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
-		$urlRootRel         = str_replace(JUri::root(), '', $url); // The above doesn't work for sub directories, so do this
-		$urlRootRelSlash    = str_replace(JUri::root(), '/', $url); // Cater for when users have added / to the url
+
+		// The above doesn't work for sub directories, so do this
+		$urlRootRel         = str_replace(JUri::root(), '', $url);
+
+		// Cater for when users have added / to the url
+		$urlRootRelSlash    = str_replace(JUri::root(), '/', $url);
 		$urlWithoutQuery    = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
 		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
 

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -237,7 +237,7 @@ class PlgSystemRedirect extends JPlugin
 					$redirect->new_url .= '?' . $urlQuery;
 				}
 
-				$dest = JUri::isInternal($redirect->new_url) || strpos('http', $redirect->new_url) === FALSE ?
+				$dest = JUri::isInternal($redirect->new_url) || strpos('http', $redirect->new_url) === false ?
 					JRoute::_(JUri::root() . $redirect->new_url) :
 					$redirect->new_url;
 

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -126,7 +126,7 @@ class PlgSystemRedirect extends JPlugin
 		// The above doesn't work for sub directories, so do this
 		$orgurlRootRel         = str_replace(JUri::root(), '', $orgurl);
 
-		// Cater for when users have added / to the url
+		// For when users have added / to the url
 		$orgurlRootRelSlash    = str_replace(JUri::root(), '/', $orgurl);
 		$orgurlWithoutQuery    = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment')));
 		$orgurlRelWithoutQuery = rawurldecode($uri->toString(array('path', 'fragment')));
@@ -138,7 +138,7 @@ class PlgSystemRedirect extends JPlugin
 		// The above doesn't work for sub directories, so do this
 		$urlRootRel         = str_replace(JUri::root(), '', $url);
 
-		// Cater for when users have added / to the url
+		// For when users have added / to the url
 		$urlRootRelSlash    = str_replace(JUri::root(), '/', $url);
 		$urlWithoutQuery    = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
 		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
@@ -249,7 +249,7 @@ class PlgSystemRedirect extends JPlugin
 					JRoute::_(JUri::root() . $redirect->new_url) :
 					$redirect->new_url;
 
-				// Incase the url contains double // lets remove it
+				// In case the url contains double // lets remove it
 				$destination = str_replace(JUri::root() . '/', JUri::root(), $dest);
 
 				$app->redirect($destination, (int) $redirect->header);

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -122,16 +122,16 @@ class PlgSystemRedirect extends JPlugin
 		// These are the original URLs
 		$orgurl                = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment')));
 		$orgurlRel             = rawurldecode($uri->toString(array('path', 'query', 'fragment')));
-		$orgurlRootRel         = str_replace(JUri::root(), '', $orgurl); // the above doesn't work for sub directories, so do this
-		$orgurlRootRelSlash    = str_replace(JUri::root(), '/', $orgurl); // cater for when users have added / to the url
+		$orgurlRootRel         = str_replace(JUri::root(), '', $orgurl); // The above doesn't work for sub directories, so do this
+		$orgurlRootRelSlash    = str_replace(JUri::root(), '/', $orgurl); // Cater for when users have added / to the url
 		$orgurlWithoutQuery    = rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment')));
 		$orgurlRelWithoutQuery = rawurldecode($uri->toString(array('path', 'fragment')));
 
 		// These are the URLs we save and use
 		$url                = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'query', 'fragment'))));
 		$urlRel             = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'query', 'fragment'))));
-		$urlRootRel         = str_replace(JUri::root(), '', $url); // the above doesn't work for sub directories, so do this
-		$urlRootRelSlash    = str_replace(JUri::root(), '/', $url); // cater for when users have added / to the url
+		$urlRootRel         = str_replace(JUri::root(), '', $url); // The above doesn't work for sub directories, so do this
+		$urlRootRelSlash    = str_replace(JUri::root(), '/', $url); // Cater for when users have added / to the url
 		$urlWithoutQuery    = StringHelper::strtolower(rawurldecode($uri->toString(array('scheme', 'host', 'port', 'path', 'fragment'))));
 		$urlRelWithoutQuery = StringHelper::strtolower(rawurldecode($uri->toString(array('path', 'fragment'))));
 


### PR DESCRIPTION
Pull Request for Issue #17377 thanks to @brianteeman for the investigation into the bulk import differences with pull #17658 .

### Summary of Changes
Added text separator ability to change within the component configuration
Redirect plugin now caters for relative urls opposed to absolute, which work in sub directories. 
Also for urls starting with / and without /

### Testing Instructions
Batch import urls starting with a url and without a url and with a slash to start, new url also can have a slash or not before the redirect.

### Expected result

All redirects work

### Actual result
 
Only absolute urls works, or if the domain is a root level domain.
