### PR TITLE
Add new sample data extensions to helper

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -90,6 +90,7 @@ class ExtensionHelper
 		array('module', 'mod_multilangstatus', '', 1),
 		array('module', 'mod_popular', '', 1),
 		array('module', 'mod_quickicon', '', 1),
+		array('module', 'mod_sampledata', '', 1),
 		array('module', 'mod_stats_admin', '', 1),
 		array('module', 'mod_status', '', 1),
 		array('module', 'mod_submenu', '', 1),
@@ -198,6 +199,9 @@ class ExtensionHelper
 		array('plugin', 'extensionupdate', 'quickicon', 0),
 		array('plugin', 'joomlaupdate', 'quickicon', 0),
 		array('plugin', 'phpversioncheck', 'quickicon', 0),
+
+		// Core plugin extensions - sample data
+		array('plugin', 'blog', 'sampledata', 0),
 
 		// Core plugin extensions - search
 		array('plugin', 'categories', 'search', 0),


### PR DESCRIPTION
Adds the new sample data extensions to the helper. 

Code review for testing? It is used in the Joomla Update process to refresh the manifest data on each update. My use case for this is to make sure this extension isn't checked as part of the new Joomla Update for 3.9 (but clearly that's not in the staging branch)