### PR TITLE
[com_menus] Hide Process button when in Trashed status (Admin menu)

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -14,7 +14,7 @@ $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype')
 <a class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </a>
-<?php if ((strlen($menuType) && $menuType != '*') || ($published > 0 && $clientId == 1)): ?>
+<?php if ((strlen($menuType) && $menuType != '*' && $clientId == 0) || ($published > 0 && $clientId == 1)): ?>
 	<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
 		<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 	</button>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_footer.php
@@ -7,13 +7,14 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 defined('_JEXEC') or die;
-
+$published = $this->state->get('filter.published');
+$clientId  = $this->state->get('filter.client_id');
 $menuType = JFactory::getApplication()->getUserState('com_menus.items.menutype');
 ?>
 <a class="btn" type="button" onclick="document.getElementById('batch-menu-id').value='';document.getElementById('batch-access').value='';document.getElementById('batch-language-id').value=''" data-dismiss="modal">
 	<?php echo JText::_('JCANCEL'); ?>
 </a>
-<?php if (strlen($menuType) && $menuType != '*') : ?>
+<?php if ((strlen($menuType) && $menuType != '*') || ($published > 0 && $clientId == 1)): ?>
 	<button class="btn btn-success" type="submit" onclick="Joomla.submitbutton('item.batch');">
 		<?php echo JText::_('JGLOBAL_BATCH_PROCESS'); ?>
 	</button>


### PR DESCRIPTION
PR for #15134

This PR will ensure that the Process button is hidden (I have no idea why you cant batch process trashed items and that is beyond the scope of this PR)

### Steps to reproduce the issue
Create an Administrator menu.
Create a menu item in this Administrator menu.
Trash this menu item.
Click `Search Tools` button.
Select `Trashed` in `- Select Status -` dropdown.
Select the Administrator menu in `- Select Menu -` dropdown.
Click `Select All` checkbox.
Click `Batch` button.

### Expected result
Cancel button only.

### Actual result
![hide-process-button](https://cloud.githubusercontent.com/assets/368084/24762083/24eafaaa-1aa2-11e7-8bc4-188e20869f02.jpg)
