### PR TITLE
[4.0]Replace removed constant RELEASE with correct code, fix #18154

### DIFF
--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -172,7 +172,7 @@ class CollectionAdapter extends UpdateAdapter
 				// Set this to ourself as a default
 				if (!isset($values['targetplatformversion']))
 				{
-					$values['targetplatformversion'] = $ver::RELEASE;
+					$values['targetplatformversion'] = $ver::MAJOR_VERSION . '.' . $ver::MINOR_VERSION;
 				}
 
 				// Set this to ourselves as a default

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -213,11 +213,11 @@ final class Version
 
 		if ($addVersion)
 		{
-			$component .= '/' . self::RELEASE;
+			$component .= '/' . self::MAJOR_VERSION . '.' . self::MINOR_VERSION;
 		}
 
 		// If masked pretend to look like Mozilla 5.0 but still identify ourselves.
-		return ($mask ? 'Mozilla/5.0 ' : '') . self::PRODUCT . '/' . self::RELEASE . '.' . self::DEV_LEVEL . ($component ? ' ' . $component : '');
+		return ($mask ? 'Mozilla/5.0 ' : '') . self::PRODUCT . '/' . self::MAJOR_VERSION . '.' . self::MINOR_VERSION . ($component ? ' ' . $component : '');
 	}
 
 	/**

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -217,7 +217,7 @@ final class Version
 		}
 
 		// If masked pretend to look like Mozilla 5.0 but still identify ourselves.
-		return ($mask ? 'Mozilla/5.0 ' : '') . self::PRODUCT . '/' . self::MAJOR_VERSION . '.' . self::MINOR_VERSION . ($component ? ' ' . $component : '');
+		return ($mask ? 'Mozilla/5.0 ' : '') . self::PRODUCT . '/' . $this->getShortVersion() . ($component ? ' ' . $component : '');
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR replace the removed RELEASE  constant with correct code, fix issue #18154 while installing Joomla 4.0

### Testing Instructions
Try to install latest Joomla 4.0-dev. Before patch, there is error and install fails. After patch, install success

