### PR TITLE
Edit article -  add a tag by pressing enter or regular comma

### DIFF
--- a/layouts/joomla/html/tag.php
+++ b/layouts/joomla/html/tag.php
@@ -43,55 +43,72 @@ if ($allowCustom)
 	JFactory::getDocument()->addScriptDeclaration(
 		"
 		jQuery(document).ready(function ($) {
-
 			var customTagPrefix = '#new#';
+
+			function tagHandler(event,element) {
+				// Search a highlighted result
+
+				var highlighted = $('" . $selector . "_chzn').find('li.active-result.highlighted').first();
+
+				// Add the highlighted option
+				if (event.which === 13 && highlighted.text() !== '')
+				{
+					// Extra check. If we have added a custom tag with element text remove it
+					var customOptionValue = customTagPrefix + highlighted.text();
+					$('" . $selector . " option').filter(function () { return $(element).val() == customOptionValue; }).remove();
+
+					// Select the highlighted result
+					var tagOption = $('" . $selector . " option').filter(function () { return $(element).html() == highlighted.text(); });
+					tagOption.attr('selected', 'selected');
+				}
+				// Add the custom tag option
+				else
+				{
+					var customTag = element.value;
+
+					// Extra check. Search if the custom tag already exists (typed faster than AJAX ready)
+					var tagOption = $('" . $selector . " option').filter(function () { return $(element).html() == customTag; });
+					if (tagOption.text() !== '')
+					{
+						tagOption.attr('selected', 'selected');
+					}
+					else
+					{
+						var option = $('<option>');
+						option.text(element.value).val(customTagPrefix + element.value);
+						option.attr('selected','selected');
+
+						// Append the option and repopulate the chosen field
+						$('" . $selector . "').append(option);
+					}
+				}
+
+				element.value = '';
+				$('" . $selector . "').trigger('liszt:updated');
+			}
+
+			// Method to add tags pressing comma
+			$('" . $selector . "_chzn input').keypress(function(event) {
+				if (event.charCode === 44)
+				{
+					// Tag is greater than the minimum required chars
+					if (this.value && this.value.length >= " . $minTermLength . ")
+					{
+						tagHandler(event, this);
+					}
+
+					// Do not add comma to tag at all
+					event.preventDefault();
+				}
+			});
 
 			// Method to add tags pressing enter
 			$('" . $selector . "_chzn input').keyup(function(event) {
-
 				// Tag is greater than the minimum required chars and enter pressed
-				if (this.value && this.value.length >= " . $minTermLength . " && (event.which === 13 || event.which === 188)) {
-
-					// Search a highlighted result
-					var highlighted = $('" . $selector . "_chzn').find('li.active-result.highlighted').first();
-
-					// Add the highlighted option
-					if (event.which === 13 && highlighted.text() !== '')
-					{
-						// Extra check. If we have added a custom tag with this text remove it
-						var customOptionValue = customTagPrefix + highlighted.text();
-						$('" . $selector . " option').filter(function () { return $(this).val() == customOptionValue; }).remove();
-
-						// Select the highlighted result
-						var tagOption = $('" . $selector . " option').filter(function () { return $(this).html() == highlighted.text(); });
-						tagOption.attr('selected', 'selected');
-					}
-					// Add the custom tag option
-					else
-					{
-						var customTag = this.value;
-
-						// Extra check. Search if the custom tag already exists (typed faster than AJAX ready)
-						var tagOption = $('" . $selector . " option').filter(function () { return $(this).html() == customTag; });
-						if (tagOption.text() !== '')
-						{
-							tagOption.attr('selected', 'selected');
-						}
-						else
-						{
-							var option = $('<option>');
-							option.text(this.value).val(customTagPrefix + this.value);
-							option.attr('selected','selected');
-
-							// Append the option and repopulate the chosen field
-							$('" . $selector . "').append(option);
-						}
-					}
-
-					this.value = '';
-					$('" . $selector . "').trigger('liszt:updated');
+				if (event.which === 13 && this.value && this.value.length >= " . $minTermLength . ")
+				{
+					tagHandler(event,this);
 					event.preventDefault();
-
 				}
 			});
 		});


### PR DESCRIPTION
Pull Request for Issue #10761

1. Related and inspired by #12366
2. Do not add comma (`,`) to tags

### Summary of Changes
* Wrap code in function to use for a new event.
* Check for comma in `keypress` event
* Check for enter in `keyup` event
* Do not add a comma to tag
* Use check `event.charCode == 44` for comma which should fix the issue.

### Testing Instructions
See #10761

### Expected result
Fix mentioned issue and comma is not added at the end of tag when you are pressing comma.

### Actual result
Comma is added at the end of tag.

### Documentation Changes Required
No