### PR TITLE
Calendar Today: Items wrongly set to pending

### DIFF
--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -242,10 +242,17 @@ class JFormFieldCalendar extends JFormField
 		// Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
 		if ($this->value && $this->value != JFactory::getDbo()->getNullDate() && strtotime($this->value) !== false)
 		{
-			$tz = date_default_timezone_get();
-			date_default_timezone_set('UTC');
-			$this->value = strftime($this->format, strtotime($this->value));
-			date_default_timezone_set($tz);
+			$app        = JFactory::getApplication();
+			$input      = $app->input;
+			$name_input = $input->get($this->name);
+
+			if (!empty($name_input))
+			{
+				$tz = date_default_timezone_get();
+				date_default_timezone_set('UTC');
+				$this->value = strftime($this->format, strtotime($this->value));
+				date_default_timezone_set($tz);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue #17770 .

### Summary of Changes

@infograf768 i think 3.x has some extra code for the user_utc compared to 2.x. 
I think it's these lines: https://github.com/joomla/joomla-cms/blob/a444c1474ee16e2443b7d5cc19be772e4af72ada/libraries/joomla/form/fields/calendar.php#L247-L248

We always read the input as UTC and convert it to server or user but the user submitted the date with their local timezone (most of the times the browser will have the timezone to the area that the user is living). There is the inconsistency...

this should run **only** when the code is coming from the db, for the data that comes from a form input we need to convert it to UTC. That will fix the problem

### Testing Instructions
check #17770


### Expected result

Dates are set correctly

### Actual result

Dates are set correctly

### Documentation Changes Required
No