### PR TITLE
Searchtools css on smaller screens

### DIFF
--- a/media/jui/css/jquery.searchtools.css
+++ b/media/jui/css/jquery.searchtools.css
@@ -89,6 +89,5 @@ html[dir=rtl] .js-stools .chzn-container {
 	.js-stools .js-stools-container-list {
 		float: none;
 		display: block;
-		margin-top: 10px;
 	}
 }


### PR DESCRIPTION
The display of the modal for select author in the admin is broken on sizes between 768 and 979 pixels (note that is the modal size not the browser size so you probably need a screen sixe of <1200px)

This is because there is a margin top applied to the searchtools and not the button

I couldnt see any reason to have it on the searchtools so this PR removes it

### Before

<img width="889" alt="screenshotr17-08-31" src="https://user-images.githubusercontent.com/1296369/32238855-cd4c03b2-be60-11e7-9b6d-03cdcc214e95.png">

### After

<img width="781" alt="screenshotr17-27-56" src="https://user-images.githubusercontent.com/1296369/32238883-e545a93c-be60-11e7-92c4-cba32be0bd43.png">
