### PR TITLE
[fix] Filtering authors by 'No user` for articles and featured managers. Correcting broken filtering by author in featured manager

### DIFF
--- a/administrator/components/com_content/models/featured.php
+++ b/administrator/components/com_content/models/featured.php
@@ -82,7 +82,7 @@ class ContentModelFeatured extends ContentModelArticles
 			$this->getState(
 				'list.select',
 				'a.id, a.title, a.alias, a.checked_out, a.checked_out_time, a.catid, a.state, a.access, a.created, a.hits,' .
-					'a.featured, a.language, a.created_by_alias, a.publish_up, a.publish_down'
+					'a.created_by, a.featured, a.language, a.created_by_alias, a.publish_up, a.publish_down'
 			)
 		);
 		$query->from('#__content AS a');
@@ -114,7 +114,7 @@ class ContentModelFeatured extends ContentModelArticles
 		// Join on voting table
 		if (JPluginHelper::isEnabled('content', 'vote'))
 		{
-			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating, 
+			$query->select('COALESCE(NULLIF(ROUND(v.rating_sum  / v.rating_count, 0), 0), 0) AS rating,
 							COALESCE(NULLIF(v.rating_count, 0), 0) as rating_count')
 				->join('LEFT', '#__content_rating AS v ON a.id = v.content_id');
 		}
@@ -177,6 +177,12 @@ class ContentModelFeatured extends ContentModelArticles
 		{
 			$type = $this->getState('filter.author_id.include', true) ? '= ' : '<>';
 			$query->where('a.created_by ' . $type . (int) $authorId);
+		}
+		elseif (is_array($authorId))
+		{
+			$authorId = ArrayHelper::toInteger($authorId);
+			$authorId = implode(',', $authorId);
+			$query->where('a.created_by IN (' . $authorId . ')');
 		}
 
 		// Filter by search in title.

--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -49,7 +49,9 @@
 			multiple="true"
 			class="multipleAuthors"
 			onchange="this.form.submit();"
-		/>
+			>
+			<option value="0">JOPTION_NO_USER</option>
+		</field>
 
 		<field
 			name="language"

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -44,7 +44,7 @@
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
 		</field>
 
-			<field
+		<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
@@ -53,7 +53,7 @@
 			class="multipleAccessLevels"
 			onchange="this.form.submit();"
 		/>
-		
+
 		<field
 			name="author_id"
 			type="author"

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -44,17 +44,7 @@
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
 		</field>
 
-		<field
-			name="author_id"
-			type="author"
-			label="COM_CONTENT_FILTER_AUTHOR"
-			description="COM_CONTENT_FILTER_AUTHOR_DESC"
-			multiple="true"
-			class="multipleAuthors"
-			onchange="this.form.submit();"
-		/>
-
-		<field
+			<field
 			name="access"
 			type="accesslevel"
 			label="JOPTION_FILTER_ACCESS"
@@ -63,6 +53,18 @@
 			class="multipleAccessLevels"
 			onchange="this.form.submit();"
 		/>
+		
+		<field
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			description="COM_CONTENT_FILTER_AUTHOR_DESC"
+			multiple="true"
+			class="multipleAuthors"
+			onchange="this.form.submit();"
+			>
+			<option value="0">JOPTION_NO_USER</option>
+		</field>
 
 		<field
 			name="language"


### PR DESCRIPTION
As title says.

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18434

### Summary of Changes
Adding the option to choose `No User` to filter by author in both managers.
ALSO: Correcting impossibility to filter by author in the Featured articles manager due to the absence of the array possibility since multiple was implemented

### Testing Instructions
Edit an article and set it in the `Publishing` tab to `No User` using the Select in `Created by` field.
![screen shot 2017-10-30 at 08 34 05](https://user-images.githubusercontent.com/869724/32159277-1935b60c-bd4d-11e7-80e3-0ac8e701ebfa.png)
![screen shot 2017-10-30 at 08 35 13](https://user-images.githubusercontent.com/869724/32159303-400b5d68-bd4d-11e7-8294-da30c57c1abe.png)

### Expected result
Ability to filter authors by `No user` in both managers.

Test before and after patch.

After patch:
![screen shot 2017-10-30 at 08 41 05](https://user-images.githubusercontent.com/869724/32159512-21e24fbc-bd4e-11e7-81cf-50b7deae9466.png)
