### PR TITLE
Remove alt text for language flag images also if not dropdown list

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -66,7 +66,7 @@ if ($params->get('dropdown', 1) && !$params->get('dropdownimage', 0))
 			<a href="<?php echo $language->link; ?>">
 			<?php if ($params->get('image', 1)) : ?>
 				<?php if ($language->image) : ?>
-					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+					<?php echo JHtml::_('image', 'mod_languages/' . $language->image . '.gif', '', array('title' => $language->title_native), true); ?>
 				<?php else : ?>
 					<span class="label"><?php echo strtoupper($language->sef); ?></span>
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for no Issue.

### Summary of Changes

If an image is only used for decorative purposes then the alt tag should be blank so that screen readers will not announce it.

See PR #18475 

### Testing Instructions

Test that without this PR, the flag images have alt texts and with this PR they don't, when using flags displayed as icons (i.e. not drowdown list) in the language switcher module.

### Expected result

No alt tag.

### Actual result

Alt tag.

### Documentation Changes Required

None.