### PR TITLE
[fix] Frontend Filtering by author broken in modal when inserting article via xtd

### DIFF
--- a/components/com_content/models/forms/filter_articles.xml
+++ b/components/com_content/models/forms/filter_articles.xml
@@ -24,10 +24,33 @@
 			type="category"
 			label="JOPTION_FILTER_CATEGORY"
 			description="JOPTION_FILTER_CATEGORY_DESC"
+			multiple="true"
+			class="multipleCategories"
 			extension="com_content"
 			onchange="this.form.submit();"
+			published="0,1,2"
+		/>
+
+		<field
+			name="access"
+			type="accesslevel"
+			label="JOPTION_FILTER_ACCESS"
+			description="JOPTION_FILTER_ACCESS_DESC"
+			multiple="true"
+			class="multipleAccessLevels"
+			onchange="this.form.submit();"
+		/>
+
+		<field
+			name="author_id"
+			type="author"
+			label="COM_CONTENT_FILTER_AUTHOR"
+			description="COM_CONTENT_FILTER_AUTHOR_DESC"
+			multiple="true"
+			class="multipleAuthors"
+			onchange="this.form.submit();"
 			>
-			<option value="">JOPTION_SELECT_CATEGORY</option>
+			<option value="0">JOPTION_NO_USER</option>
 		</field>
 
 		<field
@@ -42,26 +65,6 @@
 			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
-		</field>
-
-		<field
-			name="access"
-			type="accesslevel"
-			label="JOPTION_FILTER_ACCESS"
-			description="JOPTION_FILTER_ACCESS_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_ACCESS</option>
-		</field>
-
-		<field
-			name="author_id"
-			type="author"
-			label="COM_CONTENT_FILTER_AUTHOR"
-			description="COM_CONTENT_FILTER_AUTHOR_DESC"
-			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_AUTHOR</option>
 		</field>
 
 		<field
@@ -80,11 +83,11 @@
 			type="tag"
 			label="JOPTION_FILTER_TAG"
 			description="JOPTION_FILTER_TAG_DESC"
+			multiple="true"
+			class="multipleTags"
 			mode="nested"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
 	</fields>
 	<fields name="list">
 		<field

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -293,6 +293,7 @@ JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
 JLIB_ERROR_INFINITE_LOOP="Infinite loop detected in JError"
 
 JOPTION_DO_NOT_USE="- None Selected -"
+JOPTION_NO_USER="- No User -"
 JOPTION_SELECT_ACCESS="- Select Access -"
 JOPTION_SELECT_AUTHOR="- Select Author -"
 JOPTION_SELECT_CATEGORY="- Select Category -"


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18442

### Summary of Changes
As the modal uses multiple, the filter_articles xml in frontend has also to use that.
Is also added here the possibility to filter by `No User` as in https://github.com/joomla/joomla-cms/pull/18440

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/18442


### Expected result
No more 500 or PHP Warning. Filtering works OK after patch.

@brianteeman

After patch
![screen shot 2017-10-30 at 11 02 22](https://user-images.githubusercontent.com/869724/32165067-d72c8e38-bd61-11e7-90e6-b2eb74f88dc3.png)
