### PR TITLE
[4.0] Add support for logging deprecations through PHP trigger_error()

### DIFF
--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -58,6 +58,9 @@ require_once JPATH_LIBRARIES . '/classmap.php';
 // Register the global exception handler.
 set_exception_handler(['JErrorPage', 'render']);
 
+// Register the error handler which processes E_USER_DEPRECATED errors
+set_error_handler(['JErrorPage', 'handleUserDeprecatedErrors'], E_USER_DEPRECATED);
+
 // Define the Joomla version if not already defined.
 defined('JVERSION') or define('JVERSION', (new JVersion)->getShortVersion());
 

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -22,6 +22,40 @@ use Joomla\CMS\Log\Log;
 class ExceptionHandler
 {
 	/**
+	 * Handles an error triggered with the E_USER_DEPRECATED level.
+	 *
+	 * @param   integer  $errorNumber   The level of the raised error, represented by the E_* constants.
+	 * @param   string   $errorMessage  The error message.
+	 * @param   string   $errorFile     The file the error was triggered from.
+	 * @param   integer  $errorLine     The line number the error was triggered from.
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function handleUserDeprecatedErrors(int $errorNumber, string $errorMessage, string $errorFile, int $errorLine): bool
+	{
+		// We only want to handle user deprecation messages, these will be triggered in code
+		if ($errorNumber === E_USER_DEPRECATED)
+		{
+			Log::add(
+				$errorMessage,
+				Log::WARNING,
+				'deprecated'
+			);
+
+			// If debug mode is enabled, we want to let PHP continue to handle the error; otherwise, we can bail early
+			if (defined('JDEBUG') && JDEBUG)
+			{
+				return true;
+			}
+		}
+
+		// Always return false, this will tell PHP to handle the error internally
+		return false;
+	}
+
+	/**
 	 * Render the error page based on an exception.
 	 *
 	 * @param   \Throwable  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Mail\Mail;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\CMS\User\User;
 use Joomla\Registry\Registry;
@@ -168,13 +169,12 @@ abstract class Factory
 	 */
 	public static function getConfig($file = null, $type = 'PHP', $namespace = '')
 	{
-		Log::add(
+		@trigger_error(
 			sprintf(
 				'%s() is deprecated. The configuration object should be read from the application.',
 				__METHOD__
 			),
-			Log::WARNING,
-			'deprecated'
+			E_USER_DEPRECATED
 		);
 
 		// If there is an application object, fetch the configuration from there
@@ -230,10 +230,13 @@ abstract class Factory
 	 */
 	public static function getSession(array $options = array())
 	{
-		Log::add(
-			__METHOD__ . '() is deprecated. Load the session from the dependency injection container or via JFactory::getApplication()->getSession().',
-			Log::WARNING,
-			'deprecated'
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. Load the session from the dependency injection container or via %2$s::getApplication()->getSession().',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
 		);
 
 		return self::getApplication()->getSession();
@@ -467,13 +470,12 @@ abstract class Factory
 	 */
 	protected static function createConfig($file, $type = 'PHP', $namespace = '')
 	{
-		Log::add(
+		@trigger_error(
 			sprintf(
 				'%s() is deprecated. The configuration object should be read from the application.',
 				__METHOD__
 			),
-			Log::WARNING,
-			'deprecated'
+			E_USER_DEPRECATED
 		);
 
 		if (is_file($file))
@@ -537,7 +539,13 @@ abstract class Factory
 	 */
 	protected static function createSession(array $options = array())
 	{
-		Log::add(__METHOD__ . '() is deprecated. The session should be a service in the dependency injection container.', JLog::WARNING, 'deprecated');
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated. The session should be a service in the dependency injection container.',
+				__METHOD__
+			),
+			E_USER_DEPRECATED
+		);
 
 		// Get the Joomla configuration settings
 		$conf    = self::getConfig();
@@ -573,8 +581,13 @@ abstract class Factory
 	 */
 	protected static function createDbo()
 	{
-		Log::add(
-			__METHOD__ . '() is deprecated, register a service provider to create a JDatabaseDriver instance instead.', JLog::WARNING, 'deprecated'
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated, register a service provider to create a %2$s instance instead.',
+				__METHOD__,
+				DatabaseInterface::class
+			),
+			E_USER_DEPRECATED
 		);
 
 		$conf = self::getConfig();


### PR DESCRIPTION
### Summary of Changes

It's a somewhat common and accepted practice in the PHP ecosystem for libraries to use PHP's `trigger_error()` function to raise deprecation notices (the Symfony ecosystem being the most prevalent example of this).  So, let's implement an error handler that can process these and use it in core (FWIW this would allow us in the Framework to start using this practice without spamming CMS installs with error messages).

### Testing Instructions

Apply the patch and make sure the debug plugin is logging deprecated errors.  Pre- and post-patch the deprecations in `Joomla\CMS\Factory` should continue to be logged.