### PR TITLE
[com_associations] - use cache for getContentLanguages()

### DIFF
--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -437,6 +437,20 @@ class AssociationsHelper extends JHelperContent
 	}
 
 	/**
+	 * Get all the content languages.
+	 *
+	 * @return  array  Array of objects all content languages by language code.
+	 *
+	 * @since   3.7.0
+	 *
+	 * @deprecated  4.0  Use LanguageHelper::getContentLanguages().
+	 */
+	public static function getContentLanguages()
+	{
+		return LanguageHelper::getContentLanguages(false, true);
+	}
+
+	/**
 	 * Get the associated items for an item
 	 *
 	 * @param   string  $extensionName  The extension name with com_

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -178,7 +178,7 @@ class AssociationsHelper extends JHelperContent
 		$titleFieldName = self::getTypeFieldName($extensionName, $typeName, 'title');
 
 		// Get all content languages.
-		$languages = LanguageHelper::getContentLanguages();
+		$languages = self::getContentLanguages();
 
 		$canEditReference = self::allowEdit($extensionName, $typeName, $itemId);
 		$canCreate        = self::allowAdd($extensionName, $typeName);
@@ -435,6 +435,18 @@ class AssociationsHelper extends JHelperContent
 
 		return $db->loadObjectList();
 	}
+
+	/**
+	 * Get all the content languages.
+	 *
+	 * @return  array  Array of objects all content languages by language code.
+	 *
+	 * @since   3.7.0
+	 */
+	public static function getContentLanguages()
+	{
+		return LanguageHelper::getContentLanguages();
+   	}
 
 	/**
 	 * Get the associated items for an item

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -452,18 +452,13 @@ class AssociationsHelper extends JHelperContent
 	 */
 	public static function getContentLanguages()
 	{
-		if (count(static::$languages) > 0 || static::load())
-		{
-			$result = static::$languages;
-		}
-		else
+		if (empty(static::$languages))
 		{
 			static::load();
-            		$result = static::$languages;
 		}
-
-		return $result;
-	}
+ 
+		return static::$languages;
+   	}
 
 	/**
 	 * Get the associated items for an item
@@ -693,7 +688,7 @@ class AssociationsHelper extends JHelperContent
 			$query = $db->getQuery(true)
 			    ->select($db->quoteName(array('sef', 'lang_code', 'image', 'title', 'published')))
 			    ->from($db->quoteName('#__languages'))
-			    ->where($db->quoteName('published') . ' != -2')
+			    ->where($db->quoteName('published') . ' > 0')
 			    ->order($db->quoteName('ordering') . ' ASC');
 
 			$db->setQuery($query);

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -178,7 +178,7 @@ class AssociationsHelper extends JHelperContent
 		$titleFieldName = self::getTypeFieldName($extensionName, $typeName, 'title');
 
 		// Get all content languages.
-		$languages = self::getContentLanguages();
+		$languages = LanguageHelper::getContentLanguages(false, true);
 
 		$canEditReference = self::allowEdit($extensionName, $typeName, $itemId);
 		$canCreate        = self::allowAdd($extensionName, $typeName);
@@ -434,18 +434,6 @@ class AssociationsHelper extends JHelperContent
 		$db->setQuery($query);
 
 		return $db->loadObjectList();
-	}
-
-	/**
-	 * Get all the content languages.
-	 *
-	 * @return  array  Array of objects all content languages by language code.
-	 *
-	 * @since   3.7.0
-	 */
-	public static function getContentLanguages()
-	{
-		return LanguageHelper::getContentLanguages();
 	}
 
 	/**

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -708,6 +708,6 @@ class AssociationsHelper extends JHelperContent
 			static::$languages = $loader();
 		}
 
-    		return true;
+		return true;
 	}
 }

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -446,7 +446,7 @@ class AssociationsHelper extends JHelperContent
 	public static function getContentLanguages()
 	{
 		return LanguageHelper::getContentLanguages();
-   	}
+	}
 
 	/**
 	 * Get the associated items for an item

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -37,9 +37,10 @@ class AssociationsHelper extends JHelperContent
 	public static $supportedExtensionsList = array();
 
 	/**
-	 * List languages of languages
+	 * List of available languages
 	 *
 	 * @var    installed languages
+	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected static $languages = array();
@@ -686,15 +687,15 @@ class AssociationsHelper extends JHelperContent
 		{
 			$db = \JFactory::getDbo();
 			$query = $db->getQuery(true)
-			    ->select($db->quoteName(array('sef', 'lang_code', 'image', 'title', 'published')))
-			    ->from($db->quoteName('#__languages'))
-			    ->where($db->quoteName('published') . ' > 0')
-			    ->order($db->quoteName('ordering') . ' ASC');
+				->select($db->quoteName(array('sef', 'lang_code', 'image', 'title', 'published')))
+				->from($db->quoteName('#__languages'))
+				->where($db->quoteName('published') . ' > 0')
+				->order($db->quoteName('ordering') . ' ASC');
 
 			$db->setQuery($query);
 
 			return $db->loadObjectList('lang_code');
-		};
+		}
 
 		$cache = \JFactory::getCache('_system', 'callback');
 

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -456,9 +456,9 @@ class AssociationsHelper extends JHelperContent
 		{
 			static::load();
 		}
- 
+
 		return static::$languages;
-   	}
+	}
 
 	/**
 	 * Get the associated items for an item

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\Registry\Registry;
+use Joomla\CMS\Language\LanguageHelper;
 
 /**
  * Associations component helper.
@@ -35,15 +36,6 @@ class AssociationsHelper extends JHelperContent
 	 * @since   3.7.0
 	 */
 	public static $supportedExtensionsList = array();
