### PR TITLE
Visible Indicators for Labels with Popover

### DIFF
--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1646,9 +1646,21 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label {
+	cursor: pointer;
+}
 .control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
+	cursor: help;
+}
+.control-label .hasPopover:after,
+.control-label .hasTooltip:after {
+	content: "E";
+	font-family: IcoMoon;
+	font-size: 0.6rem;
+	margin-left: 0.2rem;
+	color: #ababab;
 }
 .subform-repeatable-wrapper .btn-group>.btn.button {
 	min-width: 0;

--- a/administrator/templates/isis/css/template-rtl.css
+++ b/administrator/templates/isis/css/template-rtl.css
@@ -1656,9 +1656,9 @@ legend + .control-group {
 }
 .control-label .hasPopover:after,
 .control-label .hasTooltip:after {
-	content: "E";
+	content: "\e220";
 	font-family: IcoMoon;
-	font-size: 0.6rem;
+	font-size: 0.8rem;
 	margin-left: 0.2rem;
 	color: #ababab;
 }

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1646,9 +1646,21 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label {
+	cursor: pointer;
+}
 .control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
+	cursor: help;
+}
+.control-label .hasPopover:after,
+.control-label .hasTooltip:after {
+	content: "E";
+	font-family: IcoMoon;
+	font-size: 0.6rem;
+	margin-left: 0.2rem;
+	color: #ababab;
 }
 .subform-repeatable-wrapper .btn-group>.btn.button {
 	min-width: 0;

--- a/administrator/templates/isis/css/template.css
+++ b/administrator/templates/isis/css/template.css
@@ -1656,9 +1656,9 @@ legend + .control-group {
 }
 .control-label .hasPopover:after,
 .control-label .hasTooltip:after {
-	content: "E";
+	content: "\e220";
 	font-family: IcoMoon;
-	font-size: 0.6rem;
+	font-size: 0.8rem;
 	margin-left: 0.2rem;
 	color: #ababab;
 }

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -701,9 +701,9 @@ legend + .control-group {
 		cursor: help;
 
 		&:after {
-			content: "E";
+			content: "\e220";
 			font-family: IcoMoon;
-			font-size: 0.6rem;
+			font-size: 0.8rem;
 			margin-left: 0.2rem;
 			color:#ababab;
     }

--- a/media/jui/less/forms.less
+++ b/media/jui/less/forms.less
@@ -691,9 +691,23 @@ legend + .control-group {
 }
 
 /*Fix for tooltips wrong positioning*/
-.control-label .hasPopover,
-.control-label .hasTooltip {
-  display: inline-block;
+.control-label {
+
+	cursor: pointer;
+
+	.hasPopover,
+	.hasTooltip {
+		display: inline-block;
+		cursor: help;
+
+		&:after {
+			content: "E";
+			font-family: IcoMoon;
+			font-size: 0.6rem;
+			margin-left: 0.2rem;
+			color:#ababab;
+    }
+  }
 }
 
 /* Field subform repeatable */

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1691,9 +1691,21 @@ legend + .control-group {
 .form-horizontal .form-actions {
 	padding-left: 180px;
 }
+.control-label {
+	cursor: pointer;
+}
 .control-label .hasPopover,
 .control-label .hasTooltip {
 	display: inline-block;
+	cursor: help;
+}
+.control-label .hasPopover:after,
+.control-label .hasTooltip:after {
+	content: "E";
+	font-family: IcoMoon;
+	font-size: 0.6rem;
+	margin-left: 0.2rem;
+	color: #ababab;
 }
 .subform-repeatable-wrapper .btn-group>.btn.button {
 	min-width: 0;

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -362,7 +362,7 @@ a:focus {
 	box-sizing: border-box;
 	float: left;
 	margin-left: 2.127659574%;
-	*margin-left: 2.07446808464%;
+	*margin-left: 2.0744680846383%;
 }
 .row-fluid [class*="span"]:first-child {
 	margin-left: 0;
@@ -372,147 +372,147 @@ a:focus {
 }
 .row-fluid .span12 {
 	width: 99.99999999%;
-	*width: 99.9468085006%;
+	*width: 99.946808500638%;
 }
 .row-fluid .span11 {
 	width: 91.489361693%;
-	*width: 91.4361702036%;
+	*width: 91.436170203638%;
 }
 .row-fluid .span10 {
 	width: 82.978723396%;
-	*width: 82.9255319066%;
+	*width: 82.925531906638%;
 }
 .row-fluid .span9 {
 	width: 74.468085099%;
-	*width: 74.4148936096%;
+	*width: 74.414893609638%;
 }
 .row-fluid .span8 {
 	width: 65.957446802%;
-	*width: 65.9042553126%;
+	*width: 65.904255312638%;
 }
 .row-fluid .span7 {
 	width: 57.446808505%;
-	*width: 57.3936170156%;
+	*width: 57.393617015638%;
 }
 .row-fluid .span6 {
 	width: 48.936170208%;
-	*width: 48.8829787186%;
+	*width: 48.882978718638%;
 }
 .row-fluid .span5 {
 	width: 40.425531911%;
-	*width: 40.3723404216%;
+	*width: 40.372340421638%;
 }
 .row-fluid .span4 {
 	width: 31.914893614%;
-	*width: 31.8617021246%;
+	*width: 31.861702124638%;
 }
 .row-fluid .span3 {
 	width: 23.404255317%;
-	*width: 23.3510638276%;
+	*width: 23.351063827638%;
 }
 .row-fluid .span2 {
 	width: 14.89361702%;
-	*width: 14.8404255306%;
+	*width: 14.840425530638%;
 }
 .row-fluid .span1 {
 	width: 6.382978723%;
-	*width: 6.32978723364%;
+	*width: 6.3297872336383%;
 }
 .row-fluid .offset12 {
 	margin-left: 104.255319138%;
-	*margin-left: 104.148936159%;
+	*margin-left: 104.14893615928%;
 }
 .row-fluid .offset12:first-child {
 	margin-left: 102.127659564%;
-	*margin-left: 102.021276585%;
+	*margin-left: 102.02127658528%;
 }
 .row-fluid .offset11 {
 	margin-left: 95.744680841%;
-	*margin-left: 95.6382978623%;
+	*margin-left: 95.638297862277%;
 }
 .row-fluid .offset11:first-child {
 	margin-left: 93.617021267%;
-	*margin-left: 93.5106382883%;
+	*margin-left: 93.510638288277%;
 }
 .row-fluid .offset10 {
 	margin-left: 87.234042544%;
-	*margin-left: 87.1276595653%;
+	*margin-left: 87.127659565277%;
 }
 .row-fluid .offset10:first-child {
 	margin-left: 85.10638297%;
-	*margin-left: 84.9999999913%;
+	*margin-left: 84.999999991277%;
 }
 .row-fluid .offset9 {
 	margin-left: 78.723404247%;
-	*margin-left: 78.6170212683%;
+	*margin-left: 78.617021268277%;
 }
 .row-fluid .offset9:first-child {
 	margin-left: 76.595744673%;
-	*margin-left: 76.4893616943%;
+	*margin-left: 76.489361694277%;
 }
 .row-fluid .offset8 {
 	margin-left: 70.21276595%;
-	*margin-left: 70.1063829713%;
+	*margin-left: 70.106382971277%;
 }
 .row-fluid .offset8:first-child {
 	margin-left: 68.085106376%;
-	*margin-left: 67.9787233973%;
+	*margin-left: 67.978723397277%;
 }
 .row-fluid .offset7 {
 	margin-left: 61.702127653%;
-	*margin-left: 61.5957446743%;
+	*margin-left: 61.595744674277%;
 }
 .row-fluid .offset7:first-child {
 	margin-left: 59.574468079%;
-	*margin-left: 59.4680851003%;
+	*margin-left: 59.468085100277%;
 }
 .row-fluid .offset6 {
 	margin-left: 53.191489356%;
-	*margin-left: 53.0851063773%;
+	*margin-left: 53.085106377277%;
 }
 .row-fluid .offset6:first-child {
 	margin-left: 51.063829782%;
-	*margin-left: 50.9574468033%;
+	*margin-left: 50.957446803277%;
 }
 .row-fluid .offset5 {
 	margin-left: 44.680851059%;
-	*margin-left: 44.5744680803%;
+	*margin-left: 44.574468080277%;
 }
 .row-fluid .offset5:first-child {
 	margin-left: 42.553191485%;
-	*margin-left: 42.4468085063%;
+	*margin-left: 42.446808506277%;
 }
 .row-fluid .offset4 {
 	margin-left: 36.170212762%;
-	*margin-left: 36.0638297833%;
+	*margin-left: 36.063829783277%;
 }
 .row-fluid .offset4:first-child {
 	margin-left: 34.042553188%;
-	*margin-left: 33.9361702093%;
+	*margin-left: 33.936170209277%;
 }
 .row-fluid .offset3 {
 	margin-left: 27.659574465%;
-	*margin-left: 27.5531914863%;
+	*margin-left: 27.553191486277%;
 }
 .row-fluid .offset3:first-child {
 	margin-left: 25.531914891%;
-	*margin-left: 25.4255319123%;
+	*margin-left: 25.425531912277%;
 }
 .row-fluid .offset2 {
 	margin-left: 19.148936168%;
-	*margin-left: 19.0425531893%;
+	*margin-left: 19.042553189277%;
 }
 .row-fluid .offset2:first-child {
 	margin-left: 17.021276594%;
-	*margin-left: 16.9148936153%;
+	*margin-left: 16.914893615277%;
 }
 .row-fluid .offset1 {
 	margin-left: 10.638297871%;
-	*margin-left: 10.5319148923%;
+	*margin-left: 10.531914892277%;
 }
 .row-fluid .offset1:first-child {
 	margin-left: 8.510638297%;
-	*margin-left: 8.40425531828%;
+	*margin-left: 8.4042553182766%;
 }
 [class*="span"].hide,
 .row-fluid [class*="span"].hide {
@@ -5071,7 +5071,7 @@ a.badge:focus {
 		box-sizing: border-box;
 		float: left;
 		margin-left: 2.127659574%;
-		*margin-left: 2.07446808464%;
+		*margin-left: 2.0744680846383%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
@@ -5081,147 +5081,147 @@ a.badge:focus {
 	}
 	.row-fluid .span12 {
 		width: 99.99999999%;
-		*width: 99.9468085006%;
+		*width: 99.946808500638%;
 	}
 	.row-fluid .span11 {
 		width: 91.489361693%;
-		*width: 91.4361702036%;
+		*width: 91.436170203638%;
 	}
 	.row-fluid .span10 {
 		width: 82.978723396%;
-		*width: 82.9255319066%;
+		*width: 82.925531906638%;
 	}
 	.row-fluid .span9 {
 		width: 74.468085099%;
-		*width: 74.4148936096%;
+		*width: 74.414893609638%;
 	}
 	.row-fluid .span8 {
 		width: 65.957446802%;
-		*width: 65.9042553126%;
+		*width: 65.904255312638%;
 	}
 	.row-fluid .span7 {
 		width: 57.446808505%;
-		*width: 57.3936170156%;
+		*width: 57.393617015638%;
 	}
 	.row-fluid .span6 {
 		width: 48.936170208%;
-		*width: 48.8829787186%;
+		*width: 48.882978718638%;
 	}
 	.row-fluid .span5 {
 		width: 40.425531911%;
-		*width: 40.3723404216%;
+		*width: 40.372340421638%;
 	}
 	.row-fluid .span4 {
 		width: 31.914893614%;
-		*width: 31.8617021246%;
+		*width: 31.861702124638%;
 	}
 	.row-fluid .span3 {
 		width: 23.404255317%;
-		*width: 23.3510638276%;
+		*width: 23.351063827638%;
 	}
 	.row-fluid .span2 {
 		width: 14.89361702%;
-		*width: 14.8404255306%;
+		*width: 14.840425530638%;
 	}
 	.row-fluid .span1 {
 		width: 6.382978723%;
-		*width: 6.32978723364%;
+		*width: 6.3297872336383%;
 	}
 	.row-fluid .offset12 {
 		margin-left: 104.255319138%;
-		*margin-left: 104.148936159%;
+		*margin-left: 104.14893615928%;
 	}
 	.row-fluid .offset12:first-child {
 		margin-left: 102.127659564%;
-		*margin-left: 102.021276585%;
+		*margin-left: 102.02127658528%;
 	}
 	.row-fluid .offset11 {
 		margin-left: 95.744680841%;
-		*margin-left: 95.6382978623%;
+		*margin-left: 95.638297862277%;
 	}
 	.row-fluid .offset11:first-child {
 		margin-left: 93.617021267%;
-		*margin-left: 93.5106382883%;
+		*margin-left: 93.510638288277%;
 	}
 	.row-fluid .offset10 {
 		margin-left: 87.234042544%;
-		*margin-left: 87.1276595653%;
+		*margin-left: 87.127659565277%;
 	}
 	.row-fluid .offset10:first-child {
 		margin-left: 85.10638297%;
-		*margin-left: 84.9999999913%;
+		*margin-left: 84.999999991277%;
 	}
 	.row-fluid .offset9 {
 		margin-left: 78.723404247%;
-		*margin-left: 78.6170212683%;
+		*margin-left: 78.617021268277%;
 	}
 	.row-fluid .offset9:first-child {
 		margin-left: 76.595744673%;
-		*margin-left: 76.4893616943%;
+		*margin-left: 76.489361694277%;
 	}
 	.row-fluid .offset8 {
 		margin-left: 70.21276595%;
-		*margin-left: 70.1063829713%;
+		*margin-left: 70.106382971277%;
 	}
 	.row-fluid .offset8:first-child {
 		margin-left: 68.085106376%;
-		*margin-left: 67.9787233973%;
+		*margin-left: 67.978723397277%;
 	}
 	.row-fluid .offset7 {
 		margin-left: 61.702127653%;
-		*margin-left: 61.5957446743%;
+		*margin-left: 61.595744674277%;
 	}
 	.row-fluid .offset7:first-child {
 		margin-left: 59.574468079%;
-		*margin-left: 59.4680851003%;
+		*margin-left: 59.468085100277%;
 	}
 	.row-fluid .offset6 {
 		margin-left: 53.191489356%;
-		*margin-left: 53.0851063773%;
+		*margin-left: 53.085106377277%;
 	}
 	.row-fluid .offset6:first-child {
 		margin-left: 51.063829782%;
-		*margin-left: 50.9574468033%;
+		*margin-left: 50.957446803277%;
 	}
 	.row-fluid .offset5 {
 		margin-left: 44.680851059%;
-		*margin-left: 44.5744680803%;
+		*margin-left: 44.574468080277%;
 	}
 	.row-fluid .offset5:first-child {
 		margin-left: 42.553191485%;
-		*margin-left: 42.4468085063%;
+		*margin-left: 42.446808506277%;
 	}
 	.row-fluid .offset4 {
 		margin-left: 36.170212762%;
-		*margin-left: 36.0638297833%;
+		*margin-left: 36.063829783277%;
 	}
 	.row-fluid .offset4:first-child {
 		margin-left: 34.042553188%;
-		*margin-left: 33.9361702093%;
+		*margin-left: 33.936170209277%;
 	}
 	.row-fluid .offset3 {
 		margin-left: 27.659574465%;
-		*margin-left: 27.5531914863%;
+		*margin-left: 27.553191486277%;
 	}
 	.row-fluid .offset3:first-child {
 		margin-left: 25.531914891%;
-		*margin-left: 25.4255319123%;
+		*margin-left: 25.425531912277%;
 	}
 	.row-fluid .offset2 {
 		margin-left: 19.148936168%;
-		*margin-left: 19.0425531893%;
+		*margin-left: 19.042553189277%;
 	}
 	.row-fluid .offset2:first-child {
 		margin-left: 17.021276594%;
-		*margin-left: 16.9148936153%;
+		*margin-left: 16.914893615277%;
 	}
 	.row-fluid .offset1 {
 		margin-left: 10.638297871%;
-		*margin-left: 10.5319148923%;
+		*margin-left: 10.531914892277%;
 	}
 	.row-fluid .offset1:first-child {
 		margin-left: 8.510638297%;
-		*margin-left: 8.40425531828%;
+		*margin-left: 8.4042553182766%;
 	}
 	input,
 	textarea,
@@ -5411,7 +5411,7 @@ a.badge:focus {
 		box-sizing: border-box;
 		float: left;
 		margin-left: 2.127659574%;
-		*margin-left: 2.07446808464%;
+		*margin-left: 2.0744680846383%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
@@ -5421,147 +5421,147 @@ a.badge:focus {
 	}
 	.row-fluid .span12 {
 		width: 99.99999999%;
-		*width: 99.9468085006%;
+		*width: 99.946808500638%;
 	}
 	.row-fluid .span11 {
 		width: 91.489361693%;
-		*width: 91.4361702036%;
+		*width: 91.436170203638%;
 	}
 	.row-fluid .span10 {
 		width: 82.978723396%;
-		*width: 82.9255319066%;
+		*width: 82.925531906638%;
 	}
 	.row-fluid .span9 {
 		width: 74.468085099%;
-		*width: 74.4148936096%;
+		*width: 74.414893609638%;
 	}
 	.row-fluid .span8 {
 		width: 65.957446802%;
-		*width: 65.9042553126%;
+		*width: 65.904255312638%;
 	}
 	.row-fluid .span7 {
 		width: 57.446808505%;
-		*width: 57.3936170156%;
+		*width: 57.393617015638%;
 	}
 	.row-fluid .span6 {
 		width: 48.936170208%;
-		*width: 48.8829787186%;
+		*width: 48.882978718638%;
 	}
 	.row-fluid .span5 {
 		width: 40.425531911%;
-		*width: 40.3723404216%;
+		*width: 40.372340421638%;
 	}
 	.row-fluid .span4 {
 		width: 31.914893614%;
-		*width: 31.8617021246%;
+		*width: 31.861702124638%;
 	}
 	.row-fluid .span3 {
 		width: 23.404255317%;
-		*width: 23.3510638276%;
+		*width: 23.351063827638%;
 	}
 	.row-fluid .span2 {
 		width: 14.89361702%;
-		*width: 14.8404255306%;
+		*width: 14.840425530638%;
 	}
 	.row-fluid .span1 {
 		width: 6.382978723%;
-		*width: 6.32978723364%;
+		*width: 6.3297872336383%;
 	}
 	.row-fluid .offset12 {
 		margin-left: 104.255319138%;
-		*margin-left: 104.148936159%;
+		*margin-left: 104.14893615928%;
 	}
 	.row-fluid .offset12:first-child {
 		margin-left: 102.127659564%;
-		*margin-left: 102.021276585%;
+		*margin-left: 102.02127658528%;
 	}
 	.row-fluid .offset11 {
 		margin-left: 95.744680841%;
-		*margin-left: 95.6382978623%;
+		*margin-left: 95.638297862277%;
 	}
 	.row-fluid .offset11:first-child {
 		margin-left: 93.617021267%;
-		*margin-left: 93.5106382883%;
+		*margin-left: 93.510638288277%;
 	}
 	.row-fluid .offset10 {
 		margin-left: 87.234042544%;
-		*margin-left: 87.1276595653%;
+		*margin-left: 87.127659565277%;
 	}
 	.row-fluid .offset10:first-child {
 		margin-left: 85.10638297%;
-		*margin-left: 84.9999999913%;
+		*margin-left: 84.999999991277%;
 	}
 	.row-fluid .offset9 {
 		margin-left: 78.723404247%;
-		*margin-left: 78.6170212683%;
+		*margin-left: 78.617021268277%;
 	}
 	.row-fluid .offset9:first-child {
 		margin-left: 76.595744673%;
-		*margin-left: 76.4893616943%;
+		*margin-left: 76.489361694277%;
 	}
 	.row-fluid .offset8 {
 		margin-left: 70.21276595%;
-		*margin-left: 70.1063829713%;
+		*margin-left: 70.106382971277%;
 	}
 	.row-fluid .offset8:first-child {
 		margin-left: 68.085106376%;
-		*margin-left: 67.9787233973%;
+		*margin-left: 67.978723397277%;
 	}
 	.row-fluid .offset7 {
 		margin-left: 61.702127653%;
-		*margin-left: 61.5957446743%;
+		*margin-left: 61.595744674277%;
 	}
 	.row-fluid .offset7:first-child {
 		margin-left: 59.574468079%;
-		*margin-left: 59.4680851003%;
+		*margin-left: 59.468085100277%;
 	}
 	.row-fluid .offset6 {
 		margin-left: 53.191489356%;
-		*margin-left: 53.0851063773%;
+		*margin-left: 53.085106377277%;
 	}
 	.row-fluid .offset6:first-child {
 		margin-left: 51.063829782%;
-		*margin-left: 50.9574468033%;
+		*margin-left: 50.957446803277%;
 	}
 	.row-fluid .offset5 {
 		margin-left: 44.680851059%;
-		*margin-left: 44.5744680803%;
+		*margin-left: 44.574468080277%;
 	}
 	.row-fluid .offset5:first-child {
 		margin-left: 42.553191485%;
-		*margin-left: 42.4468085063%;
+		*margin-left: 42.446808506277%;
 	}
 	.row-fluid .offset4 {
 		margin-left: 36.170212762%;
-		*margin-left: 36.0638297833%;
+		*margin-left: 36.063829783277%;
 	}
 	.row-fluid .offset4:first-child {
 		margin-left: 34.042553188%;
-		*margin-left: 33.9361702093%;
+		*margin-left: 33.936170209277%;
 	}
 	.row-fluid .offset3 {
 		margin-left: 27.659574465%;
-		*margin-left: 27.5531914863%;
+		*margin-left: 27.553191486277%;
 	}
 	.row-fluid .offset3:first-child {
 		margin-left: 25.531914891%;
-		*margin-left: 25.4255319123%;
+		*margin-left: 25.425531912277%;
 	}
 	.row-fluid .offset2 {
 		margin-left: 19.148936168%;
-		*margin-left: 19.0425531893%;
+		*margin-left: 19.042553189277%;
 	}
 	.row-fluid .offset2:first-child {
 		margin-left: 17.021276594%;
-		*margin-left: 16.9148936153%;
+		*margin-left: 16.914893615277%;
 	}
 	.row-fluid .offset1 {
 		margin-left: 10.638297871%;
-		*margin-left: 10.5319148923%;
+		*margin-left: 10.531914892277%;
 	}
 	.row-fluid .offset1:first-child {
 		margin-left: 8.510638297%;
-		*margin-left: 8.40425531828%;
+		*margin-left: 8.4042553182766%;
 	}
 	input,
 	textarea,

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -362,7 +362,7 @@ a:focus {
 	box-sizing: border-box;
 	float: left;
 	margin-left: 2.127659574%;
-	*margin-left: 2.0744680846383%;
+	*margin-left: 2.07446808464%;
 }
 .row-fluid [class*="span"]:first-child {
 	margin-left: 0;
@@ -372,147 +372,147 @@ a:focus {
 }
 .row-fluid .span12 {
 	width: 99.99999999%;
-	*width: 99.946808500638%;
+	*width: 99.9468085006%;
 }
 .row-fluid .span11 {
 	width: 91.489361693%;
-	*width: 91.436170203638%;
+	*width: 91.4361702036%;
 }
 .row-fluid .span10 {
 	width: 82.978723396%;
-	*width: 82.925531906638%;
+	*width: 82.9255319066%;
 }
 .row-fluid .span9 {
 	width: 74.468085099%;
-	*width: 74.414893609638%;
+	*width: 74.4148936096%;
 }
 .row-fluid .span8 {
 	width: 65.957446802%;
-	*width: 65.904255312638%;
+	*width: 65.9042553126%;
 }
 .row-fluid .span7 {
 	width: 57.446808505%;
-	*width: 57.393617015638%;
+	*width: 57.3936170156%;
 }
 .row-fluid .span6 {
 	width: 48.936170208%;
-	*width: 48.882978718638%;
+	*width: 48.8829787186%;
 }
 .row-fluid .span5 {
 	width: 40.425531911%;
-	*width: 40.372340421638%;
+	*width: 40.3723404216%;
 }
 .row-fluid .span4 {
 	width: 31.914893614%;
-	*width: 31.861702124638%;
+	*width: 31.8617021246%;
 }
 .row-fluid .span3 {
 	width: 23.404255317%;
-	*width: 23.351063827638%;
+	*width: 23.3510638276%;
 }
 .row-fluid .span2 {
 	width: 14.89361702%;
-	*width: 14.840425530638%;
+	*width: 14.8404255306%;
 }
 .row-fluid .span1 {
 	width: 6.382978723%;
-	*width: 6.3297872336383%;
+	*width: 6.32978723364%;
 }
 .row-fluid .offset12 {
 	margin-left: 104.255319138%;
-	*margin-left: 104.14893615928%;
+	*margin-left: 104.148936159%;
 }
 .row-fluid .offset12:first-child {
 	margin-left: 102.127659564%;
-	*margin-left: 102.02127658528%;
+	*margin-left: 102.021276585%;
 }
 .row-fluid .offset11 {
 	margin-left: 95.744680841%;
-	*margin-left: 95.638297862277%;
+	*margin-left: 95.6382978623%;
 }
 .row-fluid .offset11:first-child {
 	margin-left: 93.617021267%;
-	*margin-left: 93.510638288277%;
+	*margin-left: 93.5106382883%;
 }
 .row-fluid .offset10 {
 	margin-left: 87.234042544%;
-	*margin-left: 87.127659565277%;
+	*margin-left: 87.1276595653%;
 }
 .row-fluid .offset10:first-child {
 	margin-left: 85.10638297%;
-	*margin-left: 84.999999991277%;
+	*margin-left: 84.9999999913%;
 }
 .row-fluid .offset9 {
 	margin-left: 78.723404247%;
-	*margin-left: 78.617021268277%;
+	*margin-left: 78.6170212683%;
 }
 .row-fluid .offset9:first-child {
 	margin-left: 76.595744673%;
-	*margin-left: 76.489361694277%;
+	*margin-left: 76.4893616943%;
 }
 .row-fluid .offset8 {
 	margin-left: 70.21276595%;
-	*margin-left: 70.106382971277%;
+	*margin-left: 70.1063829713%;
 }
 .row-fluid .offset8:first-child {
 	margin-left: 68.085106376%;
-	*margin-left: 67.978723397277%;
+	*margin-left: 67.9787233973%;
 }
 .row-fluid .offset7 {
 	margin-left: 61.702127653%;
-	*margin-left: 61.595744674277%;
+	*margin-left: 61.5957446743%;
 }
 .row-fluid .offset7:first-child {
 	margin-left: 59.574468079%;
-	*margin-left: 59.468085100277%;
+	*margin-left: 59.4680851003%;
 }
 .row-fluid .offset6 {
 	margin-left: 53.191489356%;
-	*margin-left: 53.085106377277%;
+	*margin-left: 53.0851063773%;
 }
 .row-fluid .offset6:first-child {
 	margin-left: 51.063829782%;
-	*margin-left: 50.957446803277%;
+	*margin-left: 50.9574468033%;
 }
 .row-fluid .offset5 {
 	margin-left: 44.680851059%;
-	*margin-left: 44.574468080277%;
+	*margin-left: 44.5744680803%;
 }
 .row-fluid .offset5:first-child {
 	margin-left: 42.553191485%;
-	*margin-left: 42.446808506277%;
+	*margin-left: 42.4468085063%;
 }
 .row-fluid .offset4 {
 	margin-left: 36.170212762%;
-	*margin-left: 36.063829783277%;
+	*margin-left: 36.0638297833%;
 }
 .row-fluid .offset4:first-child {
 	margin-left: 34.042553188%;
-	*margin-left: 33.936170209277%;
+	*margin-left: 33.9361702093%;
 }
 .row-fluid .offset3 {
 	margin-left: 27.659574465%;
-	*margin-left: 27.553191486277%;
+	*margin-left: 27.5531914863%;
 }
 .row-fluid .offset3:first-child {
 	margin-left: 25.531914891%;
-	*margin-left: 25.425531912277%;
+	*margin-left: 25.4255319123%;
 }
 .row-fluid .offset2 {
 	margin-left: 19.148936168%;
-	*margin-left: 19.042553189277%;
+	*margin-left: 19.0425531893%;
 }
 .row-fluid .offset2:first-child {
 	margin-left: 17.021276594%;
-	*margin-left: 16.914893615277%;
+	*margin-left: 16.9148936153%;
 }
 .row-fluid .offset1 {
 	margin-left: 10.638297871%;
-	*margin-left: 10.531914892277%;
+	*margin-left: 10.5319148923%;
 }
 .row-fluid .offset1:first-child {
 	margin-left: 8.510638297%;
-	*margin-left: 8.4042553182766%;
+	*margin-left: 8.40425531828%;
 }
 [class*="span"].hide,
 .row-fluid [class*="span"].hide {
@@ -5071,7 +5071,7 @@ a.badge:focus {
 		box-sizing: border-box;
 		float: left;
 		margin-left: 2.127659574%;
-		*margin-left: 2.0744680846383%;
+		*margin-left: 2.07446808464%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
@@ -5081,147 +5081,147 @@ a.badge:focus {
 	}
 	.row-fluid .span12 {
 		width: 99.99999999%;
-		*width: 99.946808500638%;
+		*width: 99.9468085006%;
 	}
 	.row-fluid .span11 {
 		width: 91.489361693%;
-		*width: 91.436170203638%;
+		*width: 91.4361702036%;
 	}
 	.row-fluid .span10 {
 		width: 82.978723396%;
-		*width: 82.925531906638%;
+		*width: 82.9255319066%;
 	}
 	.row-fluid .span9 {
 		width: 74.468085099%;
-		*width: 74.414893609638%;
+		*width: 74.4148936096%;
 	}
 	.row-fluid .span8 {
 		width: 65.957446802%;
-		*width: 65.904255312638%;
+		*width: 65.9042553126%;
 	}
 	.row-fluid .span7 {
 		width: 57.446808505%;
-		*width: 57.393617015638%;
+		*width: 57.3936170156%;
 	}
 	.row-fluid .span6 {
 		width: 48.936170208%;
-		*width: 48.882978718638%;
+		*width: 48.8829787186%;
 	}
 	.row-fluid .span5 {
 		width: 40.425531911%;
-		*width: 40.372340421638%;
+		*width: 40.3723404216%;
 	}
 	.row-fluid .span4 {
 		width: 31.914893614%;
-		*width: 31.861702124638%;
+		*width: 31.8617021246%;
 	}
 	.row-fluid .span3 {
 		width: 23.404255317%;
-		*width: 23.351063827638%;
+		*width: 23.3510638276%;
 	}
 	.row-fluid .span2 {
 		width: 14.89361702%;
-		*width: 14.840425530638%;
+		*width: 14.8404255306%;
 	}
 	.row-fluid .span1 {
 		width: 6.382978723%;
-		*width: 6.3297872336383%;
+		*width: 6.32978723364%;
 	}
 	.row-fluid .offset12 {
 		margin-left: 104.255319138%;
-		*margin-left: 104.14893615928%;
+		*margin-left: 104.148936159%;
 	}
 	.row-fluid .offset12:first-child {
 		margin-left: 102.127659564%;
-		*margin-left: 102.02127658528%;
+		*margin-left: 102.021276585%;
 	}
 	.row-fluid .offset11 {
 		margin-left: 95.744680841%;
-		*margin-left: 95.638297862277%;
+		*margin-left: 95.6382978623%;
 	}
 	.row-fluid .offset11:first-child {
 		margin-left: 93.617021267%;
-		*margin-left: 93.510638288277%;
+		*margin-left: 93.5106382883%;
 	}
 	.row-fluid .offset10 {
 		margin-left: 87.234042544%;
-		*margin-left: 87.127659565277%;
+		*margin-left: 87.1276595653%;
 	}
 	.row-fluid .offset10:first-child {
 		margin-left: 85.10638297%;
-		*margin-left: 84.999999991277%;
+		*margin-left: 84.9999999913%;
 	}
 	.row-fluid .offset9 {
 		margin-left: 78.723404247%;
-		*margin-left: 78.617021268277%;
+		*margin-left: 78.6170212683%;
 	}
 	.row-fluid .offset9:first-child {
 		margin-left: 76.595744673%;
-		*margin-left: 76.489361694277%;
+		*margin-left: 76.4893616943%;
 	}
 	.row-fluid .offset8 {
 		margin-left: 70.21276595%;
-		*margin-left: 70.106382971277%;
+		*margin-left: 70.1063829713%;
 	}
 	.row-fluid .offset8:first-child {
 		margin-left: 68.085106376%;
-		*margin-left: 67.978723397277%;
+		*margin-left: 67.9787233973%;
 	}
 	.row-fluid .offset7 {
 		margin-left: 61.702127653%;
-		*margin-left: 61.595744674277%;
+		*margin-left: 61.5957446743%;
 	}
 	.row-fluid .offset7:first-child {
 		margin-left: 59.574468079%;
-		*margin-left: 59.468085100277%;
+		*margin-left: 59.4680851003%;
 	}
 	.row-fluid .offset6 {
 		margin-left: 53.191489356%;
-		*margin-left: 53.085106377277%;
+		*margin-left: 53.0851063773%;
 	}
 	.row-fluid .offset6:first-child {
 		margin-left: 51.063829782%;
-		*margin-left: 50.957446803277%;
+		*margin-left: 50.9574468033%;
 	}
 	.row-fluid .offset5 {
 		margin-left: 44.680851059%;
-		*margin-left: 44.574468080277%;
+		*margin-left: 44.5744680803%;
 	}
 	.row-fluid .offset5:first-child {
 		margin-left: 42.553191485%;
-		*margin-left: 42.446808506277%;
+		*margin-left: 42.4468085063%;
 	}
 	.row-fluid .offset4 {
 		margin-left: 36.170212762%;
-		*margin-left: 36.063829783277%;
+		*margin-left: 36.0638297833%;
 	}
 	.row-fluid .offset4:first-child {
 		margin-left: 34.042553188%;
-		*margin-left: 33.936170209277%;
+		*margin-left: 33.9361702093%;
 	}
 	.row-fluid .offset3 {
 		margin-left: 27.659574465%;
-		*margin-left: 27.553191486277%;
+		*margin-left: 27.5531914863%;
 	}
 	.row-fluid .offset3:first-child {
 		margin-left: 25.531914891%;
-		*margin-left: 25.425531912277%;
+		*margin-left: 25.4255319123%;
 	}
 	.row-fluid .offset2 {
 		margin-left: 19.148936168%;
-		*margin-left: 19.042553189277%;
+		*margin-left: 19.0425531893%;
 	}
 	.row-fluid .offset2:first-child {
 		margin-left: 17.021276594%;
-		*margin-left: 16.914893615277%;
+		*margin-left: 16.9148936153%;
 	}
 	.row-fluid .offset1 {
 		margin-left: 10.638297871%;
-		*margin-left: 10.531914892277%;
+		*margin-left: 10.5319148923%;
 	}
 	.row-fluid .offset1:first-child {
 		margin-left: 8.510638297%;
-		*margin-left: 8.4042553182766%;
+		*margin-left: 8.40425531828%;
 	}
 	input,
 	textarea,
@@ -5411,7 +5411,7 @@ a.badge:focus {
 		box-sizing: border-box;
 		float: left;
 		margin-left: 2.127659574%;
-		*margin-left: 2.0744680846383%;
+		*margin-left: 2.07446808464%;
 	}
 	.row-fluid [class*="span"]:first-child {
 		margin-left: 0;
@@ -5421,147 +5421,147 @@ a.badge:focus {
 	}
 	.row-fluid .span12 {
 		width: 99.99999999%;
-		*width: 99.946808500638%;
+		*width: 99.9468085006%;
 	}
 	.row-fluid .span11 {
 		width: 91.489361693%;
-		*width: 91.436170203638%;
+		*width: 91.4361702036%;
 	}
 	.row-fluid .span10 {
 		width: 82.978723396%;
-		*width: 82.925531906638%;
+		*width: 82.9255319066%;
 	}
 	.row-fluid .span9 {
 		width: 74.468085099%;
-		*width: 74.414893609638%;
+		*width: 74.4148936096%;
 	}
 	.row-fluid .span8 {
 		width: 65.957446802%;
-		*width: 65.904255312638%;
+		*width: 65.9042553126%;
 	}
 	.row-fluid .span7 {
 		width: 57.446808505%;
-		*width: 57.393617015638%;
+		*width: 57.3936170156%;
 	}
 	.row-fluid .span6 {
 		width: 48.936170208%;
-		*width: 48.882978718638%;
+		*width: 48.8829787186%;
 	}
 	.row-fluid .span5 {
 		width: 40.425531911%;
-		*width: 40.372340421638%;
+		*width: 40.3723404216%;
 	}
 	.row-fluid .span4 {
 		width: 31.914893614%;
-		*width: 31.861702124638%;
+		*width: 31.8617021246%;
 	}
 	.row-fluid .span3 {
 		width: 23.404255317%;
-		*width: 23.351063827638%;
+		*width: 23.3510638276%;
 	}
 	.row-fluid .span2 {
 		width: 14.89361702%;
-		*width: 14.840425530638%;
+		*width: 14.8404255306%;
 	}
 	.row-fluid .span1 {
 		width: 6.382978723%;
-		*width: 6.3297872336383%;
+		*width: 6.32978723364%;
 	}
 	.row-fluid .offset12 {
 		margin-left: 104.255319138%;
-		*margin-left: 104.14893615928%;
+		*margin-left: 104.148936159%;
 	}
 	.row-fluid .offset12:first-child {
 		margin-left: 102.127659564%;
-		*margin-left: 102.02127658528%;
+		*margin-left: 102.021276585%;
 	}
 	.row-fluid .offset11 {
 		margin-left: 95.744680841%;
-		*margin-left: 95.638297862277%;
+		*margin-left: 95.6382978623%;
 	}
 	.row-fluid .offset11:first-child {
 		margin-left: 93.617021267%;
-		*margin-left: 93.510638288277%;
+		*margin-left: 93.5106382883%;
 	}
 	.row-fluid .offset10 {
 		margin-left: 87.234042544%;
-		*margin-left: 87.127659565277%;
+		*margin-left: 87.1276595653%;
 	}
 	.row-fluid .offset10:first-child {
 		margin-left: 85.10638297%;
-		*margin-left: 84.999999991277%;
+		*margin-left: 84.9999999913%;
 	}
 	.row-fluid .offset9 {
 		margin-left: 78.723404247%;
-		*margin-left: 78.617021268277%;
+		*margin-left: 78.6170212683%;
 	}
 	.row-fluid .offset9:first-child {
 		margin-left: 76.595744673%;
-		*margin-left: 76.489361694277%;
+		*margin-left: 76.4893616943%;
 	}
 	.row-fluid .offset8 {
 		margin-left: 70.21276595%;
-		*margin-left: 70.106382971277%;
+		*margin-left: 70.1063829713%;
 	}
 	.row-fluid .offset8:first-child {
 		margin-left: 68.085106376%;
-		*margin-left: 67.978723397277%;
+		*margin-left: 67.9787233973%;
 	}
 	.row-fluid .offset7 {
 		margin-left: 61.702127653%;
-		*margin-left: 61.595744674277%;
+		*margin-left: 61.5957446743%;
 	}
 	.row-fluid .offset7:first-child {
 		margin-left: 59.574468079%;
-		*margin-left: 59.468085100277%;
+		*margin-left: 59.4680851003%;
 	}
 	.row-fluid .offset6 {
 		margin-left: 53.191489356%;
-		*margin-left: 53.085106377277%;
+		*margin-left: 53.0851063773%;
 	}
 	.row-fluid .offset6:first-child {
 		margin-left: 51.063829782%;
-		*margin-left: 50.957446803277%;
+		*margin-left: 50.9574468033%;
 	}
 	.row-fluid .offset5 {
 		margin-left: 44.680851059%;
-		*margin-left: 44.574468080277%;
+		*margin-left: 44.5744680803%;
 	}
 	.row-fluid .offset5:first-child {
 		margin-left: 42.553191485%;
-		*margin-left: 42.446808506277%;
+		*margin-left: 42.4468085063%;
 	}
 	.row-fluid .offset4 {
 		margin-left: 36.170212762%;
-		*margin-left: 36.063829783277%;
+		*margin-left: 36.0638297833%;
 	}
 	.row-fluid .offset4:first-child {
 		margin-left: 34.042553188%;
-		*margin-left: 33.936170209277%;
+		*margin-left: 33.9361702093%;
 	}
 	.row-fluid .offset3 {
 		margin-left: 27.659574465%;
-		*margin-left: 27.553191486277%;
+		*margin-left: 27.5531914863%;
 	}
 	.row-fluid .offset3:first-child {
 		margin-left: 25.531914891%;
-		*margin-left: 25.425531912277%;
+		*margin-left: 25.4255319123%;
 	}
 	.row-fluid .offset2 {
 		margin-left: 19.148936168%;
-		*margin-left: 19.042553189277%;
+		*margin-left: 19.0425531893%;
 	}
 	.row-fluid .offset2:first-child {
 		margin-left: 17.021276594%;
-		*margin-left: 16.914893615277%;
+		*margin-left: 16.9148936153%;
 	}
 	.row-fluid .offset1 {
 		margin-left: 10.638297871%;
-		*margin-left: 10.531914892277%;
+		*margin-left: 10.5319148923%;
 	}
 	.row-fluid .offset1:first-child {
 		margin-left: 8.510638297%;
-		*margin-left: 8.4042553182766%;
+		*margin-left: 8.40425531828%;
 	}
 	input,
 	textarea,

--- a/templates/protostar/css/template.css
+++ b/templates/protostar/css/template.css
@@ -1701,9 +1701,9 @@ legend + .control-group {
 }
 .control-label .hasPopover:after,
 .control-label .hasTooltip:after {
-	content: "E";
+	content: "\e220";
 	font-family: IcoMoon;
-	font-size: 0.6rem;
+	font-size: 0.8rem;
 	margin-left: 0.2rem;
 	color: #ababab;
 }


### PR DESCRIPTION
This PR gives a visible indicator to the labels that have a popover.
Also it removes the "hand" cursor from labels that don't have a popover because this causes a confusion if the popover is just not working or if there is no help text available.

### Summary of Changes
Isis and Protostar:
Remove Hand Cursor from labels
Add Pointer Cursor to labels
Add help cursor to labels with popover
Add help icon to labels with popover

### Testing Instructions
Just see if it looks ok for you. 
I actually wonder why this has not been made yet, if there is a reason for it, please just close the PR.

### Expected result
Labels that have a help text available will appear like that:
<img width="438" alt="grafik" src="https://user-images.githubusercontent.com/828371/32202120-d9ca2b40-bdda-11e7-84bf-64b77af948f5.png">

<img width="339" alt="grafik" src="https://user-images.githubusercontent.com/828371/32202253-ae5e8720-bddb-11e7-80cd-edce8b7d459c.png">


### Documentation Changes Required
No
