### PR TITLE
[4.0] Correct wrong tag "base" to "head" in templates/system/incompatible.html

### DIFF
--- a/templates/system/incompatible.html
+++ b/templates/system/incompatible.html
@@ -1,5 +1,5 @@
 <html>
-	<base>
+	<head>
 		<base href="{{BASEPATH}}">
 		<meta charset=utf-8">
 		<meta http-equiv="Content-Language" content="en-GB">


### PR DESCRIPTION
Pull Request for no issue.

### Summary of Changes

In templates/system/incompatible.html, "base" tag is used instead of "head".

This error comes from PR #18777.

### Testing Instructions

Code review.

### Expected result

Correct HTML.

### Actual result

Incorrect HTML.

### Documentation Changes Required

None.