### PR TITLE
[ChangeItem] - the check query should return array instead of object - PHP 7.2

### DIFF
--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -196,7 +196,7 @@ abstract class ChangeItem
 
 			try
 			{
-				$rows = $this->db->loadRowList();
+				$rows = $this->db->loadRowList(0);
 			}
 			catch (\RuntimeException $e)
 			{

--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -196,7 +196,7 @@ abstract class ChangeItem
 
 			try
 			{
-				$rows = $this->db->loadObject();
+				$rows = $this->db->loadRowList();
 			}
 			catch (\RuntimeException $e)
 			{


### PR DESCRIPTION
Pull Request for Issue #18437.

### Summary of Changes
from object  `loadObject()` to array `loadRowList(0)`



### Testing Instructions

see #18437 with php 7.2
test that Database check works as before

