### PR TITLE
Allow components whose XML manifests are without submenus to be selected

### DIFF
--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -422,43 +422,41 @@ class MenusModelMenutypes extends JModelLegacy
 		// Process submenu options.
 		$submenu = $manifest->administration->submenu;
 
-		if (!$submenu)
+		if ($submenu)
 		{
-			return $options;
-		}
-
-		foreach ($submenu->menu as $child)
-		{
-			$attributes = $child->attributes();
-
-			$o = new stdClass;
-			$o->title       = (string) trim($child);
-			$o->description = '';
-
-			if ((string) $attributes->link)
+			foreach ($submenu->menu as $child)
 			{
-				parse_str((string) $attributes->link, $request);
-			}
-			else
-			{
-				$request = array();
+				$attributes = $child->attributes();
 
-				$request['option']     = $component;
-				$request['act']        = (string) $attributes->act;
-				$request['task']       = (string) $attributes->task;
-				$request['controller'] = (string) $attributes->controller;
-				$request['view']       = (string) $attributes->view;
-				$request['layout']     = (string) $attributes->layout;
-				$request['sub']        = (string) $attributes->sub;
-			}
+				$o              = new stdClass;
+				$o->title       = (string) trim($child);
+				$o->description = '';
 
-			$o->request = array_filter($request, 'strlen');
-			$options[]  = new JObject($o);
+				if ((string) $attributes->link)
+				{
+					parse_str((string) $attributes->link, $request);
+				}
+				else
+				{
+					$request = array();
 
-			// Do not repeat the default view link (index.php?option=com_abc).
-			if (count($o->request) == 1)
-			{
-				$ro = null;
+					$request['option']     = $component;
+					$request['act']        = (string) $attributes->act;
+					$request['task']       = (string) $attributes->task;
+					$request['controller'] = (string) $attributes->controller;
+					$request['view']       = (string) $attributes->view;
+					$request['layout']     = (string) $attributes->layout;
+					$request['sub']        = (string) $attributes->sub;
+				}
+
+				$o->request = array_filter($request, 'strlen');
+				$options[]  = new JObject($o);
+
+				// Do not repeat the default view link (index.php?option=com_abc).
+				if (count($o->request) == 1)
+				{
+					$ro = null;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Since a while now we can create back-end menus. This works for most components but not all. When you have a component which has no submenus in the manifest XML, this component won't show up.

This change will also make these components available that don't have a submenu entry in their manifest xml.

### Testing Instructions
1. Go to Menus -> Manage
2. Filter the list on Administrator
![image](https://user-images.githubusercontent.com/359377/32607189-56095e0e-c558-11e7-9c05-ca34afb19780.png)
3. Click on New
4. Create a new menu like this. Make sure the client is set to Administrator
![image](https://user-images.githubusercontent.com/359377/32607227-7c6cc73e-c558-11e7-9fef-ae2a0bfb63c7.png)
5. Click on Save & Close
6. The new menu appears in the list now
7. Click on the title *My Menu*
8. You are now taken to the Menu Items list which is empty for this menu
9. Click on New
10. Click on Select behind Menu Item Type
![image](https://user-images.githubusercontent.com/359377/32607284-b5e2c96e-c558-11e7-82aa-cc369d4461fa.png)
11.  In the list there is no option to choose the Multilangual Associations component. So we can't create a link to this component.
12. Apply the patch
13. Reload the page
14. Click on Select behind Menu Item Type
15. Now you will see the Multilangual Associations component in the list
![image](https://user-images.githubusercontent.com/359377/32607535-9aeb12dc-c559-11e7-9d49-bea84e41231b.png)

### Expected result
All installed components are shown to be selected

### Actual result
Some components are missing and cannot be selected


### Documentation Changes Required
None
