### PR TITLE
Fix invalid markup

### DIFF
--- a/components/com_finder/helpers/html/filter.php
+++ b/components/com_finder/helpers/html/filter.php
@@ -185,8 +185,8 @@ abstract class JHtmlFilter
 				// Build a node.
 				$html .= '<div class="control-group">';
 				$html .= '<div class="controls">';
-				$html .= '<label class="checkbox" tax-'
-					. $bk . '>';
+				$html .= '<label class="checkbox" for="tax-'
+					. $bk . '">';
 				$html .= '<input type="checkbox" class="selector filter-node' . $classSuffix . '" value="' . $nk . '" name="t[]" id="tax-'
 					. $bk . '"' . $checked . ' />';
 				$html .= $nv->title;


### PR DESCRIPTION
In administrator ->Smart search -> filters -> new

View the source and you will see something like `<label class="checkbox" tax-15>` which is clearly invalid markup and it was introduced in error at #6322

This pr reverts the change made in that pr and the markup will now be something like `<label class="checkbox" for="tax-15">`