### PR TITLE
If the link is the same as active menu item then use it

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -74,25 +74,24 @@ class MenuRules implements RulesInterface
 				return;
 			}
 
-			$query2 = array();
-
-			foreach ($active->query as $k => $v)
+			if ((isset($query['option']) === false || $query['option'] === $active->query['option'])
+				&& (isset($query['view']) === false
+					|| isset($active->query['view']) && $query['view'] === $active->query['view'])
+				&& (isset($query['layout']) === false
+					|| isset($active->query['layout']) && $query['layout'] === $active->query['layout']))
 			{
-				if (isset($query[$k])) {
-					// Remove every alias from query2 because item query does not contain aliases
-					list($query2[$k]) = explode(':', $query[$k], 2);
-				}
-				else
+				$views = $this->router->getViews();
+
+				if (isset($views[$active->query['view']]))
 				{
-					// Add missing keys in query that exists in item->query
-					$query2[$k] = $v;
-				}
-			}
+					$key = $views[$active->query['view']]->key;
 
-			if ($active->query === $query2)
-			{
-				// If the same view has two different menu items and one of them is active then use the active one
-				return;
+					if ($key === false || isset($query[$key]) === false || current(explode(':', $query[$key], 2)) == $active->query[$key])
+					{
+						// If the same view has two different menu items and one of them is active then use the active one
+						return;
+					}
+				}
 			}
 		}
 

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -63,21 +63,33 @@ class MenuRules implements RulesInterface
 	{
 		$active = $this->router->menu->getActive();
 
-		/**
-		 * If the active item id is not the same as the supplied item id or we have a supplied item id and no active
-		 * menu item then we just use the supplied menu item and continue
-		 */
-		if (isset($query['Itemid']) && ($active === null || $query['Itemid'] != $active->id))
+		if (isset($query['Itemid']))
 		{
-			return;
-		}
+			/**
+			* If the active item id is not the same as the supplied item id or we have a supplied item id and no active
+			* menu item then we just use the supplied menu item and continue
+			*/
+			if ($active === null || $query['Itemid'] != $active->id)
+			{
+				return;
+			}
 
-		if ($active !== null)
-		{
-			$activeQuery = $active->query;
-			$activeQuery['Itemid'] = $active->id;
+			$query2 = array();
 
-			if ($activeQuery === $query)
+			foreach ($active->query as $k => $v)
+			{
+				if (isset($query[$k])) {
+					// Remove every alias from query2 because item query does not contain aliases
+					list($query2[$k]) = explode(':', $query[$k], 2);
+				}
+				else
+				{
+					// Add missing keys in query that exists in item->query
+					$query2[$k] = $v;
+				}
+			}
+
+			if ($active->query === $query2)
 			{
 				// If the same view has two different menu items and one of them is active then use the active one
 				return;

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -75,6 +75,11 @@ class MenuRules implements RulesInterface
 		// Get query language
 		$language = isset($query['lang']) ? $query['lang'] : '*';
 
+		if ($language !== '*' && isset($this->lookup[$language]) === false)
+		{
+			$this->buildLookup($language);
+		}
+
 		if ($active !== null)
 		{
 			// Test if query lang match active language
@@ -107,11 +112,6 @@ class MenuRules implements RulesInterface
 					}
 				}
 			}
-		}
-
-		if ($language !== '*' && isset($this->lookup[$language]) === false)
-		{
-			$this->buildLookup($language);
 		}
 
 		$needles = $this->router->getPath($query);

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -254,7 +254,13 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$this->assertEquals($expect, $query);
 
 		// Test if the active Itemid is used although an article has other Itemid with id=52
