### PR TITLE
[4.0] PHP 7 cleanup in libraries

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -21,17 +21,7 @@ class JNamespacePsr4Map
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $file = '';
-
-	/**
-	 * Constructor. For PHP 5.5 compatibility we must set the file property like this
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public function __construct()
-	{
-		$this->file = JPATH_LIBRARIES . '/autoload_psr4.php';
-	}
+	protected $file = JPATH_LIBRARIES . '/autoload_psr4.php';
 
 	/**
 	 * Check if the file exists

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -89,11 +89,11 @@ class CacheStorage
 		$config = \JFactory::getConfig();
 
 		$this->_hash        = md5($config->get('secret'));
-		$this->_application = (isset($options['application'])) ? $options['application'] : null;
-		$this->_language    = (isset($options['language'])) ? $options['language'] : 'en-GB';
-		$this->_locking     = (isset($options['locking'])) ? $options['locking'] : true;
-		$this->_lifetime    = (isset($options['lifetime'])) ? $options['lifetime'] * 60 : $config->get('cachetime') * 60;
-		$this->_now         = (isset($options['now'])) ? $options['now'] : time();
+		$this->_application = $options['application'] ?? null;
+		$this->_language    = $options['language'] ?? 'en-GB';
+		$this->_locking     = $options['locking'] ?? true;
+		$this->_lifetime    = ($options['lifetime'] ?? $config->get('cachetime')) * 60;
+		$this->_now         = $options['now'] ?? time();
 
 		// Set time threshold value.  If the lifetime is not set, default to 60 (0 is BAD)
 		// _threshold is now available ONLY as a legacy (it's deprecated).  It's no longer used in the core.

--- a/libraries/src/Cache/Controller/CallbackController.php
+++ b/libraries/src/Cache/Controller/CallbackController.php
@@ -69,7 +69,7 @@ class CallbackController extends CacheController
 			{
 				echo Cache::getWorkarounds(
 					$data['output'],
-					array('mergehead' => isset($woptions['mergehead']) ? $woptions['mergehead'] : 0)
+					array('mergehead' => $woptions['mergehead'] ?? 0)
 				);
 			}
 			else
@@ -113,9 +113,9 @@ class CallbackController extends CacheController
 			$coptions['modulemode'] = 0;
 		}
 
-		$coptions['nopathway'] = isset($woptions['nopathway']) ? $woptions['nopathway'] : 1;
-		$coptions['nohead']    = isset($woptions['nohead'])    ? $woptions['nohead'] : 1;
-		$coptions['nomodules'] = isset($woptions['nomodules']) ? $woptions['nomodules'] : 1;
+		$coptions['nopathway'] = $woptions['nopathway'] ?? 1;
+		$coptions['nohead']    = $woptions['nohead'] ?? 1;
+		$coptions['nomodules'] = $woptions['nomodules'] ?? 1;
 
 		ob_start();
 		ob_implicit_flush(false);

--- a/libraries/src/Cache/Controller/PageController.php
+++ b/libraries/src/Cache/Controller/PageController.php
@@ -69,7 +69,7 @@ class PageController extends CacheController
 
 			if ($etag == $id)
 			{
-				$browserCache = isset($this->options['browsercache']) ? $this->options['browsercache'] : false;
+				$browserCache = $this->options['browsercache'] ?? false;
 
 				if ($browserCache)
 				{

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -105,11 +105,11 @@ class Categories
 		$this->_table      = $options['table'];
 		$this->_field      = isset($options['field']) && $options['field'] ? $options['field'] : 'catid';
 		$this->_key        = isset($options['key']) && $options['key'] ? $options['key'] : 'id';
-		$this->_statefield = isset($options['statefield']) ? $options['statefield'] : 'state';
+		$this->_statefield = $options['statefield'] ?? 'state';
 
-		$options['access']      = isset($options['access']) ? $options['access'] : 'true';
-		$options['published']   = isset($options['published']) ? $options['published'] : 1;
-		$options['countItems']  = isset($options['countItems']) ? $options['countItems'] : 0;
+		$options['access']      = $options['access'] ?? 'true';
+		$options['published']   = $options['published'] ?? 1;
+		$options['countItems']  = $options['countItems'] ?? 0;
 		$options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
 
 		$this->_options = $options;

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -428,7 +428,7 @@ class ComponentHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected static function dispatchComponent(DispatcherInterface $dispatcher)
+	protected static function dispatchComponent(DispatcherInterface $dispatcher): string
 	{
 		ob_start();
 		$dispatcher->dispatch();
@@ -544,7 +544,7 @@ class ComponentHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function getComponentName($object, $alternativeName)
+	public static function getComponentName($object, string $alternativeName): string
 	{
 		$reflect = new \ReflectionClass($object);
 

--- a/libraries/src/Crypt/Crypt.php
+++ b/libraries/src/Crypt/Crypt.php
@@ -35,7 +35,6 @@ class Crypt extends JCrypt
 	 */
 	public static function timingSafeCompare($known, $unknown)
 	{
-		// This function is native in PHP as of 5.6 and backported via the symfony/polyfill-56 library
 		return hash_equals((string) $known, (string) $unknown);
 	}
 

