### PR TITLE
Removing menu children on component install can destroy the whole menu tree

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1128,7 +1128,7 @@ class ComponentAdapter extends InstallerAdapter
 			// Iterate the items to delete each one.
 			foreach ($ids as $menuid)
 			{
-				if (!$table->delete((int) $menuid))
+				if (!$table->delete((int) $menuid, false))
 				{
 					$this->setError($table->getError());
 


### PR DESCRIPTION
Menu table inherits Nested and since delete without second argument set to false, removes node and its children. As all child ids that need to be removed are already collected in previous step this means:
a) errors are generated if tree is consistent - all children are already removed in first delete, so all following deletes fail
b) with inconsistent trees this can delete random ranges of menus as delete only looks at lft-rgt values. This is not a unusual scenario as admin menus were previously not checked for consistency - I just had the whole menu wiped out due to faulty record.

To prevent this I propose that we delete only explicit records as I assume was also originally intended due to ids collection in previous step.


### Summary of Changes
Set Children parameter to false in delete

### Testing Instructions
Copy existing record from menu tree from one of installed 3rd party components (needs to be installable, not core) to create a faulty record: : copy existing record, change parent to non-existing id and set lft to 0 and rgt to 99999. It needs to be an admin menu (client = 1 ).

Update(reinstall) component with faulty record.


### Expected result
Record disapears,  the rest of the records remain.


### Actual result
All records are erased.


### Documentation Changes Required

