### PR TITLE
[4.0] Removed required state for Secret Key field

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -81,8 +81,7 @@ if ($spacing > 0)
 					autocomplete="off"
 					id="mod-login-secretkey"
 					type="text"
-					class="form-control input-full required"
-					required="true"
+					class="form-control input-full"
 				>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
### System Information

* Running on xampp v3.2.2
* Windows 10 (1703: 15063:540)
* Chrome 60.0.3112.101 (64bit)
* PHP 7.1.7
* Joomla! 4.0-dev (joomla@4.0.0)

### Steps to reproduce the issue

With Two Factor Authentication (afterwards called TFA) enabled, try to log in to `<yourinstallpath>/administrator` with a user which has no TFA enabled. 
For more information, see __ > Testing instructions__.

### Summary of Changes

I removed the required class from the input field. There is a JS running which checks for this class and then adds the `required aria-required="true"` which isn't needed for the Secret Key field.

### Testing instructions

1. Fresh installation of Joomla! 4.0-dev
1. Enable TFA in administrator
    1. Go to Extensions > Plugins
        1. Enable Two Factor Authentication - Google Authenticator
        1. Enable Two Factor Authentication - YubiKey
1. Create users
    1. Go to Users > Manage
    1. Create a new user
    1. Edit the new user and enable Two Factor Authentication
        1. Go to Two Factor Authentication Tab
        1. Select Google Authenticator as Authentication Method
        1. Follow the on screen instructions to set up Google Authenticator
    1. Create a new user
    1. Edit the new user and enable Two Factor Authentication
        1. Got to Two Factor Authentication Tab
        1. Select YubiKey as Authentication Method
        1. Follow the on screen instructions to set up YubiKey Authenticator
1. Go to backend/administrator `<yourinstallpath/administrator`
    1. Test without TFA
        1. Try to log in with superuser with wrong password
        1. Try to log in with superuser with wrong password and additional secret key (is always wrong)
        1. Try to log in with superuser with correct password and additional secret key (is always wrong)
        1. Login with superuser without TFA
        1. Log out
    1. Test with Google TFA
        1. Try to log in with Google TFA user with wrong password but no secret key
        1. Try to log in with Google TFA user with wrong password and wrong secret key
        1. Try to log in with Google TFA user with wrong password but correct secret key
        1. Try to log in with Google TFA user with correct password but no secret key
        1. Try to log in with Google TFA user with correct password but incorrect secret key
        1. Login with the user with Google TFA with the login box
        1. Log out
    1. Test with YubiKey TFA
        1. Try to log in with YubiKey TFA user with wrong password but no secret key
        1. Try to log in with YubiKey TFA user with wrong password and wrong secret key
        1. Try to log in with YubiKey TFA user with wrong password but correct secret key
        1. Try to log in with YubiKey TFA user with correct password but no secret key
        1. Try to log in with YubiKey TFA user with correct password but incorrect secret key
        1. Login with the user with YubiKey TFA with the login box
        1. Log out

If you have any other ideas to test this, please think outside the box!

### Expected result

Checking if a user has TFA enabled in PHP is laborious (would be more of a JS thing). Therefore, it is okay to display the Secret Key field, but ignore it for users with no TFA enabled.

For users with not TFA enabled for them, it should look like this and login needs to be possible:

![image](https://user-images.githubusercontent.com/31202904/29707579-0284d0a0-8986-11e7-85a8-044eca66dbd9.png)


### Actual result

At the moment, login with non-TFA-users in administrator is not possible. The Secret Key field is always required.

![image](https://user-images.githubusercontent.com/31202904/29707546-eb1dc656-8985-11e7-8a9e-064423923574.png)


### Summary of Changes

I removed the required class from the input field. There is a JS running which checks for this class and then adds the `required aria-required="true"` which isn't needed for the Secret Key field.

### Additional comments

This is a bugfix according to the bug I found in #17687
This fix is compatible with the changes made in #17687 

### Documentation Changes Required

The template file (default.php) isn't really documented so there are no changes needed.

Developed @iCampus