### PR TITLE
Allow vendor usage for libraries

### DIFF
--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -182,8 +182,16 @@ class InstallerModel extends JModelList
 						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
 				break;
 				case 'library':
-					$extension = 'lib_' . $item->element;
-						$lang->load("$extension.sys", JPATH_SITE, null, false, true);
+					$parts = explode('/', $item->element);
+					$vendor = (isset($parts[1]) ? $parts[0] : null);
+					$extension = 'lib_' . ($vendor ? implode('_', $parts) : $item->element);
+					$source = $path . '/libraries/' . ($vendor ? $vendor . '/' . $parts[1] : $item->element);
+					$lang->load("$extension.sys", $path, null, false, true);
+
+					if ($source != $path)
+					{
+						$lang->load("$extension.sys", $source, null, false, true);
+					}
 				break;
 				case 'module':
 					$extension = $item->element;

--- a/administrator/components/com_installer/models/extension.php
+++ b/administrator/components/com_installer/models/extension.php
@@ -185,11 +185,10 @@ class InstallerModel extends JModelList
 					$parts = explode('/', $item->element);
 					$vendor = (isset($parts[1]) ? $parts[0] : null);
 					$extension = 'lib_' . ($vendor ? implode('_', $parts) : $item->element);
-					$source = $path . '/libraries/' . ($vendor ? $vendor . '/' . $parts[1] : $item->element);
-					$lang->load("$extension.sys", $path, null, false, true);
 
-					if ($source != $path)
+					if (!$lang->load("$extension.sys", $path, null, false, true))
 					{
+						$source = $path . '/libraries/' . ($vendor ? $vendor . '/' . $parts[1] : $item->element);
 						$lang->load("$extension.sys", $source, null, false, true);
 					}
 				break;

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -464,6 +464,15 @@ class LibraryAdapter extends InstallerAdapter
 		$this->parent->removeFiles($xml->media);
 		$this->parent->removeFiles($xml->languages);
 
