### PR TITLE
[3.8] Fix fatal error on Stub generator script

### DIFF
--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -12,7 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Table\Observer\ContentHistory;
+use Joomla\CMS\Table\Observer\ContentHistory as ContentHistoryObserver;
 use Joomla\CMS\Table\Observer\Tags;
 use Joomla\Registry\Registry;
 
@@ -35,7 +35,7 @@ class Category extends Nested
 		parent::__construct('#__categories', 'id', $db);
 
 		Tags::createObserver($this, array('typeAlias' => '{extension}.category'));
-		ContentHistory::createObserver($this, array('typeAlias' => '{extension}.category'));
+		ContentHistoryObserver::createObserver($this, array('typeAlias' => '{extension}.category'));
 
 		$this->access = (int) \JFactory::getConfig()->get('access');
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR fixes fatal error while running Stub generator script introduced by PR #16291

### Testing Instructions
Follow the instructions at https://github.com/joomla/joomla-cms/pull/16291 to run the script. Before patch, you will get fatal error. After path, the error is gone, stubs.php is generated properly.

### Additional comment
There is still an issue with the generated subs.php file. The class name is in lower case 

class jregistry extends \Joomla\Registry\Registry {}

instead of 

class JRegistry extends \Joomla\Registry\Registry {}

as expected. It causes by some changes in JLoader in this PR https://github.com/joomla/joomla-cms/pull/17834 .

