### PR TITLE
Frontend module editing opens in default template

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -18,7 +18,7 @@ $menusEditing = $displayData['menusediting'];
 $parameters   = JComponentHelper::getParams('com_modules');
 $redirectUri  = '&return=' . urlencode(base64_encode(JUri::getInstance()->toString()));
 $target       = '_blank';
-$itemid		  = JFactory::getApplication()->input->get('Itemid', '0', 'int');
+$itemid       = JFactory::getApplication()->input->get('Itemid', '0', 'int');
 
 if (preg_match('/<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]* jmoddiv"/', $moduleHtml))
 {

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -18,6 +18,7 @@ $menusEditing = $displayData['menusediting'];
 $parameters   = JComponentHelper::getParams('com_modules');
 $redirectUri  = '&return=' . urlencode(base64_encode(JUri::getInstance()->toString()));
 $target       = '_blank';
+$itemid		  = JFactory::getApplication()->input->get('Itemid', '0', 'int');
 
 if (preg_match('/<(?:div|span|nav|ul|ol|h\d) [^>]*class="[^"]* jmoddiv"/', $moduleHtml))
 {
@@ -30,7 +31,7 @@ $editUrl = JUri::base() . 'administrator/index.php?option=com_modules&task=modul
 
 if ($parameters->get('redirect_edit', 'site') === 'site')
 {
-	$editUrl = JUri::base() . 'index.php?option=com_config&controller=config.display.modules&id=' . (int) $mod->id . $redirectUri;
+	$editUrl = JUri::base() . 'index.php?option=com_config&controller=config.display.modules&id=' . (int) $mod->id . '&Itemid=' . $itemid . $redirectUri;
 	$target  = '_self';
 }
 


### PR DESCRIPTION
PR for #17884

### Expected result

Frontend editing of the module should open with Template Style of the current menu item

### Actual result

Frontend Module editing always uses default template

### Test Instructions

1. Set the site default template to Beez

2. Create a menu item with Template Style other then default, select Protostar

3. Make sure that Frontend Modulle editing is enabled in global config

4. Login frontend as admin user

5. Go to menu item created in step 2 and click the edit module icon

6. Module opens to edit settings in default Beez template.

7. Apply PR

8. Repeat above and now the module opens to edit settings in the assigned Protostar template
