### PR TITLE
[CS] Code Style fixes for administrator/components/com_media/

### DIFF
--- a/administrator/components/com_media/controllers/file.json.php
+++ b/administrator/components/com_media/controllers/file.json.php
@@ -115,12 +115,12 @@ class MediaControllerFile extends JControllerLegacy
 				return;
 			}
 
-		// Trigger the onContentBeforeSave event.
-		JPluginHelper::importPlugin('content');
-		$dispatcher  = JEventDispatcher::getInstance();
-		$object_file = new JObject($file);
-		$object_file->filepath = $filepath;
-		$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
+			// Trigger the onContentBeforeSave event.
+			JPluginHelper::importPlugin('content');
+			$dispatcher  = JEventDispatcher::getInstance();
+			$object_file = new JObject($file);
+			$object_file->filepath = $filepath;
+			$result = $dispatcher->trigger('onContentBeforeSave', array('com_media.file', &$object_file, true));
 
 			if (in_array(false, $result, true))
 			{

--- a/administrator/components/com_media/media.php
+++ b/administrator/components/com_media/media.php
@@ -15,7 +15,7 @@ $asset  = $input->get('asset');
 $author = $input->get('author');
 
 // Access check.
-if (!$user->authorise('core.manage', 'com_media') && (!$asset or (!$user->authorise('core.edit', $asset)
+if (!$user->authorise('core.manage', 'com_media') && (!$asset || (!$user->authorise('core.edit', $asset)
 	&& !$user->authorise('core.create', $asset)
 	&& count($user->getAuthorisedCategories($asset, 'core.create')) == 0)
 	&& !($user->id == $author && $user->authorise('core.edit.own', $asset))))

--- a/administrator/components/com_media/models/manager.php
+++ b/administrator/components/com_media/models/manager.php
@@ -65,6 +65,7 @@ class MediaModelManager extends JModelLegacy
 		{
 			$base = COM_MEDIA_BASE;
 		}
+
 		// Corrections for windows paths
 		$base = str_replace(DIRECTORY_SEPARATOR, '/', $base);
 		$com_media_base_uni = str_replace(DIRECTORY_SEPARATOR, '/', COM_MEDIA_BASE);


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Line indented incorrectly;
- Logical operator "or" not allowed; use "||" instead
- No blank line found after control structure

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style check on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none