### PR TITLE
[installer] - sanitize extensions type as lower case

### DIFF
--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -185,6 +185,9 @@ abstract class InstallerAdapter extends \JAdapterInstance
 	 */
 	protected function checkExistingExtension()
 	{
+		// Extension type is stored as lowercase on the #__extensions table field type
+		$this->type = strtolower($this->type);
+
 		try
 		{
 			$this->currentExtensionId = $this->extension->find(


### PR DESCRIPTION
Pull Request for Issue #18412.

### Summary of Changes
the `#__extensions.type` field is stored as lower case


### Testing Instructions
see #18412
you can test with weblinks https://github.com/joomla-extensions/weblinks/releases

### Expected result
same behaviuor as mysql


### Actual result
installed twice on postgresql




