### PR TITLE
Fix sqlsrv syntax for query SELECT with DISTINCT and LIMIT

### DIFF
--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -963,7 +963,18 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		if ($limit)
 		{
 			$total = $offset + $limit;
-			$query = substr_replace($query, 'SELECT TOP ' . (int) $total, stripos($query, 'SELECT'), 6);
+
+			$position = stripos($query, 'SELECT');
+			$distinct = stripos($query, 'SELECT DISTINCT');
+
+			if ($position === $distinct)
+			{
+				$query = substr_replace($query, 'SELECT DISTINCT TOP ' . (int) $total, $position, 15);
+			}
+			else
+			{
+				$query = substr_replace($query, 'SELECT TOP ' . (int) $total, $position, 6);
+			}
 		}
 
 		if (!$offset)

--- a/libraries/joomla/database/query/sqlsrv.php
+++ b/libraries/joomla/database/query/sqlsrv.php
@@ -356,7 +356,18 @@ class JDatabaseQuerySqlsrv extends JDatabaseQuery implements JDatabaseQueryLimit
 		if ($limit)
 		{
 			$total = $offset + $limit;
-			$query = substr_replace($query, 'SELECT TOP ' . (int) $total, stripos($query, 'SELECT'), 6);
+
+			$position = stripos($query, 'SELECT');
+			$distinct = stripos($query, 'SELECT DISTINCT');
+
+			if ($position === $distinct)
+			{
+				$query = substr_replace($query, 'SELECT DISTINCT TOP ' . (int) $total, $position, 15);
+			}
+			else
+			{
+				$query = substr_replace($query, 'SELECT TOP ' . (int) $total, $position, 6);
+			}
 		}
 
 		if (!$offset)


### PR DESCRIPTION
Pull Request for Issue #18313 .

### Summary of Changes
Fix `JDatabaseDriverSqlsrv::limit()` and `JDatabaseQuerySqlsrv::processLimit()` methods to support query with distinct and limit statements like:

```sql
SELECT DISTINCT * FROM t LIMIT n
```

in mssql should be:
```sql
SELECT DISTINCT TOP n * FROM t
```
### Testing Instructions

See issue #18313


### Expected result
Sqlsrv syntax is correct.

### Actual result
Invalid sqlsrv syntax for query with distinct and limit.

### Documentation Changes Required
No
