### PR TITLE
[3.9] Check MVC Factory existance to avoid B/C Fatal Error

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -556,6 +556,11 @@ class BaseController extends \JObject
 	 */
 	protected function createModel($name, $prefix = '', $config = array())
 	{
+		// Check that MVC factory is initialized
+		if(is_null($this->factory)) {
+			$this->factory = new LegacyFactory;
+		}
+		
 		$model = $this->factory->createModel($name, $prefix, $config);
 
 		if ($model === null)
@@ -586,6 +591,11 @@ class BaseController extends \JObject
 	 */
 	protected function createView($name, $prefix = '', $type = '', $config = array())
 	{
+		// Check that MVC factory is initialized
+		if(is_null($this->factory)) {
+			$this->factory = new LegacyFactory;
+		}
+		
 		$config['paths'] = $this->paths['view'];
 		return $this->factory->createView($name, $prefix, $type, $config);
 	}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -150,6 +150,22 @@ class BaseController extends \JObject
 	 * @since  3.4
 	 */
 	protected static $views;
+	
+	/**
+	 * Return the MVCFactoryInterface class only instantiating it if not exist
+	 *
+	 * @return  MVCFactoryInterface 
+	 *
+	 * @since   3.9
+	 */
+	private function getFactory() {
+		// Check if MVC factory is initialized
+		if(is_null($this->factory)) {
+			$this->factory = new LegacyFactory;
+		}
+		
+		return $this->factory;
+	}
 
 	/**
 	 * Adds to the stack of model paths in LIFO order.
@@ -556,12 +572,7 @@ class BaseController extends \JObject
 	 */
 	protected function createModel($name, $prefix = '', $config = array())
 	{
-		// Check that MVC factory is initialized
-		if(is_null($this->factory)) {
-			$this->factory = new LegacyFactory;
-		}
-		
-		$model = $this->factory->createModel($name, $prefix, $config);
+		$model = $this->getFactory()->createModel($name, $prefix, $config);
 
 		if ($model === null)
 		{
@@ -591,13 +602,8 @@ class BaseController extends \JObject
 	 */
 	protected function createView($name, $prefix = '', $type = '', $config = array())
 	{
-		// Check that MVC factory is initialized
-		if(is_null($this->factory)) {
-			$this->factory = new LegacyFactory;
-		}
-		
 		$config['paths'] = $this->paths['view'];
-		return $this->factory->createView($name, $prefix, $type, $config);
+		return $this->getFactory()->createView($name, $prefix, $type, $config);
 	}
 
 	/**
@@ -1115,3 +1121,4 @@ class BaseController extends \JObject
 		return $this;
 	}
 }
+


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Check that the legacy factory is initialized to avoid B/C and Fatal Error for extensions extending JControllerLegacy/BaseController with its own constructor

### Testing Instructions
Install an extension running on J 3.8 that extends JControllerLegacy and override the constructor __construct

### Expected result
All works fine

### Actual result
Fatal error: Call to a member function createModel() on null in E:\vhosts\joomla39\libraries\src\MVC\Controller\BaseController.php on line 559

### Documentation Changes Required
With the current MVC backported from J4.0 now a class that extends JControllerLegacy AKA Joomla\CMS\MVC\Controller\BaseController throws a fatal error if there is an override for the constructor not calling parent::__construct() and so the property 'factory' results to be empty
