### PR TITLE
Update srcset url conversion to handle commas and spaces

### DIFF
--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -138,11 +138,32 @@ class PlgSystemSef extends JPlugin
 				function ($match) use ($base, $protocols)
 				{
 					$data = array();
-					foreach (explode(",", $match[1]) as $url)
-					{
-						$data[] = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
+										
+					preg_match_all('#((?:[^\s]+)\s*([\d\.]+[wx])?,*)#m', $match[1], $matches);
+					
+					foreach($matches[1] as $src) {
+						// trim spaces
+						$src = trim($src);
+					
+						// remove comma seperator
+						$src = trim($src, ",");
+						
+						$url = $src;
+						$descriptor = '';
+						
+						// assign url and descriptor from match
+						if (strpos(' ', $src) !== false) {
+							list($url, $descriptor) = explode(' ', $src);
+						}
+
+						// process url
+						$url = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
+						
+						// join url and descriptor by space and trim
+						$data[] = trim(implode(' ', array($url, $descriptor)));
 					}
-					return ' srcset="' . implode(",", $data) . '"';
+
+					return ' srcset="' . implode(", ", $data) . '"';
 				},
 				$buffer
 			);	

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -137,35 +137,15 @@ class PlgSystemSef extends JPlugin
 				$regex,
 				function ($match) use ($base, $protocols)
 				{
-					$data = array();
-										
-					preg_match_all('#((?:[^\s]+)\s*([\d\.]+[wx])?,*)#m', $match[1], $matches);
-					
-					foreach($matches[1] as $src) 
-					{
-						// trim spaces
-						$src = trim($src);
-					
-						// remove comma seperator
-						$src = trim($src, ",");
-						
-						$url = $src;
-						$descriptor = '';
-						
-						// assign url and descriptor from match
-						if (strpos(' ', $src) !== false) 
-						{
-							list($url, $descriptor) = explode(' ', $src);
-						}
+					preg_match_all('#(?:[^\s]+)\s*(?:[\d\.]+[wx])?(?:\,\s*)?#i', $match[1], $matches);
 
-						// process url
-						$url = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', trim($url));
-						
-						// join url and descriptor by space and trim
-						$data[] = trim(implode(' ', array($url, $descriptor)));
+					foreach ($matches[0] as &$src)
+					{
+    						$src = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $src);
+    						$src = trim($src);
 					}
 
-					return ' srcset="' . implode(", ", $data) . '"';
+					return ' srcset="' . implode(' ', $matches[0]) . '"';
 				},
 				$buffer
 			);	

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -142,10 +142,9 @@ class PlgSystemSef extends JPlugin
 					foreach ($matches[0] as &$src)
 					{
     						$src = preg_replace('#^(?!/|' . $protocols . '|\#|\')(.+)#', $base . '$1', $src);
-    						$src = trim($src);
 					}
 
-					return ' srcset="' . implode(' ', $matches[0]) . '"';
+					return ' srcset="' . implode($matches[0]) . '"';
 				},
 				$buffer
 			);	

--- a/plugins/system/sef/sef.php
+++ b/plugins/system/sef/sef.php
@@ -141,7 +141,8 @@ class PlgSystemSef extends JPlugin
 										
 					preg_match_all('#((?:[^\s]+)\s*([\d\.]+[wx])?,*)#m', $match[1], $matches);
 					
-					foreach($matches[1] as $src) {
+					foreach($matches[1] as $src) 
+					{
 						// trim spaces
 						$src = trim($src);
 					
@@ -152,7 +153,8 @@ class PlgSystemSef extends JPlugin
 						$descriptor = '';
 						
 						// assign url and descriptor from match
-						if (strpos(' ', $src) !== false) {
+						if (strpos(' ', $src) !== false) 
+						{
 							list($url, $descriptor) = explode(' ', $src);
 						}
 


### PR DESCRIPTION
### Summary of Changes

With reference to #18269 and #18273 this PR updates the srcset URL conversion to correctly identify each srcset url based on  https://html.spec.whatwg.org/multipage/images.html#image-candidate-string

So, the following srcset values should be correctly converted

```html
srcset="images/responsive/winter-hd.jpg 2x, images/responsive/winter-2x.jpg 1.5x, images/responsive/winter.jpg 1x"
```
and 

```html
srcset="images/responsive/winter-hd.jpg, images/responsive/winter-2x.jpg 1.5x, images/responsive/winter.jpg 1x"
```
and

```html
srcset="images/responsive/winter-hd.jpg,images/responsive/winter-2x.jpg 1.5x,images/responsive/winter.jpg 1x"
```
and variations thereof, including instances where the url contains a comma, eg: https://res.cloudinary.com/demo/image/upload/w_133,h_133,c_thumb,g_face/bike.jpg

### Testing Instructions

Create a new article using the following HTML code, or similar. You will need 3 images of different resolutions, or just three different images of any resolution.
 
```html
<img src="images/image1.jpg" srcset="images/image3.jpg 2x, images/image2.jpg 1.5x, images/image1.jpg 1x" alt="" />
```

### Expected result

The image displays correctly in the browser as all the srcset values are converted.

### Actual result

See #18269 and #18273

### Documentation Changes Required

None