### PR TITLE
Update search bar layout

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -42,7 +42,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<?php if ($filters['filter_search']->description) : ?>
 				<?php JHtmlBootstrap::tooltip('#filter_search', array('title' => JText::_($filters['filter_search']->description))); ?>
 			<?php endif; ?>
-			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>" aria-label="<?php echo JTEXT::_('JSEARCH_FILTER_SUBMIT'); ?>">
+			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>" aria-label="<?php echo JText::_('JSEARCH_FILTER_SUBMIT'); ?>">
 				<span class="icon-search" aria-hidden="true"></span>
 			</button>
 		</div>

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -42,8 +42,8 @@ $filters = $data['view']->filterForm->getGroup('filter');
 			<?php if ($filters['filter_search']->description) : ?>
 				<?php JHtmlBootstrap::tooltip('#filter_search', array('title' => JText::_($filters['filter_search']->description))); ?>
 			<?php endif; ?>
-			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>">
-				<span class="icon-search"></span>
+			<button type="submit" class="btn hasTooltip" title="<?php echo JHtml::_('tooltipText', 'JSEARCH_FILTER_SUBMIT'); ?>" aria-label="<?php echo JTEXT::_('JSEARCH_FILTER_SUBMIT'); ?>">
+				<span class="icon-search" aria-hidden="true"></span>
 			</button>
 		</div>
 		<?php if ($filterButton) : ?>


### PR DESCRIPTION
Following best practice as applied elsewhere this PR adds the aria-hidden attribute to the font icon and ensures that the button has an aria-label so that the meaning of the button can be conveyed correctly to users for assistive technology

To test go to any admin page with a search bar and check the source cod of the search button. Before this pr it will be

`<button type="submit" class="btn hasTooltip" title="" data-original-title="Search">
<span class="icon-search"></span>
</button>
`

After this pr it will be

`
<button type="submit" class="btn hasTooltip" title="" aria-label="Search" data-original-title="Search">
	<span class="icon-search" aria-hidden="true"></span>
</button>`
