### PR TITLE
Optimize `ComponentHelper`: isInstalled and other

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -80,7 +80,7 @@ class ComponentHelper
 	 */
 	public static function isInstalled($option)
 	{
-		return (bool) static::getComponent($option, true)->id;
+		return static::getComponent($option, true)->id ? 1 : 0;
 	}
 
 	/**

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -47,9 +47,8 @@ class ComponentHelper
 		}
 		else
 		{
-			$result            = new ComponentRecord;
-			$result->enabled   = $strict ? false : true;
-			$result->installed = false;
+			$result          = new ComponentRecord;
+			$result->enabled = $strict ? false : true;
 			$result->setParams(new Registry);
 		}
 
@@ -81,7 +80,7 @@ class ComponentHelper
 	 */
 	public static function isInstalled($option)
 	{
-		return (bool) static::getComponent($option, true)->installed;
+		return (bool) static::getComponent($option, true)->id;
 	}
 
 	/**

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -41,22 +41,16 @@ class ComponentHelper
 	 */
 	public static function getComponent($option, $strict = false)
 	{
-		if (!isset(static::$components[$option]))
+		if (isset(static::$components[$option]) || static::load($option))
 		{
-			if (static::load($option))
-			{
-				$result = static::$components[$option];
-			}
-			else
-			{
-				$result = new ComponentRecord;
-				$result->enabled = $strict ? false : true;
-				$result->setParams(new Registry);
-			}
+			$result = static::$components[$option];
 		}
 		else
 		{
-			$result = static::$components[$option];
+			$result            = new ComponentRecord;
+			$result->enabled   = $strict ? false : true;
+			$result->installed = false;
+			$result->setParams(new Registry);
 		}
 
 		return $result;
@@ -87,15 +81,7 @@ class ComponentHelper
 	 */
 	public static function isInstalled($option)
 	{
-		$db = \JFactory::getDbo();
-
-		return (int) $db->setQuery(
-			$db->getQuery(true)
-				->select('COUNT(' . $db->quoteName('extension_id') . ')')
-				->from($db->quoteName('#__extensions'))
-				->where($db->quoteName('element') . ' = ' . $db->quote($option))
-				->where($db->quoteName('type') . ' = ' . $db->quote('component'))
-		)->loadResult();
+		return (bool) static::getComponent($option, true)->installed;
 	}
 
 	/**
@@ -111,7 +97,7 @@ class ComponentHelper
 	 */
 	public static function getParams($option, $strict = false)
 	{
-		return static::getComponent($option, $strict)->params;
+		return static::getComponent($option, $strict)->getParams();
 	}
 
 	/**

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -54,6 +54,14 @@ class ComponentRecord extends \JObject
 	public $enabled;
 
 	/**
+	 * Indicates if this component is installed
+	 *
+	 * @var    integer
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $installed = true;
+
+	/**
 	 * Class constructor
 	 *
 	 * @param   array  $data  The component record data to load

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -54,14 +54,6 @@ class ComponentRecord extends \JObject
 	public $enabled;
 
 	/**
-	 * Indicates if this component is installed
-	 *
-	 * @var    integer
-	 * @since  __DEPLOY_VERSION__
-	 */
-	public $installed = true;
-
-	/**
 	 * Class constructor
 	 *
 	 * @param   array  $data  The component record data to load


### PR DESCRIPTION
### Summary of Changes
Currently `isInstalled` does a separate query when called multiple times. Also CMS does not use it anywhere. Changed the implementation of `ComponentHelper` and `ComponentRecord` to use the same cached data as in `isEnabled`


### Testing Instructions
ComponentHelper::isInstalled should return correct value for installed and not installed component.

1. Check if this returns correct values for installed and not installed components:
```php
// Following should normally return true
JComponentHelper::isInstalled('com_content');

// Following should normally return false - unless you really have such component installed. 
JComponentHelper::isInstalled('com_whatever');
```

2. Now install some component say `com_test` and check following
```php
// true
JComponentHelper::isInstalled('com_test');

// true
JComponentHelper::isEnabled('com_test');
```

2. Now disable the component `com_test` in extension manager and check following
```php
// true
JComponentHelper::isInstalled('com_test');

// false
JComponentHelper::isEnabled('com_test');
```

### Documentation Changes Required
~~Update `ComponentRecord` doc.~~
