### PR TITLE
Call router->preprocesss only once per link when sef is off

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -12,6 +12,7 @@ defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Component\Router\RouterBase;
 use Joomla\CMS\Component\Router\RouterInterface;
 use Joomla\CMS\Component\Router\RouterLegacy;
 use Joomla\String\StringHelper;
@@ -477,9 +478,12 @@ class SiteRouter extends Router
 
 		$component = preg_replace('/[^A-Z0-9_\.-]/i', '', $query['option']);
 		$crouter   = $this->getComponentRouter($component);
-		$query     = $crouter->preprocess($query);
 
-		$uri->setQuery($query);
+		if ($crouter instanceof RouterBase === false)
+		{
+			$query = $crouter->preprocess($query);
+			$uri->setQuery($query);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #18289

### Summary of Changes
Do not call `MenuRules::preprocess` twice per query link if SEO settings `Search Engine Friendly URLs` is off.


### Testing Instructions
See issue #18289

After line 63 add debug to see difference after patch:
```php
static $i=0;$i++;$this->router->app->enqueueMessage("$i: " . print_r($query, 1));
```


### Expected result
Method is called only once per query link.


### Actual result
Method is called twice.


### Documentation Changes Required
No
