### PR TITLE
Fix unneeded repetitive filesystem access / checks (e.g. 10,000 in category view) causing performance issue in custom fields feature

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -93,7 +93,8 @@ abstract class FieldsPlugin extends JPlugin
 		}
 
 		// Add to cache and return the data
-		return $types_cache[$this->_type . $this->_name] = $types;
+		$types_cache[$this->_type . $this->_name] = $types;
+		return $types;
 	}
 
 	/**

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -26,6 +26,14 @@ abstract class FieldsPlugin extends JPlugin
 	 */
 	public function onCustomFieldsGetTypes()
 	{
+		// Cache filesystem access / checks
+		static $types_cache = array();
+
+		if (isset($types_cache[$this->_type][$this->_name]))
+		{
+			return $types_cache[$this->_type][$this->_name];
+		}
+
 		$types = array();
 
 		// The root of the plugin
@@ -83,6 +91,9 @@ abstract class FieldsPlugin extends JPlugin
 
 			$types[] = $data;
 		}
+
+		// Add to cache
+		$types_cache[$this->_type][$this->_name] = $types;
 
 		// Return the data
 		return $types;

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -29,9 +29,9 @@ abstract class FieldsPlugin extends JPlugin
 		// Cache filesystem access / checks
 		static $types_cache = array();
 
-		if (isset($types_cache[$this->_type][$this->_name]))
+		if (isset($types_cache[$this->_type . $this->_name]))
 		{
-			return $types_cache[$this->_type][$this->_name];
+			return $types_cache[$this->_type . $this->_name];
 		}
 
 		$types = array();
@@ -93,7 +93,7 @@ abstract class FieldsPlugin extends JPlugin
 		}
 
 		// Add to cache
-		$types_cache[$this->_type][$this->_name] = $types;
+		$types_cache[$this->_type . $this->_name] = $types;
 
 		// Return the data
 		return $types;

--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -92,11 +92,8 @@ abstract class FieldsPlugin extends JPlugin
 			$types[] = $data;
 		}
 
-		// Add to cache
-		$types_cache[$this->_type . $this->_name] = $types;
-
-		// Return the data
-		return $types;
+		// Add to cache and return the data
+		return $types_cache[$this->_type . $this->_name] = $types;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #17889 

This should fix a considerable part of the performance problem reported in #17889 

e.g. 25% or 50% or 75% (please note that i have not tested the performance improvement)

Also the above performance improvement is when having --zero-- textareas / editor fields, since these also include a **different** performance issue which is that of triggering content plugins, in which case you have performance that depends on slow content plugins !!!

### Summary of Changes
If you have 10 or more fields per record (e.g. per article)

Then the layouts of fields are checked several thousands of times (in category view) if they exist
and a few hundrends of times in single record view

With this PR every layou is checked only once

### Testing Instructions
Custom fields display in frontend works as before


### Expected result
The layouts of fields are checked only once if they exist


### Actual result
The layouts of fields are checked several thousands of time if they exist


### Documentation Changes Required
None
