### PR TITLE
Help screen invalid markup

### DIFF
--- a/administrator/components/com_admin/views/help/tmpl/default.php
+++ b/administrator/components/com_admin/views/help/tmpl/default.php
@@ -21,7 +21,7 @@ JHtml::_('bootstrap.tooltip');
 					<li><?php echo JHtml::_('link', $this->latest_version_check, JText::_('COM_ADMIN_LATEST_VERSION_CHECK'), array('target' => 'helpFrame')); ?></li>
 					<li><?php echo JHtml::_('link', 'https://www.gnu.org/licenses/gpl-2.0.html', JText::_('COM_ADMIN_LICENSE'), array('target' => 'helpFrame')); ?></li>
 					<li><?php echo JHtml::_('link', JHelp::createUrl('JHELP_GLOSSARY'), JText::_('COM_ADMIN_GLOSSARY'), array('target' => 'helpFrame')); ?></li>
-					<hr class="hr-condensed" />
+					<li class="divider"></li>
 					<li class="nav-header"><?php echo JText::_('COM_ADMIN_ALPHABETICAL_INDEX'); ?></li>
 					<?php foreach ($this->toc as $k => $v) : ?>
 						<li>


### PR DESCRIPTION
Lists must be marked up correctly, meaning they must not contain content elements other than <li> elements. The divider between the items in the list of help pages is an hr which is invalid.

This PR changes that to a li with a class of divider just as in the drop down menus. There is no visual change

Screen readers have a specific way of announcing lists. This feature makes lists clearer to understand, but will only work if lists are properly structured. Properly-structured lists only include <li> content elements.

This resolves an a11y level (A): MUST fix
WCAG Success Criteria:1.3.1 Info and Relationships