### PR TITLE
[com_fields] Multilanguage: correcting custom fields display in function of item language

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -111,6 +111,10 @@ class FieldsHelper
 		{
 			self::$fieldsCache->setState('filter.language', array('*', $item->language));
 		}
+		elseif (JLanguageMultilang::isEnabled() && isset($item->language) && $item->language == '*')
+		{
+			self::$fieldsCache->setState('filter.language', '*');
+		}
 
 		self::$fieldsCache->setState('filter.context', $context);
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/18396
Issue: An item (article in that case) tagged to ALL languages is displaying all fields tagged to  specific languages.
### Summary of Changes
When an item is tagged to ALL languages, only display custom fields tagged to ALL languages.

### Testing Instructions
Create a multilingual site. 2 Content languages are enough. Here for en-GB and fr-FR
Structure:
===>Categories
<img width="1179" alt="screen shot 2017-11-02 at 09 44 48" src="https://user-images.githubusercontent.com/869724/32316944-8515b8c4-bfb2-11e7-88b1-0046d8933bb2.png">
===>Articles set as Featured
<img width="791" alt="screen shot 2017-11-02 at 09 46 07" src="https://user-images.githubusercontent.com/869724/32317022-b3d968fe-bfb2-11e7-88f2-8ab531f901cc.png">
===> Home menu as Featured Articles menu item for each language.
<img width="1171" alt="screen shot 2017-11-02 at 09 50 10" src="https://user-images.githubusercontent.com/869724/32317193-4880ce7a-bfb3-11e7-908a-a6a244fa5ac3.png">
===> Create some articles custom fields and assign languages, including ALL
For the sake of this demo I added a Media field tagged to ALL and choose the same image for each article.
<img width="1171" alt="screen shot 2017-11-02 at 09 48 24" src="https://user-images.githubusercontent.com/869724/32317147-16ca08d8-bfb3-11e7-90a7-90943b20bf5d.png">

###Before patch
-----Back-end: when editing an article tagged to ALL languages, we also get the fields tagged to specific languages.
<img width="490" alt="screen shot 2017-11-02 at 09 55 15" src="https://user-images.githubusercontent.com/869724/32317386-fd05b1b2-bfb3-11e7-939c-5859b21824d0.png">
---- Which is also the case in frontend
==> Active language is fr-FR
<img width="1021" alt="screen shot 2017-11-02 at 09 57 08" src="https://user-images.githubusercontent.com/869724/32317496-404195b8-bfb4-11e7-83fd-0246da43e3a9.png">
==>Active language is en-GB
<img width="1022" alt="screen shot 2017-11-02 at 09 58 09" src="https://user-images.githubusercontent.com/869724/32317543-5ee309d4-bfb4-11e7-840a-a17e29b0e2e1.png">

### After patch
----- Backend: only fields tagged to ALL languages display in an article tagged to ALL languages.
<img width="490" alt="screen shot 2017-11-02 at 10 03 48" src="https://user-images.githubusercontent.com/869724/32317755-2d9a814e-bfb5-11e7-8f57-efd92ecd167a.png">

-----Same in frontend
==> Active language is fr-FR
<img width="1071" alt="screen shot 2017-11-02 at 10 05 13" src="https://user-images.githubusercontent.com/869724/32317804-5f59076e-bfb5-11e7-8958-6453a54f9117.png">
==>Active language is en-GB
<img width="1026" alt="screen shot 2017-11-02 at 10 06 01" src="https://user-images.githubusercontent.com/869724/32317833-81e4a798-bfb5-11e7-8644-1f8194100f1b.png">

@ajejebrazorf01
@AlexRed 
@ggppdk 
