### PR TITLE
Set missing column system_data for template installation

### DIFF
--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -382,6 +382,7 @@ class TemplateAdapter extends InstallerAdapter
 
 			// Custom data
 			$this->extension->custom_data = '';
+			$this->extension->system_data = '';
 		}
 
 		// Name might change in an update


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18390

### Summary of Changes
Set empty text for column in template installation adapter.
This is the same as in other adapters. Mysql do not trigger any errors if we do not declare such column but postgresql is more strict.


### Testing Instructions
Install free template on postgresql.


### Expected result
Installation success.


### Actual result
Error.


### Documentation Changes Required
No
