### PR TITLE
Remove Vote plugin check for DB Select

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -216,13 +216,12 @@ class ContentModelArticles extends JModelList
 		// Join on voting table
 		$assogroup = 'a.id, l.title, l.image, uc.name, ag.title, c.title, ua.name';
 
-		if (JPluginHelper::isEnabled('content', 'vote'))
-		{
-			$assogroup .= ', v.rating_sum, v.rating_count';
-			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
-					COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
-				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
-		}
+		// Part of the core, always implement.
+		$assogroup .= ', v.rating_sum, v.rating_count';
+		$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
+				COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
+			->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
+
 
 		// Join over the associations.
 		if (JLanguageAssociations::isEnabled())


### PR DESCRIPTION
Fixes #18281
Removed Vote plugin check, because the plugin doesn't touch the database and the filter still exists.

Please test, I see no issue with this since it doesn't rely on the vote plugin.