### PR TITLE
[4.0] Remove language options on non multilingual site

### DIFF
--- a/administrator/components/com_banners/View/Banners/Html.php
+++ b/administrator/components/com_banners/View/Banners/Html.php
@@ -80,6 +80,13 @@ class Html extends HtmlView
 		\JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 		$this->sidebar = \JHtmlSidebar::render();
+		
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
 
 		return parent::display($tpl);
 	}

--- a/administrator/components/com_banners/forms/filter_banners.xml
+++ b/administrator/components/com_banners/forms/filter_banners.xml
@@ -82,8 +82,8 @@
 			<option value="impmade DESC">COM_BANNERS_HEADING_IMPRESSIONS_DESC</option>
 			<option value="clicks ASC">COM_BANNERS_HEADING_CLICKS_ASC</option>
 			<option value="clicks DESC">COM_BANNERS_HEADING_CLICKS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -69,9 +69,11 @@ if ($saveOrder)
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_BANNERS_HEADING_CLICKS', 'clicks', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -156,9 +158,11 @@ if ($saveOrder)
 										<?php echo $item->clicks; ?> -
 										<?php echo sprintf('%.2f%%', $item->impmade ? 100 * $item->clicks / $item->impmade : 0); ?>
 									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
 									<td class="small nowrap hidden-sm-down text-center">
 										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 									</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<?php echo $item->id; ?>
 									</td>

--- a/administrator/components/com_categories/View/Categories/Html.php
+++ b/administrator/components/com_categories/View/Categories/Html.php
@@ -121,6 +121,13 @@ class Html extends HtmlView
 			}
 		}
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -76,8 +76,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="access_level ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="access_level DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -121,9 +121,11 @@ if ($saveOrder)
 										<?php echo JHtml::_('searchtools.sort', 'COM_CATEGORY_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 									</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -254,9 +256,11 @@ if ($saveOrder)
 											<?php endif; ?>
 										</td>
 									<?php endif; ?>
-									<td class="small nowrap hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 											<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -51,9 +51,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<th style="width:10%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:15%" class="nowrap hidden-sm-down">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:15%" class="nowrap hidden-sm-down">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:1%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -110,9 +112,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<td class="small hidden-sm-down">
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
-							<td class="small hidden-sm-down">
-								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-							</td>
+							<?php if (JLanguageMultilang::isEnabled()) : ?>
+								<td class="small hidden-sm-down">
+									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+								</td>
+							<?php endif; ?>
 							<td class="hidden-sm-down">
 								<?php echo (int) $item->id; ?>
 							</td>

--- a/administrator/components/com_contact/View/Contacts/Html.php
+++ b/administrator/components/com_contact/View/Contacts/Html.php
@@ -121,6 +121,13 @@ class Html extends HtmlView
 				$this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
 			}
 		}
+		
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
 
 		return parent::display($tpl);
 	}

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -103,8 +103,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -66,9 +66,11 @@ if ($saveOrder)
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTACT_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -159,9 +161,11 @@ if ($saveOrder)
 									<?php endif; ?>
 								</td>
 								<?php endif; ?>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="hidden-sm-down text-center">
 									<?php echo $item->id; ?>
 								</td>

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -62,9 +62,11 @@ if (!empty($editor))
 						<th style="width:15%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:10%" class="nowrap hidden-sm-down">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:10%" class="nowrap hidden-sm-down">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:1%" class="nowrap">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -128,9 +130,11 @@ if (!empty($editor))
 						<td class="small hidden-sm-down">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<td class="small hidden-sm-down">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small hidden-sm-down">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+						<?php endif; ?>
 						<td align="text-center">
 							<?php echo (int) $item->id; ?>
 						</td>

--- a/administrator/components/com_content/View/Articles/Html.php
+++ b/administrator/components/com_content/View/Articles/Html.php
@@ -132,7 +132,7 @@ class Html extends HtmlView
 		}
 		
 		// We do not need to filter by language when multilingual is disabled
-		if (!JLanguageMultilang::isEnabled())
+		if (!\JLanguageMultilang::isEnabled())
 		{
 			unset($this->activeFilters['language']);
 			$this->filterForm->removeField('language', 'filter');

--- a/administrator/components/com_content/View/Articles/Html.php
+++ b/administrator/components/com_content/View/Articles/Html.php
@@ -130,6 +130,13 @@ class Html extends HtmlView
 				$this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
 			}
 		}
