### PR TITLE
admin login using keyboard fix tab order

### DIFF
--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -49,7 +49,7 @@ abstract class ModLoginHelper
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 
-		return JHtml::_('select.genericlist', $languages, 'lang', ' class="advancedSelect" tabindex="4" ', 'value', 'text', null);
+		return JHtml::_('select.genericlist', $languages, 'lang', 'class="advancedSelect" tabindex="4"', 'value', 'text', null);
 	}
 
 	/**

--- a/administrator/modules/mod_login/helper.php
+++ b/administrator/modules/mod_login/helper.php
@@ -49,7 +49,7 @@ abstract class ModLoginHelper
 
 		array_unshift($languages, JHtml::_('select.option', '', JText::_('JDEFAULTLANGUAGE')));
 
-		return JHtml::_('select.genericlist', $languages, 'lang', ' class="advancedSelect"', 'value', 'text', null);
+		return JHtml::_('select.genericlist', $languages, 'lang', ' class="advancedSelect" tabindex="4" ', 'value', 'text', null);
 	}
 
 	/**

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -88,7 +88,7 @@ if ($langs)
 		<div class="control-group">
 			<div class="controls">
 				<div class="btn-group">
-					<button tabindex="3" class="btn btn-primary btn-block btn-large login-button">
+					<button tabindex="5" class="btn btn-primary btn-block btn-large login-button">
 						<span class="icon-lock icon-white"></span> <?php echo JText::_('MOD_LOGIN_LOGIN'); ?>
 					</button>
 				</div>


### PR DESCRIPTION
It should be possible to login using the keyboard only by using the tab key to move between fields. It works fine until you have a language select as thiis doesnt have a tabindex. As a result you have to tab past the login button to reach the language select. In addition if you have the tfa option enabled then the tfa option and the login button have the same tabindex. This PR resolves this - see animations

## Before
### Before with language
![before-lang](https://user-images.githubusercontent.com/1296369/31312113-045040aa-abb3-11e7-9bc1-3f1c6e7d3254.gif)

### Before with TFA
![before-tfa](https://user-images.githubusercontent.com/1296369/31312114-0451dece-abb3-11e7-84bc-6e4b259285cd.gif)

### Before with TFA and language
![before-tfa-lang](https://user-images.githubusercontent.com/1296369/31312112-0448945e-abb3-11e7-9070-e6b2763b0aa7.gif)

## After
### After with language
![after-lang](https://user-images.githubusercontent.com/1296369/31312119-2b34b23c-abb3-11e7-887c-c62ed8c500ce.gif)

### After with tfa
![after-tfa](https://user-images.githubusercontent.com/1296369/31312120-2b3735c0-abb3-11e7-8ead-33ad12afae1a.gif)

### After with tfa and language
![after-lang-tfa](https://user-images.githubusercontent.com/1296369/31312124-3d94310a-abb3-11e7-842c-d05048be30c5.gif)

