### PR TITLE
Deterministic version of URL routing

### DIFF
--- a/components/com_contact/router.php
+++ b/components/com_contact/router.php
@@ -27,7 +27,10 @@ class ContactRouter extends JComponentRouterView
 	public function __construct($app = null, $menu = null)
 	{
 		$params = JComponentHelper::getParams('com_contact');
-		$this->noIDs = (bool) $params->get('sef_ids');
+
+		$this->noIDs       = (bool) $params->get('sef_ids');
+		$this->sefAdvanced = (bool) $params->get('sef_advanced');
+
 		$categories = new JComponentRouterViewconfiguration('categories');
 		$categories->setKey('id');
 		$this->registerView($categories);
@@ -43,7 +46,7 @@ class ContactRouter extends JComponentRouterView
 
 		$this->attachRule(new JComponentRouterRulesMenu($this));
 
-		if ($params->get('sef_advanced', 0))
+		if ($this->sefAdvanced)
 		{
 			$this->attachRule(new JComponentRouterRulesStandard($this));
 			$this->attachRule(new JComponentRouterRulesNomenu($this));

--- a/components/com_content/router.php
+++ b/components/com_content/router.php
@@ -27,7 +27,10 @@ class ContentRouter extends JComponentRouterView
 	public function __construct($app = null, $menu = null)
 	{
 		$params = JComponentHelper::getParams('com_content');
-		$this->noIDs = (bool) $params->get('sef_ids');
+
+		$this->noIDs       = (bool) $params->get('sef_ids');
+		$this->sefAdvanced = (bool) $params->get('sef_advanced');
+
 		$categories = new JComponentRouterViewconfiguration('categories');
 		$categories->setKey('id');
 		$this->registerView($categories);
@@ -47,7 +50,7 @@ class ContentRouter extends JComponentRouterView
 
 		$this->attachRule(new JComponentRouterRulesMenu($this));
 
-		if ($params->get('sef_advanced', 0))
+		if ($this->sefAdvanced)
 		{
 			$this->attachRule(new JComponentRouterRulesStandard($this));
 			$this->attachRule(new JComponentRouterRulesNomenu($this));

--- a/components/com_newsfeeds/router.php
+++ b/components/com_newsfeeds/router.php
@@ -27,7 +27,10 @@ class NewsfeedsRouter extends JComponentRouterView
 	public function __construct($app = null, $menu = null)
 	{
 		$params = JComponentHelper::getParams('com_newsfeeds');
-		$this->noIDs = (bool) $params->get('sef_ids');
+
+		$this->noIDs       = (bool) $params->get('sef_ids');
+		$this->sefAdvanced = (bool) $params->get('sef_advanced');
+
 		$categories = new JComponentRouterViewconfiguration('categories');
 		$categories->setKey('id');
 		$this->registerView($categories);
@@ -42,7 +45,7 @@ class NewsfeedsRouter extends JComponentRouterView
 
 		$this->attachRule(new JComponentRouterRulesMenu($this));
 
-		if ($params->get('sef_advanced', 0))
+		if ($this->sefAdvanced)
 		{
 			$this->attachRule(new JComponentRouterRulesStandard($this));
 			$this->attachRule(new JComponentRouterRulesNomenu($this));

--- a/components/com_users/router.php
+++ b/components/com_users/router.php
@@ -24,6 +24,10 @@ class UsersRouter extends JComponentRouterView
 	 */
 	public function __construct($app = null, $menu = null)
 	{
+		$params = JComponentHelper::getParams('com_users');
+
+		$this->sefAdvanced = (bool) $params->get('sef_advanced');
+
 		$this->registerView(new JComponentRouterViewconfiguration('login'));
 		$profile = new JComponentRouterViewconfiguration('profile');
 		$profile->addLayout('edit');
@@ -36,9 +40,7 @@ class UsersRouter extends JComponentRouterView
 
 		$this->attachRule(new JComponentRouterRulesMenu($this));
 
-		$params = JComponentHelper::getParams('com_users');
-
-		if ($params->get('sef_advanced', 0))
+		if ($this->sefAdvanced)
 		{
 			$this->attachRule(new JComponentRouterRulesStandard($this));
 			$this->attachRule(new JComponentRouterRulesNomenu($this));

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -69,6 +69,7 @@ class MenuRules implements RulesInterface
 		 */
 		if (isset($query['Itemid']) && ($active === null || $query['Itemid'] != $active->id))
 		{
+			// Just use the supplied menu item
 			return;
 		}
 
@@ -156,12 +157,29 @@ class MenuRules implements RulesInterface
 			}
 		}
 
-		// Check if the active menuitem matches the requested language
-		if ($active && $active->component === 'com_' . $this->router->getName()
-			&& ($language === '*' || in_array($active->language, array('*', $language)) || !\JLanguageMultilang::isEnabled()))
+		// Add active item id to legacy routing for B/C
+		if (empty($this->router->sefAdvanced))
 		{
-			$query['Itemid'] = $active->id;
-			return;
+			// Check if the active menuitem matches the requested language
+			if ($active && $active->component === 'com_' . $this->router->getName()
+				&& ($language === '*'
+				|| in_array($active->language, array('*', $language))
+				|| !\JLanguageMultilang::isEnabled()))
+			{
+				$query['Itemid'] = $active->id;
+				return;
+			}
+		}
+		else
+		{
+			// Modern routing does not use active menu to build new URL
+			unset($query['Itemid']);
+
+			if (isset($query['view']))
+			{
+				// If query contains a view then does not need default Itemid
+				return;
+			}
 		}
 
 		// If not found, return language specific home link

--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -67,20 +67,171 @@ class NomenuRules implements RulesInterface
 	{
 		$active = $this->router->menu->getActive();
 
-		if (!is_object($active))
+		if ($active !== null)
 		{
-			$views = $this->router->getViews();
+			return;
+		}
 
-			if (isset($views[$segments[0]]))
+		$views = $this->router->getViews();
+
+		if (!isset($views[$segments[0]]))
+		{
+			return;
+		}
+
+		$vars['view'] = array_shift($segments);
+		$mainView     = $views[$vars['view']];
+
+		// Create a temporary copy of vars to use in get<View>Id
+		$vars2 = $vars;
+
+		// Total views in path
+		$totalViews = count($mainView->path);
+
+		foreach ($mainView->path as $i => $element)
+		{
+			if (!$segments)
 			{
-				$vars['view'] = array_shift($segments);
+				// Wrong URL, some segment missing
+				return;
+			}
 
-				if (isset($views[$vars['view']]->key) && isset($segments[0]))
+			$view = $views[$element];
+
+			if ($element !== $vars['view'] && $view->key !== false)
+			{
+				$child = $views[$mainView->path[$i+1]];
+
+				if ($child->parent_key === false && $child->key !== false || ($child->nestable && $view->key === $child->key))
 				{
-					$vars[$views[$vars['view']]->key] = preg_replace('/-/', ':', array_shift($segments), 1);
+					// Do not process this view, child will do it as they work on the same path elements
+					continue;
 				}
 			}
+
+			// Remember parent key value from parent view
+			$parentId = $view->parent_key !== false && isset($vars2[$view->parent->key]) ? $vars2[$view->parent->key] : null;
+
+			// Generate function name
+			$func = array($this->router, 'get' . ucfirst($view->name) . 'Id');
+
+			while ($segments)
+			{
+				if ($view->nestable)
+				{
+					// Limit number of calls to get<View>Id()
+					if (count($segments) + $i >= $totalViews)
+					{
+						// If query has no key set, we assume 0.
+						if (!isset($vars2[$view->key]))
+						{
+							$vars2[$view->key] = 0;
+						}
+
+						// Required for noIDs to get id from alias
+						if (is_callable($func))
+						{
+							$key = call_user_func_array($func, array($segments[0], $vars2));
+
+							// Did we get a proper key? If not, we need to look in the next view
+							if ($key)
+							{
+								$vars2[$view->key] = $key;
+								array_shift($segments);
+
+								// Found, go to the next segment
+								continue;
+							}
+						}
+						else
+						{
+							// The router is not complete. The get<View>Id() method is missing.
+							return;
+						}
+					}
+
+					// Add parent key
+					if ($view->parent_key !== false && isset($parentId))
+					{
+						$vars2[$view->parent_key] = $parentId;
+
+						// Do not unset own key
+						if ($view->key !== $view->parent->key)
+						{
+							unset($vars2[$view->parent->key]);
+						}
+					}
+
+					if ($element !== $vars['view'])
+					{
+						// Key not found, jump to the next view
+						break;
+					}
+
+					// Wrong URL
+					return;
+				}
+
+				if ($view->key === false)
+				{
+					if ($view->name === $segments[0])
+					{
+						// Add parent key
+						if ($view->parent_key && isset($parentId))
+						{
+							$vars2[$view->parent_key] = $parentId;
+							unset($vars2[$view->parent->key]);
+						}
+
+						array_shift($segments);
+
+						// Found, jump to the next view
+						break;
+					}
+
+					// Wrong URL
+					return;
+				}
+
+				// Required for noIDs to get id from alias
+				if (is_callable($func))
+				{
+					// If query has no key set, we assume 0.
+					if (!isset($vars2[$view->key]))
+					{
+						$vars2[$view->key] = 0;
+					}
+
+					// Hand the data over to the router specific method and see if there is a content item that fits
+					$key = call_user_func_array($func, array($segments[0], $vars2));
+
+					if ($key)
+					{
+						// Add parent key
+						if ($view->parent_key !== false && isset($parentId))
+						{
+							$vars2[$view->parent_key] = $parentId;
+							unset($vars2[$view->parent->key]);
+						}
+
+						$vars2[$view->key] = $key;
+						array_shift($segments);
+
+						// Found, jump to the next view
+						break;
+					}
+
+					// Wrong URL
+					return;
+				}
+
+				// The router is not complete. The get<View>Id() method is missing.
+				return;
+			}
 		}
+
+		// Copy all found variables
+		$vars = $vars2;
 	}
 
 	/**
@@ -95,41 +246,87 @@ class NomenuRules implements RulesInterface
 	 */
 	public function build(&$query, &$segments)
 	{
-		$menu_found = false;
-
 		if (isset($query['Itemid']))
 		{
 			$item = $this->router->menu->getItem($query['Itemid']);
 
 			if (!isset($query['option']) || ($item && $item->query['option'] === $query['option']))
 			{
-				$menu_found = true;
+				return;
 			}
 		}
 
-		if (!$menu_found && isset($query['view']))
+		// Get the path from the view of the current URL and parse it
+		$path = array_reverse($this->router->getPath($query), true);
+
+		// Check if specified view is known
+		if (!$path || !isset($path[$query['view']]))
 		{
-			$views = $this->router->getViews();
-			if (isset($views[$query['view']]))
-			{
-				$view = $views[$query['view']];
-				$segments[] = $query['view'];
+			return;
+		}
 
-				if ($view->key && isset($query[$view->key]))
+		// Get all views for this component
+		$views = $this->router->getViews();
+
+		$segments[] = $query['view'];
+
+		// Requested view
+		$mainView = $views[$query['view']];
+
+		foreach ($mainView->path as $i => $element)
+		{
+			$view = $views[$element];
+			$ids  = $path[$element];
+
+			if ($element !== $query['view'] && $view->key !== false)
+			{
+				$child = $views[$mainView->path[$i+1]];
+
+				if ($child->parent_key === false && $child->key !== false || ($child->nestable && $view->key === $child->key))
 				{
-					if (is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Segment')))
-					{
-						$result = call_user_func_array(array($this->router, 'get' . ucfirst($view->name) . 'Segment'), array($query[$view->key], $query));
-						$segments[] = str_replace(':', '-', array_shift($result));
-					}
-					else
-					{
-						$segments[] = str_replace(':', '-', $query[$view->key]);
-					}
-					unset($query[$views[$query['view']]->key]);
+					// Do not process this view, child will do it as they work on the same path elements
+					continue;
 				}
-				unset($query['view']);
+			}
+
+			if ($ids)
+			{
+				if ($view->nestable)
+				{
+					// Remove 1:root
+					array_pop($ids);
+
+					foreach (array_reverse($ids, true) as $id => $segment)
+					{
+						$segments[] = str_replace(':', '-', $segment);
+					}
+				}
+				elseif ($ids === true)
+				{
+					if ($element !== $query['view'])
+					{
+						$segments[] = $element;
+					}
+				}
+				else
+				{
+					$segments[] = str_replace(':', '-', current($ids));
+				}
+			}
+
+			if ($view->name === $query['view'])
+			{
+				// Remove key from query
+				unset($query[$view->key]);
+			}
+
+			if ($view->parent_key !== false)
+			{
+				// Remove parent key from query
+				unset($query[$view->parent_key]);
 			}
 		}
+
+		unset($query['view']);
 	}
 }

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -292,6 +292,15 @@ class StandardRules implements RulesInterface
 						}
 						elseif (($view->parent && !$view->parent->key) || $last_id === (int) $id)
 						{
+							/**
+							 * Note: To be more strict on J4 should be another test if ($view->parent_key !== false || ...)
+							 *
+							 * Check relations between views.
+							 *
+							 * If there is no view->parent_key and there is defined view->parent->key
+							 * then this view has relative segments,
+							 * this means this view has to skip segments added in parent view until last_id == id.
+							 */
 							$found2 = true;
 						}
 					}

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -241,65 +241,84 @@ class StandardRules implements RulesInterface
 		}
 
 		// Get the path from the view of the current URL and parse it to the menu item
-		$path   = array_reverse($this->router->getPath($query), true);
-		$found  = false;
-		$found2 = false;
+		$path  = array_reverse($this->router->getPath($query), true);
+		$found = false;
 
-		for ($i = 0, $j = count($path); $i < $j; $i++)
+		// Id of the last added segment
+		$last_id = 0;
+
+		foreach ($path as $element => $ids)
 		{
-			reset($path);
-			$view = key($path);
+			$view = $views[$element];
 
-			if ($found)
+			if ($found === false && $item && $item->query['view'] === $element)
 			{
-				$ids = array_shift($path);
-
-				if ($views[$view]->nestable)
+				if ($view->key)
 				{
+					// Get id from menu item
+					$last_id = (int) $item->query[$view->key];
+				}
+
+				if ($view->nestable)
+				{
+					$found = true;
+				}
+				elseif ($view->children)
+				{
+					$found = true;
+
+					continue;
+				}
+			}
+
+			if ($found === false)
+			{
+				// Jump to the next view
+				continue;
+			}
+
+			if ($ids)
+			{
+				if ($view->nestable)
+				{
+					$found2 = false;
+
 					foreach (array_reverse($ids, true) as $id => $segment)
 					{
 						if ($found2)
 						{
 							$segments[] = str_replace(':', '-', $segment);
+							$last_id    = (int) $id;
 						}
-						elseif ((int) $item->query[$views[$view]->key] == (int) $id)
+						elseif (($view->parent && !$view->parent->key) || $last_id === (int) $id)
 						{
 							$found2 = true;
 						}
 					}
 				}
-				elseif (is_bool($ids))
+				elseif ($ids === true)
 				{
-					$segments[] = $views[$view]->name;
+					$segments[] = $element;
+					$last_id    = 0;
 				}
 				else
 				{
-					$segments[] = str_replace(':', '-', array_shift($ids));
-				}
-			}
-			elseif ($item->query['view'] !== $view)
-			{
-				array_shift($path);
-			}
-			else
-			{
-				if (!$views[$view]->nestable)
-				{
-					array_shift($path);
-				}
-				else
-				{
-					$i--;
-					$found2 = false;
-				}
-
-				if (count($views[$view]->children))
-				{
-					$found = true;
+					$segments[] = str_replace(':', '-', current($ids));
+					$last_id    = (int) key($ids);
 				}
 			}
 
-			unset($query[$views[$view]->parent_key]);
+			if ($view->name === $query['view'])
+			{
+				// Remove key from query
+				unset($query[$view->key]);
+			}
+
+			if ($view->parent_key)
+			{
+				// Remove parent key from query
+				unset($query[$view->parent_key]);
+			}
 		}
 
 		if ($found)

--- a/tests/unit/suites/libraries/cms/component/router/JComponentRouterViewTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/JComponentRouterViewTest.php
@@ -139,14 +139,19 @@ class JComponentRouterViewTest extends TestCaseDatabase
 		$cases[] = array(array('view' => 'categories'), array('categories' => array()));
 
 		// View with parent and children
-		$cases[] = array(array('view' => 'category', 'id' => '9'), array('category' => array(9 => '9:uncategorised'), 'categories' => array(9 => '9:uncategorised')));
+		$cases[] = array(array('view' => 'category', 'id' => '9'),
+			array(
+				'category' => array(9 => '9:uncategorised', 0 => '1:root'),
+				'categories' => array(9 => '9:uncategorised', 0 => '1:root')
+			)
+		);
 
 		// View with parent, no children
 		$cases[] = array(array('view' => 'article', 'id' => '42:question-for-everything', 'catid' => '9'),
 			array(
 				'article' => array(42 => '42:question-for-everything'),
-				'category' => array(9 => '9:uncategorised'),
-				'categories' => array(9 => '9:uncategorised')
+				'category' => array(9 => '9:uncategorised', 0 => '1:root'),
+				'categories' => array(9 => '9:uncategorised', 0 => '1:root')
 			)
 		);
 
@@ -156,11 +161,13 @@ class JComponentRouterViewTest extends TestCaseDatabase
 				'article' => array(42 => '42:question-for-everything'),
 				'category' => array(20 => '20:extensions',
 					19 => '19:joomla',
-					14 => '14:sample-data-articles'
+					14 => '14:sample-data-articles',
+					0 => '1:root'
 				),
 				'categories' => array(20 => '20:extensions',
 					19 => '19:joomla',
-					14 => '14:sample-data-articles'
+					14 => '14:sample-data-articles',
+					0 => '1:root'
 				)
 			)
 		);

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesNomenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesNomenuTest.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/../stubs/JComponentRouterViewInspector.php';
  * @subpackage  Component
  * @since       3.4
  */
-class JComponentRouterRulesNomenuTest extends TestCase
+class JComponentRouterRulesNomenuTest extends TestCaseDatabase
 {
 	/**
 	 * Object under test
@@ -26,6 +26,25 @@ class JComponentRouterRulesNomenuTest extends TestCase
 	 * @since  3.4
 	 */
 	protected $object;
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getDataSet()
+	{
+		$dataSet = new PHPUnit_Extensions_Database_DataSet_CsvDataSet(',', "'", '\\');
+
+		$dataSet->addTable('jos_categories', JPATH_TEST_DATABASE . '/jos_categories.csv');
+		$dataSet->addTable('jos_content', JPATH_TEST_DATABASE . '/jos_content.csv');
+		$dataSet->addTable('jos_extensions', JPATH_TEST_DATABASE . '/jos_extensions.csv');
+		$dataSet->addTable('jos_menu', JPATH_TEST_DATABASE . '/jos_menu.csv');
+
+		return $dataSet;
+	}
 
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
@@ -57,6 +76,7 @@ class JComponentRouterRulesNomenuTest extends TestCase
 		$router->registerView($featured);
 		$form = new JComponentRouterViewconfiguration('form');
 		$router->registerView($form);
+		$router->sefAdvanced = true;
 
 		$this->object = new JComponentRouterRulesNomenuInspector($router);
 	}
@@ -97,12 +117,43 @@ class JComponentRouterRulesNomenuTest extends TestCase
 		$this->assertEquals(array(), $segments);
 		$this->assertEquals(array('option' => 'com_content', 'view' => 'featured'), $vars);
 
-		// Check if a view with ID is properly parsed
-		$segments = array('category', '23-the-question');
+		/**
+		 * Check if a view with exists ID is properly parsed
+		 * Note: only segment from first category level is available for categories view
+		 */
+		$segments = array('categories', '14-sample-data-articles');
 		$vars = array('option' => 'com_content');
 		$this->object->parse($segments, $vars);
 		$this->assertEquals(array(), $segments);
-		$this->assertEquals(array('option' => 'com_content', 'view' => 'category', 'id' => '23:the-question'), $vars);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'categories', 'id' => '14'), $vars);
+
+		// Check if a view with exists ID is properly parsed
+		$segments = array('category', '14-sample-data-articles');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category', 'id' => '14'), $vars);
+
+		// Check if a view with not exists ID is properly parsed
+		$segments = array('category', '1499-sample-data-articles');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array('1499-sample-data-articles'), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category'), $vars);
+
+		// Check if a nested view with identifier is properly parsed
+		$segments = array('category', '14-sample-data-articles', '19-joomla', '20-extensions', '22-modules', '64-articles-modules');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category', 'id' => '64'), $vars);
+
+		// Check if a single view with identifier in nested parent is properly parsed
+		$segments = array('article', '14-sample-data-articles', '19-joomla', '8-beginners');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'article', 'id' => '8', 'catid' => '19'), $vars);
 
 		// Check if a view that normally has an ID but which is missing is properly parsed
 		$segments = array('category');