+		
+		// We do not need to filter by language when multilingual is disabled
+		if (!JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
 
 		return parent::display($tpl);
 	}

--- a/administrator/components/com_content/View/Featured/Html.php
+++ b/administrator/components/com_content/View/Featured/Html.php
@@ -106,7 +106,13 @@ class Html extends HtmlView
 
 		$this->addToolbar();
 		$this->sidebar = \JHtmlSidebar::render();
-
+		
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -98,8 +98,8 @@
 			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
 			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.modified ASC">COM_CONTENT_MODIFIED_ASC</option>

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -97,8 +97,8 @@
 			<option value="a.publish_up DESC">COM_CONTENT_PUBLISH_UP_DESC</option>
 			<option value="a.publish_down ASC">COM_CONTENT_PUBLISH_DOWN_ASC</option>
 			<option value="a.publish_down DESC">COM_CONTENT_PUBLISH_DOWN_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -92,9 +92,11 @@ $assoc = JLanguageAssociations::isEnabled();
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort',  'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
@@ -200,9 +202,11 @@ $assoc = JLanguageAssociations::isEnabled();
 										<?php echo $this->escape($item->author_name); ?></a>
 									<?php endif; ?>
 								</td>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="nowrap small hidden-sm-down text-center">
 									<?php
 									$date = $item->{$orderingColumn};

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -60,9 +60,11 @@ if (!empty($editor))
 						<th style="width:10%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:15%" class="nowrap">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:15%" class="nowrap">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:5%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JDATE', 'a.created', $listDirn, $listOrder); ?>
 						</th>
@@ -130,9 +132,11 @@ if (!empty($editor))
 						<td class="small hidden-sm-down">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<td class="small">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+						<?php endif; ?>
 						<td class="nowrap small hidden-sm-down">
 							<?php echo JHtml::_('date', $item->created, JText::_('DATE_FORMAT_LC4')); ?>
 						</td>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -79,9 +79,11 @@ if ($saveOrder)
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JAUTHOR', 'a.created_by', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
@@ -182,9 +184,11 @@ if ($saveOrder)
 										<?php echo $this->escape($item->author_name); ?>
 									<?php endif; ?>
 								</td>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="nowrap small hidden-sm-down text-center">
 									<?php
 									$date = $item->{$orderingColumn};

--- a/administrator/components/com_fields/View/Fields/Html.php
+++ b/administrator/components/com_fields/View/Fields/Html.php
@@ -104,6 +104,13 @@ class Html extends HtmlView
 		\FieldsHelper::addSubmenu($this->state->get('filter.context'), 'fields');
 		$this->sidebar = \JHtmlSidebar::render();
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_fields/View/Groups/Html.php
+++ b/administrator/components/com_fields/View/Groups/Html.php
@@ -100,7 +100,13 @@ class Html extends HtmlView
 
 		\FieldsHelper::addSubmenu($this->state->get('filter.context'), 'groups');
 		$this->sidebar = \JHtmlSidebar::render();
-
+		
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
 		return parent::display($tpl);
 	}
 

--- a/administrator/components/com_fields/forms/filter_fields.xml
+++ b/administrator/components/com_fields/forms/filter_fields.xml
@@ -81,8 +81,8 @@
 			<option value="g.title DESC">COM_FIELDS_VIEW_FIELDS_SORT_GROUP_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_fields/forms/filter_groups.xml
+++ b/administrator/components/com_fields/forms/filter_groups.xml
@@ -57,8 +57,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -72,9 +72,11 @@ if ($saveOrder)
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -158,9 +160,11 @@ if ($saveOrder)
 									<td class="small hidden-sm-down text-center">
 										<?php echo $this->escape($item->access_level); ?>
 									</td>
-									<td class="small nowrap hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="hidden-sm-down text-center">
 										<span><?php echo (int) $item->id; ?></span>
 									</td>

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -49,9 +49,11 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 						<th style="width:10%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:10%" class="nowrap hidden-sm-down">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:10%" class="nowrap hidden-sm-down">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:1%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -90,9 +92,11 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 						<td class="small hidden-sm-down">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<td class="small hidden-sm-down">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small hidden-sm-down">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+						<?php endif; ?>
 						<td class="hidden-sm-down">
 							<?php echo (int) $item->id; ?>
 						</td>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -71,9 +71,11 @@ if ($saveOrder)
 								<th style="width:10%" class="nowrap hidden-sm-down">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 								</th>