+		$elementParts = explode('/', $row->element);
+
+		// Delete empty vendor folders
+		if (2 === count($elementParts))
+		{
+			@rmdir(JPATH_MANIFESTS . '/libraries/' . $elementParts[0]);
+			@rmdir(JPATH_PLATFORM . '/' . $elementParts[0]);
+		}
+
 		$row->delete($row->extension_id);
 		unset($row);
 

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -501,7 +501,7 @@ class LibraryAdapter extends InstallerAdapter
 
 		foreach ($iterator as $file => $pattern)
 		{
-			$element = str_replace(array($mainFolder . '/', '.xml'), '', $file);
+			$element = str_replace(array($mainFolder . DIRECTORY_SEPARATOR, '.xml'), '', $file);
 			$manifestCache = Installer::parseXMLInstallFile($file);
 
 			$extension = Table::getInstance('extension');

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -106,7 +106,15 @@ class LibraryAdapter extends InstallerAdapter
 		{
 			$manifest = array();
 			$manifest['src'] = $this->parent->getPath('manifest');
-			$manifest['dest'] = JPATH_MANIFESTS . '/libraries/' . basename($this->parent->getPath('manifest'));
+			$manifest['dest'] = JPATH_MANIFESTS . '/libraries/' . $this->element . '.xml';
+
+			$destFolder = dirname($manifest['dest']);
+
+			if (!is_dir($destFolder) && !@mkdir($destFolder))
+			{
+				// Install failed, rollback changes
+				throw new \RuntimeException(\JText::_('JLIB_INSTALLER_ABORT_LIB_INSTALL_COPY_SETUP'));
+			}
 
 			if (!$this->parent->copyFiles(array($manifest), true))
 			{
@@ -150,8 +158,7 @@ class LibraryAdapter extends InstallerAdapter
 	{
 		if (!$element)
 		{
-			$manifestPath = \JPath::clean($this->parent->getPath('manifest'));
-			$element = preg_replace('/\.xml/', '', basename($manifestPath));
+			$element  = (string) $this->getManifest()->libraryname;
 		}
 
 		return $element;
@@ -175,7 +182,7 @@ class LibraryAdapter extends InstallerAdapter
 			$this->parent->setPath('source', JPATH_PLATFORM . '/' . $this->getElement());
 		}
 
-		$extension = 'lib_' . $this->getElement();
+		$extension = 'lib_' . str_replace('/', '_', $this->getElement());
 		$librarypath = (string) $this->getManifest()->libraryname;
 		$source = $path ?: JPATH_PLATFORM . '/' . $librarypath;
 
@@ -473,20 +480,29 @@ class LibraryAdapter extends InstallerAdapter
 	public function discover()
 	{
 		$results = array();
-		$file_list = \JFolder::files(JPATH_MANIFESTS . '/libraries', '\.xml$');
 
-		foreach ($file_list as $file)
+
+		$mainFolder = JPATH_MANIFESTS . '/libraries';
+		$folder = new \RecursiveDirectoryIterator($mainFolder);
+		$iterator = new \RegexIterator(
+			new \RecursiveIteratorIterator($folder),
+			'/\.xml$/i',
+			\RecursiveRegexIterator::GET_MATCH
+		);
+
+		foreach ($iterator as $file => $pattern)
 		{
-			$manifest_details = Installer::parseXMLInstallFile(JPATH_MANIFESTS . '/libraries/' . $file);
-			$file = \JFile::stripExt($file);
+			$element = str_replace(array($mainFolder . '/', '.xml'), '', $file);
+			$manifestCache = Installer::parseXMLInstallFile($file);
+
 			$extension = Table::getInstance('extension');
 			$extension->set('type', 'library');
 			$extension->set('client_id', 0);
-			$extension->set('element', $file);
+			$extension->set('element', $element);
 			$extension->set('folder', '');
-			$extension->set('name', $file);
+			$extension->set('name', $element);
 			$extension->set('state', -1);
-			$extension->set('manifest_cache', json_encode($manifest_details));
+			$extension->set('manifest_cache', json_encode($manifestCache));
 			$extension->set('params', '{}');
 			$results[] = $extension;
 		}


### PR DESCRIPTION
Currently libraries are intended to be stored in `/libraries/{NAME}` which can lead to conflicts between library names and can make the libraries folder a total mess if you have a lot of libraries installed. 

Wouldn't be awesome that developers could use it's own vendor library folder? Something like what we already use for [libraries/joomla](https://github.com/joomla/joomla-cms/tree/staging/libraries/joomla) that contains a set of "sub-libraries".

The main idea is that devs could have a folder with an structure like:

* `libraries`
    * `phproberto`
        * `my_library`
        * `another_library`

Seeing that loader already supports loading such libraries I thought that it shouldn't be complicated so I decided to play with it a couple of hours. Sample loading calls:

```php
// How we are already doing it
JLoader::import('joomla.filesystem.file');

// How a vendor library class could be loaded
JLoader::import('phproberto.my_library.some_class');
```

### Summary of Changes

This modifies the library installer to allow that manifests can use:

```xml
<libraryname>phproberto/sample</libraryname>
```

instead of:

```xml
<libraryname>sample</libraryname>
```

I was surprised when I saw that the installer already supports my idea partially. The library installer is already exploding the `libraryname` to copy files into a subfolder:

https://github.com/joomla/joomla-cms/blob/staging/libraries/src/Installer/Adapter/LibraryAdapter.php#L230

So this only modifies the installer to update manifest destination, discover install, load language string and extension appearance in extension manager.

This pull request also fixes a side bug I found when testing that everything works correctly: when a library stores language files inside its library folder (example: `libraries/phproberto/sample/language`) those language files weren't automatically loaded in extension manager. They are loaded for other extensions like components, modules, plugins and templates. 

### Testing Instructions

I'm providing an sample vendor library for testing purposes:
 
[sample-vendor-library.zip](https://github.com/joomla/joomla-cms/files/1498727/sample-vendor-library.zip)

#### Test library installation/usage
1. Install Sample Vendor Library
2. Check that description of the library is translated in the postinstallation message.
3. Check that the library is found in `libraries/phproberto/sample`
4. Go to extension manager and check that library is listed correctly.
5. In your frontend template index.php file add this lines to test library usage:

```php
// Test library loading
JLoader::import('phproberto.sample.library');

// Test library class usage
$class = new \Phproberto\Joomla\Sample\TestClass;

// This echoes a library language string to test it
echo $class->hello();
```

You should see a message like:
`Hello!! This is a sample language string loaded from a vendor library `

#### Test library uninstall
1. Go to extension manager and search for `Phproberto`. You should see the library listed. 
2. Uninstall the library.
3. Ensure that uninstallation works.

#### Test library discover install
1. Go to extension manager and install the sample library from the zip provided.
2. In your database editor search for the library in the `#_extensions` table. 
3. Delete the library row.
4. Go to extension manager > Discover and click discover.
5. Ensure that the extension is shown with its name translated
6. Select the extension and click `Install`
7. Ensure that the installation finished correctly.

#### Additional suggested tests
1. Install a third party library to ensure install/uninstall still works

### Documentation Changes Required

Update library manifest information to add information to use the vendor folder.