### PR TITLE
[4.0] Update scss_lint to v0.56.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'scss_lint', '~> 0.55.0'
+gem 'scss_lint', '~> 0.56.0'


### PR DESCRIPTION
### Summary of Changes

Update scss_lint to v0.56.0

@ciar4n @dgt41 When merged, please run `gem install scss_lint`