### PR TITLE
Modules - number not text

### DIFF
--- a/administrator/modules/mod_custom/mod_custom.xml
+++ b/administrator/modules/mod_custom/mod_custom.xml
@@ -65,7 +65,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/administrator/modules/mod_feed/mod_feed.xml
+++ b/administrator/modules/mod_feed/mod_feed.xml
@@ -83,7 +83,7 @@
 
 				<field
 					name="rssitems"
-					type="text"
+					type="number"
 					label="MOD_FEED_FIELD_ITEMS_LABEL"
 					description="MOD_FEED_FIELD_ITEMS_DESC"
 					default="3"
@@ -103,7 +103,7 @@
 
 				<field
 					name="word_count"
-					type="text"
+					type="number"
 					label="MOD_FEED_FIELD_WORDCOUNT_LABEL"
 					description="MOD_FEED_FIELD_WORDCOUNT_DESC" 
 					size="6"
@@ -139,7 +139,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC" 
 					default="900"

--- a/administrator/modules/mod_latest/mod_latest.xml
+++ b/administrator/modules/mod_latest/mod_latest.xml
@@ -24,7 +24,7 @@
 			<fieldset name="basic">
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_LATEST_FIELD_COUNT_LABEL"
 					description="MOD_LATEST_FIELD_COUNT_DESC" 
 					default="5"

--- a/administrator/modules/mod_logged/mod_logged.xml
+++ b/administrator/modules/mod_logged/mod_logged.xml
@@ -23,7 +23,7 @@
 			<fieldset name="basic">
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_LOGGED_FIELD_COUNT_LABEL"
 					description="MOD_LOGGED_FIELD_COUNT_DESC" 
 					default="5"

--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -38,9 +38,10 @@
 
 				<field
 					name="moduleclass_sfx"
-					type="textarea" rows="3"
+					type="textarea"
 					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
 					description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC"
+					rows="3"
 				/>
 
 			</fieldset>

--- a/administrator/modules/mod_popular/mod_popular.xml
+++ b/administrator/modules/mod_popular/mod_popular.xml
@@ -24,7 +24,7 @@
 			<fieldset name="basic">
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_POPULAR_FIELD_COUNT_LABEL"
 					description="MOD_POPULAR_FIELD_COUNT_DESC"
 					default="5"

--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -59,7 +59,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.xml
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.xml
@@ -61,7 +61,7 @@
 
 				<field
 					name="increase"
-					type="text"
+					type="number"
 					label="MOD_STATS_FIELD_INCREASECOUNTER_LABEL"
 					description="MOD_STATS_FIELD_INCREASECOUNTER_DESC"
 					default="0"
@@ -96,7 +96,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_archive/mod_articles_archive.xml
+++ b/modules/mod_articles_archive/mod_articles_archive.xml
@@ -24,7 +24,7 @@
 			<fieldset name="basic">
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_ARTICLES_ARCHIVE_FIELD_COUNT_LABEL"
 					description="MOD_ARTICLES_ARCHIVE_FIELD_COUNT_DESC"
 					default="10"
@@ -60,7 +60,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -158,7 +158,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -59,7 +59,7 @@
 
 				<field
 					name="count"
-					type="text"
+					type="numbertext"
 					label="MOD_ARTICLES_CATEGORY_FIELD_COUNT_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_COUNT_DESC"
 					default="0"
@@ -121,7 +121,7 @@
 
 				<field
 					name="levels"
-					type="text"
+					type="number"
 					label="MOD_ARTICLES_CATEGORY_FIELD_CATDEPTH_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_CATDEPTH_DESC"
 					default="1"
@@ -281,7 +281,7 @@
 
 				<field
 					name="relative_date"
-					type="text"
+					type="number"
 					label="MOD_ARTICLES_CATEGORY_FIELD_RELATIVEDATE_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_RELATIVEDATE_DESC"
 					default="30"
@@ -466,7 +466,7 @@
 
 				<field
 					name="introtext_limit"
-					type="text"
+					type="number"
 					label="MOD_ARTICLES_CATEGORY_FIELD_INTROTEXTLIMIT_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_INTROTEXTLIMIT_DESC"
 					default="100"
@@ -498,7 +498,7 @@
 
 				<field
 					name="readmore_limit"
-					type="text"
+					type="number"
 					label="JGLOBAL_SHOW_READMORE_LIMIT_LABEL"
 					description="JGLOBAL_SHOW_READMORE_LIMIT_DESC"
 					default="15"
@@ -536,7 +536,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -59,7 +59,7 @@
 
 				<field
 					name="count"
-					type="numbertext"
+					type="number"
 					label="MOD_ARTICLES_CATEGORY_FIELD_COUNT_LABEL"
 					description="MOD_ARTICLES_CATEGORY_FIELD_COUNT_DESC"
 					default="0"

--- a/modules/mod_articles_latest/mod_articles_latest.xml
+++ b/modules/mod_articles_latest/mod_articles_latest.xml
@@ -37,7 +37,7 @@
 
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_LATEST_NEWS_FIELD_COUNT_LABEL"
 					description="MOD_LATEST_NEWS_FIELD_COUNT_DESC"
 					default="5"
@@ -110,7 +110,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -146,7 +146,7 @@
 
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_ARTICLES_NEWS_FIELD_ITEMS_LABEL"
 					description="MOD_ARTICLES_NEWS_FIELD_ITEMS_DESC"
 					default="5"
@@ -220,7 +220,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_articles_popular/mod_articles_popular.xml
+++ b/modules/mod_articles_popular/mod_articles_popular.xml
@@ -37,7 +37,7 @@
 
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_POPULAR_FIELD_COUNT_LABEL"
 					description="MOD_POPULAR_FIELD_COUNT_DESC"
 					default="5"
