### PR TITLE
Update folder.php

### DIFF
--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -233,9 +233,11 @@ abstract class JFolder
 				{
 					$obdSeparator = ';';
 					
-					// Issue #18523
-					// If open_basedir path contains CAPITAL letters
-					// Windows is case insensitive
+					/*	
+					Issue #18523
+					If open_basedir path contains CAPITAL letters
+					Windows is case insensitive
+					*/
 					$obd = utf8_strtolower($obd);
 					$path = utf8_strtolower($path);
 				}

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -232,6 +232,7 @@ abstract class JFolder
 				if (IS_WIN)
 				{
 					$obdSeparator = ';';
+					
 					// Issue #18523
 					// If open_basedir path contains CAPITAL letters
 					// Windows is case insensitive

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -232,6 +232,11 @@ abstract class JFolder
 				if (IS_WIN)
 				{
 					$obdSeparator = ';';
+                                        // https://issues.joomla.org/tracker/joomla-cms/18523
+                                        // If open_basedir path contains CAPITAL letters
+                                        // Windows is case insensitive
+                                        $obd = utf8_strtolower($obd);
+                                        $path = utf8_strtolower($path);
 				}
 				else
 				{

--- a/libraries/joomla/filesystem/folder.php
+++ b/libraries/joomla/filesystem/folder.php
@@ -232,11 +232,11 @@ abstract class JFolder
 				if (IS_WIN)
 				{
 					$obdSeparator = ';';
-                                        // https://issues.joomla.org/tracker/joomla-cms/18523
-                                        // If open_basedir path contains CAPITAL letters
-                                        // Windows is case insensitive
-                                        $obd = utf8_strtolower($obd);
-                                        $path = utf8_strtolower($path);
+					// Issue #18523
+					// If open_basedir path contains CAPITAL letters
+					// Windows is case insensitive
+					$obd = utf8_strtolower($obd);
+					$path = utf8_strtolower($path);
 				}
 				else
 				{


### PR DESCRIPTION
Pull Request for Issue #18523 
Summary of Changes

Added conversion CAPITAL letters to lowercase for $path and $obd(open_basedir path) variables in Windows (because windows is case insensitive)
Testing Instructions
Windows, Php 56, additional information about system in issue tracker
Try to change open_basedir value in php.ini to value with CAPITAL letters
Try CAPITAL national symbols
Expected result

No issues
Actual result

modules/additional languages cannot be installed if open_basedir in php.ini contains CAPITAL letters.
Documentation Changes Required

No
