### PR TITLE
[redis] - add db selection for redis session storage

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -181,7 +181,7 @@
 
 		<field
 			name="redis_server_db"
-			type="text"
+			type="number"
 			label="COM_CONFIG_FIELD_REDIS_DB_LABEL"
 			description="COM_CONFIG_FIELD_REDIS_DB_DESC"
 			default="0"
@@ -949,7 +949,7 @@
 
 		<field
 			name="session_redis_server_db"
-			type="text"
+			type="number"
 			label="COM_CONFIG_FIELD_REDIS_DB_LABEL"
 			description="COM_CONFIG_FIELD_REDIS_DB_DESC"
 			default="0"

--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -948,6 +948,16 @@
 		/>
 
 		<field
+			name="session_redis_server_db"
+			type="text"
+			label="COM_CONFIG_FIELD_REDIS_DB_LABEL"
+			description="COM_CONFIG_FIELD_REDIS_DB_DESC"
+			default="0"
+			filter="integer"
+			showon="session_handler:redis"
+			size="4"
+		/>
+		<field
 			name="lifetime"
 			type="number"
 			label="COM_CONFIG_FIELD_SESSION_TIME_LABEL"

--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -36,6 +36,7 @@ class JSessionStorageRedis extends JSessionStorage
 		$this->_server = array(
 			'host' => $config->get('session_redis_server_host', 'localhost'),
 			'port' => $config->get('session_redis_server_port', 6379),
+			'db'   => (int) $config->get('session_redis_server_db', 0)
 		);
 
 		parent::__construct($options);
@@ -54,7 +55,14 @@ class JSessionStorageRedis extends JSessionStorage
 		{
 			if (!headers_sent())
 			{
-				ini_set('session.save_path', "{$this->_server['host']}:{$this->_server['port']}");
+				$path = $this->_server['host'] . ":" . $this->_server['port'];
+
+				if (isset($this->_server['db']) && ($this->_server['db'] !== 0))
+				{
+					$path = 'tcp://' . $path . '?database=' . $this->_server['db'];
+				}
+				
+				ini_set('session.save_path', $path);
 				ini_set('session.save_handler', 'redis');
 			}
 


### PR DESCRIPTION
Pull Request for Issue #18259 .

### Summary of Changes
added the missing db selection option


### Testing Instructions
enable redis session storage 
and select a different redis database for session storage ex. 2
then connect to redis from console `redis-cli -n 2`
and list KEYS *

![screenshot from 2017-10-07 11-55-18](https://user-images.githubusercontent.com/181681/31306737-712a5fba-ab56-11e7-887f-6fc8cc9d8922.png)


### Expected result
you are able to store php session on different from default `0` redis database
![screenshot from 2017-10-07 11-43-49](https://user-images.githubusercontent.com/181681/31306665-decf4320-ab54-11e7-8557-47ee5a52ea9d.png)

### Actual result

only default  `0` db




