### PR TITLE
Extend support for creating a separate cache for mobile and add tablet

### DIFF
--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -59,6 +59,25 @@ class Cache
 			'caching'      => ($conf->get('caching') >= 1) ? true : false,
 		);
 
+		if ($conf->get('cache_platformprefix', '0'))
+		{
+			$webclient = new WebClient;
+
+			 // Add a platform key to cache key if device calls for separate caching
+			if ($webclient->mobile)
+			{
+				if ($webclient->platform === WebClient::ANDROIDTABLET
+					|| $webclient->platform === WebClient::IPAD)
+				{
+					$this->_options['platformKey'] = 'T';
+				}
+				else
+				{
+					$this->_options['platformKey'] = 'M';
+				}
+			}
+		}
+
 		// Overwrite default options with given options
 		foreach ($options as $option => $value)
 		{
@@ -758,6 +777,7 @@ class Cache
 	 * @return  string
 	 *
 	 * @since   3.5
+	 * @deprecated  4.0
 	 */
 	public static function getPlatformPrefix()
 	{
@@ -771,6 +791,12 @@ class Cache
 
 		if ($webclient->mobile)
 		{
+			if ($webclient->platform === WebClient::ANDROIDTABLET
+				|| $webclient->platform === WebClient::IPAD)
+			{
+				return 'T-';
+			}
+
 			return 'M-';
 		}
 

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -83,15 +83,15 @@ class CacheStorage
 	 * @var    string
 	 * @since  __DEPLOY_VERSION__
 	 */
-	public $_platformKey;
+	public $platformKey = '';
 
 	/**
 	 * Whether platform key is used as suffix
 	 *
-	 * @var    string
+	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $_platformKeyAsSuffix = false;
+	protected $platformKeyAsSuffix = false;
 
 	/**
 	 * Constructor
@@ -110,7 +110,7 @@ class CacheStorage
 		$this->_locking     = isset($options['locking']) ? $options['locking'] : true;
 		$this->_lifetime    = isset($options['lifetime']) ? $options['lifetime'] * 60 : $config->get('cachetime') * 60;
 		$this->_now         = isset($options['now']) ? $options['now'] : time();
-		$this->_platformKey = isset($options['platformKey']) ? $options['platformKey'] : '';
+		$this->platformKey  = isset($options['platformKey']) ? $options['platformKey'] : '';
 
 		// Set time threshold value.  If the lifetime is not set, default to 60 (0 is BAD)
 		// _threshold is now available ONLY as a legacy (it's deprecated).  It's no longer used in the core.
@@ -393,14 +393,14 @@ class CacheStorage
 
 		$cacheId = $this->_hash . '-cache-' . $group . '-' . $name;
 
-		if ($this->_platformKey !== '')
+		if ($this->platformKey !== '')
 		{
-			if ($this->_platformKeyAsSuffix)
+			if ($this->platformKeyAsSuffix)
 			{
-				return $cacheId . '-' . $this->_platformKey;
+				return $cacheId . '-' . $this->platformKey;
 			}
 
-			return $this->_platformKey . '-' . $cacheId;
+			return $this->platformKey . '-' . $cacheId;
 		}
 
 		return $cacheId;

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -78,6 +78,22 @@ class CacheStorage
 	public $_hash;
 
 	/**
+	 * Platform key used as prefix or suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public $_platformKey;
+
+	/**
+	 * Whether platform key is used as suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_platformKeyAsSuffix = false;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters
@@ -89,11 +105,12 @@ class CacheStorage
 		$config = \JFactory::getConfig();
 
 		$this->_hash        = md5($config->get('secret'));
-		$this->_application = (isset($options['application'])) ? $options['application'] : null;
-		$this->_language    = (isset($options['language'])) ? $options['language'] : 'en-GB';
-		$this->_locking     = (isset($options['locking'])) ? $options['locking'] : true;
-		$this->_lifetime    = (isset($options['lifetime'])) ? $options['lifetime'] * 60 : $config->get('cachetime') * 60;
-		$this->_now         = (isset($options['now'])) ? $options['now'] : time();
+		$this->_application = isset($options['application']) ? $options['application'] : null;
+		$this->_language    = isset($options['language']) ? $options['language'] : 'en-GB';
+		$this->_locking     = isset($options['locking']) ? $options['locking'] : true;
+		$this->_lifetime    = isset($options['lifetime']) ? $options['lifetime'] * 60 : $config->get('cachetime') * 60;
+		$this->_now         = isset($options['now']) ? $options['now'] : time();
+		$this->_platformKey = isset($options['platformKey']) ? $options['platformKey'] : '';
 
 		// Set time threshold value.  If the lifetime is not set, default to 60 (0 is BAD)
 		// _threshold is now available ONLY as a legacy (it's deprecated).  It's no longer used in the core.
@@ -374,7 +391,19 @@ class CacheStorage
 		$name          = md5($this->_application . '-' . $id . '-' . $this->_language);
 		$this->rawname = $this->_hash . '-' . $name;
 
-		return Cache::getPlatformPrefix() . $this->_hash . '-cache-' . $group . '-' . $name;
+		$cacheId = $this->_hash . '-cache-' . $group . '-' . $name;
+
+		if ($this->_platformKey !== '')
+		{
+			if ($this->_platformKeyAsSuffix)
+			{
+				return $cacheId . '-' . $this->_platformKey;
+			}
+
+			return $this->_platformKey . '-' . $cacheId;
+		}
+
+		return $cacheId;
 	}
 
 	/**

--- a/libraries/src/Cache/Storage/MemcacheStorage.php
+++ b/libraries/src/Cache/Storage/MemcacheStorage.php
@@ -39,6 +39,14 @@ class MemcacheStorage extends CacheStorage
 	protected $_compress = 0;
 
 	/**
+	 * Whether platform key is used as suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_platformKeyAsSuffix = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.
@@ -96,31 +104,6 @@ class MemcacheStorage extends CacheStorage
 
 			throw new CacheConnectingException('Could not connect to memcache server');
 		}
-	}
-
-	/**
-	 * Get a cache_id string from an id/group pair
-	 *
-	 * @param   string  $id     The cache data id
-	 * @param   string  $group  The cache data group
-	 *
-	 * @return  string   The cache_id string
-	 *
-	 * @since   11.1
-	 */
-	protected function _getCacheId($id, $group)
-	{
-		$prefix   = Cache::getPlatformPrefix();
-		$length   = strlen($prefix);
-		$cache_id = parent::_getCacheId($id, $group);
-
-		if ($length)
-		{
-			// Memcache use suffix instead of prefix
-			$cache_id = substr($cache_id, $length) . strrev($prefix);
-		}
-
-		return $cache_id;
 	}
 
 	/**

--- a/libraries/src/Cache/Storage/MemcacheStorage.php
+++ b/libraries/src/Cache/Storage/MemcacheStorage.php
@@ -41,10 +41,10 @@ class MemcacheStorage extends CacheStorage
 	/**
 	 * Whether platform key is used as suffix
 	 *
-	 * @var    string
+	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $_platformKeyAsSuffix = true;
+	protected $platformKeyAsSuffix = true;
 
 	/**
 	 * Constructor

--- a/libraries/src/Cache/Storage/MemcachedStorage.php
+++ b/libraries/src/Cache/Storage/MemcachedStorage.php
@@ -39,6 +39,14 @@ class MemcachedStorage extends CacheStorage
 	protected $_compress = 0;
 
 	/**
+	 * Whether platform key is used as suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_platformKeyAsSuffix = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.

--- a/libraries/src/Cache/Storage/MemcachedStorage.php
+++ b/libraries/src/Cache/Storage/MemcachedStorage.php
@@ -41,10 +41,10 @@ class MemcachedStorage extends CacheStorage
 	/**
 	 * Whether platform key is used as suffix
 	 *
-	 * @var    string
+	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $_platformKeyAsSuffix = true;
+	protected $platformKeyAsSuffix = true;
 
 	/**
 	 * Constructor

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -37,6 +37,14 @@ class RedisStorage extends CacheStorage
 	protected $_persistent = false;
 
 	/**
+	 * Whether platform key is used as suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_platformKeyAsSuffix = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   array  $options  Optional parameters.

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -39,10 +39,10 @@ class RedisStorage extends CacheStorage
 	/**
 	 * Whether platform key is used as suffix
 	 *
-	 * @var    string
+	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $_platformKeyAsSuffix = true;
+	protected $platformKeyAsSuffix = true;
 
 	/**
 	 * Constructor


### PR DESCRIPTION
Pull Request for Issue #6859

### Summary of Changes
Create a right `cacheId` (with suffix -M or -T) for mobile cache in redis and memcached based on memcache.
Add separate cache for tablet.
Check browser type (mobile, tablet, etc) only once on cache constructor.


### Testing Instructions
See at #6859
