### PR TITLE
Check if array property exists.

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -180,7 +180,7 @@ class MenuRules implements RulesInterface
 						$layout = ':' . $item->query['layout'];
 					}
 
-					if ($views[$view]->key)
+					if (isset($views[$view]) && $views[$view]->key)
 					{
 						if (!isset($this->lookup[$language][$view . $layout]))
 						{


### PR DESCRIPTION
Prevents throwing ```Notice: Trying to get property of non-object in libraries/src/Component/Router/Rules/MenuRules.php on line 183```