### PR TITLE
[com_fields] Add processing flag for custom fields request

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -56,10 +56,12 @@ class FieldsHelper
 			{
 				$section = call_user_func_array(array($cName, 'validateSection'), array($parts[1], $item));
 
-				if ($section)
+				if (!$section)
 				{
-					$parts[1] = $section;
+					return null;
 				}
+
+				$parts[1] = $section;
 			}
 		}
 

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -279,6 +279,9 @@ class FieldsHelper
 			return true;
 		}
 
+		// Mark in the form that it is processed by com_fields
+		$form->load('<form><field type="hidden" name="processed-by-fields" default="1" fieldset="basic"/></form>');
+
 		$context = $parts[0] . '.' . $parts[1];
 
 		// When no fields available return here

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -126,14 +126,6 @@ class PlgSystemFields extends JPlugin
 
 		$user = JFactory::getUser($userData['id']);
 
-		$task = JFactory::getApplication()->input->getCmd('task');
-
-		// Skip fields save when we activate a user, because we will lose the saved data
-		if (in_array($task, array('activate', 'block', 'unblock')))
-		{
-			return true;
-		}
-
 		// Trigger the events with a real user
 		$this->onContentAfterSave('com_users.user', $user, false, $userData);
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -48,6 +48,14 @@ class PlgSystemFields extends JPlugin
 			return true;
 		}
 
+		$formInput = JFactory::getApplication()->input->get('jform', array(), 'array');
+
+		// Check if it is a form we have processed
+		if (!$formInput || empty($formInput['processed-by-fields']))
+		{
+			return;
+		}
+
 		// Create correct context for category
 		if ($context == 'com_categories.category')
 		{


### PR DESCRIPTION
Pull Request for Issue #17801.

### Summary of Changes
The problem with the current way of processing forms and handling the saved data is that com_fields has no clue if the current save operation is one where custom fields got activated. This pr adds a hidden flag that this form is processed which gets checked on the save operation.

For me this workaround is a hack, but for the moment I have no other clue how to do it. @Bakual any feedback?

### Testing Instructions
- Create custom user fields.
- Edit user and fill any data in custom fields.
- Execute: `$user = JFactory::getUser(); $user->save();`

### Expected result
The user custom fields data stays.

### Actual result
The user custom fields got wiped out.