### PR TITLE
Suppress empty class attribute in pagination

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -95,7 +95,7 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li<?php echo $liClass ? ' class="' . $liClass . '"' : ''; ?>>
-		<a class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -78,7 +78,7 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li>
-		<a class="<?php echo implode(' ', $cssClasses); ?>" <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>


### PR DESCRIPTION
### Summary of Changes
Don't output empty class attribute.

### Testing Instructions
Go to Administration > Content > Articles
View page source
Search `<a class=""`

### Expected result
`<a   href="#"`

### Actual result
`<a class=""  href="#"`

### Documentation Changes Required
None
