### PR TITLE
[4.0] Class 'Joomla\Component\Content\Administrator\Model\Articles' not found

### DIFF
--- a/administrator/components/com_content/Model/FeatureModel.php
+++ b/administrator/components/com_content/Model/FeatureModel.php
@@ -16,7 +16,7 @@ defined('_JEXEC') or die;
  *
  * @since  1.6
  */
-class FeatureModel extends Article
+class FeatureModel extends ArticleModel
 {
 	/**
 	 * Returns a Table object, always creating it.

--- a/administrator/components/com_content/Model/FeaturedModel.php
+++ b/administrator/components/com_content/Model/FeaturedModel.php
@@ -18,7 +18,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class FeaturedModel extends Articles
+class FeaturedModel extends ArticlesModel
 {
 	/**
 	 * Constructor.


### PR DESCRIPTION
As title says. 
Error when displaying Featured articles  manager.