@@ -111,15 +162,57 @@ class JComponentRouterRulesNomenuTest extends TestCase
 		$this->assertEquals(array(), $segments);
 		$this->assertEquals(array('option' => 'com_content', 'view' => 'category'), $vars);
 
-		// Test if the rule is properly skipped when a menu item is set
+		// Test noIDs
 		$router = $this->object->get('router');
+		$router->set('noIDs', true);
+
+		/**
+		 * Check if a view with exists ID is properly parsed
+		 * Note: only segment from first category level is available for categories view now
+		 */
+		$segments = array('categories', 'sample-data-articles');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'categories', 'id' => '14'), $vars);
+
+		// Check if a view with exists ID is properly parsed
+		$segments = array('category', 'sample-data-articles');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category', 'id' => '14'), $vars);
+
+		// Check if a view with not exists ID is properly parsed
+		$segments = array('category', 'unknown-sample-data-articles');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array('unknown-sample-data-articles'), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category'), $vars);
+
+		// Check if a nested view with identifier is properly parsed
+		$segments = array('category', 'sample-data-articles', 'joomla', 'extensions', 'modules', 'articles-modules');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'category', 'id' => '64'), $vars);
+
+		// Check if a single view with identifier in nested parent is properly parsed
+		$segments = array('article', 'sample-data-articles', 'joomla', 'beginners');
+		$vars = array('option' => 'com_content');
+		$this->object->parse($segments, $vars);
+		$this->assertEquals(array(), $segments);
+		$this->assertEquals(array('option' => 'com_content', 'view' => 'article', 'id' => '8', 'catid' => '19'), $vars);
+
+		// Test if the rule is properly skipped when a menu item is set
 		$router->menu->expects($this->any())
 			->method('getActive')
 			->will($this->returnValue(new stdClass));
