### PR TITLE
New Router: Optimizing installation of Joomla as a multingual site.

### DIFF
--- a/installation/controller/setdefaultlanguage.php
+++ b/installation/controller/setdefaultlanguage.php
@@ -130,7 +130,19 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 					continue;
 				}
 
-				if (!$tableMenuItem = $model->addMenuItem($siteLang))
+				if (!$data['installLocalisedContent'])
+				{
+					if (!$tableMenuItem = $model->addFeaturedMenuItem($siteLang))
+					{
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM', $siteLang->name), 'warning');
+
+						continue;
+					}
+
+					$groupedAssociations['com_menus.item'][$siteLang->language] = $tableMenuItem->id;
+				}
+
+				if (!$tableMenuItem = $model->addAllCategoriesMenuItem($siteLang))
 				{
 					$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM', $siteLang->name), 'warning');
 
@@ -156,6 +168,15 @@ class InstallationControllerSetdefaultlanguage extends JControllerBase
 					}
 
 					$groupedAssociations['com_categories.item'][$siteLang->language] = $tableCategory->id;
+
+					if (!$tableMenuItem = $model->addBlogMenuItem($siteLang, $tableCategory->id))
+					{
+						$app->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM', $siteLang->name), 'warning');
+
+						continue;
+					}
+
+					$groupedAssociations['com_menus.item'][$siteLang->language] = $tableMenuItem->id;
 
 					if (!$tableArticle = $model->addArticle($siteLang, $tableCategory->id))
 					{

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -974,7 +974,23 @@ class InstallationModelLanguages extends JModelBase
 			'parent_id'    => 1,
 			'level'        => 1,
 			'home'         => 0,
-			'params'       => '{"show_base_description":"","categories_description":"","maxLevelcat":"","show_empty_categories_cat":"","show_subcat_desc_cat":"","show_cat_num_articles_cat":"","show_category_title":"","show_description":"","show_description_image":"","maxLevel":"","show_empty_categories":"","show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"","num_leading_articles":"","num_intro_articles":"","num_columns":"","num_links":"","multi_column_order":"","show_subcategory_content":"","orderby_pri":"","orderby_sec":"","order_date":"","show_pagination_limit":"","filter_field":"","show_headings":"","list_show_date":"","date_format":"","list_show_hits":"","list_show_author":"","display_num":"10","show_pagination":"","show_pagination_results":"","show_title":"","link_titles":"","show_intro":"","show_category":"","link_category":"","show_parent_category":"","link_parent_category":"","show_author":"","link_author":"","show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","show_noauth":"","show_feed_link":"","feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_image_css":"","menu_text":1,"menu_show":0,"page_title":"","show_page_heading":"","page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}',
+			'params'       => '{"show_base_description":"","categories_description":"","maxLevelcat":"",'
+				. '"show_empty_categories_cat":"","show_subcat_desc_cat":"","show_cat_num_articles_cat":"",'
+				. '"show_category_title":"","show_description":"","show_description_image":"","maxLevel":"",'
+				. '"show_empty_categories":"","show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"",'
+				. '"num_leading_articles":"","num_intro_articles":"","num_columns":"","num_links":"",'
+				. '"multi_column_order":"","show_subcategory_content":"","orderby_pri":"","orderby_sec":"",'
+				. '"order_date":"","show_pagination_limit":"","filter_field":"","show_headings":"",'
+				. '"list_show_date":"","date_format":"","list_show_hits":"","list_show_author":"","display_num":"10",'
+				. '"show_pagination":"","show_pagination_results":"","show_title":"","link_titles":"",'
+				. '"show_intro":"","show_category":"","link_category":"","show_parent_category":"",'
+				. '"link_parent_category":"","show_author":"","link_author":"","show_create_date":"",'
+				. '"show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"",'
+				. '"show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"",'
+				. '"show_email_icon":"","show_hits":"","show_noauth":"","show_feed_link":"","feed_summary":"",'
+				. '"menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_image_css":"","menu_text":1,'
+				. '"menu_show":0,"page_title":"","show_page_heading":"","page_heading":"","pageclass_sfx":"",'
+				. '"menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}',
 			'language'     => $itemLanguage->language,
 		);
 
@@ -1313,7 +1329,21 @@ class InstallationModelLanguages extends JModelBase
 			'parent_id'    => 1,
 			'level'        => 1,
 			'home'         => 1,
