### PR TITLE
Fix allowEdit check for module

### DIFF
--- a/administrator/components/com_modules/controllers/module.php
+++ b/administrator/components/com_modules/controllers/module.php
@@ -118,14 +118,19 @@ class ModulesControllerModule extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// Check general edit permission first.
+		// Zero record (id:0), return component edit permission by calling parent controller method
+		if (!$recordId)
+		{
+			return parent::allowEdit($data, $key);
+		}
+
+		// Check edit on the record asset (explicit or inherited)
 		if ($user->authorise('core.edit', 'com_modules.module.' . $recordId))
 		{
 			return true;
 		}
 
-		// Since there is no asset tracking, revert to the component permissions.
-		return parent::allowEdit($data, $key);
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #17188 

### Summary of Changes
Fixing the `allowEdit` in the module controller. Currently using the component permissions as a fallback, even while a ID is set to edit. Due to this, editing a module is allowed when the edit permission is denied for the module specifically but allowed for `com_modules`.

The controller only should use the component permissions if the module ID is not set.

### Testing Instructions
- Create a new user group `Module Test`
- Assign this user group to access level `Special`
- Allow the backend login action for the `Module Test` user group in the Global Configuration permissions
- Allow `Access Administration Interface` and `Edit` action for both Menu & Module component permissions for the `Module Test` user group.
- Open the module that displays one of your menu's, eg the `Main Menu`. Set `Edit` action permission to denied for the `Module Test` user group
- Create a test user, assign to `Module Test` user group
- Login with test user
- Go to Menus -> Manage, and click on the module title under the `Linked Modules` column of the menu module you just denied action for

### Actual result
A modal shows up, containing the module you can edit. Check under the module manager that you can't edit the module over there.

### Expected result
Apply the patch, now the module shows up, but with a list of modules and the error message `Edit not permitted.`