-								<th style="width:5%" class="nowrap hidden-sm-down">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:5%" class="nowrap hidden-sm-down">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:1%" class="nowrap hidden-sm-down">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -138,9 +140,11 @@ if ($saveOrder)
 									<td class="small hidden-sm-down">
 										<?php echo $this->escape($item->access_level); ?>
 									</td>
-									<td class="small nowrap hidden-sm-down">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+									<?php if (JLanguageMultilang::isEnabled()) : ?>
+										<td class="small nowrap hidden-sm-down">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 									<td class="text-center hidden-sm-down">
 										<span><?php echo (int) $item->id; ?></span>
 									</td>

--- a/administrator/components/com_installer/forms/filter_languages.xml
+++ b/administrator/components/com_installer/forms/filter_languages.xml
@@ -17,8 +17,8 @@
 			default="name ASC"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="name ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="name DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="name ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="name DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="element ASC">COM_INSTALLER_HEADING_LANGUAGE_TAG_ASC</option>
 			<option value="element DESC">COM_INSTALLER_HEADING_LANGUAGE_TAG_DESC</option>
 		</field>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -31,8 +31,8 @@
 			<option value="name DESC">COM_LANGUAGES_HEADING_LANGUAGE_DESC</option>
 			<option value="nativeName ASC">COM_LANGUAGES_HEADING_TITLE_NATIVE_ASC</option>
 			<option value="nativeName DESC">COM_LANGUAGES_HEADING_TITLE_NATIVE_DESC</option>
-			<option value="language ASC" requires="multilanguage"COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
-			<option value="language DESC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
+			<option value="language ASC">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
+			<option value="language DESC">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
 			<option value="published ASC">COM_LANGUAGES_HEADING_DEFAULT_ASC</option>
 			<option value="published DESC">COM_LANGUAGES_HEADING_DEFAULT_DESC</option>
 			<option value="version ASC">COM_LANGUAGES_HEADING_VERSION_ASC</option>

--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -31,8 +31,8 @@
 			<option value="name DESC">COM_LANGUAGES_HEADING_LANGUAGE_DESC</option>
 			<option value="nativeName ASC">COM_LANGUAGES_HEADING_TITLE_NATIVE_ASC</option>
 			<option value="nativeName DESC">COM_LANGUAGES_HEADING_TITLE_NATIVE_DESC</option>
-			<option value="language ASC">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
-			<option value="language DESC">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
+			<option value="language ASC" requires="multilanguage"COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
+			<option value="language DESC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
 			<option value="published ASC">COM_LANGUAGES_HEADING_DEFAULT_ASC</option>
 			<option value="published DESC">COM_LANGUAGES_HEADING_DEFAULT_DESC</option>
 			<option value="version ASC">COM_LANGUAGES_HEADING_VERSION_ASC</option>

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -95,8 +95,8 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_menus/forms/filter_items.xml
+++ b/administrator/components/com_menus/forms/filter_items.xml
@@ -95,7 +95,7 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 			<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
 			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -87,10 +87,12 @@ if ($menuType == '')
 									<?php echo JHtml::_('searchtools.sort', 'COM_MENUS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 							<?php endif; ?>
-							<?php if ($this->state->get('filter.client_id') == 0) : ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-								</th>
+							<?php if (JLanguageMultilang::isEnabled()) : ?>
+								<?php if ($this->state->get('filter.client_id') == 0) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 							<?php endif; ?>
 							<th style="width:5%" class="nowrap hidden-sm-down text-center">
 								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
@@ -251,10 +253,12 @@ if ($menuType == '')
 										<?php endif; ?>
 									</td>
 								<?php endif; ?>
-								<?php if ($this->state->get('filter.client_id') == 0) : ?>
-									<td class="small hidden-sm-down text-center">
-										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-									</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<?php if ($this->state->get('filter.client_id') == 0) : ?>
+										<td class="small hidden-sm-down text-center">
+											<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+										</td>
+									<?php endif; ?>
 								<?php endif; ?>
 								<td class="hidden-sm-down text-center">
 									<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -61,9 +61,11 @@ if (!empty($editor))
 						<th style="width:10%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:15%" class="nowrap hidden-sm-down">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:15%" class="nowrap hidden-sm-down">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:1%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -138,15 +140,17 @@ if (!empty($editor))
 							<td class="small hidden-sm-down">
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
-							<td class="small hidden-sm-down">
-								<?php if ($item->language == '') : ?>
-									<?php echo JText::_('JDEFAULT'); ?>
-								<?php elseif ($item->language == '*') : ?>
-									<?php echo JText::alt('JALL', 'language'); ?>
-								<?php else : ?>
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								<?php endif; ?>
-							</td>
+							<?php if (JLanguageMultilang::isEnabled()) : ?>
+								<td class="small hidden-sm-down">
+									<?php if ($item->language == '') : ?>
+										<?php echo JText::_('JDEFAULT'); ?>
+									<?php elseif ($item->language == '*') : ?>
+										<?php echo JText::alt('JALL', 'language'); ?>
+									<?php else : ?>
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									<?php endif; ?>
+								</td>
+							<?php endif; ?>
 							<td class="hidden-sm-down">
 								<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 									<?php echo (int) $item->id; ?>

--- a/administrator/components/com_modules/View/Modules/Html.php
+++ b/administrator/components/com_modules/View/Modules/Html.php
@@ -118,6 +118,13 @@ class Html extends HtmlView
 			}
 		}
 
