### PR TITLE
[CS] Code Style fixes for administrator/components/com_menus/

### DIFF
--- a/administrator/components/com_menus/controllers/item.php
+++ b/administrator/components/com_menus/controllers/item.php
@@ -172,7 +172,7 @@ class MenusControllerItem extends JControllerForm
 			$this->setRedirect(
 				JRoute::_(
 					'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
-				. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
+					. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
 				)
 			);
 		}
@@ -484,8 +484,8 @@ class MenusControllerItem extends JControllerForm
 				// Redirect to the list screen.
 				$this->setRedirect(
 					JRoute::_(
-					'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
-					. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
+						'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
+						. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
 					)
 				);
 				break;
@@ -551,7 +551,7 @@ class MenusControllerItem extends JControllerForm
 		}
 
 		unset($data['request']);
-		
+
 		$data['type'] = $title;
 
 		if ($this->input->get('fieldtype') == 'type')

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -176,7 +176,7 @@ class MenusControllerItems extends JControllerAdmin
 		$this->setRedirect(
 			JRoute::_(
 				'index.php?option=' . $this->option . '&view=' . $this->view_list
-						. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
+				. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
 			)
 		);
 	}

--- a/administrator/components/com_menus/controllers/items.php
+++ b/administrator/components/com_menus/controllers/items.php
@@ -174,11 +174,11 @@ class MenusControllerItems extends JControllerAdmin
 		}
 
 		$this->setRedirect(
-				JRoute::_(
-						'index.php?option=' . $this->option . '&view=' . $this->view_list
+			JRoute::_(
+				'index.php?option=' . $this->option . '&view=' . $this->view_list
 						. '&menutype=' . $app->getUserState('com_menus.items.menutype'), false
-						)
-				);
+			)
+		);
 	}
 
 	/**
@@ -247,7 +247,6 @@ class MenusControllerItems extends JControllerAdmin
 				}
 
 				$this->setMessage(JText::plural($ntext, count($cid)), $messageType);
-
 			}
 			catch (Exception $e)
 			{

--- a/administrator/components/com_menus/helpers/associations.php
+++ b/administrator/components/com_menus/helpers/associations.php
@@ -130,7 +130,6 @@ class MenusAssociationsHelper extends AssociationExtensionHelper
 
 		if (in_array($typeName, $this->itemTypes))
 		{
-
 			switch ($typeName)
 			{
 				case 'item':

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -184,7 +184,8 @@ class MenusHelper
 					  a.template_style_id,
 					  a.checked_out,
 					  a.language,
-					  a.lft')
+					  a.lft'
+			)
 			->from('#__menu AS a');
 
 		$query->select('e.name as componentname, e.element')

--- a/administrator/components/com_menus/models/fields/menuparent.php
+++ b/administrator/components/com_menus/models/fields/menuparent.php
@@ -96,7 +96,6 @@ class JFormFieldMenuParent extends JFormFieldList
 			{
 				$options[$i]->text = str_repeat('- ', $options[$i]->level) . $options[$i]->text;
 			}
-
 		}
 
 		// Merge any additional options in the XML definition.

--- a/administrator/components/com_menus/models/fields/menutype.php
+++ b/administrator/components/com_menus/models/fields/menutype.php
@@ -89,7 +89,8 @@ class JFormFieldMenutype extends JFormFieldList
 			function jSelectPosition_' . $this->id . '(name) {
 				document.getElementById("' . $this->id . '").value = name;
 			}
-		');
+		'
+		);
 
 		$link = JRoute::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-append"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id

--- a/administrator/components/com_menus/models/fields/modal/menu.php
+++ b/administrator/components/com_menus/models/fields/modal/menu.php
@@ -176,7 +176,8 @@ class JFormFieldModal_Menu extends JFormField
 				function jSelectMenu_" . $this->id . "(id, title, object) {
 					window.processModalSelect('Item', '" . $this->id . "', id, title, '', object);
 				}
-				");
+				"
+				);
 
 				$scriptSelect[$this->id] = true;
 			}
@@ -221,7 +222,7 @@ class JFormFieldModal_Menu extends JFormField
 
 		// Placeholder if option is present or not
 		if (empty($title))
- 		{
+		{
 			if ($this->element->option && (string) $this->element->option['value'] == '')
 			{
 				$title_holder = JText::_($this->element->option, true);

--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -296,6 +296,7 @@ class MenusModelItem extends JModelAdmin
 
 				return false;
 			}
+
 			// Store the row.
 			if (!$table->store())
 			{
@@ -688,9 +689,8 @@ class MenusModelItem extends JModelAdmin
 		// If the link has been set in the state, possibly changing link type.
 		if ($link = $this->getState('item.link'))
 		{
-
 			// Check if we are changing away from the actual link type.
-			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id === (int) $this->getState('item.id')) 
+			if (MenusHelper::getLinkKey($table->link) !== MenusHelper::getLinkKey($link) && (int) $table->id === (int) $this->getState('item.id'))
 			{
 				$table->link = $link;
 			}
@@ -1491,7 +1491,8 @@ class MenusModelItem extends JModelAdmin
 			if ($associations)
 			{
 				$query->where('(' . $db->quoteName('id') . ' IN (' . implode(',', $associations) . ') OR '
-					. $db->quoteName('key') . ' = ' . $db->quote($old_key) . ')');
+					. $db->quoteName('key') . ' = ' . $db->quote($old_key) . ')'
+				);
 			}
 			else
 			{

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -469,7 +469,7 @@ class MenusModelItems extends JModelList
 	 * @param   string  $menuType  The menutype identifier for the menu
 	 * @param   bool    $check     Flag whether to perform check against ACL as well as existence
 	 *
-	 * @return  int
+	 * @return  integer
 	 *
 	 * @since   3.7.0
 	 */

