### PR TITLE
[CS] Code Style fixes for administrator/components/com_joomlaupdate/

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -243,7 +243,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	/**
 	 * Downloads the update package to the site.
 	 *
-	 * @return  bool|string False on failure, basename of the file in any other case.
+	 * @return  boolean|string False on failure, basename of the file in any other case.
 	 *
 	 * @since   2.5.4
 	 */
@@ -916,7 +916,7 @@ ENDDATA;
 	 *
 	 * @param   array  $credentials  The credentials to authenticate the user with
 	 *
-	 * @return  bool
+	 * @return  boolean
 	 *
 	 * @since   3.6.0
 	 */
@@ -952,7 +952,7 @@ ENDDATA;
 	/**
 	 * Does the captive (temporary) file we uploaded before still exist?
 	 *
-	 * @return  bool
+	 * @return  boolean
 	 *
 	 * @since   3.6.0
 	 */

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -243,7 +243,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 	/**
 	 * Downloads the update package to the site.
 	 *
-	 * @return  boolean|string False on failure, basename of the file in any other case.
+	 * @return  boolean|string  False on failure, basename of the file in any other case.
 	 *
 	 * @since   2.5.4
 	 */

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -49,7 +49,7 @@ if (!class_exists('JFile'))
 		 *
 		 * @param   string  $fileName  The path to the file to be checked
 		 *
-		 * @return  bool
+		 * @return  boolean
 		 *
 		 * @since   3.5.1
 		 */
@@ -63,7 +63,7 @@ if (!class_exists('JFile'))
 		 *
 		 * @param   string  $fileName  The path to the file to be deleted
 		 *
-		 * @return  bool
+		 * @return  boolean
 		 *
 		 * @since   3.5.1
 		 */
@@ -90,7 +90,7 @@ if (!class_exists('JFolder'))
 		 *
 		 * @param   string  $folderName  The path to the folder to be checked
 		 *
-		 * @return  bool
+		 * @return  boolean
 		 *
 		 * @since   3.5.1
 		 */


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Expected "boolean" but found "bool" for function return type
(Joomla.Commenting.FunctionComment.InvalidReturn)

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
