### PR TITLE
[Fix] Strength meter not working within password form field

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -46,6 +46,8 @@ extract($displayData);
 
 if ($meter)
 {
+	JHtml::_('script', 'system/passwordstrength.js', array('version' => 'auto', 'relative' => true, 'framework' => true));
+
 	// Load script on document load.
 	JFactory::getDocument()->addScriptDeclaration(
 		"


### PR DESCRIPTION
### Summary of Changes
Adds the neccesarry Javascript for the strength meter in the password form field layout.

### Testing Instructions / Steps to reproduce the issue
Joomla! does not use any password form field with activated strength meter, so to reproduce the issue you have to edit **administrator/components/com_admin/models/forms/profile.xml** and add the attribute ```strengthmeter="true"``` to the field named password2.
Log in to the backend and navigate to 'My Profile'.
Type in some chars into the 'Password' field.

### Expected result
The strength meter should be displayed when typing in some chars into the password input field.

### Actual result
No strength meter appears, the Javascript error 'ReferenceError: Form is not defined' occurs.

After applying the patch the password strenght meter should be displayed again.
