### PR TITLE
Update sidebar toggle layout for aria

### DIFF
--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -367,7 +367,7 @@
 				$main.removeClass('span10').addClass('span12 expanded');
 				$toggleSidebarIcon.removeClass(openIcon).addClass(closedIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );
-				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );				
+				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );
 				$sidebar.attr('aria-hidden', true);
 				$sidebar.find('a').attr('tabindex', '-1');
 				$sidebar.find(':input').attr('tabindex', '-1');
@@ -392,7 +392,7 @@
 				$main.removeClass('span12 expanded').addClass('span10');
 				$toggleSidebarIcon.removeClass(closedIcon).addClass(openIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );
-				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );								
+				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );
 				$sidebar.removeAttr('aria-hidden');
 				$sidebar.find('a').removeAttr('tabindex');
 				$sidebar.find(':input').removeAttr('tabindex');

--- a/administrator/templates/isis/js/template.js
+++ b/administrator/templates/isis/js/template.js
@@ -367,6 +367,7 @@
 				$main.removeClass('span10').addClass('span12 expanded');
 				$toggleSidebarIcon.removeClass(openIcon).addClass(closedIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );
+				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_SHOW_SIDEBAR') );				
 				$sidebar.attr('aria-hidden', true);
 				$sidebar.find('a').attr('tabindex', '-1');
 				$sidebar.find(':input').attr('tabindex', '-1');
@@ -391,6 +392,7 @@
 				$main.removeClass('span12 expanded').addClass('span10');
 				$toggleSidebarIcon.removeClass(closedIcon).addClass(openIcon);
 				$toggleButton.attr( 'data-original-title', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );
+				$toggleButton.attr( 'aria-label', Joomla.JText._('JTOGGLE_HIDE_SIDEBAR') );								
 				$sidebar.removeAttr('aria-hidden');
 				$sidebar.find('a').removeAttr('tabindex');
 				$sidebar.find(':input').removeAttr('tabindex');

--- a/layouts/joomla/sidebars/toggle.php
+++ b/layouts/joomla/sidebars/toggle.php
@@ -18,5 +18,5 @@ JText::script('JTOGGLE_SHOW_SIDEBAR');
 	class="j-toggle-sidebar-button hidden-phone hasTooltip"
 	onclick="toggleSidebar(false); return false;"
 	>
-		<span id="j-toggle-sidebar-icon" class="icon-arrow-left-2"></span>
+		<span id="j-toggle-sidebar-icon" class="icon-arrow-left-2" aria-hidden="true"></span>
 </div>


### PR DESCRIPTION
This PR updates the toggle sidebar layout used in the admin eg com_content
It ensures that there is an aria-label and that the icon is hidden as per the fontawesome recommendations applied elsewhere
