### PR TITLE
Passing a null value for the first argument of Text::script() is depr…

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -145,7 +145,7 @@ class HtmlDocument extends Document
 		$data['scripts']     = $this->_scripts;
 		$data['script']      = $this->_script;
 		$data['custom']      = $this->_custom;
-		$data['scriptText']  = \JText::script();
+		$data['scriptText']  = \JText::getScriptStrings();
 
 		return $data;
 	}


### PR DESCRIPTION
…ecated

Use Text::getScriptStrings() instead.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

