### PR TITLE
A redo of Fix for admin menu link attribute in component manifest doing nothing

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Installer\Adapter;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerAdapter;
 use Joomla\CMS\Table\Asset;
@@ -382,7 +381,8 @@ class ComponentAdapter extends InstallerAdapter
 		}
 
 		// Filter the name for illegal characters
-		$element = strtolower(InputFilter::getInstance()->clean($element, 'cmd'));
+		$uri     = \JUri::getInstance($element);
+		$element = strtolower($uri->toString());
 
 		if (strpos($element, 'com_') !== 0)
 		{
@@ -418,11 +418,9 @@ class ComponentAdapter extends InstallerAdapter
 				{
 					// Gets the option from the link attribute
 					$option = substr($link, strpos($link, $delimiter) + strlen($delimiter));
+					$uri    = \JUri::getInstance($option);
 
-					// Filter the option for illegal characters
-					$option = InputFilter::getInstance()->clean($option, 'string');
-
-					return $option;
+					return $uri->toString();
 				}
 			}
 		}

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -417,7 +417,7 @@ class ComponentAdapter extends InstallerAdapter
 				if (strpos($link, $delimiter) !== false)
 				{
 					// Gets the option from the link attribute
-					$option = substr($link, strpos($link, $delimiter), strlen($delimiter));
+					$option = substr($link, strpos($link, $delimiter) + strlen($delimiter));
 
 					// Filter the option for illegal characters
 					$option = InputFilter::getInstance()->clean($option, 'string');


### PR DESCRIPTION
Pull Request for Issue #9892 .

Just copying what was in the original issue as it is complete and elaborate. Merely making the PR compatible with the new codebase.

### Issue

The link attribute in the parent administrator
element of a component XML manifest is currently completely ignored on installation; it isn't used anywhere. Instead the link is built using a value derived from the undocumented, therefore typically not present, element. As there is usually not a value set for this it defaults to using the component's , causing issues if you want to have the component named slightly differently from any desired URLs.

I'm assuming the link attribute should do something on parent menus, as it's included in all the core component manifests, as well as the 3.x MVC Component tutorial and the manifest files docs (where it doesn't state the attribute is for submenu use only).
Summary of Changes

Created a new method, getMenuLinkOption(), in JInstallerAdapter. This is executed in the getElement() method in the same class. If the admin menu element's link attribute is set it returns a filtered string matching all text after 'option='.

If a string is returned it becomes the extension's element attribute, otherwise the element value defaults to the element from the manifest as usual.

### Testing Instructions

1. Download the MVC Component [tutorial archive](https://github.com/scionescire/Joomla-3.2-Hello-World-Component/archive/step-3-adding-a-site-menu.zip).
2. In the component's XML manifest file change value of the element to com_helloworlds so it looks like ```<menu link='index.php?option=com_helloworlds'>Hello World!</menu>```
3. Install the component
4. Under Components -> Hello World, notice that the link goes to option=com_helloworld
5. Uninstall the component
6. Apply the patch
7. Install the component
8. Under Components -> Hello World, notice that the link goes to option=com_helloworlds

### Additional Comments

I originally started out changing _buildAdminMenus in JInstallerAdapterComponent. The $option variable used to build all the admin menu links is the value of the manifest's element. This isn't set in any XML manifest I've found and the only reference to it in the code is in the JUpdate class where it doesn't seem to do anything. Rather than modifying _buildAdminMenus, it was far neater to create a new method in JInstallerAdapter and set the element to the menu link's option. Setting the element attribute this way seems to make more sense given what it's used for anyway.

The new method maintains compatibility should anyone have used in a manifest. It will also function as normal and default to the element's value if a menu link is not set. If the link attribute's option is changed without a clean install of the component you'll get the same errors you would by changing the component's .
Look for these lines in the XML:

<administration> <menu view="cpanel" img="components/com_jce/media/img/menu/logo.png" link="option=com_jce">JCE</menu>

Currently link="option=com_jce" is completely redundant, it isn't used anywhere. Instead admin menu links are built using:

$data['link'] = 'index.php?option=' . $option;

in the _buildAdminMenus() method in JInstallerAdapterComponent. That value, $option, is initialised like this at the start of the method:

$option = $this->get('element');

This then executes the getElement() method from JInstallerAdapter (which is what I've changed).

In any manifest without tags, which is probably all of them, this line always returns null:

$element = (string) $this->getManifest()->element;

Consequently $element always defaults to the value of , and in turn the value of $data['link'] = 'index.php?option=' . $option; will always be the same as $data['link'] = 'index.php?option=jce, regardless of how the link option is set in the manifest.

If, for any reason, you decided to set link="option=com_jceditor", for example, it wouldn't work - that link attribute is completely pointless at the moment.
