### PR TITLE
Regression: Menu forum links conditional

### DIFF
--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -453,6 +453,9 @@ class MenusHelper
 			$components = ArrayHelper::getColumn((array) $components, 'element', 'extension_id');
 		}
 
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger('onPreprocessMenuItems', array('com_menus.administrator.import', &$items, null, true));
+
 		foreach ($items as &$item)
 		{
 			/** @var  JTableMenu  $table */
@@ -480,6 +483,20 @@ class MenusHelper
 			}
 			elseif ($item->type == 'url' || $item->type == 'component')
 			{
+				if (substr($item->link, 0, 8) === 'special:')
+				{
+					$special = substr($item->link, 8);
+
+					if ($special === 'language-forum')
+					{
+						$item->link = 'index.php?option=com_admin&amp;view=help&amp;layout=langforum';
+					}
+					elseif ($special === 'custom-forum')
+					{
+						$item->link = '';
+					}
+				}
+
 				// Try to match an existing record to have minimum collision for a link
 				$keys  = array(
 					'menutype'  => $menutype,

--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -480,8 +480,16 @@
 		<menuitem
 			type="url"
 			target="_blank"
+			title="MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM"
+			link="special:custom-forum"
+			class="class:help-forum"
+			scope="help"
+		/>
+		<menuitem
+			type="url"
+			target="_blank"
 			title="MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM"
-			link="index.php?option=com_admin&amp;view=help&amp;layout=langforum"
+			link="special:language-forum"
 			class="class:help-forum"
 			scope="help"
 		/>

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -507,8 +507,16 @@
 		<menuitem
 			type="url"
 			target="_blank"
+			title="MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM"
+			link="special:custom-forum"
+			class="class:help-forum"
+			scope="help"
+		/>
+		<menuitem
+			type="url"
+			target="_blank"
 			title="MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM"
-			link="index.php?option=com_admin&amp;view=help&amp;layout=langforum"
+			link="special:language-forum"
 			class="class:help-forum"
 			scope="help"
 		/>

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -240,6 +240,11 @@ class JAdminCssMenu
 
 		$noSeparator = true;
 
+		// Call preprocess for the menu items on plugins.
+		// Plugins should normally process the current level only unless their logic needs deep levels too.
+		$dispatcher = JEventDispatcher::getInstance();
+		$dispatcher->trigger('onPreprocessMenuItems', array('com_menus.administrator.module', &$items, $this->params, $this->enabled));
+
 		foreach ($items as $i => &$item)
 		{
 			// Exclude item with menu item option set to exclude from menu modules
@@ -255,6 +260,20 @@ class JAdminCssMenu
 			if (($item->scope == 'help' && !$this->params->get('showhelp')) || ($item->scope == 'edit' && !$this->params->get('shownew')))
 			{
 				continue;
+			}
+
+			if (substr($item->link, 0, 8) === 'special:')
+			{
+				$special = substr($item->link, 8);
+
+				if ($special === 'language-forum')
+				{
+					$item->link = 'index.php?option=com_admin&amp;view=help&amp;layout=langforum';
+				}
+				elseif ($special === 'custom-forum')
+				{
+					$item->link = $this->params->get('forum_url');
+				}
 			}
 
 			// Exclude item if the component is not authorised

--- a/administrator/modules/mod_menu/mod_menu.xml
+++ b/administrator/modules/mod_menu/mod_menu.xml
@@ -81,6 +81,17 @@
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
 				</field>
+
+				<field
+					name="forum_url"
+					type="url"
+					label="MOD_MENU_FIELD_FORUMURL_LABEL"
+					description="MOD_MENU_FIELD_FORUMURL_DESC"
+					filter="url"
+					size="30"
+					default=""
+					showon="menutype:*"
+				/>
 			</fieldset>
 
 			<fieldset name="advanced">
@@ -97,16 +108,6 @@
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
 					rows="3"
-				/>
-
-				<field
-					name="forum_url"
-					type="url"
-					label="MOD_MENU_FIELD_FORUMURL_LABEL"
-					description="MOD_MENU_FIELD_FORUMURL_DESC"
-					filter="url"
-					size="30"
-					default=""
 				/>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
### Summary of Changes
Currently we have the custom forum link missing in admin menu preset and we had no option to show/hide depending on whether it is set or not in the module options.

This PR aims to fix this and get the menu item back in J3.8

Add plugin triggers to allow plugins to further process the menu items as needed.

### Testing Instructions
Install staging and add custom forum link in the admin menu module.


### Expected result
The link should be shown in the admin menu under 'help'.


### Actual result
The link is never displayed.


### Documentation Changes Required
Add documentation about the plugin events added.

Notify @infograf768
