### PR TITLE
Label element without control

### DIFF
--- a/components/com_users/views/login/tmpl/default_login.php
+++ b/components/com_users/views/login/tmpl/default_login.php
@@ -60,7 +60,7 @@ JHtml::_('behavior.formvalidator');
 			<?php if (JPluginHelper::isEnabled('system', 'remember')) : ?>
 				<div class="control-group">
 					<div class="control-label">
-						<label>
+						<label for="remember">
 							<?php echo JText::_('COM_USERS_LOGIN_REMEMBER_ME'); ?>
 						</label>
 					</div>


### PR DESCRIPTION
When using the label element it should be explicitly associated with the form element. The for attribute of the label must exactly match the id of the form control.

A <label> can be associated with a control either by placing the control element inside the <label> element, or by using the for attribute.

This PR fixes the missing "for" element for the remember me label on com_login

To test go to the login component (not module) and check that the markup for the word remember me is

`<label for "remember">` where remember is the id of the checkbox.

The remember me plugin must be enabled