-		$segments = array('article', '42:the-answer');
+
+		$segments = array('category', 'sample-data-articles');
 		$vars = array('option' => 'com_content');
 		$this->object->parse($segments, $vars);
-		$this->assertEquals(array('article', '42:the-answer'), $segments);
+		$this->assertEquals(array('category', 'sample-data-articles'), $segments);
 		$this->assertEquals(array('option' => 'com_content'), $vars);
 	}
 
@@ -159,5 +252,50 @@ class JComponentRouterRulesNomenuTest extends TestCase
 		$this->object->build($query, $segments);
 		$this->assertEquals(array('option' => 'com_content'), $query);
 		$this->assertEquals(array('article', '42-the-answer'), $segments);
+
+		// Test if a nested view with identifier is properly build
+		$query = array('option' => 'com_content', 'view' => 'category', 'id' => '64:articles-modules');
+		$segments = array();
+		$this->object->build($query, $segments);
+		$this->assertEquals(array('option' => 'com_content'), $query);
+		$this->assertEquals(
+			array('category', '14-sample-data-articles', '19-joomla', '20-extensions', '22-modules', '64-articles-modules'),
+			$segments
+		);
+
+		// Test if a single view with identifier in nested parent is properly build
+		$query = array('option' => 'com_content', 'view' => 'article', 'id' => '8:beginners', 'catid' => '19:joomla');
+		$segments = array();
+		$this->object->build($query, $segments);
+		$this->assertEquals(array('option' => 'com_content'), $query);
+		$this->assertEquals(array('article', '14-sample-data-articles', '19-joomla', '8-beginners'), $segments);
+
+		// Test noIDs
+		$router = $this->object->get('router');
+		$router->set('noIDs', true);
+
+		// Test if a single view with identifier is properly build
+		$query = array('option' => 'com_content', 'view' => 'article', 'id' => '42:the-answer');
+		$segments = array();
+		$this->object->build($query, $segments);
+		$this->assertEquals(array('option' => 'com_content'), $query);
+		$this->assertEquals(array('article', 'the-answer'), $segments);
+
+		// Test if a nested view with identifier is properly build
+		$query = array('option' => 'com_content', 'view' => 'category', 'id' => '64:articles-modules');
+		$segments = array();
+		$this->object->build($query, $segments);
+		$this->assertEquals(array('option' => 'com_content'), $query);
+		$this->assertEquals(
+			array('category', 'sample-data-articles', 'joomla', 'extensions', 'modules', 'articles-modules'),
+			$segments
+		);
+
+		// Test if a single view with identifier in nested parent is properly build
+		$query = array('option' => 'com_content', 'view' => 'article', 'id' => '8:beginners', 'catid' => '19:joomla');
+		$segments = array();
+		$this->object->build($query, $segments);
+		$this->assertEquals(array('option' => 'com_content'), $query);
+		$this->assertEquals(array('article', 'sample-data-articles', 'joomla', 'beginners'), $segments);
 	}
 }

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesStandardTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesStandardTest.php
@@ -82,6 +82,7 @@ class JComponentRouterRulesStandardTest extends TestCaseDatabase
 		$router->registerView($featured);
 		$form = new JComponentRouterViewconfiguration('form');
 		$router->registerView($form);
