### PR TITLE
[CS] Code Style fixes for  administrator/components/com_languages/

### DIFF
--- a/administrator/components/com_languages/models/installed.php
+++ b/administrator/components/com_languages/models/installed.php
@@ -280,6 +280,7 @@ class LanguagesModelInstalled extends JModelList
 		if ($limit !== 0)
 		{
 			$start = (int) $this->getState('list.start', 0);
+
 			return array_slice($installedLanguages, $start, $limit);
 		}
 

--- a/administrator/components/com_languages/models/override.php
+++ b/administrator/components/com_languages/models/override.php
@@ -105,7 +105,7 @@ class LanguagesModelOverride extends JModelAdmin
 			$result->override = $strings[$pk];
 		}
 
-		$opposite_filename = constant('JPATH_' . strtoupper($this->getState('filter.client') == 'site' ? 'administrator' : 'site')) 
+		$opposite_filename = constant('JPATH_' . strtoupper($this->getState('filter.client') == 'site' ? 'administrator' : 'site'))
 			. '/language/overrides/' . $this->getState('filter.language', 'en-GB') . '.override.ini';
 		$opposite_strings = LanguagesHelper::parseFile($opposite_filename);
 		$result->both = isset($opposite_strings[$pk]) && ($opposite_strings[$pk] == $strings[$pk]);

--- a/administrator/components/com_languages/models/strings.php
+++ b/administrator/components/com_languages/models/strings.php
@@ -44,8 +44,8 @@ class LanguagesModelStrings extends JModelLegacy
 
 		// Create the insert query.
 		$query = $this->_db->getQuery(true)
-					->insert($this->_db->quoteName('#__overrider'))
-					->columns('constant, string, file');
+			->insert($this->_db->quoteName('#__overrider'))
+			->columns('constant, string, file');
 
 		// Initialize some variables.
 		$client   = $app->getUserState('com_languages.overrides.filter.client', 'site') ? 'administrator' : 'site';
@@ -148,7 +148,7 @@ class LanguagesModelStrings extends JModelLegacy
 
 			// Check whether there are more results than already loaded.
 			$query->clear('select')->clear('limit')
-						->select('COUNT(id)');
+				->select('COUNT(id)');
 			$this->_db->setQuery($query);
 
 			if ($this->_db->loadResult() > $limitstart + 10)


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Please consider an empty line before the return statement
- Whitespace found at end of line

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style check on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none