### PR TITLE
[com_tags] Always use slug to create tag links

### DIFF
--- a/components/com_tags/views/tags/tmpl/default_items.php
+++ b/components/com_tags/views/tags/tmpl/default_items.php
@@ -89,7 +89,7 @@ JFactory::getDocument()->addScriptDeclaration("
 			<?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
 				<li class="cat-list-row<?php echo $i % 2; ?>">
 					<h3>
-						<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . '-' . $item->alias)); ?>">
+						<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->id . ':' . $item->alias)); ?>">
 							<?php echo $this->escape($item->title); ?>
 						</a>
 					</h3>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -23,7 +23,7 @@ $authorised = JFactory::getUser()->getAuthorisedViewLevels();
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'label label-info'); ?>
 				<li class="tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
-					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . '-' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
+					<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
 				</li>

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -43,7 +43,7 @@ if (!count($list)) : ?>
 		endif;
 ?>
 		<span class="tag">
-			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">
+			<a class="tag-name" style="font-size: <?php echo $fontsize . 'em'; ?>" href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
 				<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 			<?php if ($display_count) : ?>
 				<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 	<ul>
 	<?php foreach ($list as $item) : ?>
 	<li>
-		<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . '-' . $item->alias)); ?>">
+		<a href="<?php echo JRoute::_(TagsHelperRoute::getTagRoute($item->tag_id . ':' . $item->alias)); ?>">
 			<?php echo htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8'); ?></a>
 		<?php if ($display_count) : ?>
 			<span class="tag-count badge badge-info"><?php echo $item->count; ?></span>

--- a/plugins/search/tags/tags.php
+++ b/plugins/search/tags/tags.php
@@ -152,7 +152,7 @@ class PlgSearchTags extends JPlugin
 
 			foreach ($rows as $key => $row)
 			{
-				$rows[$key]->href       = TagsHelperRoute::getTagRoute($row->id);
+				$rows[$key]->href       = TagsHelperRoute::getTagRoute($row->slug);
 				$rows[$key]->text       = ($row->description !== '' ? $row->description : $row->title);
 				$rows[$key]->text      .= $row->note;
 				$rows[$key]->section    = $section;


### PR DESCRIPTION
Pull Request for Issue partly for #18363.

### Summary of Changes
Create a link to tag always using `slug=id:alias`, I mean replace '-' to ':' and add alias to id if missing.

### Testing Instructions
1. Install joomla staging with sample data testing
2. At home page the is a search box, search for existed tag 'lime' (`../index.php/search?searchword=lime&searchphrase=all`)
    * you should get incorrect link to tag (only id): `.../index.php/all-tags/5`
3. Apply patch and refresh page or search again.
    * now you get correct link: `../index.php/all-tags/lime`

This is a link to set status of test https://issues.joomla.org/tracker/joomla-cms/18407

### Expected result
Links to tag view should always use alias. 
When SEF is disabled then tag id is equal to `id:alias` not `id-alias`

### Actual result
Joomla generates different links to the same tag.

### Documentation Changes Required
No