### PR TITLE
Editors deprecation

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -237,6 +237,8 @@ class Editor extends \JObject
 	 * @return  void
 	 *
 	 * @since   1.5
+	 *
+	 * @deprecated 4.0 This function will not load any custom tag from 4.0 forward, use JHtml::script
 	 */
 	public function initialise()
 	{


### PR DESCRIPTION
Pull Request for Issue #17909 .

### Summary of Changes

In Joomla 4.0 we are removing the `addCustomTag` from the `initialise` method in favour of `JHtml::script`


### Testing Instructions

Nothing to test here, it's just a deprecated comment

### Expected result



### Actual result



### Documentation Changes Required