### PR TITLE
Login footer links with debug enabled

### DIFF
--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -95,7 +95,7 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		margin-right: auto;
 	}
 	.view-login .navbar-fixed-bottom {
-		position: relative
+		position: relative;
 	}');
 }
 ?>

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -95,7 +95,7 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		margin-right: auto;
 	}
 	.view-login .navbar-fixed-bottom {
-		position:relative
+		position: relative
 	}');
 }
 ?>

--- a/administrator/templates/isis/login.php
+++ b/administrator/templates/isis/login.php
@@ -95,7 +95,7 @@ if (JPluginHelper::isEnabled('system', 'debug') && ($app->get('debug_lang', 0) |
 		margin-right: auto;
 	}
 	.view-login .navbar-fixed-bottom {
-		display: none;
+		position:relative
 	}');
 }
 ?>


### PR DESCRIPTION
Before this PR if you enable debug mode then on the login screen the footer links are set to display:none

After this PR they are set to display above the debug information as shown in the screenshot below

<img width="1015" alt="screenshotr11-34-46" src="https://user-images.githubusercontent.com/1296369/31334414-282fe4ba-ace6-11e7-8a07-2925e1e7f6d0.png">
