### PR TITLE
tag observer dirty fix

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -798,7 +798,7 @@ class CategoriesModelCategory extends JModelAdmin
 				$tags = array($value);
 
 				/** @var  JTableObserverTags  $tagsObserver */
-				$tagsObserver = $table->getObserverOfClass('JTableObserverTags');
+				$tagsObserver = $table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 				$result = $tagsObserver->setNewTags($tags, false);
 
 				if (!$result)

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -223,7 +223,7 @@ abstract class AdminModel extends FormModel
 			$this->type = $type->getTypeByAlias($this->typeAlias);
 		}
 
-		$this->tagsObserver = $this->table->getObserverOfClass('\JTableObserverTags');
+		$this->tagsObserver = $this->table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 
 		if ($this->batch_copymove && !empty($commands[$this->batch_copymove]))
 		{
@@ -631,7 +631,7 @@ abstract class AdminModel extends FormModel
 				/**
 				 * @var  \JTableObserverTags  $tagsObserver
 				 */
-				$tagsObserver = $table->getObserverOfClass('\JTableObserverTags');
+				$tagsObserver = $table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 				$result = $tagsObserver->setNewTags($tags, false);
 
 				if (!$result)
@@ -1311,7 +1311,7 @@ abstract class AdminModel extends FormModel
 		$tableClassName = get_class($table);
 		$contentType = new \JUcmType;
 		$type = $contentType->getTypeByTable($tableClassName);
-		$tagsObserver = $table->getObserverOfClass('\JTableObserverTags');
+		$tagsObserver = $table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 		$conditions = array();
 
 		if (empty($pks))


### PR DESCRIPTION
Pull Request for Issue #17710 .

### Summary of Changes
tag observer dirty fix
i'm sure  it can be done in a more clean way

### Testing Instructions
In the article manager, try to batch assign a tag to an article


### Expected result
batch process complete


### Actual result
Call to a member function setNewTags() on null


### Documentation Changes Required

