### PR TITLE
Atom feeed not displaying when Site Name in Page Titles is set

### DIFF
--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -65,11 +65,11 @@ class AtomRenderer extends DocumentRenderer
 
 		if ($app->get('sitename_pagetitles', 0) == 1)
 		{
-			$title = JText::sprintf('JPAGETITLE', $app->get('sitename'), $data->getTitle());
+			$title = \JText::sprintf('JPAGETITLE', $app->get('sitename'), $data->getTitle());
 		}
 		elseif ($app->get('sitename_pagetitles', 0) == 2)
 		{
-			$title = JText::sprintf('JPAGETITLE', $data->getTitle(), $app->get('sitename'));
+			$title = \JText::sprintf('JPAGETITLE', $data->getTitle(), $app->get('sitename'));
 		}
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18095
See tests instructions there.

Make sure `Site Name in Page Titles` is set to after or before in Global Configuration

### Summary of Changes
escaping JText 


@AlexRed 
@franz-wohlkoenig