### PR TITLE
[4.0] Drop the deprecated const in the version class

### DIFF
--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -63,39 +63,12 @@ final class Version
 	const EXTRA_VERSION = 'dev';
 
 	/**
-	 * Release version.
-	 *
-	 * @var    string
-	 * @since  3.5
-	 * @deprecated  4.0  Use separated version constants instead
-	 */
-	const RELEASE = '4.0';
-
-	/**
-	 * Maintenance version.
-	 *
-	 * @var    string
-	 * @since  3.5
-	 * @deprecated  4.0  Use separated version constants instead
-	 */
-	const DEV_LEVEL = '0-dev';
-
-	/**
 	 * Development status.
 	 *
 	 * @var    string
 	 * @since  3.5
 	 */
 	const DEV_STATUS = 'Development';
-
-	/**
-	 * Build number.
-	 *
-	 * @var    string
-	 * @since  3.5
-	 * @deprecated  4.0
-	 */
-	const BUILD = '';
 
 	/**
 	 * Code name.


### PR DESCRIPTION
### Summary of Changes

Drop the deprecated const in the version class

### Expected result

no deprecated const in the version class

### Actual result

deprecated const in the version class

### Documentation Changes Required

Dokument the removed consts