### PR TITLE
[4.0] Update error renderers for PHP 7 code structure, update Exception/Throwable references

### DIFF
--- a/installation/controller/removefolder.php
+++ b/installation/controller/removefolder.php
@@ -210,7 +210,7 @@ class InstallationResponseJson
 		}
 
 		// Check if we are dealing with an error.
-		if ($data instanceof Exception || $data instanceof Throwable)
+		if ($data instanceof Throwable)
 		{
 			// Prepare the error response.
 			$this->error   = true;

--- a/installation/error/json.php
+++ b/installation/error/json.php
@@ -29,13 +29,13 @@ class InstallationErrorJson extends AbstractRenderer
 	/**
 	 * Render the error page for the given object
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   4.0
 	 */
-	protected function doRender($error)
+	public function render(Throwable $error): string
 	{
 		return json_encode(new InstallationResponseJson($error));
 	}

--- a/installation/response/json.php
+++ b/installation/response/json.php
@@ -53,7 +53,7 @@ class InstallationResponseJson
 		}
 
 		// Check if we are dealing with an error.
-		if ($data instanceof Exception || $data instanceof Throwable)
+		if ($data instanceof Throwable)
 		{
 			// Prepare the error response.
 			$this->error   = true;

--- a/libraries/src/Document/ErrorDocument.php
+++ b/libraries/src/Document/ErrorDocument.php
@@ -40,7 +40,7 @@ class ErrorDocument extends Document
 	/**
 	 * Error Object
 	 *
-	 * @var    \Exception|\Throwable
+	 * @var    \Throwable
 	 * @since  11.1
 	 */
 	public $error;
@@ -64,7 +64,7 @@ class ErrorDocument extends Document
 	/**
 	 * Error Object
 	 *
-	 * @var    \Exception|\Throwable
+	 * @var    \Throwable
 	 * @since  11.1
 	 */
 	protected $_error;
@@ -90,7 +90,7 @@ class ErrorDocument extends Document
 	/**
 	 * Set error object
 	 *
-	 * @param   \Exception|\Throwable  $error  Error object to set
+	 * @param   \Throwable  $error  Error object to set
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -98,9 +98,7 @@ class ErrorDocument extends Document
 	 */
 	public function setError($error)
 	{
-		$expectedClass = PHP_MAJOR_VERSION >= 7 ? '\\Throwable' : '\\Exception';
-
-		if ($error instanceof $expectedClass)
+		if ($error instanceof \Throwable)
 		{
 			$this->_error = & $error;
 

--- a/libraries/src/Error/AbstractRenderer.php
+++ b/libraries/src/Error/AbstractRenderer.php
@@ -8,6 +8,11 @@
 
 namespace Joomla\CMS\Error;
 
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Document\Document;
+use Joomla\CMS\Factory;
+
 /**
  * Base class for error page renderers
  *
@@ -16,9 +21,9 @@ namespace Joomla\CMS\Error;
 abstract class AbstractRenderer implements RendererInterface
 {
 	/**
-	 * The JDocument instance
+	 * The Document instance
 	 *
-	 * @var    \JDocument
+	 * @var    Document
 	 * @since  4.0
 	 */
 	protected $document;
@@ -32,24 +37,13 @@ abstract class AbstractRenderer implements RendererInterface
 	protected $type;
 
 	/**
-	 * Render the error page for the given object
+	 * Retrieve the Document instance attached to this renderer
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
-	 *
-	 * @return  string
+	 * @return  Document
 	 *
 	 * @since   4.0
 	 */
-	abstract protected function doRender($error);
-
-	/**
-	 * Retrieve the JDocument instance attached to this renderer
-	 *
-	 * @return  \JDocument
-	 *
-	 * @since   4.0
-	 */
-	public function getDocument()
+	public function getDocument(): Document
 	{
 		// Load the document if not already
 		if (!$this->document)
@@ -70,15 +64,15 @@ abstract class AbstractRenderer implements RendererInterface
 	 * @since   4.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public static function getRenderer($type)
+	public static function getRenderer(string $type)
 	{
 		// Build the class name
 		$class = __NAMESPACE__ . '\\Renderer\\' . ucfirst(strtolower($type)) . 'Renderer';
 
 		// First check if an object may exist in the container and prefer that over everything else
-		if (\JFactory::getContainer()->exists($class))
+		if (Factory::getContainer()->has($class))
 		{
-			return \JFactory::getContainer()->get($class);
+			return Factory::getContainer()->get($class);
 		}
 
 		// Next check if a local class exists and use that
@@ -92,54 +86,29 @@ abstract class AbstractRenderer implements RendererInterface
 	}
 
 	/**
-	 * Create the JDocument object for this renderer
+	 * Create the Document object for this renderer
 	 *
-	 * @return  \JDocument
+	 * @return  Document
 	 *
 	 * @since   4.0
 	 */
-	protected function loadDocument()
+	protected function loadDocument(): Document
 	{
-		$attributes = array(
+		$attributes = [
 			'charset'   => 'utf-8',
 			'lineend'   => 'unix',
 			'tab'       => "\t",
 			'language'  => 'en-GB',
 			'direction' => 'ltr',
-		);
+		];
 
-		// If there is a JLanguage instance in JFactory then let's pull the language and direction from its metadata
-		if (\JFactory::$language)
+		// If there is a Language instance in Factory then let's pull the language and direction from its metadata
+		if (Factory::$language)
 		{
-			$attributes['language']  = \JFactory::getLanguage()->getTag();
-			$attributes['direction'] = \JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
+			$attributes['language']  = Factory::getLanguage()->getTag();
+			$attributes['direction'] = Factory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
 		}
 
-		return \JDocument::getInstance($this->type, $attributes);
-	}
-
-	/**
-	 * Render the error page for the given object
-	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
-	 *
-	 * @return  string
-	 *
-	 * @since   4.0
-	 * @throws  \InvalidArgumentException if a non-Throwable object was provided
-	 */
-	public function render($error)
-	{
-		// If this isn't a Throwable then bail out
-		if (!($error instanceof \Throwable) && !($error instanceof \Exception))
-		{
-			$expectedType = PHP_VERSION_ID >= 70000 ? 'a Throwable' : 'an Exception';
-
-			throw new \InvalidArgumentException(
-				sprintf('The error renderer requires %1$s object, a %2$s object was given instead.', $expectedType, get_class($error))
-			);
-		}
-
-		return $this->doRender($error);
+		return Document::getInstance($this->type, $attributes);
 	}
 }

--- a/libraries/src/Error/Renderer/CliRenderer.php
+++ b/libraries/src/Error/Renderer/CliRenderer.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\Error\Renderer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Error\AbstractRenderer;
 
 /**
@@ -28,13 +30,13 @@ class CliRenderer extends AbstractRenderer
 	/**
 	 * Render the error for the given object.
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   \Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function doRender($error)
+	public function render(\Throwable $error): string
 	{
 		$buffer = PHP_EOL . 'Error occurred: ' . $error->getMessage() . PHP_EOL . $this->getTrace($error);
 
@@ -49,13 +51,13 @@ class CliRenderer extends AbstractRenderer
 	/**
 	 * Returns a trace for the given error.
 	 *
-	 * @param   \Throwable|\Exception  $error  The error
+	 * @param   \Throwable  $error  The error
 	 *
 	 * @return  string
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	private function getTrace($error)
+	private function getTrace(\Throwable $error): string
 	{
 		// Include the stack trace only if in debug mode
 		if (!JDEBUG)

--- a/libraries/src/Error/Renderer/FeedRenderer.php
+++ b/libraries/src/Error/Renderer/FeedRenderer.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\Error\Renderer;
 
+defined('JPATH_PLATFORM') or die;
+
 /**
  * RSS/Atom feed error page renderer
  *

--- a/libraries/src/Error/Renderer/HtmlRenderer.php
+++ b/libraries/src/Error/Renderer/HtmlRenderer.php
@@ -8,7 +8,10 @@
 
 namespace Joomla\CMS\Error\Renderer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Error\AbstractRenderer;
+use Joomla\CMS\Factory;
 
 /**
  * HTML error page renderer
@@ -29,15 +32,15 @@ class HtmlRenderer extends AbstractRenderer
 	/**
 	 * Render the error page for the given object
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   \Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   4.0
 	 */
-	protected function doRender($error)
+	public function render(\Throwable $error): string
 	{
-		$app = \JFactory::getApplication();
+		$app = Factory::getApplication();
 
 		// Get the current template from the application
 		$template = $app->getTemplate();

--- a/libraries/src/Error/Renderer/JsonRenderer.php
+++ b/libraries/src/Error/Renderer/JsonRenderer.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\Error\Renderer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Error\AbstractRenderer;
 
 /**
@@ -28,13 +30,13 @@ class JsonRenderer extends AbstractRenderer
 	/**
 	 * Render the error page for the given object
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   \Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   4.0
 	 */
-	protected function doRender($error)
+	public function render(\Throwable $error): string
 	{
 		// Create our data object to be rendered
 		$data = [

--- a/libraries/src/Error/Renderer/XmlRenderer.php
+++ b/libraries/src/Error/Renderer/XmlRenderer.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\Error\Renderer;
 
+defined('JPATH_PLATFORM') or die;
+
 use Joomla\CMS\Error\AbstractRenderer;
 
 /**
@@ -28,13 +30,13 @@ class XmlRenderer extends AbstractRenderer
 	/**
 	 * Render the error page for the given object
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   \Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   4.0
 	 */
-	protected function doRender($error)
+	public function render(\Throwable $error): string
 	{
 		// Create our data object to be rendered
 		$xw = new \XMLWriter;

--- a/libraries/src/Error/RendererInterface.php
+++ b/libraries/src/Error/RendererInterface.php
@@ -8,6 +8,10 @@
 
 namespace Joomla\CMS\Error;
 
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Document\Document;
+
 /**
  * Interface defining the rendering engine for the error handling layer
  *
@@ -16,23 +20,22 @@ namespace Joomla\CMS\Error;
 interface RendererInterface
 {
 	/**
-	 * Retrieve the JDocument instance attached to this renderer
+	 * Retrieve the Document instance attached to this renderer
 	 *
-	 * @return  \JDocument
+	 * @return  Document
 	 *
 	 * @since   4.0
 	 */
-	public function getDocument();
+	public function getDocument(): Document;
 
 	/**
 	 * Render the error page for the given object
 	 *
-	 * @param   \Throwable|\Exception  $error  The error object to be rendered
+	 * @param   \Throwable  $error  The error object to be rendered
 	 *
 	 * @return  string
 	 *
 	 * @since   4.0
-	 * @throws  \InvalidArgumentException if a non-Throwable object was provided
 	 */
-	public function render($error);
+	public function render(\Throwable $error): string;
 }

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -11,6 +11,8 @@ namespace Joomla\CMS\Exception;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Error\AbstractRenderer;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Log\Log;
 
 /**
  * Displays the custom error page when an uncaught exception occurs.
@@ -22,119 +24,108 @@ class ExceptionHandler
 	/**
 	 * Render the error page based on an exception.
 	 *
-	 * @param   \Exception|\Throwable  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.
+	 * @param   \Throwable  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.0
 	 */
-	public static function render($error)
+	public static function render(\Throwable $error)
 	{
-		$expectedClass = PHP_MAJOR_VERSION >= 7 ? '\Throwable' : '\Exception';
-		$isException   = $error instanceof $expectedClass;
-		$isCli         = false;
+		$isCli = false;
 
-		// In PHP 5, the $error object should be an instance of \Exception; PHP 7 should be a Throwable implementation
-		if ($isException)
+		try
 		{
+			// Try to log the error, but don't let the logging cause a fatal error
 			try
 			{
-				// Try to log the error, but don't let the logging cause a fatal error
-				try
-				{
-					\JLog::add(
-						sprintf(
-							'Uncaught %1$s of type %2$s thrown. Stack trace: %3$s',
-							$expectedClass,
-							get_class($error),
-							$error->getTraceAsString()
-						),
-						\JLog::CRITICAL,
-						'error'
-					);
-				}
-				catch (\Throwable $e)
-				{
-					// Logging failed, don't make a stink about it though
-				}
-				catch (\Exception $e)
-				{
-					// Logging failed, don't make a stink about it though
-				}
-
-				$app = \JFactory::getApplication();
-
-				// Flag if we are on cli
-				$isCli = \JFactory::getApplication()->isClient('cli');
-
-				// If site is offline and it's a 404 error, just go to index (to see offline message, instead of 404)
-				if (!$isCli && $error->getCode() == '404' && $app->get('offline') == 1)
-				{
-					$app->redirect('index.php');
-				}
-
-				/*
-				 * Try and determine the format to render the error page in
-				 *
-				 * First we check if a JDocument instance was registered to JFactory and use the type from that if available
-				 * If a type doesn't exist for that format, we try to use the format from the application's JInput object
-				 * Lastly, if all else fails, we default onto the HTML format to at least render something
-				 */
-				if (\JFactory::$document)
-				{
-					$format = \JFactory::$document->getType();
-				}
-				else
-				{
-					$format = $app->input->getString('format', 'html');
-				}
-
-				try
-				{
-					$renderer = AbstractRenderer::getRenderer($format);
-				}
-				catch (\InvalidArgumentException $e)
-				{
-					// Default to the HTML renderer
-					$renderer = AbstractRenderer::getRenderer('html');
-				}
-
-				$data = $renderer->render($error);
-
-				// If nothing was rendered, just use the message from the Exception
-				if (empty($data))
-				{
-					$data = $error->getMessage();
-				}
-
-				if ($isCli)
-				{
-					echo $data;
-				}
-				else
-				{
-					// Do not allow cache
-					$app->allowCache(false);
-
-					$app->setBody($data);
-
-					echo $app->toString();
-				}
-
-				// This return is needed to ensure the test suite does not trigger the non-Exception handling below
-				return;
+				Log::add(
+					sprintf(
+						'Uncaught Throwable of type %1$s thrown with message "%2$s". Stack trace: %3$s',
+						get_class($error),
+						$error->getMessage(),
+						$error->getTraceAsString()
+					),
+					Log::CRITICAL,
+					'error'
+				);
 			}
 			catch (\Throwable $e)
 			{
-				// Pass the error down
+				// Logging failed, don't make a stink about it though
 			}
-			catch (\Exception $e)
+
+			$app = Factory::getApplication();
+
+			// Flag if we are on cli
+			$isCli = $app->isClient('cli');
+
+			// If site is offline and it's a 404 error, just go to index (to see offline message, instead of 404)
+			if (!$isCli && $error->getCode() == '404' && $app->get('offline') == 1)
 			{
-				// Pass the error down
+				$app->redirect('index.php');
 			}
+
+			/*
+			 * Try and determine the format to render the error page in
+			 *
+			 * First we check if a Document instance was registered to Factory and use the type from that if available
+			 * If a type doesn't exist for that format, we try to use the format from the application's Input object
+			 * Lastly, if all else fails, we default onto the HTML format to at least render something
+			 */
+			if (Factory::$document)
+			{
+				$format = Factory::$document->getType();
+			}
+			else
+			{
+				$format = $app->input->getString('format', 'html');
+			}
+
+			try
+			{
+				$renderer = AbstractRenderer::getRenderer($format);
+			}
+			catch (\InvalidArgumentException $e)
+			{
+				// Default to the HTML renderer
+				$renderer = AbstractRenderer::getRenderer('html');
+			}
+
+			$data = $renderer->render($error);
+
+			// If nothing was rendered, just use the message from the Exception
+			if (empty($data))
+			{
+				$data = $error->getMessage();
+			}
+
+			if ($isCli)
+			{
+				echo $data;
+			}
+			else
+			{
+				// Do not allow cache
+				$app->allowCache(false);
+
+				$app->setBody($data);
+
+				echo $app->toString();
+			}
+
+			// This return is needed to ensure the test suite does not trigger the non-Exception handling below
+			return;
+		}
+		catch (\Throwable $e)
+		{
+			// Pass the error down
 		}
 
-		// This isn't an Exception, we can't handle it.
+		/*
+		 * To reach this point in the code means there was an error creating the error page.
+		 * We try to send at least something back other than a WSOD at this point.
+		 */
 		if (!$isCli && !headers_sent())
 		{
 			header('HTTP/1.1 500 Internal Server Error');
@@ -142,20 +133,17 @@ class ExceptionHandler
 
 		$message = 'Error displaying the error page';
 
-		if ($isException)
+		// Make sure we do not display sensitive data in production environments
+		if (ini_get('display_errors'))
 		{
-			// Make sure we do not display sensitive data in production environments
-			if (ini_get('display_errors'))
+			$message .= ': ';
+
+			if (isset($e))
 			{
-				$message .= ': ';
-
-				if (isset($e))
-				{
-					$message .= $e->getMessage() . ': ';
-				}
-
-				$message .= $error->getMessage();
+				$message .= $e->getMessage() . ': ';
 			}
+
+			$message .= $error->getMessage();
 		}
 
 		echo $message;

--- a/libraries/src/Response/JsonResponse.php
+++ b/libraries/src/Response/JsonResponse.php
@@ -93,7 +93,7 @@ class JsonResponse
 		}
 
 		// Check if we are dealing with an error
-		if ($response instanceof \Exception || $response instanceof \Throwable)
+		if ($response instanceof \Throwable)
 		{
 			// Prepare the error response
 			$this->success = false;

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -71,36 +71,28 @@ class PlgSystemRedirect extends JPlugin
 	/**
 	 * Method to handle an uncaught exception.
 	 *
-	 * @param   Exception|Throwable  $exception  The Exception or Throwable object to be handled.
+	 * @param   Throwable  $exception  The Throwable object to be handled.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.5
 	 * @throws  InvalidArgumentException
 	 */
-	public static function handleException($exception)
+	public static function handleException(Throwable $exception)
 	{
-		// If this isn't a Throwable then bail out
-		if (!($exception instanceof Throwable) && !($exception instanceof Exception))
-		{
-			throw new InvalidArgumentException(
-				sprintf('The error handler requires an Exception or Throwable object, a "%s" object was given instead.', get_class($exception))
-			);
-		}
-
 		self::doErrorHandling($exception);
 	}
 
 	/**
 	 * Internal processor for all error handlers
 	 *
-	 * @param   Exception|Throwable  $error  The Exception or Throwable object to be handled.
+	 * @param   Throwable  $error  The Throwable object to be handled.
 	 *
 	 * @return  void
 	 *
 	 * @since   3.5
 	 */
-	private static function doErrorHandling($error)
+	private static function doErrorHandling(Throwable $error)
 	{
 		$app = JFactory::getApplication();
 

--- a/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
+++ b/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
@@ -81,8 +81,6 @@ class JErrorPageTest extends TestCaseDatabase
 
 	/**
 	 * @covers  JErrorPage::render
-	 *
-	 * @requires  PHP 7.0
 	 */
 	public function testEnsureTheErrorPageIsCorrectlyRenderedWithThrowables()
 	{
@@ -121,21 +119,5 @@ class JErrorPageTest extends TestCaseDatabase
 
 		// Validate the mocked response from JDocument was received
 		$this->assertEquals($documentResponse, $output);
-	}
-
-	/**
-	 * @covers  JErrorPage::render
-	 */
-	public function testEnsureTheRenderMethodCorrectlyHandlesNonExceptionClasses()
-	{
-		// Create an object to inject into the method
-		$object = new stdClass;
-
-		// The render method echoes the output, so catch it in a buffer
-		ob_start();
-		JErrorPage::render($object);
-		$output = ob_get_clean();
-
-		$this->assertEquals('Error displaying the error page', $output);
 	}
 }


### PR DESCRIPTION
### Summary of Changes

- Updates the new error handling library to use PHP 7 typing features (typehint `Throwable`, scalar typehints, return types)
- Removes the protected `doRender` method in the error handling library, only existed to allow the interface's `render()` method handle type checking that we can now handle with the method signature alone
- Adds the `Throwable` typehint to methods we register as a global Exception handler via `set_exception_handler()` and removes the internal type checking
- Removes checks for the base `Exception` class when also checking for the `Throwable` interface, we only need to check the interface in these locations

### Testing Instructions

- Error handling code still processes correctly

### Documentation Changes Required

The `Joomla\CMS\Exception\ExceptionHandler::render()` signature is changed to include the `Throwable` typehint.  Before 3.5 when PHP 7 support was added this was typehinted as `Exception`.  As this method normally shouldn't be directly called except for code which is already handling a `Throwable` object, this should be a minimal impact change.