### PR TITLE
[4.0] Minify the output html

### DIFF
--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -27,6 +27,12 @@ JHtml::_('stylesheet', 'user.css', array('version' => 'auto', 'relative' => true
 
 // Load specific language related CSS
 JHtml::_('stylesheet', 'administrator/language/' . $lang->getTag() . '/' . $lang->getTag() . '.css', array('version' => 'auto'));
+
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
 ?>
 
 <!DOCTYPE html>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -28,6 +28,12 @@ $hidden      = $app->input->get('hidemainmenu');
 $logoLg      = $this->baseurl . '/templates/' . $this->template . '/images/logo.svg';
 $logoSm      = $this->baseurl . '/templates/' . $this->template . '/images/logo-icon.svg';
 
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
+
 // Add JavaScript
 JHtml::_('bootstrap.framework');
 JHtml::_('script', 'media/vendor/flying-focus-a11y/js/flying-focus.min.js', ['version' => 'auto']);

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -45,6 +45,11 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 // @TODO sync with _variables.scss
 $this->setMetaData('theme-color', '#1c3d5c');
 
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -26,6 +26,14 @@ jimport('joomla.utilities.utility');
 class HtmlDocument extends Document
 {
 	/**
+	 * Minification switch
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $minify = false;
+
+	/**
 	 * Array of Header `<link>` tags
 	 *
 	 * @var    array
@@ -556,7 +564,7 @@ class HtmlDocument extends Document
 		parent::render();
 
 		// Minify the output if we're not in debug mode
-		if (!JDEBUG)
+		if ($this->minify)
 		{
 			return preg_replace('~>\s+<~', '><', $data);
 		}

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -555,6 +555,12 @@ class HtmlDocument extends Document
 		$data = $this->_renderTemplate();
 		parent::render();
 
+		// Minify the output if we're not in debug mode
+		if (!JDEBUG)
+		{
+			return preg_replace('~>\s+<~', '><', $data);
+		}
+
 		return $data;
 	}
 

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -19,6 +19,12 @@ JHtml::_('stylesheet', 'template.css', ['version' => 'auto', 'relative' => true]
 
 // Load optional rtl Bootstrap css and Bootstrap bugfixes
 //JHtml::_('bootstrap.loadCss', false, $this->direction);
+
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -25,6 +25,12 @@ $task     = $app->input->getCmd('task', '');
 $itemid   = $app->input->getCmd('Itemid', '');
 $sitename = $app->get('sitename');
 
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
+
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -76,6 +76,12 @@ else
 {
 	$logo = '<span class="site-title" title="' . $sitename . '">' . $sitename . '</span>';
 }
+
+// Minify the output
+if (!JDEBUG)
+{
+	$this->minify = true;
+}
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">


### PR DESCRIPTION
### Blast from the past: https://github.com/joomla/joomla-cms/pull/3413

### Summary of Changes
When **not** in debug mode then the output gets minified. The minification will **not** alter:
- content inside script tags
- content inside style tags
- content inside any tag!
Just removes the spaces, tabs, returns between tags. 

#### Why
Simple answer: less code over the wire!

Here is the proof:
- com_content/artcles without any minification, html size = **95.57KB**
<img width="2106" alt="screen shot 2017-10-30 at 16 00 27" src="https://user-images.githubusercontent.com/3889375/32175093-7defaed8-bd8c-11e7-817e-f81baa1e523f.png">

- com_content/artcles with active minification, html size = **84.79KB**
<img width="2106" alt="screen shot 2017-10-30 at 16 00 59" src="https://user-images.githubusercontent.com/3889375/32175120-9776cfda-bd8c-11e7-853d-c69b798d95bd.png">

Around 10KB less data to transmit. WIN!

### Testing Instructions
Apply patch, check the html code (in the network tab)
Enable debug, refresh page recheck the page code, size

### Documentation Changes Required
None, I think