### PR TITLE
Batch users modal has invalid markup

### DIFF
--- a/administrator/components/com_users/views/users/tmpl/default_batch_body.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_body.php
@@ -26,21 +26,21 @@ JHtml::_('formbehavior.chosen', 'select');
 
 <div class="container-fluid">
 	<div class="row-fluid">
-		<div id="batch-choose-action" class="combo control-group">
+		<div class="controls">
 			<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
 				<?php echo JText::_('COM_USERS_BATCH_GROUP'); ?>
 			</label>
-		</div>
-		<div id="batch-choose-action" class="combo controls">
-			<div class="control-group">
-				<select name="batch[group_id]" id="batch-group-id">
-					<option value=""><?php echo JText::_('JSELECT'); ?></option>
-					<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
-				</select>
+			<div id="batch-choose-action" class="combo controls">
+				<div class="control-group">
+					<select name="batch[group_id]" id="batch-group-id">
+						<option value=""><?php echo JText::_('JSELECT'); ?></option>
+						<?php echo JHtml::_('select.options', JHtml::_('user.groups')); ?>
+					</select>
+				</div>
 			</div>
-		</div>
-		<div class="control-group radio">
-			<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add'); ?>
+			<div class="control-group radio">
+				<?php echo JHtml::_('select.radiolist', $options, 'batch[group_action]', '', 'value', 'text', 'add'); ?>
+			</div>
 		</div>
 	</div>
 	<label><?php echo JText::_('COM_USERS_REQUIRE_PASSWORD_RESET'); ?></label>

--- a/administrator/components/com_users/views/users/tmpl/default_batch_body.php
+++ b/administrator/components/com_users/views/users/tmpl/default_batch_body.php
@@ -27,7 +27,7 @@ JHtml::_('formbehavior.chosen', 'select');
 <div class="container-fluid">
 	<div class="row-fluid">
 		<div class="controls">
-			<label id="batch-choose-action-lbl" class="control-label" for="batch-choose-action">
+			<label id="batch-choose-action-lbl" class="control-label" for="batch-group-id">
 				<?php echo JText::_('COM_USERS_BATCH_GROUP'); ?>
 			</label>
 			<div id="batch-choose-action" class="combo controls">


### PR DESCRIPTION
Document has multiple elements with the same id attribute: batch-choose-action. An id attribute has to be unique. This PR resolves this in the same way as similar batch modals

There is no visual difference
