### PR TITLE
Missing string in admin mod_menu

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_menu.ini
+++ b/administrator/language/en-GB/en-GB.mod_menu.ini
@@ -67,6 +67,7 @@ MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM="Official Support Forum"
 ; the string below will be used if the localised sample data contains a URL for the desired community forum or if the 'Custom Support Forum' field parameter in the Administrator Menu module contains a URL
 MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM="Custom Support Forum"
 ; The string below will be used if MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE has a value, i.e the # of the specific language forum in https://forum.joomla.org/. Use something like 'Official english forum'.
+MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE=""
 MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official Language Forums"
 MOD_MENU_HELP_TRANSLATIONS="Joomla! Translations"
 MOD_MENU_HELP_XCHANGE="Stack Exchange"


### PR DESCRIPTION
### Summary of Changes
The string
`MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE=""`

should NOT have been deleted! ( see https://github.com/joomla/joomla-cms/pull/12467 )
When the value is not set it automatically loads the Languages forums page with the correct text
For en-GB it gives

![screen shot 2017-09-02 at 11 58 10](https://user-images.githubusercontent.com/869724/29994701-165e4178-8fd6-11e7-95d1-f0c0e79c6f4f.png)

When value is set to the correct language forum (for example `19` for French, it loads the French Language forum.

![screen shot 2017-09-02 at 11 59 31](https://user-images.githubusercontent.com/869724/29994711-3bf62d2e-8fd6-11e7-9481-0f91ab0aa6bf.png)
