### PR TITLE
Versions toolbar button consistency

### DIFF
--- a/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
+++ b/administrator/templates/isis/html/layouts/joomla/toolbar/versions.php
@@ -37,7 +37,7 @@ echo JHtml::_(
 	)
 );
 ?>
-<button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-small" data-toggle="modal" title="<?php echo $title; ?>">
-	<span class="icon-archive"></span><?php echo $title; ?>
+<button onclick="jQuery('#versionsModal').modal('show')" class="btn btn-small" data-toggle="modal">
+	<span class="icon-archive" aria-hidden="true"></span><?php echo $title; ?>
 </button>
 


### PR DESCRIPTION
The markup for the versions button was not consistent with the other toolbar buttons. aria-hidden=true was missing and an unnecessary title attribute was present.
