### PR TITLE
[Fix] Search Module does not display in the error.php page

### DIFF
--- a/templates/beez3/error.php
+++ b/templates/beez3/error.php
@@ -123,7 +123,7 @@ $navposition = $params->get('navposition');
 								<li><?php echo JText::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
 								<li><?php echo JText::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
 							</ul>
-							<?php if (JModuleHelper::getModule('search')) : ?>
+							<?php if (JModuleHelper::getModule('mod_search')) : ?>
 								<div id="searchbox">
 									<h3 class="unseen">
 										<?php echo JText::_('TPL_BEEZ3_SEARCH'); ?>
@@ -131,7 +131,7 @@ $navposition = $params->get('navposition');
 									<p>
 										<?php echo JText::_('JERROR_LAYOUT_SEARCH'); ?>
 									</p>
-									<?php $module = JModuleHelper::getModule('search'); ?>
+									<?php $module = JModuleHelper::getModule('mod_search'); ?>
 									<?php echo JModuleHelper::renderModule($module); ?>
 								</div><!-- end searchbox -->
 							<?php endif; ?>

--- a/templates/protostar/error.php
+++ b/templates/protostar/error.php
@@ -144,10 +144,11 @@ else
 								</ul>
 							</div>
 							<div class="span6">
-								<?php if (JModuleHelper::getModule('search')) : ?>
+								<?php if (JModuleHelper::getModule('mod_search')) : ?>
 									<p><strong><?php echo JText::_('JERROR_LAYOUT_SEARCH'); ?></strong></p>
 									<p><?php echo JText::_('JERROR_LAYOUT_SEARCH_PAGE'); ?></p>
-									<?php echo $this->getBuffer('module', 'search'); ?>
+									<?php $module = JModuleHelper::getModule('mod_search'); ?>
+									<?php echo JModuleHelper::renderModule($module); ?>
 								<?php endif; ?>
 								<p><?php echo JText::_('JERROR_LAYOUT_GO_TO_THE_HOME_PAGE'); ?></p>
 								<p><a href="<?php echo $this->baseurl; ?>/index.php" class="btn"><span class="icon-home" aria-hidden="true"></span> <?php echo JText::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></p>


### PR DESCRIPTION
### Testing Instructions
Display the error page with Protostar or Beez with a link like
mydomain.com/whatever


### Expected result
The search module should display

### Actual result
It does not not display

Patch and test again

You should get for Protostar
![screen shot 2017-10-20 at 18 01 59](https://user-images.githubusercontent.com/869724/31830535-cef19fb8-b5c0-11e7-9f58-6c5708066418.png)

and for Beez

![screen shot 2017-10-20 at 18 03 40](https://user-images.githubusercontent.com/869724/31830621-10958a56-b5c1-11e7-8d02-91aef61823cc.png)


