### PR TITLE
[3.9-dev] Use JText::sprintf over plain sprintf

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1072,7 +1072,7 @@ ENDDATA;
 		if (version_compare($this->getUpdateInformation()['latest'], '4', '>='))
 		{
 			$option = new stdClass;
-			$option->label  = sprintf(JText::_('INSTL_DATABASE_SUPPORTED'), $this->getConfiguredDatabaseType());
+			$option->label  = JText::sprintf('INSTL_DATABASE_SUPPORTED', $this->getConfiguredDatabaseType());
 			$option->state  = $this->isDatabaseTypeSupported();
 			$option->notice = null;
 			$options[]      = $option;


### PR DESCRIPTION
### Summary of Changes

Use JText::sprintf over plain sprintf

### Testing Instructions

- install 3.9
- apply this patch
- set the update server to `https://update.joomla.org/core/nightlies/next_major_list.xml`
- notice the update
- notice the pre update checker

### Expected result

Database supported is showed as expected using JText::sprintf

### Actual result

The string uses plain sprintf

### Documentation Changes Required

None