### PR TITLE
[com_content] - no votes/ratings label if vote plugin disabled

### DIFF
--- a/administrator/components/com_content/models/fields/voteradio.php
+++ b/administrator/components/com_content/models/fields/voteradio.php
@@ -33,7 +33,7 @@ class JFormFieldVoteradio extends JFormFieldRadio
 	 *
 	 * @throws \Exception
 	 *
-	 * @since  3.7.1
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public function getLabel()
 	{

--- a/administrator/components/com_content/models/fields/voteradio.php
+++ b/administrator/components/com_content/models/fields/voteradio.php
@@ -27,6 +27,21 @@ class JFormFieldVoteradio extends JFormFieldRadio
 	protected $type = 'Voteradio';
 
 	/**
+	 * Method to get the field Label.
+	 *
+	 * @return array The field label objects.
+	 *
+	 * @throws \Exception
+	 *
+	 * @since  3.7.1
+	 */
+	public function getLabel()
+	{
+		// Requires vote plugin enabled
+		return JPluginHelper::isEnabled('content', 'vote') ? parent::getLabel() : null;
+	}
+
+	/**
 	 * Method to get the field options.
 	 *
 	 * @return array The field option objects.


### PR DESCRIPTION
Pull Request for Issue  #18079 .

### Summary of Changes
override the getLabel method 
to show the label only if vote plugin is enabled

### Testing Instructions
see  #18079


### Expected result
don't show vote/rating labels if vote plugin is disabled
![screenshot from 2017-10-16 20-58-02](https://user-images.githubusercontent.com/181681/31629718-bfe0df16-b2b4-11e7-8218-88d777622d08.png)


### Actual result
![screenshot from 2017-10-16 20-57-08](https://user-images.githubusercontent.com/181681/31629672-a02e9672-b2b4-11e7-9228-ac456c55158c.png)




### Documentation Changes Required

