### PR TITLE
[4.0] Fix dropdown menu alignment

### DIFF
--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -21,10 +21,10 @@ $articleId = $displayData['item']->id;
 
 		<?php if ($canEdit || $displayData['params']->get('show_print_icon') || $displayData['params']->get('show_email_icon')) : ?>
 			<div class="btn-group float-right">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS'); ?>"
-                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    <span class="fa fa-cog" aria-hidden="true"></span>
-                </button>
+				<button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS'); ?>"
+					data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+					<span class="fa fa-cog" aria-hidden="true"></span>
+				</button>
 				<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton-<?php echo $articleId; ?>">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>
 						<?php echo JHtml::_('icon.print_popup', $displayData['item'], $displayData['params']); ?>

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -11,7 +11,7 @@ defined('JPATH_BASE') or die;
 
 JHtml::_('bootstrap.framework');
 
-$canEdit = $displayData['params']->get('access-edit');
+$canEdit   = $displayData['params']->get('access-edit');
 $articleId = $displayData['item']->id;
 
 ?>
@@ -24,12 +24,8 @@ $articleId = $displayData['item']->id;
                 <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton-<?php echo $articleId; ?>" aria-label="<?php echo JText::_('JUSER_TOOLS'); ?>"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     <span class="fa fa-cog" aria-hidden="true"></span>
-                    <span class="caret" aria-hidden="true"></span>
                 </button>
-
-                <a class=""  href="#"> <span class=""></span><span class="caret"></span> </a>
-				<?php // Note the actions class is deprecated. Use dropdown-menu instead. ?>
-				<div class="dropdown-menu" aria-labelledby="dropdownMenuButton-<?php echo $articleId; ?>">
+				<div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton-<?php echo $articleId; ?>">
 					<?php if ($displayData['params']->get('show_print_icon')) : ?>
 						<?php echo JHtml::_('icon.print_popup', $displayData['item'], $displayData['params']); ?>
 					<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #18613

### Summary of Changes

Align the dropdown menu to the right so it doesn't overflow on the viewport, on smaller devices.