### PR TITLE
If there is no menu item with layout then use menu item without layout

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -110,30 +110,27 @@ class MenuRules implements RulesInterface
 
 		$needles = $this->router->getPath($query);
 
-		$layout = '';
-
-		if (isset($query['layout']))
-		{
-			$layout = ':' . $query['layout'];
-		}
+		$layout = isset($query['layout']) && $query['layout'] !== 'default' ? ':' . $query['layout'] : '';
 
 		if ($needles)
 		{
 			foreach ($needles as $view => $ids)
 			{
-				if (isset($query['layout'], $this->lookup[$language][$view . $layout]))
+				$viewLayout = $view . $layout;
+
+				if ($layout && isset($this->lookup[$language][$viewLayout]))
 				{
 					if (is_bool($ids))
 					{
-						$query['Itemid'] = $this->lookup[$language][$view . $layout];
+						$query['Itemid'] = $this->lookup[$language][$viewLayout];
 						return;
 					}
 
 					foreach ($ids as $id => $segment)
 					{
-						if (isset($this->lookup[$language][$view . $layout][(int) $id]))
+						if (isset($this->lookup[$language][$viewLayout][(int) $id]))
 						{
-							$query['Itemid'] = $this->lookup[$language][$view . $layout][(int) $id];
+							$query['Itemid'] = $this->lookup[$language][$viewLayout][(int) $id];
 							return;
 						}
 					}

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -121,7 +121,7 @@ class MenuRules implements RulesInterface
 		{
 			foreach ($needles as $view => $ids)
 			{
-				if (isset($this->lookup[$language][$view . $layout]))
+				if (isset($query['layout'], $this->lookup[$language][$view . $layout]))
 				{
 					if (is_bool($ids))
 					{
@@ -136,7 +136,19 @@ class MenuRules implements RulesInterface
 							$query['Itemid'] = $this->lookup[$language][$view . $layout][(int) $id];
 							return;
 						}
+					}
+				}
 
+				if (isset($this->lookup[$language][$view]))
+				{
+					if (is_bool($ids))
+					{
+						$query['Itemid'] = $this->lookup[$language][$view];
+						return;
+					}
+
+					foreach ($ids as $id => $segment)
+					{
 						if (isset($this->lookup[$language][$view][(int) $id]))
 						{
 							$query['Itemid'] = $this->lookup[$language][$view][(int) $id];

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -152,10 +152,6 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49'));
 
-		// Check indirect link to a nested view with a key if the layout is different
-		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'layout' => 'blog'),
-			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49', 'layout' => 'blog'));
-
 		// Check indirect link to a nested view with a key and a language
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB', 'Itemid' => '49'));
@@ -263,6 +259,37 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 			'view' => 'article',
 			'id' => '1:some-alias',
 			'Itemid' => '53');
+		$this->object->preprocess($query);
+		$this->assertEquals($expect, $query);
+
+		$this->restoreFactoryState();
+	}
+
+	/**
+	 * Tests the preprocess() method
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testPreprocessLayout()
+	{
+		$this->saveFactoryState();
+
+		$router = $this->object->get('router');
+
+		// Unset an active menu
+		$router->menu->active = null;
+
+		// Check link if default layout is set explicitly
+		$query = array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'layout' => 'default');
+		$expect = array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49', 'layout' => 'default');
+		$this->object->preprocess($query);
+		$this->assertEquals($expect, $query);
+
+		// Check link if the layout is different than in menu item for parent category
+		$query = array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'layout' => 'blog');
+		$expect = array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49', 'layout' => 'blog');
 		$this->object->preprocess($query);
 		$this->assertEquals($expect, $query);
 

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesMenuTest.php
@@ -152,6 +152,10 @@ class JComponentRouterRulesMenuTest extends TestCaseDatabase
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49'));
 
+		// Check indirect link to a nested view with a key if the layout is different
+		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'layout' => 'blog'),
+			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'Itemid' => '49', 'layout' => 'blog'));
+
 		// Check indirect link to a nested view with a key and a language
 		$cases[] = array(array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB'),
 			array('option' => 'com_content', 'view' => 'category', 'id' => '22', 'lang' => 'en-GB', 'Itemid' => '49'));


### PR DESCRIPTION
### Summary of Changes

If there is no menu item for supplied layout then use fallback to menu item without layout, for all cases.

#### On joomla 3.8.1 with modern routing:
For example, a menu item with type `Category List` has the link `index.php?option=content&view=category&id=2` to "Uncategorised" category.
The sef URL looks like 'index.php/uncategorised'

* If we create an article with link `index.php?option=content&view=category&id=2&layout=blog` and there is no any menu item with layout blog then above menu item won't be used.
  If there exists at least one blog for other category then the menu item will be found. 

* If we add url like `index.php?option=content&view=category&id=2&layout=default` to the article then menu item won't be found.

### Testing Instructions
1. Install staging joomla without sample data.
2. Create menu item with type `Category List` for Uncategorised category.
3. Create featured article in `Uncategorised` category. Set article text:
```html
<p>Uncategorised with layout explicitly</p>
<p><a href="index.php?option=com_content&amp;view=category&amp;id=2&amp;layout=default">Layout default</a></p>
<p><a href="index.php?option=com_content&amp;view=category&amp;id=2&amp;layout=blog">Layout blog</a></p>
<p>Link to readmore with layout default <a href="index.php?option=com_content&amp;view=article&amp;id=1&amp;catid=2&amp;layout=default">Article</a></p>
```
4. Go to home page and check above links from the article
    * before patch not all links use correct menu item, I mean links contains `/2-uncategorised`  

5. Check article link for button `print`. (stay in home page - featured view)

6. Before patch links do not use menu item "Uncategorised".
7. After patch links uses the menu item.

### Benefits
*  links with explicitly added `&layout=default` will be generated correctly, I mean the correct menu item will be used
* If a link uses a layout (ex blog) that not exists in menu items then the link will try to use menu item with different layout (that current exists) in all cases - not only when the layout blog exists in other category 
