### PR TITLE
Fixing so that editors-xtd plugins works with com_ajax

### DIFF
--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -257,7 +257,7 @@ abstract class PluginHelper
 
 				if ($autocreate)
 				{
-					$className = 'Plg' . $plugin->type . $plugin->name;
+					$className = 'Plg' . str_replace( '-', '', $plugin->type ) . $plugin->name;
 
 					if (class_exists($className))
 					{

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -257,7 +257,7 @@ abstract class PluginHelper
 
 				if ($autocreate)
 				{
-					$className = 'Plg' . str_replace( '-', '', $plugin->type ) . $plugin->name;
+					$className = 'Plg' . str_replace('-', '', $plugin->type) . $plugin->name;
 
 					if (class_exists($className))
 					{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Because php does not support class names with a - character editors-xtd can't use com_ajax, all I did was to remove the - from the class name.


### Testing Instructions
I made a simple editor-xtd plugin to test it with https://gist.github.com/johansundell/eb505037336a6c6965283f502dac4558



### Expected result



### Actual result



### Documentation Changes Required

