### PR TITLE
Add new RouteNotFound Exception

### DIFF
--- a/libraries/src/Router/Exception/RouteNotFoundException.php
+++ b/libraries/src/Router/Exception/RouteNotFoundException.php
@@ -6,18 +6,16 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\CMS\Component\Exception;
-
-use Joomla\CMS\Router\Exception\RouteNotFoundException;
+namespace Joomla\CMS\Router\Exception;
 
 defined('JPATH_PLATFORM') or die;
 
 /**
- * Exception class defining an error for a missing component
+ * Exception class defining an error for a missing route
  *
- * @since  3.7.0
+ * @since  __DEPLOY_VERSION__
  */
-class MissingComponentException extends RouteNotFoundException
+class RouteNotFoundException extends \InvalidArgumentException
 {
 	/**
 	 * Constructor
@@ -26,10 +24,15 @@ class MissingComponentException extends RouteNotFoundException
 	 * @param   integer     $code      The Exception code.
 	 * @param   \Exception  $previous  The previous exception used for the exception chaining.
 	 *
-	 * @since   3.7.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct($message = '', $code = 404, \Exception $previous = null)
 	{
+		if (empty($message))
+		{
+			$message = 'URL was not found';
+		}
+
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Router\Exception\RouteNotFoundException;
 
 /**
  * Class to create and parse routes
@@ -234,7 +235,7 @@ class Router
 		if (strlen($uri->getPath()) > 0 && array_key_exists('option', $vars)
 			&& ComponentHelper::getParams($vars['option'])->get('sef_advanced', 0))
 		{
-			throw new \Exception('URL invalid', 404);
+			throw new RouteNotFoundException('URL invalid');
 		}
 
 		return array_merge($this->getVars(), $vars);


### PR DESCRIPTION
As part of the new routing we have added an `Exception` thrown in the Router when a route is invalid. There are now multiple ways of giving 404 issues and it's all getting a bit crazy, with us adding webservices into 4.0 this is becoming a bit of a problem, so I'm adding a parent exception that all 404 issues should extend from (I'm choosing to add it into 3.8 so that we're using it from day 1 rather than waiting for 4). The new exception in 3.8 will use this as well as the `MissingComponentException` (note this is b/c because `RouteNotFoundException` also extends `InvalidArgumentException` which means instanceof checks will still work).


### Testing
By definition nothing here should change there's now just a single parent exception to cover them all. So you can test that all 404 exceptions continue to be thrown as before.