### PR TITLE
Menu manager delete error message color is wrong

### DIFF
--- a/administrator/components/com_menus/controllers/menus.php
+++ b/administrator/components/com_menus/controllers/menus.php
@@ -92,7 +92,7 @@ class MenusControllerMenus extends JControllerLegacy
 				// Remove the items.
 				if (!$model->delete($cids))
 				{
-					$this->setMessage($model->getError());
+					$this->setMessage($model->getError(), 'error');
 				}
 				else
 				{


### PR DESCRIPTION
Pull Request for Issue #17729

### Summary of Changes
Set mesage type to error


### Testing Instructions
Do something that fails menu deletion. e.g - add `return false` with some dummy `setError` message from `MenusModelMenu::delete` method.

### Expected result
Red error message


### Actual result
Green error message


### Documentation Changes Required
None
