### PR TITLE
Fixes the double event firing

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -189,25 +189,6 @@ class ContentViewArticle extends JViewLegacy
 		JPluginHelper::importPlugin('content');
 		$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
 
-		// Check if the intro text needs to be processed as well
-		if ($item->introtext && strpos($item->text, $item->introtext) !== 0)
-		{
-			// Save the old text of the article
-			$text = $item->text;
-
-			// Set the intro text as new text
-			$item->text = $item->introtext;
-
-			// Trigger the event with the introtext
-			$dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
-
-			// Set the prepared intro text back
-			$item->introtext = $item->text;
-
-			// Restore the original text variable
-			$item->text = $text;
-		}
-
 		$item->event = new stdClass;
 		$results = $dispatcher->trigger('onContentAfterTitle', array('com_content.article', &$item, &$item->params, $offset));
 		$item->event->afterDisplayTitle = trim(implode("\n", $results));

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -52,83 +52,102 @@ class PlgContentFields extends JPlugin
 		// Register FieldsHelper
 		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 
+		// Prepare the text
+		if (isset($item->text))
+		{
+			$item->text = $this->prepare($item->text, $context, $item);
+		}
+
+		// Prepare the intro text
+		if (isset($item->introtext))
+		{
+			$item->introtext = $this->prepare($item->introtext, $context, $item);
+		}
+	}
+
+	private function prepare($string, $context, $item)
+	{
 		// Search for {field ID} or {fieldgroup ID} tags and put the results into $matches.
 		$regex = '/{(field|fieldgroup)\s+(.*?)}/i';
-		preg_match_all($regex, $item->text, $matches, PREG_SET_ORDER);
+		preg_match_all($regex, $string, $matches, PREG_SET_ORDER);
 
-		if ($matches)
+		if (!$matches)
 		{
-			$parts = FieldsHelper::extract($context);
+			return $string;
+		}
 
-			if (count($parts) < 2)
+		$parts = FieldsHelper::extract($context);
+
+		if (count($parts) < 2)
+		{
+			return $string;
+		}
+
+		$context    = $parts[0] . '.' . $parts[1];
+		$fields     = FieldsHelper::getFields($context, $item, true);
+		$fieldsById = array();
+		$groups     = array();
+
+		// Rearranging fields in arrays for easier lookup later.
+		foreach ($fields as $field)
+		{
+			$fieldsById[$field->id]     = $field;
+			$groups[$field->group_id][] = $field;
+		}
+
+		foreach ($matches as $i => $match)
+		{
+			// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID and optional the layout
+			$explode = explode(',', $match[2]);
+			$id      = (int) $explode[0];
+			$layout  = !empty($explode[1]) ? trim($explode[1]) : 'render';
+			$output  = '';
+
+
+			if ($match[1] == 'field' && $id)
 			{
-				return;
-			}
-
-			$context    = $parts[0] . '.' . $parts[1];
-			$fields     = FieldsHelper::getFields($context, $item, true);
-			$fieldsById = array();
-			$groups     = array();
-
-			// Rearranging fields in arrays for easier lookup later.
-			foreach ($fields as $field)
-			{
-				$fieldsById[$field->id]     = $field;
-				$groups[$field->group_id][] = $field;
-			}
-
-			foreach ($matches as $i => $match)
-			{
-				// $match[0] is the full pattern match, $match[1] is the type (field or fieldgroup) and $match[2] the ID and optional the layout
-				$explode = explode(',', $match[2]);
-				$id      = (int) $explode[0];
-				$layout  = !empty($explode[1]) ? trim($explode[1]) : 'render';
-				$output  = '';
-
-
-				if ($match[1] == 'field' && $id)
+				if (isset($fieldsById[$id]))
 				{
-					if (isset($fieldsById[$id]))
-					{
-						$output = FieldsHelper::render(
-							$context,
-							'field.' . $layout,
-							array(
-								'item'    => $item,
-								'context' => $context,
-								'field'   => $fieldsById[$id]
-							)
-						);
-					}
+					$output = FieldsHelper::render(
+						$context,
+						'field.' . $layout,
+						array(
+							'item'    => $item,
+							'context' => $context,
+							'field'   => $fieldsById[$id]
+						)
+					);
+				}
+			}
+			else
+			{
+				if ($match[2] === '*')
+				{
+					$match[0]     = str_replace('*', '\*', $match[0]);
+					$renderFields = $fields;
 				}
 				else
 				{
-					if ($match[2] === '*')
-					{
-						$match[0]     = str_replace('*', '\*', $match[0]);
-						$renderFields = $fields;
-					}
-					else
-					{
-						$renderFields = isset($groups[$id]) ? $groups[$id] : '';
-					}
-
-					if ($renderFields)
-					{
-						$output = FieldsHelper::render(
-							$context,
-							'fields.' . $layout,
-							array(
-								'item'    => $item,
-								'context' => $context,
-								'fields'  => $renderFields
-							)
-						);
-					}
+					$renderFields = isset($groups[$id]) ? $groups[$id] : '';
 				}
 
-				$item->text = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $item->text, 1);
+				if ($renderFields)
+				{
+					$output = FieldsHelper::render(
+						$context,
+						'fields.' . $layout,
+						array(
+							'item'    => $item,
+							'context' => $context,
+							'fields'  => $renderFields
+						)
+					);
+				}
 			}
+
+			$string = preg_replace("|$match[0]|", addcslashes($output, '\\$'), $string, 1);
 		}
+
+		return $string;
 	}
 }

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -65,6 +65,17 @@ class PlgContentFields extends JPlugin
 		}
 	}
 
+	/**
+	 * Prepares the given string by parsing {field} and {fieldgroup} groups and replacing them.
+	 *
+	 * @param   string  $string   The text to prepare
+	 * @param   string  $context  The context of the content
+	 * @param   object  $item     The item object
+	 *
+	 * @return string
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
 	private function prepare($string, $context, $item)
 	{
 		// Search for {field ID} or {fieldgroup ID} tags and put the results into $matches.


### PR DESCRIPTION
Pull Request for Issue #18016.

### Summary of Changes
Prepares the intro text within the same prepare event. Removes double onContentPrepare event triggering.

### Testing Instructions
See #17175 and #18016.

### Expected result
No twice event triggering and field is rendered in intro text as well.

### Actual result
Side effects like modules get loaded twice.