### PR TITLE
Case insensitive alias support in JLoader

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -268,7 +268,7 @@ abstract class JLoader
 			if (!class_exists($class, false))
 			{
 				// Search the alias class, first none namespaced and then namespaced
-				$original = array_search($class, self::$classAliases) ? : array_search('\\' . $class, self::$classAliases);
+				$original = array_search(strtolower($class), self::$classAliases) ? : array_search('\\' . strtolower($class), self::$classAliases);
 
 				// When we have an original and the class exists an alias should be created
 				if ($original && class_exists($original, false))
@@ -297,9 +297,9 @@ abstract class JLoader
 	public static function register($class, $path, $force = true)
 	{
 		// When an alias exists, register it as well
-		if (key_exists($class, self::$classAliases))
+		if (key_exists(strtolower($class), self::$classAliases))
 		{
-			self::register(self::stripFirstBackslash(self::$classAliases[$class]), $path, $force);
+			self::register(self::stripFirstBackslash(self::$classAliases[strtolower($class)]), $path, $force);
 		}
 
 		// Sanitize class name.
@@ -377,6 +377,9 @@ abstract class JLoader
 	 */
 	public static function registerAlias($alias, $original, $version = false)
 	{
+		// PHP is case insensitive so support all kind of alias combination
+		$alias = strtolower($alias);
+
 		if (!isset(self::$classAliases[$alias]))
 		{
 			self::$classAliases[$alias] = $original;
@@ -631,7 +634,7 @@ abstract class JLoader
 	 */
 	public static function loadByAlias($class)
 	{
-		$class = self::stripFirstBackslash($class);
+		$class = strtolower(self::stripFirstBackslash($class));
 
 		if (isset(self::$classAliases[$class]))
 		{

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -268,7 +268,7 @@ abstract class JLoader
 			if (!class_exists($class, false))
 			{
 				// Search the alias class, first none namespaced and then namespaced
-				$original = array_search(strtolower($class), self::$classAliases) ? : array_search('\\' . strtolower($class), self::$classAliases);
+				$original = array_search($class, self::$classAliases) ? : array_search('\\' . $class, self::$classAliases);
 
 				// When we have an original and the class exists an alias should be created
 				if ($original && class_exists($original, false))

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -302,6 +302,24 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
+	 * Tests the JLoader::registerAlias method if the alias works ignoring cases
+	 *
+	 * @return  void
+	 *
+	 * @since   3.8.0
+	 */
+	public function testAliasIgnoreCase()
+	{
+		// Normally register the class
+		JLoader::register('JLoaderAliasStub', JPATH_TEST_STUBS . '/loaderoveralias/jloaderaliasstub.php');
+
+		// Register the alias
+		JLoader::registerAlias('CASEinsensitiveALIAS', 'JLoaderAliasStub');
+
+		$this->assertTrue(class_exists('caseINSENSITIVEalias'));
+	}
+
+	/**
 	 * Tests the JLoader::load method.
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for Issue #17804.

### Summary of Changes
As class names are not case sensitive in PHP, the alias support in `JLoader` must also be case insensitive. This pr fixes it.

### Testing Instructions
In the file administrator/components/com_content/content.php change line 11 to `JHTML::_('behavior.tabstate');`

### Expected result
No error is thrown.

### Actual result
`Class 'JHTML' not found` error is thrown.