### PR TITLE
Fix tags being deleted by any batch action and by drap and drop reordering of records

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -107,7 +107,7 @@ abstract class AdminModel extends FormModel
 	protected $batchSet = null;
 
 	/**
-	 * Current user object (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 * The user performing the actions (re-usable in batch methods & saveorder(), initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
@@ -115,7 +115,7 @@ abstract class AdminModel extends FormModel
 	protected $user = null;
 
 	/**
-	 * A table instance to manage the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 * A JTable instance (of appropropriate type) to manage the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
@@ -123,7 +123,7 @@ abstract class AdminModel extends FormModel
 	protected $table = null;
 
 	/**
-	 * The class name of the table instance managing the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 * The class name of the JTable instance managing the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
 	 *
 	 * @var     string
 	 * @since   __DEPLOY_VERSION__
@@ -131,7 +131,15 @@ abstract class AdminModel extends FormModel
 	protected $tableClassName = null;
 
 	/**
-	 * UCM Type data object corresponding to the current model class (re-usable in batch action methods, initialized via initBatch())
+	 * UCM Type corresponding to the current model class (re-usable in batch action methods, initialized via initBatch())
+	 *
+	 * @var     object
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $contentType = null;
+
+	/**
+	 * DB data of UCM Type corresponding to the current model class (re-usable in batch action methods, initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
@@ -1506,9 +1514,9 @@ abstract class AdminModel extends FormModel
 			$this->tableClassName = end($tc);
 
 			// Get UCM Type data
-			$contentType = new \JUcmType;
-			$this->type = $contentType->getTypeByTable($this->tableClassName)
-				?: $contentType->getTypeByAlias($this->typeAlias);
+			$this->contentType = new \JUcmType;
+			$this->type = $this->contentType->getTypeByTable($this->tableClassName)
+				?: $this->contentType->getTypeByAlias($this->typeAlias);
 
 			// Get tabs observer
 			$this->tagsObserver = $this->table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -99,7 +99,7 @@ abstract class AdminModel extends FormModel
 	protected $associationsContext = null;
 
 	/**
-	 * A table instance to manage DB records (re-usable in batch action methods)
+	 * A table instance to manage DB records (re-usable in batch action methods, initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
@@ -108,7 +108,7 @@ abstract class AdminModel extends FormModel
 
 
 	/**
-	 * UCM Type data object corresponding to the current model class (re-usable in batch action methods)
+	 * UCM Type data object corresponding to the current model class (re-usable in batch action methods, initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
@@ -116,7 +116,7 @@ abstract class AdminModel extends FormModel
 	protected $type;
 
 	/**
-	 * A tags Observer instance to handle assigned tags (re-usable in batch action methods)
+	 * A tags Observer instance to handle assigned tags (re-usable in batch action methods, initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -104,16 +104,31 @@ abstract class AdminModel extends FormModel
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected $batchInitialized = null;
+	protected $batchSet = null;
 
 	/**
-	 * A table instance to manage DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 * Current user object (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 *
+	 * @var     object
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $user = null;
+
+	/**
+	 * A table instance to manage the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
 	 */
 	protected $table = null;
 
