### PR TITLE
[com_fields] Multilanguage: fixing display of User fields in profile depending on Active language

### DIFF
--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -107,6 +107,18 @@ class FieldsHelper
 			$item = (object) $item;
 		}
 
+		// Multilingual conditions for user fields
+		if ($context == 'com_users.user')
+		{
+			$app = JFactory::getApplication();
+
+			if ($app->isClient('site') && JLanguageMultilang::isEnabled())
+			{
+				$lang = $app->getLanguage()->getTag();
+				self::$fieldsCache->setState('filter.language', array('*', $lang));
+			}
+		}
+
 		if (JLanguageMultilang::isEnabled() && isset($item->language) && $item->language != '*')
 		{
 			self::$fieldsCache->setState('filter.language', array('*', $item->language));


### PR DESCRIPTION
### Summary of Changes
Filtering display of User fields by Active language and ALL 
Profile, edit profile and registration should only display custom fields tagged to the same language as the Active language or tagged to ALL

### Testing Instructions
Create a multilingual site (2 languages are enough)
Create User fields: 1 per language and 1 tagged to ALL
<img width="1205" alt="fileds_users" src="https://user-images.githubusercontent.com/869724/33011100-2b9cb228-cddd-11e7-81cb-01b3166f53f6.png">
<img width="557" alt="backend_edit user" src="https://user-images.githubusercontent.com/869724/33011206-8b4807ea-cddd-11e7-9479-8ae1b6e31cd4.png">

### Before patch
All user fields display, whatever the assigned language. Examples for English, the French tagged field also displays

<img width="761" alt="registration" src="https://user-images.githubusercontent.com/869724/33011133-4969dfce-cddd-11e7-98e0-884601c55a0d.png">

<img width="705" alt="frontend_editprofile" src="https://user-images.githubusercontent.com/869724/33011165-6a7095c8-cddd-11e7-856b-902496b1443a.png">

### After patch
english registration
<img width="761" alt="after_englishregsitration" src="https://user-images.githubusercontent.com/869724/33011275-c25ae43c-cddd-11e7-99d3-31df33a6b694.png">

french registration
<img width="784" alt="after_frenchregistration" src="https://user-images.githubusercontent.com/869724/33011291-d5ce5bb6-cddd-11e7-94b5-cf3b53457c6f.png">

Edit profile English
<img width="577" alt="frontend_editprofile_english" src="https://user-images.githubusercontent.com/869724/33011309-e75a9502-cddd-11e7-9a9a-ac6629a78b55.png">

Edit Profile French
<img width="581" alt="frontend_editprofile_french" src="https://user-images.githubusercontent.com/869724/33011321-f4e8fd4e-cddd-11e7-997f-f40b2736e1f3.png">

Profile display for English
<img width="560" alt="profileviewenglish" src="https://user-images.githubusercontent.com/869724/33011344-03f17ffa-cdde-11e7-8cf8-6486ff25077a.png">

etc.

Note: using the getData() method solves the filtering for profile display and edit, but not registration. See https://github.com/joomla/joomla-cms/pull/18474#issuecomment-342895182

@laoneo 



