### PR TITLE
[4.0] Plugin factory

### DIFF
--- a/installation/application/app.php
+++ b/installation/application/app.php
@@ -45,6 +45,7 @@ JFactory::$container = (new \Joomla\DI\Container)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Form)
+	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Plugin)
 	->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database);
 
 // Instantiate and execute the application

--- a/libraries/src/Authentication/AuthenticationPluginInterface.php
+++ b/libraries/src/Authentication/AuthenticationPluginInterface.php
@@ -23,7 +23,7 @@ interface AuthenticationPluginInterface
 	 *
 	 * @param   array                   $credentials  Array holding the user credentials
 	 * @param   array                   $options      Array of extra options
-	 * @param   AuthenticationResponse  $response    Authentication response object
+	 * @param   AuthenticationResponse  $response     Authentication response object
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Authentication/AuthenticationPluginInterface.php
+++ b/libraries/src/Authentication/AuthenticationPluginInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package     Joomla.Libraries
+ * @subpackage  Dispatcher
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Authentication;
+
+defined('_JEXEC') or die;
+
+/**
+ * Interface for authentication plugins
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface AuthenticationPluginInterface
+{
+	/**
+	 * This method should handle any authentication and report back to the subject
+	 *
+	 * @param   array                   $credentials  Array holding the user credentials
+	 * @param   array                   $options      Array of extra options
+	 * @param   AuthenticationResponse  $response    Authentication response object
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onUserAuthenticate(array $credentials, array $options, AuthenticationResponse $response);
+}

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -517,6 +517,7 @@ abstract class Factory
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Database)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Dispatcher)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Form)
+			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Plugin)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Document)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Menu)
 			->registerServiceProvider(new \Joomla\CMS\Service\Provider\Session)

--- a/libraries/src/Plugin/CMSEventPlugin.php
+++ b/libraries/src/Plugin/CMSEventPlugin.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Plugin;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\Event\AbstractEvent;
+use Joomla\Event\Dispatcher;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\Priority;
+use Joomla\Event\SubscriberInterface;
+
+/**
+ * Plugin Class
+ *
+ * @since  1.5
+ */
+abstract class CMSEventPlugin extends CMSPlugin implements DispatcherAwareInterface
+{
+	use DispatcherAwareTrait;
+
+	/**
+	 * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
+	 * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
+	 * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
+	 * parameter, for best performance. Also bear in mind that Joomla! 5.x onwards will only allow proper listeners,
+	 * removing support for legacy Listeners.
+	 *
+	 * @var    boolean
+	 * @since  4.0
+	 *
+	 * @deprecated
+	 */
+	protected $allowLegacyListeners = true;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   DispatcherInterface  &$subject  The object to observe
+	 * @param   array                $config    An optional associative array of configuration settings.
+	 *                                          Recognized key values include 'name', 'group', 'params', 'language'
+	 *                                         (this list is not meant to be comprehensive).
+	 *
+	 * @since   1.5
+	 */
+	public function __construct(&$subject, $config = array())
+	{
+		parent::__construct($config);
+
+		// Set the dispatcher we are to register our listeners with
+		$this->setDispatcher($subject);
+
+		// Register the event listeners with the dispatcher. Override the registerListeners method to customise.
+		$this->registerListeners();
+	}
+
+	/**
+	 * Registers legacy Listeners to the Dispatcher, emulating how plugins worked under Joomla! 3.x and below.
+	 *
+	 * By default, this method will look for all public methods whose name starts with "on". It will register
+	 * lambda functions (closures) which try to unwrap the arguments of the dispatched Event into method call
+	 * arguments and call your on<Something> method. The result will be passed back to the Event into its 'result'
+	 * argument.
+	 *
+	 * This method additionally supports Joomla\Event\SubscriberInterface and plugins implementing this will be
+	 * registered to the dispatcher as a subscriber.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	protected function registerListeners()
+	{
+		// Plugins which are SubscriberInterface implementations are handled without legacy layer support
+		if ($this instanceof SubscriberInterface)
+		{
+			// The addSubscriber method isn't part of the DispatcherInterface, emulate it if need be
+			if ($this->getDispatcher() instanceof Dispatcher)
+			{
+				$this->getDispatcher()->addSubscriber($this);
+			}
+			else
+			{
+				foreach ($this->getSubscribedEvents() as $eventName => $params)
+				{
+					if (is_array($params))
+					{
+						$this->getDispatcher()->addListener($eventName, [$this, $params[0]], isset($params[1]) ? $params[1] : Priority::NORMAL);
+					}
+					else
+					{
+						$this->getDispatcher()->addListener($eventName, [$this, $params]);
+					}
+				}
+			}
+
+			return;
+		}
+
+		$reflectedObject = new \ReflectionObject($this);
+		$methods = $reflectedObject->getMethods(\ReflectionMethod::IS_PUBLIC);
+
+		/** @var \ReflectionMethod $method */
+		foreach ($methods as $method)
+		{
+			if (substr($method->name, 0, 2) != 'on')
+			{
+				continue;
+			}
+
+			// Save time if I'm not to detect legacy listeners
+			if (!$this->allowLegacyListeners)
+			{
+				$this->registerListener($method->name);
+
+				continue;
+			}
+
+			/** @var \ReflectionParameter[] $parameters */
+			$parameters = $method->getParameters();
+
+			// If the parameter count is not 1 it is by definition a legacy listener
+			if (count($parameters) != 1)
+			{
+				$this->registerLegacyListener($method->name);
+
+				continue;
+			}
+
+			/** @var \ReflectionParameter $param */
+			$param = array_shift($parameters);
+			$typeHint = $param->getClass();
+			$paramName = $param->getName();
+
+			// No type hint / type hint class not an event and parameter name is not "event"? It's a legacy listener.
+			if ((empty($typeHint) || !$typeHint->implementsInterface('Joomla\\Event\\EventInterface')) && ($paramName != 'event'))
+			{
+				$this->registerLegacyListener($method->name);
+
+				continue;
+			}
+
+			// Everything checks out, this is a proper listener.
+			$this->registerListener($method->name);
+		}
+	}
+
+	/**
+	 * Registers a legacy event listener, i.e. a method which accepts individual arguments instead of an AbstractEvent
+	 * in its arguments. This provides backwards compatibility to Joomla! 3.x-style plugins.
+	 *
+	 * This method will register lambda functions (closures) which try to unwrap the arguments of the dispatched Event
+	 * into old style method arguments and call your on<Something> method with them. The result will be passed back to
+	 * the Event, as an element into an array argument called 'result'.
+	 *
+	 * @param   string  $methodName  The method name to register
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	protected final function registerLegacyListener($methodName)
+	{
+		$this->getDispatcher()->addListener(
+			$methodName,
+			function (AbstractEvent $event) use ($methodName)
+			{
+				// Get the event arguments
+				$arguments = $event->getArguments();
+
+				// Extract any old results; they must not be part of the method call.
+				$allResults = [];
+
+				if (isset($arguments['result']))
+				{
+					$allResults = $arguments['result'];
+
+					unset($arguments['result']);
+				}
+
+				// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
+				$arguments = array_values($arguments);
+
+				$result = $this->{$methodName}(...$arguments);
+
+				// Restore the old results and add the new result from our method call
+				array_push($allResults, $result);
+				$event['result'] = $allResults;
+			}
+		);
+	}
+
+	/**
+	 * Registers a proper event listener, i.e. a method which accepts an AbstractEvent as its sole argument. This is the
+	 * preferred way to implement plugins in Joomla! 4.x and will be the only possible method with Joomla! 5.x onwards.
+	 *
+	 * @param   string  $methodName  The method name to register
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	final protected function registerListener($methodName)
+	{
+		$this->getDispatcher()->addListener($methodName, [$this, $methodName]);
+	}
+}

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -11,13 +11,6 @@ namespace Joomla\CMS\Plugin;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Factory as JFactory;
-use Joomla\Event\AbstractEvent;
-use Joomla\Event\Dispatcher;
-use Joomla\Event\DispatcherInterface;
-use Joomla\Event\DispatcherAwareInterface;
-use Joomla\Event\DispatcherAwareTrait;
-use Joomla\Event\Priority;
-use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
 
 /**
@@ -25,10 +18,8 @@ use Joomla\Registry\Registry;
  *
  * @since  1.5
  */
