### PR TITLE
fixes date filtering

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -130,6 +130,12 @@ class ContentModelArticles extends JModelList
 		}
 
 		$this->setState('layout', $app->input->getString('layout'));
+
+		$this->setState('filter.date_filtering', $app->input->getString('date_filtering'));
+		$this->setState('filter.date_field', $app->input->getString('date_field'));
+		$this->setState('filter.start_date_range', $app->input->getString('start_date_range'));
+		$this->setState('filter.end_date_range', $app->input->getString('end_date_range'));
+		$this->setState('filter.relative_date', $app->input->getInt('relative_date'));
 	}
 
 	/**
@@ -450,12 +456,14 @@ class ContentModelArticles extends JModelList
 		switch ($dateFiltering)
 		{
 			case 'range':
-				$startDateRange = $db->quote($this->getState('filter.start_date_range', $nullDate));
-				$endDateRange   = $db->quote($this->getState('filter.end_date_range', $nullDate));
-				$query->where(
-					'(' . $dateField . ' >= ' . $startDateRange . ' AND ' . $dateField .
-					' <= ' . $endDateRange . ')'
-				);
+				if ($startDateRange = $this->getState('filter.start_date_range'))
+				{
+					$query->where($dateField . ' >= ' . $db->quote($startDateRange));
+				}
+				if ($endDateRange = $this->getState('filter.end_date_range'))
+				{
+					$query->where($dateField . ' <= ' . $db->quote($endDateRange));
+				}
 				break;
 
 			case 'relative':

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -214,6 +214,12 @@ class ContentModelCategory extends JModelList
 
 		// Set the featured articles state
 		$this->setState('filter.featured', $params->get('show_featured'));
+
+		$this->setState('filter.date_filtering', $app->input->getString('date_filtering'));
+		$this->setState('filter.date_field', $app->input->getString('date_field'));
+		$this->setState('filter.start_date_range', $app->input->getString('start_date_range'));
+		$this->setState('filter.end_date_range', $app->input->getString('end_date_range'));
+		$this->setState('filter.relative_date', $app->input->getInt('relative_date'));
 	}
 
 	/**
@@ -242,6 +248,11 @@ class ContentModelCategory extends JModelList
 			$model->setState('list.direction', $this->getState('list.direction'));
 			$model->setState('list.filter', $this->getState('list.filter'));
 			$model->setState('filter.tag', $this->getState('filter.tag'));
+			$model->setState('filter.date_filtering', $this->getState('filter.date_filtering'));
+			$model->setState('filter.date_field', $this->getState('filter.date_field'));
+			$model->setState('filter.start_date_range', $this->getState('filter.start_date_range'));
+			$model->setState('filter.end_date_range', $this->getState('filter.end_date_range'));
+			$model->setState('filter.relative_date', $this->getState('filter.relative_date'));
 
 			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
 			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));


### PR DESCRIPTION
### Summary of changes
Fixed Articles date filter
### Testing Instructions
Create a new featured article.
Open the page in the front-end `index.php?option=com_content&view=featured&date_filtering=relative&relative_date=1`
or the page `index.php?option=com_content&view=featured&date_filtering=range&start_date_range=2017-10-12`
### Expected result
In the first case only articles created in the last 24 hours are displayed
In the second case, only articles created since 12/10/2017 are displayed
### Actual result
All articles are displayed
#### With patch applied:
In the first case only articles created in the last 24 hours are displayed
In the second case, only articles created since 12/10/2017 are displayed
### System information (as much as possible)
Joomla! 3.8.1
### Additional comments
Category List page and Category Blog are affected by the same bug
### Documentation Changes Required
