### PR TITLE
Fix copy paste in docs

### DIFF
--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -65,7 +65,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -85,7 +85,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -85,7 +85,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to set the value.
+	 * @param   string  $name   The property name for which to get the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/administrator/components/com_categories/models/fields/categoryedit.php
+++ b/administrator/components/com_categories/models/fields/categoryedit.php
@@ -65,7 +65,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -85,7 +85,7 @@ class JFormFieldCategoryEdit extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to get the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/administrator/components/com_menus/models/fields/menuitembytype.php
+++ b/administrator/components/com_menus/models/fields/menuitembytype.php
@@ -72,7 +72,7 @@ class JFormFieldMenuitemByType extends JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -96,7 +96,7 @@ class JFormFieldMenuitemByType extends JFormFieldGroupedList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/administrator/components/com_menus/models/fields/menuitembytype.php
+++ b/administrator/components/com_menus/models/fields/menuitembytype.php
@@ -72,7 +72,7 @@ class JFormFieldMenuitemByType extends JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -60,7 +60,7 @@ class JFormFieldModal_Menu extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -60,7 +60,7 @@ class JFormFieldModal_Menu extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -83,7 +83,7 @@ class JFormFieldModal_Menu extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -78,7 +78,7 @@ class JFormFieldCalendar extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -108,7 +108,7 @@ class JFormFieldCalendar extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/calendar.php
+++ b/libraries/joomla/form/fields/calendar.php
@@ -78,7 +78,7 @@ class JFormFieldCalendar extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -39,7 +39,7 @@ class JFormFieldCheckbox extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -59,7 +59,7 @@ class JFormFieldCheckbox extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/checkbox.php
+++ b/libraries/joomla/form/fields/checkbox.php
@@ -39,7 +39,7 @@ class JFormFieldCheckbox extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -56,7 +56,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -77,7 +77,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/checkboxes.php
+++ b/libraries/joomla/form/fields/checkboxes.php
@@ -56,7 +56,7 @@ class JFormFieldCheckboxes extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -85,7 +85,7 @@ class JFormFieldColor extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -110,7 +110,7 @@ class JFormFieldColor extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/color.php
+++ b/libraries/joomla/form/fields/color.php
@@ -85,7 +85,7 @@ class JFormFieldColor extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -45,7 +45,7 @@ class JFormFieldFile extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -65,7 +65,7 @@ class JFormFieldFile extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/file.php
+++ b/libraries/joomla/form/fields/file.php
@@ -45,7 +45,7 @@ class JFormFieldFile extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -81,7 +81,7 @@ class JFormFieldFileList extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/filelist.php
+++ b/libraries/joomla/form/fields/filelist.php
@@ -81,7 +81,7 @@ class JFormFieldFileList extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -106,7 +106,7 @@ class JFormFieldFileList extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -80,7 +80,7 @@ class JFormFieldFolderList extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -105,7 +105,7 @@ class JFormFieldFolderList extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/folderlist.php
+++ b/libraries/joomla/form/fields/folderlist.php
@@ -80,7 +80,7 @@ class JFormFieldFolderList extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -244,7 +244,7 @@ class JFormFieldList extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/list.php
+++ b/libraries/joomla/form/fields/list.php
@@ -244,7 +244,7 @@ class JFormFieldList extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -71,7 +71,7 @@ class JFormFieldMeter extends JFormFieldNumber
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -94,7 +94,7 @@ class JFormFieldMeter extends JFormFieldNumber
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/meter.php
+++ b/libraries/joomla/form/fields/meter.php
@@ -71,7 +71,7 @@ class JFormFieldMeter extends JFormFieldNumber
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/number.php
+++ b/libraries/joomla/form/fields/number.php
@@ -61,7 +61,7 @@ class JFormFieldNumber extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/number.php
+++ b/libraries/joomla/form/fields/number.php
@@ -61,7 +61,7 @@ class JFormFieldNumber extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -83,7 +83,7 @@ class JFormFieldNumber extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -62,7 +62,7 @@ class JFormFieldPassword extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -84,7 +84,7 @@ class JFormFieldPassword extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/password.php
+++ b/libraries/joomla/form/fields/password.php
@@ -62,7 +62,7 @@ class JFormFieldPassword extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -37,7 +37,7 @@ class JFormFieldPlugins extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/plugins.php
+++ b/libraries/joomla/form/fields/plugins.php
@@ -37,7 +37,7 @@ class JFormFieldPlugins extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -57,7 +57,7 @@ class JFormFieldPlugins extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -53,7 +53,7 @@ class JFormFieldRules extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -75,7 +75,7 @@ class JFormFieldRules extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/rules.php
+++ b/libraries/joomla/form/fields/rules.php
@@ -53,7 +53,7 @@ class JFormFieldRules extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -61,7 +61,7 @@ class JFormFieldSQL extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/sql.php
+++ b/libraries/joomla/form/fields/sql.php
@@ -61,7 +61,7 @@ class JFormFieldSQL extends JFormFieldList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -84,7 +84,7 @@ class JFormFieldSQL extends JFormFieldList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -69,7 +69,7 @@ class JFormFieldSubform extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/subform.php
+++ b/libraries/joomla/form/fields/subform.php
@@ -69,7 +69,7 @@ class JFormFieldSubform extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -94,7 +94,7 @@ class JFormFieldSubform extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -61,7 +61,7 @@ class JFormFieldText extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/text.php
+++ b/libraries/joomla/form/fields/text.php
@@ -61,7 +61,7 @@ class JFormFieldText extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -83,7 +83,7 @@ class JFormFieldText extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -61,7 +61,7 @@ class JFormFieldTextarea extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/textarea.php
+++ b/libraries/joomla/form/fields/textarea.php
@@ -61,7 +61,7 @@ class JFormFieldTextarea extends JFormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -83,7 +83,7 @@ class JFormFieldTextarea extends JFormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -45,7 +45,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/joomla/form/fields/timezone.php
+++ b/libraries/joomla/form/fields/timezone.php
@@ -45,7 +45,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -65,7 +65,7 @@ class JFormFieldTimezone extends JFormFieldGroupedList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -71,7 +71,7 @@ class ComponentRecord extends \JObject
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -91,7 +91,7 @@ class ComponentRecord extends \JObject
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -71,7 +71,7 @@ class ComponentRecord extends \JObject
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -32,7 +32,7 @@ class CaptchaField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -53,7 +53,7 @@ class CaptchaField extends FormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -32,7 +32,7 @@ class CaptchaField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/EditorField.php
+++ b/libraries/src/Form/Field/EditorField.php
@@ -107,7 +107,7 @@ class EditorField extends \JFormFieldTextarea
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -134,7 +134,7 @@ class EditorField extends \JFormFieldTextarea
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/EditorField.php
+++ b/libraries/src/Form/Field/EditorField.php
@@ -107,7 +107,7 @@ class EditorField extends \JFormFieldTextarea
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -111,7 +111,7 @@ class MediaField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -111,7 +111,7 @@ class MediaField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -139,7 +139,7 @@ class MediaField extends FormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/MenuitemField.php
+++ b/libraries/src/Form/Field/MenuitemField.php
@@ -76,7 +76,7 @@ class MenuitemField extends \JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -100,7 +100,7 @@ class MenuitemField extends \JFormFieldGroupedList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/MenuitemField.php
+++ b/libraries/src/Form/Field/MenuitemField.php
@@ -76,7 +76,7 @@ class MenuitemField extends \JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -39,7 +39,7 @@ class ModuleorderField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -39,7 +39,7 @@ class ModuleorderField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -59,7 +59,7 @@ class ModuleorderField extends FormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/ModulepositionField.php
+++ b/libraries/src/Form/Field/ModulepositionField.php
@@ -43,7 +43,7 @@ class ModulepositionField extends \JFormFieldText
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/ModulepositionField.php
+++ b/libraries/src/Form/Field/ModulepositionField.php
@@ -43,7 +43,7 @@ class ModulepositionField extends \JFormFieldText
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -63,7 +63,7 @@ class ModulepositionField extends \JFormFieldText
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/OrderingField.php
+++ b/libraries/src/Form/Field/OrderingField.php
@@ -40,7 +40,7 @@ class OrderingField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -60,7 +60,7 @@ class OrderingField extends FormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/Field/OrderingField.php
+++ b/libraries/src/Form/Field/OrderingField.php
@@ -40,7 +40,7 @@ class OrderingField extends FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/TemplatestyleField.php
+++ b/libraries/src/Form/Field/TemplatestyleField.php
@@ -50,7 +50,7 @@ class TemplatestyleField extends \JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/Field/TemplatestyleField.php
+++ b/libraries/src/Form/Field/TemplatestyleField.php
@@ -50,7 +50,7 @@ class TemplatestyleField extends \JFormFieldGroupedList
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -71,7 +71,7 @@ class TemplatestyleField extends \JFormFieldGroupedList
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -380,7 +380,7 @@ abstract class FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -380,7 +380,7 @@ abstract class FormField
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -446,7 +446,7 @@ abstract class FormField
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -207,7 +207,7 @@ class MenuItem extends \stdClass
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to the the value.
+	 * @param   string  $name  The property name for which to set the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *
@@ -227,7 +227,7 @@ class MenuItem extends \stdClass
 	/**
 	 * Method to set certain otherwise inaccessible properties of the form field object.
 	 *
-	 * @param   string  $name   The property name for which to the the value.
+	 * @param   string  $name   The property name for which to set the value.
 	 * @param   mixed   $value  The value of the property.
 	 *
 	 * @return  void

--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -207,7 +207,7 @@ class MenuItem extends \stdClass
 	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
-	 * @param   string  $name  The property name for which to set the value.
+	 * @param   string  $name  The property name for which to get the value.
 	 *
 	 * @return  mixed  The property value or null.
 	 *


### PR DESCRIPTION
If we have doc blocks then they should be correct

> The property name for which to the the value

==>

> The property name for which to set the value
