### PR TITLE
Fix backend articles manager not listing articles in sub-categories when categories filter is active

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -271,6 +271,12 @@ class ContentModelArticles extends JModelList
 		$baselevel  = 1;
 		$categoryId = $this->getState('filter.category_id');
 
+		// Allow listing articles in sub-categories when categories filter has single category
+		if (is_array($categoryId) && count($categoryId) === 1)
+		{
+			$categoryId = (int) reset($categoryId);
+		}
+
 		if (is_numeric($categoryId))
 		{
 			$categoryTable = JTable::getInstance('Category', 'JTable');

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -279,18 +279,18 @@ class ContentModelArticles extends JModelList
 		{
 			$categoryId = ArrayHelper::toInteger($categoryId);
 			$categoryTable = JTable::getInstance('Category', 'JTable');
-			$subcat_items_where = array();
+			$subCatItemsWhere = array();
 
 			foreach ($categoryId as $filter_catid)
 			{
 				$categoryTable->load($filter_catid);
-				$subcat_items_where[] = '(' .
+				$subCatItemsWhere[] = '(' .
 					($level ? 'c.level <= ' . ((int) $level + (int) $categoryTable->level - 1) . ' AND ' : '') .
 					'c.lft >= ' . (int) $categoryTable->lft . ' AND ' .
 					'c.rgt <= ' . (int) $categoryTable->rgt . ')';
 			}
 
-			$query->where(implode(' OR ', $subcat_items_where));
+			$query->where(implode(' OR ', $subCatItemsWhere));
 		}
 
 		// Case: Using only the by level filter

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -271,7 +271,6 @@ class ContentModelArticles extends JModelList
 		$baselevel  = 1;
 		$categoryId = $this->getState('filter.category_id');
 
-		// Allow listing articles in sub-categories when categories filter has single category
 		if (is_numeric($categoryId))
 		{
 			$categoryTable = JTable::getInstance('Category', 'JTable');

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -285,8 +285,8 @@ class ContentModelArticles extends JModelList
 		{
 			$categoryId = ArrayHelper::toInteger($categoryId);
 			$categoryTable = JTable::getInstance('Category', 'JTable');
-
 			$subcat_items_where = array();
+
 			foreach ($categoryId as $filter_catid)
 			{
 				$categoryTable->load($filter_catid);
@@ -295,6 +295,7 @@ class ContentModelArticles extends JModelList
 					: $baselevel;
 				$subcat_items_where[] = '(c.lft >= ' . (int) $categoryTable->lft . ' AND c.rgt <= ' . (int) $categoryTable->rgt . ')';
 			}
+
 			$query->where('(' . implode(' OR ', $subcat_items_where) . ')');
 		}
 

--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -286,9 +286,8 @@ class ContentModelArticles extends JModelList
 			$categoryId = ArrayHelper::toInteger($categoryId);
 			$categoryTable = JTable::getInstance('Category', 'JTable');
 
-			$baselevel = 1;
 			$subcat_items_where = array();
-			foreach($categoryId as $filter_catid)
+			foreach ($categoryId as $filter_catid)
 			{
 				$categoryTable->load($filter_catid);
 				$baselevel = (int) $categoryTable->level > $baselevel
@@ -296,7 +295,7 @@ class ContentModelArticles extends JModelList
 					: $baselevel;
 				$subcat_items_where[] = '(c.lft >= ' . (int) $categoryTable->lft . ' AND c.rgt <= ' . (int) $categoryTable->rgt . ')';
 			}
-			$query->where(implode($subcat_items_where, ' OR '));
+			$query->where('(' . implode(' OR ', $subcat_items_where) . ')');
 		}
 
 		// Filter on the level.


### PR DESCRIPTION
Pull Request for Issue #18178

### Summary of Changes
Listing articles in sub-categories when categories filter is active is no longer working
This quite a big annoyance for people that need it, 
- also issue may go unnoticed by people that need

Bug was introduced when category filter in articles manager was converted to multi-value
- multi value category filtering code does not support listing sub-category articles (yet)

This PR fixes 
- the very common case of filtering by a single category
- but also fixes the case of selecting more than 1 category in the filter
- also the (max) level filter is applied per filtered category


### Testing Instructions
In a Joomla installation that e.g. has testing articles 
filter by category "Joomla" and you will notice that only 11 articles are shown , those that belong to category "Joomla"

also please test with 
- 2 categories without (max) level filter
- 2 categories with (max) level filter

### Expected result
Those that belong to subcategories should also be listed (when max level filter is not set)

### Actual result
Those that belong to subcategories are not listed (despite max level filter not set)


### Documentation Changes Required
None