### PR TITLE
Make sure the view exists before adding it to the menu lookup array, remove PHP Notices

### DIFF
--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -202,7 +202,7 @@ class MenuRules implements RulesInterface
 
 			foreach ($items as $item)
 			{
-				if (isset($item->query) && isset($item->query['view']))
+				if (isset($item->query['view'], $views[$item->query['view']]))
 				{
 					$view = $item->query['view'];
 


### PR DESCRIPTION
Other solution for the same problem as in #17323, #18043

### Summary of Changes
Do not add view name to the menu `lookup` array if the view does not exists.

Remove PHP Notice:
`Notice: Undefined index: loginx in .../libraries/src/Component/Router/Rules/MenuRules.php on line 216`

`Notice: Trying to get property of non-object in .../libraries/src/Component/Router/Rules/MenuRules.php on line 216`

### Testing Instructions
1. Install joomla.
2. Go to backend and edit a menu item.
3. Change name of view in the link field and save. 
    Please see attached video. I used FF Inspector (Ctrl + Shift + C)
![menu_check_view_name2](https://user-images.githubusercontent.com/9054379/32736026-bf39d21e-c896-11e7-9ba4-7f993101bf30.gif)


4. Go to frontend in order to see changes.
5. Before PR there are 2 php notices, after PR they disappear.


### Expected result
No PHP Notices

### Actual result
PHP Notices.

### Documentation Changes Required
No