### PR TITLE
Remove notice in com_content legacyrouting

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -93,7 +93,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 		// Are we dealing with an article or category that is attached to a menu item?
 		if ($menuItem !== null
 			&& $menuItem->query['view'] == $query['view']
-			&& isset($query['id'])
+			&& isset($menuItem->query['id'], $query['id'])
 			&& $menuItem->query['id'] == (int) $query['id'])
 		{
 			unset($query['view']);


### PR DESCRIPTION
### Summary of Changes

Do not raise PHP Notice when build URL from invalid query.

### Testing Instructions

1. Install Joomla staging without sample data.
   * Search Engine Friendly URLs is enabled by default.
2. Set Global Configuration -> Server -> Error Reporting to Maximum.
3. Create one featured article with text:
```html
<p><a href="index.php?option=com_content&amp;view=featured&amp;id=1">Broken link to featured view</a></p>
```
4. Go to home page and check your error_log

### Expected result

No PHP Notice

### Actual result

PHP notice like:
```html
Notice: Undefined index: id in .../components/com_content/helpers/legacyrouter.php on line 97
```