### PR TITLE
Flags alt tags

### DIFF
--- a/layouts/joomla/content/language.php
+++ b/layouts/joomla/content/language.php
@@ -17,7 +17,7 @@ if ($item->language === '*')
 }
 elseif ($item->language_image)
 {
-	echo JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', $item->language_title, null, true) . '&nbsp;' . htmlspecialchars($item->language_title, ENT_COMPAT, 'UTF-8');
+	echo JHtml::_('image', 'mod_languages/' . $item->language_image . '.gif', '', null, true) . '&nbsp;' . htmlspecialchars($item->language_title, ENT_COMPAT, 'UTF-8');
 }
 elseif ($item->language_title)
 {


### PR DESCRIPTION
Currently the alt tag for the flags shown (if enabled) for a language in the admin lists is the same as the text next to it. This is not correct as the alt text should not be the same as the text. In addition if an image is only used for decorative purposes then the alt tag should be blank so that screen readers will not announce it.

> ##  [WCAG 2.0](https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=131#text-equiv)
> 1.1.1 Non-text Content - All non-text content that is presented to the user has a text alternative that serves the equivalent purpose (some exceptions). (Level A)

> Note: If non-text content is pure decoration, is used only for visual formatting, or is not presented to users, then it does not need text alternatives.