### PR TITLE
[fix] fixed PluginHelper import of xtd-editors plugins

### DIFF
--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -259,6 +259,19 @@ abstract class PluginHelper
 				{
 					$className = 'Plg' . $plugin->type . $plugin->name;
 
+					if ($plugin->type == 'editors-xtd')
+					{
+						if (!class_exists($className))
+						{
+							$className = 'PlgEditorsXtd' . $plugin->name;
+						}
+
+						if (!class_exists($className))
+						{
+							$className = 'PlgButton' . $plugin->name;
+						}
+					}
+
 					if (class_exists($className))
 					{
 						// Load the plugin from the database.

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -261,10 +261,8 @@ abstract class PluginHelper
 
 					if ($plugin->type == 'editors-xtd')
 					{
-						if (!class_exists($className))
-						{
-							$className = 'PlgEditorsXtd' . $plugin->name;
-						}
+						// This type doesn't follow the convention
+						$className = 'PlgEditorsXtd' . $plugin->name;
 
 						if (!class_exists($className))
 						{


### PR DESCRIPTION
Pull Request for Issue #17908 .

### Summary of Changes
Modified PluginHelper import so that it can properly 'autocreate' editors-xtd type plugins.
The problem is that regular class name construction uses 'Plg' + Type + name, but it doesn't work here as those plugins actually use PlgButton or PlgEditorsXtd prefix. Of course, it would be best to rename the plugin type, but i guess it's not possible due to B/C.
Note that the same workaround is used in the Editor\Editor class
https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Editor/Editor.php#L472

This changes allows to use com_ajax interface with editors-xtd plugins (for example to load a layout for the modal content), which is not possible at the moment.

### Testing Instructions
Use provided loadtest plugin, which loads it's modal content using com_ajax
[plg_xtd_editors_loadtest.zip](https://github.com/joomla/joomla-cms/files/1289836/plg_xtd_editors_loadtest.zip)

### Expected result
Modal content should display 'Plugin was loaded' after clicking on the button

![selection_216](https://user-images.githubusercontent.com/169588/30240750-61f02b06-9576-11e7-8c5a-2ceb3ffc22eb.jpg)

### Actual result
It doesn't trigger the right function


### Documentation Changes Required

