### PR TITLE
Refactored ExceptionHandler

### DIFF
--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -49,7 +49,7 @@ if (!class_exists('FOFAutoloaderFof'))
 }
 
 // Register a handler for uncaught exceptions that shows a pretty error page when possible
-set_exception_handler(array('JErrorPage', 'render'));
+set_exception_handler(array('Joomla\CMS\Exception\ExceptionHandler', 'handleException'));
 
 // Define the Joomla version if not already defined.
 if (!defined('JVERSION'))

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -7,6 +7,8 @@
  */
 
 namespace Joomla\CMS\Exception;
+use Joomla\CMS\Log\Log, Joomla\CMS\Factory, Joomla\CMS\Document\Document;
+use Joomla\CMS\Language\Text;
 
 defined('JPATH_PLATFORM') or die;
 
@@ -18,6 +20,25 @@ defined('JPATH_PLATFORM') or die;
 class ExceptionHandler
 {
 	/**
+	 * Handles exceptions: logs errors and renders error page.
+	 *
+	 * @param   \Exception|\Throwable  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function handleException($error)
+	{
+		if (static::isException($error))
+		{
+			static::logException($error);
+		}
+
+		static::render($error);
+	}
+
+	/**
 	 * Render the error page based on an exception.
 	 *
 	 * @param   \Exception|\Throwable  $error  An Exception or Throwable (PHP 7+) object for which to render the error page.
@@ -28,38 +49,12 @@ class ExceptionHandler
 	 */
 	public static function render($error)
 	{
-		$expectedClass = PHP_MAJOR_VERSION >= 7 ? '\Throwable' : '\Exception';
-		$isException   = $error instanceof $expectedClass;
-
-		// In PHP 5, the $error object should be an instance of \Exception; PHP 7 should be a Throwable implementation
-		if ($isException)
+		// Render template error page for exceptions only, because template will expect exception object
+		if (static::isException($error))
 		{
 			try
 			{
-				// Try to log the error, but don't let the logging cause a fatal error
-				try
-				{
-					\JLog::add(
-						sprintf(
-							'Uncaught %1$s of type %2$s thrown. Stack trace: %3$s',
-							$expectedClass,
-							get_class($error),
-							$error->getTraceAsString()
-						),
-						\JLog::CRITICAL,
-						'error'
-					);
-				}
-				catch (\Throwable $e)
-				{
-					// Logging failed, don't make a stink about it though
-				}
-				catch (\Exception $e)
-				{
-					// Logging failed, don't make a stink about it though
-				}
-
-				$app = \JFactory::getApplication();
+				$app = Factory::getApplication();
 
 				// If site is offline and it's a 404 error, just go to index (to see offline message, instead of 404)
 				if ($error->getCode() == '404' && $app->get('offline') == 1)
@@ -75,14 +70,14 @@ class ExceptionHandler
 					'direction' => 'ltr',
 				);
 
-				// If there is a \JLanguage instance in \JFactory then let's pull the language and direction from its metadata
-				if (\JFactory::$language)
+				// If there is a \JLanguage instance in Factory then let's pull the language and direction from its metadata
+				if (Factory::$language)
 				{
-					$attributes['language']  = \JFactory::getLanguage()->getTag();
-					$attributes['direction'] = \JFactory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
+					$attributes['language']  = Factory::getLanguage()->getTag();
+					$attributes['direction'] = Factory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
 				}
 
-				$document = \JDocument::getInstance('error', $attributes);
+				$document = Document::getInstance('error', $attributes);
 
 				if (!$document)
 				{
@@ -96,12 +91,13 @@ class ExceptionHandler
 				// Push the error object into the document
 				$document->setError($error);
 
-				if (ob_get_contents())
+				// Clear buffered output
+				if (ob_get_level())
 				{
-					ob_end_clean();
+					ob_clean();
 				}
 
-				$document->setTitle(\JText::_('ERROR') . ': ' . $error->getCode());
+				$document->setTitle(Text::_('ERROR') . ': ' . $error->getCode());
 
 				$data = $document->render(
 					false,
@@ -148,7 +144,7 @@ class ExceptionHandler
 
 		$message = 'Error displaying the error page';
 
-		if ($isException)
+		if (static::isException($error))
 		{
 			// Make sure we do not display sensitive data in production environments
 			if (ini_get('display_errors'))
@@ -167,5 +163,56 @@ class ExceptionHandler
 		echo $message;
 
 		jexit(1);
+	}
+
+	/**
+	 * Checks if given error belong to PHP exception class (\Throwable for PHP 7+, \Exception for PHP 5-).
+	 *
+	 * @param   mixed  $error  Any error value.
+	 *
+	 * @return  bool
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isException($error)
+	{
+		$expectedClass = PHP_MAJOR_VERSION >= 7 ? '\Throwable' : '\Exception';
+
+		return $error instanceof $expectedClass;
+	}
+
+	/**
+	 * Logs exception, catching all possible errors during logging.
+	 *
+	 * @param   \Exception|\Throwable  $error  An Exception or Throwable (PHP 7+) object to get error message from.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected static function logException($error)
+	{
+		// Try to log the error, but don't let the logging cause a fatal error
+		try
+		{
+			Log::add(
+				sprintf(
+					'Uncaught %1$s of type %2$s thrown. Stack trace: %3$s',
+					PHP_MAJOR_VERSION >= 7 ? 'Throwable' : 'Exception',
+					get_class($error),
+					$error->getTraceAsString()
+				),
+				Log::CRITICAL,
+				'error'
+			);
+		}
+		catch (\Throwable $e)
+		{
+			// Logging failed, don't make a stink about it though
+		}
+		catch (\Exception $e)
+		{
+			// Logging failed, don't make a stink about it though
+		}
 	}
 }


### PR DESCRIPTION
### Summary of Changes

Refactored ExceptionHandler class (previously JErrorPage): separated logging and rendering, added helper methods, replaced old class names (JXxx) with namespaced ones.
Now if `ExceptionHandler::render()` is called manually from anywhere, no logging is performed. If `ExceptionHandler::handleException()` is called, both logging and rendering is performed. 

### Testing Instructions

Enter non-existing url in browser to trigger 404 page.

### Expected result

Default template error page should be displayed, as usual.

### Documentation Changes Required

No changes.