### PR TITLE
[4.0] Getting rid of tips for admin modules on the model of site modules

### DIFF
--- a/administrator/components/com_modules/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/forms/moduleadmin.xml
@@ -13,7 +13,6 @@
 			name="title" 
 			type="text"
 			label="JGLOBAL_TITLE"
-			description="COM_MODULES_FIELD_TITLE_DESC"
 			class="input-xxlarge input-large-text"
 			size="40"
 			maxlength="100"
@@ -24,7 +23,6 @@
 			name="note" 
 			type="text"
 			label="COM_MODULES_FIELD_NOTE_LABEL"
-			description="COM_MODULES_FIELD_NOTE_DESC"
 			maxlength="255"
 			size="40"
 			class="span12"
@@ -34,7 +32,6 @@
 			name="module" 
 			type="hidden"
 			label="COM_MODULES_FIELD_MODULE_LABEL"
-			description="COM_MODULES_FIELD_MODULE_DESC"
 			readonly="readonly"
 			size="20"
 		/>
@@ -43,7 +40,6 @@
 			name="showtitle" 
 			type="radio"
 			label="COM_MODULES_FIELD_SHOWTITLE_LABEL"
-			description="COM_MODULES_FIELD_SHOWTITLE_DESC"
 			class="switcher"
 			default="1"
 			size="1"
@@ -56,7 +52,6 @@
 			name="published" 
 			type="list"
 			label="JSTATUS"
-			description="COM_MODULES_FIELD_PUBLISHED_DESC"
 			class="chzn-color-state"
 			default="1"
 			size="1"
@@ -90,7 +85,6 @@
 			name="client_id" 
 			type="hidden"
 			label="COM_MODULES_FIELD_CLIENT_ID_LABEL"
-			description="COM_MODULES_FIELD_CLIENT_ID_DESC"
 			readonly="true"
 			size="1"
 		/>
@@ -99,7 +93,6 @@
 			name="position" 
 			type="moduleposition"
 			label="COM_MODULES_FIELD_POSITION_LABEL"
-			description="COM_MODULES_FIELD_POSITION_DESC"
 			default=""
 			maxlength="50"
 		/>
@@ -108,7 +101,6 @@
 			name="access" 
 			type="accesslevel"
 			label="JFIELD_ACCESS_LABEL"
-			description="JFIELD_ACCESS_DESC"
 			size="1"
 		/>
 
@@ -116,7 +108,6 @@
 			name="ordering" 
 			type="moduleorder"
 			label="JFIELD_ORDERING_LABEL"
-			description="JFIELD_ORDERING_DESC"
 			linked="position"
 		/>
 
@@ -124,7 +115,6 @@
 			name="language"
 			type="language"
 			label="JFIELD_LANGUAGE_LABEL"
-			description="JFIELD_MODULE_LANGUAGE_DESC"
 			default="*"
 			client="administrator"
 			>
@@ -135,7 +125,6 @@
 			name="content" 
 			type="editor"
 			label="COM_MODULES_FIELD_CONTENT_LABEL"
-			description="COM_MODULES_FIELD_CONTENT_DESC"
 			buttons="true"
 			filter="JComponentHelper::filterText"
 			hide="readmore,pagebreak,module"


### PR DESCRIPTION
### Before patch

<img width="361" alt="screen shot 2017-11-18 at 08 18 38" src="https://user-images.githubusercontent.com/869724/32978039-0c2d1a12-cc3a-11e7-839b-46d4a716318e.png">


### After patch => No more tips
<img width="373" alt="screen shot 2017-11-18 at 08 28 07" src="https://user-images.githubusercontent.com/869724/32978061-79f9c2b6-cc3a-11e7-97f1-f3bb2e00dd98.png">

