### PR TITLE
[4.0] Load the field table correctly

### DIFF
--- a/administrator/components/com_fields/Table/FieldTable.php
+++ b/administrator/components/com_fields/Table/FieldTable.php
@@ -112,7 +112,7 @@ class FieldTable extends Table
 		$this->name = str_replace(',', '-', $this->name);
 
 		// Verify that the name is unique
-		$table = new Field($this->_db);
+		$table = new FieldTable($this->_db);
 
 		if ($table->load(array('name' => $this->name)) && ($table->id != $this->id || $this->id == 0))
 		{


### PR DESCRIPTION
Saving a field crashes because it tries to load the Field table with the wrong name.