--- a/administrator/components/com_menus/models/items.php
+++ b/administrator/components/com_menus/models/items.php
@@ -466,8 +466,8 @@ class MenusModelItems extends JModelList
 	/**
 	 * Get the client id for a menu
 	 *
-	 * @param   string  $menuType  The menutype identifier for the menu
-	 * @param   bool    $check     Flag whether to perform check against ACL as well as existence
+	 * @param   string   $menuType  The menutype identifier for the menu
+	 * @param   boolean  $check     Flag whether to perform check against ACL as well as existence
 	 *
 	 * @return  integer
 	 *

--- a/administrator/components/com_menus/models/menutypes.php
+++ b/administrator/components/com_menus/models/menutypes.php
@@ -175,7 +175,7 @@ class MenusModelMenutypes extends JModelLegacy
 	 * @param   string  $file       File path
 	 * @param   string  $component  Component option as in URL
 	 *
-	 * @return  array|bool
+	 * @return  array|boolean
 	 *
 	 * @since   1.6
 	 */
@@ -262,7 +262,7 @@ class MenusModelMenutypes extends JModelLegacy
 	 *
 	 * @param   string  $component  Component option like in URLs
 	 *
-	 * @return  array|bool
+	 * @return  array|boolean
 	 *
 	 * @since   1.6
 	 */
@@ -377,7 +377,7 @@ class MenusModelMenutypes extends JModelLegacy
 	 *
 	 * @param   string  $component  Component option like in URLs
 	 *
-	 * @return  array|bool
+	 * @return  array|boolean
 	 *
 	 * @since   3.7.0
 	 */

--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -189,8 +189,8 @@ class MenusViewItems extends JViewLegacy
 							{
 								$titleParts[] = $vars['view'];
 							}
-
 						}
+
 						$value = implode(' » ', $titleParts);
 					}
 					else


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Blank line found at end of control structure
- Blank line found at start of control structure
- No blank line found after control structure
- Expected "array|boolean" but found "array|bool" for function return type
- Expected "integer" but found "int" for function return type
- Closing parenthesis of a multi-line function call must be on a line by itself
- Multi-line function call not indented correctly
- Expected 1 newline after opening brace
- Tabs must be used to indent lines; spaces are not allowed

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style check on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none