### PR TITLE
[4.0] Form field descriptions styling improvements

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -14,9 +14,10 @@ extract($displayData);
 /**
  * Layout variables
  * ---------------------
- * 	$options         : (array)  Optional parameters
- * 	$label           : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
- * 	$input           : (string) The input field html code
+ * 	$options      : (array)  Optional parameters
+ * 	$label        : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
+ * 	$input        : (string) The input field html code
+ * 	$description  : (string)  An optional description to use in a tooltip
  */
 
 if (!empty($options['showonEnabled']))

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -33,4 +33,9 @@ $rel   = empty($options['rel']) ? '' : ' ' . $options['rel'];
 		<div class="control-label"><?php echo $label; ?></div>
 	<?php endif; ?>
 	<div class="controls"><?php echo $input; ?></div>
+	<?php if (!empty($description)) : ?>
+		<div>
+			<small class="form-text text-muted"><?php echo $description; ?></small>
+		</div>
+	<?php endif; ?>
 </div>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -17,7 +17,7 @@ extract($displayData);
  * 	$options      : (array)  Optional parameters
  * 	$label        : (string) The html code for the label (not required if $options['hiddenLabel'] is true)
  * 	$input        : (string) The input field html code
- * 	$description  : (string)  An optional description to use in a tooltip
+ * 	$description  : (string) An optional description to use in a tooltip
  */
 
 if (!empty($options['showonEnabled']))

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -57,7 +57,3 @@ if ($required)
 <label id="<?php echo $id; ?>" for="<?php echo $for; ?>"<?php if (!empty($classes)) echo ' class="' . implode(' ', $classes) . '"'; ?><?php echo $title; ?><?php echo $position; ?>>
 	<?php echo $text; ?><?php if ($required) : ?><span class="star">&#160;*</span><?php endif; ?>
 </label>
-<?php if (!empty($description)): ?>
-
-<div class="alert alert-info "><?php echo $description; ?></div>
-<?php endif; ?>

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -970,9 +970,9 @@ abstract class FormField
 		}
 
 		$data = array(
-			'input'       => $this->getInput(),
-			'label'       => $this->getLabel(),
-			'options'     => $options,
+			'input'   => $this->getInput(),
+			'label'   => $this->getLabel(),
+			'options' => $options,
 		);
 
 		$data = array_merge($this->getLayoutData(), $data);

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -970,10 +970,12 @@ abstract class FormField
 		}
 
 		$data = array(
-			'input'   => $this->getInput(),
-			'label'   => $this->getLabel(),
-			'options' => $options,
+			'input'       => $this->getInput(),
+			'label'       => $this->getLabel(),
+			'options'     => $options,
 		);
+
+		$data = array_merge($this->getLayoutData(), $data);
 
 		return $this->getRenderer($this->renderLayout)->render($data);
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Let me just firstly say that this is not a concrete styling solution, so please send all disputes and complaints to UX

In J4, any form field descriptions will appear as alerts and due to the PHP file they reside in, they push the actual element.

This PR changes the description to a more simplstic helper text and move them from `renderlabel.php` to `renderfield.php`

### Screenshot

![screeny](https://user-images.githubusercontent.com/2019801/32287321-576d89cc-bf28-11e7-8130-413da14230e6.png)



