### PR TITLE
Add additional check that view exists before proceeding

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -92,9 +92,8 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 
 		// Are we dealing with an article or category that is attached to a menu item?
 		if ($menuItem !== null
-			&& isset($menuItem->query['view'])
+			&& isset($menuItem->query['view'], $query['view'], $menuItem->query['id'], $query['id'])
 			&& $menuItem->query['view'] == $query['view']
-			&& isset($menuItem->query['id'], $query['id'])
 			&& $menuItem->query['id'] == (int) $query['id'])
 		{
 			unset($query['view']);

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -92,6 +92,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 
 		// Are we dealing with an article or category that is attached to a menu item?
 		if ($menuItem !== null
+			&& isset($menuItem->query['view'], $query['view'])
 			&& $menuItem->query['view'] == $query['view']
 			&& isset($menuItem->query['id'], $query['id'])
 			&& $menuItem->query['id'] == (int) $query['id'])

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -92,7 +92,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 
 		// Are we dealing with an article or category that is attached to a menu item?
 		if ($menuItem !== null
-			&& isset($menuItem->query['view'], $query['view'])
+			&& isset($menuItem->query['view'])
 			&& $menuItem->query['view'] == $query['view']
 			&& isset($menuItem->query['id'], $query['id'])
 			&& $menuItem->query['id'] == (int) $query['id'])


### PR DESCRIPTION
We assume the array key exists with view but not ID. I have come across some installations where view does not exist and it causes php warnings. So just check it does exist before actually proceeding further as we do with ID.