+		// We do not need to filter by language when multilingual is disabled
+		if (!\JLanguageMultilang::isEnabled())
+		{
+			unset($this->activeFilters['language']);
+			$this->filterForm->removeField('language', 'filter');
+		}
+				
 		// Include the component HTML helpers.
 		\JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 

--- a/administrator/components/com_modules/forms/filter_modules.xml
+++ b/administrator/components/com_modules/forms/filter_modules.xml
@@ -89,8 +89,8 @@
 			<option value="pages DESC">COM_MODULES_HEADING_PAGES_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="l.title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="l.title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="l.title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="l.title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -91,8 +91,8 @@
 			<option value="name DESC">COM_MODULES_HEADING_MODULE_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_modules/forms/filter_modulesadmin.xml
+++ b/administrator/components/com_modules/forms/filter_modulesadmin.xml
@@ -91,8 +91,8 @@
 			<option value="name DESC">COM_MODULES_HEADING_MODULE_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC" requires="adminlanguage">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -61,8 +61,8 @@ $colSpan = $clientId === 1 ? 8 : 10;
 								<th style="width:10%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
 								</th>
-								<?php endif; ?>
-							<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
+							<?php endif; ?>
+						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 							<th width="10%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
 							</th>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -56,12 +56,10 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<th style="width:10%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'ag.title', $listDirn, $listOrder); ?>
 						</th>
-						<?php if ($clientId === 0) : ?>
-							<?php if (JLanguageMultilang::isEnabled()) : ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
-								</th>
-							<?php endif; ?>
+						<?php if ($clientId === 0 && JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:10%" class="nowrap hidden-sm-down text-center">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
+							</th>
 						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 							<th width="10%" class="nowrap hidden-phone">
 								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
@@ -167,12 +165,10 @@ $colSpan = $clientId === 1 ? 8 : 10;
 						<td class="small hidden-sm-down text-center">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<?php if ($clientId === 0) : ?>
-							<?php if (JLanguageMultilang::isEnabled()) : ?>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
-							<?php endif; ?>
+						<?php if ($clientId === 0 && JLanguageMultilang::isEnabled()) : ?>
+							<td class="small hidden-sm-down text-center">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
 						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 							<td class="small hidden-phone">
 								<?php if ($item->language == ''):?>

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -57,14 +57,16 @@ $colSpan = $clientId === 1 ? 8 : 10;
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'ag.title', $listDirn, $listOrder); ?>
 						</th>
 						<?php if ($clientId === 0) : ?>
-						<th style="width:10%" class="nowrap hidden-sm-down text-center">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
-						</th>
-						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
-						<th width="10%" class="nowrap hidden-phone">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
-						</th>
-						<?php endif; ?>
+							<?php if (JLanguageMultilang::isEnabled()) : ?>
+								<th style="width:10%" class="nowrap hidden-sm-down text-center">
+									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
+								</th>
+								<?php endif; ?>
+							<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
+							<th width="10%" class="nowrap hidden-phone">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>						
 						<th style="width:5%" class="nowrap text-center hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -166,9 +168,11 @@ $colSpan = $clientId === 1 ? 8 : 10;
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
 						<?php if ($clientId === 0) : ?>
