### PR TITLE
BUG: Sample Data blog various issues

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -82,8 +82,6 @@ class PlgSampledataBlog extends JPlugin
 	 */
 	public function onAjaxSampledataApplyStep1()
 	{
-		$unicode = JFactory::getConfig()->get('unicodeslugs', 1);
-
 		if ($this->app->input->get('type') != $this->_name)
 		{
 			return;
@@ -121,8 +119,9 @@ class PlgSampledataBlog extends JPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			JFactory::getConfig()->set('unicodeslugs', 1);
+			$unicode = JFactory::getConfig()->set('unicodeslugs', 1);
 			$alias = JApplicationHelper::stringURLSafe($categoryTitle);
+			JFactory::getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -167,8 +166,9 @@ class PlgSampledataBlog extends JPlugin
 		// Set unicodeslugs if alias is empty
 		if (trim(str_replace('-', '', $alias) == ''))
 		{
-			JFactory::getConfig()->set('unicodeslugs', 1);
+			$unicode = JFactory::getConfig()->set('unicodeslugs', 1);
 			$alias = JApplicationHelper::stringURLSafe($categoryTitle);
+			JFactory::getConfig()->set('unicodeslugs', $unicode);
 		}
 
 		$category      = array(
@@ -253,8 +253,9 @@ class PlgSampledataBlog extends JPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $alias) == ''))
 			{
-				JFactory::getConfig()->set('unicodeslugs', 1);
+				$unicode = JFactory::getConfig()->set('unicodeslugs', 1);
 				$article['alias'] = JApplicationHelper::stringURLSafe($article['title']);
+				JFactory::getConfig()->set('unicodeslugs', $unicode);
 			}
 
 			$article['language']        = $language;
@@ -291,8 +292,6 @@ class PlgSampledataBlog extends JPlugin
 		$response          = new stdClass;
 		$response->success = true;
 		$response->message = JText::_('PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS');
-
-		JFactory::getConfig()->set('unicodeslugs', $unicode);
 
 		return $response;
 	}
@@ -971,8 +970,6 @@ class PlgSampledataBlog extends JPlugin
 	 */
 	private function addMenuItems(array $menuItems, $level)
 	{
-		$unicode = JFactory::getConfig()->get('unicodeslugs', 1);
-
 		$itemIds = array();
 		$access  = (int) $this->app->get('access', 1);
 		$user    = JFactory::getUser();
@@ -994,8 +991,9 @@ class PlgSampledataBlog extends JPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $menuItem['alias']) == ''))
 			{
-				JFactory::getConfig()->set('unicodeslugs', 1);
+				$unicode = JFactory::getConfig()->set('unicodeslugs', 1);
 				$menuItem['alias'] = JApplicationHelper::stringURLSafe($menuItem['title']);
+				JFactory::getConfig()->set('unicodeslugs', $unicode);
 			}
 
 			// Append language suffix to title.
@@ -1059,8 +1057,6 @@ class PlgSampledataBlog extends JPlugin
 			// Get ID from menuitem we just added
 			$itemIds[] = $this->menuItemModel->getstate('item.id');
 		}
-
-		JFactory::getConfig()->set('unicodeslugs', $unicode);
 
 		return $itemIds;
 	}

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -226,7 +226,7 @@ class PlgSampledataBlog extends JPlugin
 			// Set values which are always the same.
 			$article['id']              = 0;
 			$article['created_user_id'] = $user->id;
-			$article['alias']           = $i . 'sample' . JApplicationHelper::stringURLSafe($article['title']);
+			$article['alias']           = JApplicationHelper::stringURLSafe($article['title'] . '-' . $i);
 			$article['language']        = $language;
 			$article['associations']    = array();
 			$article['state']           = 1;

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -305,7 +305,7 @@ class PlgSampledataBlog extends JPlugin
 			);
 
 			// Calculate menutype. The number of characters allowed is 24.
