### PR TITLE
Check if exists variable is equal to null instead use isset

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -711,7 +711,7 @@ class SiteRouter extends Router
 			{
 				$item = $this->menu->getItem($this->getVar('Itemid'));
 
-				if (isset($item) && $item->component === $option)
+				if ($item !== null && $item->component === $option)
 				{
 					$uri->setVar('Itemid', $item->id);
 				}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Simple improvement. 
Do not use function `isset()` if you can compare to null only, for variables that exists.

### Testing Instructions

Code review.
Or check the home page and one more page to see if links work as before.

### Expected result

Joomla works as before.

