### PR TITLE
Beez3: Add missing double quote after nofollow noopener noreferrer

### DIFF
--- a/templates/beez3/html/com_content/article/default_links.php
+++ b/templates/beez3/html/com_content/article/default_links.php
@@ -48,7 +48,7 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 					{
 						case 1:
 							// open in a new window
-							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer>' .
+							echo '<a href="' . htmlspecialchars($link, ENT_COMPAT, 'UTF-8') . '" target="_blank"  rel="nofollow noopener noreferrer">' .
 								htmlspecialchars($label, ENT_COMPAT, 'UTF-8') .'</a>';
 							break;
 


### PR DESCRIPTION
### Summary of Changes
Adds a missing closing double quote after `rel="nofollow noopener noreferrer` for _blank target

### Testing Instructions
Code review
AND/OR:
Edit an article.
Add a Link A in tabulator Images and Links.
Set "URL Target Window" setting:  "Open in new window"

![13-10-_2017_17-21-30](https://user-images.githubusercontent.com/20780646/31553550-1f7f051e-b03b-11e7-8537-7bfb5fa5e5bc.jpg)

Open article in front-end. Link is not visible and some following text is missing:

![13-10-_2017_17-20-24](https://user-images.githubusercontent.com/20780646/31553561-2cb2d422-b03b-11e7-9ef3-0f871a79d7b8.jpg)

See HTML source code. Missing closing double quote with fatal consequences ;-) 

![13-10-_2017_17-23-53](https://user-images.githubusercontent.com/20780646/31553638-652ec16c-b03b-11e7-9bc7-c62a14e90fdf.jpg)

Apply patch. Try again.

![13-10-_2017_17-25-47](https://user-images.githubusercontent.com/20780646/31553708-9dc7d734-b03b-11e7-9274-1d4f6d0650a8.jpg)
