### PR TITLE
Allow to delete cache items without any errors is system cache is disabled.

### DIFF
--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -279,7 +279,19 @@ class Cache
 		// Get the default group
 		$group = $group ?: $this->_options['defaultgroup'];
 
-		return $this->_getStorage()->remove($id, $group);
+		try
+		{
+			return $this->_getStorage()->remove($id, $group);
+		}
+		catch (JCacheException $e)
+		{
+			if (!$this->getCaching())
+			{
+				return false;
+			}
+
+			throw $e;
+		}
 	}
 
 	/**
@@ -300,7 +312,19 @@ class Cache
 		// Get the default group
 		$group = $group ?: $this->_options['defaultgroup'];
 
-		return $this->_getStorage()->clean($group, $mode);
+		try
+		{
+			return $this->_getStorage()->clean($group, $mode);
+		}
+		catch (JCacheException $e)
+		{
+			if (!$this->getCaching())
+			{
+				return false;
+			}
+
+			throw $e;
+		}
 	}
 
 	/**
@@ -312,7 +336,19 @@ class Cache
 	 */
 	public function gc()
 	{
-		return $this->_getStorage()->gc();
+		try
+		{
+			return $this->_getStorage()->gc();
+		}
+		catch (JCacheException $e)
+		{
+			if (!$this->getCaching())
+			{
+				return false;
+			}
+
+			throw $e;
+		}
 	}
 
 	/**

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Cache;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\Application\Web\WebClient;
+use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\String\StringHelper;
 
 /**
@@ -283,7 +284,7 @@ class Cache
 		{
 			return $this->_getStorage()->remove($id, $group);
 		}
-		catch (JCacheException $e)
+		catch (CacheExceptionInterface $e)
 		{
 			if (!$this->getCaching())
 			{
@@ -316,7 +317,7 @@ class Cache
 		{
 			return $this->_getStorage()->clean($group, $mode);
 		}
-		catch (JCacheException $e)
+		catch (CacheExceptionInterface $e)
 		{
 			if (!$this->getCaching())
 			{
@@ -340,7 +341,7 @@ class Cache
 		{
 			return $this->_getStorage()->gc();
 		}
-		catch (JCacheException $e)
+		catch (CacheExceptionInterface $e)
 		{
 			if (!$this->getCaching())
 			{


### PR DESCRIPTION
Related to https://github.com/joomla/joomla-cms/pull/17430#issuecomment-320814871

### Summary of Changes

Do not throw exception of unsupported handler if cache system is disabled.


### Testing Instructions
Code review or

1. Install staging joomla on system with 2 handlers available: `File` and one other.
2. Check you cache setting in `System->Global Configuration->System`, it should looks like:
![cache_2](https://user-images.githubusercontent.com/9054379/29568637-37362682-8751-11e7-838c-7f80677648b4.png)

3. Now change permission for `administrator/cache` folder to read-only.
4. After you change it correctly then File handler will disappear.
5. Now try to save configuration with a new handler.
6. Before patch:
  * the new handler won't be saved in configuration file, you can check it after re-login
  * you get error message that file storage is unsupported
  * you stuck with unsupported cache handler although `System Cache` option is disabled.

7. Apply patch:
  * you can change handler from `File` to other without above problem.

8. Mark PR as tested at https://issues.joomla.org/tracker/joomla-cms/17671

### Expected result
You can change unsupported handler to new one.

### Actual result
You stuck with unsupported cache handler and can not change it at the joomla backend.

### Documentation Changes Required
No