--- a/libraries/src/Dispatcher/Dispatcher.php
+++ b/libraries/src/Dispatcher/Dispatcher.php
@@ -10,9 +10,10 @@ namespace Joomla\CMS\Dispatcher;
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Access\Exception\Notallowed;
+use Joomla\CMS\Access\Exception\NotAllowed;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\MVC\Controller\BaseController;
+use Joomla\Input\Input;
 use Joomla\CMS\MVC\Factory\MVCFactory;
 
 /**
@@ -29,7 +30,7 @@ abstract class Dispatcher implements DispatcherInterface
 	 * The URL option for the component.
 	 *
 	 * @var    string
-	 * @since  1.6
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $option;
 
@@ -37,25 +38,22 @@ abstract class Dispatcher implements DispatcherInterface
 	 * The extension namespace
 	 *
 	 * @var    string
-	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $namespace;
 
 	/**
-	 * The CmsApplication instance
+	 * The application instance
 	 *
 	 * @var    CMSApplication
-	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $app;
 
 	/**
-	 * The JApplication instance
+	 * The input instance
 	 *
-	 * @var    \JInput
-	 *
+	 * @var    Input
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $input;
@@ -63,12 +61,12 @@ abstract class Dispatcher implements DispatcherInterface
 	/**
 	 * Constructor for Dispatcher
 	 *
-	 * @param   CMSApplication  $app    The JApplication for the dispatcher
-	 * @param   \JInput         $input  JInput
+	 * @param   CMSApplication  $app    The application instance
+	 * @param   Input           $input  The input instance
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(CMSApplication $app, \JInput $input = null)
+	public function __construct(CMSApplication $app, Input $input = null)
 	{
 		if (empty($this->namespace))
 		{
@@ -119,7 +117,7 @@ abstract class Dispatcher implements DispatcherInterface
 		// Check the user has permission to access this component if in the backend
 		if ($this->app->isClient('administrator') && !$this->app->getIdentity()->authorise('core.manage', $this->option))
 		{
-			throw new Notallowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+			throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 	}
 
@@ -175,7 +173,7 @@ abstract class Dispatcher implements DispatcherInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected function getApplication()
+	protected function getApplication(): CMSApplication
 	{
 		return $this->app;
 	}
@@ -187,17 +185,17 @@ abstract class Dispatcher implements DispatcherInterface
 	 * @param   string  $client  Optional client (like Administrator, Site etc.)
 	 * @param   array   $config  Optional controller config
 	 *
-	 * @return  Controller
+	 * @return  BaseController
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getController($name, $client = null, $config = array())
+	public function getController(string $name, string $client = '', array $config = array()): BaseController
 	{
 		// Set up the namespace
 		$namespace = rtrim($this->namespace, '\\') . '\\';
 
 		// Set up the client
-		$client = $client ? $client : ucfirst($this->app->getName());
+		$client = $client ?: ucfirst($this->app->getName());
 
 		$controllerClass = $namespace . $client . '\\Controller\\' . ucfirst($name) . 'Controller';
 
@@ -206,8 +204,6 @@ abstract class Dispatcher implements DispatcherInterface
 			throw new \InvalidArgumentException(\JText::sprintf('JLIB_APPLICATION_ERROR_INVALID_CONTROLLER_CLASS', $controllerClass));
 		}
 
-		$controller = new $controllerClass($config, new MVCFactory($namespace, $this->app), $this->app, $this->input);
-
-		return $controller;
+		return new $controllerClass($config, new MVCFactory($namespace, $this->app), $this->app, $this->input);
 	}
 }

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -342,7 +342,7 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setFactory(FactoryInterface $factory)
+	public function setFactory(FactoryInterface $factory): self
 	{
 		$this->factory = $factory;
 
@@ -953,7 +953,7 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setPreloadManager(PreloadManagerInterface $preloadManager)
+	public function setPreloadManager(PreloadManagerInterface $preloadManager): self
 	{
 		$this->preloadManager = $preloadManager;
 
@@ -967,7 +967,7 @@ class Document
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getPreloadManager()
+	public function getPreloadManager(): PreloadManagerInterface
 	{
 		return $this->preloadManager;
 	}

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -560,7 +560,7 @@ class Document
 			$attribs = array();
 
 			// Old version parameter.
-			$options['version'] = isset($argList[1]) && !is_null($argList[1]) ? $argList[1] : 'auto';
+			$options['version'] = $argList[1] ?? 'auto';
 
 			// Old mime type parameter.
 			if (!empty($argList[2]))
@@ -751,7 +751,7 @@ class Document
 			$attribs = array();
 
 			// Old version parameter.
-			$options['version'] = isset($argList[1]) && !is_null($argList[1]) ? $argList[1] : 'auto';
+			$options['version'] = $argList[1] ?? 'auto';
 
 			// Old mime type parameter.
 			if (!empty($argList[2]))

--- a/libraries/src/Document/ErrorDocument.php
+++ b/libraries/src/Document/ErrorDocument.php
@@ -146,7 +146,7 @@ class ErrorDocument extends Document
 		$file = 'error.php';
 
 		// Check template
-		$directory = isset($params['directory']) ? $params['directory'] : 'templates';
+		$directory = $params['directory'] ?? 'templates';
 		$template = isset($params['template']) ? \JFilterInput::getInstance()->clean($params['template'], 'cmd') : 'system';
 
 		if (!file_exists($directory . '/' . $template . '/' . $file))
@@ -157,7 +157,7 @@ class ErrorDocument extends Document
 		// Set variables
 		$this->baseurl = Uri::base(true);
 		$this->template = $template;
-		$this->debug = isset($params['debug']) ? $params['debug'] : false;
+		$this->debug = $params['debug'] ?? false;
 		$this->error = $this->_error;
 
 		// Load the language file for the template if able

--- a/libraries/src/Document/Factory.php
+++ b/libraries/src/Document/Factory.php
@@ -27,7 +27,7 @@ class Factory implements FactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createDocument($type = 'html', array $attributes = array())
+	public function createDocument(string $type = 'html', array $attributes = []): Document
 	{
 		$type  = preg_replace('/[^A-Z0-9_\.-]/i', '', $type);
 		$ntype = null;
@@ -73,7 +73,7 @@ class Factory implements FactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createRenderer(Document $document, $type)
+	public function createRenderer(Document $document, string $type): RendererInterface
 	{
 		// Determine the path and class
 		$class = __NAMESPACE__ . '\\Renderer\\' . ucfirst($document->getType()) . '\\' . ucfirst($type) . 'Renderer';

--- a/libraries/src/Document/FactoryInterface.php
+++ b/libraries/src/Document/FactoryInterface.php
@@ -27,7 +27,7 @@ interface FactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createDocument($type = 'html', array $attributes = array());
+	public function createDocument(string $type = 'html', array $attributes = []): Document;
 
 	/**
 	 * Creates a new renderer object.
@@ -39,5 +39,5 @@ interface FactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createRenderer(Document $document, $type);
+	public function createRenderer(Document $document, string $type): RendererInterface;
 }

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -237,16 +237,16 @@ class HtmlDocument extends Document
 			return;
 		}
 
-		$this->title        = (isset($data['title']) && !empty($data['title'])) ? $data['title'] : $this->title;
-		$this->description  = (isset($data['description']) && !empty($data['description'])) ? $data['description'] : $this->description;
-		$this->link         = (isset($data['link']) && !empty($data['link'])) ? $data['link'] : $this->link;
-		$this->_metaTags    = (isset($data['metaTags']) && !empty($data['metaTags'])) ? $data['metaTags'] : $this->_metaTags;
-		$this->_links       = (isset($data['links']) && !empty($data['links'])) ? $data['links'] : $this->_links;
-		$this->_styleSheets = (isset($data['styleSheets']) && !empty($data['styleSheets'])) ? $data['styleSheets'] : $this->_styleSheets;
-		$this->_style       = (isset($data['style']) && !empty($data['style'])) ? $data['style'] : $this->_style;
-		$this->_scripts     = (isset($data['scripts']) && !empty($data['scripts'])) ? $data['scripts'] : $this->_scripts;
-		$this->_script      = (isset($data['script']) && !empty($data['script'])) ? $data['script'] : $this->_script;
-		$this->_custom      = (isset($data['custom']) && !empty($data['custom'])) ? $data['custom'] : $this->_custom;
+		$this->title        = $data['title'] ?? $this->title;
+		$this->description  = $data['description'] ?? $this->description;
+		$this->link         = $data['link'] ?? $this->link;
+		$this->_metaTags    = $data['metaTags'] ?? $this->_metaTags;
+		$this->_links       = $data['links'] ?? $this->_links;
+		$this->_styleSheets = $data['styleSheets'] ?? $this->_styleSheets;
+		$this->_style       = $data['style'] ?? $this->_style;
+		$this->_scripts     = $data['scripts'] ?? $this->_scripts;
+		$this->_script      = $data['script'] ?? $this->_script;
+		$this->_custom      = $data['custom'] ?? $this->_custom;
 
 		if (isset($data['scriptText']) && !empty($data['scriptText']))
 		{
@@ -448,7 +448,7 @@ class HtmlDocument extends Document
 			return parent::$_buffer;
 		}
 
-		$title = (isset($attribs['title'])) ? $attribs['title'] : null;
+		$title = $attribs['title'] ?? null;
 
 		if (isset(parent::$_buffer[$type][$name][$title]))
 		{
@@ -510,8 +510,8 @@ class HtmlDocument extends Document
 			$args = func_get_args();
 			$options = array();
 			$options['type'] = $args[1];
-			$options['name'] = (isset($args[2])) ? $args[2] : null;
-			$options['title'] = (isset($args[3])) ? $args[3] : null;
+			$options['name'] = $args[2] ?? null;
+			$options['title'] = $args[3] ?? null;
 		}
 
 		parent::$_buffer[$options['type']][$options['name']][$options['title']] = $content;
@@ -687,7 +687,7 @@ class HtmlDocument extends Document
 	protected function _fetchTemplate($params = array())
 	{
 		// Check
-		$directory = isset($params['directory']) ? $params['directory'] : 'templates';
+		$directory = $params['directory'] ?? 'templates';
 		$filter = \JFilterInput::getInstance();
 		$template = $filter->clean($params['template'], 'cmd');
 		$file = $filter->clean($params['file'], 'cmd');
@@ -712,7 +712,7 @@ class HtmlDocument extends Document
 		// Assign the variables
 		$this->template = $template;
 		$this->baseurl = Uri::base(true);
-		$this->params = isset($params['params']) ? $params['params'] : new Registry;
+		$this->params = $params['params'] ?? new Registry;
 
 		// Load
 		$this->_template = $this->_loadTemplate($directory . '/' . $template, $file);
@@ -741,7 +741,7 @@ class HtmlDocument extends Document
 			{
 				$type = $matches[1][$i];
 				$attribs = empty($matches[2][$i]) ? array() : \JUtility::parseAttributes($matches[2][$i]);
-				$name = isset($attribs['name']) ? $attribs['name'] : null;
+				$name = $attribs['name'] ?? null;
 
 				// Separate buffers to be executed first and last
 				if ($type == 'module' || $type == 'modules')

--- a/libraries/src/Document/PreloadManager.php
+++ b/libraries/src/Document/PreloadManager.php
@@ -48,7 +48,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getLinkProvider()
+	public function getLinkProvider(): EvolvableLinkProviderInterface
 	{
 		return $this->linkProvider;
 	}
@@ -79,7 +79,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preload($uri, array $attributes = [])
+	public function preload(string $uri, array $attributes = [])
 	{
 		$this->link($uri, 'preload', $attributes);
 	}
@@ -94,7 +94,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dnsPrefetch($uri, array $attributes = [])
+	public function dnsPrefetch(string $uri, array $attributes = [])
 	{
 		$this->link($uri, 'dns-prefetch', $attributes);
 	}
@@ -109,7 +109,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preconnect($uri, array $attributes = [])
+	public function preconnect(string $uri, array $attributes = [])
 	{
 		$this->link($uri, 'preconnect', $attributes);
 	}
@@ -124,7 +124,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prefetch($uri, array $attributes = [])
+	public function prefetch(string $uri, array $attributes = [])
 	{
 		$this->link($uri, 'prefetch', $attributes);
 	}
@@ -139,7 +139,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prerender($uri, array $attributes = [])
+	public function prerender(string $uri, array $attributes = [])
 	{
 		$this->link($uri, 'prerender', $attributes);
 	}
@@ -155,7 +155,7 @@ class PreloadManager implements PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	private function link($uri, $rel, array $attributes = [])
+	private function link(string $uri, string $rel, array $attributes = [])
 	{
 		$link = new Link($rel, $uri);
 

--- a/libraries/src/Document/PreloadManagerInterface.php
+++ b/libraries/src/Document/PreloadManagerInterface.php
@@ -26,7 +26,7 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getLinkProvider();
+	public function getLinkProvider(): EvolvableLinkProviderInterface;
 
 	/**
 	 * Set the link provider
@@ -49,7 +49,7 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preload($uri, array $attributes = []);
+	public function preload(string $uri, array $attributes = []);
 
 	/**
 	 * Resolves a resource origin as early as possible.
@@ -61,7 +61,7 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dnsPrefetch($uri, array $attributes = []);
+	public function dnsPrefetch(string $uri, array $attributes = []);
 
 	/**
 	 * Initiates a early connection to a resource (DNS resolution, TCP handshake, TLS negotiation).
@@ -73,7 +73,7 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function preconnect($uri, array $attributes = []);
+	public function preconnect(string $uri, array $attributes = []);
 
 	/**
 	 * Indicates to the client that it should prefetch this resource.
@@ -85,7 +85,7 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prefetch($uri, array $attributes = []);
+	public function prefetch(string $uri, array $attributes = []);
 
 	/**
 	 * Indicates to the client that it should prerender this resource.
@@ -97,5 +97,5 @@ interface PreloadManagerInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function prerender($uri, array $attributes = []);
+	public function prerender(string $uri, array $attributes = []);
 }

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -38,7 +38,7 @@ class ModuleRenderer extends DocumentRenderer
 	{
 		if (!is_object($module))
 		{
-			$title = isset($attribs['title']) ? $attribs['title'] : null;
+			$title = $attribs['title'] ?? null;
 
 			$module = ModuleHelper::getModule($module, $title);
 

--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -50,7 +50,7 @@ abstract class AbstractEvent extends BaseEvent
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  BadMethodCallException  If you do not provide a subject argument
 	 */
