### PR TITLE
Fix allowedit for field, only use component ACL if field ID is zero (new record)

### DIFF
--- a/administrator/components/com_fields/controllers/field.php
+++ b/administrator/components/com_fields/controllers/field.php
@@ -73,12 +73,12 @@ class FieldsControllerField extends JControllerForm
 	protected function allowEdit($data = array(), $key = 'id')
 	{
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
-		$user     = JFactory::getUser();
+		$user = JFactory::getUser();
 
-		// Check general edit permission first.
-		if ($user->authorise('core.edit', $this->component))
+		// Zero record (id:0), return component edit permission by calling parent controller method
+		if (!$recordId)
 		{
-			return true;
+			return parent::allowEdit($data, $key);
 		}
 
 		// Check edit on the record asset (explicit or inherited)


### PR DESCRIPTION
Same fix as fix that had been applied here in the past to the article controller :

https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/controllers/article.php#L80-L89

https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/controllers/article.php#L112

Same as PRs
https://github.com/joomla/joomla-cms/pull/17838
https://github.com/joomla/joomla-cms/pull/17840

This is minor security issue, 
if user than has "edit" on fields component, is denied editing configuration of a specific field , 
then user will still be able to edit the field's configuration

### Summary of Changes



### Testing Instructions


### Expected result



### Actual result



### Documentation Changes Required

