### PR TITLE
Added vote requires to array for list type

### DIFF
--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -123,6 +123,12 @@ class JFormFieldList extends JFormField
 				{
 					continue;
 				}
+				
+				// Requires vote plugin
+				if (in_array('vote', $requires) && !JPluginHelper::isEnabled('content', 'vote'))
+				{
+					continue;
+				}
 			}
 
 			$value = (string) $option['value'];

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -123,7 +123,7 @@ class JFormFieldList extends JFormField
 				{
 					continue;
 				}
-				
+
 				// Requires vote plugin
 				if (in_array('vote', $requires) && !JPluginHelper::isEnabled('content', 'vote'))
 				{


### PR DESCRIPTION
Vote has been set as a 'requires' on options. This allows it to function as expected, hiding the vote filtering options in lists

Pull Request for Issue #18281 and follow on from pull #18283.

@brianteeman @Quy here is the updated pull. 
