### PR TITLE
Add useglobal to JFormFieldNumber

### DIFF
--- a/libraries/joomla/form/fields/number.php
+++ b/libraries/joomla/form/fields/number.php
@@ -143,6 +143,41 @@ class JFormFieldNumber extends JFormField
 	 */
 	protected function getInput()
 	{
+		if ($this->element['useglobal'])
+		{
+			$component = JFactory::getApplication()->input->getCmd('option');
+
+			// Get correct component for menu items
+			if ($component == 'com_menus')
+			{
+				$link      = $this->form->getData()->get('link');
+				$uri       = new JUri($link);
+				$component = $uri->getVar('option', 'com_menus');
+			}
+
+			$params = JComponentHelper::getParams($component);
+			$value  = $params->get($this->fieldname);
+
+			// Try with global configuration
+			if (is_null($value))
+			{
+				$value = JFactory::getConfig()->get($this->fieldname);
+			}
+
+			// Try with menu configuration
+			if (is_null($value) && JFactory::getApplication()->input->getCmd('option') == 'com_menus')
+			{
+				$value = JComponentHelper::getParams('com_menus')->get($this->fieldname);
+			}
+
+			if (!is_null($value))
+			{
+				$value = (string) $value;
+
+				$this->hint = JText::sprintf('JGLOBAL_USE_GLOBAL_VALUE', $value);
+			}
+		}
+
 		// Trim the trailing line in the layout file
 		return rtrim($this->getRenderer($this->layout)->render($this->getLayoutData()), PHP_EOL);
 	}


### PR DESCRIPTION
This PR adds the useglobal attiribute for the number form field.

Pull Request for Issue # .

### Summary of Changes
Adds useglobal to JFormFieldNumber


### Testing Instructions
Test the number field in a component, for example in the Category Blog:
Change in [/components/com_content/views/category/tmpl/blog.xml#L182](https://github.com/joomla/joomla-cms/blob/staging/components/com_content/views/category/tmpl/blog.xml#L182)  the type from text to number.


### Expected result
As with the type text: The global value should be displayed if no text is entered.


### Actual result
The field is empty, the notice with the global value is missing.


### Documentation Changes Required
Add a notice about useglobal to the Documentation: https://docs.joomla.org/Number_form_field_type.
