### PR TITLE
Adjust version attribute in package manifest

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="3.7" client="administrator">
+<metafile version="3.8" client="administrator">
 	<name>English (en-GB)</name>
 	<version>3.8.3</version>
 	<creationDate>November 2017</creationDate>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.7" client="administrator" type="language" method="upgrade">
+<extension version="3.8" client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.8.3</version>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<extension type="package" version="3.7" method="upgrade">
+<extension type="package" version="3.8" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
 	<version>3.8.3.1</version>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile
-	version="3.7"
+	version="3.8"
 	client="installation">
 	<name>English (United Kingdom)</name>
 	<version>3.8.3</version>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<metafile version="3.7" client="site">
+<metafile version="3.8" client="site">
 	<name>English (en-GB)</name>
 	<version>3.8.3</version>
 	<creationDate>November 2017</creationDate>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="3.7" client="site" type="language" method="upgrade">
+<extension version="3.8" client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.8.3</version>


### PR DESCRIPTION
Simple change to bring the version attribute of the english package manifest to 3.8.