### PR TITLE
Fix cases that a submitted form has a multiple-value category id field (e.g. a filtering form), causing notices in article  / record forms

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -141,6 +141,11 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('option', 'com_content');
 		}
 
+		// Account for case that of a submitted form with multiple-value category id field (e.g. a filtering form), just use the first one
+		$oldCat = is_array($oldCat)
+			? reset($oldCat)
+			: $oldCat;
+
 		$db = JFactory::getDbo();
 		$user = JFactory::getUser();
 

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -143,8 +143,8 @@ class JFormFieldCategoryEdit extends JFormFieldList
 
 		// Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category
 		$oldCat = is_array($oldCat)
-			? reset($oldCat)
-			: $oldCat;
+			? (int) reset($oldCat)
+			: (int) $oldCat;
 
 		$db = JFactory::getDbo();
 		$user = JFactory::getUser();

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -141,7 +141,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 			$extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('option', 'com_content');
 		}
 
-		// Account for case that of a submitted form with multiple-value category id field (e.g. a filtering form), just use the first one
+		// Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category
 		$oldCat = is_array($oldCat)
 			? reset($oldCat)
 			: $oldCat;

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -294,6 +294,11 @@ class FieldsHelper
 
 		$assignedCatids = isset($data->catid) ? $data->catid : (isset($data->fieldscatid) ? $data->fieldscatid : $form->getValue('catid'));
 
+		// Account for case that of a submitted form with multiple-value category id field (e.g. a filtering form), just use the first one
+		$assignedCatids = is_array($assignedCatids)
+			? reset($assignedCatids)
+			: $assignedCatids;
+
 		if (!$assignedCatids && $formField = $form->getField('catid'))
 		{
 			$assignedCatids = $formField->getAttribute('default', null);

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -296,8 +296,8 @@ class FieldsHelper
 
 		// Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category
 		$assignedCatids = is_array($assignedCatids)
-			? reset($assignedCatids)
-			: $assignedCatids;
+			? (int) reset($assignedCatids)
+			: (int) $assignedCatids;
 
 		if (!$assignedCatids && $formField = $form->getField('catid'))
 		{

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -294,7 +294,7 @@ class FieldsHelper
 
 		$assignedCatids = isset($data->catid) ? $data->catid : (isset($data->fieldscatid) ? $data->fieldscatid : $form->getValue('catid'));
 
-		// Account for case that of a submitted form with multiple-value category id field (e.g. a filtering form), just use the first one
+		// Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category
 		$assignedCatids = is_array($assignedCatids)
 			? reset($assignedCatids)
 			: $assignedCatids;


### PR DESCRIPTION
Pull Request for Issue #17974
This is a rather minor issue, but it looks like easy to fix

### Summary of Changes
The category filter (like other filters) in backend articles manager was made multi-value
but there is code in 2 (maybe more) places that assumes that filter is single value

In new article (new record) forms we have
- fields helper trying to load fields of the filtered category
- the category selector of the form trying to auto-select the filtered category

Solution just if posted category id is an array , then use the first category out of the categories

### Testing Instructions
1. In global configuration set error reporting to maximum
2. In article manager select 1 or more categories for the filter,
3. Listing reloads
4. Now select new article to open new article form

### Expected result
- No notices printed
- Custom fields of first category (of categories fillter) are loaded
- Category selector auto selects the first category (of categories fillter)

### Actual result
Notices printed, form loads as without any category selected, and 'all categories' fields are shown

### Documentation Changes Required
None
