### PR TITLE
[com_menus] Hide move/copy in admin menu batch modal

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -15,6 +15,26 @@ $options = array(
 $published = $this->state->get('filter.published');
 $clientId  = $this->state->get('filter.client_id');
 $menuType  = JFactory::getApplication()->getUserState('com_menus.items.menutype');
+if ($clientId == 1) :
+	JFactory::getDocument()->addScriptDeclaration(
+		'
+			jQuery(document).ready(function($){
+				if ($("#batch-menu-id").length){var batchSelector = $("#batch-menu-id");}
+				if ($("#batch-copy-move").length) {
+					$("#batch-copy-move").hide();
+					batchSelector.on("change", function(){
+						if (batchSelector.val() != 0 || batchSelector.val() != "") {
+							$("#batch-copy-move").show();
+						} else {
+							$("#batch-copy-move").hide();
+						}
+					});
+				}
+			});
+				'
+	);
+	endif;
+	
 ?>
 <div class="container-fluid">
 	<?php if (strlen($menuType) && $menuType != '*') : ?>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -33,7 +33,8 @@ if ($clientId == 1) :
 			});
 		'
 	);
-	endif;	
+endif;
+
 ?>
 <div class="container-fluid">
 	<?php if (strlen($menuType) && $menuType != '*') : ?>

--- a/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
+++ b/administrator/components/com_menus/views/items/tmpl/default_batch_body.php
@@ -31,10 +31,9 @@ if ($clientId == 1) :
 					});
 				}
 			});
-				'
+		'
 	);
-	endif;
-	
+	endif;	
 ?>
 <div class="container-fluid">
 	<?php if (strlen($menuType) && $menuType != '*') : ?>


### PR DESCRIPTION
PR for #15133

### Steps to reproduce the issue
Create an Administrator menu.
Create a menu item under this Administrator menu.
Click this menu item.
Click `Batch` button.

### Expected result
Copy/Move radios to display only after a menu/parent item is selected.

### Actual result
![batchmenu](https://cloud.githubusercontent.com/assets/368084/24759500/845c17e2-1a9a-11e7-95af-26cc18793cd7.jpg)