-abstract class CMSPlugin implements DispatcherAwareInterface
+abstract class CMSPlugin
 {
-	use DispatcherAwareTrait;
-
 	/**
 	 * A Registry object holding the parameters for the plugin
 	 *
@@ -61,31 +52,17 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 	 */
 	protected $autoloadLanguage = false;
 
-	/**
-	 * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-	 * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-	 * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-	 * parameter, for best performance. Also bear in mind that Joomla! 5.x onwards will only allow proper listeners,
-	 * removing support for legacy Listeners.
-	 *
-	 * @var    boolean
-	 * @since  4.0
-	 *
-	 * @deprecated
-	 */
-	protected $allowLegacyListeners = true;
 
 	/**
 	 * Constructor
 	 *
-	 * @param   DispatcherInterface  &$subject  The object to observe
 	 * @param   array                $config    An optional associative array of configuration settings.
 	 *                                          Recognized key values include 'name', 'group', 'params', 'language'
 	 *                                         (this list is not meant to be comprehensive).
 	 *
 	 * @since   1.5
 	 */
-	public function __construct(&$subject, $config = array())
+	public function __construct($config = array())
 	{
 		// Get the parameters.
 		if (isset($config['params']))
@@ -139,12 +116,6 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 				$this->db = JFactory::getDbo();
 			}
 		}
