### PR TITLE
Fix Undefined index: JHtmlBootstrap::startAccordion / JHtmlBootstrap::startTabSet

### DIFF
--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -144,21 +144,16 @@ $tparams = $this->item->params;
 
 	<?php if ($tparams->get('show_links')) : ?>
 		<?php if ($presentation_style === 'sliders') : ?>
-			<?php if (!$accordionStarted)
-			{
-				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-links'));
-				$accordionStarted = true;
-			}
-			?>
+			<?php if (!$accordionStarted) : ?>
+				<?php echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-links')); ?>
+				<?php $accordionStarted = true; ?>
+			<?php endif; ?>
 		<?php elseif ($presentation_style === 'tabs') : ?>
-			<?php if (!$tabSetStarted)
-			{
-				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-links'));
-				$tabSetStarted = true;
-			}
-			?>
+			<?php if (!$tabSetStarted) : ?>
+				<?php echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-links')); ?>
+				<?php $tabSetStarted = true; ?>
+			<?php endif; ?>
 		<?php endif; ?>
-
 		<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 

--- a/components/com_contact/views/contact/tmpl/default.php
+++ b/components/com_contact/views/contact/tmpl/default.php
@@ -143,6 +143,22 @@ $tparams = $this->item->params;
 	<?php endif; ?>
 
 	<?php if ($tparams->get('show_links')) : ?>
+		<?php if ($presentation_style === 'sliders') : ?>
+			<?php if (!$accordionStarted)
+			{
+				echo JHtml::_('bootstrap.startAccordion', 'slide-contact', array('active' => 'display-links'));
+				$accordionStarted = true;
+			}
+			?>
+		<?php elseif ($presentation_style === 'tabs') : ?>
+			<?php if (!$tabSetStarted)
+			{
+				echo JHtml::_('bootstrap.startTabSet', 'myTab', array('active' => 'display-links'));
+				$tabSetStarted = true;
+			}
+			?>
+		<?php endif; ?>
+
 		<?php echo $this->loadTemplate('links'); ?>
 	<?php endif; ?>
 


### PR DESCRIPTION
Pull Request for Issue #17853.

### Summary of Changes
Contact links section does not have the accordion/tab initialization code so when it is the first section to display, the slide/tab cannot be added to.


### Testing Instructions
Install `Test English Sample Data` demo.
Enable `Maximum` for Error Reporting.
Under `Configuration > Contacts > Contact`, set `Contact Information` to hide.
On front end, click `Featured Contacts`.
Click `Shop Address` contact.


### Expected result
No notice warnings.


### Actual result
```
Notice: Undefined index: JHtmlBootstrap::startAccordion in C:\xampp\htdocs\joomla-cms\libraries\cms\html\bootstrap.php on line 693

Notice: Undefined index: JHtmlBootstrap::startAccordion in C:\xampp\htdocs\joomla-cms\libraries\cms\html\bootstrap.php on line 694

Notice: Undefined index: JHtmlBootstrap::startAccordion in C:\xampp\htdocs\joomla-cms\libraries\cms\html\bootstrap.php on line 695
```
or 
```
Notice: Undefined index: JHtmlBootstrap::startTabSet in C:\xampp\htdocs\joomla-cms\libraries\cms\html\bootstrap.php on line 788
```

### Documentation Changes Required
None
