### PR TITLE
[4.0] Move 4.0 to the standalone update server for 4.0-dev (temp)

### DIFF
--- a/administrator/components/com_joomlaupdate/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/Model/UpdateModel.php
@@ -52,12 +52,12 @@ class UpdateModel extends BaseDatabaseModel
 			// "Minor & Patch Release for Current version AND Next Major Release".
 			case 'sts':
 			case 'next':
-				$updateURL = 'https://update.joomla.org/core/sts/list_sts.xml';
+				$updateURL = 'https://update.joomla.org/core/test/next_major_list.xml';
 				break;
 
 			// "Testing"
 			case 'testing':
-				$updateURL = 'https://update.joomla.org/core/test/list_test.xml';
+				$updateURL = 'https://update.joomla.org/core/test/next_major_list.xml';
 				break;
 
 			// "Custom"
@@ -81,7 +81,7 @@ class UpdateModel extends BaseDatabaseModel
 			 * case 'nochange':
 			 */
 			default:
-				$updateURL = 'https://update.joomla.org/core/list.xml';
+				$updateURL = 'https://update.joomla.org/core//test/next_major_list.xml';
 		}
 
 		$db = $this->getDbo();

--- a/administrator/components/com_joomlaupdate/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/Model/UpdateModel.php
@@ -81,7 +81,7 @@ class UpdateModel extends BaseDatabaseModel
 			 * case 'nochange':
 			 */
 			default:
-				$updateURL = 'https://update.joomla.org/core//test/next_major_list.xml';
+				$updateURL = 'https://update.joomla.org/core/test/next_major_list.xml';
 		}
 
 		$db = $this->getDbo();


### PR DESCRIPTION
### Summary of Changes

This is a temp change requested by @wilsonge for the first dev versions of Joomla 4.0. At the time this get merged there is going to be a PR to revert this change for the stable version.

### Testing Instructions

Just a review. Until the file is prepared / uploaded to the update server: https://github.com/joomla/update.joomla.org/pull/79

### Expected result

4.0 updates points to `https://update.joomla.org/core/test/next_major_list.xml` for updates during the development

### Actual result

4.0 points to the stable update server we should not use for testing.

### Documentation Changes Required

None.