### PR TITLE
Searchtools look ugly on IE11

### DIFF
--- a/media/jui/css/jquery.searchtools.css
+++ b/media/jui/css/jquery.searchtools.css
@@ -69,16 +69,6 @@ html[dir=rtl] .js-stools .chzn-container {
 	margin-right: 0;
 }
 
-/* Fix for IE8 */
-@media all\0 {
-	.js-stools .js-stools-field-list,
-	.js-stools .js-stools-field-filter {
-		display:  block;
-		width: 180px;
-		float:left;
-	}
-}
-
 /* Media queries */
 @media (max-width: 480px) {
 	.js-stools-container-filters {


### PR DESCRIPTION
Apparently, the CSS block which is supposed to target IE8, also affects IE11 and breaks it.

### Summary of Changes
Removes the code unless someone knows a better way to fix it.
Pretty sure IE11 is currently used more than IE8 thus I'd go with breaking the smaller percentage of users :smile: 
Code was added with https://github.com/joomla/joomla-cms/pull/3474

Please note I wasn't able to test with IE8. The PR also fixed various issues which probably aren't tied to that CSS rules. So I'm not sure what exactly will break in IE8.

### Testing Instructions
use Searchtools (eg in Articles Manager)


### Expected result
![ie11fixed](https://user-images.githubusercontent.com/1018684/29824038-b2ca76ca-8cd0-11e7-825d-ced8ccaa662c.PNG)



### Actual result
![ie11](https://user-images.githubusercontent.com/1018684/29823989-9005540c-8cd0-11e7-9150-442eccd3f954.PNG)



### Documentation Changes Required
None