-	public static function create($eventName, $arguments = [])
+	public static function create(string $eventName, array $arguments = [])
 	{
 		// Get the class name from the arguments, if specified
 		$eventClassName = '';
@@ -98,7 +98,7 @@ abstract class AbstractEvent extends BaseEvent
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct($name, array $arguments = array())
+	public function __construct(string $name, array $arguments = [])
 	{
 		parent::__construct($name, $arguments);
 

--- a/libraries/src/Event/AbstractImmutableEvent.php
+++ b/libraries/src/Event/AbstractImmutableEvent.php
@@ -21,10 +21,10 @@ use BadMethodCallException;
 class AbstractImmutableEvent extends AbstractEvent
 {
 	/**
-	 * A flag to see if the constructor has been
-	 * already called.
+	 * A flag to see if the constructor has been already called.
 	 *
-	 * @var  boolean
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $constructed = false;
 
@@ -34,11 +34,10 @@ class AbstractImmutableEvent extends AbstractEvent
 	 * @param   string  $name       The event name.
 	 * @param   array   $arguments  The event arguments.
 	 *
-	 * @throws  BadMethodCallException
-	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  BadMethodCallException
 	 */
-	public function __construct($name, array $arguments = array())
+	public function __construct(string $name, array $arguments = [])
 	{
 		if ($this->constructed)
 		{
@@ -81,9 +80,8 @@ class AbstractImmutableEvent extends AbstractEvent
 	 *
 	 * @return  void
 	 *
-	 * @throws  BadMethodCallException
-	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  BadMethodCallException
 	 */
 	public function offsetUnset($name)
 	{

--- a/libraries/src/Event/BeforeExecuteEvent.php
+++ b/libraries/src/Event/BeforeExecuteEvent.php
@@ -26,7 +26,7 @@ class BeforeExecuteEvent extends AbstractImmutableEvent
 	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public function getApplication()
+	public function getApplication(): AbstractApplication
 	{
 		return $this->getArgument('subject');
 	}

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -61,7 +61,7 @@ class Feed implements \ArrayAccess, \Countable
 	 */
 	public function __get($name)
 	{
-		return isset($this->properties[$name]) ? $this->properties[$name] : null;
+		return $this->properties[$name] ?? null;
 	}
 
 	/**

--- a/libraries/src/Feed/FeedEntry.php
+++ b/libraries/src/Feed/FeedEntry.php
@@ -56,7 +56,7 @@ class FeedEntry
 	 */
 	public function __get($name)
 	{
-		return (isset($this->properties[$name])) ? $this->properties[$name] : null;
+		return $this->properties[$name] ?? null;
 	}
 
 	/**

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -101,7 +101,7 @@ class Form
 		$this->data = new Registry;
 
 		// Set the options if specified.
-		$this->options['control'] = isset($options['control']) ? $options['control'] : false;
+		$this->options['control'] = $options['control'] ?? false;
 	}
 
 	/**

--- a/libraries/src/Form/FormFactory.php
+++ b/libraries/src/Form/FormFactory.php
@@ -23,11 +23,11 @@ class FormFactory implements FormFactoryInterface
 	 * @param   string  $name     The name of the form.
 	 * @param   array   $options  An array of form options.
 	 *
-	 * @return  Form  Form instance.
+	 * @return  Form
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createForm($name, $options = array())
+	public function createForm(string $name, array $options = array()): Form
 	{
 		return new Form($name, $options);
 	}

--- a/libraries/src/Form/FormFactoryInterface.php
+++ b/libraries/src/Form/FormFactoryInterface.php
@@ -23,9 +23,9 @@ interface FormFactoryInterface
 	 * @param   string  $name     The name of the form.
 	 * @param   array   $options  An array of form options.
 	 *
-	 * @return  Form  Form instance.
+	 * @return  Form
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createForm($name, $options = array());
+	public function createForm(string $name, array $options = array()): Form;
 }

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -696,18 +696,18 @@ abstract class HTMLHelper
 			$options = array();
 
 			// Old parameters.
-			$attribs                  = isset($argList[1]) ? $argList[1] : array();
-			$options['relative']      = isset($argList[2]) ? $argList[2] : false;
-			$options['pathOnly']      = isset($argList[3]) ? $argList[3] : false;
-			$options['detectBrowser'] = isset($argList[4]) ? $argList[4] : true;
-			$options['detectDebug']   = isset($argList[5]) ? $argList[5] : true;
+			$attribs                  = $argList[1] ?? array();
+			$options['relative']      = $argList[2] ?? false;
+			$options['pathOnly']      = $argList[3] ?? false;
+			$options['detectBrowser'] = $argList[4] ?? true;
+			$options['detectDebug']   = $argList[5] ?? true;
 		}
 		else
 		{
-			$options['relative']      = isset($options['relative']) ? $options['relative'] : false;
-			$options['pathOnly']      = isset($options['pathOnly']) ? $options['pathOnly'] : false;
-			$options['detectBrowser'] = isset($options['detectBrowser']) ? $options['detectBrowser'] : true;
-			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
+			$options['relative']      = $options['relative'] ?? false;
+			$options['pathOnly']      = $options['pathOnly'] ?? false;
+			$options['detectBrowser'] = $options['detectBrowser'] ?? true;
+			$options['detectDebug']   = $options['detectDebug'] ?? true;
 		}
 
 		$includes = static::includeRelativeFiles('css', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
@@ -769,19 +769,19 @@ abstract class HTMLHelper
 			$attribs = array();
 
 			// Old parameters.
-			$options['framework']     = isset($argList[1]) ? $argList[1] : false;
-			$options['relative']      = isset($argList[2]) ? $argList[2] : false;
-			$options['pathOnly']      = isset($argList[3]) ? $argList[3] : false;
-			$options['detectBrowser'] = isset($argList[4]) ? $argList[4] : true;
-			$options['detectDebug']   = isset($argList[5]) ? $argList[5] : true;
+			$options['framework']     = $argList[1] ?? false;
+			$options['relative']      = $argList[2] ?? false;
+			$options['pathOnly']      = $argList[3] ?? false;
+			$options['detectBrowser'] = $argList[4] ?? true;
+			$options['detectDebug']   = $argList[5] ?? true;
 		}
 		else
 		{
-			$options['framework']     = isset($options['framework']) ? $options['framework'] : false;
-			$options['relative']      = isset($options['relative']) ? $options['relative'] : false;
-			$options['pathOnly']      = isset($options['pathOnly']) ? $options['pathOnly'] : false;
-			$options['detectBrowser'] = isset($options['detectBrowser']) ? $options['detectBrowser'] : true;
-			$options['detectDebug']   = isset($options['detectDebug']) ? $options['detectDebug'] : true;
+			$options['framework']     = $options['framework'] ?? false;
+			$options['relative']      = $options['relative'] ?? false;
+			$options['pathOnly']      = $options['pathOnly'] ?? false;
+			$options['detectBrowser'] = $options['detectBrowser'] ?? true;
+			$options['detectDebug']   = $options['detectDebug'] ?? true;
 		}
 
 		// Include MooTools framework
@@ -1173,15 +1173,15 @@ abstract class HTMLHelper
 		$autofocus    = isset($attribs['autofocus']) && $attribs['autofocus'] === '';
 		$required     = isset($attribs['required']) && $attribs['required'] === '';
 		$filter       = isset($attribs['filter']) && $attribs['filter'] === '';
-		$todayBtn     = isset($attribs['todayBtn']) ? $attribs['todayBtn'] : true;
-		$weekNumbers  = isset($attribs['weekNumbers']) ? $attribs['weekNumbers'] : true;
-		$showTime     = isset($attribs['showTime']) ? $attribs['showTime'] : false;
-		$fillTable    = isset($attribs['fillTable']) ? $attribs['fillTable'] : true;
-		$timeFormat   = isset($attribs['timeFormat']) ? $attribs['timeFormat'] : 24;
-		$singleHeader = isset($attribs['singleHeader']) ? $attribs['singleHeader'] : false;
-		$hint         = isset($attribs['placeholder']) ? $attribs['placeholder'] : '';
-		$class        = isset($attribs['class']) ? $attribs['class'] : '';
-		$onchange     = isset($attribs['onChange']) ? $attribs['onChange'] : '';
+		$todayBtn     = $attribs['todayBtn'] ?? true;
+		$weekNumbers  = $attribs['weekNumbers'] ?? true;
+		$showTime     = $attribs['showTime'] ?? false;
+		$fillTable    = $attribs['fillTable'] ?? true;
+		$timeFormat   = $attribs['timeFormat'] ?? 24;
+		$singleHeader = $attribs['singleHeader'] ?? false;
+		$hint         = $attribs['placeholder'] ?? '';
+		$class        = $attribs['class'] ?? '';
+		$onchange     = $attribs['onChange'] ?? '';
 
 		$showTime     = ($showTime) ? "1" : "0";
 		$todayBtn     = ($todayBtn) ? "1" : "0";

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -285,7 +285,7 @@ abstract class HTMLHelper
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public static function getServiceRegistry()
+	public static function getServiceRegistry(): Registry
 	{
 		if (!static::$serviceRegistry)
 		{
@@ -837,7 +837,7 @@ abstract class HTMLHelper
 	 *
 	 * @return  void
 	 */
-	public static function webcomponent($component = [], $options = [])
+	public static function webcomponent(array $component = [], array $options = [])
 	{
 		if (empty($component))
 		{
@@ -855,13 +855,13 @@ abstract class HTMLHelper
 				continue;
 			}
 			$version      = '';
-			$mediaVersion = \JFactory::getDocument()->getMediaVersion();
+			$mediaVersion = Factory::getDocument()->getMediaVersion();
 			$includes     = static::includeRelativeFiles(
 				'webcomponents',
 				$value,
-				isset($options['relative']) ? $options['relative'] : true,
-				isset($options['detectBrowser']) ? $options['detectBrowser'] : false,
-				isset($options['detectDebug']) ? $options['detectDebug'] : false
+				$options['relative'] ?? true,
+				$options['detectBrowser'] ?? false,
+				$options['detectDebug'] ?? false
 			);
 
 			if (count($includes) === 0)

--- a/libraries/src/HTML/Registry.php
+++ b/libraries/src/HTML/Registry.php
@@ -76,7 +76,7 @@ final class Registry
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function getService($key)
+	public function getService(string $key)
 	{
 		if (!$this->hasService($key))
 		{
@@ -95,7 +95,7 @@ final class Registry
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function hasService($key)
+	public function hasService(string $key): bool
 	{
 		return isset($this->serviceMap[$key]);
 	}
@@ -111,7 +111,7 @@ final class Registry
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function register($key, $handler, $replace = false)
+	public function register(string $key, $handler, bool $replace = false)
 	{
 		// If the key exists already and we aren't instructed to replace existing services, bail early
 		if (isset($this->serviceMap[$key]) && !$replace)

--- a/libraries/src/Helper/ContentHistoryHelper.php
+++ b/libraries/src/Helper/ContentHistoryHelper.php
@@ -149,7 +149,7 @@ class ContentHistoryHelper extends CMSHelper
 		// Load history_limit config from extension.
 		$aliasParts = explode('.', $this->typeAlias);
 
-		$context = isset($aliasParts[1]) ? $aliasParts[1] : '';
+		$context = $aliasParts[1] ?? '';
 
 		$maxVersionsContext = ComponentHelper::getParams($aliasParts[0])->get('history_limit' . '_' . $context, 0);
 

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -73,7 +73,7 @@ class MediaHelper
 			elseif ($isImage && function_exists('getimagesize'))
 			{
 				$imagesize = getimagesize($file);
-				$mime      = isset($imagesize['mime']) ? $imagesize['mime'] : false;
+				$mime      = $imagesize['mime'] ?? false;
 			}
 			elseif (function_exists('mime_content_type'))
 			{

--- a/libraries/src/Helper/RouteHelper.php
+++ b/libraries/src/Helper/RouteHelper.php
@@ -135,7 +135,7 @@ class RouteHelper
 	{
 		$app      = \JFactory::getApplication();
 		$menus    = $app->getMenu('site');
-		$language = isset($needles['language']) ? $needles['language'] : '*';
+		$language = $needles['language'] ?? '*';
 
 		// $this->extension may not be set if coming from a static method, check it
 		if ($this->extension === null)

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -247,7 +247,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
 		else
 		{
 			// Get the number of redirects that occurred.
-			$redirects = isset($info['redirect_count']) ? $info['redirect_count'] : 0;
+			$redirects = $info['redirect_count'] ?? 0;
 
 			/*
 			 * Split the response into headers and body. If cURL encountered redirects, the headers for the redirected requests will

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -154,7 +154,7 @@ class Cli extends Input
 					}
 					else
 					{
-						$value = isset($out[$key]) ? $out[$key] : true;
+						$value = $out[$key] ?? true;
 					}
 
 					$out[$key] = $value;

--- a/libraries/src/Input/Input.php
+++ b/libraries/src/Input/Input.php
@@ -167,7 +167,7 @@ class Input extends \Joomla\Input\Input
 			}
 			else
 			{
-				$filter = isset($defaultFilter) ? $defaultFilter : $v;
+				$filter = $defaultFilter ?? $v;
 
 				if (is_null($datasource))
 				{

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -360,7 +360,7 @@ class ComponentAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -151,7 +151,7 @@ class FileAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		\JFile::delete(JPATH_MANIFESTS . '/files/' . $this->extension->element . '.xml');
 

--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -87,7 +87,7 @@ class LanguageAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		if ($this->ignoreUninstallQueries)
 		{

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -145,7 +145,7 @@ class LibraryAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -207,7 +207,7 @@ class ModuleAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -300,7 +300,7 @@ class PackageAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -195,7 +195,7 @@ class PluginAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -176,7 +176,7 @@ class TemplateAdapter extends InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	protected function finaliseUninstall()
+	protected function finaliseUninstall(): bool
 	{
 		$db = $this->parent->getDbo();
 

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -535,7 +535,7 @@ abstract class InstallerAdapter
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \RuntimeException
 	 */
-	abstract protected function finaliseUninstall();
+	abstract protected function finaliseUninstall(): bool;
 
 	/**
 	 * Checks if the adapter supports discover_install

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1332,7 +1332,7 @@ class Language
 	 */
 	public function getFirstDay()
 	{
-		return (int) (isset($this->metadata['firstDay']) ? $this->metadata['firstDay'] : 0);
+		return (int) ($this->metadata['firstDay'] ?? 0);
 	}
 
 	/**
@@ -1344,7 +1344,7 @@ class Language
 	 */
 	public function getWeekEnd()
 	{
-		return (isset($this->metadata['weekEnd']) && $this->metadata['weekEnd']) ? $this->metadata['weekEnd'] : '0,6';
+		return $this->metadata['weekEnd'] ?? '0,6';
 	}
 
 	/**

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -43,7 +43,7 @@ class LanguageHelper
 			$metadata = $installed ? $language->metadata : $language;
 
 			$list[] = array(
-				'text'     => isset($metadata['nativeName']) ? $metadata['nativeName'] : $metadata['name'],
+				'text'     => $metadata['nativeName'] ?? $metadata['name'],
 				'value'    => $languageCode,
 				'selected' => $languageCode === $actualLanguage ? 'selected="selected"' : null,
 			);

--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -223,7 +223,7 @@ class BaseLayout implements LayoutInterface
 	 */
 	public function get($key, $defaultValue = null)
 	{
-		return isset($this->data[$key]) ? $this->data[$key] : $defaultValue;
+		return $this->data[$key] ?? $defaultValue;
 	}
 
 	/**

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -220,7 +220,7 @@ class FormController extends BaseController
 	 */
 	protected function allowSave($data, $key = 'id')
 	{
-		$recordId = isset($data[$key]) ? $data[$key] : '0';
+		$recordId = $data[$key] ?? '0';
 
 		if ($recordId)
 		{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -158,7 +158,7 @@ abstract class AdminModel extends FormModel
 			$this->event_change_state = 'onContentChangeState';
 		}
 
-		$config['events_map'] = isset($config['events_map']) ? $config['events_map'] : array();
+		$config['events_map'] = $config['events_map'] ?? array();
 
 		$this->events_map = array_merge(
 			array(

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -50,7 +50,7 @@ abstract class FormModel extends BaseModel
 	 */
 	public function __construct($config = array(), MVCFactoryInterface $factory = null)
 	{
-		$config['events_map'] = isset($config['events_map']) ? $config['events_map'] : array();
+		$config['events_map'] = $config['events_map'] ?? array();
 
 		$this->events_map = array_merge(
 			array(

--- a/libraries/src/Menu/MenuFactory.php
+++ b/libraries/src/Menu/MenuFactory.php
@@ -28,7 +28,7 @@ class MenuFactory implements MenuFactoryInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \InvalidArgumentException
 	 */
-	public function createMenu($client, array $options = [])
+	public function createMenu(string $client, array $options = []): AbstractMenu
 	{
 		// Create a Menu object
 		$classname = __NAMESPACE__ . '\\' . ucfirst(strtolower($client)) . 'Menu';

--- a/libraries/src/Menu/MenuFactoryInterface.php
+++ b/libraries/src/Menu/MenuFactoryInterface.php
@@ -27,5 +27,5 @@ interface MenuFactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createMenu($client, array $options = []);
+	public function createMenu(string $client, array $options = []): AbstractMenu;
 }

--- a/libraries/src/Menu/MenuHelper.php
+++ b/libraries/src/Menu/MenuHelper.php
@@ -218,8 +218,8 @@ class MenuHelper
 			if ($item->link = in_array($item->type, array('separator', 'heading', 'container')) ? '#' : trim($item->link))
 			{
 				$item->submenu    = array();
-				$item->class      = isset($item->img) ? $item->img : '';
-				$item->scope      = isset($item->scope) ? $item->scope : null;
+				$item->class      = $item->img ?? '';
+				$item->scope      = $item->scope ?? null;
 				$item->browserNav = $item->browserNav ? '_blank' : '';
 
 				$result[$item->parent_id][$item->id] = $item;

--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -344,7 +344,7 @@ class MenuItem extends \stdClass
 	 */
 	public function set($property, $value = null)
 	{
-		$previous = isset($this->$property) ? $this->$property : null;
+		$previous = $this->$property ?? null;
 		$this->$property = $value;
 
 		return $previous;

--- a/libraries/src/Menu/Node.php
+++ b/libraries/src/Menu/Node.php
@@ -244,7 +244,7 @@ class Node
 	 */
 	public function getParam($key)
 	{
-		return isset($this->params[$key]) ? $this->params[$key] : null;
+		return $this->params[$key] ?? null;
 	}
 
 	/**

--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -193,7 +193,7 @@ class CMSObject
 	 */
 	public function set($property, $value = null)
 	{
-		$previous = isset($this->$property) ? $this->$property : null;
+		$previous = $this->$property ?? null;
 		$this->$property = $value;
 
 		return $previous;

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -191,7 +191,7 @@ class Pagination
 	public function setAdditionalUrlParam($key, $value)
 	{
 		// Get the old value to return and set the new one for the URL parameter.
-		$result = isset($this->additionalUrlParams[$key]) ? $this->additionalUrlParams[$key] : null;
+		$result = $this->additionalUrlParams[$key] ?? null;
 
 		// If the passed parameter value is null unset the parameter, otherwise set it to the given value.
 		if ($value === null)
@@ -218,9 +218,7 @@ class Pagination
 	 */
 	public function getAdditionalUrlParam($key)
 	{
-		$result = isset($this->additionalUrlParams[$key]) ? $this->additionalUrlParams[$key] : null;
-
-		return $result;
+		return $this->additionalUrlParams[$key] ?? null;
 	}
 
 	/**

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -208,7 +208,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface
 				{
 					if (is_array($params))
 					{
-						$this->getDispatcher()->addListener($eventName, [$this, $params[0]], isset($params[1]) ? $params[1] : Priority::NORMAL);
+						$this->getDispatcher()->addListener($eventName, [$this, $params[0]], $params[1] ?? Priority::NORMAL);
 					}
 					else
 					{

--- a/libraries/src/Table/ContentHistory.php
+++ b/libraries/src/Table/ContentHistory.php
@@ -108,8 +108,8 @@ class ContentHistory extends Table
 		if (isset($typeTable->content_history_options) && is_object(json_decode($typeTable->content_history_options)))
 		{
 			$options = json_decode($typeTable->content_history_options);
-			$this->ignoreChanges = isset($options->ignoreChanges) ? $options->ignoreChanges : $this->ignoreChanges;
-			$this->convertToInt = isset($options->convertToInt) ? $options->convertToInt : $this->convertToInt;
+			$this->ignoreChanges = $options->ignoreChanges ?? $this->ignoreChanges;
+			$this->convertToInt = $options->convertToInt ?? $this->convertToInt;
 		}
 
 		foreach ($this->ignoreChanges as $remove)

--- a/libraries/src/Table/ContentType.php
+++ b/libraries/src/Table/ContentType.php
@@ -143,7 +143,7 @@ class ContentType extends Table
 		{
 			if (is_object($tableInfo->special) && isset($tableInfo->special->type) && isset($tableInfo->special->prefix))
 			{
-				$class = isset($tableInfo->special->class) ? $tableInfo->special->class : 'Joomla\\CMS\\Table\\Table';
+				$class = $tableInfo->special->class ?? 'Joomla\\CMS\\Table\\Table';
 
 				if (!class_implements($class, 'Joomla\\CMS\\Table\\TableInterface'))
 				{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -299,7 +299,7 @@ abstract class Table extends \JObject implements \JTableInterface, DispatcherAwa
 		}
 
 		// If a database object was passed in the configuration array use it, otherwise get the global one from \JFactory.
-		$db = isset($config['dbo']) ? $config['dbo'] : \JFactory::getDbo();
+		$db = $config['dbo'] ?? \JFactory::getDbo();
 
 		// Check for a possible service from the container otherwise manually instantiate the class
 		if (\JFactory::getContainer()->exists($tableClass))

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -33,7 +33,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 	 * @since   3.8.0
 	 * @throws  \InvalidArgumentException
 	 */
-	public function createButton(Toolbar $toolbar, $type)
+	public function createButton(Toolbar $toolbar, string $type): ToolbarButton
 	{
 		$buttonClass = $this->loadButtonClass($type);
 
@@ -80,7 +80,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createToolbar($name = 'toolbar')
+	public function createToolbar(string $name = 'toolbar'): Toolbar
 	{
 		return new Toolbar($name, $this);
 	}
@@ -94,7 +94,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	private function loadButtonClass($type)
+	private function loadButtonClass(string $type)
 	{
 		$buttonClasses = [
 			'Joomla\\CMS\\Toolbar\\Button\\' . ucfirst($type) . 'Button',

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -126,7 +126,7 @@ class Toolbar
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function setFactory(ToolbarFactoryInterface $factory)
+	public function setFactory(ToolbarFactoryInterface $factory): self
 	{
 		$this->factory = $factory;
 
@@ -340,7 +340,7 @@ class Toolbar
 	 * @since   __DEPLOY_VERSION__
 	 * @deprecated  5.0  ToolbarButton classes should be autoloaded
 	 */
-	public function getButtonPath()
+	public function getButtonPath(): array
 	{
 		\JLog::add(
 			sprintf(

--- a/libraries/src/Toolbar/ToolbarFactoryInterface.php
+++ b/libraries/src/Toolbar/ToolbarFactoryInterface.php
@@ -28,7 +28,7 @@ interface ToolbarFactoryInterface
 	 * @since   __DEPLOY_VERSION__
 	 * @throws  \InvalidArgumentException
 	 */
-	public function createButton(Toolbar $toolbar, $type);
+	public function createButton(Toolbar $toolbar, string $type): ToolbarButton;
 
 	/**
 	 * Creates a new Toolbar object.
@@ -39,5 +39,5 @@ interface ToolbarFactoryInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function createToolbar($name = 'toolbar');
+	public function createToolbar(string $name = 'toolbar'): Toolbar;
 }

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -680,7 +680,7 @@ abstract class ToolbarHelper
 			}
 
 			$options['group'] = true;
-			$altText = isset($button[2]) ? $button[2] : $validOptions[$button[0]];
+			$altText = $button[2] ?? $validOptions[$button[0]];
 			call_user_func_array('JToolbarHelper::' . $button[0], array($button[1], $altText, $firstItem));
 
 			if (!$firstItem)

--- a/libraries/src/UCM/UCMBase.php
+++ b/libraries/src/UCM/UCMBase.php
@@ -49,9 +49,9 @@ class UCMBase implements UCM
 	{
 		// Setup dependencies.
 		$input = \JFactory::getApplication()->input;
-		$this->alias = isset($alias) ? $alias : $input->get('option') . '.' . $input->get('view');
+		$this->alias = $alias ?: $input->get('option') . '.' . $input->get('view');
 
-		$this->type = isset($type) ? $type : $this->getType();
+		$this->type = $type ?: $this->getType();
 	}
 
 	/**
@@ -73,7 +73,7 @@ class UCMBase implements UCM
 			$table = Table::getInstance('Ucm');
 		}
 
-		$ucmId      = isset($data['ucm_id']) ? $data['ucm_id'] : null;
+		$ucmId      = $data['ucm_id'] ?? null;
 		$primaryKey = $primaryKey ?: $ucmId;
 
 		if (isset($primaryKey))

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -132,7 +132,7 @@ class UCMContent extends UCMBase
 	 */
 	public function mapData($original, UCMType $type = null)
 	{
-		$contentType = isset($type) ? $type : $this->type;
+		$contentType = $type ?: $this->type;
 
 		$fields = json_decode($contentType->type->field_mappings);
 

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -247,6 +247,6 @@ class UCMType implements UCM
 			$this->fieldmapExpand(false);
 		}
 
-		return isset($this->fieldmap->common->$ucmField) ? $this->fieldmap->common->$ucmField : null;
+		return $this->fieldmap->common->$ucmField ?? null;
 	}
 }

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -168,12 +168,9 @@ final class Version
 	{
 		$version = self::MAJOR_VERSION . '.' . self::MINOR_VERSION . '.' . self::PATCH_VERSION;
 
-		// Has to be assigned to a variable to support PHP 5.3 and 5.4
-		$extraVersion = self::EXTRA_VERSION;
-
-		if (!empty($extraVersion))
+		if (!empty(self::EXTRA_VERSION))
 		{
-			$version .= '-' . $extraVersion;
+			$version .= '-' . self::EXTRA_VERSION;
 		}
 
 		return $version;


### PR DESCRIPTION
### Summary of Changes

Some cleanup for PHP 7 in the libraries

- New APIs using scalar typehints and return type declarations
- Use null coalescing operator
- Remove some workarounds for PHP 5 version behaviors

### Testing Instructions

General review, CMS still runs