### PR TITLE
PHP 7.2 Compatibility: Count on non Countable obj in ContentModelArticles

### DIFF
--- a/administrator/components/com_content/models/articles.php
+++ b/administrator/components/com_content/models/articles.php
@@ -267,7 +267,7 @@ class ContentModelArticles extends JModelList
 		}
 
 		// Filter by categories and by level
-		$categoryId = $this->getState('filter.category_id');
+		$categoryId = $this->getState('filter.category_id', array());
 		$level = $this->getState('filter.level');
 
 		$categoryId = $categoryId && !is_array($categoryId)


### PR DESCRIPTION
PHP Warning:  count(): Parameter must be an array or an object that implements Countable
in administrator/components/com_content/models/articles.php

### Summary of Changes
Given a reasonable default value instead of null.

### Testing Instructions
The error is raised browsing back-end control panel or articles list, with no filter set.
It is raised on PHP 7.2 (and newer) only.
See http://php.net/manual/en/migration72.incompatible.php (Warn when counting non-countable types)

