### PR TITLE
Missing language code in help config at install time

### DIFF
--- a/installation/application/web.php
+++ b/installation/application/web.php
@@ -405,7 +405,7 @@ final class InstallationApplicationWeb extends JApplicationCms
 		// Check for custom helpurl.
 		if (empty($forced['helpurl']))
 		{
-			$options['helpurl'] = 'https://help.joomla.org/proxy/index.php?keyref=Help{major}{minor}:{keyref}';
+			$options['helpurl'] = 'https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&lang={langcode}';
 		}
 		else
 		{


### PR DESCRIPTION
We can only get the Help in English via the help button in admin even when switching language to French for example.

### Summary of Changes
Although the correct url exists in help.xml and configuration.php-dist, the `$options['helpurl']` variable is fetched from web.php when there is by default no forced `$forced['helpurl']` at install time.


### Testing Instructions
Install Joomla before patch and look at the configuration.php file.
the variable $helpurl does not contain `&lang={langcode}`

Patch.
Now it will correctly contain that part.
Switching to French for example will display the help in French (at least the parts which have been translated on the wiki)

Can be merged on review as it is a simple pr

@mbabker 
