### PR TITLE
[com_fields] Support categories with a section for field categories

### DIFF
--- a/administrator/components/com_fields/models/field.php
+++ b/administrator/components/com_fields/models/field.php
@@ -960,11 +960,17 @@ class FieldsModelField extends JModelAdmin
 		}
 
 		// Setting the context for the category field
-		$cat = JCategories::getInstance(str_replace('com_', '', $component));
+		$cat = JCategories::getInstance(str_replace('com_', '', $component) . '.' . $section);
+
+		// If there is no category for the component and section, so check the component only
+		if (!$cat)
+		{
+			$cat = JCategories::getInstance(str_replace('com_', '', $component));
+		}
 
 		if ($cat && $cat->get('root')->hasChildren())
 		{
-			$form->setFieldAttribute('assigned_cat_ids', 'extension', $component);
+			$form->setFieldAttribute('assigned_cat_ids', 'extension', $cat->getExtension());
 		}
 		else
 		{

--- a/administrator/components/com_fields/models/fields.php
+++ b/administrator/components/com_fields/models/fields.php
@@ -187,7 +187,13 @@ class FieldsModelFields extends JModelList
 			if ($parts)
 			{
 				// Get the category
-				$cat = JCategories::getInstance(str_replace('com_', '', $parts[0]));
+				$cat = JCategories::getInstance(str_replace('com_', '', $parts[0]) . '.' . $parts[1]);
+
+				// If there is no category for the component and section, so check the component only
+				if (!$cat)
+				{
+					$cat = JCategories::getInstance(str_replace('com_', '', $parts[0]));
+				}
 
 				if ($cat)
 				{

--- a/administrator/components/com_fields/views/fields/tmpl/default.php
+++ b/administrator/components/com_fields/views/fields/tmpl/default.php
@@ -20,13 +20,20 @@ $user      = JFactory::getUser();
 $userId    = $user->get('id');
 $context   = $this->escape($this->state->get('filter.context'));
 $component = $this->state->get('filter.component');
+$section   = $this->state->get('filter.section');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $ordering  = ($listOrder == 'a.ordering');
 $saveOrder = ($listOrder == 'a.ordering' && strtolower($listDirn) == 'asc');
 
 // The category object of the component
-$category = JCategories::getInstance(str_replace('com_', '', $component));
+$category = JCategories::getInstance(str_replace('com_', '', $component) . '.' . $section);
+
+// If there is no category for the component and section, so check the component only
+if (!$category)
+{
+	$category = JCategories::getInstance(str_replace('com_', '', $component));
+}
 
 if ($saveOrder)
 {

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -201,6 +201,18 @@ class Categories
 	}
 
 	/**
+	 * Returns the extension of the category.
+	 *
+	 * @return   string  The extension
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getExtension()
+	{
+		return $this->_extension;
+	}
+
+	/**
 	 * Load method
 	 *
 	 * @param   integer  $id  Id of category to load


### PR DESCRIPTION
### Summary of Changes
Categories can also have a section. As the custom fields can be assigned to a category, sections need to be supported as well. To improve this situation, this pr makes a section check first to determine the categories for an extension.

### Testing Instructions
- Log in on the back end
- Create two categories for articles
- Create a custom field
- Choose a category
- Save the field

### Expected result
All is working as expected.

### Actual result
All is working as expected.