### PR TITLE
Fast temporary fix for update joomla from 3.6.0 and lower to 3.8

### DIFF
--- a/libraries/src/Menu/MenuHelper.php
+++ b/libraries/src/Menu/MenuHelper.php
@@ -311,7 +311,15 @@ class MenuHelper
 					$query->innerJoin($iJoin);
 				}
 
-				$results = $db->setQuery($query)->loadObjectList();
+				try
+				{
+					$results = $db->setQuery($query)->loadObjectList();
+				}
+				catch (\JDatabaseExceptionExecuting $e)
+				{
+					// The database has not yet been updated
+					$results = array();
+				}
 
 				// Skip the entire group if no items to iterate over.
 				if ($results)


### PR DESCRIPTION
Pull Request for Issue #18192 and related.

### Summary of Changes
Add 'try catch' for database error when `#__menu_types.client_id` column has no yet exists.


### Testing Instructions
install J3.6.0 and try to update to 3.8.0. After error add this pach and refresh page to relogin


### Expected result
Update success


### Actual result
Error at page `administrator/index.php?option=com_joomlaupdate&view=update&layout=finaliseconfirm`


### Documentation Changes Required
No

Thank you @ggppdk for comment https://github.com/joomla/joomla-cms/issues/18192#issuecomment-333645465