-			'params'       => '{"layout_type":"blog","show_category_heading_title_text":"","show_category_title":"","show_description":"","show_description_image":"","maxLevel":"","show_empty_categories":"","show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"","show_cat_tags":"","page_subheading":"","num_leading_articles":"1","num_intro_articles":"3","num_columns":"3","num_links":"0","multi_column_order":"1","show_subcategory_content":"","orderby_pri":"","orderby_sec":"front","order_date":"","show_pagination":"2","show_pagination_results":"1","show_featured":"","show_title":"","link_titles":"","show_intro":"","info_block_position":"","info_block_show_title":"","show_category":"","link_category":"","show_parent_category":"","link_parent_category":"","show_associations":"","show_author":"","link_author":"","show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","show_tags":"","show_noauth":"","show_feed_link":"1","feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_image_css":"","menu_text":1,"menu_show":1,"page_title":"","show_page_heading":"1","page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":""}',
+			'params'       => '{"layout_type":"blog","show_category_heading_title_text":"","show_category_title":"",'
+				. '"show_description":"","show_description_image":"","maxLevel":"","show_empty_categories":"",'
+				. '"show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"","show_cat_tags":"",'
+				. '"page_subheading":"","num_leading_articles":"1","num_intro_articles":"3","num_columns":"3",'
+				. '"num_links":"0","multi_column_order":"1","show_subcategory_content":"","orderby_pri":"",'
+				. '"orderby_sec":"front","order_date":"","show_pagination":"2","show_pagination_results":"1",'
+				. '"show_featured":"","show_title":"","link_titles":"","show_intro":"","info_block_position":"",'
+				. '"info_block_show_title":"","show_category":"","link_category":"","show_parent_category":"",'
+				. '"link_parent_category":"","show_associations":"","show_author":"","link_author":"",'
+				. '"show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"",'
+				. '"show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"",'
+				. '"show_email_icon":"","show_hits":"","show_tags":"","show_noauth":"","show_feed_link":"1",'
+				. '"feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"",'
+				. '"menu_image_css":"","menu_text":1,"menu_show":1,"page_title":"","show_page_heading":"1",'
+				. '"page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":""}',
 			'language'     => $itemLanguage->language,
 		);
 

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -872,7 +872,7 @@ class InstallationModelLanguages extends JModelBase
 	}
 
 	/**
-	 * Add Menu Item.
+	 * Add Featured Menu Item.
 	 *
 	 * @param   stdClass  $itemLanguage  Language Object.
 	 *
@@ -880,7 +880,7 @@ class InstallationModelLanguages extends JModelBase
 	 *
 	 * @since   3.2
 	 */
