### PR TITLE
Allow alternate menuitems being selected as alternate layouts

### DIFF
--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -181,7 +181,7 @@ class JFormFieldComponentlayout extends JFormField
 					{
 						foreach ($files as $i => $file)
 						{
-							// Remove layout files that exist in the component folder or that have XML files
+							// Remove layout files that exist in the component folder
 							if (in_array(basename($file, '.php'), $component_layouts))
 							{
 								unset($files[$i]);

--- a/libraries/legacy/form/field/componentlayout.php
+++ b/libraries/legacy/form/field/componentlayout.php
@@ -179,20 +179,10 @@ class JFormFieldComponentlayout extends JFormField
 					// Add the layout options from the template path.
 					if (is_dir($template_path) && ($files = JFolder::files($template_path, '^[^_]*\.php$', false, true)))
 					{
-						// Files with corresponding XML files are alternate menu items, not alternate layout files
-						// so we need to exclude these files from the list.
-						$xml_files = JFolder::files($template_path, '^[^_]*\.xml$', false, true);
-
-						for ($j = 0, $count = count($xml_files); $j < $count; $j++)
-						{
-							$xml_files[$j] = basename($xml_files[$j], '.xml');
-						}
-
 						foreach ($files as $i => $file)
 						{
 							// Remove layout files that exist in the component folder or that have XML files
-							if (in_array(basename($file, '.php'), $component_layouts)
-								|| in_array(basename($file, '.php'), $xml_files))
+							if (in_array(basename($file, '.php'), $component_layouts))
 							{
 								unset($files[$i]);
 							}


### PR DESCRIPTION
Pull Request for Issue #15547.

### Summary of Changes
Removing the code which unsets alternative layouts if there is an accompagning XML file (making it an alternative menuitem)


### Testing Instructions
* Create an alternative layout (just the php file) and an alternative menuitem (php file plus xml file).
* Test that they both can be selected as alternative layout in the global com_content config and in the article.
* Test that the selected layout is shown in frontend.


### Expected result
Alternative menuitems are available also as alternative layouts


### Actual result
They're not shown


### Documentation Changes Required
Not sure if that is documented anywhere

### Caveat
As you can see in the comments, the current behavior seems to be intended. I just don't know why as I can't imagine as side effect.
The code was introduced years ago with https://developer.joomla.org/joomlacode-archive/issue-23054.html