-			$type = JHtmlString::truncate($menu['title'], 23, true, false);
+			$type = JHtml::_('string.truncate', $menu['title'], 23, true, false);
 
 			$menu['menutype'] = $i . $type;
 

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -82,6 +82,8 @@ class PlgSampledataBlog extends JPlugin
 	 */
 	public function onAjaxSampledataApplyStep1()
 	{
+		$unicode = JFactory::getConfig()->get('unicodeslugs', 1);
+
 		if ($this->app->input->get('type') != $this->_name)
 		{
 			return;
@@ -289,6 +291,8 @@ class PlgSampledataBlog extends JPlugin
 		$response          = new stdClass;
 		$response->success = true;
 		$response->message = JText::_('PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS');
+
+		JFactory::getConfig()->set('unicodeslugs', $unicode);
 
 		return $response;
 	}
@@ -967,6 +971,8 @@ class PlgSampledataBlog extends JPlugin
 	 */
 	private function addMenuItems(array $menuItems, $level)
 	{
+		$unicode = JFactory::getConfig()->get('unicodeslugs', 1);
+
 		$itemIds = array();
 		$access  = (int) $this->app->get('access', 1);
 		$user    = JFactory::getUser();
@@ -1053,6 +1059,8 @@ class PlgSampledataBlog extends JPlugin
 			// Get ID from menuitem we just added
 			$itemIds[] = $this->menuItemModel->getstate('item.id');
 		}
+
+		JFactory::getConfig()->set('unicodeslugs', $unicode);
 
 		return $itemIds;
 	}

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -123,7 +123,7 @@ class PlgSampledataBlog extends JPlugin
 			'created_user_id' => $user->id,
 			'extension'       => 'com_content',
 			'level'           => 1,
-			'alias'           => JApplicationHelper::stringURLSafe($categoryTitle),
+			'alias'           => 'sample-blog' . $langSuffix,
 			'associations'    => array(),
 			'description'     => '',
 			'language'        => $language,
@@ -160,7 +160,7 @@ class PlgSampledataBlog extends JPlugin
 			'created_user_id' => $user->id,
 			'extension'       => 'com_content',
 			'level'           => 1,
-			'alias'           => JApplicationHelper::stringURLSafe($categoryTitle),
+			'alias'           => 'sample-help' . $langSuffix,
 			'associations'    => array(),
 			'description'     => '',
 			'language'        => $language,
@@ -226,7 +226,7 @@ class PlgSampledataBlog extends JPlugin
 			// Set values which are always the same.
 			$article['id']              = 0;
 			$article['created_user_id'] = $user->id;
-			$article['alias']           = JApplicationHelper::stringURLSafe($article['title']);
+			$article['alias']           = $i . 'sample' . JApplicationHelper::stringURLSafe($article['title']);
 			$article['language']        = $language;
 			$article['associations']    = array();
 			$article['state']           = 1;
@@ -304,8 +304,10 @@ class PlgSampledataBlog extends JPlugin
 				'description' => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_MENU_' . $i . '_DESCRIPTION'),
 			);
 
-			// Calculate menutype.
-			$menu['menutype'] = JApplicationHelper::stringURLSafe($menu['title']);
+			// Calculate menutype. The number of characters allowed is 24.
+			$type = JHtmlString::truncate($menu['title'], 23, true, false);
+
+			$menu['menutype'] = $i . $type;
 
 			$menuTable->load();
 			$menuTable->bind($menu);
@@ -349,6 +351,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_0_TITLE'),
 				'link'         => 'index.php?option=com_content&view=category&layout=blog&id=' . $catids[0],
 				'component_id' => 22,
