### PR TITLE
[4.0] Fix sendmail token error

### DIFF
--- a/administrator/components/com_config/tmpl/application/default_mail.php
+++ b/administrator/components/com_config/tmpl/application/default_mail.php
@@ -25,7 +25,7 @@ JText::script('JLIB_JS_AJAX_ERROR_PARSE');
 JText::script('JLIB_JS_AJAX_ERROR_TIMEOUT');
 
 // Ajax request data.
-$ajaxUri = JRoute::_('index.php?option=com_config&task=application.sendtestmail&format=json');
+$ajaxUri = JRoute::_('index.php?option=com_config&task=application.sendtestmail&format=json&' . JSession::getFormToken() .'=1');
 
 $this->name = JText::_('COM_CONFIG_MAIL_SETTINGS');
 $this->fieldsname = 'mail';


### PR DESCRIPTION
Pull Request for Issue #18596

### Summary of Changes

Fix the error due to the token check always returning false

### Testing Instructions

Attempt to submit a test mail via com_config