### PR TITLE
[4.0] Add the missing files to the ignore array of the build script

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -106,6 +106,7 @@ $filesArray = array(
  * These paths are from the repository root without the leading slash
  */
 $doNotPackage = array(
+	'dev',
 	'.appveyor.yml',
 	'.drone.yml',
 	'.github',
@@ -114,6 +115,7 @@ $doNotPackage = array(
 	'.php_cs',
 	'.travis.yml',
 	'README.md',
+	'acceptance.suite.yml',
 	'appveyor-phpunit.xml',
 	'build',
 	'build.xml',
@@ -126,11 +128,12 @@ $doNotPackage = array(
 	'karma.conf.js',
 	'phpunit.xml.dist',
 	'scss-lint-report.xml',
-	'sccs-lint.yml',
+	'scss-lint.yml',
 	'stubs.php',
 	'tests',
 	'travisci-phpunit.xml',
 	'drone-package.json',
+	'package.json',
 	'codeception.yml',
 	'Jenkinsfile',
 	'jenkins-phpunit.xml',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add the missing files to the ignore array of the build script

### Testing Instructions

run build and confirm the files and folders are not there

### Expected result

- `dev` folder dropped
- `acceptance.suite.yml` dropped
- `package.json` dropped
- `scss-lint.yml` dropped

### Actual result

the above files & folders are still in the package see e.g the 4.0.0 alpha2 package

### Documentation Changes Required

none