### PR TITLE
[com_fields] Translate the label of the user custom fields in the contact page

### DIFF
--- a/components/com_contact/views/contact/tmpl/default_user_custom_fields.php
+++ b/components/com_contact/views/contact/tmpl/default_user_custom_fields.php
@@ -47,7 +47,7 @@ $userFieldGroups    = array();
 				<?php continue; ?>
 			<?php endif; ?>
 
-			<?php echo '<dt>' . $field->label . '</dt>'; ?>
+			<?php echo '<dt>' . JText::_($field->label) . '</dt>'; ?>
 			<?php echo '<dd>' . $field->value . '</dd>'; ?>
 		<?php endforeach; ?>
 		</dl>


### PR DESCRIPTION
### Summary of Changes
It is possible to show the user custom fields in a linked contact page. Normally the label is translated, but not here.

### Testing Instructions
- Install another lanuguage
- Create user custom field and set the label to "TO_TRANSLATE"
- Create a new user and fill in a value for the field
- Create a contact and link to the new user
- Set "Set show user custom fields" in the contact options to "All"
- Create a contact menu item with the new contact
- Create a language override for the key TO_TRANSLATE in the new language and in English
- Open the contact on the front

### Expected result
The label is shown with the translated key.

### Actual result
The label is shown with TO_TRANSLATE as text.