### PR TITLE
Use CodeMirror's functions to try to determine the correct mode

### DIFF
--- a/plugins/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/codemirror.php
@@ -30,12 +30,7 @@ class PlgEditorCodemirror extends JPlugin
 	 *
 	 * @var array
 	 */
-	protected $modeAlias = array(
-			'html' => 'htmlmixed',
-			'ini'  => 'properties',
-			'json' => array('name' => 'javascript', 'json' => true),
-			'scss' => 'css',
-		);
+	protected $modeAlias = array();
 
 	/**
 	 * Initialises the Editor.

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -38,7 +38,7 @@ JFactory::getDocument()->addScriptDeclaration(
 			cm.defineInitHook(function (editor)
 			{
 				// Try to set up the mode
-				var mode = cm.findModeByName(edtior.options.mode || '');
+				var mode = cm.findModeByName(editor.options.mode || '');
 
 				if (mode)
 				{
@@ -47,7 +47,7 @@ JFactory::getDocument()->addScriptDeclaration(
 				}
 				else
 				{
-					cm.autoLoadMode(editor, edtior.options.mode);
+					cm.autoLoadMode(editor, editor.options.mode);
 				}
 
 				// Handle gutter clicks (place or remove a marker).

--- a/plugins/editors/codemirror/layouts/editors/codemirror/init.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/init.php
@@ -37,8 +37,19 @@ JFactory::getDocument()->addScriptDeclaration(
 			// Fire this function any time an editor is created.
 			cm.defineInitHook(function (editor)
 			{
-				// Load the editor mode (typically 'htmlmixed').
-				cm.autoLoadMode(editor, editor.options.mode);
+				// Try to set up the mode
+				var mode = cm.findModeByName(edtior.options.mode || '');
+
+				if (mode)
+				{
+					cm.autoLoadMode(editor, mode.mode);
+					editor.setOption('mode', mode.mime);
+				}
+				else
+				{
+					cm.autoLoadMode(editor, edtior.options.mode);
+				}
+
 				// Handle gutter clicks (place or remove a marker).
 				editor.on("gutterClick", function (ed, n, gutter) {
 					if (gutter != "CodeMirror-markergutter") { return; }
@@ -46,6 +57,7 @@ JFactory::getDocument()->addScriptDeclaration(
 						hasMarker = !!info.gutterMarkers && !!info.gutterMarkers["CodeMirror-markergutter"];
 					ed.setGutterMarker(n, "CodeMirror-markergutter", hasMarker ? null : makeMarker());
 				});
+
 				// jQuery's ready function.
 				$(function () {
 					// Some browsers do something weird with the fieldset which doesn't work well with CodeMirror. Fix it.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Instead of trying to determine the correct mode in PHP and explicitly set it in CodeMirror, use CodeMirror's built in functions to get the mode information. This means that (with no known exceptions) we can just pass the `syntax` parameter and get the right mode. This also means many more modes should be available. For example, until now, setting `syntax="less"` in the jform xml for the codemirror element would not give you less-mode. Now it should.


### Testing Instructions
Try using codemirror with as many different modes as you can. HTML (obviously), CSS, JS, XML, PHP, etc. 

### Expected result
The mode settings (such as syntax coloring) should be correct.


### Actual result
Until now, modes commonly used by Joomla users probably worked properly but some others (such as `less`) might not have. 


### Documentation Changes Required
No, I think not. 
