### PR TITLE
Fixes #18228. Renaming a menutype while a list is filtered on it, causes error in list.

### DIFF
--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -154,6 +154,18 @@ class MenusModelItems extends JModelList
 			$this->setState('menutypetitle', $cMenu->title);
 			$this->setState('menutypeid', $cMenu->id);
 		}
+		// This menutype does not exist, leave client id unchanged but reset menutype and pagination
+		else
+		{
+			$menuType = '';
+
+			$app->input->set('limitstart', 0);
+			$app->input->set('menutype', $menuType);
+
+			$app->setUserState($this->context . '.menutype', $menuType);
+			$this->setState('menutypetitle', '');
+			$this->setState('menutypeid', '');
+		}
 
 		// Client id filter
 		$clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
@@ -476,12 +488,16 @@ class MenusModelItems extends JModelList
 			// Check if menu type exists.
 			if (!$cMenu)
 			{
-				$this->setError(JText::_('COM_MENUS_ERROR_MENUTYPE_NOT_FOUND'));
+				JLog::add(JText::_('COM_MENUS_ERROR_MENUTYPE_NOT_FOUND'), JLog::ERROR, 'jerror');
+
+				return false;
 			}
 			// Check if menu type is valid against ACL.
 			elseif (!JFactory::getUser()->authorise('core.manage', 'com_menus.menu.' . $cMenu->id))
 			{
-				$this->setError(JText::_('JERROR_ALERTNOAUTHOR'));
+				JLog::add(JText::_('JERROR_ALERTNOAUTHOR'), JLog::ERROR, 'jerror');
+
+				return false;
 			}
 		}
 


### PR DESCRIPTION
The state persistent filter for client id causes death end in menu manager navigation when the selected menutype is renamed in another page or session.

Pull Request for Issue #18228.

### Summary of Changes
Reset filter if the matching menutype does not exist and allow the request to complete with unfiltered list.


### Testing Instructions

Go to the menu items page:
joomla.example.com/administrator/index.php?option=com_menus&view=items
Choose a menu from the - Select menu - search tools dropdown.
Then go and edit the chosen menu:
joomla.example.com/administrator/index.php?option=com_menus&view=menu&layout=edit&id=<id of the menu type chosen in the previous page's search filter>
Change the menu's Menu Type.
Now go back to the first page. It crashes with a 500 Joomla error and there is no way to view the menu items anymore unless (I guess) logging out and logging back in or resetting the server session or reverting the menu type of the chosen menu to its old value.




### Expected result
The joomla.example.com/administrator/index.php?option=com_menus&view=items page should work with the updated menu type in the filter or at least the filter should get reset.


### Actual result
The joomla.example.com/administrator/index.php?option=com_menus&view=items page becomes unusable.


### Documentation Changes Required
None