### PR TITLE
JED message invalid html

### DIFF
--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -116,7 +116,7 @@ JFactory::getDocument()->addStyleDeclaration(
 						<?php echo JHtml::_(
 							'link',
 							JRoute::_('index.php?option=com_config&view=component&component=com_installer&path=&return=' . urlencode(base64_encode(JUri::getInstance()))),
-							'',
+							'<span class="element-invisible">' .str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '</span>',
 							'class="alert-options hasTooltip icon-options" data-dismiss="alert" title="' . str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '"'
 						);
 						?>

--- a/administrator/components/com_installer/views/install/tmpl/default.php
+++ b/administrator/components/com_installer/views/install/tmpl/default.php
@@ -116,7 +116,7 @@ JFactory::getDocument()->addStyleDeclaration(
 						<?php echo JHtml::_(
 							'link',
 							JRoute::_('index.php?option=com_config&view=component&component=com_installer&path=&return=' . urlencode(base64_encode(JUri::getInstance()))),
-							'<span class="element-invisible">' .str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '</span>',
+							'<span class="element-invisible">' . str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '</span>',
 							'class="alert-options hasTooltip icon-options" data-dismiss="alert" title="' . str_replace('"', '&quot;', JText::_('COM_INSTALLER_SHOW_JED_INFORMATION_TOOLTIP')) . '"'
 						);
 						?>


### PR DESCRIPTION
The cog icon link in the Install JED message in the installer is invalid html as there is nothing inside the a link. This pr fixes that in an accessible way. There is no visual change

<img width="403" alt="screenshotr12-21-42" src="https://user-images.githubusercontent.com/1296369/31818728-438862ce-b591-11e7-9d83-5c488dfd47a1.png">