-						<td class="small hidden-sm-down text-center">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+							<?php if (JLanguageMultilang::isEnabled()) : ?>
+								<td class="small hidden-sm-down text-center">
+									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+								</td>
+							<?php endif; ?>
 						<?php elseif ($clientId === 1 && JModuleHelper::isAdminMultilang()) : ?>
 							<td class="small hidden-phone">
 								<?php if ($item->language == ''):?>

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -52,9 +52,11 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 					<th style="width:10%" class="nowrap hidden-sm-down">
 						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'ag.title', $listDirn, $listOrder); ?>
 					</th>
-					<th style="width:10%" class="nowrap hidden-sm-down">
-						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
-					</th>
+					<?php if (JLanguageMultilang::isEnabled()) : ?>
+						<th style="width:10%" class="nowrap hidden-sm-down">
+							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'l.title', $listDirn, $listOrder); ?>
+						</th>
+					<?php endif; ?>
 					<th style="width:1%" class="nowrap hidden-sm-down">
 						<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 					</th>
@@ -102,9 +104,11 @@ $editor    = JFactory::getApplication()->input->get('editor', '', 'cmd');
 					<td class="small hidden-sm-down">
 						<?php echo $this->escape($item->access_level); ?>
 					</td>
-					<td class="small hidden-sm-down">
-						<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-					</td>
+					<?php if (JLanguageMultilang::isEnabled()) : ?>
+						<td class="small hidden-sm-down">
+							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+						</td>
+					<?php endif; ?>
 					<td class="hidden-sm-down">
 						<?php echo (int) $item->id; ?>
 					</td>

