### PR TITLE
Perfomance issue for forms with large number of categories, fix 1000 queries generated by categoryedit when you have 500 categories (aka 2 queries per category)

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -227,7 +227,8 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$db = JFactory::getDbo();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('language') . ', ' . $db->quoteName('id'))
-				->from($db->quoteName('#__categories'));
+				->from($db->quoteName('#__categories'))
+				->where($db->quoteName('extension') . ' = ' . $db->quote($extension));
 			$cat_languages[$extension] = $db->setQuery($query)->loadObjectList('id');
 		}
 

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -220,6 +220,17 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			JError::raiseWarning(500, $e->getMessage());
 		}
 
+		// Get language of the categories and cache it per extension
+		static $cat_languages = array();
+		if (!isset($cat_languages[$extension]))
+		{
+			$db = JFactory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName('language') . ', ' . $db->quoteName('id'))
+				->from($db->quoteName('#__categories'));
+			$cat_languages[$extension] = $db->setQuery($query)->loadObjectList('id');
+		}
+
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
@@ -233,14 +244,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			}
 
 			// Displays language code if not set to All
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select($db->quoteName('language'))
-				->where($db->quoteName('id') . '=' . (int) $options[$i]->value)
-				->from($db->quoteName('#__categories'));
-
-			$db->setQuery($query);
-			$language = $db->loadResult();
+			$language = $cat_languages[$extension][$options[$i]->value]->language;
 
 			if ($options[$i]->level != 0)
 			{

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -145,7 +145,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 		$user = JFactory::getUser();
 
 		$query = $db->getQuery(true)
-			->select('a.id AS value, a.title AS text, a.level, a.published, a.lft')
+			->select('a.id AS value, a.title AS text, a.level, a.published, a.lft, a.language')
 			->from('#__categories AS a');
 
 		// Filter by the extension type
@@ -220,18 +220,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			JError::raiseWarning(500, $e->getMessage());
 		}
 
-		// Get language of the categories and cache it per extension
-		static $cat_languages = array();
-		if (!isset($cat_languages[$extension]))
-		{
-			$db = JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select($db->quoteName('language') . ', ' . $db->quoteName('id'))
-				->from($db->quoteName('#__categories'))
-				->where($db->quoteName('extension') . ' = ' . $db->quote($extension));
-			$cat_languages[$extension] = $db->setQuery($query)->loadObjectList('id');
-		}
-
 		// Pad the option text with spaces using depth level as a multiplier.
 		for ($i = 0, $n = count($options); $i < $n; $i++)
 		{
@@ -243,9 +231,6 @@ class JFormFieldCategoryEdit extends JFormFieldList
 					$options[$i]->text = JText::_('JGLOBAL_ROOT_PARENT');
 				}
 			}
-
-			// Displays language code if not set to All
-			$language = $cat_languages[$extension][$options[$i]->value]->language;
 
 			if ($options[$i]->level != 0)
 			{
@@ -261,9 +246,10 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
 			}
 
-			if ($language !== '*')
+			// Displays language code if not set to All
+			if ($options[$i]->language !== '*')
 			{
-				$options[$i]->text = $options[$i]->text . ' (' . $language . ')';
+				$options[$i]->text = $options[$i]->text . ' (' . $options[$i]->language . ')';
 			}
 		}
 


### PR DESCRIPTION
Categoryedit field is quering the #__categories table, 2 times per category
- because it has the query inside the loop that examines each category

Solution move query outside of the loop
[EDIT]
Better solution just remove the query completely, there is an other query to the categories table just above, we can use that one to retrieve each categories language

### Testing Instructions
Open forms having categoryedit, 
e.g. article form
the category selector appears as befoe

### Expected result
a single query is done to categories table by categoryedit field,
to get the language of categories that appear in the category selector

### Actual result
multiple queries are done:  1 query is done per category
- and because when using fields the categoryedit is created twice

you get 2 queries per category
e.g. 500 categories you get 1000 queries
e.g. 5000  categories you get 10000 queries


### Documentation Changes Required
none