@@ -112,7 +112,7 @@
 
 				<field
 					name="relative_date"
-					type="text"
+					type="number"
 					label="MOD_POPULAR_FIELD_RELATIVEDATE_LABEL"
 					description="MOD_POPULAR_FIELD_RELATIVEDATE_DESC"
 					default="30"
@@ -149,7 +149,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_banners/mod_banners.xml
+++ b/modules/mod_banners/mod_banners.xml
@@ -40,7 +40,7 @@
 
 				<field
 					name="count"
-					type="text"
+					type="number"
 					label="MOD_BANNERS_FIELD_COUNT_LABEL"
 					description="MOD_BANNERS_FIELD_COUNT_DESC"
 					default="5"
@@ -139,7 +139,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.xml
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.xml
@@ -103,7 +103,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="0"

--- a/modules/mod_custom/mod_custom.xml
+++ b/modules/mod_custom/mod_custom.xml
@@ -73,7 +73,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_feed/mod_feed.xml
+++ b/modules/mod_feed/mod_feed.xml
@@ -139,7 +139,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_finder/mod_finder.xml
+++ b/modules/mod_finder/mod_finder.xml
@@ -56,7 +56,7 @@
 
 				<field
 					name="field_size"
-					type="text"
+					type="number"
 					label="MOD_FINDER_FIELDSET_ADVANCED_FIELD_SIZE_LABEL"
 					description="MOD_FINDER_FIELDSET_ADVANCED_FIELD_SIZE_DESCRIPTION"
 					default="25"

--- a/modules/mod_footer/mod_footer.xml
+++ b/modules/mod_footer/mod_footer.xml
@@ -49,7 +49,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_languages/mod_languages.xml
+++ b/modules/mod_languages/mod_languages.xml
@@ -178,7 +178,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_menu/mod_menu.xml
+++ b/modules/mod_menu/mod_menu.xml
@@ -147,7 +147,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_random_image/mod_random_image.xml
+++ b/modules/mod_random_image/mod_random_image.xml
@@ -46,14 +46,14 @@
 
 				<field
 					name="width"
-					type="text"
+					type="number"
 					label="MOD_RANDOM_IMAGE_FIELD_WIDTH_LABEL"
 					description="MOD_RANDOM_IMAGE_FIELD_WIDTH_DESC"
 				/>
 
 				<field
 					name="height"
-					type="text"
+					type="number"
 					label="MOD_RANDOM_IMAGE_FIELD_HEIGHT_LABEL"
 					description="MOD_RANDOM_IMAGE_FIELD_HEIGHT_DESC"
 				/>

--- a/modules/mod_related_items/mod_related_items.xml
+++ b/modules/mod_related_items/mod_related_items.xml
@@ -36,7 +36,7 @@
 
 				<field
 					name="maximum"
-					type="text"
+					type="number"
 					label="MOD_RELATED_FIELD_MAX_LABEL"
 					description="MOD_RELATED_FIELD_MAX_DESC"
 					default="5"
@@ -71,7 +71,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_search/mod_search.xml
+++ b/modules/mod_search/mod_search.xml
@@ -31,7 +31,7 @@
 
 				<field
 					name="width"
-					type="text"
+					type="number"
 					label="MOD_SEARCH_FIELD_BOXWIDTH_LABEL"
 					description="MOD_SEARCH_FIELD_BOXWIDTH_DESC"
 				/>
@@ -149,7 +149,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_stats/mod_stats.xml
+++ b/modules/mod_stats/mod_stats.xml
@@ -60,7 +60,7 @@
 
 				<field
 					name="increase"
-					type="text"
+					type="number"
 					label="MOD_STATS_FIELD_INCREASECOUNTER_LABEL"
 					description="MOD_STATS_FIELD_INCREASECOUNTER_DESC"
 					default="0"
@@ -95,7 +95,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -110,7 +110,7 @@
 			>
 				<field
 					name="minsize"
-					type="text"
+					type="number"
 					label="MOD_TAGS_POPULAR_FIELD_MINSIZE_LABEL"
 					description="MOD_TAGS_POPULAR_FIELD_MINSIZE_DESC"
 					default="1"
@@ -119,7 +119,7 @@
 
 				<field
 					name="maxsize"
-					type="text"
+					type="number"
 					label="MOD_TAGS_POPULAR_FIELD_MAXSIZE_LABEL"
 					description="MOD_TAGS_POPULAR_FIELD_MAXSIZE_DESC"
 					default="2"
@@ -156,7 +156,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -86,7 +86,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_users_latest/mod_users_latest.xml
+++ b/modules/mod_users_latest/mod_users_latest.xml
@@ -24,7 +24,7 @@
 			<fieldset name="basic">
 				<field
 					name="shownumber"
-					type="text"
+					type="number"
 					label="MOD_USERS_LATEST_FIELD_NUMBER_LABEL"
 					description="MOD_USERS_LATEST_FIELD_NUMBER_DESC"
 					default="5"
@@ -71,7 +71,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_whosonline/mod_whosonline.xml
+++ b/modules/mod_whosonline/mod_whosonline.xml
@@ -74,7 +74,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -134,7 +134,7 @@
 
 				<field
 					name="cache_time"
-					type="text"
+					type="number"
 					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
 					description="COM_MODULES_FIELD_CACHE_TIME_DESC"
 					default="900"


### PR DESCRIPTION
Numerous options in the modules are for numbers but the xml field type is text. This pr changes them to the correct value of number.

This ensures that a user cannot enter a letter and only numbers. There are no b/c issues as only a numerical character could ever have worked and there is no change in the way the data is stored.

_I spotted this when debugging a user's site where they put "five" in the count field instead of "5" and wondered why it didnt work. After this PR that isnt possible_