-
-		// Set the dispatcher we are to register our listeners with
-		$this->setDispatcher($subject);
-
-		// Register the event listeners with the dispatcher. Override the registerListeners method to customise.
-		$this->registerListeners();
 	}
 
 	/**
@@ -175,156 +146,5 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 
 		return $lang->load($extension, $basePath, null, false, true)
 			|| $lang->load($extension, JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name, null, false, true);
-	}
-
-	/**
-	 * Registers legacy Listeners to the Dispatcher, emulating how plugins worked under Joomla! 3.x and below.
-	 *
-	 * By default, this method will look for all public methods whose name starts with "on". It will register
-	 * lambda functions (closures) which try to unwrap the arguments of the dispatched Event into method call
-	 * arguments and call your on<Something> method. The result will be passed back to the Event into its 'result'
-	 * argument.
-	 *
-	 * This method additionally supports Joomla\Event\SubscriberInterface and plugins implementing this will be
-	 * registered to the dispatcher as a subscriber.
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0
-	 */
-	protected function registerListeners()
-	{
-		// Plugins which are SubscriberInterface implementations are handled without legacy layer support
-		if ($this instanceof SubscriberInterface)
-		{
-			// The addSubscriber method isn't part of the DispatcherInterface, emulate it if need be
-			if ($this->getDispatcher() instanceof Dispatcher)
-			{
-				$this->getDispatcher()->addSubscriber($this);
-			}
-			else
-			{
-				foreach ($this->getSubscribedEvents() as $eventName => $params)
-				{
-					if (is_array($params))
-					{
-						$this->getDispatcher()->addListener($eventName, [$this, $params[0]], isset($params[1]) ? $params[1] : Priority::NORMAL);
-					}
-					else
-					{
-						$this->getDispatcher()->addListener($eventName, [$this, $params]);
-					}
-				}
-			}
-
-			return;
-		}
-
-		$reflectedObject = new \ReflectionObject($this);
-		$methods = $reflectedObject->getMethods(\ReflectionMethod::IS_PUBLIC);
-
-		/** @var \ReflectionMethod $method */
-		foreach ($methods as $method)
-		{
-			if (substr($method->name, 0, 2) != 'on')
-			{
-				continue;
-			}
-
-			// Save time if I'm not to detect legacy listeners
-			if (!$this->allowLegacyListeners)
-			{
-				$this->registerListener($method->name);
-
-				continue;
-			}
-
-			/** @var \ReflectionParameter[] $parameters */
-			$parameters = $method->getParameters();
-
-			// If the parameter count is not 1 it is by definition a legacy listener
-			if (count($parameters) != 1)
-			{
-				$this->registerLegacyListener($method->name);
-
-				continue;
-			}
-
-			/** @var \ReflectionParameter $param */
-			$param = array_shift($parameters);
-			$typeHint = $param->getClass();
-			$paramName = $param->getName();
-
-			// No type hint / type hint class not an event and parameter name is not "event"? It's a legacy listener.
-			if ((empty($typeHint) || !$typeHint->implementsInterface('Joomla\\Event\\EventInterface')) && ($paramName != 'event'))
-			{
-				$this->registerLegacyListener($method->name);
-
-				continue;
-			}
-
-			// Everything checks out, this is a proper listener.
-			$this->registerListener($method->name);
-		}
-	}
-
-	/**
-	 * Registers a legacy event listener, i.e. a method which accepts individual arguments instead of an AbstractEvent
-	 * in its arguments. This provides backwards compatibility to Joomla! 3.x-style plugins.
-	 *
-	 * This method will register lambda functions (closures) which try to unwrap the arguments of the dispatched Event
-	 * into old style method arguments and call your on<Something> method with them. The result will be passed back to
-	 * the Event, as an element into an array argument called 'result'.
-	 *
-	 * @param   string  $methodName  The method name to register
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0
-	 */
-	protected final function registerLegacyListener($methodName)
-	{
-		$this->getDispatcher()->addListener(
-			$methodName,
-			function (AbstractEvent $event) use ($methodName)
-			{
-				// Get the event arguments
-				$arguments = $event->getArguments();
-
-				// Extract any old results; they must not be part of the method call.
-				$allResults = [];
-
-				if (isset($arguments['result']))
-				{
-					$allResults = $arguments['result'];
-
-					unset($arguments['result']);
-				}
-
-				// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
-				$arguments = array_values($arguments);
-
-				$result = $this->{$methodName}(...$arguments);
-
-				// Restore the old results and add the new result from our method call
-				array_push($allResults, $result);
-				$event['result'] = $allResults;
-			}
-		);
-	}
-
-	/**
-	 * Registers a proper event listener, i.e. a method which accepts an AbstractEvent as its sole argument. This is the
-	 * preferred way to implement plugins in Joomla! 4.x and will be the only possible method with Joomla! 5.x onwards.
-	 *
-	 * @param   string  $methodName  The method name to register
-	 *
-	 * @return  void
-	 *
-	 * @since   4.0
-	 */
-	final protected function registerListener($methodName)
-	{
-		$this->getDispatcher()->addListener($methodName, [$this, $methodName]);
 	}
 }

