### PR TITLE
Fix corrupt language assets records

### DIFF
--- a/libraries/src/Table/Language.php
+++ b/libraries/src/Table/Language.php
@@ -121,8 +121,8 @@ class Language extends Table
 	 * The extended class can define a table and id to lookup.  If the
 	 * asset does not exist it will be created.
 	 *
-	 * @param   Table   $table A Table object for the asset parent.
-	 * @param   integer $id    Id to look up
+	 * @param   Table    $table  A Table object for the asset parent.
+	 * @param   integer  $id     Id to look up
 	 *
 	 * @return  integer
 	 *

--- a/libraries/src/Table/Language.php
+++ b/libraries/src/Table/Language.php
@@ -87,4 +87,57 @@ class Language extends Table
 
 		return parent::store($updateNulls);
 	}
+
+	/**
+	 * Method to compute the default name of the asset.
+	 * The default name is in the form table_name.id
+	 * where id is the value of the primary key of the table.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _getAssetName()
+	{
+		return 'com_languages.language.' . $this->lang_id;
+	}
+
+	/**
+	 * Method to return the title to use for the asset table.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _getAssetTitle()
+	{
+		return $this->title;
+	}
+
+	/**
+	 * Method to get the parent asset under which to register this one.
+	 * By default, all assets are registered to the ROOT node with ID,
+	 * which will default to 1 if none exists.
+	 * The extended class can define a table and id to lookup.  If the
+	 * asset does not exist it will be created.
+	 *
+	 * @param   Table   $table A Table object for the asset parent.
+	 * @param   integer $id    Id to look up
+	 *
+	 * @return  integer
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _getAssetParentId(Table $table = null, $id = null)
+	{
+		$assetId = null;
+		$asset   = Table::getInstance('asset');
+
+		if ($asset->loadByName('com_languages'))
+		{
+			$assetId = $asset->id;
+		}
+
+		return $assetId === null ? parent::_getAssetParentId($table, $id) : $assetId;
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #13602 #14824.

### Summary of Changes
This PR adds the `_getAssetName`, `_getAssetTitle` and `_getAssetParentId` methods to the Language table class. Prevents storing corrupt asset enties to the `#__assets` table.

### Testing Instructions
Go to `Extensions` -> `Language(s)` -> `Content Languages`, open one of the languages and save it. Check the `#__assets` table and you will notice an entry like:
<img width="622" alt="screen shot 2017-08-25 at 13 39 07" src="https://user-images.githubusercontent.com/522834/29712572-d874c4d6-899a-11e7-8653-5110d9ec4f7c.png">

Notice that the parent_id points to asset `root.1`, the level is `1` and the name and title are not set correctly.

Apply the patch and save the language again. Now the assets table shows an entry like:
<img width="610" alt="screen shot 2017-08-25 at 13 39 28" src="https://user-images.githubusercontent.com/522834/29712623-1bb2264e-899b-11e7-8843-f54c7c285917.png">

### Expected result
The PR makes sure the correct asset data is set. So:
- `parent_id`: should be ID of `com_languages` asset
- `level`: should be `2`
- `name`: should be `com_languages.language.X` (where X is ID of language)
- `title`: should be equal to language title, so e.g. `English (en-GB)` 