--- a/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
@@ -103,8 +103,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -69,9 +69,11 @@ if ($saveOrder)
 									<?php echo JHtml::_('searchtools.sort', 'COM_NEWSFEEDS_HEADING_ASSOCIATION', 'association', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
-								<th style="width:10%" class="nowrap hidden-sm-down text-center">
-									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-								</th>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<th style="width:10%" class="nowrap hidden-sm-down text-center">
+										<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<th style="width:5%" class="nowrap hidden-sm-down text-center">
 									<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
@@ -157,9 +159,11 @@ if ($saveOrder)
 									<?php endif; ?>
 								</td>
 								<?php endif; ?>
-								<td class="small hidden-sm-down text-center">
-									<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-								</td>
+								<?php if (JLanguageMultilang::isEnabled()) : ?>
+									<td class="small hidden-sm-down text-center">
+										<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+									</td>
+								<?php endif; ?>
 								<td class="hidden-sm-down text-center">
 									<?php echo (int) $item->id; ?>
 								</td>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -44,9 +44,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<th style="width:15%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ACCESS', 'access_level', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:15%" class="nowrap hidden-sm-down">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:15%" class="nowrap hidden-sm-down">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'language_title', $listDirn, $listOrder); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:1%" class="nowrap hidden-sm-down">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -103,9 +105,11 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						<td class="small hidden-sm-down">
 							<?php echo $this->escape($item->access_level); ?>
 						</td>
-						<td class="small hidden-sm-down">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small hidden-sm-down">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+						<?php endif; ?>
 						<td class="hidden-sm-down">
 							<?php echo (int) $item->id; ?>
 						</td>

--- a/administrator/components/com_tags/forms/filter_tags.xml
+++ b/administrator/components/com_tags/forms/filter_tags.xml
@@ -64,8 +64,8 @@
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="a.language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="a.language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="a.language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="a.language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -108,9 +108,11 @@ if ($saveOrder)
 						<th style="width:10%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort',  'JGRID_HEADING_ACCESS', 'a.access', $listDirn, $listOrder); ?>
 						</th>
-						<th style="width:10%" class="nowrap hidden-sm-down text-center">
-							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?>
-						</th>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<th style="width:10%" class="nowrap hidden-sm-down text-center">
+								<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_LANGUAGE', 'a.language', $this->state->get('list.direction'), $this->state->get('list.ordering')); ?>
+							</th>
+						<?php endif; ?>
 						<th style="width:5%" class="nowrap hidden-sm-down text-center">
 							<?php echo JHtml::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 						</th>
@@ -234,9 +236,11 @@ if ($saveOrder)
 						<td class="small hidden-sm-down text-center">
 							<?php echo $this->escape($item->access_title); ?>
 						</td>
-						<td class="small nowrap hidden-sm-down text-center">
-							<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
-						</td>
+						<?php if (JLanguageMultilang::isEnabled()) : ?>
+							<td class="small nowrap hidden-sm-down text-center">
+								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
+							</td>
+						<?php endif ;?>
 						<td class="hidden-sm-down text-center">
 							<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 								<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -232,7 +232,7 @@ if ($saveOrder)
 								<a class="badge <?php echo $item->count_trashed > 0 ? 'badge-danger' : 'badge-secondary'; ?>" title="<?php echo JText::_('COM_TAGS_COUNT_TRASHED_ITEMS'); ?>" href="<?php echo JRoute::_('index.php?option=' . $component . ($mode ? '&extension=' . $section : '&view=' . $section) . '&filter[tag]=' . (int) $item->id . '&filter[published]=-2'); ?>">
 									<?php echo $item->count_trashed; ?></a>
 							</td>
-						<?php endif;?>
+						<?php endif; ?>
 						<td class="small hidden-sm-down text-center">
 							<?php echo $this->escape($item->access_title); ?>
 						</td>
@@ -240,7 +240,7 @@ if ($saveOrder)
 							<td class="small nowrap hidden-sm-down text-center">
 								<?php echo JLayoutHelper::render('joomla.content.language', $item); ?>
 							</td>
-						<?php endif ;?>
+						<?php endif; ?>
 						<td class="hidden-sm-down text-center">
 							<span title="<?php echo sprintf('%d-%d', $item->lft, $item->rgt); ?>">
 								<?php echo (int) $item->id; ?></span>

--- a/administrator/components/com_templates/View/Style/Html.php
+++ b/administrator/components/com_templates/View/Style/Html.php
@@ -70,6 +70,13 @@ class Html extends HtmlView
 		{
 			throw new \JViewGenericdataexception(implode("\n", $errors), 500);
 		}
+		
+		// Change the assignment for default template from a select to switcher
+		if (!\JLanguageMultilang::isEnabled() && $this->item->client_id == 0)
+		{
+			$this->form->setFieldAttribute('home', 'type', 'radio');
+			$this->form->setFieldAttribute('home', 'class', 'switcher');
+		}
 
 		$this->addToolbar();
 

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -117,8 +117,8 @@
 				>
 				JASSOCIATIONS_DESC
 			</option>
-			<option value="language_title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language_title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language_title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language_title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -110,8 +110,8 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
 			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>

--- a/components/com_content/forms/filter_articles.xml
+++ b/components/com_content/forms/filter_articles.xml
@@ -110,7 +110,7 @@
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 			<option value="a.created_by ASC">JAUTHOR_ASC</option>
 			<option value="a.created_by DESC">JAUTHOR_DESC</option>
-			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
 			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>

--- a/components/com_fields/forms/filter_fields.xml
+++ b/components/com_fields/forms/filter_fields.xml
@@ -82,8 +82,8 @@
 			<option value="category_title DESC">COM_FIELDS_FIELD_GROUP_LABEL</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/components/com_fields/forms/filter_fields.xml
+++ b/components/com_fields/forms/filter_fields.xml
@@ -82,7 +82,7 @@
 			<option value="category_title DESC">COM_FIELDS_FIELD_GROUP_LABEL</option>
 			<option value="a.access ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
 			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -77,7 +77,7 @@
 				<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 				<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 				<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-				<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+				<option value="language ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
 				<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 				<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 				<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>

--- a/components/com_menus/forms/filter_items.xml
+++ b/components/com_menus/forms/filter_items.xml
@@ -77,8 +77,8 @@
 				<option value="a.access DESC">JGRID_HEADING_ACCESS_DESC</option>
 				<option value="association ASC" requires="associations">JASSOCIATIONS_ASC</option>
 				<option value="association DESC" requires="associations">JASSOCIATIONS_DESC</option>
-				<option value="language ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-				<option value="language DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+				<option value="language ASC" requires="multilanguage"JGRID_HEADING_LANGUAGE_ASC</option>
+				<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 				<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 				<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 			</field>

--- a/components/com_modules/forms/filter_modules.xml
+++ b/components/com_modules/forms/filter_modules.xml
@@ -62,8 +62,8 @@
 			<option value="pages DESC">COM_MODULES_HEADING_PAGES_DESC</option>
 			<option value="ag.title ASC">JGRID_HEADING_ACCESS_ASC</option>
 			<option value="ag.title DESC">JGRID_HEADING_ACCESS_DESC</option>
-			<option value="l.title ASC">JGRID_HEADING_LANGUAGE_ASC</option>
-			<option value="l.title DESC">JGRID_HEADING_LANGUAGE_DESC</option>
+			<option value="l.title ASC" requires="multilanguage">JGRID_HEADING_LANGUAGE_ASC</option>
+			<option value="l.title DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
 			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 		</field>

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -43,6 +43,12 @@ if (!$saveHistory)
 	$hiddenFields[] = 'version_note';
 }
 
