### PR TITLE
[4.0] Create a registry for logger types

### DIFF
--- a/libraries/src/Log/Log.php
+++ b/libraries/src/Log/Log.php
@@ -128,12 +128,21 @@ class Log
 	protected $lookup = array();
 
 	/**
+	 * The registry of available loggers
+	 *
+	 * @var    LoggerRegistry
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $loggerRegistry;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since   11.1
 	 */
 	protected function __construct()
 	{
+		$this->loggerRegistry = new LoggerRegistry;
 	}
 
 	/**
@@ -187,6 +196,28 @@ class Log
 		}
 
 		static::$instance->addLoggerInternal($options, $priorities, $categories, $exclude);
+	}
+
+	/**
+	 * Register a logger to the registry
+	 *
+	 * @param   string   $key      The service key to be registered
+	 * @param   string   $class    The class name of the logger
+	 * @param   boolean  $replace  Flag indicating the service key may replace an existing definition
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function registerLogger(string $key, string $class, bool $replace = false)
+	{
+		// Automatically instantiate the singleton object if not already done.
+		if (empty(static::$instance))
+		{
+			static::setInstance(new static);
+		}
+
+		static::$instance->loggerRegistry->register($key, $class, $replace);
 	}
 
 	/**
@@ -306,11 +337,27 @@ class Log
 			// Attempt to instantiate the logger object if it doesn't already exist.
 			if (empty($this->loggers[$signature]))
 			{
-				$class = __NAMESPACE__ . '\\Logger\\' . ucfirst($this->configurations[$signature]['logger']) . 'Logger';
-
-				if (!class_exists($class))
+				if ($this->loggerRegistry->hasLogger($this->configurations[$signature]['logger']))
 				{
-					throw new \RuntimeException('Unable to create a Logger instance: ' . $class);
+					$class = $this->loggerRegistry->getLoggerClass($this->configurations[$signature]['logger']);
+				}
+				else
+				{
+					@trigger_error(
+						sprintf(
+							'Attempting to automatically resolve loggers to the %s namespace is deprecated as of 4.0 and will be removed in 5.0.'
+							. ' Use the logger registry instead.',
+							__NAMESPACE__
+						),
+						E_USER_DEPRECATED
+					);
+
+					$class = __NAMESPACE__ . '\\Logger\\' . ucfirst($this->configurations[$signature]['logger']) . 'Logger';
+
+					if (!class_exists($class))
+					{
+						throw new \RuntimeException('Unable to create a Logger instance: ' . $class);
+					}
 				}
 
 				$this->loggers[$signature] = new $class($this->configurations[$signature]);

--- a/libraries/src/Log/LoggerRegistry.php
+++ b/libraries/src/Log/LoggerRegistry.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Log;
+
+defined('JPATH_PLATFORM') or die;
+
+/**
+ * Service registry for loggers
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+final class LoggerRegistry
+{
+	/**
+	 * Array holding the registered services
+	 *
+	 * @var    string[]
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $loggerMap = [
+		'callback'      => Logger\CallbackLogger::class,
+		'database'      => Logger\DatabaseLogger::class,
+		'echo'          => Logger\EchoLogger::class,
+		'formattedtext' => Logger\FormattedtextLogger::class,
+		'messagequeue'  => Logger\MessagequeueLogger::class,
+		'syslog'        => Logger\SyslogLogger::class,
+		'w3c'           => Logger\W3cLogger::class,
+	];
+
+	/**
+	 * Get the logger class for a given key
+	 *
+	 * @param   string  $key  The key to look up
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
+	 */
+	public function getLoggerClass(string $key): string
+	{
+		if (!$this->hasLogger($key))
+		{
+			throw new \InvalidArgumentException("The '$key' key is not registered.");
+		}
+
+		return $this->loggerMap[$key];
+	}
+
+	/**
+	 * Check if the registry has a logger for the given key
+	 *
+	 * @param   string  $key  The key to look up
+	 *
+	 * @return  boolean
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function hasLogger(string $key): bool
+	{
+		return isset($this->loggerMap[$key]);
+	}
+
+	/**
+	 * Register a logger
+	 *
+	 * @param   string   $key      The service key to be registered
+	 * @param   string   $class    The class name of the logger
+	 * @param   boolean  $replace  Flag indicating the service key may replace an existing definition
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function register(string $key, string $class, bool $replace = false)
+	{
+		// If the key exists already and we aren't instructed to replace existing services, bail early
+		if (isset($this->loggerMap[$key]) && !$replace)
+		{
+			throw new \RuntimeException("The '$key' key is already registered.");
+		}
+
+		// The class must exist
+		if (!class_exists($class))
+		{
+			throw new \RuntimeException("The '$class' class for key '$key' does not exist.");
+		}
+
+		$this->loggerMap[$key] = $class;
+	}
+}


### PR DESCRIPTION
### Summary of Changes

Creating new logger types requires classes to follow a hardcoded naming convention using a core namespace.  To improve this, a logger registry is introduced which allows loggers to be registered with any valid PHP class name.

### Testing Instructions

In general, the CMS' logging functionality continues to work without noticeable change.

For developers adding custom logger types, the hardcoded naming convention will continue to work through 4.x but is a deprecated behavior to be removed in 5.0.  Instead, you should call the new `Joomla\CMS\Log\Log::registerLogger()` method to register your custom logger object.

### Documentation Changes Required

The new API and deprecation should be documented.