### PR TITLE
Fix error on session_write_close after mysql crash on on heavy query

### DIFF
--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -630,11 +630,16 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 				// If connect fails, ignore that exception and throw the normal exception.
 				catch (RuntimeException $e)
 				{
-					// Get the error number and message.
-					$this->errorNum = $this->getErrorNumber();
-					$this->errorMsg = $this->getErrorMessage();
-
 					JLog::add(JText::sprintf('JLIB_DATABASE_QUERY_FAILED', $this->errorNum, $this->errorMsg), JLog::ERROR, 'database-error');
+
+					if ($this->errorNum === 2006)
+					{
+						/**
+						 * Can not connect because MySQL server has gone away.
+						 * Give a time to restart in order to save the session to the database.
+						 */
+						sleep(1);
+					}
 
 					throw new JDatabaseExceptionExecuting($query, $this->errorMsg, $this->errorNum, $e);
 				}


### PR DESCRIPTION
### Summary of Changes

After mysql crash on heavy query (or mysql server is working for a long time) session can not be saved because connection fails.

I have got below errors:
```
[18-Nov-2017 16:06:09 Europe/Berlin] PHP Warning:  mysqli_errno() expects parameter 1 to be mysqli, boolean given in .../libraries/joomla/database/driver/mysqli.php on line 987
[18-Nov-2017 16:06:09 Europe/Berlin] PHP Warning:  mysqli_error() expects parameter 1 to be mysqli, boolean given in .../libraries/joomla/database/driver/mysqli.php on line 999
[18-Nov-2017 16:06:09 Europe/Berlin] PHP Warning:  Invalid argument supplied for foreach() in .../components/com_content/models/articles.php on line 612
[18-Nov-2017 16:06:09 Europe/Berlin] PHP Warning:  Invalid argument supplied for foreach() in .../modules/mod_articles_latest/helper.php on line 122
[18-Nov-2017 16:06:09 Europe/Berlin] PHP Warning:  Invalid argument supplied for foreach() in .../templates/.../html/mod_articles_latest/default.php on line 13
```

and in apache2 error:
```
PHP Warning:  session_write_close(): Failed to write session data (user). Please verify that the current setting of session.save_path is correct (/var/lib/php/sessions) in .../libraries/joomla/session/handler/native.php on line 201
```

### Testing Instructions
Core review. 

For me it only takes 1 second to start mysql again. Less value does not work.


### Expected result
After a query fails because mysql crash do not block session to save data by connection fails.
