### PR TITLE
[Travis] Redis exists returns integer values

### DIFF
--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -179,12 +179,7 @@ class RedisStorage extends CacheStorage
 		}
 
 		// Redis exists returns integer values lets convert that to boolean see: https://redis.io/commands/exists
-		if (static::$_redis->exists($this->_getCacheId($id, $group)) === 0)
-		{
-			return false;
-		}
-
-		return true;
+		return (bool) static::$_redis->exists($this->_getCacheId($id, $group));
 	}
 
 	/**

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -178,7 +178,13 @@ class RedisStorage extends CacheStorage
 			return false;
 		}
 
-		return static::$_redis->exists($this->_getCacheId($id, $group));
+		// Redis exists returns integer values lets convert that to boolean see: https://redis.io/commands/exists
+		if (static::$_redis->exists($this->_getCacheId($id, $group)) === 0)
+		{
+			return false;
+		}
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://travis-ci.org/joomla/joomla-cms/jobs/297187052

### Summary of Changes

Travis fails with the following error on PHP7.2

```
1) JCacheStorageRedisTest::testCacheContains
Failed validating data exists in the cache store
Failed asserting that 1 is true.
/home/travis/build/joomla/joomla-cms/tests/unit/core/case/cache.php:81
```

This is because Redis retruns integer (1/0) for exists see https://redis.io/commands/exists and php7.2 is stricter about that.

### Testing Instructions

See that travis is happy now.

### Expected result

See that travis is happy now.

### Actual result

Travis fails with the mention error

### Documentation Changes Required

