### PR TITLE
[4.0] Drop the not needed params column

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-11-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2017-11-18.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__fields_groups` DROP `params`;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-11-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2017-11-18.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__fields_groups" DROP COLUMN "params";

--- a/installation/sql/mysql/joomla.sql
+++ b/installation/sql/mysql/joomla.sql
@@ -718,7 +718,6 @@ CREATE TABLE IF NOT EXISTS `#__fields_groups` (
   `checked_out` int(11) NOT NULL DEFAULT '0',
   `checked_out_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `ordering` int(11) NOT NULL DEFAULT '0',
-  `params` text NOT NULL,
   `language` char(7) NOT NULL DEFAULT '',
   `created` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `created_by` int(10) unsigned NOT NULL DEFAULT '0',

--- a/installation/sql/postgresql/joomla.sql
+++ b/installation/sql/postgresql/joomla.sql
@@ -728,7 +728,6 @@ CREATE TABLE IF NOT EXISTS "#__fields_groups" (
   "checked_out" integer DEFAULT '0' NOT NULL,
   "checked_out_time" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "ordering" integer DEFAULT '0' NOT NULL,
-  "params" text DEFAULT '' NOT NULL,
   "language" varchar(7) DEFAULT '' NOT NULL,
   "created" timestamp without time zone DEFAULT '1970-01-01 00:00:00' NOT NULL,
   "created_by" bigint DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Pull Request for Issue #18609.

### Summary of Changes
The params column is not used in field groups, this pr removes them.

Ping @Bakual, can you please confirm that it is ok to remove the column?


### Testing Instructions
Create a field group.

### Expected result
Works.

### Actual result
Error is shown.