### PR TITLE
Set correct session key for category filter tag

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -114,9 +114,6 @@ class ContentModelCategory extends JModelList
 
 		$this->setState('category.id', $pk);
 
-		$value = $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', 0, 'int');
-		$this->setState('filter.tag', $value);
-
 		// Load the parameters. Merge Global and Menu Item params into new object
 		$params = $app->getParams();
 		$menuParams = new Registry;
@@ -160,6 +157,9 @@ class ContentModelCategory extends JModelList
 		}
 
 		$itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+
+		$value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int');
+		$this->setState('filter.tag', $value);
 
 		// Optional filter text
 		$search = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');


### PR DESCRIPTION
Pull Request for Issue #18138 .

### Summary of Changes
Change the session key for the tag filter in category model to be more unique between requests.
Add to session key `category id` and `Itemid`.

### Testing Instructions
See issue #18138.

### Expected result
On both menu pages articles are visible.


### Actual result
Of first page article as OK
On second category page (without filter tags) there is no articles that does not have tags.


### Documentation Changes Required
No
