### PR TITLE
[com_content] - category list/blog/featured sql error on postgresql

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -201,7 +201,7 @@ class ContentModelArticles extends JModelList
 				// Use created if publish_up is 0
 				'CASE WHEN a.publish_up = ' . $db->quote($db->getNullDate()) . ' THEN a.created ELSE a.publish_up END as publish_up,' .
 				'a.publish_down, a.images, a.urls, a.attribs, a.metadata, a.metakey, a.metadesc, a.access, ' .
-				'a.hits, a.xreference, a.featured, a.language, ' . ' ' . $query->length('a.fulltext') . ' AS readmore'
+				'a.hits, a.xreference, a.featured, a.language, ' . ' ' . $query->length('a.fulltext') . ' AS readmore, a.ordering'
 			)
 		);
 
@@ -213,6 +213,8 @@ class ContentModelArticles extends JModelList
 		// Join over the frontpage articles if required.
 		if ($this->getState('filter.frontpage'))
 		{
+			$query->select('fp.ordering');
+
 			if ($orderby_sec === 'front')
 			{
 				$query->join('INNER', '#__content_frontpage AS fp ON fp.content_id = a.id');
@@ -224,6 +226,7 @@ class ContentModelArticles extends JModelList
 		}
 		elseif ($orderby_sec === 'front' || $this->getState('list.ordering') === 'fp.ordering')
 		{
+			$query->select('fp.ordering');
 			$query->join('LEFT', '#__content_frontpage AS fp ON fp.content_id = a.id');
 		}
 

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -213,10 +213,10 @@ class ContentModelArticles extends JModelList
 		// Join over the frontpage articles if required.
 		if ($this->getState('filter.frontpage'))
 		{
-			$query->select('fp.ordering');
 
 			if ($orderby_sec === 'front')
 			{
+				$query->select('fp.ordering');
 				$query->join('INNER', '#__content_frontpage AS fp ON fp.content_id = a.id');
 			}
 			else

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -229,7 +229,7 @@ class ContentModelArticles extends JModelList
 
 		// Join over the categories.
 		$query->select('c.title AS category_title, c.path AS category_route, c.access AS category_access, c.alias AS category_alias')
-			->select('c.published, c.published AS parents_published')
+			->select('c.published, c.published AS parents_published, c.lft')
 			->join('LEFT', '#__categories AS c ON c.id = a.catid');
 
 		// Join over the users for the author and modified_by names.

--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -213,7 +213,6 @@ class ContentModelArticles extends JModelList
 		// Join over the frontpage articles if required.
 		if ($this->getState('filter.frontpage'))
 		{
-
 			if ($orderby_sec === 'front')
 			{
 				$query->select('fp.ordering');


### PR DESCRIPTION
Pull Request for Issue #17901.

### Summary of Changes
fix category list/blog/featured sql error on postgresql

you cannot ORDER BY on a field not selected


### Testing Instructions
Go to frontpage and click on Article Category Blog or Article Category List
/index.php/article-category-list
/index.php/article-category-blog
/index.php/featured-articles
/index.php/content-modules
### Expected result

no error

### Actual result
sql error

