### PR TITLE
Prevent PlgSystemFields::onContentAfterSave from deleting user values from #__fields_values

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -88,7 +88,7 @@ class PlgSystemFields extends JPlugin
 			// Determine the value if it is available from the data
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
-			// Setting a null value deletes the record
+			// Test before setting a null value, which deletes the record
 			if (!is_null($value))
 			{
 				// Setting the value for the field and the item

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -89,7 +89,7 @@ class PlgSystemFields extends JPlugin
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
 			// Setting a null value deletes the record
-			if(!is_null($value))
+			if (!is_null($value))
 			{
 				// Setting the value for the field and the item
 				$model->setFieldValue($field->id, $item->id, $value);

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -88,8 +88,12 @@ class PlgSystemFields extends JPlugin
 			// Determine the value if it is available from the data
 			$value = key_exists($field->name, $fieldsData) ? $fieldsData[$field->name] : null;
 
-			// Setting the value for the field and the item
-			$model->setFieldValue($field->id, $item->id, $value);
+			// Setting a null value deletes the record
+			if(!is_null($value))
+			{
+				// Setting the value for the field and the item
+				$model->setFieldValue($field->id, $item->id, $value);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
Changing user groups via JUserHelper without first setting a task input variable to activate, block or unblock deletes ALL user values from #__fields_values.  $model->setFieldValue deletes records where the value is null.  This change tests for a null value before calling setFieldValue to prevent that deletion.

Pull Request for Issue # .

### Summary of Changes

Test for null value to prevent the fields model from deleting user values from the table.

### Testing Instructions

Create a system plugin that calls JUserHelper::setUserGroups

Before the patch, all user field values for the updated user will be deleted.

After the patch, all user field values for the updated user will remain.

Prior to this change, I had to JFactory::getApplication()->input->set('task','unblock'); in order to update user groups without losing all of their field data.

### Expected result

User fields remain

### Actual result

User fields are deleted

### Documentation Changes Required

