### PR TITLE
Localised date formats for publishing state tooltip

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -188,12 +188,12 @@ abstract class JHtmlJGrid
 
 			if ($publish_up)
 			{
-				$tips[] = JText::sprintf('JLIB_HTML_PUBLISHED_START', $publish_up->format(JDate::$format, true));
+				$tips[] = JText::sprintf('JLIB_HTML_PUBLISHED_START', JHtml::_('date', $publish_up, JText::_('DATE_FORMAT_LC5'), 'UTC'));
 			}
 
 			if ($publish_down)
 			{
-				$tips[] = JText::sprintf('JLIB_HTML_PUBLISHED_FINISHED', $publish_down->format(JDate::$format, true));
+				$tips[] = JText::sprintf('JLIB_HTML_PUBLISHED_FINISHED', JHtml::_('date', $publish_down, JText::_('DATE_FORMAT_LC5'), 'UTC'));
 			}
 
 			$tip = empty($tips) ? false : implode('<br />', $tips);


### PR DESCRIPTION
This is a rather simple change to allow localised date formats in the publishing state tooltip.

### Summary of Changes
Uses JHtml::_('date') to format the date.


### Testing Instructions
In the article manager create a pending and a retired article.
* Check that they still show correct with the expected symbols
* Check that the date is formatted according to the active language. Eg in english it should be YYYY-MM-DD HH:MM and in german it will be DD.MM.YYYY HH:MM

### Expected result
![after](https://user-images.githubusercontent.com/1018684/30559785-181b1134-9cb6-11e7-945e-220a57a3c656.PNG)

### Actual result
![before](https://user-images.githubusercontent.com/1018684/30559788-1df3f1de-9cb6-11e7-9b55-beeec4661b39.PNG)


### Documentation Changes Required
None that I can think of.
