### PR TITLE
patch the non existent editor

### DIFF
--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -42,7 +42,7 @@ if (!empty($editor))
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items&layout=modal&tmpl=component&editor=' . $editor . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -32,17 +32,19 @@ $function     = $app->input->get('function', 'jSelectMenuItem', 'cmd');
 $editor    = $app->input->getCmd('editor', '');
 $listOrder    = $this->escape($this->state->get('list.ordering'));
 $listDirn     = $this->escape($this->state->get('list.direction'));
+$link         = 'index.php?option=com_menus&view=items&layout=modal&tmpl=component&' . JSession::getFormToken() . '=1';
 
 if (!empty($editor))
 {
 	// This view is used also in com_menus. Load the xtd script only if the editor is set!
 	JFactory::getDocument()->addScriptOptions('xtd-menus', array('editor' => $editor));
 	$onclick = "jSelectMenuItem";
+	$link    = 'index.php?option=com_menus&view=items&layout=modal&tmpl=component&editor=' . $editor . '&' . JSession::getFormToken() . '=1';
 }
 ?>
 <div class="container-popup">
 
-	<form action="<?php echo JRoute::_('index.php?option=com_menus&view=items&layout=modal&tmpl=component&editor=' . $editor . '&' . JSession::getFormToken() . '=1'); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
+	<form action="<?php echo JRoute::_($link); ?>" method="post" name="adminForm" id="adminForm" class="form-inline">
 
 		<?php echo JLayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18340.

### Summary of Changes

We need the editor variable whenever the form is submitted, eg on filter applied

### Testing Instructions

Apply the patch, edit an article, click on the menus xtd icon, select or apply some filtering, then try clicking on any menu. The menu link should be inserted in the editor and the modal should close (normal expected behaviour).

Edit: Also try to create a new menu `Menu Item Alias` and repeat the above steps

### Expected result

Link inserted in the editor

### Actual result

Broken, nothing appended

### Documentation Changes Required
None, bug fix