### PR TITLE
Tagged Items: make accessible, avoid nesting headers (missing h2 between h1 and h3)

### DIFF
--- a/components/com_tags/views/tag/tmpl/default.php
+++ b/components/com_tags/views/tag/tmpl/default.php
@@ -18,21 +18,15 @@ $isSingleTag = count($this->item) === 1;
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>
 		</h1>
-		<?php	// Workaround for Accessibility: in case page_heading is shown and no tag_title (<h2>) follows, emit it anyway, hidden,
-				// using the 'hidden' class attribute for prototype template and 'unseen' for beez3, so assuring a <h2> always follows <h1>.
-				// As all subsequent tagged items are listed in <h3> elements (see default_items.php), this avoids a 'hole' in header elements,
-				// so solving Accessibility 'header nesting' error.
-		if (!($this->params->get('show_tag_title', 1))) : ?>	
-			<h2 class="hidden unseen">
-				<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
-			</h2>
-		<?php endif; ?>
 	<?php endif; ?>
-	<?php if ($this->params->get('show_tag_title', 1)) : ?>
-		<h2>
-			<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
-		</h2>
-	<?php endif; ?>
+	<?php // Workaround for Accessibility: in case page_heading is shown and no tag_title (<h2>) follows, emit it anyway, hidden,
+ 		// using the 'hidden' class attribute, so assuring a <h2> always follows <h1>.
+ 		// As all subsequent tagged items are listed in <h3> elements (see default_items.php), this avoids a 'hole' in header elements,
+ 		// so solving Accessibility 'header nesting' error. ?>
+	<?php $a11y_hidden_h2_fix = ( $this->params->get('show_page_heading') && !($this->params->get('show_tag_title', 1)) ) ? ' class="hidden"' : ''; ?>
+	<h2 <?php echo $a11y_hidden_h2_fix; ?> >
+		<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
+	</h2>
 	<?php // We only show a tag description if there is a single tag. ?>
 	<?php if (count($this->item) === 1 && ($this->params->get('tag_list_show_tag_image', 1) || $this->params->get('tag_list_show_tag_description', 1))) : ?>
 		<div class="category-desc">

--- a/components/com_tags/views/tag/tmpl/default.php
+++ b/components/com_tags/views/tag/tmpl/default.php
@@ -18,6 +18,15 @@ $isSingleTag = count($this->item) === 1;
 		<h1>
 			<?php echo $this->escape($this->params->get('page_heading')); ?>
 		</h1>
+		<?php	// Workaround for Accessibility: in case page_heading is shown and no tag_title (<h2>) follows, emit it anyway, hidden,
+				// using the 'hidden' class attribute for prototype template and 'unseen' for beez3, so assuring a <h2> always follows <h1>.
+				// As all subsequent tagged items are listed in <h3> elements (see default_items.php), this avoids a 'hole' in header elements,
+				// so solving Accessibility 'header nesting' error.
+		if (!($this->params->get('show_tag_title', 1))) : ?>	
+			<h2 class="hidden unseen">
+				<?php echo JHtml::_('content.prepare', $this->tags_title, '', 'com_tag.tag'); ?>
+			</h2>
+		<?php endif; ?>
 	<?php endif; ?>
 	<?php if ($this->params->get('show_tag_title', 1)) : ?>
 		<h2>

--- a/templates/beez3/css/position.css
+++ b/templates/beez3/css/position.css
@@ -200,6 +200,11 @@ body {
     width: 0;
 }
 
+.hidden {
+	display: none;
+    visibility: hidden;
+}
+
 /* ++++++++++++++  nav after content  ++++++++++++++ */
 .left {
     padding-top: 0;

--- a/templates/beez3/css/position.css
+++ b/templates/beez3/css/position.css
@@ -201,7 +201,7 @@ body {
 }
 
 .hidden {
-	display: none;
+    display: none;
     visibility: hidden;
 }
 


### PR DESCRIPTION
We expect that a page, listing tagged elements ("Tagged Items" menu item type), would "accessible" in any configuration of menuitem options.

### Summary of Changes
In a "Tagged Items" menuitem, in case:
- page_heading (that is contained in `<h1>` element) is shown and
- tag_title (that is contained in `<h2>` element) is set by user not to be shown,

modify code to emit tag_title (in `<h2>` element) anyway, using the `hidden` class attribute, so assuring that a `<h2>` element follows `<h1>` element and at the same time having tag_tile not shown (as it has the `hidden` class attribute) as desired by user.
All subsequent tagged items code remains untouched: tagged items are listed in `<h3>` elements (see default_items.php).
So the elements sequence will begin anyway (with any menuitem options settings) with a `<h1>` or a `<h2>` element, followed by `<h2>` element(s), so there will be no 'hole' in header elements, and the accessibility 'header nesting' errors will be fixed.

### Testing Instructions

- Create some items (articles, contacts, ...) and tag them with "Joomla" tag.
- Create a "Tagged Items" type menuitem.
- In menuitem's "Detalis" options group, set "Tag*" field to "Joomla".
- In menuitem's "Tag Options" options group set "Show Tag Name" to "Hide".
- In menuitem's "Page Display" options group set "Show Page Heading" to "Yes".

### Expected result
The page at that menuitem should pass accessibility validation (https://achecker.ca/checker/index.php)

### Actual result
The page is not accessible.
There is a _**header nesting error**_ (https://achecker.ca/checker/index.php), as a `<h3>` element (tagged item) follows `<h1>` element (page_header) with no `<h2>` element (Tag Name, tag_title) in between.
  