### PR TITLE
[4.0] Fix PHP error on module uninstall

### DIFF
--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -209,7 +209,8 @@ class ModuleAdapter extends InstallerAdapter
 	 */
 	protected function finaliseUninstall(): bool
 	{
-		$db = $this->parent->getDbo();
+		$db     = $this->parent->getDbo();
+		$retval = true;
 
 		// Remove the schema version
 		$query = $db->getQuery(true)

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -290,6 +290,7 @@ class ModuleAdapter extends InstallerAdapter
 		catch (\RuntimeException $e)
 		{
 			// Ignore the error...
+			$retval = false;
 		}
 
 		// Remove the installation folder

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -291,7 +291,6 @@ class ModuleAdapter extends InstallerAdapter
 		catch (\RuntimeException $e)
 		{
 			// Ignore the error...
-			$retval = false;
 		}
 
 		// Remove the installation folder


### PR DESCRIPTION
### Summary of Changes

When trying to uninstall a module, the following error is thrown:

> Return value of Joomla\CMS\Installer\Adapter\ModuleAdapter::finaliseUninstall() must be of the type boolean, null returned 

This PR addresses that

### Testing Instructions

1. Install a module
2. Uninstall the module
3. No PHP errors should be displayed

### Expected result

No PHP errors

### Actual result

> Return value of Joomla\CMS\Installer\Adapter\ModuleAdapter::finaliseUninstall() must be of the type boolean, null returned 