### PR TITLE
[com_fields] Fix front end articles category switch

### DIFF
--- a/components/com_content/controllers/article.php
+++ b/components/com_content/controllers/article.php
@@ -172,7 +172,7 @@ class ContentControllerArticle extends JControllerForm
 			$cancelMenuitemId = (int) $params->get('cancel_redirect_menuitem');
 
 			if ($cancelMenuitemId > 0)
-			{				
+			{
 				$item = $app->getMenu()->getItem($cancelMenuitemId);
 				$lang = '';
 
@@ -387,6 +387,21 @@ class ContentControllerArticle extends JControllerForm
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Method to reload a record.
+	 *
+	 * @param   string  $key     The name of the primary key of the URL variable.
+	 * @param   string  $urlVar  The name of the URL variable if different from the primary key (sometimes required to avoid router collisions).
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function reload($key = null, $urlVar = 'a_id')
+	{
+		return parent::reload($key, $urlVar);
 	}
 
 	/**

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -873,6 +873,10 @@ class FormController extends BaseController
 
 		$recordId = $this->input->getInt($urlVar);
 
+		// Populate the row id from the session.
+		$data[$key] = $recordId;
+
+		// Check if it is allowed to edit the data
 		if (!$this->allowEdit($data, $key))
 		{
 			$this->setRedirect(
@@ -883,9 +887,6 @@ class FormController extends BaseController
 			);
 			$this->redirect();
 		}
-
-		// Populate the row id from the session.
-		$data[$key] = $recordId;
 
 		// The redirect url
 		$redirectUrl = \JRoute::_(

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -876,8 +876,8 @@ class FormController extends BaseController
 		// Populate the row id from the session.
 		$data[$key] = $recordId;
 
-		// Check if it is allowed to edit the data
-		if (!$this->allowEdit($data, $key))
+		// Check if it is allowed to edit or create the data
+		if (($recordId && !$this->allowEdit($data, $key)) || (!$recordId && !$this->allowAdd($data)))
 		{
 			$this->setRedirect(
 				\JRoute::_(


### PR DESCRIPTION
Pull Request for Issue #17867.

### Summary of Changes
Changing the category when editing an article redirects to the start page. This pr fixes that bug.

### Testing Instructions
- Log in on the back end
- Create a second category for an article
- Create an article with the title DEMO and give the Registered and Author groups edit and edit state right
- Create a new user which is assigned to the Registered and Author group, NO super admin
- Log in on the front with this new user
- Edit the article with the title DEMO
- Open the publishing tab
- Change the category

### Expected result
The edit form is reloaded.

### Actual result
It redirects to the wrong url.