### PR TITLE
Phase out deprecated `$php_errormsg` variable and `track_errors` use in HTTP and Language packages

### DIFF
--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -177,30 +177,21 @@ class StreamTransport implements TransportInterface
 			$uri->setPass($this->options->get('passwordauth'));
 		}
 
-		// Capture PHP errors
-		$php_errormsg = '';
-		$track_errors = ini_get('track_errors');
-		ini_set('track_errors', true);
-
 		// Open the stream for reading.
 		$stream = @fopen((string) $uri, 'r', false, $context);
 
 		if (!$stream)
 		{
-			if (!$php_errormsg)
+			$lastError = error_get_last();
+			$message   = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
+
+			if ($lastError !== null)
 			{
-				// Error but nothing from php? Create our own
-				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
+				$message = $lastError['message'];
 			}
 
-			// Restore error tracking to give control to the exception handler
-			ini_set('track_errors', $track_errors);
-
-			throw new \RuntimeException($php_errormsg);
+			throw new \RuntimeException($message);
 		}
-
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $track_errors);
 
 		// Get the metadata for the stream, including response headers.
 		$metadata = stream_get_meta_data($stream);

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -824,11 +824,7 @@ class Language
 		// Capture hidden PHP errors from the parsing.
 		if ($this->debug)
 		{
-			// See https://secure.php.net/manual/en/reserved.variables.phperrormsg.php
-			$php_errormsg = null;
-
-			$trackErrors = ini_get('track_errors');
-			ini_set('track_errors', true);
+			$oldErrorReporting = error_reporting(E_ALL);
 		}
 
 		// This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
@@ -855,7 +851,7 @@ class Language
 		// Restore error tracking to what it was before.
 		if ($this->debug)
 		{
-			ini_set('track_errors', $trackErrors);
+			error_reporting($oldErrorReporting);
 
 			$this->debugFile($filename);
 		}
@@ -888,7 +884,6 @@ class Language
 		$debug = $this->getDebug();
 		$this->debug = false;
 		$errors = array();
-		$php_errormsg = null;
 
 		// Open the file as a stream.
 		$file = new \SplFileObject($filename);
@@ -949,15 +944,17 @@ class Language
 			}
 		}
 
+		$lastError = error_get_last();
+
 		// Check if we encountered any errors.
 		if (count($errors))
 		{
 			$this->errorfiles[$filename] = $filename . ' : error(s) in line(s) ' . implode(', ', $errors);
 		}
-		elseif ($php_errormsg)
+		elseif ($lastError !== null)
 		{
 			// We didn't find any errors but there's probably a parse notice.
-			$this->errorfiles['PHP' . $filename] = 'PHP parser errors :' . $php_errormsg;
+			$this->errorfiles['PHP' . $filename] = 'PHP parser errors :' . $lastError['message'];
 		}
 
 		$this->debug = $debug;


### PR DESCRIPTION
Partial Pull Request for Issue #16584

### Summary of Changes

PHP 7.2 deprecates the `track_errors` INI configuration and the scoped `$php_errormsg` variable in favor of using the `error_get_last()` function for retrieving error data, and at PHP 7.0 using `error_clear_last()` to clear any errors (to my knowledge we aren't doing anything in core requiring the latter at the moment).

This PR phases out this deprecated functionality for the HTTP and Language packages.

### Testing Instructions

The packages should still function normally, including error handling (easiest way to test error handling is enable debug mode and language debug and break one of the language files with a parsing error).