### PR TITLE
Modern routing - remove view from query string

### DIFF
--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -196,7 +196,7 @@ class StandardRules implements RulesInterface
 		}
 
 		// Get menu item layout
-		$mLayout = isset($item->query['layout']) ? $item->query['layout'] : 'default';
+		$mLayout = isset($item->query['layout']) ? $item->query['layout'] : null;
 
 		// Get all views for this component
 		$views = $this->router->getViews();

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -182,7 +182,7 @@ class StandardRules implements RulesInterface
 	 */
 	public function build(&$query, &$segments)
 	{
-		if (isset($query['Itemid'], $query['view']) === false)
+		if (!isset($query['Itemid'], $query['view']))
 		{
 			return;
 		}
@@ -190,7 +190,7 @@ class StandardRules implements RulesInterface
 		// Get the menu item belonging to the Itemid that has been found
 		$item = $this->router->menu->getItem($query['Itemid']);
 
-		if ($item === null)
+		if ($item === null || $item->component !== 'com_' . $this->router->getName())
 		{
 			return;
 		}
@@ -219,7 +219,7 @@ class StandardRules implements RulesInterface
 			}
 
 			// If item has no key set, we assume 0.
-			if (isset($item->query[$view->key]) === false)
+			if (!isset($item->query[$view->key]))
 			{
 				$item->query[$view->key] = 0;
 			}

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -206,7 +206,7 @@ class StandardRules implements RulesInterface
 		{
 			$view = $views[$query['view']];
 
-			if ($view->key === false)
+			if (!$view->key)
 			{
 				unset($query['view']);
 

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -218,12 +218,6 @@ class StandardRules implements RulesInterface
 				return;
 			}
 
-			// If item has no key set, we assume 0.
-			if (!isset($item->query[$view->key]))
-			{
-				$item->query[$view->key] = 0;
-			}
-
 			if (isset($query[$view->key]) && $item->query[$view->key] == (int) $query[$view->key])
 			{
 				unset($query[$view->key]);

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -104,7 +104,7 @@ class StandardRules implements RulesInterface
 				}
 				else
 				{
-					// The router is not complete. The get<View>Key() method is missing.
+					// The router is not complete. The get<View>Id() method is missing.
 					return;
 				}
 			}
@@ -182,13 +182,21 @@ class StandardRules implements RulesInterface
 	 */
 	public function build(&$query, &$segments)
 	{
-		// Get the menu item belonging to the Itemid that has been found
-		$item = $this->router->menu->getItem($query['Itemid']);
-
-		if (!isset($query['view']))
+		if (isset($query['Itemid'], $query['view']) === false)
 		{
 			return;
 		}
+
+		// Get the menu item belonging to the Itemid that has been found
+		$item = $this->router->menu->getItem($query['Itemid']);
+
+		if ($item === null)
+		{
+			return;
+		}
+
+		// Get menu item layout
+		$mLayout = isset($item->query['layout']) ? $item->query['layout'] : 'default';
 
 		// Get all views for this component
 		$views = $this->router->getViews();
@@ -198,7 +206,25 @@ class StandardRules implements RulesInterface
 		{
 			$view = $views[$query['view']];
 
-			if (isset($item->query[$view->key], $query[$view->key]) && $item->query[$view->key] == (int) $query[$view->key])
+			if ($view->key === false)
+			{
+				unset($query['view']);
+
+				if (isset($query['layout']) && $mLayout === $query['layout'])
+				{
+					unset($query['layout']);
+				}
+
+				return;
+			}
+
+			// If item has no key set, we assume 0.
+			if (isset($item->query[$view->key]) === false)
+			{
+				$item->query[$view->key] = 0;
+			}
+
+			if (isset($query[$view->key]) && $item->query[$view->key] == (int) $query[$view->key])
 			{
 				unset($query[$view->key]);
 
@@ -211,21 +237,12 @@ class StandardRules implements RulesInterface
 
 				unset($query['view']);
 
-				if (isset($item->query['layout']) && isset($query['layout']) && $item->query['layout'] === $query['layout'])
+				if (isset($query['layout']) && $mLayout === $query['layout'])
 				{
 					unset($query['layout']);
 				}
 
 				return;
-			}
-
-			if (!$view->key)
-			{
-				if (isset($item->query['layout']) && isset($query['layout']) && $item->query['layout'] === $query['layout'])
-				{
-					unset($query['view'], $query['layout']);
-					return;
-				}
 			}
 		}
 
@@ -293,7 +310,12 @@ class StandardRules implements RulesInterface
 
 		if ($found)
 		{
-			unset($query['layout'], $query[$views[$query['view']]->key], $query['view']);
+			unset($query[$views[$query['view']]->key], $query['view']);
+
+			if (isset($query['layout']) && $mLayout === $query['layout'])
+			{
+				unset($query['layout']);
+			}
 		}
 	}
 }

--- a/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesStandardTest.php
+++ b/tests/unit/suites/libraries/cms/component/router/rules/JComponentRouterRulesStandardTest.php
@@ -183,15 +183,42 @@ class JComponentRouterRulesStandardTest extends TestCaseDatabase
 					'view' => 'form',
 					'Itemid' => 263
 				),
-				// TODO: I think this might be a bug? I think view should be unset whatever the status of the layout
 				array(
 					'option' => 'com_content',
-					'view' => 'form',
 					'Itemid' => 263
 				),
 				array(
 				),
 				'Error building a URL for a menu item that doesn\'t have a key'
+			),
+			array(
+				array(
+					'option' => 'com_content',
+					'view' => 'form',
+					'layout' => 'edit',
+					'Itemid' => 263
+				),
+				array(
+					'option' => 'com_content',
+					'Itemid' => 263
+				),
+				array(
+				),
+				'Error building a URL with layout=edit for a menu item that doesn\'t have a key'
+			),
+			array(
+				array(
+					'option' => 'com_content',
+					'view' => 'featured',
+					'Itemid' => 262
+				),
+				array(
+					'option' => 'com_content',
+					'Itemid' => 262
+				),
+				array(
+				),
+				'Error building a URL for featured that has a menu item without a key'
 			),
 			array(
 				array(


### PR DESCRIPTION
### Summary of Changes

Build a correct URL for links without layout or when the layout from URL is different than from menu item.

### Testing Instructions
1. Install staging joomla or 3.8.2 with sample data.
2. On back-end enable modern routing in `users`.
3. Optional enable `Allow User Registration`
3. Go to home page and:
    - check module login links, 
    - try to login with wrong password and check URL address after that
    - check URL address on profile edit form

    | Before | After |
    | -------- | ------- |
    | `/index.php/password-reset?view=reset` | `/index.php/password-reset` |
    | `/index.php/username-reminder?view=remind` | `/index.php/username-reminder` |
    | `/index.php/login?view=login` | `/index.php/login` |
    | `/index.php/registration-form?view=registration` | `/index.php/registration-form` |
    | `/index.php/your-profile?view=profile&layout=edit` | `/index.php/your-profile?layout=edit` |

### Expected result
Links with own menu item does not have a view parameter in query string.

### Documentation Changes Required
No