-		$expect = $query = array('option' => 'com_content', 'view' => 'article', 'id' => '1:some-alias', 'Itemid' => '53');
+		$expect = $query = array(
+			'option' => 'com_content',
+			'view' => 'article',
+			'id' => '1:some-alias',
+			// Additional parameter that is not a key but exists for example in category view
+			'filter_tag' => array(''),
+			'Itemid' => '53');
 		$this->object->preprocess($query);
 		$this->assertEquals($expect, $query);
 

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -115,7 +115,8 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 			'*' => array(
 				'featured' => '47',
 				'categories' => array(14 => '48'),
-				'category' => array (20 => '49'))
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 	}
@@ -232,6 +233,30 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Tests the preprocess() method
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testPreprocessActive()
+	{
+		$this->saveFactoryState();
+
+		$router = $this->object->get('router');
+
+		// Set an active menu
+		$router->menu->active = 53;
+
+		// Test if the active Itemid is used although an article has other Itemid with id=52
+		$expect = $query = array('option' => 'com_content', 'view' => 'article', 'id' => '1', 'Itemid' => '53');
+		$this->object->preprocess($query);
+		$this->assertEquals($expect, $query);
+
+		$this->restoreFactoryState();
+	}
+
+	/**
 	 * Tests the buildLookup() method
 	 *
 	 * @return  void
@@ -244,7 +269,8 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 			'*' => array(
 				'featured' => '47',
 				'categories' => array(14 => '48'),
-				'category' => array (20 => '49'))
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 
@@ -253,11 +279,13 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 			'*' => array(
 				'featured' => '47',
 				'categories' => array(14 => '48'),
-				'category' => array (20 => '49')),
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			'en-GB' => array(
 				'featured' => '51',
 				'categories' => array(14 => '50'),
-				'category' => array (20 => '49'))
+				'category' => array (20 => '49'),
+				'article' => array(1 => '52')),
 			), $this->object->get('lookup')
 		);
 	}

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -258,8 +258,6 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 			'option' => 'com_content',
 			'view' => 'article',
 			'id' => '1:some-alias',
-			// Additional parameter that is not a key but exists for example in category view
-			'filter_tag' => array(''),
 			'Itemid' => '53');
 		$this->object->preprocess($query);
 		$this->assertEquals($expect, $query);

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -253,6 +253,11 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$this->object->preprocess($query);
 		$this->assertEquals($expect, $query);
 
+		// Test if the active Itemid is used although an article has other Itemid with id=52
+		$expect = $query = array('option' => 'com_content', 'view' => 'article', 'id' => '1:some-alias', 'Itemid' => '53');
+		$this->object->preprocess($query);
+		$this->assertEquals($expect, $query);
+
 		$this->restoreFactoryState();
 	}
 

--- a/tests/unit/suites/libraries/cms/component/router/rules/stubs/MockJComponentRouterRulesMenuMenuObject.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/stubs/MockJComponentRouterRulesMenuMenuObject.php
@@ -111,6 +111,37 @@ class MockJComponentRouterRulesMenuMenuObject
 			'component'    => 'com_content',
 			'parent_id'    => '0',
 			'query'        => array('option' => 'com_content', 'view' => 'featured'));
+
+
+		$this->items[52] = (object) array(
+			'id'           => '52',
+			'menutype'     => 'testmenu',
+			'title'        => 'Content Article',
+			'alias'        => 'content-article',
+			'route'        => 'content-article',
+			'link'         => 'index.php?option=com_content&view=article&id=1',
+			'type'         => 'component',
+			'level'        => '1',
+			'language'     => '*',
+			'component_id' => '22',
+			'component'    => 'com_content',
+			'parent_id'    => '0',
+			'query'        => array('option' => 'com_content', 'view' => 'article', 'id' => '1'));
+
+		$this->items[53] = (object) array(
+			'id'           => '53',
+			'menutype'     => 'testmenu',
+			'title'        => 'Content Article (2)',
+			'alias'        => 'content-article-2',
+			'route'        => 'content-article-2',
+			'link'         => 'index.php?option=com_content&view=article&id=1',
+			'type'         => 'component',
+			'level'        => '1',
+			'language'     => '*',
+			'component_id' => '22',
+			'component'    => 'com_content',
+			'parent_id'    => '0',
+			'query'        => array('option' => 'com_content', 'view' => 'article', 'id' => '1'));
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #17719 and #16774

### Summary of Changes
If link Itemid is equal to active menu and link query is equal to active query then use it, do not try to find a better match.
Add unit tests to prove that.

### Testing Instructions
Use tests from  #17719 or #16774 or this below.

1. Turn off Search Engine Friendly URLs in Global Configuration
2. Create menu item (Style 1) to an article, save, then save as copy (Style 2), publish and save and close.
3. Go to front-page and click on the first one (Style 1), check both URLs, it is OK.
4. Go to second (Style 2), and check link at (Style 2), the Itemid in URL point to (Style 1) instead to itself (Style 2).

### Expected result
Active second menu item (Style 2) should have URL to (Style 2) 

### Actual result
Active second menu item (Style 2) use first menu item URL (Style 1) 

### Documentation Changes Required
No
