### PR TITLE
[com_menus] Check for edit permission linked menu modules

### DIFF
--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -170,12 +170,12 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<ul class="dropdown-menu">
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
-												<?php if ($user->authorise('core.edit',   'com_modules.module.' . (int) $module->id)) : ?>
+												<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>
 													<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 													<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>">
 														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else : ?>
-                                                <a href="#" class="disabled" disabled="disabled">
+													<a href="#" class="disabled" disabled="disabled">
 													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php endif; ?>
 											</li>
@@ -183,7 +183,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									</ul>
 								 </div>
 								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
-									<?php if ($user->authorise('core.edit',   'com_modules.module.' . (int) $module->id)) : ?>
+									<?php if ($user->authorise('core.edit', 'com_modules.module.' . (int) $module->id)) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 										<?php echo JHtml::_(
 												'bootstrap.renderModal',

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -170,19 +170,20 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 									<ul class="dropdown-menu">
 										<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
 											<li>
-												<?php if ($canEdit) : ?>
+												<?php if ($user->authorise('core.edit',   'com_modules.module.' . (int) $module->id)) : ?>
 													<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 													<a href="#moduleEdit<?php echo $module->id; ?>Modal" role="button" class="button" data-toggle="modal" title="<?php echo JText::_('COM_MENUS_EDIT_MODULE_SETTINGS'); ?>">
 														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else : ?>
-													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?>
+                                                <a href="#" class="disabled" disabled="disabled">
+													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php endif; ?>
 											</li>
 										<?php endforeach; ?>
 									</ul>
 								 </div>
 								<?php foreach ($this->modules[$item->menutype] as &$module) : ?>
-									<?php if ($canEdit) : ?>
+									<?php if ($user->authorise('core.edit',   'com_modules.module.' . (int) $module->id)) : ?>
 										<?php $link = JRoute::_('index.php?option=com_modules&task=module.edit&id=' . $module->id . '&return=' . $return . '&tmpl=component&layout=modal'); ?>
 										<?php echo JHtml::_(
 												'bootstrap.renderModal',

--- a/administrator/components/com_menus/views/menus/tmpl/default.php
+++ b/administrator/components/com_menus/views/menus/tmpl/default.php
@@ -176,7 +176,7 @@ JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 														<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php else : ?>
 													<a href="#" class="disabled" disabled="disabled">
-													<?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
+													    <?php echo JText::sprintf('COM_MENUS_MODULE_ACCESS_POSITION', $this->escape($module->title), $this->escape($module->access_title), $this->escape($module->position)); ?></a>
 												<?php endif; ?>
 											</li>
 										<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Issue #17188 & related to PR #17838 

### Summary of Changes
Right now the linked modules in the menus view of com_menus are checked for the edit permission for the menu, instead of the linked module. This PR checks if the user can edit the linked module, if not the link will be disabled, as it is common in Joomla to disable links instead of hiding them.

### Testing Instructions
- Create a new user group `Module Test`
- Assign this user group to access level `Special`
- Allow the backend login action for the `Module Test` user group in the Global Configuration permissions
- Allow `Access Administration Interface` and `Edit` action for both Menu & Module component permissions for the `Module Test` user group.
- Open the module that displays one of your menu's, eg the `Main Menu`. Set `Edit` action permission to denied for the `Module Test` user group
- Create a test user, assign to `Module Test` user group
- Login with test user
- Go to Menus -> Manage

### Actual result
Right now you can click on the linked modules, even when you do not have permissions. With #17838 an error message will be visible (without that PR you can edit the module, which is an ACL violation).

### Expected result
Apply the patch, and not the linked menu module without edit access is disabled and you can't click on it to edit the module anymore.

In this example the sitemap menu module is disabled:
<img width="1074" alt="screen shot 2017-09-03 at 11 41 24" src="https://user-images.githubusercontent.com/522834/30001921-edf492ce-909c-11e7-8a3f-7de1b9ae6d28.png">

