### PR TITLE
Optimized PSR-4 namespace prefix search

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -438,6 +438,9 @@ abstract class JLoader
 			throw new RuntimeException('Library path ' . $path . ' cannot be found.', 500);
 		}
 
+		// Trim leading and trailing backslashes from namespace, allowing "\Parent\Child", "Parent\Child\" and "\Parent\Child\" to be treated the same way.
+		$namespace = trim($namespace, '\\');
+
 		// If the namespace is not yet registered or we have an explicit reset flag then set the path.
 		if ($reset || !isset(self::$namespaces[$type][$namespace]))
 		{
@@ -533,10 +536,10 @@ abstract class JLoader
 		// Loop through registered namespaces until we find a match.
 		foreach (self::$namespaces['psr4'] as $ns => $paths)
 		{
-			$nsPath = trim(str_replace('\\', DIRECTORY_SEPARATOR, $ns), DIRECTORY_SEPARATOR);
-
-			if (strpos($class, $ns) === 0)
+			if (strpos($class, "{$ns}\\") === 0)
 			{
+				$nsPath = trim(str_replace('\\', DIRECTORY_SEPARATOR, $ns), DIRECTORY_SEPARATOR);
+
 				// Loop through paths registered to this namespace until we find a match.
 				foreach ($paths as $path)
 				{

--- a/tests/unit/stubs/DummyNamespace/DummyClass.php
+++ b/tests/unit/stubs/DummyNamespace/DummyClass.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+namespace DummyNamespace;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Dummy class, used for namespaced class loading tests.
+ *
+ * @package  None
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class DummyClass
+{
+	/**
+	 * Returns class name without namespace.
+	 * @return string
+	 */
+	public static function getName ()
+	{
+		return 'DummyClass';
+	}
+}

--- a/tests/unit/suites/libraries/joomla/JLoaderTest.php
+++ b/tests/unit/suites/libraries/joomla/JLoaderTest.php
@@ -280,6 +280,21 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 	}
 
 	/**
+	 * Tests the JLoader::loadByPsr4 method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testLoadByPsr4()
+	{
+		// Register namespace at first. Odd leading and trailing backslashes must be automatically removed from namespace
+		JLoader::registerNamespace('\\DummyNamespace\\', JPATH_TEST_STUBS . '/DummyNamespace', $reset = true, $prepend = false, $type = 'psr4');
+
+		$this->assertThat(JLoader::loadByPsr4('DummyNamespace\DummyClass'), $this->isTrue(), 'Tests that the class file was loaded.');
+	}
+
+	/**
 	 * Tests the JLoader::registerAlias method if the alias is loaded when the original class is loaded.
 	 *
 	 * @return  void
@@ -485,6 +500,32 @@ class JLoaderTest extends \PHPUnit\Framework\TestCase
 	public function testRegisterNamespaceException()
 	{
 		JLoader::registerNamespace('Color', 'dummy');
+	}
+
+	/**
+	 * Tests the JLoader::registerNamespace method for namespace trimming of leading and trailing backslashes.
+	 *
+	 * @return  void
+	 *
+	 * @since   12.3
+	 */
+	public function testRegisterNamespaceTrimming()
+	{
+		// Try registering namespace with leading backslash.
+		$path = JPATH_TEST_STUBS . '/discover1';
+		JLoader::registerNamespace('\\discover1', $path);
+
+		$namespaces = JLoader::getNamespaces();
+
+		$this->assertContains($path, $namespaces['discover1']);
+
+		// Try registering namespace with trailing backslash.
+		$path = JPATH_TEST_STUBS . '/discover2';
+		JLoader::registerNamespace('discover2\\', $path);
+
+		$namespaces = JLoader::getNamespaces();
+
+		$this->assertContains($path, $namespaces['discover2']);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Namespace prefix is now searched as "XXX\\" instead of "XXX" in qualified class name. Previously, if prefix 'A' was registered, all namespaces, beginning with 'A' were tested, like "Apple\\", "AI\\", etc.
