### PR TITLE
[Regression] Fix being able to add custom tags in a form field when explicitely denied

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -260,7 +260,7 @@ class TagField extends \JFormFieldList
 	 */
 	public function allowCustom()
 	{
-		if (isset($this->element['custom']) && $this->element['custom'] === 'deny')
+		if (isset($this->element['custom']) && (string) $this->element['custom'] === 'deny')
 		{
 			return false;
 		}


### PR DESCRIPTION
Fixes regression in https://github.com/joomla/joomla-cms/commit/5aa724ad7a650de795df50af9e05da11c0810e46#diff-069d36e84093f570923bd7b0459eac93R257

### Summary of Changes
You can explicitly stop new tags from being created in the tags form field, which is useful when for example you want people to only be able to select from existing tags in a module. However we have broken this functionality, by doing an explicit typecheck of a `string` against a `SimpleXMLElement` (which fails all the time allowing you to create tags all the time)

### Testing Instructions
Find a `type="tag"` field in the CMS and add modify it to have `custom="deny"` in it's definition. For example:

```
<field
	name="tags"
	type="tag"
	label="JTAG"
	description="JTAG_DESC"
	multiple="true"
	custom="deny"
/>
```

### Expected result
You can't create tags in the field 


### Actual result
You can before the patch. You cannot afterwards


### Documentation Changes Required
N/A - fixes regression