-	public function addMenuItem($itemLanguage)
+	public function addFeaturedMenuItem($itemLanguage)
 	{
 		// Add Menu Item.
 		$tableItem = JTable::getInstance('Menu', 'MenusTable');
@@ -911,6 +911,70 @@ class InstallationModelLanguages extends JModelBase
 				. '"show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","menu-anchor_title":"",'
 				. '"menu-anchor_css":"","menu_image":"","show_page_heading":1,"page_title":"","page_heading":"",'
 				. '"pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}',
+			'language'     => $itemLanguage->language,
+		);
+
+		// Bind the data.
+		if (!$tableItem->bind($menuItem))
+		{
+			return false;
+		}
+
+		$tableItem->setLocation($menuItem['parent_id'], 'last-child');
+
+		// Check the data.
+		if (!$tableItem->check())
+		{
+			return false;
+		}
+
+		// Store the data.
+		if (!$tableItem->store())
+		{
+			return false;
+		}
+
+		// Rebuild the tree path.
+		if (!$tableItem->rebuildPath($tableItem->id))
+		{
+			return false;
+		}
+
+		return $tableItem;
+	}
+
+	/**
+	 * Add AllCategories Menu Item for new router.
+	 *
+	 * @param   stdClass  $itemLanguage  Language Object.
+	 *
+	 * @return  JTable|boolean Menu Item Object. False otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+
+	public function addAllCategoriesMenuItem($itemLanguage)
+	{
+		// Add Menu Item.
+		$tableItem = JTable::getInstance('Menu', 'MenusTable');
+
+		$newlanguage = new JLanguage($itemLanguage->language, false);
+		$newlanguage->load('joomla', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
+		$title = $newlanguage->_('JCATEGORIES');
+		$alias = 'allcategories_' . $itemLanguage->language;
+
+		$menuItem = array(
+			'title'        => $title,
+			'alias'        => $alias,
+			'menutype'     => 'mainmenu-' . strtolower($itemLanguage->language),
+			'type'         => 'component',
+			'link'         => 'index.php?option=com_content&view=categories&id=0',
+			'component_id' => 22,
+			'published'    => 1,
+			'parent_id'    => 1,
+			'level'        => 1,
+			'home'         => 0,
+			'params'       => '{"show_base_description":"","categories_description":"","maxLevelcat":"","show_empty_categories_cat":"","show_subcat_desc_cat":"","show_cat_num_articles_cat":"","show_category_title":"","show_description":"","show_description_image":"","maxLevel":"","show_empty_categories":"","show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"","num_leading_articles":"","num_intro_articles":"","num_columns":"","num_links":"","multi_column_order":"","show_subcategory_content":"","orderby_pri":"","orderby_sec":"","order_date":"","show_pagination_limit":"","filter_field":"","show_headings":"","list_show_date":"","date_format":"","list_show_hits":"","list_show_author":"","display_num":"10","show_pagination":"","show_pagination_results":"","show_title":"","link_titles":"","show_intro":"","show_category":"","link_category":"","show_parent_category":"","link_parent_category":"","show_author":"","link_author":"","show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","show_noauth":"","show_feed_link":"","feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_image_css":"","menu_text":1,"menu_show":0,"page_title":"","show_page_heading":"","page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":"","secure":0}',
 			'language'     => $itemLanguage->language,
 		);
 
@@ -1216,6 +1280,70 @@ class InstallationModelLanguages extends JModelBase
 		}
 
 		return $article;
+	}
+
+	/**
+	 * Add Blog Menu Item.
+	 *
+	 * @param   stdClass  $itemLanguage  Language Object.
+	 * @param   int       $categoryId    The id of the category displayed by the blog.
+	 *
+	 * @return  JTable|boolean Menu Item Object. False otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addBlogMenuItem($itemLanguage, $categoryId)
+	{
+		// Add Menu Item.
+		$tableItem = JTable::getInstance('Menu', 'MenusTable');
+
+		$newlanguage = new JLanguage($itemLanguage->language, false);
+		$newlanguage->load('com_languages', JPATH_ADMINISTRATOR, $itemLanguage->language, true);
+		$title = $newlanguage->_('COM_LANGUAGES_HOMEPAGE');
+		$alias = 'home_' . $itemLanguage->language;
+
+		$menuItem = array(
+			'title'        => $title,
+			'alias'        => $alias,
+			'menutype'     => 'mainmenu-' . strtolower($itemLanguage->language),
+			'type'         => 'component',
+			'link'         => 'index.php?option=com_content&view=category&layout=blog&id=' . $categoryId,
+			'component_id' => 22,
+			'published'    => 1,
+			'parent_id'    => 1,
+			'level'        => 1,
+			'home'         => 1,
+			'params'       => '{"layout_type":"blog","show_category_heading_title_text":"","show_category_title":"","show_description":"","show_description_image":"","maxLevel":"","show_empty_categories":"","show_no_articles":"","show_subcat_desc":"","show_cat_num_articles":"","show_cat_tags":"","page_subheading":"","num_leading_articles":"1","num_intro_articles":"3","num_columns":"3","num_links":"0","multi_column_order":"1","show_subcategory_content":"","orderby_pri":"","orderby_sec":"front","order_date":"","show_pagination":"2","show_pagination_results":"1","show_featured":"","show_title":"","link_titles":"","show_intro":"","info_block_position":"","info_block_show_title":"","show_category":"","link_category":"","show_parent_category":"","link_parent_category":"","show_associations":"","show_author":"","link_author":"","show_create_date":"","show_modify_date":"","show_publish_date":"","show_item_navigation":"","show_vote":"","show_readmore":"","show_readmore_title":"","show_icons":"","show_print_icon":"","show_email_icon":"","show_hits":"","show_tags":"","show_noauth":"","show_feed_link":"1","feed_summary":"","menu-anchor_title":"","menu-anchor_css":"","menu_image":"","menu_image_css":"","menu_text":1,"menu_show":1,"page_title":"","show_page_heading":"1","page_heading":"","pageclass_sfx":"","menu-meta_description":"","menu-meta_keywords":"","robots":""}',
+			'language'     => $itemLanguage->language,
+		);
+
+		// Bind the data.
+		if (!$tableItem->bind($menuItem))
+		{
+			return false;
+		}
+
+		$tableItem->setLocation($menuItem['parent_id'], 'last-child');
+
+		// Check the data.
+		if (!$tableItem->check())
+		{
+			return false;
+		}
+
+		// Store the data.
+		if (!$tableItem->store())
+		{
+			return false;
+		}
+
+		// Rebuild the tree path.
+		if (!$tableItem->rebuildPath($tableItem->id))
+		{
+			return false;
+		}
+
+		return $tableItem;
 	}
 
 	/**


### PR DESCRIPTION
As we all know, if one clicks on the title of an article displayed in a featured menu item, the url obtained is quite weird when the new Router is implemented.

Until now, when installing Joomla as multilingual with data, the home menus are featured menu items.

### Summary of Changes
When "Install Localised Content" is set to Yes, this PR changes the default home menu item to a blog 
If "Install Localised Content" is set to No, the home will still be a featured menu item (remember: no specific categories or articles are created).
In both cases, It also adds a hidden menu item of type "List All Categories".

### Testing Instructions
Make an installation with "Install Localised Content" set to Yes and then set to No in another installation.

![screen shot 2017-08-23 at 17 11 26](https://user-images.githubusercontent.com/869724/29623305-32db43d0-8826-11e7-9ef4-798221714ce8.png)

Make sure you enable "Experimental" in Articles Options=>Integration

![screen shot 2017-08-23 at 17 16 52](https://user-images.githubusercontent.com/869724/29623507-f0ae0e56-8826-11e7-8ad8-97fb5b079217.png)

Verify the menu items created and the urls obtained. Below with Localised Content installed

![screen shot 2017-08-23 at 17 15 24](https://user-images.githubusercontent.com/869724/29623475-cce3ac1a-8826-11e7-8b5b-227dc16e9aa2.png)

### Expected result
We will now get for the article displayed in the homes, urls of type
`http://localhost:8888/en/article-en-gb`

instead of
`http://localhost:8888/en/?view=article&id=1:article-en-gb`

Careful though before testing:
https://github.com/joomla/joomla-cms/pull/17668 has broken frontend multilang!