### PR TITLE
Prevent displaying xtd-field when com_fields is disabled

### DIFF
--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -35,6 +35,12 @@ class PlgButtonFields extends JPlugin
 	 */
 	public function onDisplay($name)
 	{
+		// Check if com_fields is enabled
+		if (!JComponentHelper::isEnabled('com_fields'))
+		{
+			return;
+		}
+
 		// Register FieldsHelper
 		JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
 


### PR DESCRIPTION
### Summary of Changes
Check if com_fields is enabled


### Testing Instructions
Disable the com_fields component via Extensions=> Manage=>Manage
Edit an article and click on the Field icon in the editor toolbar.
=> 404

Patch and test again: the button will not display
