### PR TITLE
Fix popover hidden behind modal header

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/modal.php
+++ b/administrator/components/com_categories/views/categories/tmpl/modal.php
@@ -23,6 +23,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 
 // Special case for the search field tooltip.

--- a/administrator/components/com_contact/views/contacts/tmpl/modal.php
+++ b/administrator/components/com_contact/views/contacts/tmpl/modal.php
@@ -22,6 +22,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
 JHtml::_('script', 'com_contact/admin-contacts-modal.min.js', array('version' => 'auto', 'relative' => true));

--- a/administrator/components/com_content/views/articles/tmpl/modal.php
+++ b/administrator/components/com_content/views/articles/tmpl/modal.php
@@ -25,6 +25,7 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
 JHtml::_('script', 'com_content/admin-articles-modal.min.js', array('version' => 'auto', 'relative' => true));
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('behavior.multiselect');
 JHtml::_('formbehavior.chosen', '.multipleTags', null, array('placeholder_text_multiple' => JText::_('JOPTION_SELECT_TAG')));
 JHtml::_('formbehavior.chosen', '.multipleCategories', null, array('placeholder_text_multiple' => JText::_('JOPTION_SELECT_CATEGORY')));

--- a/administrator/components/com_fields/views/fields/tmpl/modal.php
+++ b/administrator/components/com_fields/views/fields/tmpl/modal.php
@@ -16,6 +16,7 @@ if (JFactory::getApplication()->isClient('site'))
 
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('script', 'com_fields/admin-fields-modal.js', array('version' => 'auto', 'relative' => true));
 

--- a/administrator/components/com_menus/views/items/tmpl/modal.php
+++ b/administrator/components/com_menus/views/items/tmpl/modal.php
@@ -22,6 +22,7 @@ JHtml::_('behavior.core');
 JHtml::_('behavior.polyfill', array('event'), 'lt IE 9');
 JHtml::_('script', 'com_menus/admin-items-modal.min.js', array('version' => 'auto', 'relative' => true));
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 
 // Special case for the search field tooltip.

--- a/administrator/components/com_modules/views/modules/tmpl/modal.php
+++ b/administrator/components/com_modules/views/modules/tmpl/modal.php
@@ -17,6 +17,7 @@ if (JFactory::getApplication()->isClient('site'))
 // Load needed scripts
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 
 // Scripts for the modules xtd-button

--- a/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/tmpl/modal.php
@@ -15,6 +15,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('behavior.core');
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 
 // Special case for the search field tooltip.

--- a/administrator/components/com_users/views/users/tmpl/modal.php
+++ b/administrator/components/com_users/views/users/tmpl/modal.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
 
 JHtml::_('bootstrap.tooltip', '.hasTooltip', array('placement' => 'bottom'));
+JHtml::_('bootstrap.popover', '.hasPopover', array('placement' => 'bottom'));
 JHtml::_('formbehavior.chosen', 'select');
 JHtml::_('behavior.multiselect');
 


### PR DESCRIPTION
Pull Request for Issue #15028.

### Summary of Changes
Change placement of popover from top to  bottom.

### Testing Instructions
Edit article.
Under Publishing tab, click blue button to Select User.
Hover mouser over a column header.

### Expected result
Popover to  be visible.

### Actual result
Popover partially hidden under modal header.

### Documentation Changes Required
None
