### PR TITLE
Flags ALT tags in language switcher module

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -37,7 +37,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 				<a href="#" data-toggle="dropdown" class="btn dropdown-toggle">
 					<span class="caret"></span>
 					<?php if ($language->image) : ?>
-						&nbsp;<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+						&nbsp;<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
 					<?php echo $language->title_native; ?>
 				</a>
@@ -49,7 +49,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 				<li<?php echo $language->active ? ' class="lang-active"' : ''; ?>>
 				<a href="<?php echo $language->link; ?>">
 					<?php if ($language->image) : ?>
-						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+						<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
 					<?php endif; ?>
 					<?php echo $language->title_native; ?>
 				</a>


### PR DESCRIPTION
Currently the alt tag for the flags shown (if enabled and a dropdown) for a language in the frontend module language switcher lists is the same as the text next to it. This is not correct as the alt text should not be the same as the text. In addition if an image is only used for decorative purposes then the alt tag should be blank so that screen readers will not announce it.

> ##  [WCAG 2.0](https://www.w3.org/WAI/WCAG20/quickref/?showtechniques=131#text-equiv)
> 1.1.1 Non-text Content - All non-text content that is presented to the user has a text alternative that serves the equivalent purpose (some exceptions). (Level A)

> Note: If non-text content is pure decoration, is used only for visual formatting, or is not presented to users, then it does not need text alternatives.

To test create a multilingual web site and then publish the language switcher module with
Use Dropdown - Yes
Use Flags For Dropdown - Yes

After this PR you will see that there is NO alt or title tags

For extra credit check all the other module options that display a flag and you will see that the alt and title tags are still present
