### PR TITLE
Allow to connect to redis by socket

### DIFF
--- a/administrator/components/com_config/model/form/application.xml
+++ b/administrator/components/com_config/model/form/application.xml
@@ -923,6 +923,20 @@
 		/>
 
 		<field
+			name="session_redis_persist"
+			type="radio"
+			label="COM_CONFIG_FIELD_REDIS_PERSISTENT_LABEL"
+			description="COM_CONFIG_FIELD_REDIS_PERSISTENT_DESC"
+			class="btn-group btn-group-yesno"
+			default="1"
+			filter="integer"
+			showon="session_handler:redis"
+			>
+			<option value="1">JYES</option>
+			<option value="0">JNO</option>
+		</field>
+
+		<field
 			name="session_redis_server_host"
 			type="text"
 			label="COM_CONFIG_FIELD_REDIS_HOST_LABEL"
@@ -945,6 +959,17 @@
 			validate="number"
 			filter="integer"
 			size="5"
+		/>
+
+		<field
+			name="session_redis_server_auth"
+			type="password"
+			label="COM_CONFIG_FIELD_REDIS_AUTH_LABEL"
+			description="COM_CONFIG_FIELD_REDIS_AUTH_DESC"
+			filter="raw"
+			showon="session_handler:redis"
+			autocomplete="off"
+			size="30"
 		/>
 
 		<field

--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -34,10 +34,17 @@ class JSessionStorageRedis extends JSessionStorage
 		$config = JFactory::getConfig();
 
 		$this->_server = array(
-			'host' => $config->get('session_redis_server_host', 'localhost'),
-			'port' => $config->get('session_redis_server_port', 6379),
-			'db'   => (int) $config->get('session_redis_server_db', 0)
+			'host'    => $config->get('session_redis_server_host', 'localhost'),
+			'port'    => $config->get('session_redis_server_port', 6379),
+			'persist' => $config->get('session_redis_persist', true),
+			'db'      => (int) $config->get('session_redis_server_db', 0),
 		);
+
+		// If you are trying to connect to a socket file, ignore the supplied port
+		if ($this->_server['host'][0] === '/')
+		{
+			$this->_server['port'] = 0;
+		}
 
 		parent::__construct($options);
 	}
@@ -51,17 +58,24 @@ class JSessionStorageRedis extends JSessionStorage
 	 */
 	public function register()
 	{
-		if (!empty($this->_server) && isset($this->_server['host']) && isset($this->_server['port']))
+		if (!empty($this->_server) && isset($this->_server['host'], $this->_server['port']))
 		{
 			if (!headers_sent())
 			{
-				$path = $this->_server['host'] . ":" . $this->_server['port'];
-
-				if (isset($this->_server['db']) && ($this->_server['db'] !== 0))
+				if ($this->_server['port'] === 0)
 				{
-					$path = 'tcp://' . $path . '?database=' . $this->_server['db'];
+					$path = 'unix://' . $this->_server['host'];
 				}
-				
+				else
+				{
+					$path = 'tcp://' . $this->_server['host'] . ":" . $this->_server['port'];
+				}
+
+				$persist = isset($this->_server['persist']) ? $this->_server['persist'] : false;
+				$db      = isset($this->_server['db']) ? $this->_server['db'] : 0;
+
+				$path .= '?persistent=' . (int) $persist . '&database=' . $db;
+
 				ini_set('session.save_path', $path);
 				ini_set('session.save_handler', 'redis');
 			}

--- a/libraries/joomla/session/storage/redis.php
+++ b/libraries/joomla/session/storage/redis.php
@@ -37,6 +37,7 @@ class JSessionStorageRedis extends JSessionStorage
 			'host'    => $config->get('session_redis_server_host', 'localhost'),
 			'port'    => $config->get('session_redis_server_port', 6379),
 			'persist' => $config->get('session_redis_persist', true),
+			'auth'    => $config->get('session_redis_server_auth', null),
 			'db'      => (int) $config->get('session_redis_server_db', 0),
 		);
 
@@ -75,6 +76,11 @@ class JSessionStorageRedis extends JSessionStorage
 				$db      = isset($this->_server['db']) ? $this->_server['db'] : 0;
 
 				$path .= '?persistent=' . (int) $persist . '&database=' . $db;
+
+				if (!empty($this->_server['auth']))
+				{
+					$path .= '&auth=' . $this->_server['auth'];
+				}
 
 				ini_set('session.save_path', $path);
 				ini_set('session.save_handler', 'redis');

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -68,49 +68,47 @@ class RedisStorage extends CacheStorage
 			return false;
 		}
 
-		$app = \JFactory::getApplication();
+		$config = \JFactory::getConfig();
 