+	/**
+	 * The class name of the table instance managing the DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 *
+	 * @var     string
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $tableClassName = null;
 
 	/**
 	 * UCM Type data object corresponding to the current model class (re-usable in batch action methods, initialized via initBatch())
@@ -316,11 +331,10 @@ abstract class AdminModel extends FormModel
 	{
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
-		$user = \JFactory::getUser();
 
 		foreach ($pks as $pk)
 		{
-			if ($user->authorise('core.edit', $contexts[$pk]))
+			if ($this->user->authorise('core.edit', $contexts[$pk]))
 			{
 				$this->table->reset();
 				$this->table->load($pk);
@@ -367,7 +381,6 @@ abstract class AdminModel extends FormModel
 	{
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
-		$user = \JFactory::getUser();
 
 		$categoryId = $value;
 
@@ -481,11 +494,10 @@ abstract class AdminModel extends FormModel
 	{
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
-		$user = \JFactory::getUser();
 
 		foreach ($pks as $pk)
 		{
-			if ($user->authorise('core.edit', $contexts[$pk]))
+			if ($this->user->authorise('core.edit', $contexts[$pk]))
 			{
 				$this->table->reset();
 				$this->table->load($pk);
@@ -532,7 +544,6 @@ abstract class AdminModel extends FormModel
 	{
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
-		$user = \JFactory::getUser();
 
 		$categoryId = (int) $value;
 
@@ -544,7 +555,7 @@ abstract class AdminModel extends FormModel
 		// Parent exists so we proceed
 		foreach ($pks as $pk)
 		{
-			if (!$user->authorise('core.edit', $contexts[$pk]))
+			if (!$this->user->authorise('core.edit', $contexts[$pk]))
 			{
 				$this->setError(\JText::_('JLIB_APPLICATION_ERROR_BATCH_CANNOT_EDIT'));
 
@@ -615,12 +626,11 @@ abstract class AdminModel extends FormModel
 	{
 		// Initialize re-usable member properties, and re-usable local variables
 		$this->initBatch();
-		$user = \JFactory::getUser();
 		$tags = array($value);
 
 		foreach ($pks as $pk)
 		{
-			if ($user->authorise('core.edit', $contexts[$pk]))
+			if ($this->user->authorise('core.edit', $contexts[$pk]))
 			{
 				$this->table->reset();
 				$this->table->load($pk);
@@ -1481,20 +1491,23 @@ abstract class AdminModel extends FormModel
 	 */
 	public function initBatch()
 	{
-		if ($this->batchInitialized === null)
+		if ($this->batchSet === null)
 		{
-			$this->batchInitialized = true;
+			$this->batchSet = true;
+
+			// Get current user
+			$this->user = \JFactory::getUser();
 
 			// Get table
 			$this->table = $this->getTable();
 
 			// Get table class name
 			$tc = explode('\\', get_class($this->table));
-			$tableClassName = end($tc);
+			$this->tableClassName = end($tc);
 
 			// Get UCM Type data
 			$contentType = new \JUcmType;
-			$this->type = $contentType->getTypeByTable($tableClassName)
+			$this->type = $contentType->getTypeByTable($this->tableClassName)
 				?: $contentType->getTypeByAlias($this->typeAlias);
 
 			// Get tabs observer

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1433,6 +1433,7 @@ abstract class AdminModel extends FormModel
 
 		// Check that the user has create permission for the component
 		$extension = \JFactory::getApplication()->input->get('option', '');
+		$user = \JFactory::getUser();
 
 		if (!$user->authorise('core.create', $extension . '.category.' . $categoryId))
 		{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -99,12 +99,20 @@ abstract class AdminModel extends FormModel
 	protected $associationsContext = null;
 
 	/**
-	 * A table instance to manage DB records (re-usable in batch action methods, initialized via initBatch())
+	 * A flag to indicate if member variables for batch actions (and saveorder) have been initialized
 	 *
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected $table;
+	protected $batchInitialized = null;
+
+	/**
+	 * A table instance to manage DB records (re-usable in batch methods & saveorder(), initialized via initBatch())
+	 *
+	 * @var     object
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected $table = null;
 
 
 	/**
@@ -113,7 +121,7 @@ abstract class AdminModel extends FormModel
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected $type;
+	protected $type = null;
 
 	/**
 	 * A tags Observer instance to handle assigned tags (re-usable in batch action methods, initialized via initBatch())
@@ -121,7 +129,7 @@ abstract class AdminModel extends FormModel
 	 * @var     object
 	 * @since   __DEPLOY_VERSION__
 	 */
-	protected $tagsObserver;
+	protected $tagsObserver = null;
 
 
 	/**
@@ -1473,11 +1481,9 @@ abstract class AdminModel extends FormModel
 	 */
 	public function initBatch()
 	{
-		static $batchSet = null;
-
-		if ($batchSet === null)
+		if ($this->batchInitialized === null)
 		{
-			$batchSet = true;
+			$this->batchInitialized = true;
 
 			// Get table
 			$this->table = $this->getTable();

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1474,10 +1474,10 @@ abstract class AdminModel extends FormModel
 	public function initBatch()
 	{
 		static $batchSet = null;
-		
+
 		if ($batchSet === null)
 		{
-			$this->batchSet = true;
+			$batchSet = true;
 
 			// Get table
 			$this->table = $this->getTable();

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -590,7 +590,7 @@ abstract class AdminModel extends FormModel
 				/**
 				 * @var  \JTableObserverTags  $tagsObserver
 				 */
-				$tagsObserver = $table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');;
+				$tagsObserver = $table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 				$result = $tagsObserver->setNewTags($tags, false);
 
 				if (!$result)

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1461,7 +1461,7 @@ abstract class AdminModel extends FormModel
 			$this->type = $this->contentType->getTypeByTable($this->tableClassName)
 				?: $this->contentType->getTypeByAlias($this->typeAlias);
 
-			// Get get tabs observer
+			// Get tabs observer
 			$this->tagsObserver = $this->table->getObserverOfClass('Joomla\CMS\Table\Observer\Tags');
 		}
 	}


### PR DESCRIPTION
Pull Request for Issues #18317 and #18086 and #18057 

### Summary of Changes
The tags are not retrieved properly by the code of AdminModel class
(by the batch actions methods and saveorder() method)

This is to due wrongly calculated '**tableClassName**'
(when the **descendant** of this class is namespaced ?)
which results in empty UCM type & typeAlias, thus tags do not get loaded

There was common code (same code) called in 6 places 
- batch() method
- 4 batch*() methods
- saveorder() method

Fixed the code and moved it into a new method , initBatch()
(saveorder() needed some more fixing that the others)

### Testing Instructions
Use batch actions and manual reordering of records


### Expected result
The above task work properly 
and they also do not delete the tags assigned to the articles 


### Actual result
The tags are deleted


### Documentation Changes Required
initBatch() method added 

Should this be protected or private ?
