### PR TITLE
Fix undefined $langCode

### DIFF
--- a/libraries/src/Helper/CMSHelper.php
+++ b/libraries/src/Helper/CMSHelper.php
@@ -38,7 +38,8 @@ class CMSHelper
 	public function getCurrentLanguage($detectBrowser = true)
 	{
 		$app = Factory::getApplication();
-
+		$langCode = null;
+		
 		// Get the languagefilter parameters
 		if (Multilanguage::isEnabled())
 		{

--- a/libraries/src/Helper/CMSHelper.php
+++ b/libraries/src/Helper/CMSHelper.php
@@ -39,7 +39,7 @@ class CMSHelper
 	{
 		$app = Factory::getApplication();
 		$langCode = null;
-		
+
 		// Get the languagefilter parameters
 		if (Multilanguage::isEnabled())
 		{

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -157,6 +157,7 @@ class ContentHelper
 	public static function getCurrentLanguage($detectBrowser = true)
 	{
 		$app = Factory::getApplication();
+		$langCode = null;
 
 		// Get the languagefilter parameters
 		if (Multilanguage::isEnabled())


### PR DESCRIPTION
Pull Request for Issue #18484 .
When calling JHelperContent::getCurrentLanguage() within an extension where multilang fails we check agains $langCode but it hasn't been set, so set it before we do anything.