### PR TITLE
[4.0] Fix wrong Model class name call

### DIFF
--- a/administrator/components/com_users/Model/UserModel.php
+++ b/administrator/components/com_users/Model/UserModel.php
@@ -916,7 +916,7 @@ class UserModel extends AdminModel
 
 		if ($user->authorise('core.edit', 'com_users') && $user->authorise('core.manage', 'com_users'))
 		{
-			$model = new Groups(array('ignore_request' => true));
+			$model = new GroupsModel(array('ignore_request' => true));
 
 			return $model->getItems();
 		}


### PR DESCRIPTION
### Summary of Changes
A small fix for the wrong model class name


### Testing Instructions
Edit a user


### Expected result
Form is visible


### Actual result
```
An error has occurred.

    0 Class 'Joomla\Component\Users\Administrator\Model\Groups' not found 
```