### PR TITLE
Syncing lib.joomla lang files in frontend

### DIFF
--- a/language/en-GB/en-GB.lib_joomla.ini
+++ b/language/en-GB/en-GB.lib_joomla.ini
@@ -359,6 +359,7 @@ JLIB_HTML_ADD_TO_THIS_MENU="Add to this menu."
 JLIB_HTML_BATCH_ACCESS_LABEL="Set Access Level"
 JLIB_HTML_BATCH_ACCESS_LABEL_DESC="Not making a selection will keep the original access levels when processing."
 JLIB_HTML_BATCH_COPY="Copy"
+JLIB_HTML_BATCH_FLIPORDERING_LABEL="Reverse the ordering of all articles in the selected categories"
 JLIB_HTML_BATCH_LANGUAGE_LABEL="Set Language"
 JLIB_HTML_BATCH_LANGUAGE_LABEL_DESC="Not making a selection will keep the original language when processing."
 JLIB_HTML_BATCH_LANGUAGE_NOCHANGE="- Keep original Language -"
@@ -674,6 +675,9 @@ JLIB_MEDIA_ERROR_WARNINVALID_IMG="Not a valid image."
 JLIB_MEDIA_ERROR_WARNINVALID_MIME="Invalid mime type detected."
 JLIB_MEDIA_ERROR_WARNINVALID_MIMETYPE="Illegal mime type detected: %s"
 JLIB_MEDIA_ERROR_WARNNOTADMIN="Uploaded file is not an image file and you do not have permission."
+
+JLIB_MENUS_PRESET_JOOMLA="Preset - Joomla"
+JLIB_MENUS_PRESET_MODERN="Preset - Modern"
 
 JLIB_NO_EDITOR_PLUGIN_PUBLISHED="Unable to display an editor because no editor plugin is published."
 


### PR DESCRIPTION
Some strings added to backend en-GB.lib_joomla.ini were not added in the same file in frontend
These have to be in sync.

To be merged on review.

@mbabker 
We will let it know to TTs as soon as merged.