### PR TITLE
Add list and table fieldgroup layout overrides to com_content

### DIFF
--- a/components/com_content/layouts/fields/list.php
+++ b/components/com_content/layouts/fields/list.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+// Check if we have all the data
+if (!key_exists('item', $displayData) || !key_exists('context', $displayData))
+{
+	return;
+}
+
+// Setting up for display
+$item = $displayData['item'];
+
+if (!$item)
+{
+	return;
+}
+
+$context = $displayData['context'];
+
+if (!$context)
+{
+	return;
+}
+
+JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
+$parts     = explode('.', $context);
+$component = $parts[0];
+$fields    = null;
+
+if (key_exists('fields', $displayData))
+{
+	$fields = $displayData['fields'];
+}
+else
+{
+	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
+}
+
+if (!$fields)
+{
+	return;
+}
+
+?>
+<ul class="fields-container">
+	<?php foreach ($fields as $field) : ?>
+		<?php // If the value is empty do nothing ?>
+		<?php if (!isset($field->value) || $field->value == '') : ?>
+			<?php continue; ?>
+		<?php endif; ?>
+		<?php $class = $field->params->get('render_class'); ?>
+		<li class="field-entry <?php echo $class; ?>">
+			<?php echo FieldsHelper::render($context, 'field.render', array('field' => $field)); ?>
+		</li>
+	<?php endforeach; ?>
+</ul>

--- a/components/com_content/layouts/fields/table.php
+++ b/components/com_content/layouts/fields/table.php
@@ -53,7 +53,7 @@ $fieldgroupTitle = JText::_($fields[0]->group_title); // We get the fieldgroup t
 
 ?>
 <table class="fields-container">
-	<caption><?php echo $fieldgroupTitle ?></caption>
+	<caption><?php echo $fieldgroupTitle; ?></caption>
 	<tbody>
 	<?php foreach ($fields as $field) : ?>
 		<?php // If the value is empty do nothing ?>

--- a/components/com_content/layouts/fields/table.php
+++ b/components/com_content/layouts/fields/table.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_fields
+ *
+ * @copyright   Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+defined('_JEXEC') or die;
+
+// Check if we have all the data
+if (!key_exists('item', $displayData) || !key_exists('context', $displayData))
+{
+	return;
+}
+
+// Setting up for display
+$item = $displayData['item'];
+
+if (!$item)
+{
+	return;
+}
+
+$context = $displayData['context'];
+
+if (!$context)
+{
+	return;
+}
+
+JLoader::register('FieldsHelper', JPATH_ADMINISTRATOR . '/components/com_fields/helpers/fields.php');
+
+$parts     = explode('.', $context);
+$component = $parts[0];
+$fields    = null;
+
+if (key_exists('fields', $displayData))
+{
+	$fields = $displayData['fields'];
+}
+else
+{
+	$fields = $item->jcfields ?: FieldsHelper::getFields($context, $item, true);
+}
+
+if (!$fields)
+{
+	return;
+}
+
+$fieldgroupTitle = JText::_($fields[0]->group_title); // We get the fieldgroup title from the first field
+
+?>
+<table class="fields-container">
+	<caption><?php echo $fieldgroupTitle ?></caption>
+	<tbody>
+	<?php foreach ($fields as $field) : ?>
+		<?php // If the value is empty do nothing ?>
+		<?php if (!isset($field->value) || $field->value == '') : ?>
+			<?php continue; ?>
+		<?php endif; ?>
+		<?php $class = $field->params->get('render_class'); ?>
+		<?php $label = JText::_($field->label); ?>
+		<?php $value = $field->value; ?>
+		<?php $showLabel = $field->params->get('showlabel'); ?>
+		<tr class="field-entry <?php echo $class; ?>">
+			<?php if ($showLabel == 1) : ?>
+				<th scope="row" class="field-label"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?></th>
+			<?php endif; ?>
+			<td class="field-value"><?php echo $value; ?></td>
+		</tr>
+	<?php endforeach; ?>
+	</tbody>
+</table>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR adds two new layout overrides to com_content for rendering fieldgroups.
The list layout produces an unordered list (`<ul><li></li></ul>`) which surrounds the default field layout for the single element.
The table layout produces a table view of the fieldgroup with a `<caption>` element which uses the fieldgroup title. Labels are rendered as `<th scope="row">` (if set to display label), while values are normal `<td>` entries.


### Testing Instructions
Create a fieldgroup with one or more fields. Display the fieldgroup in an article body. Use {fieldgroup x} for the default com_fields layout and {fieldgroup x,list} or {fieldgroup x,table} for, respectively, list layout override or table layout override.


### Expected result
Add more nicer ways to render fieldgroups inside articles.


### Actual result
Only the default com_fields layout is available.


### Documentation Changes Required
The layout override option is only mentioned inside the Content - Fields plugin settings. It would be nice an addition to Joomla documentation.
