### PR TITLE
Improve Database connection error messages

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -366,7 +366,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 		if (!mysql_select_db($database, $this->connection))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to MySQL database');
+			throw new JDatabaseExceptionConnecting('Could not connect to MySQL database.');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -72,13 +72,13 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		// Make sure the MySQL extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new JDatabaseExceptionUnsupported('Could not connect to MySQL.');
+			throw new JDatabaseExceptionUnsupported('Make sure the MySQL extension for PHP is installed and enabled.');
 		}
 
 		// Attempt to connect to the server.
 		if (!($this->connection = @ mysql_connect($this->options['host'], $this->options['user'], $this->options['password'], true)))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to MySQL.');
+			throw new JDatabaseExceptionConnecting('Could not connect to MySQL server.');
 		}
 
 		// Set sql_mode to non_strict mode
@@ -366,7 +366,7 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 
 		if (!mysql_select_db($database, $this->connection))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to database');
+			throw new JDatabaseExceptionConnecting('Could not connect to MySQL database');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -160,7 +160,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Make sure the MySQLi extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new JDatabaseExceptionUnsupported('The MySQL adapter mysqli is not available');
+			throw new JDatabaseExceptionUnsupported('The MySQLi extension for PHP is not installed or enabled.');
 		}
 
 		$this->connection = @mysqli_connect(
@@ -170,7 +170,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		// Attempt to connect to the server.
 		if (!$this->connection)
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to MySQL.');
+			throw new JDatabaseExceptionConnecting('Could not connect to MySQL server.');
 		}
 
 		// Set sql_mode to non_strict mode
@@ -695,7 +695,7 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 
 		if (!mysqli_select_db($this->connection, $database))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to database.');
+			throw new JDatabaseExceptionConnecting('Could not connect to MySQL database.');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -108,7 +108,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		// Make sure the postgresql extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new JDatabaseExceptionUnsupported('PHP extension pg_connect is not available.');
+			throw new JDatabaseExceptionUnsupported('PHP extension pg_connect is not installed or enabled.');
 		}
 
 		// Build the DSN for the connection.

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -108,7 +108,7 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		// Make sure the postgresql extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new JDatabaseExceptionUnsupported('PHP extension pg_connect is not installed or enabled.');
+			throw new JDatabaseExceptionUnsupported('The pgsql extension for PHP is not installed or enabled.');
 		}
 
 		// Build the DSN for the connection.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -748,7 +748,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 		if (!sqlsrv_query($this->connection, 'USE ' . $database, null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to SQL Server database');
+			throw new JDatabaseExceptionConnecting('Could not connect to SQL Server database.');
 		}
 
 		return true;

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -118,7 +118,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 		// Make sure the SQLSRV extension for PHP is installed and enabled.
 		if (!self::isSupported())
 		{
-			throw new JDatabaseExceptionUnsupported('PHP extension sqlsrv_connect is not available.');
+			throw new JDatabaseExceptionUnsupported('The sqlsrv extension for PHP is not installed or enabled..');
 		}
 
 		// Attempt to connect to the server.

--- a/libraries/joomla/database/driver/sqlsrv.php
+++ b/libraries/joomla/database/driver/sqlsrv.php
@@ -748,7 +748,7 @@ class JDatabaseDriverSqlsrv extends JDatabaseDriver
 
 		if (!sqlsrv_query($this->connection, 'USE ' . $database, null, array('scrollable' => SQLSRV_CURSOR_STATIC)))
 		{
-			throw new JDatabaseExceptionConnecting('Could not connect to database');
+			throw new JDatabaseExceptionConnecting('Could not connect to SQL Server database');
 		}
 
 		return true;

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -146,7 +146,7 @@ class ExceptionHandler
 			header('HTTP/1.1 500 Internal Server Error');
 		}
 
-		$message = 'Error displaying the error page';
+		$message = 'Error';
 
 		if ($isException)
 		{

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -134,7 +134,7 @@ abstract class Factory
 		{
 			if (!$id)
 			{
-				throw new \Exception('Application Instantiation Error', 500);
+				throw new \Exception('Failed to start application', 500);
 			}
 
 			self::$application = CMSApplication::getInstance($id);

--- a/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
+++ b/tests/unit/suites/libraries/cms/error/JErrorPageTest.php
@@ -136,6 +136,6 @@ class JErrorPageTest extends TestCaseDatabase
 		JErrorPage::render($object);
 		$output = ob_get_clean();
 
-		$this->assertEquals('Error displaying the error page', $output);
+		$this->assertEquals('Error', $output);
 	}
 }


### PR DESCRIPTION
Before this PR you often get very unhelpful and hard to understand error messages

### For example
**Error displaying the error page: Application Instantiation Error: Could not connect to MySQL.**

### After this PR that error message would be
**Error: Failed to start application: Could not connect to MySQL server.**

You will see in the changes that before this PR we had identical error messages if mysql was not supported in php, mysql server details were wrong, mysql database could not be connected to.

After this PR they each have unique and more informative error messages. NOTE postgres and ms sql already had some of these more informative and accurate messages