--- a/libraries/src/Plugin/CMSServicePlugin.php
+++ b/libraries/src/Plugin/CMSServicePlugin.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Plugin;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Plugin Class
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+abstract class CMSServicePlugin
+{
+}

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -74,6 +74,7 @@ class PluginFactory implements PluginFactoryInterface
 		$plugins = [];
 
 		// Loop over the available plugins
+		// @Todo remove dependency to PluginHelper
 		foreach (PluginHelper::getPlugin($type) as $plugin)
 		{
 			$plugins[] = $this->getPlugin($plugin->name, $plugin->type);
@@ -133,6 +134,7 @@ class PluginFactory implements PluginFactoryInterface
 		}
 
 		// Get the plugin object
+		// @Todo remove dependency to PluginHelper
 		$plugin = PluginHelper::getPlugin($type, $name);
 
 		// Instantiate and register the plugin.

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -19,9 +19,29 @@ use Joomla\Event\DispatcherInterface;
  */
 class PluginFactory implements PluginFactoryInterface
 {
+	/**
+	 * Event Dispatcher
+	 *
+	 * @var    DispatcherInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
 	private $dispatcher = null;
+
+	/**
+	 * The loaded plugins.
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
 	private $loadedPlugins = array();
 
+	/**
+	 * Constructor
+	 *
+	 * @param   DispatcherInterface  $dispatcher  The dispatcher
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
 	public function __construct(DispatcherInterface $dispatcher)
 	{
 		$this->dispatcher = $dispatcher;
@@ -42,16 +62,20 @@ class PluginFactory implements PluginFactoryInterface
 	 */
 	public function getPlugin($name, $type)
 	{
+		// Cleanup the parameters
 		$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 		$name = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
 
+		// The path of the plugins
 		$path = JPATH_PLUGINS . '/' . $type . '/' . $name . '/' . $name . '.php';
 
+		// Check if the plugin is already loaded
 		if (isset($this->loadedPlugins[$path]))
 		{
 			return $this->loadedPlugins[$path];
 		}
 
+		// Check if the path exists
 		if (!file_exists($path))
 		{
 			$this->loadedPlugins[$path] = false;
@@ -59,10 +83,13 @@ class PluginFactory implements PluginFactoryInterface
 			return false;
 		}
 
+		// Include the plugin
 		require_once $path;
 
+		// Compile the class name
 		$className = 'Plg' . str_replace('-', '', $type) . $name;
 
+		// Check if the class exists
 		if (!class_exists($className))
 		{
 			$this->loadedPlugins[$path] = false;
@@ -70,7 +97,7 @@ class PluginFactory implements PluginFactoryInterface
 			return false;
 		}
 
-
+		// Get the plugin object
 		$plugin = PluginHelper::getPlugin($type, $name);
 
 		// Instantiate and register the plugin.

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -28,6 +28,14 @@ class PluginFactory implements PluginFactoryInterface
 	private $dispatcher = null;
 
 	/**
+	 * Root folder of the plugins
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $rootFolder = null;
+
+	/**
 	 * The loaded plugins.
 	 *
 	 * @var    array
@@ -38,12 +46,14 @@ class PluginFactory implements PluginFactoryInterface
 	/**
 	 * Constructor
 	 *
+	 * @param   string               $rootFolder  The root folder to look for plugins
 	 * @param   DispatcherInterface  $dispatcher  The dispatcher
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(DispatcherInterface $dispatcher)
+	public function __construct($rootFolder, DispatcherInterface $dispatcher)
 	{
+		$this->rootFolder = $rootFolder;
 		$this->dispatcher = $dispatcher;
 	}
 
@@ -67,7 +77,7 @@ class PluginFactory implements PluginFactoryInterface
 		$name = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
 
 		// The path of the plugins
-		$path = JPATH_PLUGINS . '/' . $type . '/' . $name . '/' . $name . '.php';
+		$path = $this->rootFolder . '/' . $type . '/' . $name . '/' . $name . '.php';
 
 		// Check if the plugin is already loaded
 		if (isset($this->loadedPlugins[$path]))

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -58,13 +58,38 @@ class PluginFactory implements PluginFactoryInterface
 	}
 
 	/**
+	 * Method to get an array of instances of a plugin type.
+	 *
+	 * The plugins are cached, means a second call with the same
+	 * parameters, returns the same plugin object as on the first call.
+	 *
+	 * @param   string  $type  The name of the type
+	 *
+	 * @return  CMSPlugin[]  Plugin instances
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPlugins($type)
+	{
+		$plugins = [];
+
+		// Loop over the available plugins
+		foreach (PluginHelper::getPlugin($type) as $plugin)
+		{
+			$plugins[] = $this->getPlugin($plugin->name, $plugin->type);
+		}
+
+		return $plugins;
+	}
+
+	/**
 	 * Method to get an instance of a plugin.
 	 *
 	 * The plugins are cached, means a second call with the same
 	 * parameters, returns the same plugin object as on the first call.
 	 *
 	 * @param   string  $name  The name of the plugin
-	 * @param   string  $type  The name of the type
+	 * @param   string  $type  The type of th plugin
 	 *
 	 * @return  CMSPlugin  Plugin instance.
 	 *

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Plugin;
+
+defined('_JEXEC') or die;
+
+use Joomla\Event\DispatcherInterface;
+
+/**
+ * Default factory for creating Plugin objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class PluginFactory implements PluginFactoryInterface
+{
+	private $dispatcher = null;
+	private $loadedPlugins = array();
+
+	public function __construct(DispatcherInterface $dispatcher)
+	{
+		$this->dispatcher = $dispatcher;
+	}
+
+	/**
+	 * Method to get an instance of a plugin.
+	 *
+	 * The plugins are cached, means a second call with the same
+	 * parameters, returns the same plugin object as on the first call.
+	 *
+	 * @param   string  $name  The name of the plugin
+	 * @param   string  $type  The name of the type
+	 *
+	 * @return  CMSPlugin  Plugin instance.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPlugin($name, $type)
+	{
+		$type = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
+		$name = preg_replace('/[^A-Z0-9_\.-]/i', '', $name);
+
+		$path = JPATH_PLUGINS . '/' . $type . '/' . $name . '/' . $name . '.php';
+
+		if (isset($this->loadedPlugins[$path]))
+		{
+			return $this->loadedPlugins[$path];
+		}
+
+		if (!file_exists($path))
+		{
+			$this->loadedPlugins[$path] = false;
+
+			return false;
+		}
+
+		require_once $path;
+
+		$className = 'Plg' . str_replace('-', '', $type) . $name;
+
+		if (!class_exists($className))
+		{
+			$this->loadedPlugins[$path] = false;
+
+			return false;
+		}
+
+
+		$plugin = PluginHelper::getPlugin($type, $name);
+
+		// Instantiate and register the plugin.
+		$this->loadedPlugins[$path] = new $className($this->dispatcher, (array) $plugin);
+
+		return $this->loadedPlugins[$path];
+	}
+}

--- a/libraries/src/Plugin/PluginFactory.php
+++ b/libraries/src/Plugin/PluginFactory.php
@@ -137,8 +137,19 @@ class PluginFactory implements PluginFactoryInterface
 		// @Todo remove dependency to PluginHelper
 		$plugin = PluginHelper::getPlugin($type, $name);
 
-		// Instantiate and register the plugin.
-		$this->loadedPlugins[$path] = new $className($this->dispatcher, (array) $plugin);
+		$instance = null;
+
+		if(is_subclass_of($className, CMSEventPlugin::class))
+		{
+			$instance = new $className($this->dispatcher, (array) $plugin);
+		}
+		else
+		{
+			$instance = new $className((array) $plugin);
+		}
+
+		// Register the plugin.
+		$this->loadedPlugins[$path] = $instance;
 
 		return $this->loadedPlugins[$path];
 	}

--- a/libraries/src/Plugin/PluginFactoryInterface.php
+++ b/libraries/src/Plugin/PluginFactoryInterface.php
@@ -18,17 +18,31 @@ defined('_JEXEC') or die;
 interface PluginFactoryInterface
 {
 	/**
+	 * Method to get an array of instances of a plugin type.
+	 *
+	 * The plugins are cached, means a second call with the same
+	 * parameters, returns the same plugin object as on the first call.
+	 *
+	 * @param   string  $type  The name of the type
+	 *
+	 * @return  CMSPlugin[]  Plugin instances
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPlugins($type);
+
+	/**
 	 * Method to get an instance of a plugin.
 	 *
 	 * The plugins are cached, means a second call with the same
 	 * parameters, returns the same plugin object as on the first call.
 	 *
-	 * @param   string  $name   The name of the plugin
-	 * @param   string  $group  The name of the group
+	 * @param   string  $name  The name of the plugin
+	 * @param   string  $type  The type of th plugin
 	 *
 	 * @return  CMSPlugin  Plugin instance.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getPlugin($name, $group);
+	public function getPlugin($name, $type);
 }

--- a/libraries/src/Plugin/PluginFactoryInterface.php
+++ b/libraries/src/Plugin/PluginFactoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Plugin;
+
+defined('_JEXEC') or die;
+
+/**
+ * Interface defining a factory which can create Plugin objects
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface PluginFactoryInterface
+{
+	/**
+	 * Method to get an instance of a plugin.
+	 *
+	 * The plugins are cached, means a second call with the same
+	 * parameters, returns the same plugin object as on the first call.
+	 *
+	 * @param   string  $name   The name of the plugin
+	 * @param   string  $group  The name of the group
+	 *
+	 * @return  CMSPlugin  Plugin instance.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getPlugin($name, $group);
+}

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Plugin;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\Event\DispatcherInterface;
 
 /**
@@ -242,20 +243,8 @@ abstract class PluginHelper
 
 				if ($autocreate)
 				{
-					$className = 'Plg' . str_replace('-', '', $plugin->type) . $plugin->name;
-
-					if (class_exists($className))
-					{
-						// Load the plugin from the database.
-						if (!isset($plugin->params))
-						{
-							// Seems like this could just go bye bye completely
-							$plugin = static::getPlugin($plugin->type, $plugin->name);
-						}
-
-						// Instantiate and register the plugin.
-						new $className($dispatcher, (array) $plugin);
-					}
+					$factory = Factory::getContainer()->get(PluginFactoryInterface::class);
+					$factory->getPlugin($plugin->name, $plugin->type);
 				}
 			}
 			else

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -146,6 +146,7 @@ abstract class PluginHelper
 	 * @return  boolean  True on success.
 	 *
 	 * @since   1.5
+	 * @deprecated  5.0  Use the PluginFactoryInterface::getPlugin() or PluginFactoryInterface::getPlugins() instead
 	 */
 	public static function importPlugin($type, $plugin = null, $autocreate = true, DispatcherInterface $dispatcher = null)
 	{
@@ -209,6 +210,7 @@ abstract class PluginHelper
 	 * @return  void
 	 *
 	 * @since   3.2
+	 * @deprecated  5.0  Use the PluginFactoryInterface::getPlugin() or PluginFactoryInterface::getPlugins() instead
 	 */
 	protected static function import($plugin, $autocreate = true, DispatcherInterface $dispatcher = null)
 	{

--- a/libraries/src/Service/Provider/Plugin.php
+++ b/libraries/src/Service/Provider/Plugin.php
@@ -39,7 +39,7 @@ class Plugin implements ServiceProviderInterface
 				PluginFactoryInterface::class,
 				function (Container $container)
 				{
-					return new PluginFactory($container->get(DispatcherInterface::class));
+					return new PluginFactory(JPATH_PLUGINS, $container->get(DispatcherInterface::class));
 				},
 				true
 			);

--- a/libraries/src/Service/Provider/Plugin.php
+++ b/libraries/src/Service/Provider/Plugin.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Service\Provider;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Plugin\PluginFactory;
+use Joomla\CMS\Plugin\PluginFactoryInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+
+/**
+ * Service provider for the form dependency
+ *
+ * @since  4.0
+ */
+class Plugin implements ServiceProviderInterface
+{
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
+	 */
+	public function register(Container $container)
+	{
+		$container->alias('plugin.factory', PluginFactoryInterface::class)
+			->share(
+				PluginFactoryInterface::class,
+				function (Container $container)
+				{
+					return new PluginFactory($container->get(DispatcherInterface::class));
+				},
+				true
+			);
+	}
+}

--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -9,6 +9,9 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Authentication\AuthenticationPluginInterface;
+use Joomla\CMS\Authentication\AuthenticationResponse;
+
 /**
  * Joomla Authentication plugin
  *
@@ -16,7 +19,7 @@ defined('_JEXEC') or die;
  * @note   Code based on http://jaspan.com/improved_persistent_login_cookie_best_practice
  *         and http://fishbowl.pastiche.org/2004/01/19/persistent_login_cookie_best_practice/
  */
-class PlgAuthenticationCookie extends JPlugin
+class PlgAuthenticationCookie extends JPlugin implements AuthenticationPluginInterface
 {
 	/**
 	 * Application object
@@ -37,20 +40,20 @@ class PlgAuthenticationCookie extends JPlugin
 	/**
 	 * This method should handle any authentication and report back to the subject
 	 *
-	 * @param   array   $credentials  Array holding the user credentials
-	 * @param   array   $options      Array of extra options
-	 * @param   object  &$response    Authentication response object
+	 * @param   array                   $credentials  Array holding the user credentials
+	 * @param   array                   $options      Array of extra options
+	 * @param   AuthenticationResponse  $response    Authentication response object
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */
-	public function onUserAuthenticate($credentials, $options, &$response)
+	public function onUserAuthenticate(array $credentials, array $options, AuthenticationResponse $response)
 	{
 		// No remember me for admin
 		if ($this->app->isClient('administrator'))
 		{
-			return false;
+			return;
 		}
 
 		// Get cookie
@@ -66,7 +69,7 @@ class PlgAuthenticationCookie extends JPlugin
 
 		if (!$cookieValue)
 		{
-			return false;
+			return;
 		}
 
 		$cookieArray = explode('.', $cookieValue);
@@ -78,7 +81,7 @@ class PlgAuthenticationCookie extends JPlugin
 			$this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 			JLog::add('Invalid cookie detected.', JLog::WARNING, 'error');
 
-			return false;
+			return;
 		}
 
 		$response->type = 'Cookie';
@@ -117,7 +120,7 @@ class PlgAuthenticationCookie extends JPlugin
 		{
 			$response->status = JAuthentication::STATUS_FAILURE;
 
-			return false;
+			return;
 		}
 
 		if (count($results) !== 1)
@@ -126,7 +129,7 @@ class PlgAuthenticationCookie extends JPlugin
 			$this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 			$response->status = JAuthentication::STATUS_FAILURE;
 
-			return false;
+			return;
 		}
 
 		// We have a user with one cookie with a valid series and a corresponding record in the database.
@@ -161,7 +164,7 @@ class PlgAuthenticationCookie extends JPlugin
 			JLog::add(JText::sprintf('PLG_AUTH_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), JLog::WARNING, 'security');
 			$response->status = JAuthentication::STATUS_FAILURE;
 
-			return false;
+			return;
 		}
 
 		// Make sure there really is a user with this name and get the data for the session.
@@ -179,7 +182,7 @@ class PlgAuthenticationCookie extends JPlugin
 		{
 			$response->status = JAuthentication::STATUS_FAILURE;
 
-			return false;
+			return;
 		}
 
 		if ($result)

--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -42,7 +42,7 @@ class PlgAuthenticationCookie extends JPlugin implements AuthenticationPluginInt
 	 *
 	 * @param   array                   $credentials  Array holding the user credentials
 	 * @param   array                   $options      Array of extra options
-	 * @param   AuthenticationResponse  $response    Authentication response object
+	 * @param   AuthenticationResponse  $response     Authentication response object
 	 *
 	 * @return  void
 	 *

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Authentication\AuthenticationPluginInterface;
+use Joomla\CMS\Authentication\AuthenticationResponse;
 use Joomla\Registry\Registry;
 
 /**
@@ -16,20 +18,20 @@ use Joomla\Registry\Registry;
  *
  * @since  1.5
  */
-class PlgAuthenticationGMail extends JPlugin
+class PlgAuthenticationGMail extends JPlugin implements AuthenticationPluginInterface
 {
 	/**
 	 * This method should handle any authentication and report back to the subject
 	 *
-	 * @param   array   $credentials  Array holding the user credentials
-	 * @param   array   $options      Array of extra options
-	 * @param   object  &$response    Authentication response object
+	 * @param   array                   $credentials  Array holding the user credentials
+	 * @param   array                   $options      Array of extra options
+	 * @param   AuthenticationResponse  $response    Authentication response object
 	 *
-	 * @return  boolean
+	 * @return  void
 	 *
 	 * @since   1.5
 	 */
-	public function onUserAuthenticate($credentials, $options, &$response)
+	public function onUserAuthenticate(array $credentials, array $options, AuthenticationResponse $response)
 	{
 		// Load plugin language
 		$this->loadLanguage();

--- a/plugins/authentication/gmail/gmail.php
+++ b/plugins/authentication/gmail/gmail.php
@@ -25,7 +25,7 @@ class PlgAuthenticationGMail extends JPlugin implements AuthenticationPluginInte
 	 *
 	 * @param   array                   $credentials  Array holding the user credentials
 	 * @param   array                   $options      Array of extra options
-	 * @param   AuthenticationResponse  $response    Authentication response object
+	 * @param   AuthenticationResponse  $response     Authentication response object
 	 *
 	 * @return  void
 	 *

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -25,7 +25,7 @@ class PlgAuthenticationJoomla extends JPlugin implements AuthenticationPluginInt
 	 *
 	 * @param   array                   $credentials  Array holding the user credentials
 	 * @param   array                   $options      Array of extra options
-	 * @param   AuthenticationResponse  $response    Authentication response object
+	 * @param   AuthenticationResponse  $response     Authentication response object
 	 *
 	 * @return  void
 	 *

--- a/plugins/authentication/joomla/joomla.php
+++ b/plugins/authentication/joomla/joomla.php
@@ -9,6 +9,8 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Authentication\AuthenticationPluginInterface;
+use Joomla\CMS\Authentication\AuthenticationResponse;
 use Joomla\Component\Users\Administrator\Model\User;
 
 /**
@@ -16,20 +18,20 @@ use Joomla\Component\Users\Administrator\Model\User;
  *
  * @since  1.5
  */
-class PlgAuthenticationJoomla extends JPlugin
+class PlgAuthenticationJoomla extends JPlugin implements AuthenticationPluginInterface
 {
 	/**
 	 * This method should handle any authentication and report back to the subject
 	 *
-	 * @param   array   $credentials  Array holding the user credentials
-	 * @param   array   $options      Array of extra options
-	 * @param   object  &$response    Authentication response object
+	 * @param   array                   $credentials  Array holding the user credentials
+	 * @param   array                   $options      Array of extra options
+	 * @param   AuthenticationResponse  $response    Authentication response object
 	 *
 	 * @return  void
 	 *
 	 * @since   1.5
 	 */
-	public function onUserAuthenticate($credentials, $options, &$response)
+	public function onUserAuthenticate(array $credentials, array $options, AuthenticationResponse $response)
 	{
 		$response->type = 'Joomla';
 


### PR DESCRIPTION
### Summary of Changes
We need more and more direct plugin instances to work with, especially in media manager. So it would be nice to have a plugin factory for it. This pr introduces a plugin factory and convertes the Authentication workflow to use the plugins from the factory.

Additionally it deprecated the `PluginHelper::importPlugin` and `PluginHelper::import` functions.

### Testing Instructions
Log in on the back end.

### Expected result
It works.

### Actual result
It works.

### Documentation Changes Required
The new authentication interface needs to be documented and the plugin factory.