### PR TITLE
Duplicate id in fields_groups

### DIFF
--- a/administrator/components/com_fields/views/group/tmpl/edit.php
+++ b/administrator/components/com_fields/views/group/tmpl/edit.php
@@ -38,7 +38,6 @@ JFactory::getDocument()->addScriptDeclaration('
 		<div class="row-fluid">
 			<div class="span9">
 				<?php echo $this->form->renderField('label'); ?>
-				<?php echo $this->form->renderField('context'); ?>
 				<?php echo $this->form->renderField('description'); ?>
 			</div>
 			<div class="span3">


### PR DESCRIPTION
If you open the view to create a new field you will find that it has multiple elements with the same id attribute: jform_context

I can not see any reason for this - no other edit view has the duplicate id. I have tested this pr with all the supported components and the context is stored correctly

This resolves a WCAG 2.0 (A): MUST fix issue with WCAG Success Criteria:4.1.1 Parsing
https://www.w3.org/TR/2008/REC-WCAG20-20081211/#ensure-compat-parses