### PR TITLE
Check for JUri::base in each srcset url before converting

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,11 +140,7 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						if (strpos($url, $base) !== 0)
-						{
-							$url = preg_replace('#(?!/|' . $protocols . '|\#|\')([^"]+)#', $base . '$1', $url);
-						}
-						$data[] = $url;
+						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')([^\s]+)\s+(.*)#', $base . '$1 $2', $url);
 					}
 					return ' srcset="' . implode(",", $data) . '"';
 				},

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,7 +140,7 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')([^\s]+)\s+(.*)#', $base . '$1 $2', $url);
+						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $url);
 					}
 					return ' srcset="' . implode(",", $data) . '"';
 				},

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,7 +140,10 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						$data[] = preg_replace('#(?!/|' . $protocols . '|\#|\')([^\s]+)\s+(.*)#', $base . '$1 $2', $url);
+						if (strpos($url, $base) === false) {
+							$url = preg_replace('#(?!/|' . $protocols . '|\#|\')([^\s]+)\s+(.*)#', $base . '$1 $2', $url);
+						}
+						$data[] = $url;
 					}
 					return ' srcset="' . implode(",", $data) . '"';
 				},

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,7 +140,7 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $url);
+						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
 					}
 					return ' srcset="' . implode(",", $data) . '"';
 				},

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,7 +140,7 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						if (strpos($url, $base) === false)
+						if (strpos($url, $base) !== 0)
 						{
 							$url = preg_replace('#(?!/|' . $protocols . '|\#|\')([^"]+)#', $base . '$1', $url);
 						}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -140,8 +140,9 @@ class PlgSystemSef extends JPlugin
 					$data = array();
 					foreach (explode(",", $match[1]) as $url)
 					{
-						if (strpos($url, $base) === false) {
-							$url = preg_replace('#(?!/|' . $protocols . '|\#|\')([^\s]+)\s+(.*)#', $base . '$1 $2', $url);
+						if (strpos($url, $base) === false)
+						{
+							$url = preg_replace('#(?!/|' . $protocols . '|\#|\')([^"]+)#', $base . '$1', $url);
 						}
 						$data[] = $url;
 					}


### PR DESCRIPTION
With reference to - https://github.com/joomla/joomla-cms/pull/15300#issuecomment-329561846, this PR updates the srcset URL conversion to check for the base url before performing the replacement.

## Summary of Changes

As pointed out by @wronax - https://github.com/joomla/joomla-cms/pull/15300#issuecomment-329559714 - if the srcset URL already contained the site base url, then the conversion would add the base url again. This change checks for the base url on each of the srcset urls before performing the replacement, if necessary.

## Testing Instructions

As before, create a new article using the following HTML code, or similar. You will need 3 images of different resolutions, or just three different images of any resolution.

```html
<img src="images/image1.jpg" srcset="images/image3.jpg 2x,images/image2.jpg 1.5x,images/image1.jpg 1x" alt="" />
```

## Expected result

The image displays correctly in the browser as all the srcset values are converted.

## Actual result

With the current sef.php the images will not display correctly in a modern browser. You can check the code using the browser console to see that the srcset values have not all been converted.

## Documentation Changes Required

None