### PR TITLE
Fix top-level category allowed to be selected for new / existing records, despite disallowed via ACL core.create

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -232,18 +232,13 @@ class JFormFieldCategoryEdit extends JFormFieldList
 				}
 			}
 
-			if ($options[$i]->level != 0)
-			{
-				$options[$i]->level = $options[$i]->level -1;
-			}
-
 			if ($options[$i]->published == 1)
 			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
+				$options[$i]->text = str_repeat('- ', !$options[$i]->level ? 0 : $options[$i]->level - 1) . $options[$i]->text;
 			}
 			else
 			{
-				$options[$i]->text = str_repeat('- ', $options[$i]->level) . '[' . $options[$i]->text . ']';
+				$options[$i]->text = str_repeat('- ', !$options[$i]->level ? 0 : $options[$i]->level - 1) . '[' . $options[$i]->text . ']';
 			}
 
 			// Displays language code if not set to All


### PR DESCRIPTION
Pull Request for Issue #18027

### Summary of Changes
The issue was introduced by PR #17383 , that PR modified **option->level** to be **option->level - 1**

but **option->level** is later compared to zero to exclude checking ROOT category aka level 0 from ACL checks, thus **all top level categories that had level 1 now have level 0** thus they are excluded from ACL checks

### Testing Instructions
See issue #18027 
For the publisher usergroup, open any **top level** category and deny "create"
Login as publisher and try to create new article

### Expected result
The top category should not be shown in category selector


### Actual result
The descendants category are correctly excuded (due to heritage), but the category itself is allowed to be selected 

### Documentation Changes Required
None

@mbabker , maybe v3.8.1 milestone, 
this is easy to review, since it reverts the specific change that introduced the issue
(but also fixes the padding issue that PR #17383 was fixing in safer way)
