### PR TITLE
Fix oAuth1 unit tests to use mock session handler

### DIFF
--- a/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
+++ b/tests/unit/suites/libraries/joomla/oauth1/JOAuth1ClientTest.php
@@ -10,6 +10,7 @@
 use Joomla\Registry\Registry;
 
 include_once __DIR__ . '/stubs/JOAuth1ClientInspector.php';
+include_once __DIR__ . '/../session/handler/array.php';
 
 /**
  * Test class for JOAuth1Client.
@@ -199,8 +200,13 @@ class JOAuth1ClientTest extends TestCase
 			}
 			TestReflection::setValue($input, 'data', $data);
 
+			$memoryHandler = new JSessionHandlerArray;
+
 			// Get mock session
-			$mockSession = $this->getMockBuilder('JSession')->setMethods(array( '_start', 'get'))->getMock();
+			$mockSession = $this->getMockBuilder('JSession')
+				->setMethods(array( '_start', 'get'))
+				->setConstructorArgs(array('none', array(), $memoryHandler))
+				->getMock();
 
 			if ($fail)
 			{


### PR DESCRIPTION
Fixes the oAuth 1 session tests for PHP 7.2 in a better mock. This is an improvement (but not replacement) for https://github.com/joomla/joomla-cms/pull/17727

Before and after the oAuth1 unit tests should pass. But they now use the memory test session handler instead of the native session handler meaning they don't call `ini_set` everywhere