### PR TITLE
[com_fields] Color plugin - invalid markup

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -77,4 +77,4 @@ JHtml::_('stylesheet', 'jui/jquery.minicolors.css', array('version' => 'auto', '
 JHtml::_('script', 'system/color-field-adv-init.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 <input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($color, ENT_COMPAT, 'UTF-8'); ?>" <?php
-echo $hint . $class . $position . $control . $readonly . $disabled . $required . $onchange . $autocomplete . $autofocus . $format . $keywords . $direction . $validate; ?>/>
+echo $hint . $class . $position . $control . $disabled . $onchange . $autocomplete . $autofocus . $format . $keywords . $direction . $validate; ?>/>

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -77,4 +77,4 @@ JHtml::_('stylesheet', 'jui/jquery.minicolors.css', array('version' => 'auto', '
 JHtml::_('script', 'system/color-field-adv-init.min.js', array('version' => 'auto', 'relative' => true));
 ?>
 <input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($color, ENT_COMPAT, 'UTF-8'); ?>" <?php
-echo $hint . $class . $position . $control . $disabled . $onchange . $autocomplete . $autofocus . $format . $keywords . $direction . $validate; ?>/>
+echo $hint . $class . $position . $control . $readonly . $disabled . $onchange . $autocomplete . $autofocus . $format . $keywords . $direction . $validate; ?>/>


### PR DESCRIPTION
Create a color field for content and set it to be required
Open an article to edit and view the source
You will see
`<input type="text" name="jform[com_fields][colour]" id="jform_com_fields_colour" value="none"  placeholder="#rrggbb" class="minicolors required" data-position="default" data-control="hue"1 data-format="hex" data-validate="color"/>`

Note the` data-control="hue"1` the **1** should not be there

This PR resolves that

PR for #18067