### PR TITLE
[IMP} Changing string for no user + adding None in authors column in managers

### DIFF
--- a/administrator/components/com_content/models/forms/filter_articles.xml
+++ b/administrator/components/com_content/models/forms/filter_articles.xml
@@ -50,7 +50,7 @@
 			class="multipleAuthors"
 			onchange="this.form.submit();"
 			>
-			<option value="0">JOPTION_NO_USER</option>
+			<option value="0">JNONE</option>
 		</field>
 
 		<field

--- a/administrator/components/com_content/models/forms/filter_featured.xml
+++ b/administrator/components/com_content/models/forms/filter_featured.xml
@@ -63,7 +63,7 @@
 			class="multipleAuthors"
 			onchange="this.form.submit();"
 			>
-			<option value="0">JOPTION_NO_USER</option>
+			<option value="0">JNONE</option>
 		</field>
 
 		<field

--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -205,13 +205,22 @@ $assoc = JLanguageAssociations::isEnabled();
 						</td>
 						<?php endif; ?>
 						<td class="small hidden-phone">
-							<?php if ($item->created_by_alias) : ?>
-								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
-								<?php echo $this->escape($item->author_name); ?></a>
-								<div class="small"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
+							<?php if ((int) $item->created_by != 0) : ?>
+								<?php if ($item->created_by_alias) : ?>
+									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+									<?php echo $this->escape($item->author_name); ?></a>
+									<div class="smallsub"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
+								<?php else : ?>
+									<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+									<?php echo $this->escape($item->author_name); ?></a>
+								<?php endif; ?>
 							<?php else : ?>
-								<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
-								<?php echo $this->escape($item->author_name); ?></a>
+								<?php if ($item->created_by_alias) : ?>
+									<?php echo JText::_('JNONE'); ?>
+									<div class="smallsub"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
+								<?php else : ?>
+									<?php echo JText::_('JNONE'); ?>
+								<?php endif; ?>
 							<?php endif; ?>
 						</td>
 						<td class="small hidden-phone">

--- a/administrator/components/com_content/views/featured/tmpl/default.php
+++ b/administrator/components/com_content/views/featured/tmpl/default.php
@@ -188,11 +188,22 @@ if ($saveOrder)
 								<?php echo $this->escape($item->access_level); ?>
 							</td>
 							<td class="small hidden-phone">
-								<?php if ($item->created_by_alias) : ?>
-									<?php echo $this->escape($item->author_name); ?>
-									<p class="smallsub"> <?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></p>
+								<?php if ((int) $item->created_by != 0) : ?>
+									<?php if ($item->created_by_alias) : ?>
+										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+										<?php echo $this->escape($item->author_name); ?></a>
+										<div class="smallsub"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
+									<?php else : ?>
+										<a class="hasTooltip" href="<?php echo JRoute::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>" title="<?php echo JText::_('JAUTHOR'); ?>">
+										<?php echo $this->escape($item->author_name); ?></a>
+									<?php endif; ?>
 								<?php else : ?>
-									<?php echo $this->escape($item->author_name); ?>
+									<?php if ($item->created_by_alias) : ?>
+										<?php echo JText::_('JNONE'); ?>
+										<div class="smallsub"><?php echo JText::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
+									<?php else : ?>
+										<?php echo JText::_('JNONE'); ?>
+									<?php endif; ?>
 								<?php endif; ?>
 							</td>
 							<td class="small hidden-phone">

--- a/components/com_content/models/forms/filter_articles.xml
+++ b/components/com_content/models/forms/filter_articles.xml
@@ -50,7 +50,7 @@
 			class="multipleAuthors"
 			onchange="this.form.submit();"
 			>
-			<option value="0">JOPTION_NO_USER</option>
+			<option value="0">JNONE</option>
 		</field>
 
 		<field

--- a/language/en-GB/en-GB.ini
+++ b/language/en-GB/en-GB.ini
@@ -298,7 +298,6 @@ JLIB_DATABASE_ERROR_LOAD_DATABASE_DRIVER="Unable to load Database Driver: %s"
 JLIB_ERROR_INFINITE_LOOP="Infinite loop detected in JError"
 
 JOPTION_DO_NOT_USE="- None Selected -"
-JOPTION_NO_USER="- No User -"
 JOPTION_SELECT_ACCESS="- Select Access -"
 JOPTION_SELECT_AUTHOR="- Select Author -"
 JOPTION_SELECT_CATEGORY="- Select Category -"


### PR DESCRIPTION
Follow up on https://github.com/joomla/joomla-cms/pull/18445 and https://github.com/joomla/joomla-cms/pull/18440

### Summary of Changes
Changed string JOPTION_NO_USER to JNONE for authors in the filters.xml for the articles manager, featured manager and when filtering by author when using the xtd-article to insert an article in another article. See @brianteeman comment here https://github.com/joomla/joomla-cms/pull/18445#issuecomment-341077760

Also adding in the articles and featured articles manager the value None and the possible author alias when no author for an article.
### Testing Instructions
**Use latest staging**
Edit an article and change its author to `- No User -` in the publishing tab (See #18440)
### Result after patch
xtd-article Filtering when editing an article in frontend
<img width="881" alt="screen shot 2017-11-01 at 18 08 09" src="https://user-images.githubusercontent.com/869724/32287930-9983298e-bf32-11e7-97e1-d61b070a53d0.png">

Articles Manager
<img width="1122" alt="screen shot 2017-11-01 at 18 12 13" src="https://user-images.githubusercontent.com/869724/32287952-a88942d8-bf32-11e7-8e30-ddd3ce496e8e.png">

Featured articles manager
<img width="1348" alt="screen shot 2017-11-01 at 18 17 27" src="https://user-images.githubusercontent.com/869724/32287970-b785a916-bf32-11e7-9a49-340247942879.png">

@alikon @franz-wohlkoenig @brianteeman @coolcat-creations