### PR TITLE
Little correction for de.js

### DIFF
--- a/media/editors/tinymce/langs/de.js
+++ b/media/editors/tinymce/langs/de.js
@@ -216,7 +216,7 @@ tinymce.addI18n('de',{
 "No color": "Keine Farbe",
 "Text color": "Textfarbe",
 "Table of Contents": "Inhaltsverzeichnis",
-"Show blocks": " Bl\u00f6cke anzeigen",
+"Show blocks": "Bl\u00f6cke anzeigen",
 "Show invisible characters": "Unsichtbare Zeichen anzeigen",
 "Words: {0}": "W\u00f6rter: {0}",
 "Insert": "Einf\u00fcgen",


### PR DESCRIPTION
I have corrected a little issue in line 219 "Show blocks". There was one space too much at the beginning of the translated string.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

