### PR TITLE
Hide mass mail menu if disabled

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -164,6 +164,7 @@
 			element="com_users"
 			link="index.php?option=com_users&amp;view=mail"
 			class="class:massmail"
+			scope="massmail"
 		/>
 	</menuitem>
 	<menuitem

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -164,6 +164,7 @@
 			element="com_users"
 			link="index.php?option=com_users&amp;view=mail"
 			class="class:massmail"
+			scoppe="massmail"
 		/>
 	</menuitem>
 	<menuitem

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -164,7 +164,7 @@
 			element="com_users"
 			link="index.php?option=com_users&amp;view=mail"
 			class="class:massmail"
-			scoppe="massmail"
+			scope="massmail"
 		/>
 	</menuitem>
 	<menuitem

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -281,6 +281,12 @@ class JAdminCssMenu
 				continue;
 			}
 
+			// Exclude Mass Mail if disabled in global configuration
+			if ($item->scope == 'massmail' && (JFactory::getApplication()->get('massmailoff', 0) == 1))
+			{
+				continue;
+			}
+
 			// Exclude item if the component is not authorised
 			$assetName = $item->element;
 


### PR DESCRIPTION
PR for #18226

### Steps to reproduce the issue

Go to Global Configuration > Server
Under Mail Settings, select Yes for Disable Mass Mail
Under Users menu, select Mass Mail Users

### Expected result

Mass Mail Users not available so it can not be selected.

### Actual result

It can be selected but goes to the Control Panel dashboard.