### PR TITLE
Show the root user configuration to any superadmin when enabeld

### DIFF
--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -949,7 +949,8 @@ JWARNING_ARCHIVE_MUST_SELECT="You must select at least one item to archive."
 JWARNING_UNPUBLISH_MUST_SELECT="You must select at least one item to unpublish."
 JWARNING_TRASH_MUST_SELECT="You must select at least one item to remove."
 JWARNING_DELETE_MUST_SELECT="You must select at least one item to permanently delete."
-JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER_ADMIN="The emergency Root User setting is currently enabled for the user(id): %s.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
 
 ; Date format
 

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -949,8 +949,8 @@ JWARNING_ARCHIVE_MUST_SELECT="You must select at least one item to archive."
 JWARNING_UNPUBLISH_MUST_SELECT="You must select at least one item to unpublish."
 JWARNING_TRASH_MUST_SELECT="You must select at least one item to remove."
 JWARNING_DELETE_MUST_SELECT="You must select at least one item to permanently delete."
-JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
-JWARNING_REMOVE_ROOT_USER_ADMIN="The emergency Root User setting is currently enabled for the user(id): %s.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Click here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER_ADMIN="The emergency Root User setting is currently enabled for the user(id): %s.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Click here to try to do it automatically.</a>"
 
 ; Date format
 

--- a/administrator/language/en-GB/en-GB.ini
+++ b/administrator/language/en-GB/en-GB.ini
@@ -949,8 +949,8 @@ JWARNING_ARCHIVE_MUST_SELECT="You must select at least one item to archive."
 JWARNING_UNPUBLISH_MUST_SELECT="You must select at least one item to unpublish."
 JWARNING_TRASH_MUST_SELECT="You must select at least one item to remove."
 JWARNING_DELETE_MUST_SELECT="You must select at least one item to permanently delete."
-JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Click here to try to do it automatically.</a>"
-JWARNING_REMOVE_ROOT_USER_ADMIN="The emergency Root User setting is currently enabled for the user(id): %s.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Click here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER="You are logged-in using the emergency Root User setting in configuration.php.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
+JWARNING_REMOVE_ROOT_USER_ADMIN="The emergency Root User setting is currently enabled for the user(id): %s.<br />You should remove $root_user from the configuration.php as soon as you have restored control to your site to avoid future security breaches.<br /><a href='%s'>Select here to try to do it automatically.</a>"
 
 ; Date format
 

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -421,16 +421,30 @@ class AdministratorApplication extends CMSApplication
 		// Safety check for when configuration.php root_user is in use.
 		$rootUser = $this->get('root_user');
 
-		if (property_exists('\JConfig', 'root_user')
-			&& (\JFactory::getUser()->get('username') === $rootUser || \JFactory::getUser()->id === (string) $rootUser))
+		if (property_exists('\JConfig', 'root_user'))
 		{
-			$this->enqueueMessage(
-				\JText::sprintf(
-					'JWARNING_REMOVE_ROOT_USER',
-					'index.php?option=com_config&task=config.removeroot&' . \JSession::getFormToken() . '=1'
-				),
-				'notice'
-			);
+			if (\JFactory::getUser()->get('username') === $rootUser || \JFactory::getUser()->id === (string) $rootUser)
+			{
+				$this->enqueueMessage(
+					\JText::sprintf(
+						'JWARNING_REMOVE_ROOT_USER',
+						'index.php?option=com_config&task=config.removeroot&' . \JSession::getFormToken() . '=1'
+					),
+					'error'
+				);
+			}
+			// Show this message to superusers too
+			elseif (\JFactory::getUser()->authorise('core.admin'))
+			{
+				$this->enqueueMessage(
+					\JText::sprintf(
+						'JWARNING_REMOVE_ROOT_USER_ADMIN',
+						$rootUser,
+						'index.php?option=com_config&task=config.removeroot&' . \JSession::getFormToken() . '=1'
+					),
+					'error'
+				);
+			}
 		}
 
 		parent::render();


### PR DESCRIPTION
### Summary of Changes

Show the root user configuration to any superadmin when enabeld

### Testing Instructions

- create a user called "test1" with publisher permissions
- add `public $root_user = 'test1';` to the configuration.php
- login to the backend using a other superadmin
- login to the backend using the user test1

### post patch result

A message to the logged in root user and for any other superadmin also this message is not a error and not a notice anymore

#### test 1

![image](https://user-images.githubusercontent.com/2596554/30887488-031c3bd4-a31c-11e7-8935-d719f04219d4.png)


#### other superadmin

![image](https://user-images.githubusercontent.com/2596554/30887502-0dee0a60-a31c-11e7-8183-98a1e61314dd.png)


### pre patch result

Just a message to the logged in root user.

### Documentation Changes Required

none