### PR TITLE
If there is no menu item with layout then use menu item without layout

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -96,13 +96,14 @@ class MenuRules implements RulesInterface
 		{
 			foreach ($needles as $view => $ids)
 			{
-				if (isset($this->lookup[$language][$view . $layout]))
+				if (isset($query['layout'], $this->lookup[$language][$view . $layout]))
 				{
 					if (is_bool($ids))
 					{
 						$query['Itemid'] = $this->lookup[$language][$view . $layout];
 						return;
 					}
+
 					foreach ($ids as $id => $segment)
 					{
 						if (isset($this->lookup[$language][$view . $layout][(int) $id]))
@@ -110,7 +111,19 @@ class MenuRules implements RulesInterface
 							$query['Itemid'] = $this->lookup[$language][$view . $layout][(int) $id];
 							return;
 						}
+					}
+				}
 
+				if (isset($this->lookup[$language][$view]))
+				{
+					if (is_bool($ids))
+					{
+						$query['Itemid'] = $this->lookup[$language][$view];
+						return;
+					}
+
+					foreach ($ids as $id => $segment)
+					{
 						if (isset($this->lookup[$language][$view][(int) $id]))
 						{
 							$query['Itemid'] = $this->lookup[$language][$view][(int) $id];

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -151,6 +151,10 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49'));
 
+		// Check indirect link to a nested view with a key if the layout is different
+		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'layout' => 'blog'),
+			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49', 'layout' => 'blog'));
+
 		// Check indirect link to a nested view with a key and a language
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB', 'Itemid' => '49'));


### PR DESCRIPTION
### Summary of Changes

If there is no menu item for supplied layout then use fallback to menu item without layout, for all cases.

#### On joomla 3.8.1 with modern routing:
For example, a menu item with type `Category List` has the link `index.php?option=content&view=category&id=2` to "Uncategorised" category.
The sef URL looks like 'index.php/uncategorised'

* If we create an article with link `index.php?option=content&view=category&id=2&layout=blog` and there is no any menu item with layout blog then above menu item won't be used.
  If there exists at least one blog for other category then the menu item will be found. 

* If we add url like `index.php?option=content&view=category&id=2&layout=default` to the article then menu item won't be found.

### Testing Instructions
1. Install staging joomla without sample data.
2. Create menu item with type `Category List` for Uncategorised category.
3. Create featured article in `Uncategorised` category:
```html
<p>Uncategorised with layout explicitly</p>
<p><a href="index.php?option=com_content&amp;view=category&amp;id=2&amp;layout=default">Layout default</a></p>
<p><a href="index.php?option=com_content&amp;view=category&amp;id=2&amp;layout=blog">Layout blog</a></p>
<p>Link to readmore with layout default <a href="index.php?option=com_content&amp;view=article&amp;id=1&amp;catid=2&amp;layout=default">Article</a></p>
```
4. Change routing for com_content component to modern/experimental.
5. Go to home page and check article links.
6. Check article link for button `print`. (stay in home page - featured view)

7. Before patch links does not use menu item "Uncategorised".
8. After patch links uses the menu item.