-		$this->_persistent = $app->get('redis_persist', true);
+		$this->_persistent = $config->get('redis_persist', true);
 
 		$server = array(
-			'host' => $app->get('redis_server_host', 'localhost'),
-			'port' => $app->get('redis_server_port', 6379),
-			'auth' => $app->get('redis_server_auth', null),
-			'db'   => (int) $app->get('redis_server_db', null),
+			'host' => $config->get('redis_server_host', 'localhost'),
+			'port' => $config->get('redis_server_port', 6379),
+			'auth' => $config->get('redis_server_auth', null),
+			'db'   => (int) $config->get('redis_server_db', null),
 		);
+
+		// If you are trying to connect to a socket file, ignore the supplied port
+		if ($server['host'][0] === '/')
+		{
+			$server['port'] = 0;
+		}
 
 		static::$_redis = new \Redis;
 
-		if ($this->_persistent)
+		try
 		{
-			try
+			if ($this->_persistent)
 			{
 				$connection = static::$_redis->pconnect($server['host'], $server['port']);
-				$auth       = (!empty($server['auth'])) ? static::$_redis->auth($server['auth']) : true;
 			}
-			catch (\RedisException $e)
-			{
-				Log::add($e->getMessage(), Log::DEBUG);
-			}
-		}
-		else
-		{
-			try
+			else
 			{
 				$connection = static::$_redis->connect($server['host'], $server['port']);
-				$auth       = (!empty($server['auth'])) ? static::$_redis->auth($server['auth']) : true;
 			}
-			catch (\RedisException $e)
-			{
-				Log::add($e->getMessage(), Log::DEBUG);
-			}
+		}
+		catch (\RedisException $e)
+		{
+			Log::add($e->getMessage(), Log::DEBUG);
 		}
 
 		if ($connection == false)
 		{
 			static::$_redis = null;
 
-			if ($app->isClient('administrator'))
+			// Because the application instance may not be available on cli script, use it only if needed
+			if (\JFactory::getApplication()->isClient('administrator'))
 			{
 				\JError::raiseWarning(500, 'Redis connection failed');
 			}
@@ -118,9 +116,21 @@ class RedisStorage extends CacheStorage
 			return false;
 		}
 
+		try
+		{
+			$auth = $server['auth'] ? static::$_redis->auth($server['auth']) : true;
+		}
+		catch (\RedisException $e)
+		{
+			Log::add($e->getMessage(), Log::DEBUG);
+		}
+
 		if ($auth == false)
 		{
-			if ($app->isClient('administrator'))
+			static::$_redis = null;
+
+			// Because the application instance may not be available on cli script, use it only if needed
+			if (\JFactory::getApplication()->isClient('administrator'))
 			{
 				\JError::raiseWarning(500, 'Redis authentication failed');
 			}
@@ -134,7 +144,8 @@ class RedisStorage extends CacheStorage
 		{
 			static::$_redis = null;
 
-			if ($app->isClient('administrator'))
+			// Because the application instance may not be available on cli script, use it only if needed
+			if (\JFactory::getApplication()->isClient('administrator'))
 			{
 				\JError::raiseWarning(500, 'Redis failed to select database');
 			}
@@ -150,7 +161,8 @@ class RedisStorage extends CacheStorage
 		{
 			static::$_redis = null;
 
-			if ($app->isClient('administrator'))
+			// Because the application instance may not be available on cli script, use it only if needed
+			if (\JFactory::getApplication()->isClient('administrator'))
 			{
 				\JError::raiseWarning(500, 'Redis ping failed');
 			}

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -122,10 +122,11 @@ class RedisStorage extends CacheStorage
 		}
 		catch (\RedisException $e)
 		{
+			$auth = false;
 			Log::add($e->getMessage(), Log::DEBUG);
 		}
 
-		if ($auth == false)
+		if ($auth === false)
 		{
 			static::$_redis = null;
 


### PR DESCRIPTION
### Summary of Changes

Further development of https://github.com/joomla/joomla-cms/pull/18266

Inspired by #15822, #17528 and my own #16904

1. Allow to connect to Redis by socket (cache and session handler).
    * check first character of supplied server host to check if it is a socket path or not.

2. Fix for "CLI scripts print 'Application Instantiation Error' when redis cache enabled" but without breaking B/C. 
    * use `\JFactory::getApplication()` only if needed, this way redis can be use on CLI script, see #16904.

3. Add support for Redis Authentication in Session handler, the same as in cache handler.

4. Add option to set/unset persistent connection in Session Redis handler.

#### More info:
  * https://github.com/phpredis/phpredis/issues/284#issuecomment-13685929
  * https://github.com/phpredis/phpredis#user-content-php-session-handler

#### Before
![obraz](https://user-images.githubusercontent.com/9054379/31887089-4cf74614-b7f7-11e7-9beb-2d414d736283.png)


#### After
![obraz](https://user-images.githubusercontent.com/9054379/31886961-ccfcdece-b7f6-11e7-801f-5556a960590c.png)

### Testing Instructions

Test cache and session handler using Redis by socket.


### Expected result
All works as expected.


### Actual result
Redis by socket is not available.


### Documentation Changes Required
Maybe