### PR TITLE
Add new method BufferStreamHandler::stream_register()

### DIFF
--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Client;
 defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Utility\BufferStreamHandler;
 
 /** Error Codes:
  * - 30 : Unable to connect to host
@@ -153,11 +154,8 @@ class FtpClient
 
 		if (FTP_NATIVE)
 		{
-			// Import the generic buffer stream handler
-			\JLoader::import('joomla.utilities.buffer');
-
-			// Autoloading fails for JBuffer as the class is used as a stream handler
-			\JLoader::load('JBuffer');
+			$buffer = new BufferStreamHandler;
+			$buffer->stream_register();
 		}
 	}
 

--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -154,8 +154,7 @@ class FtpClient
 
 		if (FTP_NATIVE)
 		{
-			$buffer = new BufferStreamHandler;
-			$buffer->stream_register();
+			BufferStreamHandler::stream_register();
 		}
 	}
 

--- a/libraries/src/Utility/BufferStreamHandler.php
+++ b/libraries/src/Utility/BufferStreamHandler.php
@@ -10,8 +10,9 @@ namespace Joomla\CMS\Utility;
 
 defined('JPATH_PLATFORM') or die;
 
-// Register the stream
-stream_wrapper_register('buffer', '\\Joomla\\CMS\\Utility\\BufferStreamHandler');
+// Workaround for B/C. Will be removed with 4.0
+$buffer = new BufferStreamHandler;
+$buffer->stream_register();
 
 /**
  * Generic Buffer stream handler
@@ -46,6 +47,33 @@ class BufferStreamHandler
 	 * @since  12.1
 	 */
 	public $buffers = array();
+
+	/**
+	 * Status of registering the wrapper
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	static private $registered = false;
+
+	/**
+	 * Function to register the stream wrapper
+	 *
+	 * @return  void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function stream_register()
+	{
+		if (!self::$registered)
+		{
+			stream_wrapper_register('buffer', '\\Joomla\\CMS\\Utility\\BufferStreamHandler');
+
+			self::$registered = true;
+		}
+
+		return;
+	}
 
 	/**
 	 * Function to open file or url

--- a/libraries/src/Utility/BufferStreamHandler.php
+++ b/libraries/src/Utility/BufferStreamHandler.php
@@ -11,8 +11,7 @@ namespace Joomla\CMS\Utility;
 defined('JPATH_PLATFORM') or die;
 
 // Workaround for B/C. Will be removed with 4.0
-$buffer = new BufferStreamHandler;
-$buffer->stream_register();
+BufferStreamHandler::stream_register();
 
 /**
  * Generic Buffer stream handler
@@ -63,7 +62,7 @@ class BufferStreamHandler
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function stream_register()
+	public static function stream_register()
 	{
 		if (!self::$registered)
 		{


### PR DESCRIPTION
Pull Request for Issue #18024 .

### Summary of Changes
* Adding a new method `stream_register` to the `Joomla\CMS\Utility\BufferStreamHandler` class.
* Changing `FtpClient` to explicitely register the wrapper using that method.


### Testing Instructions
Use with any extension that uses the FtpClient class and is currently broken.


### Expected result
Works


### Actual result
White Screen of Death


### Documentation Changes Required
The new API has to be document and once we remove the B/C workaround (in 4.0) this has to be documented as well

@mbabker @laoneo What do you think? Would that work?