### PR TITLE
[CS] Code Style fixes for administrator/components/com_login/

### DIFF
--- a/administrator/components/com_login/views/login/view.html.php
+++ b/administrator/components/com_login/views/login/view.html.php
@@ -16,15 +16,15 @@ defined('_JEXEC') or die;
  */
 class LoginViewLogin extends JViewLegacy
 {
-	  /**
-	   * Display the view.
-	   *
-	   * @param   string  $tpl  The name of the template file to parse.
-	   *
-	   * @return  void
-	   *
-	   * @since  3.7.0
-	   */
+	/**
+	 * Display the view.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse.
+	 *
+	 * @return  void
+	 *
+	 * @since  3.7.0
+	 */
 	public function display($tpl = null)
 	{
 		/**

--- a/administrator/components/com_login/views/login/view.html.php
+++ b/administrator/components/com_login/views/login/view.html.php
@@ -16,21 +16,21 @@ defined('_JEXEC') or die;
  */
 class LoginViewLogin extends JViewLegacy
 {
-  	/**
-	 * Display the view.
-	 *
-	 * @param   string  $tpl  The name of the template file to parse.
-	 *
-	 * @return  void
-	 *
-	 * @since  3.7.0
-	 */
+	  /**
+	   * Display the view.
+	   *
+	   * @param   string  $tpl  The name of the template file to parse.
+	   *
+	   * @return  void
+	   *
+	   * @since  3.7.0
+	   */
 	public function display($tpl = null)
 	{
 		/**
 		 * To prevent clickjacking, only allow the login form to be used inside a frame in the same origin.
 		 * So send a X-Frame-Options HTTP Header with the SAMEORIGIN value.
-		 * 
+		 *
 		 * @link https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet
 		 * @link https://tools.ietf.org/html/rfc7034
 		 */


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Tabs must be used to indent lines; spaces are not allowed
- Whitespace found at end of line

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none