### PR TITLE
PHP 7.2 Compat - Fix count() uses

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -267,12 +267,13 @@ class ContentModelArticles extends JModelList
 		}
 
 		// Filter by categories and by level
-		$categoryId = $this->getState('filter.category_id');
+		$categoryId = $this->getState('filter.category_id', array());
 		$level = $this->getState('filter.level');
 
-		$categoryId = $categoryId && !is_array($categoryId)
-			? array($categoryId)
-			: $categoryId;
+		if (!is_array($categoryId))
+		{
+			$categoryId = $categoryId ? array($categoryId) : array();
+		}
 
 		// Case: Using both categories filter and by level filter
 		if (count($categoryId))

--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -50,16 +50,18 @@ class CollectionAdapter extends UpdateAdapter
 	protected $pop_parent = 0;
 
 	/**
-	 * @var array A list of discovered update sites
+	 * A list of discovered update sites
+	 *
+	 * @var  array
 	 */
-	protected $update_sites;
+	protected $update_sites = array();
 
 	/**
 	 * A list of discovered updates
 	 *
-	 * @var array
+	 * @var  array
 	 */
-	protected $updates;
+	protected $updates = array();
 
 	/**
 	 * Gets the reference to the current direct parent

--- a/modules/mod_tags_similar/helper.php
+++ b/modules/mod_tags_similar/helper.php
@@ -23,7 +23,7 @@ abstract class ModTagssimilarHelper
 	 *
 	 * @param   Registry  &$params  Module parameters
 	 *
-	 * @return  mixed  Results array / null
+	 * @return  array
 	 */
 	public static function getList(&$params)
 	{
@@ -35,7 +35,7 @@ abstract class ModTagssimilarHelper
 		// This module does not apply to list views in general at this point.
 		if ($option === 'com_tags' || $view === 'category' || $option === 'com_users')
 		{
-			return;
+			return array();
 		}
 
 		$db         = JFactory::getDbo();
@@ -54,7 +54,7 @@ abstract class ModTagssimilarHelper
 
 		if (!$tagsToMatch || $tagsToMatch === null)
 		{
-			return;
+			return array();
 		}
 
 		$tagCount = substr_count($tagsToMatch, ',') + 1;


### PR DESCRIPTION
### Summary of Changes

PHP 7.2 disallows the use of the `count()` function on non countable items (arrays or objects implementing the `Countable` interface).  We have places in our API where null values were being returned then pushed into a `count()` call, this PR addresses three uses found on a cursory click through a CMS install using PHP 7.2.0RC5.

### Testing Instructions

To verify:

- Install Joomla without sample data then click to the login page.  You get a countable warning coming from the `Updater.php` file by way of the plugin which checks for updates and sends an email notification triggering an update check.  This is caused by properties in the `CollectionAdapter` class not being initialized as empty arrays and therefore when no updates are found the properties are still set as null versus being array.
- After logging in, the two articles modules will give a countable warning coming from the `com_content` articles model.  This is caused by a state value not setting an appropriate default if the state value is null.
- Install Joomla with the testing sample data and navigate to the frontend "Single Contact" page.  You get a countable warning coming from the similar tags module.  This is caused by the module's helper method returning null in some conditions instead of simply returning an empty array.

Apply the patch and repeat these steps.

(If you do not reinstall before item 1, you will need to clear the update check timestamps for the `plg_system_updatenotification` plugin params and the Joomla! Core update site).

### Expected result

Data is displayed without error.

### Actual result

Errors as a result of trying to count a non-countable item.