### PR TITLE
Always add rel canonical in article view (? rare issue of alternative URLs found by search engines)

### DIFF
--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -67,8 +67,8 @@ class ContentViewArticle extends JViewLegacy
 			$item->parent_slug = null;
 		}
 
-		// Find prefered route for current page and add it as rel canonical
-		// This assumes that router maintains current menu item, when multiple menu items exists for same record (article)
+		// Find preferred route for current page and add it as rel canonical
+		// This assumes that router maintains current menu item, when multiple menu items exist for same record (article)
 		$page_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
 		JFactory::getDocument()->addHeadLink($page_link, 'canonical', 'rel');
 

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -67,8 +67,13 @@ class ContentViewArticle extends JViewLegacy
 			$item->parent_slug = null;
 		}
 
+		// Find prefered route for current page and add it as rel canonical
+		// This assumes that router maintains current menu item, when multiple menu items exists for same record (article)
+		$page_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
+		JFactory::getDocument()->addHeadLink($page_link, 'canonical', 'rel');
+
 		// TODO: Change based on shownoauth
-		$item->readmore_link = JRoute::_(ContentHelperRoute::getArticleRoute($item->slug, $item->catid, $item->language));
+		$item->readmore_link = $page_link;
 
 		// Merge article params. If this is single-article view, menu params override article params
 		// Otherwise, article params override menu item params


### PR DESCRIPTION
Pull Request for Issue #18318

### Summary of Changes
Links like this (or similar) would normally not be generated
(**so i think the necessity of this fix is small**)
`http://localhost/component/content/article?id=72:popular-tags`
`http://localhost/index.php?option=com_content&view=article&id=103:article-alias`
`http://localhost/article-category-list/item/72-popular-tags.html`

but if they were added in google index
these should be pointed to their appropiate rel canonical

`http://localhost/popular-tags.html`

Note this PR should not be merged unless the article router maintains
the current menu item when multiple menu items exist for same article
#18260 

because without the fix of #18260, the multiple pages pointing to the same article will have the same rel canonical (and i think this is not desirable in the general case (**please comment here**))

### Testing Instructions
In a site with SEF URL rewriting enabled

Open all 3 URLs
View page source


### Expected result
All 3 URLs have the same rel canonical


### Actual result
No URL canonical added, thus each of the 3 URLs is itself the rel canonical
or
3 different rel canonical are added (the current page URL)



### Documentation Changes Required