+if (!JLanguageMultilang::isEnabled())
+{
+	$form->setFieldAttribute('language', 'type', 'hidden');
+	$form->setFieldAttribute('language', 'default', '*');
+}
+
 $html   = array();
 $html[] = '<fieldset class="form-vertical form-no-margin">';
 

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -45,7 +45,7 @@ if (!$saveHistory)
 
 if (!JLanguageMultilang::isEnabled())
 {
-	$form->setFieldAttribute('language', 'type', 'hidden');
+	$hiddenFields[] = 'language';
 	$form->setFieldAttribute('language', 'default', '*');
 }
 

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -18,6 +18,13 @@ defined('JPATH_PLATFORM') or die;
 class Multilanguage
 {
 	/**
+	* Flag indicating multilanguage functionality is enabled.
+ 	*
+ 	* @var    boolean
+ 	* @since  __DEPLOY_VERSION__
+ 	*/
+ 	public static $enabled = false;
+ 	/**
 	 * Method to determine if the language filter plugin is enabled.
 	 * This works for both site and administrator.
 	 *
@@ -30,8 +37,11 @@ class Multilanguage
 		// Flag to avoid doing multiple database queries.
 		static $tested = false;
 
-		// Status of language filter plugin.
-		static $enabled = false;
+		// Do not proceed with testing if the flag is true
+		if (static::$enabled)
+		{
+			return true;
+		}
 
 		// Get application object.
 		$app = \JFactory::getApplication();
@@ -39,9 +49,9 @@ class Multilanguage
 		// If being called from the frontend, we can avoid the database query.
 		if ($app->isClient('site'))
 		{
-			$enabled = $app->getLanguageFilter();
+			static::$enabled = $app->getLanguageFilter();
 
-			return $enabled;
+			return static::$enabled;
 		}
 
 		// If already tested, don't test again.
@@ -57,11 +67,11 @@ class Multilanguage
 				->where($db->quoteName('element') . ' = ' . $db->quote('languagefilter'));
 			$db->setQuery($query);
 
-			$enabled = $db->loadResult();
+			static::$enabled = $db->loadResult();
 			$tested = true;
 		}
 
-		return (bool) $enabled;
+		return (bool) static::$enabled;
 	}
 
 	/**

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -23,8 +23,8 @@ class Multilanguage
  	* @var    boolean
  	* @since  __DEPLOY_VERSION__
  	*/
- 	public static $enabled = false;
- 	/**
+	public static $enabled = false;
+	/**
 	 * Method to determine if the language filter plugin is enabled.
 	 * This works for both site and administrator.
 	 *


### PR DESCRIPTION
Currently we have a column for the language on all list views and a field to select the language on all edit views

This PR removes them when you are on a non multilingual site. This simplifies the UI and removes a useless field when creating content

### Parts
- [x] Lists
- [x] Forms
- [x] Filters 
- [x] Search tools

## After PR and non multilingual
<img width="704" alt="screenshotr10-20-00" src="https://user-images.githubusercontent.com/1296369/28110930-bae13ee4-66eb-11e7-8022-2ad898c8b92d.png">

<img width="345" alt="screenshotr10-20-55" src="https://user-images.githubusercontent.com/1296369/28110956-cf470332-66eb-11e7-850b-e956aa011e9c.png">

## Before PR and After PR and multilingual
<img width="716" alt="screenshotr10-22-36" src="https://user-images.githubusercontent.com/1296369/28111041-1449186c-66ec-11e7-9936-f0e1898bfa1c.png">
<img width="291" alt="screenshotr10-22-46" src="https://user-images.githubusercontent.com/1296369/28111042-14516e86-66ec-11e7-99cf-feecd02e95b6.png">

## Test instructions
You don't need to install multiple languages. It is enough to enable the System - Language Filter plugin.
When enabled you will have language columns, sorts and filters AND language fields on item creation
When not enabled you never see the language columns

## Thanks
@infograf768 @mbabker @wilsonge 