### PR TITLE
[4.0] Fix JS searchtools wrong syntax.

### DIFF
--- a/media/system/js/searchtools.js
+++ b/media/system/js/searchtools.js
@@ -320,16 +320,16 @@
 
 			var self = this;
 
-			if (!this.orderField.length)
+			if (!this.orderField)
 			{
-				this.orderField = createElement('<input>');
+				this.orderField = document.createElement('input');
 				this.orderField.setAttribute('type', 'hidden');
 				this.orderField.setAttribute('id', 'js-stools-field-order');
 				this.orderField.setAttribute('class', 'js-stools-field-order');
 				this.orderField.setAttribute('name', self.options.orderFieldName);
 				this.orderField.setAttribute('value', self.activeOrder + ' ' + this.activeDirection);
 
-				this.theForm.innerHTML+= this.orderField;
+				this.theForm.innerHTML+= this.orderField.outerHTML;
 			}
 
 			// Add missing columns to the order select


### PR DESCRIPTION
### Testing Instructions
 - Change fullordering field from list to hidden type from the file `/administrator/components/com_content/forms/filter_articles.xml` line 82.
- From the articles list view:
**Before:** Uncaught ReferenceError: createElement is not defined.
**After:** should work fine.

