### PR TITLE
[4.0] Fix typo in CalendarField

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -223,7 +223,7 @@ class CalendarField extends FormField
 				{
 					// Get a date object based on the correct timezone.
 					$date = Factory::getDate($this->value, 'UTC');
-					$date->setTimezone(new DateTimeZone($config->get('offset')));
+					$date->setTimezone(new \DateTimeZone($config->get('offset')));
 
 					// Transform the date string.
 					$this->value = $date->format('Y-m-d H:i:s', true, false);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The class DateTimeZone class is used without root namespace, it causes fatal error when a calendar form field with filter="server_utc" is used. This PR fixes it.

### Testing Instructions
Code review, found it when I look at the issue https://github.com/joomla/joomla-cms/issues/18698

