### PR TITLE
Only create DB record when enabled

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -414,7 +414,10 @@ class PlgUserProfile extends JPlugin
 				$db = JFactory::getDbo();
 
 				// Sanitize the date
-				$data['profile']['dob'] = $this->date;
+				if (!empty($data['profile']['dob']))
+				{
+					$data['profile']['dob'] = $this->date;
+				}
 
 				$keys = array_keys($data['profile']);
 


### PR DESCRIPTION
PR for #14691

Wrap the code to sanitize the date in an if check to ensure that the db record is only created when the dob field is enabled

### Test instructions
Enable the user profile plugin and make sure that the DOB field in both places is disabled
Create a new user and then check the #__user_profiles tables
You will see a record for the DOB
Apply this PR and repeat and the empty record is not created