### PR TITLE
Fixed the stability check when looking for updates for an extension

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -382,7 +382,7 @@ class ExtensionAdapter extends UpdateAdapter
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Updater\\Updater::STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -382,7 +382,7 @@ class ExtensionAdapter extends UpdateAdapter
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Updater\\STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -382,7 +382,7 @@ class ExtensionAdapter extends UpdateAdapter
 	 */
 	protected function stabilityTagToInteger($tag)
 	{
-		$constant = '\\Joomla\\CMS\\Updater\\STABILITY_' . strtoupper($tag);
+		$constant = '\\Joomla\\CMS\\Update\\Updater::STABILITY_' . strtoupper($tag);
 
 		if (defined($constant))
 		{

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -18,12 +18,6 @@ use Joomla\CMS\Table\Table;
 \JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
 
-const STABILITY_DEV = 0;
-const STABILITY_ALPHA = 1;
-const STABILITY_BETA = 2;
-const STABILITY_RC = 3;
-const STABILITY_STABLE = 4;
-
 /**
  * Updater Class
  *

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -18,6 +18,12 @@ use Joomla\CMS\Table\Table;
 \JLoader::import('joomla.filesystem.path');
 \JLoader::import('joomla.base.adapter');
 
+const STABILITY_DEV = 0;
+const STABILITY_ALPHA = 1;
+const STABILITY_BETA = 2;
+const STABILITY_RC = 3;
+const STABILITY_STABLE = 4;
+
 /**
  * Updater Class
  *


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As far as I know it is not possible to import class constants, but when looking for an update to an extension Joomla was trying to do that.

I copied the const to the outside of the Updater class


### Testing Instructions
Install this extension http://pixpro.net/pixext/downloads/module/mod_helloworld/0.0.1/e8e9e3c9f3a9dd3f1d2792d83269ad64.zip and see if it has any updates.

Link to update xml http://pixpro.net/pixext/updates/module/mod_helloworld/e8e9e3c9f3a9dd3f1d2792d83269ad64.xml


### Expected result
It should have an update with version no 0.0.2


### Actual result
It has an update with version no 0.0.6


### Documentation Changes Required