+				'alias'        => 'blog' . $langSuffix,
 				'params'       => array(
 					'layout_type'             => 'blog',
 					'show_category_title'     => 0,
@@ -376,6 +379,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_1_TITLE'),
 				'link'         => 'index.php?option=com_content&view=article&id=' . $articleIds[0],
 				'component_id' => 22,
+				'alias'        => 'about' . $langSuffix,
 				'params'       => array(
 					'info_block_position' => 0,
 					'show_category'       => 0,
@@ -394,6 +398,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_2_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
+				'alias'        => 'login' . $langSuffix,
 				'params'       => array(
 					'logindescription_show'  => 1,
 					'logoutdescription_show' => 1,
@@ -407,10 +412,11 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_3_TITLE'),
 				'link'         => 'index.php?option=com_content&view=form&layout=edit',
 				'component_id' => 22,
+				'alias'        => 'post' . $langSuffix,
 				'access'       => 3,
 				'params'       => array(
 					'enable_category'   => 1,
-					'catid'             => 9,
+					'catid'             => $catids[0],
 					'menu_text'         => 1,
 					'show_page_heading' => 0,
 					'secure'            => 0,
@@ -421,6 +427,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_4_TITLE'),
 				'link'         => 'index.php?option=com_content&view=article&id=' . $articleIds[1],
 				'component_id' => 22,
+				'alias'        => 'working' . $langSuffix,
 				'params'       => array(
 					'menu_text'         => 1,
 					'show_page_heading' => 0,
@@ -433,6 +440,7 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'administrator',
 				'type'         => 'url',
 				'component_id' => 0,
+				'alias'        => 'siteadmin' . $langSuffix,
 				'browserNav'   => 1,
 				'access'       => 3,
 				'params'       => array(
@@ -444,6 +452,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_6_TITLE'),
 				'link'         => 'index.php?option=com_users&view=profile&layout=edit',
 				'component_id' => 25,
+				'alias'        => 'changepassword' . $langSuffix,
 				'access'       => 2,
 				'params'       => array(
 					'menu_text'         => 1,
@@ -456,6 +465,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_7_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
+				'alias'        => 'logout' . $langSuffix,
 				'params'       => array(
 					'logindescription_show'  => 1,
 					'logoutdescription_show' => 1,
@@ -486,6 +496,7 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_8_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
+				'alias'        => 'authorlogin' . $langSuffix,
 				'params'       => array(
 					'login_redirect_url'     => 'index.php?Itemid=' . $menuIdsLevel1[0],
 					'logindescription_show'  => 1,
@@ -518,6 +529,7 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'index.php?option=com_config&view=config&controller=config.display.config',
 				'parent_id'    => $menuIdsLevel1[4],
 				'component_id' => 23,
+				'alias'        => 'sitesettings' . $langSuffix,
 				'access'       => 6,
 				'params'       => array(
 					'menu_text'         => 1,
@@ -531,6 +543,7 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'index.php?option=com_config&view=templates&controller=config.display.templates',
 				'parent_id'    => $menuIdsLevel1[4],
 				'component_id' => 23,
+				'alias'        => 'templatesettings' . $langSuffix,
 				'params'       => array(
 					'menu_text'         => 1,
 					'show_page_heading' => 0,
@@ -594,6 +607,8 @@ class PlgSampledataBlog extends JPlugin
 
 		// Get previously entered Data from UserStates
 		$menuTypes = $this->app->getUserState('sampledata.blog.menutypes');
+
+		$catids = $this->app->getUserState('sampledata.blog.articles.catids');
 
 		$modules = array(
 			array(
@@ -674,7 +689,7 @@ class PlgSampledataBlog extends JPlugin
 				'position' => 'position-7',
 				'module'   => 'mod_articles_popular',
 				'params'   => array(
-					'catid'      => ['9'],
+					'catid'      => $catids[0],
 					'count'      => 5,
 					'show_front' => 1,
 					'layout'     => '_:default',
@@ -694,7 +709,7 @@ class PlgSampledataBlog extends JPlugin
 					'show_front'                   => 'show',
 					'count'                        => 6,
 					'category_filtering_type'      => 1,
-					'catid'                        => ['9'],
+					'catid'                        => $catids[0],
 					'show_child_category_articles' => 0,
 					'levels'                       => 1,
 					'author_filtering_type'        => 1,
@@ -954,7 +969,7 @@ class PlgSampledataBlog extends JPlugin
 			// Set values which are always the same.
 			$menuItem['id']              = 0;
 			$menuItem['created_user_id'] = $user->id;
-			$menuItem['alias']           = JApplicationHelper::stringURLSafe($menuItem['title']);
+			$menuItem['alias']           = JApplicationHelper::stringURLSafe($menuItem['alias']);
 			$menuItem['published']       = 1;
 			$menuItem['language']        = $language;
 			$menuItem['note']            = '';

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -113,9 +113,18 @@ class PlgSampledataBlog extends JPlugin
 		// Create "blog" category.
 		$categoryModel = JModelLegacy::getInstance('Category', 'CategoriesModel');
 		$catIds        = array();
-		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_0_TITLE') . $langSuffix;
+		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_0_TITLE');
+		$alias         = JApplicationHelper::stringURLSafe($categoryTitle);
+
+		// Set unicodeslugs if alias is empty
+		if (trim(str_replace('-', '', $alias) == ''))
+		{
+			JFactory::getConfig()->set('unicodeslugs', 1);
+			$alias = JApplicationHelper::stringURLSafe($categoryTitle);
+		}
+
 		$category      = array(
-			'title'           => $categoryTitle,
+			'title'           => $categoryTitle . $langSuffix,
 			'parent_id'       => 1,
 			'id'              => 0,
 			'published'       => 1,
@@ -123,7 +132,7 @@ class PlgSampledataBlog extends JPlugin
 			'created_user_id' => $user->id,
 			'extension'       => 'com_content',
 			'level'           => 1,
-			'alias'           => 'sample-blog' . $langSuffix,
+			'alias'           => $alias . $langSuffix,
 			'associations'    => array(),
 			'description'     => '',
 			'language'        => $language,
@@ -150,9 +159,18 @@ class PlgSampledataBlog extends JPlugin
 		$catIds[] = $categoryModel->getItem()->id;
 
 		// Create "help" category.
-		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_1_TITLE') . $langSuffix;
+		$categoryTitle = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_CATEGORY_1_TITLE');
+		$alias         = JApplicationHelper::stringURLSafe($categoryTitle);
+
+		// Set unicodeslugs if alias is empty
+		if (trim(str_replace('-', '', $alias) == ''))
+		{
+			JFactory::getConfig()->set('unicodeslugs', 1);
+			$alias = JApplicationHelper::stringURLSafe($categoryTitle);
+		}
+
 		$category      = array(
-			'title'           => $categoryTitle,
+			'title'           => $categoryTitle . $langSuffix,
 			'parent_id'       => 1,
 			'id'              => 0,
 			'published'       => 1,
@@ -160,7 +178,7 @@ class PlgSampledataBlog extends JPlugin
 			'created_user_id' => $user->id,
 			'extension'       => 'com_content',
 			'level'           => 1,
-			'alias'           => 'sample-help' . $langSuffix,
+			'alias'           => $alias . $langSuffix,
 			'associations'    => array(),
 			'description'     => '',
 			'language'        => $language,
@@ -219,14 +237,24 @@ class PlgSampledataBlog extends JPlugin
 		foreach ($articles as $i => $article)
 		{
 			// Set values from language strings.
-			$article['title']     = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_' . $i . '_TITLE') . $langSuffix;
+			$title                = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_' . $i . '_TITLE');
+			$alias                = JApplicationHelper::stringURLSafe($title);
+			$article['title']     = $title . $langSuffix;
 			$article['introtext'] = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_' . $i . '_INTROTEXT');
 			$article['fulltext']  = JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_' . $i . '_FULLTEXT');
 
 			// Set values which are always the same.
 			$article['id']              = 0;
 			$article['created_user_id'] = $user->id;
-			$article['alias']           = JApplicationHelper::stringURLSafe($article['title'] . '-' . $i);
+			$article['alias']           = JApplicationHelper::stringURLSafe($article['title']);
+
+			// Set unicodeslugs if alias is empty
+			if (trim(str_replace('-', '', $alias) == ''))
+			{
+				JFactory::getConfig()->set('unicodeslugs', 1);
+				$article['alias'] = JApplicationHelper::stringURLSafe($article['title']);
+			}
+
 			$article['language']        = $language;
 			$article['associations']    = array();
 			$article['state']           = 1;
@@ -305,7 +333,7 @@ class PlgSampledataBlog extends JPlugin
 			);
 
 			// Calculate menutype. The number of characters allowed is 24.
-			$type = JHtml::_('string.truncate', $menu['title'], 23, true, false);
+			$type = JHtmlString::truncate($menu['title'], 23, true, false);
 
 			$menu['menutype'] = $i . $type;
 
@@ -351,7 +379,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_0_TITLE'),
 				'link'         => 'index.php?option=com_content&view=category&layout=blog&id=' . $catids[0],
 				'component_id' => 22,
-				'alias'        => 'blog' . $langSuffix,
 				'params'       => array(
 					'layout_type'             => 'blog',
 					'show_category_title'     => 0,
@@ -379,7 +406,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_1_TITLE'),
 				'link'         => 'index.php?option=com_content&view=article&id=' . $articleIds[0],
 				'component_id' => 22,
-				'alias'        => 'about' . $langSuffix,
 				'params'       => array(
 					'info_block_position' => 0,
 					'show_category'       => 0,
@@ -398,7 +424,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_2_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
-				'alias'        => 'login' . $langSuffix,
 				'params'       => array(
 					'logindescription_show'  => 1,
 					'logoutdescription_show' => 1,
@@ -412,7 +437,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_3_TITLE'),
 				'link'         => 'index.php?option=com_content&view=form&layout=edit',
 				'component_id' => 22,
-				'alias'        => 'post' . $langSuffix,
 				'access'       => 3,
 				'params'       => array(
 					'enable_category'   => 1,
@@ -427,7 +451,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_4_TITLE'),
 				'link'         => 'index.php?option=com_content&view=article&id=' . $articleIds[1],
 				'component_id' => 22,
-				'alias'        => 'working' . $langSuffix,
 				'params'       => array(
 					'menu_text'         => 1,
 					'show_page_heading' => 0,
@@ -440,7 +463,6 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'administrator',
 				'type'         => 'url',
 				'component_id' => 0,
-				'alias'        => 'siteadmin' . $langSuffix,
 				'browserNav'   => 1,
 				'access'       => 3,
 				'params'       => array(
@@ -452,7 +474,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_6_TITLE'),
 				'link'         => 'index.php?option=com_users&view=profile&layout=edit',
 				'component_id' => 25,
-				'alias'        => 'changepassword' . $langSuffix,
 				'access'       => 2,
 				'params'       => array(
 					'menu_text'         => 1,
@@ -465,7 +486,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_7_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
-				'alias'        => 'logout' . $langSuffix,
 				'params'       => array(
 					'logindescription_show'  => 1,
 					'logoutdescription_show' => 1,
@@ -496,7 +516,6 @@ class PlgSampledataBlog extends JPlugin
 				'title'        => JText::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_ITEM_8_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
 				'component_id' => 25,
-				'alias'        => 'authorlogin' . $langSuffix,
 				'params'       => array(
 					'login_redirect_url'     => 'index.php?Itemid=' . $menuIdsLevel1[0],
 					'logindescription_show'  => 1,
@@ -529,7 +548,6 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'index.php?option=com_config&view=config&controller=config.display.config',
 				'parent_id'    => $menuIdsLevel1[4],
 				'component_id' => 23,
-				'alias'        => 'sitesettings' . $langSuffix,
 				'access'       => 6,
 				'params'       => array(
 					'menu_text'         => 1,
@@ -543,7 +561,6 @@ class PlgSampledataBlog extends JPlugin
 				'link'         => 'index.php?option=com_config&view=templates&controller=config.display.templates',
 				'parent_id'    => $menuIdsLevel1[4],
 				'component_id' => 23,
-				'alias'        => 'templatesettings' . $langSuffix,
 				'params'       => array(
 					'menu_text'         => 1,
 					'show_page_heading' => 0,
@@ -963,13 +980,21 @@ class PlgSampledataBlog extends JPlugin
 			// Reset item.id in model state.
 			$this->menuItemModel->setState('item.id', 0);
 
-			// Append language suffix to title.
-			$menuItem['title'] .= $langSuffix;
-
 			// Set values which are always the same.
 			$menuItem['id']              = 0;
 			$menuItem['created_user_id'] = $user->id;
-			$menuItem['alias']           = JApplicationHelper::stringURLSafe($menuItem['alias']);
+			$menuItem['alias']           = JApplicationHelper::stringURLSafe($menuItem['title']);
+
+			// Set unicodeslugs if alias is empty
+			if (trim(str_replace('-', '', $menuItem['alias']) == ''))
+			{
+				JFactory::getConfig()->set('unicodeslugs', 1);
+				$menuItem['alias'] = JApplicationHelper::stringURLSafe($menuItem['title']);
+			}
+
+			// Append language suffix to title.
+			$menuItem['title'] .= $langSuffix;
+
 			$menuItem['published']       = 1;
 			$menuItem['language']        = $language;
 			$menuItem['note']            = '';

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -333,7 +333,7 @@ class PlgSampledataBlog extends JPlugin
 			);
 
 			// Calculate menutype. The number of characters allowed is 24.
-			$type = JHtmlString::truncate($menu['title'], 23, true, false);
+			$type = JHtml::_('string.truncate', $menu['title'], 23, true, false);
 
 			$menu['menutype'] = $i . $type;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/17917

Thanks @imanickam  for your findings

### Issues
The sample data blog can't work with languages using non latin glyphs because aliases are set to  the same time stamp for all aliases and menutype is empty in that case.
This is due to the use of `JApplicationHelper::stringURLSafe()`

The `menutype` can use non latin glyphs but can't work for some languages because it should be limited to 24 characters in the db and it is defined in the existing code using the title which may be longer in the ini file.

The `catid` is hard coded as `['9']` although it should use the correct catid depending on the sample data blog installed.
This is specially true when installing multiple sample data blogs in a multingual site (after switching admin language).

### Changes in this PR
Truncating menutypes and not using `JApplicationHelper::stringURLSafe()` as it is not anyway necessary there. Adding numbering.

Hardcoding categories aliases to cope with the time stamp.

Hardcoding aliases for menu items to cope with the time stamp.

Adding numbering and default `sample` to articles aliases to make sure each alias is different including with non latin glyphs titles.

### Testing instructions.
This should be tested on a monolanguage site as well as on a multilingual site.

**Monolanguage site:**
Install the Tamil language pack on a clean installation of staging with no sample data.
[ta-IN_joomla_lang_full_3.8.0v1.zip](https://github.com/joomla/joomla-cms/files/1291736/ta-IN_joomla_lang_full_3.8.0v1.zip)
Switch to Tamil and in the Control panel, install the sample data blog

Reinstall a clean site in the same conditions and check all is OK too with this French pack
[fr-FR_joomla_lang_full_3.8.0v1.zip](https://github.com/joomla/joomla-cms/files/1291741/fr-FR_joomla_lang_full_3.8.0v1.zip)

**Multilingual site:**
Install a clean staging as multilingual. At time of installation, install both 3.7.5 Tamil and French language packs. Set Multilang to yes with content.

In admin, install the 2 packs above to update Tamil and French to 3.8.0.1
Switch languages in back-end and each time, install sample data for these languages (English too if desired).

Verify that both Oldest Posts modules and Mostly Read Posts are correctly set to use the Blog category in their languages.

Load frontend and switch languages. Check that all is fine.
We will now have a correctly functionning sample data blog.

IMHO this should go into 3.8.0

@imanickam 
@Bakual 
@mbabker 

