### PR TITLE
Return error 404 instead of error 0 for non-existent page, ex index.php?Itemid=9999

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -435,7 +435,7 @@ class ComponentHelper
 		}
 
 		// Core CMS will use '*' as a placeholder for required parameter in this method. In 4.0 this will not be passed at all.
-		if (isset($option) && $option != '*')
+		if ($option === null || $option !== '*')
 		{
 			// Log deprecated warning and display missing component warning only if using deprecated format.
 			try

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -41,16 +41,16 @@ class ComponentHelper
 	 */
 	public static function getComponent($option, $strict = false)
 	{
-		if (isset(static::$components[$option]) || static::load($option))
+		$components = static::getComponents();
+
+		if (isset($components[$option]))
 		{
-			$result = static::$components[$option];
+			return $components[$option];
 		}
-		else
-		{
-			$result          = new ComponentRecord;
-			$result->enabled = $strict ? false : true;
-			$result->setParams(new Registry);
-		}
+
+		$result = new ComponentRecord;
+		$result->enabled = $strict ? false : true;
+		$result->setParams(new Registry);
 
 		return $result;
 	}
@@ -435,7 +435,7 @@ class ComponentHelper
 		}
 
 		// Core CMS will use '*' as a placeholder for required parameter in this method. In 4.0 this will not be passed at all.
-		if ($option === null || $option !== '*')
+		if (isset($option) && $option != '*')
 		{
 			// Log deprecated warning and display missing component warning only if using deprecated format.
 			try


### PR DESCRIPTION
Fix bad effect of merged PR #18308

### Summary of Changes
If the menu item does not exist for a link like `index.php?Itemid=9999` then joomla returns
`Call to a member function getParams() on null
.../libraries/src/Component/ComponentHelper.php:103 `

instead of returns only error 404

### Testing Instructions
Install joomla 3.8.2 RC.
Before the patch, go to the non-existent menu item, such as `index.php?Itemid=9999`
After patch you should see only 404 error, which is correct.

### Expected result
As described above.

### Actual result
As described above.

### Documentation Changes Required
No