### PR TITLE
[4.0] Allow language strings for input addons

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -75,8 +75,8 @@ $attributes = array(
 	!empty($validationtext) ? 'data-validation-text="' . $validationtext . '"' : '',
 );
 
-$addonBeforeHtml = '<span class="input-group-addon">' . $addonBefore . '</span>';
-$addonAfterHtml  = '<span class="input-group-addon">' . $addonAfter . '</span>';
+$addonBeforeHtml = '<span class="input-group-addon">' . JText::_($addonBefore) . '</span>';
+$addonAfterHtml  = '<span class="input-group-addon">' . JText::_($addonAfter) . '</span>';
 ?>
 
 <?php if (!empty($addonBefore) || !empty($addonAfter)) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Allows the use of languages strings within https://github.com/joomla/joomla-cms/pull/15939

### Testing Instructions
Add the following to an XML and ensure it renders the langauge string correctly..

```
<field
	name="crop_width"
	type="text"
	addonBefore="PLG_MEDIA-ACTION_CROP_PARAM_WIDTH"
	addonAfter="px"
	pattern="\d*\.?\d*"
	label="PLG_MEDIA-ACTION_CROP_PARAM_WIDTH"
/>
```



### Expected result
![image](https://user-images.githubusercontent.com/2803503/30652298-f65f2af6-9e1f-11e7-994d-ffac44c74b21.png)



### Actual result



### Documentation Changes Required

@Sandra97 If we could get the addonBefore/addonAfter attributes added to https://docs.joomla.org/Text_form_field_type that would be great!)