### PR TITLE
0 default value is not applied for custom fields

### DIFF
--- a/administrator/components/com_fields/libraries/fieldsplugin.php
+++ b/administrator/components/com_fields/libraries/fieldsplugin.php
@@ -166,7 +166,7 @@ abstract class FieldsPlugin extends JPlugin
 		$node->setAttribute('hint', $field->params->get('hint'));
 		$node->setAttribute('required', $field->required ? 'true' : 'false');
 
-		if ($field->default_value)
+		if ($field->default_value !== '')
 		{
 			$defaultNode = $node->appendChild(new DOMElement('default'));
 			$defaultNode->appendChild(new DOMCdataSection($field->default_value));


### PR DESCRIPTION
### Steps to reproduce the issue

Create custom user field of Radio type.
Set Default Value to `0`
Set Radio Values with values `0` and `1`
Edit user, save field with 0 value

### Expected result

Field is displayed with `0` option selected

### Actual result

No options are selected.
