### PR TITLE
[4.0] Add a space before the copyright sign

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -106,7 +106,7 @@ $this->setMetaData('theme-color', '#1c3d5c');
 				</a>
 			</li>
 			<li class="nav-item">
-				<span class="text-white float-right">&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?></span>
+				<span class="text-white float-right">&nbsp;&copy; <?php echo date('Y'); ?> <?php echo $sitename; ?></span>
 			</li>
 		</ul>
 	</nav>


### PR DESCRIPTION
Pull Request for Issue #18690.

### Summary of Changes
Adds a space before the copyright sign in the login page.

![image](https://user-images.githubusercontent.com/251072/32991769-364a3024-cd42-11e7-9f7d-46cb3752d8fb.png)

### Testing Instructions
Open the admin login screen.

### Expected result
A space before the copyright sign.

### Actual result
No space.