### PR TITLE
[com_fields] Send the context when indexing an article

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -464,14 +464,15 @@ class FinderIndexerHelper
 	/**
 	 * Method to process content text using the onContentPrepare event trigger.
 	 *
-	 * @param   string    $text    The content to process.
-	 * @param   Registry  $params  The parameters object. [optional]
+	 * @param   string               $text    The content to process.
+	 * @param   Registry             $params  The parameters object. [optional]
+	 * @param   FinderIndexerResult  $item    The item which get prepared. [optional]
 	 *
 	 * @return  string  The processed content.
 	 *
 	 * @since   2.5
 	 */
-	public static function prepareContent($text, $params = null)
+	public static function prepareContent($text, $params = null, FinderIndexerResult $item = null)
 	{
 		static $loaded;
 
@@ -495,6 +496,17 @@ class FinderIndexerHelper
 		// Create a mock content object.
 		$content = JTable::getInstance('Content');
 		$content->text = $text;
+
+		if ($item)
+		{
+			$content->bind((array)$item);
+			$content->bind($item->getElements());
+		}
+
+		if ($item && !empty($item->context))
+		{
+			$content->context = $item->context;
+		}
 
 		// Fire the onContentPrepare event.
 		$dispatcher->trigger('onContentPrepare', array('com_finder.indexer', &$content, &$params, 0));

--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -273,6 +273,18 @@ class FinderIndexerResult
 	}
 
 	/**
+	 * Method to retrieve all elements.
+	 *
+	 * @return  array  The elements
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getElements()
+	{
+		return $this->elements;
+	}
+
+	/**
 	 * Method to set additional element values in the elements array.
 	 *
 	 * @param   string  $name   The name of the element.

--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -31,9 +31,14 @@ class PlgContentFields extends JPlugin
 	 */
 	public function onContentPrepare($context, &$item, &$params, $page = 0)
 	{
-		// Don't run this plugin when the content is being indexed
-		if ($context == 'com_finder.indexer')
+		// If the item has a context, overwrite the existing one
+		if ($context == 'com_finder.indexer' && !empty($item->context))
 		{
+			$context = $item->context;
+		}
+		elseif ($context == 'com_finder.indexer')
+		{
+			// Don't run this plugin when the content is being indexed and we have no real context
 			return;
 		}
 

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -251,6 +251,8 @@ class PlgFinderContent extends FinderIndexerAdapter
 			return;
 		}
 
+		$item->context = 'com_content.article';
+
 		// Initialise the item parameters.
 		$registry = new Registry($item->params);
 		$item->params = JComponentHelper::getParams('com_content', true);
@@ -259,8 +261,8 @@ class PlgFinderContent extends FinderIndexerAdapter
 		$item->metadata = new Registry($item->metadata);
 
 		// Trigger the onContentPrepare event.
-		$item->summary = FinderIndexerHelper::prepareContent($item->summary, $item->params);
-		$item->body = FinderIndexerHelper::prepareContent($item->body, $item->params);
+		$item->summary = FinderIndexerHelper::prepareContent($item->summary, $item->params, $item);
+		$item->body    = FinderIndexerHelper::prepareContent($item->body, $item->params, $item);
 
 		// Build the necessary route and path information.
 		$item->url = $this->getUrl($item->id, $this->extension, $this->layout);


### PR DESCRIPTION
Pull Request for Issue #17557.

### Summary of Changes
The fields content plugin gets the wrong context when indexing an article. This pr changes the indexer the way that as much information from the article are sent together to prepare the description and summary of the item to index.

### Testing Instructions
- Enable the content finder plugin (not the finder content plugin)
- Create an article custom field
- Create an article and add "Hello joomla {field 1}" into the description body (perhaps you have to replace 1 with the real id of the field)
- Run the indexer in the smart search component
- Create a smart search module for the front
- Search for "joomla" in the smart search module on the front

### Expected result
The search results to show the custom field values.

### Actual result
The search results do contain {field 1} in the description.