### PR TITLE
Corrects attribute order in implode() function

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -201,7 +201,7 @@ class FieldsHelper
 
 					if (is_array($value))
 					{
-						$value = implode($value, ' ');
+						$value = implode(' ', $value);
 					}
 
 					// Event allow plugins to modfify the output of the prepared field


### PR DESCRIPTION
Ther php `implode` function takes 2 parameters, where the first is the `glue`:
```
implode ( string $glue , array $pieces )
```

So this is wrong:
```
$value = implode($value, ' ');
```
Should be:
```
$value = implode(' ', $value);
```
