### PR TITLE
[4.0] Remove new Field group description

### DIFF
--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -27,7 +27,6 @@
 			name="title"
 			type="text"
 			label="JGLOBAL_TITLE"
-			description="JFIELD_TITLE_DESC"
 			class="input-xxlarge input-large-text"
 			size="40"
 			required="true"


### PR DESCRIPTION
Useless description for the field group title field should have been removed before

Either it was missed or it came back during a merge from staging