### PR TITLE
Fixes for PHP 7.2 not allowing session config changes after headers sent

### DIFF
--- a/libraries/joomla/session/handler/joomla.php
+++ b/libraries/joomla/session/handler/joomla.php
@@ -42,11 +42,17 @@ class JSessionHandlerJoomla extends JSessionHandlerNative
 	 */
 	public function __construct($options = array())
 	{
-		// Disable transparent sid support
-		ini_set('session.use_trans_sid', '0');
+		if (!headers_sent())
+		{
+			// Disable transparent sid support
+			ini_set('session.use_trans_sid', '0');
 
-		// Only allow the session ID to come from cookies and nothing else.
-		ini_set('session.use_only_cookies', '1');
+			// Only allow the session ID to come from cookies and nothing else.
+			if ((int) ini_get('session.use_cookies') !== 1)
+			{
+				ini_set('session.use_only_cookies', 1);
+			}
+		}
 
 		// Set options
 		$this->setOptions($options);
@@ -116,6 +122,11 @@ class JSessionHandlerJoomla extends JSessionHandlerNative
 	 */
 	protected function setCookieParams()
 	{
+		if (headers_sent())
+		{
+			return;
+		}
+
 		$cookie = session_get_cookie_params();
 
 		if ($this->force_ssl)

--- a/libraries/joomla/session/handler/native.php
+++ b/libraries/joomla/session/handler/native.php
@@ -143,7 +143,7 @@ class JSessionHandlerNative implements JSessionHandlerInterface
 	 */
 	public function regenerate($destroy = false, $lifetime = null)
 	{
-		if (null !== $lifetime)
+		if (!headers_sent() && null !== $lifetime)
 		{
 			ini_set('session.cookie_lifetime', $lifetime);
 		}

--- a/libraries/joomla/session/storage.php
+++ b/libraries/joomla/session/storage.php
@@ -95,11 +95,17 @@ abstract class JSessionStorage
 	 */
 	public function register()
 	{
-		// Use this object as the session handler
-		session_set_save_handler(
-			array($this, 'open'), array($this, 'close'), array($this, 'read'), array($this, 'write'),
-			array($this, 'destroy'), array($this, 'gc')
-		);
+		if (!headers_sent())
+		{
+			session_set_save_handler(
+				array($this, 'open'),
+				array($this, 'close'),
+				array($this, 'read'),
+				array($this, 'write'),
+				array($this, 'destroy'),
+				array($this, 'gc')
+			);
+		}
 	}
 
 	/**

--- a/libraries/joomla/session/storage/memcache.php
+++ b/libraries/joomla/session/storage/memcache.php
@@ -63,8 +63,12 @@ class JSessionStorageMemcache extends JSessionStorage
 		if (!empty($this->_servers) && isset($this->_servers[0]))
 		{
 			$serverConf = current($this->_servers);
-			ini_set('session.save_path', "{$serverConf['host']}:{$serverConf['port']}");
-			ini_set('session.save_handler', 'memcache');
+
+			if (!headers_sent())
+			{
+				ini_set('session.save_path', "{$serverConf['host']}:{$serverConf['port']}");
+				ini_set('session.save_handler', 'memcache');
+			}
 		}
 	}
 

--- a/libraries/joomla/session/storage/memcached.php
+++ b/libraries/joomla/session/storage/memcached.php
@@ -63,8 +63,12 @@ class JSessionStorageMemcached extends JSessionStorage
 		if (!empty($this->_servers) && isset($this->_servers[0]))
 		{
 			$serverConf = current($this->_servers);
-			ini_set('session.save_path', "{$serverConf['host']}:{$serverConf['port']}");
-			ini_set('session.save_handler', 'memcached');
+
+			if (!headers_sent())
+			{
+				ini_set('session.save_path', "{$serverConf['host']}:{$serverConf['port']}");
+				ini_set('session.save_handler', 'memcached');
+			}
 		}
 	}
 

--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -52,8 +52,11 @@ class JSessionStorageRedis extends JSessionStorage
 	{
 		if (!empty($this->_server) && isset($this->_server['host']) && isset($this->_server['port']))
 		{
-			ini_set('session.save_path', "{$this->_server['host']}:{$this->_server['port']}");
-			ini_set('session.save_handler', 'redis');
+			if (!headers_sent())
+			{
+				ini_set('session.save_path', "{$this->_server['host']}:{$this->_server['port']}");
+				ini_set('session.save_handler', 'redis');
+			}
 
 			// This is required if the configuration.php gzip is turned on
 			ini_set('zlib.output_compression', 'Off');

--- a/libraries/joomla/session/storage/wincache.php
+++ b/libraries/joomla/session/storage/wincache.php
@@ -44,7 +44,10 @@ class JSessionStorageWincache extends JSessionStorage
 	 */
 	public function register()
 	{
-		ini_set('session.save_handler', 'wincache');
+		if (!headers_sent())
+		{
+			ini_set('session.save_handler', 'wincache');
+		}
 	}
 
 	/**

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -937,7 +937,10 @@ class Session implements \IteratorAggregate
 		}
 
 		// Sync the session maxlifetime
-		ini_set('session.gc_maxlifetime', $this->_expire);
+		if (!headers_sent())
+		{
+			ini_set('session.gc_maxlifetime', $this->_expire);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
### Summary of Changes

In PHP 7.2 the core engine is stricter about changing session related parameters after certain event happen.  Generally, you would only run into these issues with the Joomla code in our testing environment because we're instantiating the session object (and inherently the API internals) quite a few times.

To prevent the error, PHP config changes should check if the headers have been sent first, which is what this PR does.

### Testing Instructions

On all supported environments, Joomla continues to work as normal and you don't get new session related issues.  The number of errors on the Travis-CI builds for PHP 7.2 and later is reduced from 9 to 1.