+		$router->sefAdvanced = true;
 
 		$this->object = new JComponentRouterRulesStandard($router);
 	}

--- a/tests/unit/suites/libraries/cms/component/router/stubs/JComponentRouterViewInspector.php
+++ b/tests/unit/suites/libraries/cms/component/router/stubs/JComponentRouterViewInspector.php
@@ -16,6 +16,8 @@
  */
 class JComponentRouterViewInspector extends JComponentRouterView
 {
+	protected $noIDs = false;
+
 	/**
 	 * Gets an attribute of the object
 	 *
@@ -60,7 +62,18 @@ class JComponentRouterViewInspector extends JComponentRouterView
 
 		if ($category)
 		{
-			return array_reverse($category->getPath(), true);
+			$path = array_reverse($category->getPath(), true);
+			$path[0] = '1:root';
+
+			if ($this->noIDs)
+			{
+				foreach ($path as &$segment)
+				{
+					list($id, $segment) = explode(':', $segment, 2);
+				}
+			}
+
+			return $path;
 		}
 
 		return array();
@@ -91,7 +104,107 @@ class JComponentRouterViewInspector extends JComponentRouterView
 	 */
 	public function getArticleSegment($id, $query)
 	{
+		if (!strpos($id, ':'))
+		{
+			$db = JFactory::getDbo();
+			$dbquery = $db->getQuery(true);
+			$dbquery->select('alias')
+				->from($dbquery->quoteName('#__content'))
+				->where('id = ' . $dbquery->quote($id));
+			$db->setQuery($dbquery);
+
+			$id .= ':' . $db->loadResult();
+		}
+
+		if ($this->noIDs)
+		{
+			list($void, $segment) = explode(':', $id, 2);
+
+			return array($void => $segment);
+		}
+
 		return array((int) $id => $id);
+	}
+
+	/**
+	 * Method to get the id for a category
+	 *
+	 * @param   string  $segment  Segment to retrieve the ID for
+	 * @param   array   $query    The request that is parsed right now
+	 *
+	 * @return  mixed   The id of this item or false
+	 *
+	 * @since   __DEPLY_VERSION__
+	 */
+	public function getCategoryId($segment, $query)
+	{
+		if (isset($query['id']))
+		{
+			$category = JCategories::getInstance($this->getName())->get($query['id']);
+
+			foreach ($category->getChildren() as $child)
+			{
+				if ($this->noIDs)
+				{
+					if ($child->alias == $segment)
+					{
+						return $child->id;
+					}
+				}
+				else
+				{
+					if ($child->id == (int) $segment)
+					{
+						return $child->id;
+					}
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Method to get the segment(s) for a category
+	 *
+	 * @param   string  $segment  Segment to retrieve the ID for
+	 * @param   array   $query    The request that is parsed right now
+	 *
+	 * @return  mixed   The id of this item or false
+	 *
+	 * @since   __DEPLY_VERSION__
+	 */
+	public function getCategoriesId($segment, $query)
+	{
+		return $this->getCategoryId($segment, $query);
+	}
+
+	/**
+	 * Method to get the segment(s) for an article
+	 *
+	 * @param   string  $segment  Segment of the article to retrieve the ID for
+	 * @param   array   $query    The request that is parsed right now
+	 *
+	 * @return  mixed   The id of this item or false
+	 *
+	 * @since   __DEPLY_VERSION__
+	 */
+	public function getArticleId($segment, $query)
+	{
+		if ($this->noIDs)
+		{
+			$db = JFactory::getDbo();
+			$dbquery = $db->getQuery(true);
+			$dbquery->select($dbquery->qn('id'))
+				->from($dbquery->qn('#__content'))
+				->where('alias = ' . $dbquery->q($segment))
+				->where('catid = ' . $dbquery->q($query['id']));
+			$db->setQuery($dbquery);
+
+			return (int) $db->loadResult();
+		}
+
+		return (int) $segment;
 	}
 }
 


### PR DESCRIPTION
Pull Request for Issue #17719

### Summary of Changes

Change a way of creating URL with menu item and without it.
A lots of changes will be available only in modern routing.

For now only code is up to date, I update it by `git rebase staging`.
I have plan to create a similar PR for J4.

Current changes for form view in the router of component content are wrong and will be changed.

**The description below and many comments are outdated**

-----

#### Old way:

URL without menu assigned (Itemid) is created with some other Itemid and It depends on which page we look at.

When we have article with Itemid: `/article-with-itemid` and category without Itemid then we see on article view link to category: 
* `/article-with-itemid?view=category&id=[...]` or 
* `/article-with-itemid/[id-category-alias]`
and link to another article without own Itemid, like: 
* `/article-with-itemid?view=article&id=2` or 
* `/article-with-itemid/[id-category-alias]/[id-article-alias]` 

When default page is set then all pages without own Itemid will get the default Itemid.
IMO modules dedicated to home page only, should not be displayed on other pages (without menu item). 

#### New way:
1. A link without own menu item does not inherit `Itemid` from home page - #17096
2. If a new link and current page match the same component but the link does not have specified Itemid then do not use current page Itemid without checking if query parameters match menu item query.
   * ex: active menu item for single article can not be use for category view
   * this situation is a shortcut to find Itemid when the new link does not have specified Itemid but current page has Itemid. If this does not match then `Itemid` will be searched in all menu items (in other function).

3. If menu item does not have specified layout parameter but the new link has specified layout, then match them.
   * simply ignore `layout` in query when looking for menu `Itemid` (when menu item does not support `layout`) and create link like `/menu-item?layout=edit`.
4. ~~Do not use current page Itemid in SEF build method - `component/com_content/helper/legacyrouter.php`. It is too late. It can be only used in `preprocess`.~~ - withdrawn
5. ~~'Create Article' menu type can be used for edit article too.~~ - withdrawn
6. ~~Menu type `Create Article` should be changed to ex. `Create or Edit Article`.~~ - withdrawn


### Testing Instructions

Check links in various places.

### Expected result
Fix problem described in #17719 and others


### Actual fixes:
* Url without menu item in database depend too much on active menu and has not deterministic URL. 
* Links like `/component/content/category/[alias-of-category]` did not work for experimental routing + remove IDs.~~

### Documentation Changes Required
Maybe.