### PR TITLE
Fix 2 issues with srcset handling in SEF plugin, finding multiple image URLs and also handling of URLs that contain commas

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -138,7 +138,8 @@ class PlgSystemSef extends JPlugin
 				function ($match) use ($base, $protocols)
 				{
 					$data = array();
-					foreach (explode(",", $match[1]) as $url)
+					// A whitespace space character must follow a comma when defining multiple 'srcset' images
+					foreach (preg_split("/,\s+/u", $match[1]) as $url)
 					{
 						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
 					}

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -143,7 +143,8 @@ class PlgSystemSef extends JPlugin
 					{
 						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
 					}
-					return ' srcset="' . implode(",", $data) . '"';
+					// Comma + whitespace character is needed for browser to distinguish multiple images in 'srcset'
+					return ' srcset="' . implode(",\n", $data) . '"';
 				},
 				$buffer
 			);	

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -138,12 +138,12 @@ class PlgSystemSef extends JPlugin
 				function ($match) use ($base, $protocols)
 				{
 					$data = array();
-					// A whitespace space character must follow a comma when defining multiple 'srcset' images
+					// A whitespace space character must follow a comma when defining multiple images inside 'srcset'
 					foreach (preg_split("/,\s+/u", $match[1]) as $url)
 					{
 						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
 					}
-					// Comma + whitespace character is needed for browser to distinguish multiple images in 'srcset'
+					// Comma + whitespace character is needed for browser to safely distinguish multiple images inside 'srcset'
 					return ' srcset="' . implode(",\n", $data) . '"';
 				},
 				$buffer


### PR DESCRIPTION
Pull Request for Issue #18269

### Summary of Changes
Fix 2 problems described in the above issue
- Comma is a legitimate character in URLs it should be handled
- Restoring multiple image URLs after handling should be comma + whitespace for browser to identify them

### Testing Instructions
See cases in issue  #18269


### Expected result



### Actual result



### Documentation Changes Required

