### PR TITLE
[com_fields] Fix fields display HTML prepared 4 or 5 times per article, make it be prepared only twice

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -188,7 +188,7 @@ class FieldsHelper
 				$field->rawvalue = $field->value;
 
 				// If boolean prepare, if int, it is the event type: 1 - After Title, 2 - Before Display, 3 - After Display, 0 - Do not prepare
-				if ($prepareValue && (is_boolean($prepareValue) || $prepareValue === (int) $field->params->get('display', '2')))
+				if ($prepareValue && (is_bool($prepareValue) || $prepareValue === (int) $field->params->get('display', '2')))
 				{
 					JPluginHelper::importPlugin('fields');
 

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -79,7 +79,7 @@ class FieldsHelper
 	 *
 	 * @param   string    $context           The context of the content passed to the helper
 	 * @param   stdClass  $item              item
-	 * @param   int/bool  $prepareValue      Boolean or Event type to indicate when to preparing fields display
+	 * @param   int|bool  $prepareValue      Boolean or Event type to indicate when to preparing fields display
 	 * @param   array     $valuesToOverride  The values to override
 	 *
 	 * @return  array

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -79,7 +79,7 @@ class FieldsHelper
 	 *
 	 * @param   string    $context           The context of the content passed to the helper
 	 * @param   stdClass  $item              item
-	 * @param   boolean   $prepareValue      prepareValue
+	 * @param   int/bool  $prepareValue      Boolean or Event type to indicate when to preparing fields display
 	 * @param   array     $valuesToOverride  The values to override
 	 *
 	 * @return  array
@@ -187,7 +187,8 @@ class FieldsHelper
 
 				$field->rawvalue = $field->value;
 
-				if ($prepareValue)
+				// If boolean prepare, if int, it is the event type: 1 - After Title, 2 - Before Display, 3 - After Display, 0 - Do not prepare
+				if ($prepareValue && (is_boolean($prepareValue) || $prepareValue === (int) $field->params->get('display', '2')))
 				{
 					JPluginHelper::importPlugin('fields');
 

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -79,7 +79,7 @@ class FieldsHelper
 	 *
 	 * @param   string    $context           The context of the content passed to the helper
 	 * @param   stdClass  $item              item
-	 * @param   int|bool  $prepareValue      Boolean or Event type to indicate when to preparing fields display
+	 * @param   int|bool  $prepareValue      (if int is display event): 1 - AfterTitle, 2 - BeforeDisplay, 3 - AfterDisplay, 0 - OFF
 	 * @param   array     $valuesToOverride  The values to override
 	 *
 	 * @return  array

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -474,11 +474,9 @@ class PlgSystemFields extends JPlugin
 			$item = $this->prepareTagItem($item);
 		}
 
-		// Prepare HTML display of only fields that are used manually (they have their parameter 'display' set to zero)
-		$prepareValue = 0 === (int) $field->params->get('display', '2');
-		
-		// Get item's fields, fields without zero 'display' will only have their rawvalues popuplated
-		$fields = FieldsHelper::getFields($context, $item, $prepareValue);
+		// Get item's fields, also preparing their value property for manual display
+		// (calling plugins events and loading layouts to get their HTML display)
+		$fields = FieldsHelper::getFields($context, $item, true);
 
 		// Adding the fields to the object
 		$item->jcfields = array();

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -468,7 +468,11 @@ class PlgSystemFields extends JPlugin
 			$item = $this->prepareTagItem($item);
 		}
 
-		$fields = FieldsHelper::getFields($context, $item, true);
+		// Prepare HTML display of only fields that are used manually (they have their parameter 'display' set to zero)
+		$prepareValue = 0;
+		
+		// Get item's fields, fields without zero 'display' will only have their raw values popuplated
+		$fields = FieldsHelper::getFields($context, $item, $prepareValue);
 
 		// Adding the fields to the object
 		$item->jcfields = array();

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -385,7 +385,7 @@ class PlgSystemFields extends JPlugin
 			$params = new Registry($params);
 		}
 
-		$fields = FieldsHelper::getFields($context, $item, true);
+		$fields = FieldsHelper::getFields($context, $item, $displayType);
 
 		if ($fields)
 		{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -450,6 +450,12 @@ class PlgSystemFields extends JPlugin
 	 */
 	public function onContentPrepare($context, $item)
 	{
+		// Check property exists (avoid costly & useless recreation), if need to recreate them, just unset the property!
+		if (isset($item->jcfields))
+		{
+			return;
+		}
+
 		$parts = FieldsHelper::extract($context, $item);
 
 		if (!$parts)
@@ -471,7 +477,7 @@ class PlgSystemFields extends JPlugin
 		// Prepare HTML display of only fields that are used manually (they have their parameter 'display' set to zero)
 		$prepareValue = 0 === (int) $field->params->get('display', '2');
 		
-		// Get item's fields, fields without zero 'display' will only have their raw values popuplated
+		// Get item's fields, fields without zero 'display' will only have their rawvalues popuplated
 		$fields = FieldsHelper::getFields($context, $item, $prepareValue);
 
 		// Adding the fields to the object

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -469,7 +469,7 @@ class PlgSystemFields extends JPlugin
 		}
 
 		// Prepare HTML display of only fields that are used manually (they have their parameter 'display' set to zero)
-		$prepareValue = 0;
+		$prepareValue = 0 === (int) $field->params->get('display', '2');
 		
 		// Get item's fields, fields without zero 'display' will only have their raw values popuplated
 		$fields = FieldsHelper::getFields($context, $item, $prepareValue);


### PR DESCRIPTION
Pull Request for Issue #17889 

Fields display is prepared multiple times
-- 5 times per record / article in single record view
-- 4 times per record / article in category view

Now it should be created only twice
- once for manual display
- and once if automatic display is 1 - After Title or 2 - Before Display or 3 - After Display


### Summary of Changes
Reduces field's value property **preparation** (plugin events + layout loading) to 2 times
Explanation:
field's **value** property is the field's HTML display which includes plugin triggering and loading of layouts, and (rawvalue property is the raw DB value)

### Testing Instructions
- Fields can be displayed automatically using field configuration  TAB "options" automatic display
- Fields continue to be possible to be displayed manually inside the template of the view, using `$item->jcfields[_field_id_num_]->value`

In both cases the plugins events should have been called and the layout of the field should have been loaded and the result should have been set to value property of the field

### Expected result
Fields plugin event and layouts should be called only once
(This PR reduces to 2)

### Actual result
They are called 5 times in single record (e.g. article) view 
They are called 4 times (per article ) in category view

### Documentation Changes Required
None
