### PR TITLE
Update menu.php

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -235,7 +235,6 @@ class JAdminCssMenu
 	{
 		$result     = array();
 		$user       = JFactory::getUser();
-		$authLevels = $user->getAuthorisedViewLevels();
 		$language   = JFactory::getLanguage();
 
 		$noSeparator = true;
@@ -291,12 +290,6 @@ class JAdminCssMenu
 			}
 
 			if ($assetName && !$user->authorise(($item->scope == 'edit') ? 'core.create' : 'core.manage', $assetName))
-			{
-				continue;
-			}
-
-			// Exclude if menu item set access level is not met
-			if ($item->access && !in_array($item->access, $authLevels))
 			{
 				continue;
 			}


### PR DESCRIPTION
Checking view level of menu item in the admin components menu is not needed.  Display of those menu items is controlled by the Permissions in component options not  by User Group view level.  Corrects error causing https://github.com/joomla/joomla-cms/issues/18000#issuecomment-332742364

Pull Request for Issue # . 
#18000 

### Summary of Changes
Deleted lines that checked view levels in admin menu items


### Testing Instructions

- Set Global Config > Default Access Level --> Guest
- Install a 3rd party component


### Expected result
Menu item for the 3rd party component should be seen 


### Actual result
Menu item for the 3rd party component is not seen because it is 'Guest' level and SU is not in 'Guest' user group.

### Extra tests
Create a test user and set as Administrator
In the Menu item for the 3rd party component's Options set the Administrator Permissions for 'Access Administration Interface ' as 'Denied'
Login with the Test user and make sure the Permission settings are being honoured.



### Documentation Changes Required

