### PR TITLE
[com_users] Show all accessible menu items in toolbar

### DIFF
--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -54,32 +54,33 @@ class UsersHelper
 				'index.php?option=com_users&view=levels',
 				$vName == 'levels'
 			);
+		}
 
-			if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_users')->get('custom_fields_enable', '1'))
-			{
-				JHtmlSidebar::addEntry(
-					JText::_('JGLOBAL_FIELDS'),
-					'index.php?option=com_fields&context=com_users.user',
-					$vName == 'fields.fields'
-				);
-				JHtmlSidebar::addEntry(
-					JText::_('JGLOBAL_FIELD_GROUPS'),
-					'index.php?option=com_fields&view=groups&context=com_users.user',
-					$vName == 'fields.groups'
-				);
-			}
-
+		if (JComponentHelper::isEnabled('com_fields') && JComponentHelper::getParams('com_users')->get('custom_fields_enable', '1'))
+		{
 			JHtmlSidebar::addEntry(
-				JText::_('COM_USERS_SUBMENU_NOTES'),
-				'index.php?option=com_users&view=notes',
-				$vName == 'notes'
+				JText::_('JGLOBAL_FIELDS'),
+				'index.php?option=com_fields&context=com_users.user',
+				$vName == 'fields.fields'
 			);
 			JHtmlSidebar::addEntry(
-				JText::_('COM_USERS_SUBMENU_NOTE_CATEGORIES'),
-				'index.php?option=com_categories&extension=com_users',
-				$vName == 'categories'
+				JText::_('JGLOBAL_FIELD_GROUPS'),
+				'index.php?option=com_fields&view=groups&context=com_users.user',
+				$vName == 'fields.groups'
 			);
 		}
+
+		JHtmlSidebar::addEntry(
+			JText::_('COM_USERS_SUBMENU_NOTES'),
+			'index.php?option=com_users&view=notes',
+			$vName == 'notes'
+		);
+
+		JHtmlSidebar::addEntry(
+			JText::_('COM_USERS_SUBMENU_NOTE_CATEGORIES'),
+			'index.php?option=com_categories&extension=com_users',
+			$vName == 'categories'
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
The toolbar in the back-end of `com_users` is not showing all accessible menu items if a user has `Access Administrator Interface` access.

### Testing Instructions
1.  Create a usergroup `Toolbar` with as group parent 'Public'
2. Assign the created group to the Access level `special`
3. Allow `Administrator Login` in the global configuration permission for the Toolbar group
4. Allow `Access Administration Interface` in the Users permissions for the Toolbar group
5. Create a user assigned to the Toolbar group
6. Login with the created user and notice that only the item "User" is available in the toolbar for com_users.

### Expected result
Allow allowed menu items (Users, Fields, Field Groups, User Notes, User Note Categories) should be visible since they are accessible via the menu

### Actual result
Only the item 'Users' is visible
