### PR TITLE
Load the stream handler class to register the stream wrapper

### DIFF
--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -154,10 +154,7 @@ class FtpClient
 		if (FTP_NATIVE)
 		{
 			// Import the generic buffer stream handler
-			\JLoader::import('joomla.utilities.buffer');
-
-			// Autoloading fails for JBuffer as the class is used as a stream handler
-			\JLoader::load('JBuffer');
+			class_exists('\\Joomla\\CMS\\Utility\\BufferStreamHandler');
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue #18024.

### Summary of Changes
The stream handler needs to be registered correctly in the FTP client.

### Testing Instructions
See #18024.

### Expected result
It works.

### Actual result
A buffer not exists error is thrown.