-
-	/**
-	 * List of available languages
-	 *
-	 * @var    installed languages
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
-	protected static $languages = array();
 
 	/**
 	 * Get the associated items for an item
@@ -186,7 +178,7 @@ class AssociationsHelper extends JHelperContent
 		$titleFieldName = self::getTypeFieldName($extensionName, $typeName, 'title');
 
 		// Get all content languages.
-		$languages = self::getContentLanguages();
+		$languages = LanguageHelper::getContentLanguages();
 
 		$canEditReference = self::allowEdit($extensionName, $typeName, $itemId);
 		$canCreate        = self::allowAdd($extensionName, $typeName);
@@ -445,23 +437,6 @@ class AssociationsHelper extends JHelperContent
 	}
 
 	/**
-	 * Get all the content languages.
-	 *
-	 * @return  array  Array of objects all content languages by language code.
-	 *
-	 * @since   3.7.0
-	 */
-	public static function getContentLanguages()
-	{
-		if (empty(static::$languages))
-		{
-			static::load();
-		}
-
-		return static::$languages;
-	}
-
-	/**
 	 * Get the associated items for an item
 	 *
 	 * @param   string  $extensionName  The extension name with com_
@@ -672,42 +647,5 @@ class AssociationsHelper extends JHelperContent
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Load the installed languages.
-	 *
-	 * @return  boolean  True on success
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	protected static function load()
-	{
-		$loader = function ()
-		{
-			$db = \JFactory::getDbo();
-			$query = $db->getQuery(true)
-				->select($db->quoteName(array('sef', 'lang_code', 'image', 'title', 'published')))
-				->from($db->quoteName('#__languages'))
-				->where($db->quoteName('published') . ' > 0')
-				->order($db->quoteName('ordering') . ' ASC');
-
-			$db->setQuery($query);
-
-			return $db->loadObjectList('lang_code');
-		}
-
-		$cache = \JFactory::getCache('_system', 'callback');
-
-		try
-		{
-			static::$languages = $cache->get($loader, array(), __METHOD__);
-		}
-		catch (\JCacheException $e)
-		{
-			static::$languages = $loader();
-		}
-
-		return true;
 	}
 }

--- a/administrator/components/com_associations/helpers/associations.php
+++ b/administrator/components/com_associations/helpers/associations.php
@@ -178,7 +178,7 @@ class AssociationsHelper extends JHelperContent
 		$titleFieldName = self::getTypeFieldName($extensionName, $typeName, 'title');
 
 		// Get all content languages.
-		$languages = LanguageHelper::getContentLanguages(false, true);
+		$languages = LanguageHelper::getContentLanguages(array(0, 1));
 
 		$canEditReference = self::allowEdit($extensionName, $typeName, $itemId);
 		$canCreate        = self::allowAdd($extensionName, $typeName);
@@ -442,12 +442,10 @@ class AssociationsHelper extends JHelperContent
 	 * @return  array  Array of objects all content languages by language code.
 	 *
 	 * @since   3.7.0
-	 *
-	 * @deprecated  4.0  Use LanguageHelper::getContentLanguages().
 	 */
 	public static function getContentLanguages()
 	{
-		return LanguageHelper::getContentLanguages(false, true);
+		return LanguageHelper::getContentLanguages(array(0, 1));
 	}
 
 	/**

--- a/administrator/components/com_associations/models/fields/itemlanguage.php
+++ b/administrator/components/com_associations/models/fields/itemlanguage.php
@@ -10,6 +10,7 @@
 defined('JPATH_BASE') or die;
 
 use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\Language\LanguageHelper;
 
 JLoader::register('AssociationsHelper', JPATH_ADMINISTRATOR . '/components/com_associations/helpers/associations.php');
 JFormHelper::loadFieldClass('list');
@@ -57,7 +58,7 @@ class JFormFieldItemLanguage extends JFormFieldList
 		$canCreate = AssociationsHelper::allowAdd($extensionName, $typeName);
 
 		// Gets existing languages.
-		$existingLanguages = AssociationsHelper::getContentLanguages();
+		$existingLanguages = LanguageHelper::getContentLanguages(false, true);
 
 		$options = array();
 

--- a/administrator/components/com_associations/models/fields/itemlanguage.php
+++ b/administrator/components/com_associations/models/fields/itemlanguage.php
@@ -58,7 +58,7 @@ class JFormFieldItemLanguage extends JFormFieldList
 		$canCreate = AssociationsHelper::allowAdd($extensionName, $typeName);
 
 		// Gets existing languages.
-		$existingLanguages = LanguageHelper::getContentLanguages(false, true);
+		$existingLanguages = LanguageHelper::getContentLanguages(array(0, 1));
 
 		$options = array();
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -323,19 +323,18 @@ class LanguageHelper
 	/**
 	 * Get a list of content languages.
 	 *
-	 * @param   boolean  $checkPublished  Check if the content language is published.
-	 * @param   boolean  $checkInstalled  Check if the content language is installed.
-	 * @param   string   $pivot           The pivot of the returning array.
-	 * @param   string   $orderField      Field to order the results.
-	 * @param   string   $orderDirection  Direction to order the results.
-	 * @param   boolean  $checkTrashed    Check if the content language is trashed.
+	 * @param   array    $publishedStates  Array with the content language published states. Empty array for all.
+	 * @param   boolean  $checkInstalled   Check if the content language is installed.
+	 * @param   string   $pivot            The pivot of the returning array.
+	 * @param   string   $orderField       Field to order the results.
+	 * @param   string   $orderDirection   Direction to order the results.
 	 *
 	 * @return  array  Array of the content languages.
 	 *
 	 * @since   3.7.0
 	 */
