### PR TITLE
Add forum ID to language string

### DIFF
--- a/administrator/language/en-GB/en-GB.mod_menu.ini
+++ b/administrator/language/en-GB/en-GB.mod_menu.ini
@@ -67,7 +67,7 @@ MOD_MENU_HELP_SUPPORT_OFFICIAL_FORUM="Official Support Forum"
 ; the string below will be used if the localised sample data contains a URL for the desired community forum or if the 'Custom Support Forum' field parameter in the Administrator Menu module contains a URL
 MOD_MENU_HELP_SUPPORT_CUSTOM_FORUM="Custom Support Forum"
 ; Enter in the string below the # of the specific language forum in https://forum.joomla.org/ (example: 19 for French). If left empty, it will use '511' which is the section for all languages forums.
-MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE=""
+MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE="511"
 ; If you have chosen to display in the string above the section for all languages, just translate the string below. 
 ; If you have displayed the specific language forum, use something like "Official French Forum" in your language. 
 MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM="Official Language Forums"


### PR DESCRIPTION
Crowdin doesn't allow to translate empty strings.

### Summary of Changes
This PR adds the default forum ID to the language string.
There is no change in functionality as there is currently a fallback to the same value.

https://github.com/joomla/joomla-cms/blob/5e8ea37f2918abe4ba2e4c801bbdd6458cc8fdc5/administrator/components/com_admin/views/help/tmpl/langforum.php#L14-L19

### Testing Instructions
Test that the link to the language forum works


### Expected result
Works


### Actual result
Works but can't be translated using Corwdin.


### Documentation Changes Required
Maybe translation doc.
