### PR TITLE
Fix users custom fields data lost when reset password

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -118,10 +118,11 @@ class PlgSystemFields extends JPlugin
 
 		$user = JFactory::getUser($userData['id']);
 
-		$task = JFactory::getApplication()->input->getCmd('task');
+		$option = JFactory::getApplication()->input->getCmd('option');
+		$task   = JFactory::getApplication()->input->getCmd('task');
 
 		// Skip fields save when we activate a user, because we will lose the saved data
-		if (in_array($task, array('activate', 'block', 'unblock')))
+		if ($option != 'com_users' || in_array($task, array('activate', 'block', 'unblock', 'request', 'complete')))
 		{
 			return true;
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes users custom fields data lost when reset password. See #18185 for issue description

### Testing Instructions
1. Follow the issue https://github.com/joomla/joomla-cms/issues/18185,  confirm the issue
2. Apply patch, try to reset password again, make sure users custom fields data is not lost anymore
3. Try to edit an user account from backend, make sure custom fields data still being saved properly

