### PR TITLE
plugins and templates - number not text

### DIFF
--- a/plugins/authentication/cookie/cookie.xml
+++ b/plugins/authentication/cookie/cookie.xml
@@ -21,7 +21,7 @@
 			<fieldset name="basic">
 				<field
 					name="cookie_lifetime"
-					type="text"
+					type="number"
 					label="PLG_AUTH_COOKIE_FIELD_COOKIE_LIFETIME_LABEL"
 					description="PLG_AUTH_COOKIE_FIELD_COOKIE_LIFETIME_DESC"
 					default="60"

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -45,7 +45,7 @@
 
 				<field
 					name="html_height"
-					type="text"
+					type="number"
 					label="PLG_TINY_FIELD_HTMLHEIGHT_LABEL"
 					description="PLG_TINY_FIELD_HTMLHEIGHT_DESC"
 					default="550"
@@ -53,7 +53,7 @@
 
 				<field
 					name="html_width"
-					type="text"
+					type="number"
 					label="PLG_TINY_FIELD_HTMLWIDTH_LABEL"
 					description="PLG_TINY_FIELD_HTMLWIDTH_DESC"
 					default=""

--- a/plugins/fields/text/params/text.xml
+++ b/plugins/fields/text/params/text.xml
@@ -22,7 +22,7 @@
 
 			<field
 				name="maxlength"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_LABEL"
 				description="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_DESC"
 				filter="integer"

--- a/plugins/fields/text/text.xml
+++ b/plugins/fields/text/text.xml
@@ -41,7 +41,7 @@
 
 				<field
 					name="maxlength"
-					type="text"
+					type="number"
 					label="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_LABEL"
 					description="PLG_FIELDS_TEXT_PARAMS_MAXLENGTH_DESC"
 					filter="integer"

--- a/plugins/fields/textarea/params/textarea.xml
+++ b/plugins/fields/textarea/params/textarea.xml
@@ -4,7 +4,7 @@
 		<fieldset name="fieldparams">
 			<field
 				name="rows"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_LABEL"
 				description="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_DESC"
 				size="5"
@@ -12,7 +12,7 @@
 
 			<field
 				name="cols"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_COLS_LABEL"
 				description="PLG_FIELDS_TEXTAREA_PARAMS_COLS_DESC"
 				size="5"
@@ -20,7 +20,7 @@
 
 			<field
 				name="maxlength"
-				type="text"
+				type="number"
 				label="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_LABEL"
 				description="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_DESC"
 				filter="integer"

--- a/plugins/fields/textarea/textarea.xml
+++ b/plugins/fields/textarea/textarea.xml
@@ -23,7 +23,7 @@
 			<fieldset name="basic">
 				<field
 					name="rows"
-					type="text"
+					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_LABEL"
 					description="PLG_FIELDS_TEXTAREA_PARAMS_ROWS_DESC"
 					default="10"
@@ -32,7 +32,7 @@
 
 				<field
 					name="cols"
-					type="text"
+					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_COLS_LABEL"
 					description="PLG_FIELDS_TEXTAREA_PARAMS_COLS_DESC"
 					default="10"
@@ -41,7 +41,7 @@
 
 				<field
 					name="maxlength"
-					type="text"
+					type="number"
 					label="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_LABEL"
 					description="PLG_FIELDS_TEXTAREA_PARAMS_MAXLENGTH_DESC"
 					filter="integer"

--- a/plugins/search/categories/categories.xml
+++ b/plugins/search/categories/categories.xml
@@ -22,7 +22,7 @@
 			<fieldset name="basic">
 				<field
 					name="search_limit"
-					type="text"
+					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 					default="50"

--- a/plugins/search/contacts/contacts.xml
+++ b/plugins/search/contacts/contacts.xml
@@ -21,7 +21,7 @@
 			<fieldset name="basic">
 				<field
 					name="search_limit"
-					type="text"
+					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 					default="50"

--- a/plugins/search/content/content.xml
+++ b/plugins/search/content/content.xml
@@ -21,7 +21,7 @@
 			<fieldset name="basic">
 				<field
 					name="search_limit"
-					type="text"
+					type="number"
 					label="PLG_SEARCH_CONTENT_FIELD_SEARCHLIMIT_LABEL"
 					description="PLG_SEARCH_CONTENT_FIELD_SEARCHLIMIT_DESC"
 					default="50"

--- a/plugins/search/newsfeeds/newsfeeds.xml
+++ b/plugins/search/newsfeeds/newsfeeds.xml
@@ -21,7 +21,7 @@
 			<fieldset name="basic">
 				<field
 					name="search_limit"
-					type="text"
+					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 					default="50"

--- a/plugins/search/tags/tags.xml
+++ b/plugins/search/tags/tags.xml
@@ -21,7 +21,7 @@
 			<fieldset name="basic">
 				<field
 					name="search_limit"
-					type="text"
+					type="number"
 					label="JFIELD_PLG_SEARCH_SEARCHLIMIT_LABEL"
 					description="JFIELD_PLG_SEARCH_SEARCHLIMIT_DESC"
 					default="50"

--- a/plugins/system/stats/stats.xml
+++ b/plugins/system/stats/stats.xml
@@ -50,7 +50,7 @@
 					label="PLG_SYSTEM_STATS_MODE_LABEL"
 					description="PLG_SYSTEM_STATS_MODE_DESC"
 					default="1"
-				>
+					>
 					<option value="1">PLG_SYSTEM_STATS_MODE_OPTION_ALWAYS_SEND</option>
 					<option value="2">PLG_SYSTEM_STATS_MODE_OPTION_ON_DEMAND</option>
 					<option value="3">PLG_SYSTEM_STATS_MODE_OPTION_NEVER_SEND</option>

--- a/plugins/system/stats/stats.xml
+++ b/plugins/system/stats/stats.xml
@@ -37,7 +37,7 @@
 
 				<field
 					name="interval"
-					type="text"
+					type="number"
 					label="PLG_SYSTEM_STATS_INTERVAL_LABEL"
 					description="PLG_SYSTEM_STATS_INTERVAL_DESC"
 					filter="integer"

--- a/templates/beez3/templateDetails.xml
+++ b/templates/beez3/templateDetails.xml
@@ -58,7 +58,7 @@
 			<fieldset name="advanced">
 				<field 
 					name="wrapperSmall"  
-					type="text" 
+					type="number" 
 					label="TPL_BEEZ3_FIELD_WRAPPERSMALL_LABEL"
 					description="TPL_BEEZ3_FIELD_WRAPPERSMALL_DESC"
 					class="validate-numeric" 
@@ -68,7 +68,7 @@
 
 				<field 
 					name="wrapperLarge"  
-					type="text" 
+					type="number" 
 					label="TPL_BEEZ3_FIELD_WRAPPERLARGE_LABEL"
 					description="TPL_BEEZ3_FIELD_WRAPPERLARGE_DESC"
 					class="validate-numeric" 


### PR DESCRIPTION
Numerous options in the plugins and templates are for numbers but the xml field type is text. This pr changes them to the correct value of number.

This ensures that a user cannot enter a letter and only numbers. There are no b/c issues as only a numerical character could ever have worked and there is no change in the way the data is stored.

_I spotted this when debugging a user's site where they put "five" in the count field instead of "5" and wondered why it didnt work. After this PR that isnt possible_
