### PR TITLE
[3.9] Support specifying the password hashing algorithm to use

### DIFF
--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -301,18 +301,20 @@ abstract class UserHelper
 	/**
 	 * Hashes a password using the current encryption.
 	 *
-	 * @param   string  $password  The plaintext password to encrypt.
+	 * @param   string   $password   The plaintext password to encrypt.
+	 * @param   integer  $algorithm  The hashing algorithm to use, represented by `PASSWORD_*` constants.
+	 * @param   array    $options    The options for the algorithm to use.
 	 *
 	 * @return  string  The encrypted password.
 	 *
 	 * @since   3.2.1
 	 */
-	public static function hashPassword($password)
+	public static function hashPassword($password, $algorithm = PASSWORD_BCRYPT, array $options = array())
 	{
 		// \JCrypt::hasStrongPasswordSupport() includes a fallback for us in the worst case
 		\JCrypt::hasStrongPasswordSupport();
 
-		return password_hash($password, PASSWORD_BCRYPT);
+		return password_hash($password, $algorithm, $options);
 	}
 
 	/**

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -332,6 +332,8 @@ abstract class UserHelper
 	 */
 	public static function verifyPassword($password, $hash, $user_id = 0)
 	{
+		$passwordAlgorithm = PASSWORD_BCRYPT;
+
 		// If we are using phpass
 		if (strpos($hash, '$P$') === 0)
 		{
@@ -349,6 +351,8 @@ abstract class UserHelper
 			$match = password_verify($password, $hash);
 
 			$rehash = password_needs_rehash($hash, PASSWORD_ARGON2I);
+
+			$passwordAlgorithm = PASSWORD_ARGON2I;
 		}
 		// Check for bcrypt hashes
 		elseif (strpos($hash, '$2') === 0)
@@ -389,7 +393,7 @@ abstract class UserHelper
 		if ((int) $user_id > 0 && $match && $rehash)
 		{
 			$user = new User($user_id);
-			$user->password = static::hashPassword($password);
+			$user->password = static::hashPassword($password, $passwordAlgorithm);
 			$user->save();
 		}
 

--- a/libraries/src/User/UserWrapper.php
+++ b/libraries/src/User/UserWrapper.php
@@ -137,7 +137,9 @@ class UserWrapper
 	/**
 	 * Helper wrapper method for hashPassword
 	 *
-	 * @param   string  $password  The plaintext password to encrypt.
+	 * @param   string   $password   The plaintext password to encrypt.
+	 * @param   integer  $algorithm  The hashing algorithm to use, represented by `PASSWORD_*` constants.
+	 * @param   array    $options    The options for the algorithm to use.
 	 *
 	 * @return  string  The encrypted password.
 	 *
@@ -145,9 +147,9 @@ class UserWrapper
 	 * @since   3.4
 	 * @deprecated  4.0  Use `Joomla\CMS\User\UserHelper` directly
 	 */
-	public function hashPassword($password)
+	public function hashPassword($password, $algorithm = PASSWORD_BCRYPT, array $options = array())
 	{
-		return UserHelper::hashPassword($password);
+		return UserHelper::hashPassword($password, $algorithm, $options);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -327,6 +327,29 @@ class JUserHelperTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Testing hashPassword() for argon2i hashing support.
+	 *
+	 * @covers  JUserHelper::hashPassword
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @requires  PHP 7.2
+	 */
+	public function testHashPasswordArgon2i()
+	{
+		if (!defined('PASSWORD_ARGON2I'))
+		{
+			$this->markTestSkipped('Argon2i algorithm not supported.');
+		}
+
+		$this->assertEquals(
+			strpos(JUserHelper::hashPassword('mySuperSecretPassword', PASSWORD_ARGON2I), '$argon2i'),
+			0,
+			'The password is hashed using the specified hashing algorithm'
+		);
+	}
+
+	/**
 	 * Testing verifyPassword().
 	 *
 	 * @covers  JUserHelper::verifyPassword


### PR DESCRIPTION
### Summary of Changes

In 3.8 we silently added support for validating Argon2i password hashes, a feature present in PHP 7.2.  However, our API still only supports generating bcrypt password hashes.  This PR adjusts `Joomla\CMS\User\UserHelper::hashPassword()` to allow specifying the hashing algorithm for use as well as the ability to pass options forward into the native `password_hash()` function.

### Testing Instructions

For normal use of the CMS, nothing changes.  User password hashes are still generated with bcrypt and users are able to log in without issue.  For those on a PHP 7.2 build with Argon2i support (note that while this is available in the sodium extension, right now we only support its use through the PHP `password_*` functions which requires PHP compiled with the Argon2 library available), they should be able to call `Joomla\CMS\User\UserHelper::hashPassword('myPassword', PASSWORD_ARGON2I);` and receive a password hashed with the Argon2i algorithm.

### Documentation Changes Required

API additions documented.