### PR TITLE
[3.8.3] Support for multiple downloadurl tags in update stream

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -405,7 +405,8 @@ class InstallerModelUpdate extends JModelList
 			return false;
 		}
 
-		$url = $update->downloadurl->_data;
+		$url     = $update->downloadurl->_data;
+		$mirrors = $update->get('mirrors', array());
 
 		if ($extra_query = $update->get('extra_query'))
 		{
@@ -413,7 +414,18 @@ class InstallerModelUpdate extends JModelList
 			$url .= $extra_query;
 		}
 
-		$p_file = JInstallerHelper::downloadPackage($url);
+		$mirror = 0;
+		while (!($p_file = JInstallerHelper::downloadPackage($url)) && isset($mirrors[$mirror]))
+		{
+			$name = $mirrors[$mirror];
+			$url  = $update->$name->_data;
+			if ($extra_query)
+			{
+				$url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+				$url .= $extra_query;
+			}
+			$mirror++;
+		}
 
 		// Was the package downloaded?
 		if (!$p_file)

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -90,6 +90,14 @@ class Update extends \JObject
 	protected $group;
 
 	/**
+	 * The mirrors name array
+	 *
+	 * @var    array
+	 * @since  11.1
+	 */
+	protected $mirrors = array();
+
+	/**
 	 * Update manifest `<downloads>` element
 	 *
 	 * @var    string
@@ -246,6 +254,13 @@ class Update extends \JObject
 	 */
 	public function _startElement($parser, $name, $attrs = array())
 	{
+		// Change name if is mirror
+		if ($name == 'DOWNLOADURL' && isset($this->currentUpdate->downloadurl))
+		{
+			$name            = 'MIRROR' . count($this->mirrors);
+			$this->mirrors[] = strtolower($name);
+		}
+
 		$this->stack[] = $name;
 		$tag           = $this->_getStackLocation();
 


### PR DESCRIPTION
Pull Request for Issue #18543 .

### Summary of Changes
This implements be possible to define multiple <downloadurl> tags for an element's <downloads> in an update server definition.


### Testing Instructions
# Do NOT do this on a production site! This is for testing only!
#### Joomla Update
* install 3.8.2
* apply this patch
* set this update server: `https://joomla.septdir.ru/updateserver/list.xml`
* I propose a fake update to 3.8.3
* the update should fail as the primary download url is not available
* joomla will take turns trying to download the update files until it downloads the available
* joomla will report a successful update

### Extensions Update
* install 3.8.2
* apply this patch
* [Download test plugin](https://joomla.septdir.ru/updateserver/plg_system_test_1.0.0.zip)
* I propose a fake update to 1.1.0
* joomla will take turns trying to download the update files until it downloads the available
* joomla will report a successful update

### Expected result
Joomla can be updated from other download url

### Technical Details
On the update server part we need to define the fallback like this:
#### Joomla Update
```
<?xml version="1.0" ?>
<updates>
	<update>
		<name>Joomla! 3.8</name>
		<description>Joomla! 3.8 CMS</description>
		<element>joomla</element>
		<type>file</type>
		<version>3.8.3</version>
		<infourl title="Joomla!">https://www.joomla.org/announcements/release-news/5716-joomla-3-8-2-release.html
		</infourl>
		<downloads>
			<downloadurl type="full" format="zip">https://downloads.joomla.org/fail.zip</downloadurl>
			<downloadurl type="full" format="zip">https://downloads.joomla.org/cms/joomla3/3-8-2/Joomla_3.8.2-Stable-Update_Package.zip</downloadurl>
			<downloadurl type="full" format="zip">https://github.com/joomla/joomla-cms/releases/download/3.8.2/Joomla_3.8.2-Stable-Update_Package.zip</downloadurl>
			<downloadurl type="full" format="zip">https://downloads.joomla.org/fail2.zip</downloadurl>
			<downloadurl type="full" format="zip">https://downloads.joomla.org/fail3.zip</downloadurl>
		</downloads>
		<tags>
			<tag>stable</tag>
		</tags>
		<maintainer>Joomla! PLT</maintainer>
		<maintainerurl>https://www.joomla.org</maintainerurl>
		<section>STS</section>
		<targetplatform name="joomla" version="3.[78]"/>
		<php_minimum>5.3.10</php_minimum>
	</update>
</updates>
```

### Extensions Update
```
<updates>
	<update>
		<name>Test Plguin</name>
		<description>Плагин для тестов</description>
		<element>test</element>
		<type>plugin</type>
		<folder>system</folder>
		<client>0</client>
		<version>1.1.0</version>
		<infourl title="Test Plguin">
			https://joomla.septdir.ru/updateserver/plugin.xml
		</infourl>
		<downloads>
			<downloadurl type="full" format="zip">https://joomla.septdir.ru/updateserver/fail.zip</downloadurl>
			<downloadurl type="full" format="zip">https://joomla.septdir.ru/updateserver/plg_system_test_1.0.0.zip</downloadurl>
			<downloadurl type="full" format="zip">https://joomla.septdir.ru/updateserver/fail2.zip</downloadurl>
		</downloads>
		<tags>
			<tag>stable</tag>
		</tags>
		<maintainer></maintainer>
		<maintainerurl></maintainerurl>
		<targetplatform name="joomla" version="3.[0,1,2,3,4,5,6,7,8,9]"/>
	</update>
</updates>
```
