### PR TITLE
Isis Pagination  update

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -30,26 +30,31 @@ switch ((string) $item->text)
 	// Check for "Start" item
 	case JText::_('JLIB_HTML_START') :
 		$icon = 'icon-backward icon-first';
+		$aria = JText::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "Prev" item
 	case JText::_('JPREV') :
 		$item->text = JText::_('JPREVIOUS');
 		$icon = 'icon-step-backward icon-previous';
+		$aria = JText::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "Next" item
 	case JText::_('JNEXT') :
 		$icon = 'icon-step-forward icon-next';
+		$aria = JText::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	// Check for "End" item
 	case JText::_('JLIB_HTML_END') :
 		$icon = 'icon-forward icon-last';
+		$aria = JText::sprintf('JLIB_HTML_GOTO_POSITION', strtolower($item->text));
 		break;
 
 	default:
 		$icon = null;
+		$aria = JText::sprintf('JLIB_HTML_GOTO_PAGE', $item->text);		
 		break;
 }
 
@@ -57,7 +62,7 @@ $item->text .= $addText ?: '';
 
 if ($icon !== null)
 {
-	$display = '<span class="' . $icon . '"></span>';
+	$display = '<span class="' . $icon . ' aria-hidden="true"></span>';
 }
 
 if ($displayData['active'])
@@ -95,12 +100,14 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li<?php echo $liClass ? ' class="' . $liClass . '"' : ''; ?>>
-		<a <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a aria-label="<?php echo $aria;?>" <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>
 <?php else : ?>
 	<li class="<?php echo $class; ?>">
-		<span><?php echo $display; ?></span>
+		<span aria-current="true" aria-label="<?php echo JText::sprintf('JLIB_HTML_PAGE_CURRENT', $item->text); ?>">
+			<?php echo $display; ?>
+		</span>
 	</li>
 <?php endif;

--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -106,8 +106,8 @@ else
 	</li>
 <?php else : ?>
 	<li class="<?php echo $class; ?>">
-		<span aria-current="true" aria-label="<?php echo JText::sprintf('JLIB_HTML_PAGE_CURRENT', $item->text); ?>">
-			<?php echo $display; ?>
-		</span>
+	<span <?php echo $class == 'active' ? 'aria-current="true" aria-label="' . JText::sprintf('JLIB_HTML_PAGE_CURRENT', $item->text) . '"' : '' ?>>
+		<?php echo $display; ?>
+	</span>
 	</li>
 <?php endif;

--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -106,7 +106,7 @@ else
 	</li>
 <?php else : ?>
 	<li class="<?php echo $class; ?>">
-	<span <?php echo $class == 'active' ? 'aria-current="true" aria-label="' . JText::sprintf('JLIB_HTML_PAGE_CURRENT', $item->text) . '"' : '' ?>>
+	<span <?php echo $class == 'active' ? 'aria-current="true" aria-label="' . JText::sprintf('JLIB_HTML_PAGE_CURRENT', $item->text) . '"' : ''; ?>>
 		<?php echo $display; ?>
 	</span>
 	</li>

--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -100,7 +100,7 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li<?php echo $liClass ? ' class="' . $liClass . '"' : ''; ?>>
-		<a aria-label="<?php echo $aria ;?>" <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a aria-label="<?php echo $aria; ?>" <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>

--- a/administrator/templates/isis/html/layouts/joomla/pagination/link.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/link.php
@@ -62,7 +62,7 @@ $item->text .= $addText ?: '';
 
 if ($icon !== null)
 {
-	$display = '<span class="' . $icon . ' aria-hidden="true"></span>';
+	$display = '<span class="' . $icon . '" aria-hidden="true"></span>';
 }
 
 if ($displayData['active'])
@@ -100,7 +100,7 @@ else
 ?>
 <?php if ($displayData['active']) : ?>
 	<li<?php echo $liClass ? ' class="' . $liClass . '"' : ''; ?>>
-		<a aria-label="<?php echo $aria;?>" <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
+		<a aria-label="<?php echo $aria ;?>" <?php echo $cssClasses ? 'class="' . implode(' ', $cssClasses) . '"' : ''; ?> <?php echo $title; ?> href="#" onclick="<?php echo $onClick; ?>">
 			<?php echo $display; ?>
 		</a>
 	</li>

--- a/administrator/templates/isis/html/layouts/joomla/pagination/links.php
+++ b/administrator/templates/isis/html/layouts/joomla/pagination/links.php
@@ -31,21 +31,23 @@ $showLimitStart = $options->get('showLimitStart', true);
 	<?php endif; ?>
 
 	<?php if ($showPagesLinks && (!empty($pages))) : ?>
-		<ul class="pagination-list">
-			<?php
-				$pages['start']['pagOptions'] = array('addText' => ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', 1, $pagesTotal) . ')');
-				echo JLayoutHelper::render('joomla.pagination.link', $pages['start']);
-				echo JLayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
-			<?php foreach ($pages['pages'] as $page) :
-				$page['pagOptions'] = array('liClass' => 'hidden-phone');
-			?>
-				<?php echo JLayoutHelper::render('joomla.pagination.link', $page); ?>
-			<?php endforeach; ?>
-			<?php
-				echo JLayoutHelper::render('joomla.pagination.link', $pages['next']);
-				$pages['end']['pagOptions'] = array('addText' => ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $pagesTotal, $pagesTotal) . ')');
-				echo JLayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
-		</ul>
+		<nav role="navigation" aria-label="<?php echo JText::_('JLIB_HTML_PAGINATION'); ?>">
+			<ul class="pagination-list">
+				<?php
+					$pages['start']['pagOptions'] = array('addText' => ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', 1, $pagesTotal) . ')');
+					echo JLayoutHelper::render('joomla.pagination.link', $pages['start']);
+					echo JLayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
+				<?php foreach ($pages['pages'] as $page) :
+					$page['pagOptions'] = array('liClass' => 'hidden-phone');
+				?>
+					<?php echo JLayoutHelper::render('joomla.pagination.link', $page); ?>
+				<?php endforeach; ?>
+				<?php
+					echo JLayoutHelper::render('joomla.pagination.link', $pages['next']);
+					$pages['end']['pagOptions'] = array('addText' => ' (' . JText::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $pagesTotal, $pagesTotal) . ')');
+					echo JLayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
+			</ul>
+		</nav>
 	<?php endif; ?>
 
 	<?php if ($showLimitStart) : ?>


### PR DESCRIPTION
Improve the accessibility of the pagination - there are no visual changes

1. Wrap the pagination in a nav and add a role (needed for IE) and an aria-label
2. Ensure font icons have aria-hidden=true
3. Add aria-current to the selected page
4. Add aria-title to the active links eg Go to page 1

### Note 1
This PR does not include the language strings as they were added in #18326

### Note 2
I dont know why but isis and protostar (see #18326) use an override for pagination instead of the layout. For b/c this PR is just for the override but when approved I will do a similar PR for the layout

Thanks to @fuzzbomb (Drupal 8 Core Accessibility Maintainer) for his advice and reviewing this
