### PR TITLE
[4.0] Add access checks for com_config

### DIFF
--- a/components/com_config/dispatcher.php
+++ b/components/com_config/dispatcher.php
@@ -26,4 +26,23 @@ class ConfigDispatcher extends Dispatcher
 	 * @since  4.0.0
 	 */
 	protected $namespace = 'Joomla\\Component\\Config';
+
+	/**
+	 * Method to check component access permission
+	 *
+	 * @since   4.0.0
+	 *
+	 * @return  void
+	 *
+	 * @throws  Exception|Notallowed
+	 */
+	protected function checkAccess()
+	{
+		parent::checkAccess();
+
+		if (!$this->app->getIdentity()->authorise('core.admin'))
+		{
+			throw new Notallowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
+		}
+	}
 }


### PR DESCRIPTION
### Summary of Changes

This adds ACL checks to com_config this only applys for 4.0

### Testing Instructions

- Install 4.0.0-alpha2
- Access: `index.php/component/config?view=modules&id=16` without logging in.
- Informations are shown

### Expected result

403 / Access restricted

### Actual result

Public access

cc @wilsonge @PhilETaylor 