### PR TITLE
 Fix wrong type cast breaking the updating of smart search indexer when a single token is given

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -511,8 +511,8 @@ abstract class FinderIndexer
 
 		$query = clone $this->addTokensToDbQueryTemplate;
 
-		// Force tokens to an array.
-		$tokens = (array) $tokens;
+		// Check if a single FinderIndexerToken object was given and make it to be an array of FinderIndexerToken objects
+		$tokens = is_array($tokens) ? $tokens : array($tokens);
 
 		// Count the number of token values.
 		$values = 0;


### PR DESCRIPTION
Pull Request for Issue #17880 

The issue was introduced by PR #13511

@mbabker 
@frankmayer   (i am not mentioning you by mistake this is an intentional mention
(sorry for mentioning by mistake in the past))

@Quy 
@franz-wohlkoenig 


### Summary of Changes
Smart search indexer update method accepts
`FinderIndexer::addTokensToDb()`

Accepts 
- either An array FinderIndexerToken objects
- or single FinderIndexerToken object

It has a type cast to force single FinderIndexerToken object to be an array of FinderIndexerToken objects
- but the typecast is wrong 

and converts a single FinderIndexerToken object 
to be an array

### Testing Instructions
Code review

Also smart search indexer is updated properly


### Expected result
Indexer can store single FinderIndexerToken object


### Actual result
Indexer can not store single FinderIndexerToken object


### Documentation Changes Required
None
