### PR TITLE
[com_fields] Display the custom fields admin menus only when enabled in the component

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -287,7 +287,18 @@ class JAdminCssMenu
 			elseif ($item->element == 'com_fields')
 			{
 				parse_str($item->link, $query);
-				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
+
+				// Only display Fields menus when enabled in the component
+				$createFields = JComponentHelper::getParams(strstr($query['context'], '.', true))->get('custom_fields_enable', 1);
+
+				if (!$createFields)
+				{
+					continue;
+				}
+				else
+				{
+					list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
+				}
 			}
 
 			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -289,7 +289,10 @@ class JAdminCssMenu
 				parse_str($item->link, $query);
 
 				// Only display Fields menus when enabled in the component
-				$createFields = JComponentHelper::getParams(strstr($query['context'], '.', true))->get('custom_fields_enable', 1);
+				if (isset($query['context']))
+				{
+					$createFields = JComponentHelper::getParams(strstr($query['context'], '.', true))->get('custom_fields_enable', 1);
+				}
 
 				if (!$createFields)
 				{

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -298,10 +298,8 @@ class JAdminCssMenu
 				{
 					continue;
 				}
-				else
-				{
-					list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
-				}
+
+				list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : array('com_fields');
 			}
 
 			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -289,6 +289,8 @@ class JAdminCssMenu
 				parse_str($item->link, $query);
 
 				// Only display Fields menus when enabled in the component
+				$createFields = null;
+
 				if (isset($query['context']))
 				{
 					$createFields = JComponentHelper::getParams(strstr($query['context'], '.', true))->get('custom_fields_enable', 1);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18136

### Testing Instructions
Enable custom fields for articles.
Disable custom fields for users.

After patch, the fields admin menus will display for article and not for users, as should.

@izharaazmi @n3t @waader 