### PR TITLE
Fix allowedit for field group, only use component ACL if group ID is zero (new record)

### DIFF
--- a/administrator/components/com_fields/controllers/group.php
+++ b/administrator/components/com_fields/controllers/group.php
@@ -104,10 +104,10 @@ class FieldsControllerGroup extends JControllerForm
 		$recordId = (int) isset($data[$key]) ? $data[$key] : 0;
 		$user = JFactory::getUser();
 
-		// Check general edit permission first.
-		if ($user->authorise('core.edit', $this->component))
+		// Zero record (parent_id:0), return component edit permission by calling parent controller method
+		if (!$recordId)
 		{
-			return true;
+			return parent::allowEdit($data, $key);
 		}
 
 		// Check edit on the record asset (explicit or inherited)


### PR DESCRIPTION
Same fix as fix that had been applied here in the past to the article controller :

https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/controllers/article.php#L80-L89

https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_content/controllers/article.php#L112

Same as PRs
#17838
#17839

This is minor security issue, 
if user than has "edit" on fields component, is denied editing configuration of a specific field group, 
then user will still be able to edit the field group's configuration

### Summary of Changes


### Testing Instructions


### Expected result


### Actual result


### Documentation Changes Required

