### PR TITLE
Translate the label when custom fields are send via com_contact

### DIFF
--- a/components/com_contact/layouts/field/render.php
+++ b/components/com_contact/layouts/field/render.php
@@ -14,7 +14,7 @@ if (!key_exists('field', $displayData))
 }
 
 $field     = $displayData['field'];
-$label     = $field->label;
+$label     = JText::_($field->label);
 $value     = $field->value;
 $class     = $field->params->get('render_class');
 $showLabel = $field->params->get('showlabel');


### PR DESCRIPTION
### Summary of Changes
If you send custom fields in com_contact via email, the labels are not translated


### Testing Instructions
1. Setup a custom field in com_contact (mail) and use a language constant as label
2. Create language overrides for this constant
3. Create the contact
4. Submit contact


### Expected result
Field labels are translated in the email


### Actual result
Field label are not translated
