### PR TITLE
Fix PHP HHVM incompatibility in JFormField::getAttribute()

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -888,7 +888,7 @@ abstract class FormField
 			$attributes = $this->element->attributes();
 
 			// Ensure that the attribute exists
-			if (property_exists($attributes, $name))
+			if ($attributes->$name)
 			{
 				$value = $attributes->$name;
 

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -888,14 +888,9 @@ abstract class FormField
 			$attributes = $this->element->attributes();
 
 			// Ensure that the attribute exists
-			if ($attributes->$name)
+			if ($attributes->$name !== null)
 			{
-				$value = $attributes->$name;
-
-				if ($value !== null)
-				{
-					return (string) $value;
-				}
+				return (string) $attributes->$name;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
It seems that `property_exists` has different behavior at PHP HHVM, when work with XML object.
This make Joomla! fail in a lot of places where `JFormField::getAttribute()` in use.


### Testing Instructions
You need PHP HHVM installed. 

Then run next code:
```php
JFormHelper::loadFieldClass('text');
$field = new JFormFieldText();
$field->setup(new SimpleXMLElement('<field type="text" label="Text" drink="beer"/>'), '');

var_dump($field->getAttribute('drink'));
var_dump($field->getAttribute('food'));
```


### Expected result
```php
"beer"
null
```


### Actual result
```php
null
null
```

### Documentation Changes Required
none
