### PR TITLE
[com_menus] - fix php warning

### DIFF
--- a/administrator/components/com_menus/models/fields/menuitembytype.php
+++ b/administrator/components/com_menus/models/fields/menuitembytype.php
@@ -247,7 +247,7 @@ class JFormFieldMenuitemByType extends JFormFieldGroupedList
 				// Build the options array.
 				foreach ($menu->links as $link)
 				{
-					$levelPrefix = str_repeat('- ', $link->level - 1);
+					$levelPrefix = str_repeat('- ', max(0, $link->level - 1));
 
 					// Displays language code if not set to All
 					if ($link->language !== '*')


### PR DESCRIPTION
Pull Request for Issue #18468 .

### Summary of Changes
fix Warning: str_repeat(): Second argument has to be greater than or equal to 0 

### Testing Instructions
see #18468


