### PR TITLE
fix com_redirect modal close behavior (for redirect plugin)

### DIFF
--- a/administrator/components/com_redirect/views/links/tmpl/default.php
+++ b/administrator/components/com_redirect/views/links/tmpl/default.php
@@ -33,8 +33,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'title'      => JText::_('COM_REDIRECT_EDIT_PLUGIN_SETTINGS'),
 					'height'     => '400px',
 					'modalWidth' => '60',
-					'footer'     => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
-						. JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+					'closeButton' => false,
+					'backdrop'    => 'static',
+					'keyboard'    => false,
+					'footer'     => '<button type="button" class="btn" data-dismiss="modal" aria-hidden="true"'
+						. ' onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#closeBtn\').click();">'
+						. JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 						. '<button class="btn btn-success" data-dismiss="modal" aria-hidden="true" onclick="jQuery(\'#plugin' . $this->redirectPluginId . 'Modal iframe\').contents().find(\'#saveBtn\').click();">'
 						. JText::_("JSAVE") . '</button>'
 				)


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/18285

### Summary of Changes
set backdrop to static, disable (X) button and disable keyboard outside modal to prevent closing modal without executing the close logic.
Changed the close button (footer) to execute the plugin.cancel task


### Testing Instructions
1. [tab 1]open com_redirect
2. [tab 2] open second tab with com_plugins and filter on 'redirect' plugin
3. in [tab 2] enable the redirect plugin and disable the collect urls > save the plugin
4. in [tab 1] in com_redirect click the 'Redirect System Plugin' link in the notice
5. clicking the backdrop, 'X' and [Close]  button will close the modal

### Expected result
The plg_system_redirect should be checked in


### Actual result
The plg_system_redirect is NOT checked in.
in [tab 2] press ctrl-f5 and you can see that although the modal in tab 1 is closed, the plugin is not checked in correct.

----
With patch applied:
1. the 'X' is not displayed in the modal so cannot be used.
2. the keyboard is disabled outside the modal and the backdrop is set to static, so the modal cannot be closed by using the keyboard or clicking outside the modal
2. the [Close]  button now correctly call the 'plugin.cancel' task and thereby correctly closing AND checking in the redirect plugin.

### Documentation Changes Required
not that I know of.