-	public static function getContentLanguages($checkPublished = true, $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-		$orderDirection = null, $checkTrashed = false)
+	public static function getContentLanguages($publishedStates = array(1), $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
+	                                           $orderDirection = null)
 	{
 		static $contentLanguages = null;
 
@@ -363,25 +362,22 @@ class LanguageHelper
 
 		$languages = $contentLanguages;
 
-		// Check if the language is published, if needed.
-		if ($checkPublished)
+		// B/C layer. Before __DEPLOY_VERSION__.
+		if ($publishedStates === true)
 		{
-			foreach ($languages as $key => $language)
-			{
-				if ((int) $language->published === 0)
-				{
-					unset($languages[$key]);
-				}
-			}
+			$publishedStates = array(1);
+		}
+		elseif ($publishedStates === false)
+		{
+			$publishedStates = array();
 		}
 
-		
-		// Check if the language is trashed, if needed.
-		if (!$checkTrashed)
+		// Check the language published state, if needed.
+		if (count($publishedStates) > 0)
 		{
 			foreach ($languages as $key => $language)
 			{
-				if ((int) $language->published === -2)
+				if (!in_array((int) $language->published, $publishedStates, true))
 				{
 					unset($languages[$key]);
 				}

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -334,7 +334,7 @@ class LanguageHelper
 	 * @since   3.7.0
 	 */
 	public static function getContentLanguages($publishedStates = array(1), $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-	                                           $orderDirection = null)
+		$orderDirection = null)
 	{
 		static $contentLanguages = null;
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -328,13 +328,14 @@ class LanguageHelper
 	 * @param   string   $pivot           The pivot of the returning array.
 	 * @param   string   $orderField      Field to order the results.
 	 * @param   string   $orderDirection  Direction to order the results.
+	 * @param   boolean  $checkTrashed    Check if the content language is trashed.
 	 *
 	 * @return  array  Array of the content languages.
 	 *
 	 * @since   3.7.0
 	 */
 	public static function getContentLanguages($checkPublished = true, $checkInstalled = true, $pivot = 'lang_code', $orderField = null,
-		$orderDirection = null)
+		$orderDirection = null, $checkTrashed = false)
 	{
 		static $contentLanguages = null;
 
@@ -368,6 +369,19 @@ class LanguageHelper
 			foreach ($languages as $key => $language)
 			{
 				if ((int) $language->published === 0)
+				{
+					unset($languages[$key]);
+				}
+			}
+		}
+
+		
+		// Check if the language is trashed, if needed.
+		if (!$checkTrashed)
+		{
+			foreach ($languages as $key => $language)
+			{
+				if ((int) $language->published === -2)
 				{
 					unset($languages[$key]);
 				}


### PR DESCRIPTION
Pull Request for Issue #15494.

### Summary of Changes
use cache instead of query everytime the available languages


### Testing Instructions
see  #15494


### Expected result
reduce the number of duplicate query


### Actual result
unnecessary duplicate query for get languages


### Additional Comments
reduced this one only
https://github.com/joomla/joomla-cms/issues/15494#issuecomment-343197629

