### PR TITLE
[CS] Code Style fixes for administrator/components/com_newsfeeds/

### DIFF
--- a/administrator/components/com_newsfeeds/helpers/associations.php
+++ b/administrator/components/com_newsfeeds/helpers/associations.php
@@ -143,7 +143,6 @@ class NewsfeedsAssociationsHelper extends AssociationExtensionHelper
 
 		if (in_array($typeName, $this->itemTypes))
 		{
-
 			switch ($typeName)
 			{
 				case 'newsfeed':

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -109,11 +109,14 @@ class NewsfeedsHelper extends JHelperContent
 		$db = JFactory::getDbo();
 		$parts     = explode('.', $extension);
 		$section   = null;
+
 		if (count($parts) > 1)
 		{
 			$section = $parts[1];
 		}
+
 		$join = $db->qn('#__newsfeeds') . ' AS c ON ct.content_item_id=c.id';
+
 		if ($section === 'category')
 		{
 			$join = $db->qn('#__categories') . ' AS c ON ct.content_item_id=c.id';
@@ -161,5 +164,5 @@ class NewsfeedsHelper extends JHelperContent
 		}
 
 		return $items;
-	}	
+	}
 }

--- a/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/fields/modal/newsfeed.php
@@ -67,7 +67,8 @@ class JFormFieldModal_Newsfeed extends JFormField
 				function jSelectNewsfeed_" . $this->id . "(id, title, object) {
 					window.processModalSelect('Newsfeed', '" . $this->id . "', id, title, '', object);
 				}
-				");
+				"
+				);
 
 				$scriptSelect[$this->id] = true;
 			}

--- a/administrator/components/com_newsfeeds/models/newsfeed.php
+++ b/administrator/components/com_newsfeeds/models/newsfeed.php
@@ -112,6 +112,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 			if (!$this->table->check())
 			{
 				$this->setError($this->table->getError());
+
 				return false;
 			}
 
@@ -121,6 +122,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 			if (!$this->table->store())
 			{
 				$this->setError($this->table->getError());
+
 				return false;
 			}
 
@@ -347,6 +349,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 					$data['alias'] = '';
 				}
 			}
+
 			$data['published'] = 0;
 		}
 
@@ -486,6 +489,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	{
 		$condition = array();
 		$condition[] = 'catid = ' . (int) $table->catid;
+
 		return $condition;
 	}
 
@@ -556,12 +560,14 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	{
 		// Alter the title & alias
 		$table = $this->getTable();
+
 		while ($table->load(array('alias' => $alias, 'catid' => $category_id)))
 		{
 			if ($name == $table->name)
 			{
 				$name = StringHelper::increment($name);
 			}
+
 			$alias = StringHelper::increment($alias, 'dash');
 		}
 
@@ -571,7 +577,7 @@ class NewsfeedsModelNewsfeed extends JModelAdmin
 	/**
 	 * Is the user allowed to create an on the fly category?
 	 *
-	 * @return  bool
+	 * @return  boolean
 	 *
 	 * @since   3.6.1
 	 */

--- a/administrator/components/com_newsfeeds/models/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/models/newsfeeds.php
@@ -50,6 +50,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 			);
 
 			$assoc = JLanguageAssociations::isEnabled();
+
 			if ($assoc)
 			{
 				$config['filter_fields'][] = 'association';
@@ -263,6 +264,7 @@ class NewsfeedsModelNewsfeeds extends JModelList
 		{
 			ArrayHelper::toInteger($tagId);
 			$tagId = implode(',', $tagId);
+
 			if (!empty($tagId))
 			{
 				$hasTag = true;

--- a/administrator/components/com_newsfeeds/tables/newsfeed.php
+++ b/administrator/components/com_newsfeeds/tables/newsfeed.php
@@ -50,6 +50,7 @@ class NewsfeedsTableNewsfeed extends JTable
 		if (trim($this->name) == '')
 		{
 			$this->setError(JText::_('COM_NEWSFEEDS_WARNING_PROVIDE_VALID_NAME'));
+
 			return false;
 		}
 
@@ -146,6 +147,7 @@ class NewsfeedsTableNewsfeed extends JTable
 				$this->created_by = $user->get('id');
 			}
 		}
+
 		// Verify that the alias is unique
 		$table = JTable::getInstance('Newsfeed', 'NewsfeedsTable');
 

--- a/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -105,10 +105,12 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 			JToolbarHelper::apply('newsfeed.apply');
 			JToolbarHelper::save('newsfeed.save');
 		}
+
 		if (!$checkedOut && count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
 		{
 			JToolbarHelper::save2new('newsfeed.save2new');
 		}
+
 		// If an existing item, can save to a copy.
 		if (!$isNew && $canDo->get('core.create'))
 		{

--- a/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
+++ b/administrator/components/com_newsfeeds/views/newsfeeds/view.html.php
@@ -67,6 +67,7 @@ class NewsfeedsViewNewsfeeds extends JViewLegacy
 		if (count($errors = $this->get('Errors')))
 		{
 			JError::raiseError(500, implode("\n", $errors));
+
 			return false;
 		}
 


### PR DESCRIPTION
Pull Request for Issue code style fixes

### Summary of Changes
- Expected 1 newline after opening brace
- Blank line found at start of control structure
- No blank line found before/after control structure
- Whitespace found at end of line
- Closing parenthesis of a multi-line function call must be on a line by itself
- Expected "boolean" but found "bool" for function return type

[Automatically fixed with Joomla code standards 2.0.0 PHPCS2-alpha2 fixers](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2)

None of the manual only fixes have been applied

### Testing Instructions
Merge by code review

### Expected result
code style has been applied as listed above, old code style testing on drone does not error.

### Actual result
code style had not been applied. [Autofixers from the Joomla code standards 2.0.0 PHPCS2 alpha2](https://github.com/joomla/coding-standards/releases/tag/2.0.0-alpha2) were used to implement fixable code style

### Documentation Changes Required
none
